### PR TITLE
[Streams] Add rate limit handling with retry and reschedule for LLM tasks

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/rate_limit_retry.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/rate_limit_retry.test.ts
@@ -1,0 +1,282 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { createInferenceProviderError, createInferenceInternalError } from '@kbn/inference-common';
+import { isRateLimitError, withRateLimitRetry, RateLimitTimeoutError } from './rate_limit_retry';
+
+describe('rate_limit_retry', () => {
+  describe('isRateLimitError', () => {
+    it('returns true for 429 inference provider error', () => {
+      const error = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      expect(isRateLimitError(error)).toBe(true);
+    });
+
+    it('returns false for non-429 inference provider error', () => {
+      const error = createInferenceProviderError('Server error', { status: 500 });
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false for inference provider error without status', () => {
+      const error = createInferenceProviderError('Some error');
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false for inference internal error', () => {
+      const error = createInferenceInternalError('Internal error');
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false for plain Error', () => {
+      const error = new Error('Some error');
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false for null', () => {
+      expect(isRateLimitError(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isRateLimitError(undefined)).toBe(false);
+    });
+
+    it('returns false for non-error objects', () => {
+      expect(isRateLimitError({ status: 429 })).toBe(false);
+    });
+  });
+
+  describe('RateLimitTimeoutError', () => {
+    it('is an instance of Error', () => {
+      const error = new RateLimitTimeoutError();
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it('has the correct name', () => {
+      const error = new RateLimitTimeoutError();
+      expect(error.name).toBe('RateLimitTimeoutError');
+    });
+
+    it('has a default message', () => {
+      const error = new RateLimitTimeoutError();
+      expect(error.message).toBe('Rate limit retry budget exhausted');
+    });
+
+    it('accepts a custom message', () => {
+      const error = new RateLimitTimeoutError('Custom message');
+      expect(error.message).toBe('Custom message');
+    });
+
+    it('can be caught with instanceof', () => {
+      const error = new RateLimitTimeoutError();
+      expect(error instanceof RateLimitTimeoutError).toBe(true);
+    });
+  });
+
+  describe('withRateLimitRetry', () => {
+    it('returns the result on success', async () => {
+      const fn = jest.fn().mockResolvedValue('success');
+
+      const result = await withRateLimitRetry(fn);
+
+      expect(result).toBe('success');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows non-rate-limit errors immediately', async () => {
+      const error = new Error('Some other error');
+      const fn = jest.fn().mockRejectedValue(error);
+
+      await expect(withRateLimitRetry(fn)).rejects.toThrow('Some other error');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows non-429 inference provider errors immediately', async () => {
+      const error = createInferenceProviderError('Server error', { status: 500 });
+      const fn = jest.fn().mockRejectedValue(error);
+
+      await expect(withRateLimitRetry(fn)).rejects.toThrow('Server error');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on rate limit error and succeeds', async () => {
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      const fn = jest.fn().mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce('success');
+
+      const result = await withRateLimitRetry(fn, {
+        initialDelayMs: 10,
+        maxDurationMs: 1000,
+      });
+
+      expect(result).toBe('success');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries multiple times on repeated rate limit errors', async () => {
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      const fn = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce('success');
+
+      const result = await withRateLimitRetry(fn, {
+        initialDelayMs: 10,
+        maxDurationMs: 5000,
+      });
+
+      expect(result).toBe('success');
+      expect(fn).toHaveBeenCalledTimes(4);
+    });
+
+    it('throws RateLimitTimeoutError when budget exhausted', async () => {
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      const fn = jest.fn().mockRejectedValue(rateLimitError);
+
+      await expect(
+        withRateLimitRetry(fn, {
+          initialDelayMs: 50,
+          maxDurationMs: 100, // Short budget to trigger timeout quickly
+        })
+      ).rejects.toBeInstanceOf(RateLimitTimeoutError);
+
+      // Should have attempted at least twice (initial + 1 retry within 100ms)
+      expect(fn.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('respects abort signal before first attempt', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const fn = jest.fn().mockResolvedValue('success');
+
+      await expect(withRateLimitRetry(fn, { signal: controller.signal })).rejects.toThrow(
+        'Request was aborted'
+      );
+
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('respects abort signal during retry wait', async () => {
+      const controller = new AbortController();
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      const fn = jest.fn().mockRejectedValue(rateLimitError);
+
+      // Abort after a short delay
+      setTimeout(() => controller.abort(), 50);
+
+      await expect(
+        withRateLimitRetry(fn, {
+          signal: controller.signal,
+          initialDelayMs: 1000, // Long delay to ensure abort happens during wait
+          maxDurationMs: 10000,
+        })
+      ).rejects.toThrow('Request was aborted');
+    });
+
+    it('uses exponential backoff', async () => {
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      const timestamps: number[] = [];
+
+      const fn = jest.fn().mockImplementation(async () => {
+        timestamps.push(Date.now());
+        if (fn.mock.calls.length < 4) {
+          throw rateLimitError;
+        }
+        return 'success';
+      });
+
+      await withRateLimitRetry(fn, {
+        initialDelayMs: 50,
+        maxDurationMs: 10000,
+      });
+
+      // Check that delays roughly double (with some tolerance for timing)
+      const delays = timestamps.slice(1).map((t, i) => t - timestamps[i]);
+      expect(delays.length).toBe(3);
+
+      // First delay should be around initialDelayMs (50ms)
+      expect(delays[0]).toBeGreaterThanOrEqual(45);
+      expect(delays[0]).toBeLessThan(100);
+
+      // Second delay should be around 2x initial (100ms)
+      expect(delays[1]).toBeGreaterThanOrEqual(90);
+      expect(delays[1]).toBeLessThan(200);
+
+      // Third delay should be around 4x initial (200ms)
+      expect(delays[2]).toBeGreaterThanOrEqual(180);
+      expect(delays[2]).toBeLessThan(400);
+    });
+
+    it('caps delay at maxDelayMs', async () => {
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      let callCount = 0;
+      const timestamps: number[] = [];
+
+      const fn = jest.fn().mockImplementation(async () => {
+        timestamps.push(Date.now());
+        callCount++;
+        if (callCount < 5) {
+          throw rateLimitError;
+        }
+        return 'success';
+      });
+
+      await withRateLimitRetry(fn, {
+        initialDelayMs: 20,
+        maxDelayMs: 50, // Cap at 50ms
+        maxDurationMs: 10000,
+      });
+
+      // Delays: 20, 40, 50 (capped), 50 (capped)
+      const delays = timestamps.slice(1).map((t, i) => t - timestamps[i]);
+
+      // All delays after the first couple should be capped at maxDelayMs
+      delays.slice(2).forEach((delay) => {
+        expect(delay).toBeLessThan(80); // maxDelayMs + tolerance
+      });
+    });
+
+    it('logs retry attempts when logger is provided', async () => {
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      const fn = jest.fn().mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce('success');
+
+      const mockLogger = {
+        debug: jest.fn(),
+        warn: jest.fn(),
+      } as any;
+
+      await withRateLimitRetry(fn, {
+        initialDelayMs: 10,
+        maxDurationMs: 1000,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.debug).toHaveBeenCalled();
+    });
+
+    it('logs warning when budget exhausted', async () => {
+      const rateLimitError = createInferenceProviderError('Rate limit exceeded', { status: 429 });
+      const fn = jest.fn().mockRejectedValue(rateLimitError);
+
+      const mockLogger = {
+        debug: jest.fn(),
+        warn: jest.fn(),
+      } as any;
+
+      await expect(
+        withRateLimitRetry(fn, {
+          initialDelayMs: 10,
+          maxDurationMs: 50,
+          logger: mockLogger,
+        })
+      ).rejects.toBeInstanceOf(RateLimitTimeoutError);
+
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/rate_limit_retry.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/rate_limit_retry.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { isInferenceProviderError, type InferenceTaskProviderError } from '@kbn/inference-common';
+
+const HTTP_STATUS_TOO_MANY_REQUESTS = 429;
+const DEFAULT_MAX_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_INITIAL_DELAY_MS = 1000; // 1 second
+const DEFAULT_MAX_DELAY_MS = 64000; // 64 seconds
+
+/**
+ * Error thrown when the rate limit retry budget is exhausted.
+ * The task runner should catch this and decide whether to reschedule or fail the task.
+ */
+export class RateLimitTimeoutError extends Error {
+  constructor(message: string = 'Rate limit retry budget exhausted') {
+    super(message);
+    this.name = 'RateLimitTimeoutError';
+    Object.setPrototypeOf(this, RateLimitTimeoutError.prototype);
+  }
+}
+
+/**
+ * Checks if an error is a rate limit error (HTTP 429) from an inference provider.
+ *
+ * @param error - The error to check
+ * @returns true if the error is a rate limit error
+ */
+export function isRateLimitError(error: unknown): boolean {
+  if (!isInferenceProviderError(error)) {
+    return false;
+  }
+  const providerError = error as InferenceTaskProviderError;
+  return providerError.meta?.status === HTTP_STATUS_TOO_MANY_REQUESTS;
+}
+
+export interface WithRateLimitRetryOptions {
+  /**
+   * Maximum duration in milliseconds to retry before giving up.
+   * @default 300000 (5 minutes)
+   */
+  maxDurationMs?: number;
+  /**
+   * Initial delay in milliseconds before the first retry.
+   * @default 1000 (1 second)
+   */
+  initialDelayMs?: number;
+  /**
+   * Maximum delay in milliseconds between retries.
+   * @default 64000 (64 seconds)
+   */
+  maxDelayMs?: number;
+  /**
+   * Abort signal to cancel the retry loop (e.g., from task cancellation).
+   */
+  signal?: AbortSignal;
+  /**
+   * Logger for debugging retry attempts.
+   */
+  logger?: Logger;
+}
+
+/**
+ * Wraps an async function with rate limit retry logic.
+ *
+ * On 429 errors, it retries with exponential backoff until the maxDurationMs budget
+ * is exhausted, then throws a RateLimitTimeoutError.
+ *
+ * Non-rate-limit errors are rethrown immediately.
+ *
+ * @param fn - The async function to execute
+ * @param options - Configuration options for retry behavior
+ * @returns The result of the function if successful
+ * @throws RateLimitTimeoutError if the retry budget is exhausted
+ * @throws The original error if it's not a rate limit error
+ */
+export async function withRateLimitRetry<T>(
+  fn: () => Promise<T>,
+  options: WithRateLimitRetryOptions = {}
+): Promise<T> {
+  const {
+    maxDurationMs = DEFAULT_MAX_DURATION_MS,
+    initialDelayMs = DEFAULT_INITIAL_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    signal,
+    logger,
+  } = options;
+
+  const startTime = Date.now();
+  let currentDelay = initialDelayMs;
+  let attempt = 0;
+
+  while (true) {
+    // Check if already aborted before attempting
+    if (signal?.aborted) {
+      throw new Error('Request was aborted');
+    }
+
+    try {
+      attempt++;
+      return await fn();
+    } catch (error) {
+      // Non-rate-limit errors are rethrown immediately
+      if (!isRateLimitError(error)) {
+        throw error;
+      }
+
+      const elapsed = Date.now() - startTime;
+      const remaining = maxDurationMs - elapsed;
+
+      logger?.debug(
+        `Rate limit hit (attempt ${attempt}), elapsed: ${elapsed}ms, remaining budget: ${remaining}ms`
+      );
+
+      // Check if we've exceeded the time budget
+      if (remaining <= 0) {
+        logger?.warn(
+          `Rate limit retry budget exhausted after ${attempt} attempts and ${elapsed}ms`
+        );
+        throw new RateLimitTimeoutError(
+          `Rate limit retry budget exhausted after ${attempt} attempts`
+        );
+      }
+
+      // Calculate delay, capped at remaining time and maxDelayMs
+      const delay = Math.min(currentDelay, remaining, maxDelayMs);
+
+      logger?.debug(`Waiting ${delay}ms before retry attempt ${attempt + 1}`);
+
+      // Wait with abort signal support
+      await sleep(delay, signal);
+
+      // Exponential backoff for next iteration
+      currentDelay = Math.min(currentDelay * 2, maxDelayMs);
+    }
+  }
+}
+
+/**
+ * Sleep for a specified duration, with optional abort signal support.
+ *
+ * @param ms - Duration to sleep in milliseconds
+ * @param signal - Optional abort signal to cancel the sleep
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('Request was aborted'));
+      return;
+    }
+
+    const timeoutId = setTimeout(resolve, ms);
+
+    if (signal) {
+      const onAbort = () => {
+        clearTimeout(timeoutId);
+        reject(new Error('Request was aborted'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+
+      // Clean up the abort listener when the timeout completes
+      const originalResolve = resolve;
+      resolve = () => {
+        signal.removeEventListener('abort', onAbort);
+        originalResolve();
+      };
+    }
+  });
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.test.ts
@@ -1,0 +1,294 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { TaskStatus } from '@kbn/streams-schema';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { TaskClient, MAX_RESCHEDULE_RETRIES } from './task_client';
+import type { TaskStorageClient } from './storage';
+import type { PersistedTask } from './types';
+import { CancellationInProgressError } from './cancellation_in_progress_error';
+
+describe('TaskClient', () => {
+  const createMockLogger = (): jest.Mocked<Logger> =>
+    ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as jest.Mocked<Logger>);
+
+  const createMockStorageClient = (): jest.Mocked<TaskStorageClient> =>
+    ({
+      get: jest.fn(),
+      index: jest.fn(),
+      search: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<TaskStorageClient>);
+
+  const createMockTaskManager = (): jest.Mocked<TaskManagerStartContract> =>
+    ({
+      schedule: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<TaskManagerStartContract>);
+
+  const createMockRequest = (): KibanaRequest =>
+    ({
+      headers: {},
+    } as unknown as KibanaRequest);
+
+  const createPersistedTask = (overrides: Partial<PersistedTask> = {}): PersistedTask =>
+    ({
+      id: 'test-task-id',
+      type: 'test-task-type',
+      status: TaskStatus.InProgress,
+      space: 'default',
+      created_at: new Date().toISOString(),
+      task: {
+        params: { someParam: 'value' },
+      },
+      ...overrides,
+    } as PersistedTask);
+
+  describe('reschedule', () => {
+    let taskClient: TaskClient<'test-task-type'>;
+    let mockLogger: jest.Mocked<Logger>;
+    let mockStorageClient: jest.Mocked<TaskStorageClient>;
+    let mockTaskManager: jest.Mocked<TaskManagerStartContract>;
+    let mockRequest: KibanaRequest;
+
+    beforeEach(() => {
+      mockLogger = createMockLogger();
+      mockStorageClient = createMockStorageClient();
+      mockTaskManager = createMockTaskManager();
+      mockRequest = createMockRequest();
+
+      taskClient = new TaskClient(mockTaskManager, mockStorageClient, mockLogger);
+
+      // Default: return a non-canceling task status
+      mockStorageClient.get.mockResolvedValue({
+        _source: createPersistedTask({ status: TaskStatus.Completed }),
+      } as any);
+    });
+
+    it('reschedules a task with retry_count = 1 when no previous retries', async () => {
+      const currentTask = createPersistedTask({ task: { params: { foo: 'bar' } } });
+
+      const result = await taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest);
+
+      expect(result).toBe(true);
+      expect(mockTaskManager.schedule).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Rescheduling task test-task-id (retry 1/5)')
+      );
+    });
+
+    it('increments retry_count when rescheduling', async () => {
+      const currentTask = createPersistedTask({
+        task: { params: { foo: 'bar' }, retry_count: 2 },
+      });
+
+      const result = await taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest);
+
+      expect(result).toBe(true);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Rescheduling task test-task-id (retry 3/5)')
+      );
+    });
+
+    it('returns false when retry_count equals MAX_RESCHEDULE_RETRIES', async () => {
+      const currentTask = createPersistedTask({
+        task: { params: { foo: 'bar' }, retry_count: MAX_RESCHEDULE_RETRIES },
+      });
+
+      const result = await taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest);
+
+      expect(result).toBe(false);
+      expect(mockTaskManager.schedule).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('has exceeded max reschedule retries')
+      );
+    });
+
+    it('returns false when retry_count exceeds MAX_RESCHEDULE_RETRIES', async () => {
+      const currentTask = createPersistedTask({
+        task: { params: { foo: 'bar' }, retry_count: MAX_RESCHEDULE_RETRIES + 1 },
+      });
+
+      const result = await taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest);
+
+      expect(result).toBe(false);
+      expect(mockTaskManager.schedule).not.toHaveBeenCalled();
+    });
+
+    it('treats undefined retry_count as 0', async () => {
+      const currentTask = createPersistedTask({
+        task: { params: { foo: 'bar' } }, // No retry_count
+      });
+
+      const result = await taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest);
+
+      expect(result).toBe(true);
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('retry 1/5'));
+    });
+
+    it('preserves task metadata when rescheduling', async () => {
+      const currentTask = createPersistedTask({
+        id: 'my-task-id',
+        type: 'my-task-type',
+        space: 'custom-space',
+        last_completed_at: '2024-01-01T00:00:00.000Z',
+        last_acknowledged_at: '2024-01-02T00:00:00.000Z',
+        task: { params: { original: 'params' }, retry_count: 1 },
+      });
+
+      await taskClient.reschedule(currentTask, { new: 'params' }, mockRequest);
+
+      // Verify schedule was called with correct task metadata
+      expect(mockTaskManager.schedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'my-task-id',
+          taskType: 'my-task-type',
+        }),
+        { request: mockRequest }
+      );
+    });
+
+    it('throws CancellationInProgressError if task is being canceled', async () => {
+      mockStorageClient.get.mockResolvedValue({
+        _source: createPersistedTask({ status: TaskStatus.BeingCanceled }),
+      } as any);
+
+      const currentTask = createPersistedTask({
+        task: { params: { foo: 'bar' } },
+      });
+
+      await expect(
+        taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest)
+      ).rejects.toBeInstanceOf(CancellationInProgressError);
+    });
+
+    it('stores retry_count in the task document', async () => {
+      const currentTask = createPersistedTask({
+        task: { params: { foo: 'bar' }, retry_count: 2 },
+      });
+
+      await taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest);
+
+      // Verify the storage client was called with retry_count
+      expect(mockStorageClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            task: expect.objectContaining({
+              retry_count: 3,
+            }),
+          }),
+        })
+      );
+    });
+
+    it('allows scheduling up to MAX_RESCHEDULE_RETRIES times', async () => {
+      // Test each retry count from 0 to MAX_RESCHEDULE_RETRIES - 1
+      for (let i = 0; i < MAX_RESCHEDULE_RETRIES; i++) {
+        mockTaskManager.schedule.mockClear();
+        mockStorageClient.index.mockClear();
+        mockStorageClient.get.mockResolvedValue({
+          _source: createPersistedTask({ status: TaskStatus.Completed }),
+        } as any);
+
+        const currentTask = createPersistedTask({
+          task: { params: { foo: 'bar' }, retry_count: i },
+        });
+
+        const result = await taskClient.reschedule(currentTask, { foo: 'bar' }, mockRequest);
+        expect(result).toBe(true);
+      }
+
+      // Test that MAX_RESCHEDULE_RETRIES is rejected
+      const maxedOutTask = createPersistedTask({
+        task: { params: { foo: 'bar' }, retry_count: MAX_RESCHEDULE_RETRIES },
+      });
+
+      const result = await taskClient.reschedule(maxedOutTask, { foo: 'bar' }, mockRequest);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('schedule with retryCount', () => {
+    let taskClient: TaskClient<'test-task-type'>;
+    let mockLogger: jest.Mocked<Logger>;
+    let mockStorageClient: jest.Mocked<TaskStorageClient>;
+    let mockTaskManager: jest.Mocked<TaskManagerStartContract>;
+    let mockRequest: KibanaRequest;
+
+    beforeEach(() => {
+      mockLogger = createMockLogger();
+      mockStorageClient = createMockStorageClient();
+      mockTaskManager = createMockTaskManager();
+      mockRequest = createMockRequest();
+
+      taskClient = new TaskClient(mockTaskManager, mockStorageClient, mockLogger);
+
+      mockStorageClient.get.mockResolvedValue({
+        _source: createPersistedTask({ status: TaskStatus.Completed }),
+      } as any);
+    });
+
+    it('stores retry_count when provided', async () => {
+      await taskClient.schedule({
+        task: {
+          id: 'task-id',
+          type: 'test-task-type',
+          space: 'default',
+        },
+        params: { foo: 'bar' },
+        request: mockRequest,
+        retryCount: 3,
+      });
+
+      expect(mockStorageClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            task: expect.objectContaining({
+              params: { foo: 'bar' },
+              retry_count: 3,
+            }),
+          }),
+        })
+      );
+    });
+
+    it('does not include retry_count when not provided', async () => {
+      await taskClient.schedule({
+        task: {
+          id: 'task-id',
+          type: 'test-task-type',
+          space: 'default',
+        },
+        params: { foo: 'bar' },
+        request: mockRequest,
+      });
+
+      expect(mockStorageClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            task: {
+              params: { foo: 'bar' },
+              // No retry_count property
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  describe('MAX_RESCHEDULE_RETRIES constant', () => {
+    it('is set to 5', () => {
+      expect(MAX_RESCHEDULE_RETRIES).toBe(5);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
@@ -35,6 +35,11 @@ interface PersistedTaskBase<TParams extends {} = {}> {
   last_failed_at?: string;
   task: {
     params: TParams;
+    /**
+     * Number of times this task has been rescheduled due to rate limiting.
+     * Used to limit retries (max 5) before failing permanently.
+     */
+    retry_count?: number;
   };
 }
 


### PR DESCRIPTION
## 🍒 Summary

Adds rate limit handling for LLM API calls in streams tasks. When an LLM provider returns a 429 (rate limit) error, the task will retry with exponential backoff for up to 5 minutes. If the retry budget is exhausted, the task is rescheduled (up to 5 times) before ultimately failing.

## 🛠️ Changes

- **New rate limit retry utility** (`rate_limit_retry.ts`):
  - `isRateLimitError(error)` - detects 429 errors from inference providers
  - `withRateLimitRetry<T>(fn, options)` - wrapper that retries with exponential backoff (1s initial, 64s max) for up to 5 minutes
  - `RateLimitTimeoutError` - thrown when retry budget is exhausted

- **Task document extension** (`types.ts`):
  - Added optional `retry_count` field to track reschedule attempts

- **Task client reschedule support** (`task_client.ts`):
  - `MAX_RESCHEDULE_RETRIES = 5` constant
  - `schedule()` accepts optional `retryCount` parameter
  - New `reschedule(currentTask, params, request)` method that increments retry count and returns false when max retries exceeded

- **Updated task definitions** (5 files):
  - `description_generation.ts` - wraps `generateStreamDescription()` with rate limit retry
  - `system_identification.ts` - wraps `identifySystemsWithDescription()` with rate limit retry
  - `significant_events_queries_generation.ts` - wraps each `generateSignificantEventDefinitions()` call (inside pLimit limiter) so each system gets its own 5-minute retry budget
  - `features_identification.ts` - wraps `identifyFeatures()` with rate limit retry
  - `insights_discovery.ts` - wraps `generateInsights()` with rate limit retry
  - All tasks now catch `RateLimitTimeoutError` and reschedule or fail based on retry count

- **Unit tests**:
  - `rate_limit_retry.test.ts` - comprehensive tests for the retry utility
  - `task_client.test.ts` - tests for reschedule behavior

## 🎙️ Prompts

- [streams-program#790](https://github.com/elastic/nightshift-program/issues/471)

🤖 This pull request was assisted by Cursor
