### PR TITLE
Adding support in phoenix exporter for arize (cloud managed version of phoenix)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-tracing-config/config.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing-config/config.ts
@@ -31,6 +31,7 @@ const phoenixExportConfigSchema: Type<InferenceTracingPhoenixExportConfig> = sch
   public_url: schema.maybe(schema.uri()),
   project_name: schema.maybe(schema.string()),
   api_key: schema.maybe(schema.string()),
+  headers: schema.maybe(schema.recordOf(schema.string(), schema.string())),
   scheduled_delay: scheduledDelay,
 });
 

--- a/x-pack/platform/packages/shared/kbn-inference-tracing-config/types.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing-config/types.ts
@@ -47,8 +47,16 @@ export interface InferenceTracingPhoenixExportConfig {
   project_name?: string;
   /**
    * The API key for API requests to Phoenix server.
+   * When provided, it will be sent as `Authorization: Bearer <api_key>`.
    */
   api_key?: string;
+  /**
+   * Custom headers to include in requests to the Phoenix server.
+   * These headers will be merged with (and can override) the default
+   * Authorization header. Useful for Arize compatibility which requires
+   * `space_id` and `authorization` headers.
+   */
+  headers?: Record<string, string>;
   /**
    * The delay in milliseconds before the exporter sends another
    * batch of spans.

--- a/x-pack/platform/packages/shared/kbn-inference-tracing/src/phoenix/phoenix_span_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing/src/phoenix/phoenix_span_processor.ts
@@ -35,8 +35,13 @@ function getPhoenixUrl(base: string | URL, path: string): URL {
 export class PhoenixSpanProcessor extends BaseInferenceSpanProcessor {
   private getProjectId: () => Promise<string | undefined>;
   constructor(private readonly config: InferenceTracingPhoenixExportConfig) {
+    // Build headers: start with default Bearer auth if api_key is provided,
+    // then merge/override with any custom headers from config.
+    // This allows Arize compatibility (which requires space_id and authorization headers)
+    // while maintaining backward compatibility with self-hosted Phoenix.
     const headers = {
       ...(config.api_key ? { Authorization: `Bearer ${config.api_key}` } : {}),
+      ...config.headers,
     };
 
     const exporter = new PhoenixProtoExporter({


### PR DESCRIPTION
 **DON'T MERGE, FOR INTERNAL TESTING PURPOSES ONLY**

## Summary

This pull request adds support for custom HTTP headers in the Phoenix inference tracing exporter configuration, improving compatibility with services like Arize that require additional or custom headers. The changes also clarify how the `api_key` and headers interact, ensuring that custom headers can override defaults as needed.

**Configuration schema and type updates:**

* Added an optional `headers` field to the `InferenceTracingPhoenixExportConfig` interface, allowing users to specify custom headers for requests to the Phoenix server. The documentation explains that these headers can override the default `Authorization` header, which is useful for compatibility with Arize.
* Updated the configuration schema in `config.ts` to accept an optional `headers` field as a record of string key-value pairs.

**Phoenix span processor logic:**

* Modified the `PhoenixSpanProcessor` constructor to build the HTTP headers by starting with the default Bearer authorization (if `api_key` is provided), then merging and potentially overriding with any custom headers from the config. This ensures backward compatibility with self-hosted Phoenix and allows for the flexibility required by other services.


Screenshot traces available in oblt cluster phoenix, local phoenix and arize:
arize:  
<img width="1724" height="901" alt="Screenshot 2026-01-30 at 12 09 14 AM" src="https://github.com/user-attachments/assets/d6e9c683-7118-4bf3-be80-1bba6f673646" />

local phoenix:
<img width="1726" height="824" alt="Screenshot 2026-01-30 at 12 10 41 AM" src="https://github.com/user-attachments/assets/4221bf2a-096f-49dc-9486-7a2da762b7fd" />

oblt cluster:

<img width="1547" height="613" alt="Screenshot 2026-01-30 at 12 11 17 AM" src="https://github.com/user-attachments/assets/b817df55-7a3b-4c41-ad4c-01c40fc3306f" />


Built using: Claude Code

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



