### PR TITLE
[ES|QL] [PromQL] Enable the timepicker even without named params

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -171,8 +171,8 @@ describe('esql query helpers', () => {
       ).toBe('@timestamp');
     });
 
-    it('should return undefined for PromQL if there is no time param', () => {
-      expect(getTimeFieldFromESQLQuery('PROMQL index = index1 step="5m" ')).toBeUndefined();
+    it('should return @timestamp for PromQL if there is no time param', () => {
+      expect(getTimeFieldFromESQLQuery('PROMQL index = index1 step="5m" ')).toBe('@timestamp');
     });
   });
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -213,7 +213,7 @@ export const getTimeFieldFromESQLQuery = (esql: string) => {
   );
   // PromQL queries always use @timestamp as timefield
   const isPromQLQuery = root.commands.some(({ name }) => name === 'promql');
-  if (isPromQLQuery && timeNamedParam) {
+  if (isPromQLQuery) {
     return '@timestamp';
   }
 


### PR DESCRIPTION
## Summary

Enables the timepicker for promql queries even without the user adding the named params. We know that the promql works only with timeseries with @timestamp. Otherwise the charts can be super slow and even freeze kibana.

<img width="1529" height="750" alt="image" src="https://github.com/user-attachments/assets/4165cb0b-90d2-45b2-ac4f-5b99d52fa9ea" />


If ES doesnt want us to send it, they need to do the start and end required. (I am currently discussing this with them)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




