### PR TITLE
[8.19] Use dockerized package registry for serverless (#250680)

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -4,6 +4,7 @@ disabled:
   - x-pack/solutions/observability/test/serverless/api_integration/configs/config.ts
   - x-pack/solutions/observability/test/serverless/api_integration/configs/configs.logs_essentials.ts
   - x-pack/solutions/observability/test/serverless/api_integration/test_suites/fleet/config.ts
+  - x-pack/solutions/observability/test/serverless/functional/configs/config.onboarding.ts
   - x-pack/solutions/observability/test/serverless/functional/configs/config.feature_flags.ts
   - x-pack/solutions/observability/test/serverless/functional/configs/config.log_essentials.ts
   - x-pack/solutions/observability/test/serverless/functional/configs/config.screenshots.ts

--- a/x-pack/platform/test/serverless/api_integration/config.base.ts
+++ b/x-pack/platform/test/serverless/api_integration/config.base.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { FtrConfigProviderContext } from '@kbn/test';
+import { dockerRegistryPort, type FtrConfigProviderContext } from '@kbn/test';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 
 import { services } from './services';
@@ -13,6 +13,8 @@ import type { CreateTestConfigOptions } from '../shared/types';
 export function createTestConfig(options: CreateTestConfigOptions) {
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
     const svlSharedConfig = await readConfigFile(require.resolve('../shared/config.base.ts'));
+    const enableFleetDockerRegistry = options.enableFleetDockerRegistry ?? true;
+    const dockerServers = svlSharedConfig.get('dockerServers');
 
     return {
       ...svlSharedConfig.getAll(),
@@ -22,6 +24,10 @@ export function createTestConfig(options: CreateTestConfigOptions) {
         ...services,
         ...options.services,
       },
+      dockerServers:
+        !enableFleetDockerRegistry && dockerServers?.registry
+          ? { ...dockerServers, registry: { ...dockerServers.registry, enabled: false } }
+          : dockerServers,
       esTestCluster: {
         ...svlSharedConfig.get('esTestCluster'),
         serverArgs: [
@@ -36,6 +42,9 @@ export function createTestConfig(options: CreateTestConfigOptions) {
           ...svlSharedConfig.get('kbnTestServer.serverArgs'),
           `--serverless=${options.serverlessProject}`,
           ...(options.kbnServerArgs || []),
+          ...(enableFleetDockerRegistry && dockerRegistryPort
+            ? [`--xpack.fleet.registryUrl=http://localhost:${dockerRegistryPort}`]
+            : []),
         ],
       },
       testFiles: options.testFiles,

--- a/x-pack/platform/test/serverless/api_integration/configs/security/config.group1.ts
+++ b/x-pack/platform/test/serverless/api_integration/configs/security/config.group1.ts
@@ -58,4 +58,5 @@ export default createTestConfig({
     // Enables /internal/cloud_security_posture/graph API
     `--uiSettings.overrides.securitySolution:enableGraphVisualization=true`,
   ],
+  enableFleetDockerRegistry: false,
 });

--- a/x-pack/platform/test/serverless/functional/config.base.ts
+++ b/x-pack/platform/test/serverless/functional/config.base.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrConfigProviderContext } from '@kbn/test';
+import { dockerRegistryPort, type FtrConfigProviderContext } from '@kbn/test';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import { resolve } from 'path';
 import { pageObjects } from './page_objects';
@@ -18,9 +18,15 @@ export function createTestConfig<TServices extends {} = typeof services>(
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
     const svlSharedConfig = await readConfigFile(require.resolve('../shared/config.base.ts'));
 
+    const enableFleetDockerRegistry = options.enableFleetDockerRegistry ?? true;
+    const dockerServers = svlSharedConfig.get('dockerServers');
+
     return {
       ...svlSharedConfig.getAll(),
-
+      dockerServers:
+        !enableFleetDockerRegistry && dockerServers?.registry
+          ? { ...dockerServers, registry: { ...dockerServers.registry, enabled: false } }
+          : dockerServers,
       testConfigCategory: ScoutTestRunConfigCategory.UI_TEST,
       pageObjects,
       services: { ...services, ...options.services },
@@ -45,6 +51,9 @@ export function createTestConfig<TServices extends {} = typeof services>(
             ? ['--xpack.security.roleManagementEnabled=true']
             : []),
           ...(options.kbnServerArgs ?? []),
+          ...(enableFleetDockerRegistry && dockerRegistryPort
+            ? [`--xpack.fleet.registryUrl=http://localhost:${dockerRegistryPort}`]
+            : []),
         ],
       },
       testFiles: options.testFiles,

--- a/x-pack/platform/test/serverless/shared/types/index.ts
+++ b/x-pack/platform/test/serverless/shared/types/index.ts
@@ -42,4 +42,5 @@ export interface CreateTestConfigOptions<
   services?: TServices;
   pageObjects?: TPageObjects;
   apps?: Record<string, { pathname: string; hash?: string }>;
+  enableFleetDockerRegistry?: boolean;
 }

--- a/x-pack/solutions/observability/test/serverless/functional/configs/config.onboarding.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/configs/config.onboarding.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createTestConfig } from '@kbn/test-suites-xpack-platform/serverless/functional/config.base';
+import { pageObjects } from '../page_objects';
+import { services } from '../services';
+
+export default createTestConfig({
+  serverlessProject: 'oblt',
+  services,
+  pageObjects,
+  testFiles: [require.resolve('./index.onboarding.ts')],
+  junit: {
+    reportName: 'Serverless Observability Onboarding Functional Tests',
+  },
+  suiteTags: { exclude: ['skipSvlOblt'] },
+
+  // include settings from project controller
+  esServerArgs: [],
+  kbnServerArgs: [],
+  enableFleetDockerRegistry: false,
+});

