### PR TITLE
Fix AI Connector form fields resetting to default value when cleared by user

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
@@ -78,6 +78,39 @@ describe('ConfigInputField', () => {
     expect(validateAndSetConfigValue).toHaveBeenCalledWith('');
   });
 
+  it('does not reset to default after rerender when field is cleared', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 'https://api.example.com/v1',
+    });
+
+    const { rerender } = render(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('url-input');
+
+    // User clears the entire field
+    fireEvent.change(input, { target: { value: '' } });
+
+    // Simulate parent form updating value prop to null (as it converts '' to null)
+    rerender(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={{ ...configEntry, value: null }}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Should still be empty, not reset to default
+    expect(input).toHaveValue('');
+  });
+
   it('allows user to type a new value after clearing', () => {
     const validateAndSetConfigValue = jest.fn();
     const configEntry = createConfigEntry({
@@ -190,6 +223,39 @@ describe('ConfigNumberField', () => {
     fireEvent.click(clearButton);
 
     expect(validateAndSetConfigValue).toHaveBeenCalledWith('');
+  });
+
+  it('does not reset to default after rerender when field is cleared', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 1024,
+    });
+
+    const { rerender } = render(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Find and click the clear button
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    fireEvent.click(clearButton);
+
+    // Simulate parent form updating value prop to null (as it converts '' to null)
+    rerender(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={{ ...configEntry, value: null }}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Should still be empty, not reset to default
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toHaveValue(null);
   });
 
   it('allows user to change the value', () => {

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfigInputField, ConfigNumberField } from './configuration_field';
+import { FieldType } from '../../types/types';
+import type { ConfigEntryView } from '../../types/types';
+
+describe('ConfigInputField', () => {
+  const createConfigEntry = (overrides: Partial<ConfigEntryView> = {}): ConfigEntryView => ({
+    key: 'url',
+    isValid: true,
+    label: 'URL',
+    description: 'The URL endpoint',
+    validationErrors: [],
+    required: false,
+    sensitive: false,
+    value: null,
+    default_value: 'https://api.example.com/v1',
+    updatable: true,
+    type: FieldType.STRING,
+    supported_task_types: ['text_embedding'],
+    ...overrides,
+  });
+
+  const defaultProps = {
+    isLoading: false,
+    validateAndSetConfigValue: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with default value when value is null', () => {
+    const configEntry = createConfigEntry({ value: null });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toHaveValue('https://api.example.com/v1');
+  });
+
+  it('renders with actual value when value is provided', () => {
+    const configEntry = createConfigEntry({ value: 'https://custom.url.com' });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toHaveValue('https://custom.url.com');
+  });
+
+  it('allows user to clear the field completely without resetting to default', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 'https://api.example.com/v1',
+    });
+
+    render(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('url-input');
+
+    // User clears the entire field
+    fireEvent.change(input, { target: { value: '' } });
+
+    // The input should be empty, not reset to default
+    expect(input).toHaveValue('');
+    expect(validateAndSetConfigValue).toHaveBeenCalledWith('');
+  });
+
+  it('allows user to type a new value after clearing', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 'https://api.example.com/v1',
+    });
+
+    render(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('url-input');
+
+    // User clears and types new value
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, { target: { value: 'https://new.url.com' } });
+
+    expect(input).toHaveValue('https://new.url.com');
+    expect(validateAndSetConfigValue).toHaveBeenLastCalledWith('https://new.url.com');
+  });
+
+  it('is disabled when isLoading is true', () => {
+    const configEntry = createConfigEntry();
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} isLoading={true} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toBeDisabled();
+  });
+
+  it('is disabled in edit mode when field is not updatable', () => {
+    const configEntry = createConfigEntry({ updatable: false });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} isEdit={true} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toBeDisabled();
+  });
+
+  it('shows invalid state when isValid is false', () => {
+    const configEntry = createConfigEntry({ isValid: false });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+});
+
+describe('ConfigNumberField', () => {
+  const createConfigEntry = (overrides: Partial<ConfigEntryView> = {}): ConfigEntryView => ({
+    key: 'max_tokens',
+    isValid: true,
+    label: 'Max Tokens',
+    description: 'Maximum number of tokens',
+    validationErrors: [],
+    required: false,
+    sensitive: false,
+    value: null,
+    default_value: 1024,
+    updatable: true,
+    type: FieldType.INTEGER,
+    supported_task_types: ['text_embedding'],
+    ...overrides,
+  });
+
+  const defaultProps = {
+    isLoading: false,
+    validateAndSetConfigValue: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with default value when value is null', () => {
+    const configEntry = createConfigEntry({ value: null });
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toHaveValue(1024);
+  });
+
+  it('renders with actual value when value is provided', () => {
+    const configEntry = createConfigEntry({ value: 2048 });
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toHaveValue(2048);
+  });
+
+  it('allows user to clear the field using the clear button', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 1024,
+    });
+
+    render(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Find and click the clear button
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    fireEvent.click(clearButton);
+
+    expect(validateAndSetConfigValue).toHaveBeenCalledWith('');
+  });
+
+  it('allows user to change the value', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 1024,
+    });
+
+    render(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('max_tokens-number');
+    fireEvent.change(input, { target: { value: '512' } });
+
+    expect(input).toHaveValue(512);
+    expect(validateAndSetConfigValue).toHaveBeenCalledWith('512');
+  });
+
+  it('is disabled when isLoading is true', () => {
+    const configEntry = createConfigEntry();
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} isLoading={true} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toBeDisabled();
+  });
+
+  it('is disabled when isPreconfigured is true', () => {
+    const configEntry = createConfigEntry();
+    render(
+      <ConfigNumberField {...defaultProps} configEntry={configEntry} isPreconfigured={true} />
+    );
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toBeDisabled();
+  });
+
+  it('is disabled in edit mode when field is not updatable', () => {
+    const configEntry = createConfigEntry({ updatable: false });
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} isEdit={true} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toBeDisabled();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
@@ -70,7 +70,7 @@ export const ConfigInputField: React.FC<ConfigInputFieldProps> = ({
   useEffect(() => {
     // Only sync from external value if it has actual content
     // Don't reset to default when user clears the field (value becomes null)
-    if (value !== null && value !== undefined && value.toString().length > 0) {
+    if (value != null && String(value).length > 0) {
       setInnerValue(value);
     }
   }, [value]);
@@ -151,7 +151,7 @@ export const ConfigNumberField: React.FC<ConfigInputFieldProps> = ({
   useEffect(() => {
     // Only sync from external value if it has actual content
     // Don't reset to default when user clears the field (value becomes null)
-    if (value !== null && value !== undefined && value.toString().length > 0) {
+    if (value != null && String(value).length > 0) {
       setInnerValue(value);
     }
   }, [value]);

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
@@ -68,8 +68,12 @@ export const ConfigInputField: React.FC<ConfigInputFieldProps> = ({
   );
 
   useEffect(() => {
-    setInnerValue(!value || value.toString().length === 0 ? defaultValue : value);
-  }, [defaultValue, value]);
+    // Only sync from external value if it has actual content
+    // Don't reset to default when user clears the field (value becomes null)
+    if (value !== null && value !== undefined && value.toString().length > 0) {
+      setInnerValue(value);
+    }
+  }, [value]);
   return (
     <EuiFieldText
       disabled={isLoading || (isEdit && !updatable)}
@@ -145,8 +149,12 @@ export const ConfigNumberField: React.FC<ConfigInputFieldProps> = ({
   const { isValid, value, default_value: defaultValue, key, updatable } = configEntry;
   const [innerValue, setInnerValue] = useState(value ?? defaultValue);
   useEffect(() => {
-    setInnerValue(!value || value.toString().length === 0 ? defaultValue : value);
-  }, [defaultValue, value]);
+    // Only sync from external value if it has actual content
+    // Don't reset to default when user clears the field (value becomes null)
+    if (value !== null && value !== undefined && value.toString().length > 0) {
+      setInnerValue(value);
+    }
+  }, [value]);
   return (
     <EuiFormControlLayout
       isDisabled={isLoading || (isEdit && !updatable) || isPreconfigured}


### PR DESCRIPTION
## Summary

Fixes #250953

This PR fixes a bug in the AI Connector creation flyout where fields with default values (like URL, Model ID) would reset to their default value when the user tried to clear them completely using backspace.

**Root cause:** The `useEffect` in `ConfigInputField` and `ConfigNumberField` was checking if the value was empty/null and resetting to `defaultValue`. When a user cleared a field, the form converted the empty string to `null`, which triggered the effect to reset the field back to the default.

**Fix:** Modified the `useEffect` to only sync when there's actual external content, preventing the reset when users intentionally clear the field. The initial default is still applied via `useState`.

### Changes
- `ConfigInputField`: Updated `useEffect` to not reset to default when value is cleared
- `ConfigNumberField`: Same fix applied
- Added comprehensive unit tests for both components

## Test plan

1. Go to **Alerts and Insights > Connectors**
2. Click **Create connector** → Select **AI Connector**
3. Select **DeepSeek** as the provider
4. Open **More Options** section
5. Try to backspace/delete the URL field completely
6. **Expected:** Field should clear and stay empty
7. **Before fix:** Field would reset to default URL when last character was deleted


### Before

https://github.com/user-attachments/assets/cc8832f5-ca91-4270-825f-023dcbc34615




### After
https://github.com/user-attachments/assets/49a31906-6362-4f5d-aee1-bff10008aabd



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


### Release note
Fixes AI Connector form fields incorrectly resetting to default values when users clear them using backspace.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->