### PR TITLE
fix: add maxSize to unbounded schema.arrayOf calls

### DIFF
--- a/src/platform/packages/shared/kbn-content-management-utils/src/schema.ts
+++ b/src/platform/packages/shared/kbn-content-management-utils/src/schema.ts
@@ -26,7 +26,8 @@ export const referenceSchema = schema.object(
   { unknowns: 'forbid', meta: { id: 'kbn-content-management-utils-referenceSchema' } }
 );
 
-export const referencesSchema = schema.arrayOf(referenceSchema);
+// maxSize: 100 - aligns with references pattern in visualizations/event_annotation/graph cm_services.ts
+export const referencesSchema = schema.arrayOf(referenceSchema, { maxSize: 100 });
 
 export const savedObjectSchema = <T extends ObjectType<any>>(attributesSchema: T) =>
   schema.object(
@@ -41,7 +42,8 @@ export const savedObjectSchema = <T extends ObjectType<any>>(attributesSchema: T
       error: schema.maybe(apiError),
       attributes: attributesSchema,
       references: referencesSchema,
-      namespaces: schema.maybe(schema.arrayOf(schema.string())),
+      // maxSize: 100 - aligns with namespaces in fleet/server/types and visualizations cm_services.ts
+      namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
       originId: schema.maybe(schema.string()),
       managed: schema.maybe(schema.boolean()),
     },
@@ -80,7 +82,8 @@ export const createOptionsSchemas = {
   overwrite: schema.maybe(schema.boolean()),
   version: schema.maybe(schema.string()),
   refresh: schema.maybe(schema.boolean()),
-  initialNamespaces: schema.maybe(schema.arrayOf(schema.string())),
+  // maxSize: 100 - aligns with namespaces pattern
+  initialNamespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   managed: schema.maybe(schema.boolean()),
 };
 
@@ -92,17 +95,23 @@ export const searchOptionsSchemas = {
   perPage: schema.maybe(schema.number()),
   sortField: schema.maybe(schema.string()),
   sortOrder: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
-  fields: schema.maybe(schema.arrayOf(schema.string())),
+  // maxSize: 100 - aligns with searchFields pattern in visualizations/graph/event_annotation cm_services.ts
+  fields: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   search: schema.maybe(schema.string()),
-  searchFields: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
-  rootSearchFields: schema.maybe(schema.arrayOf(schema.string())),
+  // maxSize: 100 - aligns with searchFields pattern in visualizations/graph/event_annotation cm_services.ts
+  searchFields: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string(), { maxSize: 100 })])),
+  // maxSize: 100 - aligns with searchFields pattern
+  rootSearchFields: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
 
-  hasReference: schema.maybe(schema.oneOf([referenceSchema, schema.arrayOf(referenceSchema)])),
+  // maxSize: 100 - aligns with references pattern
+  hasReference: schema.maybe(schema.oneOf([referenceSchema, schema.arrayOf(referenceSchema, { maxSize: 100 })])),
   hasReferenceOperator: schema.maybe(schemaAndOr),
-  hasNoReference: schema.maybe(schema.oneOf([referenceSchema, schema.arrayOf(referenceSchema)])),
+  // maxSize: 100 - aligns with references pattern
+  hasNoReference: schema.maybe(schema.oneOf([referenceSchema, schema.arrayOf(referenceSchema, { maxSize: 100 })])),
   hasNoReferenceOperator: schema.maybe(schemaAndOr),
   defaultSearchOperator: schema.maybe(schemaAndOr),
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
+  // maxSize: 100 - aligns with namespaces pattern
+  namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   type: schema.maybe(schema.string()),
 
   filter: schema.maybe(schema.string()),
