### PR TITLE
Add LaunchDarkly feature flag for EDOT CF Onboarding in hosted

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/common/feature_flags.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/common/feature_flags.ts
@@ -7,3 +7,4 @@
 
 export const IS_MANAGED_OTLP_SERVICE_ENABLED = 'observability.managedOtlpServiceEnabled';
 export const IS_MANAGED_OTLP_GA = 'observability.managedOtlpGa';
+export const IS_EDOT_CLOUD_FORWARDER_ENABLED = 'observability.edotCloudForwarderEnabled';

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/observability_onboarding_flow.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/observability_onboarding_flow.tsx
@@ -23,6 +23,7 @@ import {
 import type { ObservabilityOnboardingAppServices } from '..';
 import { useFlowBreadcrumb } from './shared/use_flow_breadcrumbs';
 import { useManagedOtlpServiceAvailability } from './shared/use_managed_otlp_service_availability';
+import { useCloudForwarderAvailability } from './shared/use_cloud_forwarder_availability';
 
 const queryClient = new QueryClient();
 
@@ -30,7 +31,7 @@ export function ObservabilityOnboardingFlow() {
   const { pathname } = useLocation();
   const {
     services: {
-      context: { isDev, isCloud, isServerless },
+      context: { isDev, isCloud },
     },
   } = useKibana<ObservabilityOnboardingAppServices>();
 
@@ -41,6 +42,7 @@ export function ObservabilityOnboardingFlow() {
   }, [pathname]);
 
   const isManagedOtlpServiceAvailable = useManagedOtlpServiceAvailability();
+  const isCloudForwarderAvailable = useCloudForwarderAvailability();
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -67,7 +69,7 @@ export function ObservabilityOnboardingFlow() {
             <OtelApmPage />
           </Route>
         )}
-        {(isServerless || isDev) && (
+        {(isCloudForwarderAvailable || isDev) && (
           <Route path="/cloudforwarder">
             <CloudForwarderPage />
           </Route>

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards.tsx
@@ -17,6 +17,7 @@ import type { ObservabilityOnboardingAppServices } from '../..';
 import { LogoIcon } from '../shared/logo_icon';
 import { usePricingFeature } from '../quickstart_flows/shared/use_pricing_feature';
 import { useManagedOtlpServiceAvailability } from '../shared/use_managed_otlp_service_availability';
+import { useCloudForwarderAvailability } from '../shared/use_cloud_forwarder_availability';
 
 export function useCustomCards(
   createCollectionCardHandler: (query: string) => () => void
@@ -38,6 +39,7 @@ export function useCustomCards(
     ObservabilityOnboardingPricingFeature.METRICS_ONBOARDING
   );
   const isManagedOtlpServiceAvailable = useManagedOtlpServiceAvailability();
+  const isCloudForwarderAvailable = useCloudForwarderAvailability();
 
   const { href: autoDetectUrl } = reactRouterNavigate(history, `/auto-detect/${location.search}`);
   const { href: otelLogsUrl } = reactRouterNavigate(history, `/otel-logs/${location.search}`);
@@ -497,11 +499,12 @@ export function useCustomCards(
      */
     ...(isCloud || isDev ? [firehoseQuickstartCard] : []),
     /**
-     * The EDOT Cloud Forwarder card should only be visible on Serverless
-     * as it requires Elastic Cloud infrastructure.
-     * Also visible in dev mode for local development.
+     * The EDOT Cloud Forwarder card visibility is controlled by:
+     * - Always visible on Serverless (already deployed)
+     * - On Cloud (ECH), controlled by LaunchDarkly feature flag
+     * - Also visible in dev mode for local development
      */
-    ...(isServerless || isDev ? [cloudforwarderQuickstartCard] : []),
+    ...(isCloudForwarderAvailable || isDev ? [cloudforwarderQuickstartCard] : []),
   ];
 }
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/use_cloud_forwarder_availability.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/use_cloud_forwarder_availability.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useCloudForwarderAvailability } from './use_cloud_forwarder_availability';
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: jest.fn(),
+}));
+
+describe('useCloudForwarderAvailability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true when running in Serverless context regardless of feature flag', () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        featureFlags: {
+          getBooleanValue: () => false,
+        },
+        context: { isServerless: true, isCloud: true },
+      },
+    });
+
+    const { result } = renderHook(() => useCloudForwarderAvailability());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when running in Cloud context and feature flag is enabled', () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        featureFlags: {
+          getBooleanValue: () => true,
+        },
+        context: { isServerless: false, isCloud: true },
+      },
+    });
+
+    const { result } = renderHook(() => useCloudForwarderAvailability());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when running in Cloud context and feature flag is disabled', () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        featureFlags: {
+          getBooleanValue: () => false,
+        },
+        context: { isServerless: false, isCloud: true },
+      },
+    });
+
+    const { result } = renderHook(() => useCloudForwarderAvailability());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when running on-premise (not Cloud, not Serverless)', () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        featureFlags: {
+          getBooleanValue: () => true, // Even if flag would be true
+        },
+        context: { isServerless: false, isCloud: false },
+      },
+    });
+
+    const { result } = renderHook(() => useCloudForwarderAvailability());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/use_cloud_forwarder_availability.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/use_cloud_forwarder_availability.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { IS_EDOT_CLOUD_FORWARDER_ENABLED } from '../../../common/feature_flags';
+import type { ObservabilityOnboardingAppServices } from '../..';
+
+/**
+ * Hook to determine if the EDOT Cloud Forwarder onboarding flow is available.
+ *
+ * - Always available for Serverless projects (already deployed and working)
+ * - For Cloud (ECH), controlled by LaunchDarkly feature flag
+ * - Not available for on-premise deployments
+ */
+export function useCloudForwarderAvailability() {
+  const {
+    services: {
+      featureFlags,
+      context: { isServerless, isCloud },
+    },
+  } = useKibana<ObservabilityOnboardingAppServices>();
+
+  /**
+   * Cloud Forwarder is always available for Serverless projects
+   */
+  if (isServerless) {
+    return true;
+  }
+
+  /**
+   * For Cloud (ECH), check the LaunchDarkly feature flag
+   */
+  if (isCloud) {
+    return featureFlags.getBooleanValue(IS_EDOT_CLOUD_FORWARDER_ENABLED, false);
+  }
+
+  /**
+   * Not available for on-premise deployments
+   */
+  return false;
+}


### PR DESCRIPTION
- Add new feature flag constant IS_EDOT_CLOUD_FORWARDER_ENABLED
- Create useCloudForwarderAvailability hook to control Cloud Forwarder visibility:
  - Always available on Serverless (already deployed)
  - Controlled by LaunchDarkly feature flag on Cloud (ECH)
  - Not available for on-premise deployments
- Update use_custom_cards.tsx to use the new hook for card visibility
- Update observability_onboarding_flow.tsx to use the new hook for route access
- Add unit tests for the new hook

This change allows the EDOT Cloud Forwarder onboarding to be gradually rolled out on Elastic Cloud (ECH) via LaunchDarkly while remaining always enabled on Serverless deployments.

