### PR TITLE
[Streams] Add prompt overrides for insights discovery

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config.ts
@@ -22,7 +22,12 @@ export const streamsPromptsSOAttributesV3 = streamsPromptsSOAttributesV2.extends
   systemsPromptOverride: schema.maybe(schema.string()),
 });
 
-export type PromptsConfigAttributes = TypeOf<typeof streamsPromptsSOAttributesV3>;
+export const streamsPromptsSOAttributesV4 = streamsPromptsSOAttributesV3.extends({
+  summarizeQueriesPromptOverride: schema.maybe(schema.string()),
+  summarizeStreamsPromptOverride: schema.maybe(schema.string()),
+});
+
+export type PromptsConfigAttributes = TypeOf<typeof streamsPromptsSOAttributesV4>;
 
 export const getStreamsPromptsSavedObject = (): SavedObjectsType => {
   return {
@@ -56,6 +61,13 @@ export const getStreamsPromptsSavedObject = (): SavedObjectsType => {
         schemas: {
           forwardCompatibility: streamsPromptsSOAttributesV3.extends({}, { unknowns: 'ignore' }),
           create: streamsPromptsSOAttributesV3,
+        },
+      },
+      '4': {
+        changes: [],
+        schemas: {
+          forwardCompatibility: streamsPromptsSOAttributesV4.extends({}, { unknowns: 'ignore' }),
+          create: streamsPromptsSOAttributesV4,
         },
       },
     },

--- a/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config_service.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config_service.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import type { MockedLogger } from '@kbn/logging-mocks';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { significantEventsPrompt } from '@kbn/streams-ai/src/significant_events/prompt';
+import { featuresPrompt } from '@kbn/streams-ai/src/features/prompt';
+import { descriptionPrompt } from '@kbn/streams-ai/src/description/prompt';
+import { systemsPrompt } from '@kbn/streams-ai/src/systems/prompt';
+import summarizeQueriesPrompt from '../../significant_events/insights/prompts/summarize_queries/system_prompt.text';
+import summarizeStreamsPrompt from '../../significant_events/insights/prompts/summarize_streams/system_prompt.text';
+import { PromptsConfigService } from './prompts_config_service';
+import { streamsPromptsSOType } from './prompts_config';
+
+describe('PromptsConfigService', () => {
+  let soClientMock: jest.Mocked<SavedObjectsClientContract>;
+  let loggerMock: MockedLogger;
+  let service: PromptsConfigService;
+
+  beforeEach(() => {
+    soClientMock = savedObjectsClientMock.create();
+    loggerMock = loggingSystemMock.createLogger();
+    service = new PromptsConfigService({ soClient: soClientMock, logger: loggerMock });
+  });
+
+  describe('getPrompt', () => {
+    it('returns default prompts when saved object does not exist', async () => {
+      const notFoundError = new Error('Not Found') as Error & { output?: { statusCode: number } };
+      notFoundError.output = { statusCode: 404 };
+      soClientMock.get.mockRejectedValue(notFoundError);
+
+      const result = await service.getPrompt();
+
+      expect(result).toEqual({
+        featurePromptOverride: featuresPrompt,
+        significantEventsPromptOverride: significantEventsPrompt,
+        descriptionPromptOverride: descriptionPrompt,
+        systemsPromptOverride: systemsPrompt,
+        summarizeQueriesPromptOverride: summarizeQueriesPrompt,
+        summarizeStreamsPromptOverride: summarizeStreamsPrompt,
+      });
+    });
+
+    it('returns saved prompt values when saved object exists', async () => {
+      const customPrompt = 'Custom override prompt';
+      soClientMock.get.mockResolvedValue({
+        id: 'streams-prompts-config-id',
+        type: streamsPromptsSOType,
+        references: [],
+        attributes: {
+          featurePromptOverride: customPrompt,
+          summarizeQueriesPromptOverride: 'Custom queries prompt',
+          summarizeStreamsPromptOverride: 'Custom streams prompt',
+        },
+      });
+
+      const result = await service.getPrompt();
+
+      expect(result).toEqual({
+        featurePromptOverride: customPrompt,
+        significantEventsPromptOverride: significantEventsPrompt,
+        descriptionPromptOverride: descriptionPrompt,
+        systemsPromptOverride: systemsPrompt,
+        summarizeQueriesPromptOverride: 'Custom queries prompt',
+        summarizeStreamsPromptOverride: 'Custom streams prompt',
+      });
+    });
+
+    it('falls back to defaults for empty override fields', async () => {
+      soClientMock.get.mockResolvedValue({
+        id: 'streams-prompts-config-id',
+        type: streamsPromptsSOType,
+        references: [],
+        attributes: {
+          featurePromptOverride: '',
+          summarizeQueriesPromptOverride: undefined,
+        },
+      });
+
+      const result = await service.getPrompt();
+
+      expect(result.featurePromptOverride).toBe(featuresPrompt);
+      expect(result.summarizeQueriesPromptOverride).toBe(summarizeQueriesPrompt);
+      expect(result.summarizeStreamsPromptOverride).toBe(summarizeStreamsPrompt);
+    });
+
+    it('propagates non-404 errors', async () => {
+      const serverError = new Error('Internal Server Error');
+      soClientMock.get.mockRejectedValue(serverError);
+
+      await expect(service.getPrompt()).rejects.toThrow('Internal Server Error');
+    });
+  });
+
+  describe('upsertPrompt', () => {
+    it('merges new prompt values with existing ones', async () => {
+      // Mock getPrompt to return existing values
+      soClientMock.get.mockResolvedValue({
+        id: 'streams-prompts-config-id',
+        type: streamsPromptsSOType,
+        references: [],
+        attributes: {
+          featurePromptOverride: 'Existing feature prompt',
+        },
+      });
+
+      soClientMock.create.mockResolvedValue({
+        id: 'streams-prompts-config-id',
+        type: streamsPromptsSOType,
+        references: [],
+        attributes: {
+          featurePromptOverride: 'Existing feature prompt',
+          summarizeQueriesPromptOverride: 'New queries prompt',
+        },
+      });
+
+      const result = await service.upsertPrompt({
+        summarizeQueriesPromptOverride: 'New queries prompt',
+      });
+
+      expect(soClientMock.create).toHaveBeenCalledWith(
+        streamsPromptsSOType,
+        expect.objectContaining({
+          featurePromptOverride: 'Existing feature prompt',
+          summarizeQueriesPromptOverride: 'New queries prompt',
+        }),
+        expect.objectContaining({
+          id: 'streams-prompts-config-id',
+          overwrite: true,
+        })
+      );
+
+      expect(result).toEqual({
+        featurePromptOverride: 'Existing feature prompt',
+        summarizeQueriesPromptOverride: 'New queries prompt',
+      });
+    });
+  });
+
+  describe('resetPrompts', () => {
+    it('deletes the prompts saved object', async () => {
+      soClientMock.delete.mockResolvedValue({});
+
+      await service.resetPrompts();
+
+      expect(soClientMock.delete).toHaveBeenCalledWith(
+        streamsPromptsSOType,
+        'streams-prompts-config-id'
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config_service.ts
@@ -15,6 +15,8 @@ import { significantEventsPrompt } from '@kbn/streams-ai/src/significant_events/
 import { featuresPrompt } from '@kbn/streams-ai/src/features/prompt';
 import { descriptionPrompt } from '@kbn/streams-ai/src/description/prompt';
 import { systemsPrompt } from '@kbn/streams-ai/src/systems/prompt';
+import summarizeQueriesPrompt from '../../significant_events/insights/prompts/summarize_queries/system_prompt.text';
+import summarizeStreamsPrompt from '../../significant_events/insights/prompts/summarize_streams/system_prompt.text';
 import { streamsPromptsSOType } from './prompts_config';
 import type { PromptsConfigAttributes } from './prompts_config';
 
@@ -25,6 +27,8 @@ const defaultsPrompts = {
   significantEventsPromptOverride: significantEventsPrompt,
   descriptionPromptOverride: descriptionPrompt,
   systemsPromptOverride: systemsPrompt,
+  summarizeQueriesPromptOverride: summarizeQueriesPrompt,
+  summarizeStreamsPromptOverride: summarizeStreamsPrompt,
 };
 
 const SINGLETON_PROMPTS_ID = 'streams-prompts-config-id';
@@ -81,6 +85,12 @@ export class PromptsConfigService {
           data.attributes.descriptionPromptOverride || defaultsPrompts.descriptionPromptOverride,
         systemsPromptOverride:
           data.attributes.systemsPromptOverride || defaultsPrompts.systemsPromptOverride,
+        summarizeQueriesPromptOverride:
+          data.attributes.summarizeQueriesPromptOverride ||
+          defaultsPrompts.summarizeQueriesPromptOverride,
+        summarizeStreamsPromptOverride:
+          data.attributes.summarizeStreamsPromptOverride ||
+          defaultsPrompts.summarizeStreamsPromptOverride,
       };
     } catch (err: any) {
       // saved objects client throws with statusCode 404 for not found

--- a/x-pack/platform/plugins/shared/streams/server/lib/significant_events/insights/prompts/summarize_queries/prompt.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/significant_events/insights/prompts/summarize_queries/prompt.ts
@@ -38,3 +38,33 @@ export const SummarizeQueriesPrompt = createPrompt({
     toolChoice: { function: SUBMIT_INSIGHTS_TOOL_NAME },
   })
   .get();
+
+export function createSummarizeQueriesPrompt({ systemPrompt }: { systemPrompt: string }) {
+  return createPrompt({
+    name: 'summarize_queries',
+    input: z.object({
+      streamName: z.string(),
+      queries: z.string(),
+    }),
+  })
+    .version({
+      system: {
+        mustache: {
+          template: systemPrompt,
+        },
+      },
+      template: {
+        mustache: {
+          template: userPromptTemplate,
+        },
+      },
+      tools: {
+        [SUBMIT_INSIGHTS_TOOL_NAME]: {
+          description: 'Submit the identified insights for this stream',
+          schema: insightsSchema,
+        },
+      },
+      toolChoice: { function: SUBMIT_INSIGHTS_TOOL_NAME },
+    })
+    .get();
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/significant_events/insights/prompts/summarize_streams/prompt.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/significant_events/insights/prompts/summarize_streams/prompt.ts
@@ -37,3 +37,32 @@ export const SummarizeStreamsPrompt = createPrompt({
     toolChoice: { function: SUBMIT_INSIGHTS_TOOL_NAME },
   })
   .get();
+
+export function createSummarizeStreamsPrompt({ systemPrompt }: { systemPrompt: string }) {
+  return createPrompt({
+    name: 'summarize_streams',
+    input: z.object({
+      streamInsights: z.string(),
+    }),
+  })
+    .version({
+      system: {
+        mustache: {
+          template: systemPrompt,
+        },
+      },
+      template: {
+        mustache: {
+          template: userPromptTemplate,
+        },
+      },
+      tools: {
+        [SUBMIT_INSIGHTS_TOOL_NAME]: {
+          description: 'Submit system-level insights correlating across streams',
+          schema: insightsSchema,
+        },
+      },
+      toolChoice: { function: SUBMIT_INSIGHTS_TOOL_NAME },
+    })
+    .get();
+}


### PR DESCRIPTION
## 🍒 Summary

Add configurable prompt overrides for the insights discovery task, allowing prompts to be tweaked on a live cluster via the existing streams prompts saved object. This follows the established pattern used by significant events and feature identification tasks.

Relates to: elastic/streams-program#818

## 🛠️ Changes

- **Saved Object Schema (V4)**: Added `summarizeQueriesPromptOverride` and `summarizeStreamsPromptOverride` optional string fields to the prompts saved object schema, with forward compatibility for older versions
- **PromptsConfigService**: Extended to import default insight prompts from the plugin's text files and return the new override fields via `getPrompt()` with fallback to defaults
- **Prompt Factories**: Added `createSummarizeQueriesPrompt({ systemPrompt })` and `createSummarizeStreamsPrompt({ systemPrompt })` factory functions that dynamically create prompts with configurable system prompts
- **generate_insights.ts**: Updated to accept the two prompt override parameters and use the factory functions instead of static prompts
- **insights_discovery task**: Wired in `PromptsConfigService` to fetch prompt overrides and pass them to `generateInsights()`
- **Unit Tests**: Added comprehensive tests for `PromptsConfigService` covering getPrompt defaults, saved object retrieval, error handling, upsert, and reset operations

## 🎙️ Prompts

- `summarizeQueriesPromptOverride`: Overrides the system prompt used when summarizing queries for individual streams
- `summarizeStreamsPromptOverride`: Overrides the system prompt used when correlating insights across multiple streams

🤖 This pull request was assisted by Cursor