--- a/x-pack/solutions/observability/test/serverless/functional/configs/index.onboarding.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/configs/index.onboarding.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('serverless observability UI - onboarding', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../test_suites/onboarding'));
+  });
+}

--- a/x-pack/solutions/observability/test/serverless/functional/configs/index.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/configs/index.ts
@@ -16,7 +16,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('../test_suites/discover/context_awareness'));
     loadTestFile(require.resolve('../test_suites/discover/logs'));
     loadTestFile(require.resolve('../test_suites/discover/embeddables'));
-    loadTestFile(require.resolve('../test_suites/onboarding'));
     loadTestFile(require.resolve('../test_suites/rules/rules_list'));
     loadTestFile(require.resolve('../test_suites/rules/custom_threshold_consumer'));
     loadTestFile(require.resolve('../test_suites/rules/es_query_consumer'));

--- a/x-pack/solutions/security/test/serverless/api_integration/configs/config.ts
+++ b/x-pack/solutions/security/test/serverless/api_integration/configs/config.ts
@@ -37,4 +37,5 @@ export default createTestConfig({
     `--uiSettings.overrides.securitySolution:enableGraphVisualization=true`,
     `--xpack.securitySolutionServerless.usageApi.url=http://localhost:8081`,
   ],
+  enableFleetDockerRegistry: false,
 });

--- a/x-pack/solutions/security/test/serverless/functional/configs/config.cloud_security_posture.agentless.ts
+++ b/x-pack/solutions/security/test/serverless/functional/configs/config.cloud_security_posture.agentless.ts
@@ -42,4 +42,5 @@ export default createTestConfig({
   ],
   // load tests in the index file
   testFiles: [require.resolve('../test_suites/ftr/cloud_security_posture/agentless')],
+  enableFleetDockerRegistry: false,
 });

--- a/x-pack/solutions/security/test/serverless/functional/configs/config.cloud_security_posture.basic.ts
+++ b/x-pack/solutions/security/test/serverless/functional/configs/config.cloud_security_posture.basic.ts
@@ -28,4 +28,5 @@ export default createTestConfig({
   ],
   // load tests in the index file
   testFiles: [require.resolve('../test_suites/ftr/cloud_security_posture')],
+  enableFleetDockerRegistry: false,
 });

--- a/x-pack/solutions/security/test/serverless/functional/configs/config.cloud_security_posture.essentials.ts
+++ b/x-pack/solutions/security/test/serverless/functional/configs/config.cloud_security_posture.essentials.ts
@@ -32,4 +32,5 @@ export default createTestConfig({
       '../test_suites/ftr/cloud_security_posture/csp_integrations_form.essentials.ts'
     ),
   ],
+  enableFleetDockerRegistry: false,
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Use dockerized package registry for serverless (#250680)](https://github.com/elastic/kibana/pull/250680)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"mohamedhamed-ahmed","email":"mohamed.ahmed@elastic.co"},"sourceCommit":{"committedDate":"2026-01-30T10:10:09Z","message":"Use dockerized package registry for serverless (#250680)\n\nAfter [[Dataset quality] configuring dockerized package registry in\ntests](https://github.com/elastic/kibana/pull/250040) has been merged\nsuccessfully, this PR makes use of the dockerized package registry in\nserverless configs.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"aaaef09bd49d0054017beed37850b668bb78e9c7","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:all-cypress-suites","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.3.0","v9.4.0"],"title":"Use dockerized package registry for serverless","number":250680,"url":"https://github.com/elastic/kibana/pull/250680","mergeCommit":{"message":"Use dockerized package registry for serverless (#250680)\n\nAfter [[Dataset quality] configuring dockerized package registry in\ntests](https://github.com/elastic/kibana/pull/250040) has been merged\nsuccessfully, this PR makes use of the dockerized package registry in\nserverless configs.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"aaaef09bd49d0054017beed37850b668bb78e9c7"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19","9.2","9.3"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250680","number":250680,"mergeCommit":{"message":"Use dockerized package registry for serverless (#250680)\n\nAfter [[Dataset quality] configuring dockerized package registry in\ntests](https://github.com/elastic/kibana/pull/250040) has been merged\nsuccessfully, this PR makes use of the dockerized package registry in\nserverless configs.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"aaaef09bd49d0054017beed37850b668bb78e9c7"}}]}] BACKPORT-->