### PR TITLE
[9.2] Fix disabled connector button (#250921)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/index.test.tsx
@@ -120,6 +120,20 @@ describe('AssistantHeader', () => {
     ).not.toBeDisabled();
   });
 
+  it('disables assistant settings menu when isDisabled=true', () => {
+    render(<AssistantHeader {...testProps} isDisabled={true} />, {
+      wrapper: TestProviders,
+    });
+    expect(screen.getByTestId('chat-context-menu')).toBeDisabled();
+  });
+
+  it('enables assistant settings menu when isDisabled=false', () => {
+    render(<AssistantHeader {...testProps} isDisabled={false} />, {
+      wrapper: TestProviders,
+    });
+    expect(screen.getByTestId('chat-context-menu')).not.toBeDisabled();
+  });
+
   it('disables share badge when isConversationOwner=false', () => {
     render(<AssistantHeader {...testProps} isConversationOwner={false} />, {
       wrapper: TestProviders,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -192,10 +192,8 @@ const AssistantComponent: React.FC<Props> = ({
         : (connectors?.length ?? 0) === 0,
     [connectors?.length, conversations]
   );
-  const isDisabled = useMemo(
-    () => isWelcomeSetup || !isAssistantEnabled || isInitialLoad,
-    [isWelcomeSetup, isAssistantEnabled, isInitialLoad]
-  );
+
+  const isChatDisabled = isWelcomeSetup || !isAssistantEnabled || isInitialLoad;
 
   // Settings modal state (so it isn't shared between assistant instances like Timeline)
   const [isSettingsModalVisible, setIsSettingsModalVisible] = useState(false);
@@ -242,8 +240,7 @@ const AssistantComponent: React.FC<Props> = ({
 
   useEvent('keydown', onKeyDown);
 
-  // Show missing connector callout if no connectors are configured
-
+  // Show missing connector callout if the current conversation's connector doesn't exist in the connectors list
   const showMissingConnectorCallout = useMemo(() => {
     if (
       !isLoadingCurrentUserConversations &&
@@ -263,9 +260,7 @@ const AssistantComponent: React.FC<Props> = ({
     return false;
   }, [isFetchedConnectors, connectors, currentConversation, isLoadingCurrentUserConversations]);
 
-  const isSendingDisabled = useMemo(() => {
-    return isDisabled || showMissingConnectorCallout;
-  }, [showMissingConnectorCallout, isDisabled]);
+  const isSendingDisabled = isChatDisabled || showMissingConnectorCallout;
 
   // Fixes initial render not showing buttons as code block controls are added to the DOM really late
   useEffect(() => {
@@ -307,6 +302,8 @@ const AssistantComponent: React.FC<Props> = ({
     setSelectedPromptContexts,
     setCurrentConversation,
   });
+
+  const isHeaderDisabled = !isAssistantEnabled || isInitialLoad || isLoadingChatSend;
 
   useEffect(() => {
     if (
@@ -484,7 +481,7 @@ const AssistantComponent: React.FC<Props> = ({
                     defaultConnector={defaultConnector}
                     isAssistantEnabled={isAssistantEnabled}
                     isConversationOwner={isConversationOwner}
-                    isDisabled={isDisabled || isLoadingChatSend}
+                    isDisabled={isHeaderDisabled}
                     isLoading={isInitialLoad}
                     isSettingsModalVisible={isSettingsModalVisible}
                     onChatCleared={handleOnChatCleared}
@@ -524,7 +521,7 @@ const AssistantComponent: React.FC<Props> = ({
                     }
                   `}
                   banner={
-                    !isDisabled &&
+                    !isChatDisabled &&
                     isFetchedConnectors && (
                       <AssistantConversationBanner
                         isSettingsModalVisible={isSettingsModalVisible}
@@ -573,7 +570,7 @@ const AssistantComponent: React.FC<Props> = ({
                           overflow: auto;
                         `}
                       >
-                        {!isDisabled &&
+                        {!isChatDisabled &&
                           Object.keys(promptContexts).length !== selectedPromptContextsCount && (
                             <EuiFlexGroup>
                               <EuiFlexItem>
@@ -618,7 +615,7 @@ const AssistantComponent: React.FC<Props> = ({
                         </EuiFlexGroup>
                       </EuiPanel>
 
-                      {!isDisabled && (
+                      {!isChatDisabled && (
                         <EuiPanel
                           css={css`
                             background: ${euiTheme.colors.backgroundBaseSubdued};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/add_connector_modal/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/add_connector_modal/index.tsx
@@ -21,6 +21,8 @@ interface Props {
   onSelectActionType: (actionType: ActionType) => void;
   selectedActionType: ActionType | null;
   actionTypeSelectorInline?: boolean;
+  isMissingConnectorPrivileges?: boolean;
+  missingPrivilegesTooltip?: string;
 }
 export const AddConnectorModal: React.FC<Props> = React.memo(
   ({
@@ -31,6 +33,8 @@ export const AddConnectorModal: React.FC<Props> = React.memo(
     onSelectActionType,
     selectedActionType,
     actionTypeSelectorInline = false,
+    isMissingConnectorPrivileges = false,
+    missingPrivilegesTooltip,
   }) => (
     <>
       <Suspense fallback={null}>
@@ -40,6 +44,8 @@ export const AddConnectorModal: React.FC<Props> = React.memo(
           onClose={onClose}
           onSelect={onSelectActionType}
           actionTypeSelectorInline={actionTypeSelectorInline}
+          isMissingConnectorPrivileges={isMissingConnectorPrivileges}
+          missingPrivilegesTooltip={missingPrivilegesTooltip}
         />
       </Suspense>
       {selectedActionType && (

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ActionTypeList } from './action_type_list';
+import type { ActionType } from '@kbn/actions-plugin/common';
+import { actionTypeRegistryMock } from '@kbn/triggers-actions-ui-plugin/public/application/action_type_registry.mock';
+
+const actionTypes = [
+  {
+    id: '123',
+    name: 'Gen AI',
+    enabled: true,
+    enabledInConfig: true,
+    enabledInLicense: true,
+    minimumLicenseRequired: 'basic',
+    isSystemActionType: true,
+    supportedFeatureIds: ['generativeAI'],
+  } as ActionType,
+  {
+    id: '456',
+    name: 'Another one',
+    enabled: true,
+    enabledInConfig: true,
+    enabledInLicense: true,
+    minimumLicenseRequired: 'basic',
+    isSystemActionType: true,
+    supportedFeatureIds: ['generativeAI'],
+  } as ActionType,
+];
+
+const disabledActionType = {
+  id: '789',
+  name: 'Disabled Action',
+  enabled: false,
+  enabledInConfig: true,
+  enabledInLicense: false,
+  minimumLicenseRequired: 'platinum',
+  isSystemActionType: true,
+  supportedFeatureIds: ['generativeAI'],
+} as ActionType;
+
+const actionTypeRegistry = {
+  ...actionTypeRegistryMock.create(),
+  get: jest.fn().mockReturnValue({ iconClass: 'icon-class' }),
+};
+
+const onSelect = jest.fn();
+
+const defaultProps = {
+  actionTypes,
+  actionTypeRegistry,
+  onSelect,
+  isMissingConnectorPrivileges: false,
+};
+
+describe('ActionTypeList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render all action types', () => {
+    const { getAllByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    expect(getAllByTestId('action-option')).toHaveLength(actionTypes.length);
+  });
+
+  it('should render action type buttons with correct labels', () => {
+    const { getByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    expect(getByTestId(`action-option-${actionTypes[0].name}`)).toHaveTextContent('Gen AI');
+    expect(getByTestId(`action-option-${actionTypes[1].name}`)).toHaveTextContent('Another one');
+  });
+
+  it('should call onSelect with actionType when button is clicked', () => {
+    const { getByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    fireEvent.click(getByTestId(`action-option-${actionTypes[0].name}`));
+
+    expect(onSelect).toHaveBeenCalledWith(actionTypes[0]);
+  });
+
+  it('should disable buttons when isMissingConnectorPrivileges is true', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} isMissingConnectorPrivileges={true} />
+    );
+
+    expect(getByTestId(`action-option-${actionTypes[0].name}`)).toBeDisabled();
+    expect(getByTestId(`action-option-${actionTypes[1].name}`)).toBeDisabled();
+  });
+
+  it('should show tooltip on disabled buttons when missing privileges', async () => {
+    const missingPrivilegesTooltip = 'Test tooltip';
+    render(
+      <ActionTypeList
+        {...defaultProps}
+        isMissingConnectorPrivileges={true}
+        missingPrivilegesTooltip={missingPrivilegesTooltip}
+      />
+    );
+
+    const firstButton = screen.getByTestId(`action-option-${actionTypes[0].name}`);
+    fireEvent.mouseOver(firstButton);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(missingPrivilegesTooltip);
+  });
+
+  it('should not call onSelect when clicking a disabled button due to missing privileges', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} isMissingConnectorPrivileges={true} />
+    );
+
+    fireEvent.click(getByTestId(`action-option-${actionTypes[0].name}`));
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should disable button when actionType.enabled is false', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} actionTypes={[disabledActionType]} />
+    );
+
+    expect(getByTestId(`action-option-${disabledActionType.name}`)).toBeDisabled();
+  });
+
+  it('should not call onSelect when clicking a button disabled due to actionType.enabled being false', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} actionTypes={[disabledActionType]} />
+    );
+
+    fireEvent.click(getByTestId(`action-option-${disabledActionType.name}`));
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should render enabled buttons when isMissingConnectorPrivileges is false', () => {
+    const { getByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    expect(getByTestId(`action-option-${actionTypes[0].name}`)).toBeEnabled();
+    expect(getByTestId(`action-option-${actionTypes[1].name}`)).toBeEnabled();
+  });
+
+  it('should render empty list when actionTypes is empty', () => {
+    const { queryAllByTestId } = render(<ActionTypeList {...defaultProps} actionTypes={[]} />);
+
+    expect(queryAllByTestId('action-option')).toHaveLength(0);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiKeyPadMenuItem, EuiToolTip } from '@elastic/eui';
+import type { ActionType } from '@kbn/actions-plugin/common';
+import type { ActionTypeRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
+import { css } from '@emotion/css';
+import * as i18n from '../translations';
+
+const itemClassName = css`
+  inline-size: 150px;
+
+  .euiKeyPadMenuItem__label {
+    white-space: nowrap;
+    overflow: hidden;
+  }
+`;
+
+export interface ActionTypeListProps {
+  actionTypes: ActionType[];
+  actionTypeRegistry: ActionTypeRegistryContract;
+  onSelect: (actionType: ActionType) => void;
+  isMissingConnectorPrivileges?: boolean;
+  missingPrivilegesTooltip?: string;
+}
+
+export const ActionTypeList: React.FC<ActionTypeListProps> = ({
+  actionTypes,
+  actionTypeRegistry,
+  onSelect,
+  isMissingConnectorPrivileges = false,
+  missingPrivilegesTooltip = i18n.ADD_CONNECTOR_MISSING_PRIVILEGES_DESCRIPTION,
+}) => (
+  <EuiFlexGroup
+    justifyContent="center"
+    responsive={false}
+    wrap={true}
+    data-test-subj="action-type-list"
+  >
+    {actionTypes.map((actionType: ActionType) => {
+      const fullAction = actionTypeRegistry.get(actionType.id);
+      const buttonIsDisabled = isMissingConnectorPrivileges || !actionType.enabled;
+      const button = (
+        <EuiKeyPadMenuItem
+          className={itemClassName}
+          key={actionType.id}
+          isDisabled={buttonIsDisabled}
+          label={actionType.name}
+          data-test-subj={`action-option-${actionType.name}`}
+          onClick={() => onSelect(actionType)}
+        >
+          <EuiIcon size="xl" type={fullAction.iconClass} />
+        </EuiKeyPadMenuItem>
+      );
+      return (
+        <EuiFlexItem data-test-subj="action-option" key={actionType.id} grow={false}>
+          {isMissingConnectorPrivileges && missingPrivilegesTooltip ? (
+            <EuiToolTip content={missingPrivilegesTooltip}>{button}</EuiToolTip>
+          ) : (
+            button
+          )}
+        </EuiFlexItem>
+      );
+    })}
+  </EuiFlexGroup>
+);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_selector_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_selector_modal.tsx
@@ -5,12 +5,8 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiKeyPadMenuItem,
   EuiModal,
   EuiModalBody,
   EuiModalHeader,
@@ -19,57 +15,44 @@ import {
 } from '@elastic/eui';
 import type { ActionType } from '@kbn/actions-plugin/common';
 import type { ActionTypeRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
-import { css } from '@emotion/css';
 import * as i18n from '../translations';
+import { ActionTypeList } from './action_type_list';
 
-interface Props {
+interface ActionTypeSelectorModalProps {
   actionTypes?: ActionType[];
   actionTypeRegistry: ActionTypeRegistryContract;
   onClose: () => void;
   onSelect: (actionType: ActionType) => void;
   actionTypeSelectorInline: boolean;
+  isMissingConnectorPrivileges?: boolean;
+  missingPrivilegesTooltip?: string;
 }
-const itemClassName = css`
-  inline-size: 150px;
 
-  .euiKeyPadMenuItem__label {
-    white-space: nowrap;
-    overflow: hidden;
-  }
-`;
-
-export const ActionTypeSelectorModal = React.memo(
-  ({ actionTypes, actionTypeRegistry, onClose, onSelect, actionTypeSelectorInline }: Props) => {
+export const ActionTypeSelectorModal: React.FC<ActionTypeSelectorModalProps> = React.memo(
+  ({
+    actionTypes,
+    actionTypeRegistry,
+    onClose,
+    onSelect,
+    actionTypeSelectorInline,
+    isMissingConnectorPrivileges = false,
+    missingPrivilegesTooltip,
+  }) => {
     const modalTitleId = useGeneratedHtmlId();
-
-    const content = useMemo(
-      () => (
-        <EuiFlexGroup justifyContent="center" responsive={false} wrap={true}>
-          {actionTypes?.map((actionType: ActionType) => {
-            const fullAction = actionTypeRegistry.get(actionType.id);
-            return (
-              <EuiFlexItem data-test-subj="action-option" key={actionType.id} grow={false}>
-                <EuiKeyPadMenuItem
-                  className={itemClassName}
-                  key={actionType.id}
-                  isDisabled={!actionType.enabled}
-                  label={actionType.name}
-                  data-test-subj={`action-option-${actionType.name}`}
-                  onClick={() => onSelect(actionType)}
-                >
-                  <EuiIcon size="xl" type={fullAction.iconClass} />
-                </EuiKeyPadMenuItem>
-              </EuiFlexItem>
-            );
-          })}
-        </EuiFlexGroup>
-      ),
-      [actionTypeRegistry, actionTypes, onSelect]
-    );
 
     if (!actionTypes?.length) return null;
 
-    if (actionTypeSelectorInline) return <>{content}</>;
+    const actionTypeList = (
+      <ActionTypeList
+        actionTypes={actionTypes}
+        actionTypeRegistry={actionTypeRegistry}
+        onSelect={onSelect}
+        isMissingConnectorPrivileges={isMissingConnectorPrivileges}
+        missingPrivilegesTooltip={missingPrivilegesTooltip}
+      />
+    );
+
+    if (actionTypeSelectorInline) return actionTypeList;
 
     return (
       <EuiModal
@@ -83,7 +66,7 @@ export const ActionTypeSelectorModal = React.memo(
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
-        <EuiModalBody>{content}</EuiModalBody>
+        <EuiModalBody>{actionTypeList}</EuiModalBody>
       </EuiModal>
     );
   }

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
@@ -35,7 +35,10 @@ export const ConnectorSetup = ({
   );
   const { setApiConfig } = useConversation();
   // Access all conversations so we can add connector to all on initial setup
-  const { actionTypeRegistry, http, inferenceEnabled, settings } = useAssistantContext();
+  const { actionTypeRegistry, assistantAvailability, http, inferenceEnabled, settings } =
+    useAssistantContext();
+
+  const isMissingConnectorPrivileges = !assistantAvailability.hasConnectorsAllPrivilege;
 
   const { refetch: refetchConnectors } = useLoadConnectors({ http, inferenceEnabled, settings });
 
@@ -90,6 +93,7 @@ export const ConnectorSetup = ({
       onSelectActionType={setSelectedActionType}
       selectedActionType={selectedActionType}
       actionTypeSelectorInline={true}
+      isMissingConnectorPrivileges={isMissingConnectorPrivileges}
     />
   );
 };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_helpers.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryObserverSuccessResult } from '@kbn/react-query';
+import type { IHttpFetchError } from '@kbn/core-http-browser';
+import type { AIConnector } from '../connectorland/connector_selector';
+
+/**
+ * Helper function to create a properly typed mock return value for useLoadConnectors
+ * Returns a QueryObserverSuccessResult which is compatible with UseQueryResult
+ */
+export const createMockUseLoadConnectorsResult = (
+  overrides: Partial<QueryObserverSuccessResult<AIConnector[], IHttpFetchError>>
+): QueryObserverSuccessResult<AIConnector[], IHttpFetchError> => {
+  return {
+    data: [] as AIConnector[],
+    error: null,
+    isError: false,
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isPreviousData: false,
+    status: 'success',
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: 'idle',
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isPaused: false,
+    isPlaceholderData: false,
+    refetch: jest.fn(),
+    remove: jest.fn(),
+    ...overrides,
+  };
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix disabled connector button (#250921)](https://github.com/elastic/kibana/pull/250921)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-01-30T13:54:23Z","message":"Fix disabled connector button (#250921)\n\n## Summary\n\nThis PR fixes a bug where the \"Add connector\" button in the\nConnectorSelector component was incorrectly checking\n`hasConnectorsReadPrivilege` instead of `hasConnectorsAllPrivilege`.\nUsers with read-only access were able to see an enabled \"Add connector\"\nbutton, but would encounter errors when attempting to create connectors.\n\nAdditionally, this PR includes several test improvements:\n- Resolves TypeScript type errors in test mocks by creating a properly\ntyped helper function for `useLoadConnectors`\n- Adds test coverage for the add connector button enable/disable\nbehavior based on user privileges\n- Improves test stability by adding MutationObserver mocks\n- Refactors Assistant component disabled state logic for better clarity\nand granularity\n\nCloses https://github.com/elastic/kibana/issues/250635\n\n**Before fix:**\nhttps://github.com/user-attachments/assets/c5a2a0cb-3006-4b58-845c-a5db1c57b432\n\n**After fix:**\nhttps://github.com/user-attachments/assets/70c3b76c-8bd5-4924-9a3e-839aed7d5d3a\n\n### Changes\n\n**Bug Fix:**\n- Fixed `ConnectorSelector` to check `hasConnectorsAllPrivilege` instead\nof `hasConnectorsReadPrivilege` for the \"Add connector\" button disabled\nstate\n\n**Tests:**\n- Added tests for add connector button enable/disable scenarios based on\nuser privileges\n- Added MutationObserver mock setup for better test stability\n- Improved localStorage mock implementation in Assistant tests\n- Added tests for AssistantHeader disabled state\n- Added tests for connector scenarios (no connectors, connectors exist)\n\n**Code Quality:**\n- Refactored Assistant component to use more granular disabled state\nvariables (`isChatDisabled`, `isHeaderDisabled`)\n- Added missing `key` prop to TryAIAgentContextMenuItem\n\n*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*","sha":"4c5982a08736bd4dd5823d941a2676fc21bc50ef","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","Team: SecuritySolution","backport:version","v9.4.0","v9.2.5","v8.19.11","v9.1.11","v9.3.1"],"title":"Fix disabled connector button","number":250921,"url":"https://github.com/elastic/kibana/pull/250921","mergeCommit":{"message":"Fix disabled connector button (#250921)\n\n## Summary\n\nThis PR fixes a bug where the \"Add connector\" button in the\nConnectorSelector component was incorrectly checking\n`hasConnectorsReadPrivilege` instead of `hasConnectorsAllPrivilege`.\nUsers with read-only access were able to see an enabled \"Add connector\"\nbutton, but would encounter errors when attempting to create connectors.\n\nAdditionally, this PR includes several test improvements:\n- Resolves TypeScript type errors in test mocks by creating a properly\ntyped helper function for `useLoadConnectors`\n- Adds test coverage for the add connector button enable/disable\nbehavior based on user privileges\n- Improves test stability by adding MutationObserver mocks\n- Refactors Assistant component disabled state logic for better clarity\nand granularity\n\nCloses https://github.com/elastic/kibana/issues/250635\n\n**Before fix:**\nhttps://github.com/user-attachments/assets/c5a2a0cb-3006-4b58-845c-a5db1c57b432\n\n**After fix:**\nhttps://github.com/user-attachments/assets/70c3b76c-8bd5-4924-9a3e-839aed7d5d3a\n\n### Changes\n\n**Bug Fix:**\n- Fixed `ConnectorSelector` to check `hasConnectorsAllPrivilege` instead\nof `hasConnectorsReadPrivilege` for the \"Add connector\" button disabled\nstate\n\n**Tests:**\n- Added tests for add connector button enable/disable scenarios based on\nuser privileges\n- Added MutationObserver mock setup for better test stability\n- Improved localStorage mock implementation in Assistant tests\n- Added tests for AssistantHeader disabled state\n- Added tests for connector scenarios (no connectors, connectors exist)\n\n**Code Quality:**\n- Refactored Assistant component to use more granular disabled state\nvariables (`isChatDisabled`, `isHeaderDisabled`)\n- Added missing `key` prop to TryAIAgentContextMenuItem\n\n*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*","sha":"4c5982a08736bd4dd5823d941a2676fc21bc50ef"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250921","number":250921,"mergeCommit":{"message":"Fix disabled connector button (#250921)\n\n## Summary\n\nThis PR fixes a bug where the \"Add connector\" button in the\nConnectorSelector component was incorrectly checking\n`hasConnectorsReadPrivilege` instead of `hasConnectorsAllPrivilege`.\nUsers with read-only access were able to see an enabled \"Add connector\"\nbutton, but would encounter errors when attempting to create connectors.\n\nAdditionally, this PR includes several test improvements:\n- Resolves TypeScript type errors in test mocks by creating a properly\ntyped helper function for `useLoadConnectors`\n- Adds test coverage for the add connector button enable/disable\nbehavior based on user privileges\n- Improves test stability by adding MutationObserver mocks\n- Refactors Assistant component disabled state logic for better clarity\nand granularity\n\nCloses https://github.com/elastic/kibana/issues/250635\n\n**Before fix:**\nhttps://github.com/user-attachments/assets/c5a2a0cb-3006-4b58-845c-a5db1c57b432\n\n**After fix:**\nhttps://github.com/user-attachments/assets/70c3b76c-8bd5-4924-9a3e-839aed7d5d3a\n\n### Changes\n\n**Bug Fix:**\n- Fixed `ConnectorSelector` to check `hasConnectorsAllPrivilege` instead\nof `hasConnectorsReadPrivilege` for the \"Add connector\" button disabled\nstate\n\n**Tests:**\n- Added tests for add connector button enable/disable scenarios based on\nuser privileges\n- Added MutationObserver mock setup for better test stability\n- Improved localStorage mock implementation in Assistant tests\n- Added tests for AssistantHeader disabled state\n- Added tests for connector scenarios (no connectors, connectors exist)\n\n**Code Quality:**\n- Refactored Assistant component to use more granular disabled state\nvariables (`isChatDisabled`, `isHeaderDisabled`)\n- Added missing `key` prop to TryAIAgentContextMenuItem\n\n*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*","sha":"4c5982a08736bd4dd5823d941a2676fc21bc50ef"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251063","number":251063,"state":"OPEN"}]}] BACKPORT-->