@@ -136,7 +145,8 @@ export const searchResultSchema = <T extends ObjectType<any>, M extends ObjectTy
 ) =>
   schema.object(
     {
-      hits: schema.arrayOf(soSchema),
+      // maxSize: 10000 - search result hits; aligns with fleet/server/types items patterns
+      hits: schema.arrayOf(soSchema, { maxSize: 10000 }),
       pagination: schema.object({
         total: schema.number(),
         cursor: schema.maybe(schema.string()),

--- a/src/platform/packages/shared/kbn-es-query-server/src/filter.ts
+++ b/src/platform/packages/shared/kbn-es-query-server/src/filter.ts
@@ -145,11 +145,12 @@ const oneOfConditionSchema = conditionFieldSchema.extends({
   operator: schema.oneOf([schema.literal('is_one_of'), schema.literal('is_not_one_of')], {
     meta: { description: 'Array value comparison operators' },
   }),
+  // maxSize: 1000 - filter values; generous limit for large enums or multi-select filters
   value: schema.oneOf(
     [
-      schema.arrayOf(schema.string()),
-      schema.arrayOf(schema.number()),
-      schema.arrayOf(schema.boolean()),
+      schema.arrayOf(schema.string(), { maxSize: 1000 }),
+      schema.arrayOf(schema.number(), { maxSize: 1000 }),
+      schema.arrayOf(schema.boolean(), { maxSize: 1000 }),
     ],
     { meta: { description: 'Homogeneous array of values' } }
   ),
@@ -205,11 +206,13 @@ export const asCodeGroupFilterSchema = basePropertiesSchema.extends(
     group: schema.object(
       {
         type: schema.oneOf([schema.literal('and'), schema.literal('or')]),
+        // maxSize: 100 - nested conditions; aligns with filter patterns in kbn-lens-embeddable-utils and bounds recursion depth
         conditions: schema.arrayOf(
           schema.oneOf([
             conditionSchema,
             schema.lazy(GROUP_FILTER_ID), // Recursive reference for nested groups
-          ])
+          ]),
+          { maxSize: 100 }
         ),
       },
       { meta: { description: 'Condition or nested group filter', id: GROUP_FILTER_ID } }

--- a/src/platform/plugins/shared/data_view_field_editor/server/routes/field_preview.ts
+++ b/src/platform/plugins/shared/data_view_field_editor/server/routes/field_preview.ts
@@ -38,9 +38,11 @@ const responseSchema = () => {
   return schema.object({
     values: schema.oneOf([
       // composite field
-      schema.recordOf(schema.string(), schema.arrayOf(valueSchema)),
+      // maxSize: 100 - field preview values; reasonable limit for preview response
+      schema.recordOf(schema.string(), schema.arrayOf(valueSchema, { maxSize: 100 })),
       // primitive field
-      schema.arrayOf(valueSchema),
+      // maxSize: 100 - field preview values; reasonable limit for preview response
+      schema.arrayOf(valueSchema, { maxSize: 100 }),
     ]),
     error: schema.maybe(schema.object({}, { unknowns: 'allow' })),
     status: schema.maybe(schema.number()),

--- a/src/platform/plugins/shared/data_view_management/server/routes/preview_scripted_field.ts
+++ b/src/platform/plugins/shared/data_view_management/server/routes/preview_scripted_field.ts
@@ -26,7 +26,8 @@ export function registerPreviewScriptedFieldRoute(router: IRouter): void {
           name: schema.string(),
           script: schema.string(),
           query: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-          additionalFields: schema.maybe(schema.arrayOf(schema.string())),
+          // maxSize: 100 - additional fields to include; aligns with filter patterns
+          additionalFields: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
         }),
       },
     },

--- a/src/platform/plugins/shared/data_views/server/content_management/schema/v1/cm_services.ts
+++ b/src/platform/plugins/shared/data_views/server/content_management/schema/v1/cm_services.ts
@@ -26,15 +26,18 @@ const dataViewAttributesSchema = schema.object(
     title: schema.string(),
     type: schema.maybe(schema.literal(DataViewType.ROLLUP)),
     timeFieldName: schema.maybe(schema.string()),
+    // maxSize: 100 - aligns with filter patterns in kbn-lens-embeddable-utils config_builder schemas
     sourceFilters: schema.maybe(
       schema.arrayOf(
         schema.object({
           value: schema.string(),
           clientId: schema.maybe(schema.oneOf([schema.string(), schema.number()])),
-        })
+        }),
+        { maxSize: 100 }
       )
     ),
-    fields: schema.maybe(schema.arrayOf(fieldSpecSchema)),
+    // maxSize: 10000 - data views can have many fields; aligns with fleet/server/types items patterns
+    fields: schema.maybe(schema.arrayOf(fieldSpecSchema, { maxSize: 10000 })),
     typeMeta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
     fieldFormatMap: schema.maybe(schema.recordOf(schema.string(), serializedFieldFormatSchema)),
     fieldAttrs: schema.maybe(

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/existing_indices.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/existing_indices.ts
@@ -69,12 +69,14 @@ export const registerExistingIndicesPath = (router: IRouter): void => {
         validate: {
           request: {
             query: schema.object({
-              indices: schema.oneOf([schema.string(), schema.arrayOf(schema.string())]),
+              // maxSize: 100 - index patterns to check; aligns with fleet/server/types indices pattern
+              indices: schema.oneOf([schema.string(), schema.arrayOf(schema.string(), { maxSize: 100 })]),
             }),
           },
           response: {
             200: {
-              body: () => schema.arrayOf(schema.string()),
+              // maxSize: 10000 - existing indices list; aligns with fleet/server/types items patterns
+              body: () => schema.arrayOf(schema.string(), { maxSize: 10000 }),
             },
           },
         },

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/public/get_data_views.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/public/get_data_views.ts
@@ -50,17 +50,20 @@ const getDataViewsRouteFactory =
     usageCollection?: UsageCounter
   ) => {
     const responseValidation = () => {
+      // maxSize: 10000 - list of all data views; aligns with fleet/server/types items patterns
       const dataViewListSchema = schema.arrayOf(
         schema.object({
           id: schema.string(),
-          namespaces: schema.maybe(schema.arrayOf(schema.string())),
+          // maxSize: 100 - aligns with namespaces in fleet/server/types and visualizations cm_services.ts
+          namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
           title: schema.string(),
           type: schema.maybe(schema.string()),
           typeMeta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
           name: schema.maybe(schema.string()),
           timeFieldName: schema.maybe(schema.string()),
           managed: schema.maybe(schema.boolean()),
-        })
+        }),
+        { maxSize: 10000 }
       );
       return schema.object({ [serviceKey]: dataViewListSchema });
     };

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/public/swap_references.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/public/swap_references.ts
@@ -90,7 +90,8 @@ export const swapReferencesRoute =
                 fromId: idSchema,
                 fromType: schema.maybe(schema.string()),
                 toId: idSchema,
-                forId: schema.maybe(schema.oneOf([idSchema, schema.arrayOf(idSchema)])),
+                // maxSize: 100 - batch operation IDs; aligns with reference patterns in content management
+                forId: schema.maybe(schema.oneOf([idSchema, schema.arrayOf(idSchema, { maxSize: 100 })])),
                 forType: schema.maybe(schema.string()),
                 delete: schema.maybe(schema.boolean()),
               }),
@@ -99,7 +100,8 @@ export const swapReferencesRoute =
               200: {
                 body: () =>
                   schema.object({
-                    result: schema.arrayOf(schema.object({ id: idSchema, type: schema.string() })),
+                    // maxSize: 10000 - result list; aligns with fleet/server/types items patterns
+                    result: schema.arrayOf(schema.object({ id: idSchema, type: schema.string() }), { maxSize: 10000 }),
                     deleteStatus: schema.maybe(
                       schema.object({
                         remainingRefs: schema.number(),

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.ts
@@ -35,12 +35,14 @@ const indexPatternUpdateSchema = schema.object({
   type: schema.maybe(schema.string()),
   typeMeta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   timeFieldName: schema.maybe(schema.string()),
+  // maxSize: 100 - aligns with filter patterns in kbn-lens-embeddable-utils config_builder schemas
   sourceFilters: schema.maybe(
     schema.arrayOf(
       schema.object({
         value: schema.string(),
         clientId: schema.maybe(schema.oneOf([schema.string(), schema.number()])),
-      })
+      }),
+      { maxSize: 100 }
     )
   ),
   fieldFormats: schema.maybe(schema.recordOf(schema.string(), serializedFieldFormatSchema)),

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/schema.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/schema.ts
@@ -24,12 +24,14 @@ export const dataViewSpecSchema = schema.object({
   id: schema.maybe(schema.string()),
   type: schema.maybe(schema.string()),
   timeFieldName: schema.maybe(schema.string()),
+  // maxSize: 100 - aligns with filter patterns in kbn-lens-embeddable-utils config_builder schemas
   sourceFilters: schema.maybe(
     schema.arrayOf(
       schema.object({
         value: schema.string(),
         clientId: schema.maybe(schema.oneOf([schema.string(), schema.number()])),
-      })
+      }),
+      { maxSize: 100 }
     )
   ),
   fields: schema.maybe(schema.recordOf(schema.string(), fieldSpecSchema)),
@@ -52,14 +54,16 @@ export const dataViewSpecSchema = schema.object({
   allowNoIndex: schema.maybe(schema.boolean()),
   runtimeFieldMap: schema.maybe(schema.recordOf(schema.string(), runtimeFieldSchema)),
   name: schema.maybe(schema.string()),
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
+  // maxSize: 100 - aligns with namespaces in fleet/server/types and visualizations cm_services.ts
+  namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   allowHidden: schema.maybe(schema.boolean()),
 });
 
 export const dataViewsRuntimeResponseSchema = () =>
   schema.object({
     [SERVICE_KEY]: dataViewSpecSchema,
-    fields: schema.arrayOf(schema.object(fieldSpecSchemaFields)),
+    // maxSize: 10000 - data views can have many fields; aligns with fleet/server/types items patterns
+    fields: schema.arrayOf(schema.object(fieldSpecSchemaFields), { maxSize: 10000 }),
   });
 
 export const indexPatternsRuntimeResponseSchema = () =>

--- a/src/platform/plugins/shared/data_views/server/schemas.ts
+++ b/src/platform/plugins/shared/data_views/server/schemas.ts
@@ -130,7 +130,8 @@ export const fieldSpecSchemaFields = {
     })
   ),
   format: schema.maybe(serializedFieldFormatSchema),
-  esTypes: schema.maybe(schema.arrayOf(schema.string())),
+  // maxSize: 20 - Elasticsearch field types per field; typically 1-3, rarely more than a few
+  esTypes: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 20 })),
   scripted: schema.maybe(schema.boolean()),
   subType: schema.maybe(
     schema.object({

--- a/src/platform/plugins/shared/discover/server/ui_settings.ts
+++ b/src/platform/plugins/shared/discover/server/ui_settings.ts
@@ -48,9 +48,8 @@ export const getUiSettings: (
         'Columns displayed by default in the Discover app. If empty, a summary of the document will be displayed.',
     }),
     category: ['discover'],
-    schema: enableValidations
-      ? schema.arrayOf(schema.string(), { maxSize: 50 })
-      : schema.arrayOf(schema.string()),
+    // maxSize: 50 - aligns with security_solution/server/ui_settings.ts DEFAULT_INDEX_KEY
+    schema: schema.arrayOf(schema.string(), { maxSize: 50 }),
   },
   [MAX_DOC_FIELDS_DISPLAYED]: {
     name: i18n.translate('discover.advancedSettings.maxDocFieldsDisplayedTitle', {
@@ -178,7 +177,8 @@ export const getUiSettings: (
         'From this list the first field that is present and sortable in the current data view is used.',
     }),
     category: ['discover'],
-    schema: schema.arrayOf(schema.string()),
+    // maxSize: 10 - tie-breaker fields are typically just 1-3 fields for sorting tie resolution
+    schema: schema.arrayOf(schema.string(), { maxSize: 10 }),
   },
   [MODIFY_COLUMNS_ON_SWITCH]: {
     name: i18n.translate('discover.advancedSettings.discover.modifyColumnsOnSwitchTitle', {

--- a/src/platform/plugins/shared/saved_search/server/content_management/schema/v1/cm_services.ts
+++ b/src/platform/plugins/shared/saved_search/server/content_management/schema/v1/cm_services.ts
@@ -35,8 +35,10 @@ const savedSearchUpdateOptionsSchema = schema.maybe(
 );
 const savedSearchSearchOptionsSchema = schema.maybe(
   schema.object({
-    searchFields: schema.maybe(schema.arrayOf(schema.string())),
-    fields: schema.maybe(schema.arrayOf(schema.string())),
+    // maxSize: 100 - aligns with searchFields in visualizations/server/content_management and event_annotation cm_services.ts
+    searchFields: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+    // maxSize: 100 - aligns with fields pattern in content management schemas
+    fields: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   })
 );
 

--- a/src/platform/plugins/shared/saved_search/server/saved_objects/schema.ts
+++ b/src/platform/plugins/shared/saved_search/server/saved_objects/schema.ts
@@ -21,10 +21,12 @@ const SCHEMA_SEARCH_BASE = schema.object({
   description: schema.string({ defaultValue: '' }),
 
   // Data grid
-  columns: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  // maxSize: 50 - aligns with DEFAULT_COLUMNS_SETTING in discover/server/ui_settings.ts and security_solution/server/ui_settings.ts
+  columns: schema.arrayOf(schema.string(), { defaultValue: [], maxSize: 50 }),
+  // maxSize: 10 for outer array - sort operations are typically limited to a few fields (1-3 in practice)
   sort: schema.oneOf(
     [
-      schema.arrayOf(schema.arrayOf(schema.string(), { maxSize: 2 })),
+      schema.arrayOf(schema.arrayOf(schema.string(), { maxSize: 2 }), { maxSize: 10 }),
       schema.arrayOf(schema.string(), { maxSize: 2 }),
     ],
     { defaultValue: [] }
@@ -151,7 +153,8 @@ const SCHEMA_DISCOVER_SESSION_TAB = schema.object({
 });
 
 export const SCHEMA_SEARCH_MODEL_VERSION_6 = SCHEMA_SEARCH_MODEL_VERSION_5.extends({
-  tabs: schema.maybe(schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB, { minSize: 1 })),
+  // maxSize: 50 - Discover session tabs; generous limit for UX (users rarely have more than a few tabs)
+  tabs: schema.maybe(schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB, { minSize: 1, maxSize: 50 })),
 });
 
 const { columns, grid, hideChart, isTextBasedQuery, kibanaSavedObjectMeta, rowHeight, sort } =
@@ -166,7 +169,8 @@ export const SCHEMA_SEARCH_MODEL_VERSION_7 = SCHEMA_SEARCH_MODEL_VERSION_6.exten
   kibanaSavedObjectMeta: schema.maybe(kibanaSavedObjectMeta),
   rowHeight: schema.maybe(rowHeight),
   sort: schema.maybe(sort),
-  tabs: schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB, { minSize: 1 }),
+  // maxSize: 50 - Discover session tabs; generous limit for UX
+  tabs: schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB, { minSize: 1, maxSize: 50 }),
 });
 
 const CONTROL_GROUP_JSON_SCHEMA = {
@@ -182,7 +186,8 @@ const SCHEMA_DISCOVER_SESSION_TAB_VERSION_8 = SCHEMA_DISCOVER_SESSION_TAB.extend
 
 export const SCHEMA_SEARCH_MODEL_VERSION_8 = SCHEMA_SEARCH_MODEL_VERSION_7.extends({
   ...CONTROL_GROUP_JSON_SCHEMA,
-  tabs: schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB_VERSION_8, { minSize: 1 }),
+  // maxSize: 50 - Discover session tabs; generous limit for UX
+  tabs: schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB_VERSION_8, { minSize: 1, maxSize: 50 }),
 });
 
 // We need to flatten the schema type here to avoid this error:
@@ -212,7 +217,8 @@ const SCHEMA_DISCOVER_SESSION_TAB_VERSION_10 = SCHEMA_DISCOVER_SESSION_TAB_VERSI
 });
 
 export const SCHEMA_SEARCH_MODEL_VERSION_10 = SCHEMA_SEARCH_MODEL_VERSION_8.extends({
-  tabs: schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB_VERSION_10, { minSize: 1 }),
+  // maxSize: 50 - Discover session tabs; generous limit for UX
+  tabs: schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB_VERSION_10, { minSize: 1, maxSize: 50 }),
 });
 
 const { tabs: tabsV10, ...restV10Props } = SCHEMA_SEARCH_MODEL_VERSION_10.getPropSchemas();


### PR DESCRIPTION
Adds maxSize constraints to all unbounded array schemas to address potential DoS vulnerabilities from unbounded array validation.

Values are aligned with existing conventions in the Kibana codebase:
- namespaces: 100 (matches fleet, visualizations, graph patterns)
- searchFields/fields: 100 (matches content management patterns)
- references: 100 (matches visualizations/event_annotation patterns)
- columns: 50 (matches discover/security_solution ui_settings)
- tabs: 50 (generous UX limit)
- items/hits/fields responses: 10000 (matches fleet items patterns)
- filter values: 1000 (generous for large enums)
- esTypes/intervals: 10-20 (small enum-like arrays)

Fixes elastic/kibana-team#2432, elastic/kibana-team#2429

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



