### PR TITLE
[Osquery] Skip flaky timelines test

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/timelines.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/timelines.cy.ts
@@ -10,7 +10,8 @@ import { takeOsqueryActionWithParams } from '../../tasks/live_query';
 import { ServerlessRoleName } from '../../support/roles';
 import { disableNewFeaturesTours } from '../../tasks/navigation';
 
-describe('ALL - Timelines', { tags: ['@ess'] }, () => {
+// FLAKY: https://github.com/elastic/kibana/issues/229432
+describe.skip('ALL - Timelines', { tags: ['@ess'] }, () => {
   before(() => {
     initializeDataViews();
   });


### PR DESCRIPTION
The test was unskipped since the functionality was fixed. However the test itself is flaky. 