### PR TITLE
[Streams] Add recurring stale tasks cleanup

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/stale_tasks_cleanup.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/stale_tasks_cleanup.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
+import type { CoreSetup, CoreStart } from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import {
+  StaleTasksCleanupTask,
+  STALE_TASKS_CLEANUP_TASK_TYPE,
+  STALE_TASKS_CLEANUP_TASK_VERSION,
+  STALE_THRESHOLD_DAYS,
+} from './stale_tasks_cleanup';
+
+describe('StaleTasksCleanupTask', () => {
+  let mockLogger: MockedLogger;
+  let mockCore: jest.Mocked<CoreSetup>;
+  let mockCoreStart: jest.Mocked<CoreStart>;
+  let mockTaskManagerSetup: jest.Mocked<TaskManagerSetupContract>;
+  let mockTaskManagerStart: jest.Mocked<TaskManagerStartContract>;
+  let staleTasksCleanupTask: StaleTasksCleanupTask;
+
+  beforeEach(() => {
+    mockLogger = loggerMock.create();
+
+    mockCoreStart = {
+      elasticsearch: {
+        client: {
+          asInternalUser: {
+            // Mock ES client - the StorageIndexAdapter wraps this
+          },
+        },
+      },
+    } as unknown as jest.Mocked<CoreStart>;
+
+    mockCore = {
+      getStartServices: jest
+        .fn()
+        .mockResolvedValue([mockCoreStart, { taskManager: mockTaskManagerStart }, {}]),
+    } as unknown as jest.Mocked<CoreSetup>;
+
+    mockTaskManagerSetup = {
+      registerTaskDefinitions: jest.fn(),
+    } as unknown as jest.Mocked<TaskManagerSetupContract>;
+
+    mockTaskManagerStart = {
+      ensureScheduled: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<TaskManagerStartContract>;
+
+    staleTasksCleanupTask = new StaleTasksCleanupTask({
+      core: mockCore,
+      taskManager: mockTaskManagerSetup,
+      logger: mockLogger,
+    });
+  });
+
+  describe('constructor', () => {
+    it('registers the task definition', () => {
+      expect(mockTaskManagerSetup.registerTaskDefinitions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [STALE_TASKS_CLEANUP_TASK_TYPE]: expect.objectContaining({
+            title: 'Streams Stale Tasks Cleanup',
+            timeout: '5m',
+            createTaskRunner: expect.any(Function),
+          }),
+        })
+      );
+    });
+  });
+
+  describe('taskId', () => {
+    it('returns the correct task id with version', () => {
+      expect(staleTasksCleanupTask.taskId).toBe(
+        `${STALE_TASKS_CLEANUP_TASK_TYPE}:${STALE_TASKS_CLEANUP_TASK_VERSION}`
+      );
+    });
+  });
+
+  describe('start', () => {
+    it('schedules the task with 24h interval', async () => {
+      await staleTasksCleanupTask.start({ taskManager: mockTaskManagerStart });
+
+      expect(mockTaskManagerStart.ensureScheduled).toHaveBeenCalledWith({
+        id: staleTasksCleanupTask.taskId,
+        taskType: STALE_TASKS_CLEANUP_TASK_TYPE,
+        scope: ['streams'],
+        schedule: {
+          interval: '24h',
+        },
+        state: {},
+        params: { version: STALE_TASKS_CLEANUP_TASK_VERSION },
+      });
+    });
+
+    it('logs info message on start', async () => {
+      await staleTasksCleanupTask.start({ taskManager: mockTaskManagerStart });
+
+      expect(mockLogger.get).toHaveBeenCalledWith('stale-tasks-cleanup');
+    });
+
+    it('handles scheduling errors gracefully', async () => {
+      mockTaskManagerStart.ensureScheduled.mockRejectedValue(new Error('Scheduling failed'));
+
+      await staleTasksCleanupTask.start({ taskManager: mockTaskManagerStart });
+
+      // Should not throw
+    });
+  });
+
+  describe('STALE_THRESHOLD_DAYS', () => {
+    it('is set to 7 days', () => {
+      expect(STALE_THRESHOLD_DAYS).toBe(7);
+    });
+  });
+});
+
+describe('Stale task filtering logic', () => {
+  const now = new Date('2024-01-20T10:00:00.000Z');
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  // Helper to create task with activity
+  const createTask = (
+    id: string,
+    created_at: string,
+    extras: {
+      last_completed_at?: string;
+      last_acknowledged_at?: string;
+      last_canceled_at?: string;
+      last_failed_at?: string;
+    } = {}
+  ) => ({
+    id,
+    created_at,
+    ...extras,
+  });
+
+  const getLastActivity = (task: {
+    created_at: string;
+    last_completed_at?: string;
+    last_acknowledged_at?: string;
+    last_canceled_at?: string;
+    last_failed_at?: string;
+  }): Date => {
+    const timestamps = [
+      task.created_at,
+      task.last_completed_at,
+      task.last_acknowledged_at,
+      task.last_canceled_at,
+      task.last_failed_at,
+    ]
+      .filter((ts): ts is string => ts !== undefined)
+      .map((ts) => new Date(ts).getTime());
+
+    return new Date(Math.max(...timestamps));
+  };
+
+  it('identifies stale tasks (no activity in 7+ days)', () => {
+    const staleTask = createTask('stale-task', '2024-01-10T10:00:00.000Z');
+    const lastActivity = getLastActivity(staleTask);
+
+    expect(lastActivity < sevenDaysAgo).toBe(true);
+  });
+
+  it('does not mark recent tasks as stale', () => {
+    const recentTask = createTask('recent-task', '2024-01-15T10:00:00.000Z');
+    const lastActivity = getLastActivity(recentTask);
+
+    expect(lastActivity < sevenDaysAgo).toBe(false);
+  });
+
+  it('considers last_completed_at for activity', () => {
+    const task = createTask('task-with-completion', '2024-01-01T10:00:00.000Z', {
+      last_completed_at: '2024-01-19T10:00:00.000Z', // Recent completion
+    });
+    const lastActivity = getLastActivity(task);
+
+    expect(lastActivity < sevenDaysAgo).toBe(false);
+  });
+
+  it('considers last_acknowledged_at for activity', () => {
+    const task = createTask('task-with-ack', '2024-01-01T10:00:00.000Z', {
+      last_acknowledged_at: '2024-01-18T10:00:00.000Z', // Recent acknowledgment
+    });
+    const lastActivity = getLastActivity(task);
+
+    expect(lastActivity < sevenDaysAgo).toBe(false);
+  });
+
+  it('considers last_canceled_at for activity', () => {
+    const task = createTask('task-with-cancel', '2024-01-01T10:00:00.000Z', {
+      last_canceled_at: '2024-01-19T10:00:00.000Z', // Recent cancellation
+    });
+    const lastActivity = getLastActivity(task);
+
+    expect(lastActivity < sevenDaysAgo).toBe(false);
+  });
+
+  it('considers last_failed_at for activity', () => {
+    const task = createTask('task-with-failure', '2024-01-01T10:00:00.000Z', {
+      last_failed_at: '2024-01-19T10:00:00.000Z', // Recent failure
+    });
+    const lastActivity = getLastActivity(task);
+
+    expect(lastActivity < sevenDaysAgo).toBe(false);
+  });
+
+  it('marks task as stale when all timestamps are old', () => {
+    const oldTask = createTask('old-task', '2024-01-01T10:00:00.000Z', {
+      last_completed_at: '2024-01-02T10:00:00.000Z',
+      last_acknowledged_at: '2024-01-03T10:00:00.000Z',
+      last_canceled_at: '2024-01-04T10:00:00.000Z',
+      last_failed_at: '2024-01-05T10:00:00.000Z',
+    });
+    const lastActivity = getLastActivity(oldTask);
+
+    expect(lastActivity < sevenDaysAgo).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/stale_tasks_cleanup.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/stale_tasks_cleanup.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import { StorageIndexAdapter } from '@kbn/storage-adapter';
+import { TaskClient } from './task_client';
+import { taskStorageSettings, type TaskStorageSettings } from './storage';
+import type { PersistedTask } from './types';
+
+export const STALE_TASKS_CLEANUP_TASK_TYPE = 'streams:stale-tasks-cleanup';
+export const STALE_TASKS_CLEANUP_TASK_VERSION = '1.0.0';
+const STALE_TASKS_CLEANUP_TASK_TITLE = 'Streams Stale Tasks Cleanup';
+const STALE_TASKS_CLEANUP_SCOPE = ['streams'];
+const STALE_TASKS_CLEANUP_INTERVAL = '24h';
+const STALE_TASKS_CLEANUP_TIMEOUT = '5m';
+
+/** Tasks with no activity in this many days are considered stale */
+export const STALE_THRESHOLD_DAYS = 7;
+
+interface StaleTasksCleanupSetupContract {
+  core: CoreSetup;
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+}
+
+interface StaleTasksCleanupStartContract {
+  taskManager: TaskManagerStartContract;
+}
+
+export class StaleTasksCleanupTask {
+  private core: CoreSetup;
+  private logger: Logger;
+  private wasStarted: boolean = false;
+
+  constructor({ core, taskManager, logger }: StaleTasksCleanupSetupContract) {
+    this.core = core;
+    this.logger = logger.get('stale-tasks-cleanup');
+
+    taskManager.registerTaskDefinitions({
+      [STALE_TASKS_CLEANUP_TASK_TYPE]: {
+        title: STALE_TASKS_CLEANUP_TASK_TITLE,
+        timeout: STALE_TASKS_CLEANUP_TIMEOUT,
+        createTaskRunner: ({ taskInstance }) => {
+          return {
+            run: async () => {
+              return this.runTask(taskInstance.id);
+            },
+            cancel: async () => {
+              this.logger.debug('Stale tasks cleanup task was cancelled');
+            },
+          };
+        },
+      },
+    });
+  }
+
+  public get taskId(): string {
+    return `${STALE_TASKS_CLEANUP_TASK_TYPE}:${STALE_TASKS_CLEANUP_TASK_VERSION}`;
+  }
+
+  public async start({ taskManager }: StaleTasksCleanupStartContract): Promise<void> {
+    if (!taskManager) {
+      this.logger.error('Missing required taskManager service during start');
+      return;
+    }
+
+    this.wasStarted = true;
+    this.logger.info(`Started with interval of [${STALE_TASKS_CLEANUP_INTERVAL}]`);
+
+    try {
+      await taskManager.ensureScheduled({
+        id: this.taskId,
+        taskType: STALE_TASKS_CLEANUP_TASK_TYPE,
+        scope: STALE_TASKS_CLEANUP_SCOPE,
+        schedule: {
+          interval: STALE_TASKS_CLEANUP_INTERVAL,
+        },
+        state: {},
+        params: { version: STALE_TASKS_CLEANUP_TASK_VERSION },
+      });
+    } catch (e) {
+      this.logger.error(`Error scheduling stale tasks cleanup task: ${e.message}`);
+    }
+  }
+
+  private async runTask(taskInstanceId: string): Promise<void> {
+    if (!this.wasStarted) {
+      this.logger.debug('runTask aborted: task not started yet');
+      return;
+    }
+
+    // Check that this task is current version
+    if (taskInstanceId !== this.taskId) {
+      this.logger.debug(
+        `Outdated task version: Got [${taskInstanceId}] from task instance. Current version is [${this.taskId}]`
+      );
+      return;
+    }
+
+    this.logger.debug('Starting stale tasks cleanup');
+
+    try {
+      const deletedCount = await this.cleanupStaleTasks();
+      this.logger.info(`Stale tasks cleanup completed: deleted ${deletedCount} stale tasks`);
+    } catch (error) {
+      this.logger.error(`Stale tasks cleanup failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * Cleans up stale tasks from the Streams task index.
+   * A task is considered stale if it has no activity in the last STALE_THRESHOLD_DAYS days.
+   * Activity is the maximum of: created_at, last_completed_at, last_acknowledged_at,
+   * last_canceled_at, last_failed_at.
+   *
+   * @returns The number of tasks deleted
+   */
+  public async cleanupStaleTasks(): Promise<number> {
+    const [coreStart, pluginsStart] = await this.core.getStartServices();
+    const taskManager = (pluginsStart as { taskManager: TaskManagerStartContract }).taskManager;
+
+    const storageAdapter = new StorageIndexAdapter<TaskStorageSettings, PersistedTask>(
+      coreStart.elasticsearch.client.asInternalUser,
+      this.logger.get('storage'),
+      taskStorageSettings
+    );
+
+    const taskClient = new TaskClient(
+      taskManager,
+      storageAdapter.getClient(),
+      this.logger.get('task_client')
+    );
+
+    const tasks = await taskClient.listWithActivity();
+    const now = new Date();
+    const staleThreshold = new Date(now.getTime() - STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000);
+
+    const staleTasks = tasks.filter((task) => {
+      // Don't delete the cleanup task itself
+      if (task.id === this.taskId) {
+        return false;
+      }
+
+      const lastActivity = TaskClient.getLastActivity(task);
+      return lastActivity < staleThreshold;
+    });
+
+    this.logger.debug(
+      `Found ${staleTasks.length} stale tasks out of ${
+        tasks.length
+      } total tasks (threshold: ${staleThreshold.toISOString()})`
+    );
+
+    let deletedCount = 0;
+    for (const task of staleTasks) {
+      try {
+        await taskClient.deleteTask(task.id);
+        deletedCount++;
+        this.logger.debug(`Deleted stale task: ${task.id}`);
+      } catch (error) {
+        this.logger.warn(`Failed to delete stale task ${task.id}: ${error.message}`);
+      }
+    }
+
+    return deletedCount;
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { TaskClient } from './task_client';
+
+describe('TaskClient', () => {
+  describe('getLastActivity', () => {
+    it('returns created_at when no other timestamps exist', () => {
+      const task = {
+        created_at: '2024-01-15T10:00:00.000Z',
+      };
+
+      const result = TaskClient.getLastActivity(task);
+
+      expect(result).toEqual(new Date('2024-01-15T10:00:00.000Z'));
+    });
+
+    it('returns the most recent timestamp when multiple exist', () => {
+      const task = {
+        created_at: '2024-01-15T10:00:00.000Z',
+        last_completed_at: '2024-01-16T10:00:00.000Z',
+        last_acknowledged_at: '2024-01-17T10:00:00.000Z', // Most recent
+        last_canceled_at: '2024-01-14T10:00:00.000Z',
+        last_failed_at: '2024-01-13T10:00:00.000Z',
+      };
+
+      const result = TaskClient.getLastActivity(task);
+
+      expect(result).toEqual(new Date('2024-01-17T10:00:00.000Z'));
+    });
+
+    it('returns last_completed_at when it is the most recent', () => {
+      const task = {
+        created_at: '2024-01-15T10:00:00.000Z',
+        last_completed_at: '2024-01-20T10:00:00.000Z', // Most recent
+      };
+
+      const result = TaskClient.getLastActivity(task);
+
+      expect(result).toEqual(new Date('2024-01-20T10:00:00.000Z'));
+    });
+
+    it('returns last_canceled_at when it is the most recent', () => {
+      const task = {
+        created_at: '2024-01-15T10:00:00.000Z',
+        last_completed_at: '2024-01-16T10:00:00.000Z',
+        last_canceled_at: '2024-01-20T10:00:00.000Z', // Most recent
+      };
+
+      const result = TaskClient.getLastActivity(task);
+
+      expect(result).toEqual(new Date('2024-01-20T10:00:00.000Z'));
+    });
+
+    it('returns last_failed_at when it is the most recent', () => {
+      const task = {
+        created_at: '2024-01-15T10:00:00.000Z',
+        last_failed_at: '2024-01-20T10:00:00.000Z', // Most recent
+      };
+
+      const result = TaskClient.getLastActivity(task);
+
+      expect(result).toEqual(new Date('2024-01-20T10:00:00.000Z'));
+    });
+
+    it('ignores undefined timestamps', () => {
+      const task = {
+        created_at: '2024-01-15T10:00:00.000Z',
+        last_completed_at: undefined,
+        last_acknowledged_at: '2024-01-17T10:00:00.000Z',
+        last_canceled_at: undefined,
+        last_failed_at: undefined,
+      };
+
+      const result = TaskClient.getLastActivity(task);
+
+      expect(result).toEqual(new Date('2024-01-17T10:00:00.000Z'));
+    });
+  });
+});

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
@@ -35,5 +35,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./settings'));
     loadTestFile(require.resolve('./doc_counts'));
     loadTestFile(require.resolve('./snapshot_restore'));
+    loadTestFile(require.resolve('./stale_tasks_cleanup'));
   });
 }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/stale_tasks_cleanup.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/stale_tasks_cleanup.ts
@@ -1,0 +1,389 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { TaskStatus } from '@kbn/streams-schema';
+import { TaskClient } from '@kbn/streams-plugin/server/lib/tasks/task_client';
+import {
+  STALE_THRESHOLD_DAYS,
+  STALE_TASKS_CLEANUP_TASK_TYPE,
+} from '@kbn/streams-plugin/server/lib/tasks/stale_tasks_cleanup';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import type { StreamsSupertestRepositoryClient } from './helpers/repository_client';
+import { createStreamsRepositoryAdminClient } from './helpers/repository_client';
+import { disableStreams, enableStreams } from './helpers/requests';
+
+const TASK_INDEX = '.kibana_streams_tasks';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const roleScopedSupertest = getService('roleScopedSupertest');
+  let apiClient: StreamsSupertestRepositoryClient;
+  const esClient = getService('es');
+
+  describe('Stale Tasks Cleanup', () => {
+    before(async () => {
+      apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
+      await enableStreams(apiClient);
+    });
+
+    after(async () => {
+      await disableStreams(apiClient);
+    });
+
+    describe('TaskClient.getLastActivity', () => {
+      it('returns created_at when no other activity timestamps exist', () => {
+        const task = {
+          created_at: '2024-01-01T00:00:00.000Z',
+        };
+        const lastActivity = TaskClient.getLastActivity(task);
+        expect(lastActivity.toISOString()).to.equal('2024-01-01T00:00:00.000Z');
+      });
+
+      it('returns the most recent timestamp when multiple exist', () => {
+        const task = {
+          created_at: '2024-01-01T00:00:00.000Z',
+          last_completed_at: '2024-01-05T00:00:00.000Z',
+          last_acknowledged_at: '2024-01-10T00:00:00.000Z',
+          last_canceled_at: '2024-01-03T00:00:00.000Z',
+        };
+        const lastActivity = TaskClient.getLastActivity(task);
+        expect(lastActivity.toISOString()).to.equal('2024-01-10T00:00:00.000Z');
+      });
+
+      it('returns last_failed_at when it is the most recent', () => {
+        const task = {
+          created_at: '2024-01-01T00:00:00.000Z',
+          last_failed_at: '2024-01-15T00:00:00.000Z',
+        };
+        const lastActivity = TaskClient.getLastActivity(task);
+        expect(lastActivity.toISOString()).to.equal('2024-01-15T00:00:00.000Z');
+      });
+    });
+
+    describe('Stale threshold constant', () => {
+      it('is set to 7 days', () => {
+        expect(STALE_THRESHOLD_DAYS).to.equal(7);
+      });
+    });
+
+    describe('Task type constant', () => {
+      it('has the correct task type', () => {
+        expect(STALE_TASKS_CLEANUP_TASK_TYPE).to.equal('streams:stale-tasks-cleanup');
+      });
+    });
+
+    describe('Task storage operations', () => {
+      const testTaskId = 'test-task-for-cleanup';
+
+      afterEach(async () => {
+        // Clean up test task
+        try {
+          await esClient.delete({
+            index: TASK_INDEX,
+            id: testTaskId,
+            refresh: true,
+          });
+        } catch (e) {
+          // Ignore if already deleted
+        }
+      });
+
+      it('can create and retrieve a task from the task index', async () => {
+        const now = new Date().toISOString();
+        const taskDoc = {
+          id: testTaskId,
+          type: 'test-task',
+          status: TaskStatus.Completed,
+          space: 'default',
+          created_at: now,
+          last_completed_at: now,
+          task: {
+            params: {},
+            payload: {},
+          },
+        };
+
+        await esClient.index({
+          index: TASK_INDEX,
+          id: testTaskId,
+          document: taskDoc,
+          refresh: true,
+        });
+
+        const response = await esClient.get({
+          index: TASK_INDEX,
+          id: testTaskId,
+        });
+
+        expect(response._id).to.equal(testTaskId);
+        expect(response._source).to.have.property('created_at', now);
+        expect(response._source).to.have.property('last_completed_at', now);
+      });
+
+      it('can delete a task from the task index', async () => {
+        const taskDoc = {
+          id: testTaskId,
+          type: 'test-task',
+          status: TaskStatus.Completed,
+          space: 'default',
+          created_at: new Date().toISOString(),
+          task: {
+            params: {},
+          },
+        };
+
+        await esClient.index({
+          index: TASK_INDEX,
+          id: testTaskId,
+          document: taskDoc,
+          refresh: true,
+        });
+
+        await esClient.delete({
+          index: TASK_INDEX,
+          id: testTaskId,
+          refresh: true,
+        });
+
+        let deleted = false;
+        try {
+          await esClient.get({
+            index: TASK_INDEX,
+            id: testTaskId,
+          });
+        } catch (e: any) {
+          if (e.statusCode === 404) {
+            deleted = true;
+          }
+        }
+        expect(deleted).to.be(true);
+      });
+
+      it('can search for tasks with activity timestamps', async () => {
+        const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+        const taskDoc = {
+          id: testTaskId,
+          type: 'test-task',
+          status: TaskStatus.Completed,
+          space: 'default',
+          created_at: eightDaysAgo,
+          last_completed_at: eightDaysAgo,
+          task: {
+            params: {},
+          },
+        };
+
+        await esClient.index({
+          index: TASK_INDEX,
+          id: testTaskId,
+          document: taskDoc,
+          refresh: true,
+        });
+
+        const response = await esClient.search({
+          index: TASK_INDEX,
+          query: {
+            term: { _id: testTaskId },
+          },
+          _source: [
+            'created_at',
+            'last_completed_at',
+            'last_acknowledged_at',
+            'last_canceled_at',
+            'last_failed_at',
+          ],
+        });
+
+        expect(response.hits.hits.length).to.equal(1);
+        const hit = response.hits.hits[0];
+        expect(hit._id).to.equal(testTaskId);
+        expect((hit._source as any).created_at).to.equal(eightDaysAgo);
+        expect((hit._source as any).last_completed_at).to.equal(eightDaysAgo);
+      });
+    });
+
+    describe('Stale task identification logic', () => {
+      const staleTaskId = 'stale-task-test';
+      const recentTaskId = 'recent-task-test';
+
+      afterEach(async () => {
+        // Clean up test tasks
+        for (const id of [staleTaskId, recentTaskId]) {
+          try {
+            await esClient.delete({
+              index: TASK_INDEX,
+              id,
+              refresh: true,
+            });
+          } catch (e) {
+            // Ignore if already deleted
+          }
+        }
+      });
+
+      it('identifies tasks older than 7 days as stale', async () => {
+        const now = new Date();
+        const eightDaysAgo = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000).toISOString();
+        const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+        const staleThreshold = new Date(now.getTime() - STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000);
+
+        // Create a stale task
+        await esClient.index({
+          index: TASK_INDEX,
+          id: staleTaskId,
+          document: {
+            id: staleTaskId,
+            type: 'test-task',
+            status: TaskStatus.Completed,
+            space: 'default',
+            created_at: eightDaysAgo,
+            last_completed_at: eightDaysAgo,
+            task: { params: {} },
+          },
+          refresh: true,
+        });
+
+        // Create a recent task
+        await esClient.index({
+          index: TASK_INDEX,
+          id: recentTaskId,
+          document: {
+            id: recentTaskId,
+            type: 'test-task',
+            status: TaskStatus.Completed,
+            space: 'default',
+            created_at: twoDaysAgo,
+            last_completed_at: twoDaysAgo,
+            task: { params: {} },
+          },
+          refresh: true,
+        });
+
+        // Search for all test tasks
+        const response = await esClient.search({
+          index: TASK_INDEX,
+          query: {
+            terms: { _id: [staleTaskId, recentTaskId] },
+          },
+          _source: [
+            'created_at',
+            'last_completed_at',
+            'last_acknowledged_at',
+            'last_canceled_at',
+            'last_failed_at',
+          ],
+        });
+
+        // Apply stale detection logic (same as in cleanupStaleTasks)
+        const tasks = response.hits.hits.map((hit) => ({
+          id: hit._id!,
+          created_at: (hit._source as any).created_at,
+          last_completed_at: (hit._source as any).last_completed_at,
+          last_acknowledged_at: (hit._source as any).last_acknowledged_at,
+          last_canceled_at: (hit._source as any).last_canceled_at,
+          last_failed_at: (hit._source as any).last_failed_at,
+        }));
+
+        const staleTasks = tasks.filter((task) => {
+          const lastActivity = TaskClient.getLastActivity(task);
+          return lastActivity < staleThreshold;
+        });
+
+        const recentTasks = tasks.filter((task) => {
+          const lastActivity = TaskClient.getLastActivity(task);
+          return lastActivity >= staleThreshold;
+        });
+
+        expect(staleTasks.length).to.equal(1);
+        expect(staleTasks[0].id).to.equal(staleTaskId);
+
+        expect(recentTasks.length).to.equal(1);
+        expect(recentTasks[0].id).to.equal(recentTaskId);
+      });
+
+      it('considers last_completed_at for activity determination', async () => {
+        const now = new Date();
+        // Task created 10 days ago but completed 2 days ago (not stale)
+        const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
+        const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+        const staleThreshold = new Date(now.getTime() - STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000);
+
+        await esClient.index({
+          index: TASK_INDEX,
+          id: recentTaskId,
+          document: {
+            id: recentTaskId,
+            type: 'test-task',
+            status: TaskStatus.Completed,
+            space: 'default',
+            created_at: tenDaysAgo,
+            last_completed_at: twoDaysAgo,
+            task: { params: {} },
+          },
+          refresh: true,
+        });
+
+        const response = await esClient.get({
+          index: TASK_INDEX,
+          id: recentTaskId,
+        });
+
+        const task = {
+          id: response._id!,
+          created_at: (response._source as any).created_at,
+          last_completed_at: (response._source as any).last_completed_at,
+        };
+
+        const lastActivity = TaskClient.getLastActivity(task);
+
+        // Task should NOT be stale because last_completed_at is recent
+        expect(lastActivity >= staleThreshold).to.be(true);
+      });
+
+      it('considers last_acknowledged_at for activity determination', async () => {
+        const now = new Date();
+        // Task created and completed 10 days ago, but acknowledged 1 day ago (not stale)
+        const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
+        const oneDayAgo = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString();
+        const staleThreshold = new Date(now.getTime() - STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000);
+
+        await esClient.index({
+          index: TASK_INDEX,
+          id: recentTaskId,
+          document: {
+            id: recentTaskId,
+            type: 'test-task',
+            status: TaskStatus.Acknowledged,
+            space: 'default',
+            created_at: tenDaysAgo,
+            last_completed_at: tenDaysAgo,
+            last_acknowledged_at: oneDayAgo,
+            task: { params: {} },
+          },
+          refresh: true,
+        });
+
+        const response = await esClient.get({
+          index: TASK_INDEX,
+          id: recentTaskId,
+        });
+
+        const task = {
+          id: response._id!,
+          created_at: (response._source as any).created_at,
+          last_completed_at: (response._source as any).last_completed_at,
+          last_acknowledged_at: (response._source as any).last_acknowledged_at,
+        };
+
+        const lastActivity = TaskClient.getLastActivity(task);
+
+        // Task should NOT be stale because last_acknowledged_at is recent
+        expect(lastActivity >= staleThreshold).to.be(true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## 🍒 Summary

Adds a recurring background task that cleans up stale tasks from the Streams task index (`.kibana_streams_tasks`). This addresses [streams-program#807](https://github.com/elastic/streams-program/issues/807) by implementing option 2: a recurring task that runs every 24 hours and deletes tasks with no activity in the last 7 days.

## 🛠️ Changes

- **New `StaleTasksCleanupTask` class** (`stale_tasks_cleanup.ts`):
  - Registers task definition during plugin setup
  - Schedules task via `taskManager.ensureScheduled()` during plugin start
  - Task runs every 24 hours with a 5-minute timeout
  - Identifies stale tasks (no activity in 7+ days) and deletes them
  - Skips deleting its own task instance

- **Extended `TaskClient`** (`task_client.ts`):
  - Added `getLastActivity()` static method to compute max timestamp from `created_at`, `last_completed_at`, `last_acknowledged_at`, `last_canceled_at`, `last_failed_at`
  - Added `listWithActivity()` method to list tasks with all activity timestamps

- **Plugin integration** (`plugin.ts`):
  - Creates `StaleTasksCleanupTask` instance in `setup()`
  - Calls `staleTasksCleanupTask.start()` in `start()`

- **Unit tests**:
  - `stale_tasks_cleanup.test.ts`: Tests task registration, scheduling, and stale filtering logic
  - `task_client.test.ts`: Tests `getLastActivity()` edge cases

- **Integration tests**:
  - `stale_tasks_cleanup.ts`: End-to-end tests for task storage operations and stale detection

## 🎙️ Prompts

- Implement recurring cleanup task for Streams stale tasks (24h interval, 7-day threshold)
- Follow Fleet sync_integrations_task pattern for Task Manager integration
- Add comprehensive unit and integration tests

🤖 This pull request was assisted by Cursor
