### PR TITLE
[Cases][Attachments] Add cases-attachments schema and SO

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -30,6 +30,7 @@ export const CASE_SAVED_OBJECT = 'cases' as const;
 export const CASE_CONNECTOR_MAPPINGS_SAVED_OBJECT = 'cases-connector-mappings' as const;
 export const CASE_USER_ACTION_SAVED_OBJECT = 'cases-user-actions' as const;
 export const CASE_COMMENT_SAVED_OBJECT = 'cases-comments' as const;
+export const CASE_ATTACHMENT_SAVED_OBJECT = 'cases-attachments' as const;
 export const CASE_CONFIGURE_SAVED_OBJECT = 'cases-configure' as const;
 export const CASE_RULES_SAVED_OBJECT = 'cases-rules' as const;
 export const CASE_ID_INCREMENTER_SAVED_OBJECT = 'cases-incrementing-id' as const;

--- a/x-pack/platform/plugins/shared/cases/common/types/api/attachment/latest.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/attachment/latest.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './v1';
+export * from './v2';

--- a/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v2.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v2.test.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AttachmentType } from '../../domain/attachment/v1';
+import { CombinedAttachmentRequestRt, CombinedBulkCreateAttachmentsRequestRt } from './v2';
+
+describe('Unified Attachments', () => {
+  describe('CombinedAttachmentRequestRt', () => {
+    it('accepts v1 user comment attachment request', () => {
+      const v1Request = {
+        comment: 'This is a comment',
+        type: AttachmentType.user,
+        owner: 'cases',
+      };
+
+      const query = CombinedAttachmentRequestRt.decode(v1Request);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: v1Request,
+      });
+    });
+
+    it('accepts v2 unified attachment request', () => {
+      const v2Request = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+        data: {
+          attributes: {
+            title: 'My Visualization',
+            visualizationType: 'lens',
+          },
+          timeRange: {
+            from: 'now-1d',
+            to: 'now',
+          },
+        },
+        metadata: {
+          description: 'A test visualization',
+        },
+      };
+
+      const query = CombinedAttachmentRequestRt.decode(v2Request);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: v2Request,
+      });
+    });
+
+    it('accepts v2 unified attachment request without optional fields', () => {
+      const v2Request = {
+        type: 'lens',
+      };
+
+      const query = CombinedAttachmentRequestRt.decode(v2Request);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: v2Request,
+      });
+    });
+
+    it('removes foo:bar attributes from v1 request', () => {
+      const v1Request = {
+        comment: 'This is a comment',
+        type: AttachmentType.user,
+        owner: 'cases',
+        foo: 'bar',
+      };
+
+      const query = CombinedAttachmentRequestRt.decode(v1Request);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: {
+          comment: 'This is a comment',
+          type: AttachmentType.user,
+          owner: 'cases',
+        },
+      });
+    });
+
+    it('removes foo:bar attributes from v2 request', () => {
+      const v2Request = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+        data: {
+          attributes: {
+            title: 'My Visualization',
+          },
+        },
+        metadata: {
+          description: 'A test visualization',
+        },
+        foo: 'bar',
+      };
+
+      const query = CombinedAttachmentRequestRt.decode(v2Request);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: {
+          type: 'lens',
+          attachmentId: 'attachment-123',
+          data: {
+            attributes: {
+              title: 'My Visualization',
+            },
+          },
+          metadata: {
+            description: 'A test visualization',
+          },
+        },
+      });
+    });
+  });
+
+  describe('CombinedBulkCreateAttachmentsRequestRt', () => {
+    it('accepts empty array', () => {
+      const query = CombinedBulkCreateAttachmentsRequestRt.decode([]);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: [],
+      });
+    });
+
+    it('accepts array of v1 attachment requests', () => {
+      const v1Requests = [
+        {
+          comment: 'First comment',
+          type: AttachmentType.user,
+          owner: 'cases',
+        },
+        {
+          comment: 'Second comment',
+          type: AttachmentType.user,
+          owner: 'cases',
+        },
+      ];
+
+      const query = CombinedBulkCreateAttachmentsRequestRt.decode(v1Requests);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: v1Requests,
+      });
+    });
+
+    it('accepts array of v2 attachment requests', () => {
+      const v2Requests = [
+        {
+          type: 'lens',
+          attachmentId: 'attachment-1',
+          data: {
+            attributes: {
+              title: 'First Visualization',
+            },
+          },
+        },
+        {
+          type: 'lens',
+          attachmentId: 'attachment-2',
+          data: {
+            attributes: {
+              title: 'Second Visualization',
+            },
+          },
+        },
+      ];
+
+      const query = CombinedBulkCreateAttachmentsRequestRt.decode(v2Requests);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: v2Requests,
+      });
+    });
+
+    it('accepts mixed array of v1 and v2 attachment requests', () => {
+      const mixedRequests = [
+        {
+          comment: 'This is a comment',
+          type: AttachmentType.user,
+          owner: 'cases',
+        },
+        {
+          type: 'lens',
+          attachmentId: 'attachment-123',
+          data: {
+            attributes: {
+              title: 'My Visualization',
+            },
+          },
+          metadata: {
+            description: 'A test visualization',
+          },
+        },
+      ];
+
+      const query = CombinedBulkCreateAttachmentsRequestRt.decode(mixedRequests);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: mixedRequests,
+      });
+    });
+
+    it('removes foo:bar attributes from requests in array', () => {
+      const requestsWithExtraFields = [
+        {
+          comment: 'This is a comment',
+          type: AttachmentType.user,
+          owner: 'cases',
+          foo: 'bar',
+        },
+        {
+          type: 'lens',
+          attachmentId: 'attachment-123',
+          foo: 'bar',
+        },
+      ];
+
+      const query = CombinedBulkCreateAttachmentsRequestRt.decode(requestsWithExtraFields);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: [
+          {
+            comment: 'This is a comment',
+            type: AttachmentType.user,
+            owner: 'cases',
+          },
+          {
+            type: 'lens',
+            attachmentId: 'attachment-123',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/attachment/v2.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { MAX_BULK_CREATE_ATTACHMENTS } from '../../../constants';
+import { AttachmentRequestRt } from './v1';
+import { UnifiedAttachmentPayloadRt } from '../../domain/attachment/v2';
+import { limitedArraySchema } from '../../../schema';
+
+export const CombinedAttachmentRequestRt = rt.union([
+  AttachmentRequestRt,
+  UnifiedAttachmentPayloadRt,
+]);
+
+export type CombinedAttachmentRequest = rt.TypeOf<typeof CombinedAttachmentRequestRt>;
+
+export const CombinedBulkCreateAttachmentsRequestRt = limitedArraySchema({
+  codec: CombinedAttachmentRequestRt,
+  min: 0,
+  max: MAX_BULK_CREATE_ATTACHMENTS,
+  fieldName: 'attachments',
+});
+
+export type CombinedBulkCreateAttachmentsRequest = rt.TypeOf<
+  typeof CombinedBulkCreateAttachmentsRequestRt
+>;

--- a/x-pack/platform/plugins/shared/cases/common/types/api/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/index.ts
@@ -32,3 +32,6 @@ export * as attachmentApiV1 from './attachment/v1';
 export * as metricsApiV1 from './metrics/v1';
 export * as customFieldsApiV1 from './custom_field/v1';
 export * as observableApiV1 from './observable/v1';
+
+// V2
+export * as attachmentApiV2 from './attachment/v2';

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/latest.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/latest.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './v1';
+export * from './v2';

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.test.ts
@@ -142,38 +142,89 @@ describe('Unified Attachments', () => {
       });
     });
 
-    it('accepts request without attachmentId', () => {
+    it('accepts request with only data', () => {
       const requestWithoutAttachmentId = {
-        type: 'lens',
+        type: 'user',
         data: {
-          attributes: {
-            title: 'My Visualization',
-          },
-        },
-        metadata: {
-          description: 'A test visualization',
+          content: 'My comment',
         },
       };
 
       const query = UnifiedAttachmentPayloadRt.decode(requestWithoutAttachmentId);
-
       expect(query).toStrictEqual({
         _tag: 'Right',
         right: requestWithoutAttachmentId,
       });
     });
 
-    it('accepts request with only type', () => {
+    it('accepts request with only attachmentId', () => {
+      const requestWithOnlyAttachmentId = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+      };
+
+      const query = UnifiedAttachmentPayloadRt.decode(requestWithOnlyAttachmentId);
+
+      expect(query._tag).toBe('Right');
+      if (query._tag === 'Right') {
+        expect(query.right).toMatchObject(requestWithOnlyAttachmentId);
+        expect(query.right).not.toHaveProperty('metadata');
+      }
+    });
+
+    it('accepts request with attachmentId and metadata', () => {
+      const requestWithAttachmentIdAndMetadata = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+        metadata: {
+          description: 'A test visualization',
+        },
+      };
+
+      const query = UnifiedAttachmentPayloadRt.decode(requestWithAttachmentIdAndMetadata);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithAttachmentIdAndMetadata,
+      });
+    });
+    it('accepts request without metadata', () => {
+      const requestWithoutMetadata = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+        data: {
+          attributes: {
+            title: 'My Visualization',
+          },
+        },
+      };
+
+      const query = UnifiedAttachmentPayloadRt.decode(requestWithoutMetadata);
+
+      expect(query._tag).toBe('Right');
+      if (query._tag === 'Right') {
+        expect(query.right).toMatchObject({
+          type: 'lens',
+          attachmentId: 'attachment-123',
+          data: {
+            attributes: {
+              title: 'My Visualization',
+            },
+          },
+        });
+        // metadata should not be present when not provided
+        expect(query.right).not.toHaveProperty('metadata');
+      }
+    });
+
+    it('rejects request with neither attachmentId nor data', () => {
       const requestWithOnlyType = {
         type: 'lens',
       };
 
       const query = UnifiedAttachmentPayloadRt.decode(requestWithOnlyType);
 
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: requestWithOnlyType,
-      });
+      expect(query._tag).toBe('Left');
     });
   });
 
@@ -219,8 +270,58 @@ describe('Unified Attachments', () => {
       });
     });
 
-    it('accepts request without optional fields', () => {
-      const requestWithoutOptional = {
+    it('accepts request with only attachmentId', () => {
+      const requestWithOnlyAttachmentId = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+      };
+
+      const query = UnifiedAttachmentAttributesRt.decode(requestWithOnlyAttachmentId);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithOnlyAttachmentId,
+      });
+    });
+
+    it('accepts request with only data', () => {
+      const requestWithOnlyData = {
+        type: 'user',
+        data: {
+          content: 'My comment',
+        },
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+      };
+
+      const query = UnifiedAttachmentAttributesRt.decode(requestWithOnlyData);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithOnlyData,
+      });
+    });
+
+    it('rejects request with neither attachmentId nor data', () => {
+      const requestWithoutRequired = {
         type: 'lens',
         created_at: '2019-11-25T22:32:30.608Z',
         created_by: {
@@ -234,12 +335,9 @@ describe('Unified Attachments', () => {
         pushed_by: null,
       };
 
-      const query = UnifiedAttachmentAttributesRt.decode(requestWithoutOptional);
+      const query = UnifiedAttachmentAttributesRt.decode(requestWithoutRequired);
 
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: requestWithoutOptional,
-      });
+      expect(query._tag).toBe('Left');
     });
   });
 
@@ -287,8 +385,62 @@ describe('Unified Attachments', () => {
       });
     });
 
-    it('accepts request without optional fields', () => {
-      const requestWithoutOptional = {
+    it('accepts request with only attachmentId', () => {
+      const requestWithOnlyAttachmentId = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+        id: 'attachment-id-123',
+        version: 'WzEwMCwxXQ==',
+      };
+
+      const query = UnifiedAttachmentRt.decode(requestWithOnlyAttachmentId);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithOnlyAttachmentId,
+      });
+    });
+
+    it('accepts request with only data', () => {
+      const requestWithOnlyData = {
+        type: 'user',
+        data: {
+          content: 'My comment',
+        },
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+        id: 'attachment-id-123',
+        version: 'WzEwMCwxXQ==',
+      };
+
+      const query = UnifiedAttachmentRt.decode(requestWithOnlyData);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithOnlyData,
+      });
+    });
+
+    it('rejects request with neither attachmentId nor data', () => {
+      const requestWithoutRequired = {
         type: 'lens',
         created_at: '2019-11-25T22:32:30.608Z',
         created_by: {
@@ -304,12 +456,9 @@ describe('Unified Attachments', () => {
         version: 'WzEwMCwxXQ==',
       };
 
-      const query = UnifiedAttachmentRt.decode(requestWithoutOptional);
+      const query = UnifiedAttachmentRt.decode(requestWithoutRequired);
 
-      expect(query).toStrictEqual({
-        _tag: 'Right',
-        right: requestWithoutOptional,
-      });
+      expect(query._tag).toBe('Left');
     });
   });
 
@@ -317,6 +466,7 @@ describe('Unified Attachments', () => {
     it('accepts UnifiedAttachmentRt', () => {
       const unifiedAttachment = {
         type: 'lens',
+        attachmentId: 'attachment-123',
         created_at: '2019-11-25T22:32:30.608Z',
         created_by: {
           full_name: 'elastic',

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.test.ts
@@ -1,0 +1,369 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  AttachmentAttributesBasicWithoutOwnerRt,
+  UnifiedAttachmentPayloadRt,
+  UnifiedAttachmentAttributesRt,
+  UnifiedAttachmentRt,
+  CombinedAttachmentRt,
+} from './v2';
+import { AttachmentType } from './v1';
+
+describe('Unified Attachments', () => {
+  describe('AttachmentAttributesBasicWithoutOwnerRt', () => {
+    const defaultRequest = {
+      created_at: '2019-11-25T22:32:30.608Z',
+      created_by: {
+        full_name: 'elastic',
+        email: 'testemail@elastic.co',
+        username: 'elastic',
+      },
+      updated_at: null,
+      updated_by: null,
+      pushed_at: null,
+      pushed_by: null,
+    };
+
+    it('has expected attributes in request', () => {
+      const query = AttachmentAttributesBasicWithoutOwnerRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = AttachmentAttributesBasicWithoutOwnerRt.decode({
+        ...defaultRequest,
+        foo: 'bar',
+      });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('accepts pushed_at and pushed_by as strings', () => {
+      const requestWithPushed = {
+        ...defaultRequest,
+        pushed_at: '2019-11-26T22:32:30.608Z',
+        pushed_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+      };
+
+      const query = AttachmentAttributesBasicWithoutOwnerRt.decode(requestWithPushed);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithPushed,
+      });
+    });
+
+    it('accepts updated_at and updated_by as strings', () => {
+      const requestWithUpdated = {
+        ...defaultRequest,
+        updated_at: '2019-11-26T22:32:30.608Z',
+        updated_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+      };
+
+      const query = AttachmentAttributesBasicWithoutOwnerRt.decode(requestWithUpdated);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithUpdated,
+      });
+    });
+  });
+
+  describe('UnifiedAttachmentPayloadRt', () => {
+    const defaultRequest = {
+      type: 'lens',
+      attachmentId: 'attachment-123',
+      data: {
+        attributes: {
+          title: 'My Visualization',
+          visualizationType: 'lens',
+        },
+        timeRange: {
+          from: 'now-1d',
+          to: 'now',
+        },
+      },
+      metadata: {
+        description: 'A test visualization',
+      },
+    };
+
+    it('has expected attributes in request', () => {
+      const query = UnifiedAttachmentPayloadRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = UnifiedAttachmentPayloadRt.decode({ ...defaultRequest, foo: 'bar' });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('accepts null data', () => {
+      const requestWithNullData = {
+        type: 'lens',
+        attachmentId: 'attachment-123',
+        data: null,
+        metadata: null,
+      };
+
+      const query = UnifiedAttachmentPayloadRt.decode(requestWithNullData);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithNullData,
+      });
+    });
+
+    it('accepts request without attachmentId', () => {
+      const requestWithoutAttachmentId = {
+        type: 'lens',
+        data: {
+          attributes: {
+            title: 'My Visualization',
+          },
+        },
+        metadata: {
+          description: 'A test visualization',
+        },
+      };
+
+      const query = UnifiedAttachmentPayloadRt.decode(requestWithoutAttachmentId);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithoutAttachmentId,
+      });
+    });
+
+    it('accepts request with only type', () => {
+      const requestWithOnlyType = {
+        type: 'lens',
+      };
+
+      const query = UnifiedAttachmentPayloadRt.decode(requestWithOnlyType);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithOnlyType,
+      });
+    });
+  });
+
+  describe('UnifiedAttachmentAttributesRt', () => {
+    const defaultRequest = {
+      type: 'lens',
+      attachmentId: 'attachment-123',
+      data: {
+        attributes: {
+          title: 'My Visualization',
+        },
+      },
+      metadata: {
+        description: 'A test visualization',
+      },
+      created_at: '2019-11-25T22:32:30.608Z',
+      created_by: {
+        full_name: 'elastic',
+        email: 'testemail@elastic.co',
+        username: 'elastic',
+      },
+      updated_at: null,
+      updated_by: null,
+      pushed_at: null,
+      pushed_by: null,
+    };
+
+    it('has expected attributes in request', () => {
+      const query = UnifiedAttachmentAttributesRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = UnifiedAttachmentAttributesRt.decode({ ...defaultRequest, foo: 'bar' });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('accepts request without optional fields', () => {
+      const requestWithoutOptional = {
+        type: 'lens',
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+      };
+
+      const query = UnifiedAttachmentAttributesRt.decode(requestWithoutOptional);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithoutOptional,
+      });
+    });
+  });
+
+  describe('UnifiedAttachmentRt', () => {
+    const defaultRequest = {
+      type: 'lens',
+      attachmentId: 'attachment-123',
+      data: {
+        attributes: {
+          title: 'My Visualization',
+        },
+      },
+      metadata: {
+        description: 'A test visualization',
+      },
+      created_at: '2019-11-25T22:32:30.608Z',
+      created_by: {
+        full_name: 'elastic',
+        email: 'testemail@elastic.co',
+        username: 'elastic',
+      },
+      updated_at: null,
+      updated_by: null,
+      pushed_at: null,
+      pushed_by: null,
+      id: 'attachment-id-123',
+      version: 'WzEwMCwxXQ==',
+    };
+
+    it('has expected attributes in request', () => {
+      const query = UnifiedAttachmentRt.decode(defaultRequest);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('removes foo:bar attributes from request', () => {
+      const query = UnifiedAttachmentRt.decode({ ...defaultRequest, foo: 'bar' });
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: defaultRequest,
+      });
+    });
+
+    it('accepts request without optional fields', () => {
+      const requestWithoutOptional = {
+        type: 'lens',
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+        id: 'attachment-id-123',
+        version: 'WzEwMCwxXQ==',
+      };
+
+      const query = UnifiedAttachmentRt.decode(requestWithoutOptional);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: requestWithoutOptional,
+      });
+    });
+  });
+
+  describe('CombinedAttachmentRt', () => {
+    it('accepts UnifiedAttachmentRt', () => {
+      const unifiedAttachment = {
+        type: 'lens',
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+        id: 'attachment-id-123',
+        version: 'WzEwMCwxXQ==',
+      };
+
+      const query = CombinedAttachmentRt.decode(unifiedAttachment);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: unifiedAttachment,
+      });
+    });
+
+    it('accepts AttachmentRt (v1)', () => {
+      const v1Attachment = {
+        type: AttachmentType.user,
+        comment: 'This is a comment',
+        owner: 'cases',
+        created_at: '2019-11-25T22:32:30.608Z',
+        created_by: {
+          full_name: 'elastic',
+          email: 'testemail@elastic.co',
+          username: 'elastic',
+        },
+        updated_at: null,
+        updated_by: null,
+        pushed_at: null,
+        pushed_by: null,
+        id: 'attachment-id-123',
+        version: 'WzEwMCwxXQ==',
+      };
+
+      const query = CombinedAttachmentRt.decode(v1Attachment);
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: v1Attachment,
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { jsonValueRt } from '../../../api';
+import { UserRt } from '../user/v1';
+import { AttachmentRt } from './v1';
+
+/**
+ * Payload for Unified Attachments
+ */
+export const UnifiedAttachmentPayloadRt = rt.intersection([
+  rt.strict({
+    type: rt.string,
+  }),
+  rt.exact(
+    rt.partial({
+      attachmentId: rt.string,
+      data: rt.union([rt.null, rt.record(rt.string, jsonValueRt)]),
+      metadata: rt.union([rt.null, rt.record(rt.string, jsonValueRt)]),
+    })
+  ),
+]);
+
+/**
+ * Basic attributes for Unified Attachments
+ * Contains all the basic attributes minus the owner
+ */
+export const AttachmentAttributesBasicWithoutOwnerRt = rt.strict({
+  created_at: rt.string,
+  created_by: UserRt,
+  pushed_at: rt.union([rt.string, rt.null]),
+  pushed_by: rt.union([UserRt, rt.null]),
+  updated_at: rt.union([rt.string, rt.null]),
+  updated_by: rt.union([UserRt, rt.null]),
+});
+
+/**
+ * Saved Object attributes for Unified Attachments
+ * Contains the payload and the basic attributes
+ */
+export const UnifiedAttachmentAttributesRt = rt.intersection([
+  UnifiedAttachmentPayloadRt,
+  AttachmentAttributesBasicWithoutOwnerRt,
+]);
+
+/**
+ * Full Saved Object representationfor Unified Attachments
+ * Contains payload, basic attributes and id and version
+ */
+export const UnifiedAttachmentRt = rt.intersection([
+  UnifiedAttachmentAttributesRt,
+  rt.strict({
+    id: rt.string,
+    version: rt.string,
+  }),
+]);
+
+export type UnifiedAttachmentPayload = rt.TypeOf<typeof UnifiedAttachmentPayloadRt>;
+export type UnifiedAttachmentAttributes = rt.TypeOf<typeof UnifiedAttachmentAttributesRt>;
+export type UnifiedAttachment = rt.TypeOf<typeof UnifiedAttachmentRt>;
+
+/**
+ * Combined v1 legacy and v2 unified attachment types
+ */
+export const CombinedAttachmentRt = rt.union([AttachmentRt, UnifiedAttachmentRt]);
+export type CombinedAttachment = rt.TypeOf<typeof CombinedAttachmentRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/attachment/v2.ts
@@ -12,6 +12,12 @@ import { AttachmentRt } from './v1';
 
 /**
  * Payload for Unified Attachments
+ * - type: always required
+ * - metadata: always optional
+ * - Either attachmentId or data (or both) must be present
+ *   - attachmentId: for references to external entities (alerts, events, external references)
+ *   - data: for content/state (user comments, persistable state)
+ *   - Both: persistable state attachments use both (typeId -> attachmentId, state -> data)
  */
 export const UnifiedAttachmentPayloadRt = rt.intersection([
   rt.strict({
@@ -19,11 +25,21 @@ export const UnifiedAttachmentPayloadRt = rt.intersection([
   }),
   rt.exact(
     rt.partial({
-      attachmentId: rt.string,
-      data: rt.union([rt.null, rt.record(rt.string, jsonValueRt)]),
       metadata: rt.union([rt.null, rt.record(rt.string, jsonValueRt)]),
     })
   ),
+  rt.union([
+    rt.strict({
+      attachmentId: rt.string,
+      data: rt.union([rt.null, rt.record(rt.string, jsonValueRt)]),
+    }),
+    rt.strict({
+      attachmentId: rt.string,
+    }),
+    rt.strict({
+      data: rt.union([rt.null, rt.record(rt.string, jsonValueRt)]),
+    }),
+  ]),
 ]);
 
 /**

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/index.ts
@@ -28,3 +28,6 @@ export * as connectorDomainV1 from './connector/v1';
 export * as attachmentDomainV1 from './attachment/v1';
 export * as observableDomainV1 from './observable/v1';
 export * as templateDomainV1 from './template/v1';
+
+// V2
+export * as attachmentDomainV2 from './attachment/v2';

--- a/x-pack/platform/plugins/shared/cases/common/ui/types.ts
+++ b/x-pack/platform/plugins/shared/cases/common/ui/types.ts
@@ -36,6 +36,8 @@ import type {
   Configuration,
   CustomFieldTypes,
   EventAttachment,
+  UnifiedAttachment,
+  CombinedAttachment,
 } from '../types/domain';
 import type {
   CasePatchRequest,
@@ -104,6 +106,9 @@ export type CaseViewRefreshPropInterface = null | {
 };
 
 export type AttachmentUI = SnakeToCamelCase<Attachment>;
+export type UnifiedAttachmentUI = SnakeToCamelCase<UnifiedAttachment>;
+export type CombinedAttachmentUI = SnakeToCamelCase<CombinedAttachment>;
+
 export type AlertAttachmentUI = SnakeToCamelCase<AlertAttachment>;
 export type ExternalReferenceAttachmentUI = SnakeToCamelCase<ExternalReferenceAttachment>;
 export type PersistableStateAttachmentUI = SnakeToCamelCase<PersistableStateAttachment>;

--- a/x-pack/platform/plugins/shared/cases/common/utils/saved_object_types.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/saved_object_types.ts
@@ -12,10 +12,14 @@ import {
   CASE_COMMENT_SAVED_OBJECT,
   CASE_CONFIGURE_SAVED_OBJECT,
   CASE_TEMPLATE_SAVED_OBJECT,
+  CASE_ATTACHMENT_SAVED_OBJECT,
 } from '../constants';
 
 interface CasesConfigType {
   templates?: {
+    enabled?: boolean;
+  };
+  attachments?: {
     enabled?: boolean;
   };
 }
@@ -32,9 +36,15 @@ export const getSavedObjectsTypes = (config?: Partial<CasesConfigType>): string[
     CASE_CONFIGURE_SAVED_OBJECT,
   ];
 
-  if (!config?.templates?.enabled) {
-    return baseSavedObjects;
+  const experimentalSOs: string[] = [];
+
+  if (config?.templates?.enabled) {
+    experimentalSOs.push(CASE_TEMPLATE_SAVED_OBJECT);
   }
 
-  return [...baseSavedObjects, CASE_TEMPLATE_SAVED_OBJECT];
+  if (config?.attachments?.enabled) {
+    experimentalSOs.push(CASE_ATTACHMENT_SAVED_OBJECT);
+  }
+
+  return [...baseSavedObjects, ...experimentalSOs];
 };

--- a/x-pack/platform/plugins/shared/cases/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.test.ts
@@ -17,6 +17,9 @@ describe('config validation', () => {
               "enabled": false,
             },
           },
+          "attachments": Object {
+            "enabled": false,
+          },
           "enabled": true,
           "files": Object {
             "allowedMimeTypes": Array [
@@ -125,6 +128,21 @@ describe('config validation', () => {
           },
         }
       `);
+    });
+
+    it('sets attachments.enabled default to false', () => {
+      const config = ConfigSchema.validate({});
+      expect(config.attachments.enabled).toBe(false);
+    });
+
+    it('allows attachments.enabled to be set to true', () => {
+      const config = ConfigSchema.validate({ attachments: { enabled: true } });
+      expect(config.attachments.enabled).toBe(true);
+    });
+
+    it('allows attachments.enabled to be set to false explicitly', () => {
+      const config = ConfigSchema.validate({ attachments: { enabled: false } });
+      expect(config.attachments.enabled).toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -22,6 +22,9 @@ export const ConfigSchema = schema.object({
       }),
     }),
   }),
+  attachments: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
   files: schema.object({
     allowedMimeTypes: schema.arrayOf(schema.string({ minLength: 1 }), {
       defaultValue: ALLOWED_MIME_TYPES,

--- a/x-pack/platform/plugins/shared/cases/server/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/index.ts
@@ -22,6 +22,9 @@ export const config: PluginConfigDescriptor<ConfigType> = {
     templates: {
       enabled: true,
     },
+    attachments: {
+      enabled: true,
+    },
   },
   deprecations: ({ renameFromRoot }) => [
     renameFromRoot('xpack.case.enabled', 'xpack.cases.enabled', { level: 'critical' }),

--- a/x-pack/platform/plugins/shared/cases/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/mocks.ts
@@ -775,6 +775,9 @@ export const mockCasesContract = (): CasesServerStart => ({
     templates: {
       enabled: true,
     },
+    attachments: {
+      enabled: true,
+    },
   },
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -21,6 +21,7 @@ import { alertsMock } from '@kbn/alerting-plugin/server/mocks';
 import { CasePlugin } from './plugin';
 import type { ConfigType } from './config';
 import { ALLOWED_MIME_TYPES } from '../common/constants/mime_types';
+import { CASE_ATTACHMENT_SAVED_OBJECT } from '../common/constants';
 import type { CasesServerSetupDependencies, CasesServerStartDependencies } from './types';
 
 function getConfig(overrides: Partial<ConfigType> = {}): ConfigType {
@@ -32,6 +33,7 @@ function getConfig(overrides: Partial<ConfigType> = {}): ConfigType {
     incrementalId: { enabled: true, taskIntervalMinutes: 10, taskStartDelayMinutes: 10 },
     analytics: { index: { enabled: true } },
     templates: { enabled: true },
+    attachments: { enabled: true },
     ...overrides,
   };
 }
@@ -109,6 +111,51 @@ describe('Cases Plugin', () => {
 
       expect(pluginsSetup.features.registerKibanaFeature).not.toHaveBeenCalled();
     });
+
+    it('should register cases-attachments SO when attachments.enabled is true', async () => {
+      context = coreMock.createPluginInitializerContext<ConfigType>(
+        getConfig({ attachments: { enabled: true } })
+      );
+      const pluginWithAttachmentsEnabled = new CasePlugin(context);
+
+      pluginWithAttachmentsEnabled.setup(coreSetup, pluginsSetup);
+
+      const registerTypeCalls = coreSetup.savedObjects.registerType.mock.calls;
+      const attachmentSOCall = registerTypeCalls.find(
+        (call) => call[0]?.name === CASE_ATTACHMENT_SAVED_OBJECT
+      );
+      expect(attachmentSOCall).toBeDefined();
+    });
+
+    it('should not register cases-attachments SO when attachments.enabled is false', async () => {
+      context = coreMock.createPluginInitializerContext<ConfigType>(
+        getConfig({ attachments: { enabled: false } })
+      );
+      const pluginWithAttachmentsDisabled = new CasePlugin(context);
+
+      pluginWithAttachmentsDisabled.setup(coreSetup, pluginsSetup);
+
+      const registerTypeCalls = coreSetup.savedObjects.registerType.mock.calls;
+      const attachmentSOCall = registerTypeCalls.find(
+        (call) => call[0]?.name === 'cases-attachments'
+      );
+      expect(attachmentSOCall).toBeUndefined();
+    });
+
+    it('should not register cases-attachments SO when attachments is undefined', async () => {
+      context = coreMock.createPluginInitializerContext<ConfigType>(
+        getConfig({ attachments: undefined } as Partial<ConfigType>)
+      );
+      const pluginWithAttachmentsUndefined = new CasePlugin(context);
+
+      pluginWithAttachmentsUndefined.setup(coreSetup, pluginsSetup);
+
+      const registerTypeCalls = coreSetup.savedObjects.registerType.mock.calls;
+      const attachmentSOCall = registerTypeCalls.find(
+        (call) => call[0]?.name === 'cases-attachments'
+      );
+      expect(attachmentSOCall).toBeUndefined();
+    });
   });
 
   describe('start', () => {
@@ -124,6 +171,9 @@ describe('Cases Plugin', () => {
               "index": Object {
                 "enabled": true,
               },
+            },
+            "attachments": Object {
+              "enabled": true,
             },
             "enabled": true,
             "files": Object {

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -128,7 +128,7 @@ export class CasePlugin
       logger: this.logger,
       persistableStateAttachmentTypeRegistry: this.persistableStateAttachmentTypeRegistry,
       lensEmbeddableFactory: this.lensEmbeddableFactory,
-      templatesConfig: this.caseConfig.templates,
+      config: this.caseConfig,
     });
 
     core.http.registerRouteHandlerContext<CasesRequestHandlerContext, 'cases'>(

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/index.ts
@@ -10,6 +10,9 @@ import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-serve
 import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../common/constants';
 
 /**
+ * Saved object type for unified attachments
+ * This is the v2 version of the comments saved object type (CASE_COMMENT_SAVED_OBJECT).
+ *
  * The comments in the mapping indicate the additional properties that are stored in Elasticsearch but are not indexed.
  * Remove these comments when https://github.com/elastic/kibana/issues/152756 is resolved.
  */

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/attachments/index.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsType } from '@kbn/core/server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { CASE_ATTACHMENT_SAVED_OBJECT } from '../../../common/constants';
+
+/**
+ * The comments in the mapping indicate the additional properties that are stored in Elasticsearch but are not indexed.
+ * Remove these comments when https://github.com/elastic/kibana/issues/152756 is resolved.
+ */
+
+export const createCaseAttachmentSavedObjectType = (): SavedObjectsType => ({
+  name: CASE_ATTACHMENT_SAVED_OBJECT,
+  indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
+  hidden: true,
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
+  mappings: {
+    dynamic: false,
+    properties: {
+      type: {
+        type: 'keyword',
+      },
+      attachmentId: {
+        type: 'keyword',
+      },
+      data: {
+        properties: {
+          content: {
+            type: 'text',
+          },
+          /*
+          persistableState: {
+            dynamic: false,
+            properties: {},
+          },
+           */
+        },
+      },
+      metadata: {
+        properties: {
+          actionType: {
+            type: 'keyword',
+          },
+        },
+      },
+      created_at: {
+        type: 'date',
+      },
+      created_by: {
+        properties: {
+          /*
+          full_name: {
+            type: 'keyword',
+          },
+          email: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+           */
+          username: {
+            type: 'keyword',
+          },
+        },
+      },
+      pushed_at: {
+        type: 'date',
+      },
+      /*
+      pushed_by: {
+        properties: {
+          username: {
+            type: 'keyword',
+          },
+          full_name: {
+            type: 'keyword',
+          },
+          email: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+        },
+      },
+       */
+      updated_at: {
+        type: 'date',
+      },
+      /*
+      updated_by: {
+        properties: {
+          username: {
+            type: 'keyword',
+          },
+          full_name: {
+            type: 'keyword',
+          },
+          email: {
+            type: 'keyword',
+          },
+          profile_uid: {
+            type: 'keyword',
+          },
+        },
+      },
+       */
+    },
+  },
+  migrations: () => ({}),
+  modelVersions: {},
+  management: {
+    importableAndExportable: true,
+    visibleInManagement: false,
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
@@ -15,6 +15,7 @@ import { caseConnectorMappingsSavedObjectType } from './connector_mappings';
 import { casesTelemetrySavedObjectType } from './telemetry';
 import { casesRulesSavedObjectType } from './cases_rules';
 import { caseIdIncrementerSavedObjectType } from './id_incrementer';
+import { createCaseAttachmentSavedObjectType } from './attachments';
 import type { PersistableStateAttachmentTypeRegistry } from '../attachment_framework/persistable_state_registry';
 import { caseTemplateSavedObjectType } from './templates';
 import type { ConfigType } from '../config';
@@ -24,7 +25,7 @@ interface RegisterSavedObjectsArgs {
   logger: Logger;
   persistableStateAttachmentTypeRegistry: PersistableStateAttachmentTypeRegistry;
   lensEmbeddableFactory: LensServerPluginSetup['lensEmbeddableFactory'];
-  templatesConfig?: ConfigType['templates'];
+  config: ConfigType;
 }
 
 export const registerSavedObjects = ({
@@ -32,7 +33,7 @@ export const registerSavedObjects = ({
   logger,
   persistableStateAttachmentTypeRegistry,
   lensEmbeddableFactory,
-  templatesConfig,
+  config,
 }: RegisterSavedObjectsArgs) => {
   core.savedObjects.registerType(
     createCaseCommentSavedObjectType({
@@ -56,7 +57,10 @@ export const registerSavedObjects = ({
   core.savedObjects.registerType(casesTelemetrySavedObjectType);
   core.savedObjects.registerType(casesRulesSavedObjectType);
 
-  if (templatesConfig?.enabled) {
+  if (config.templates?.enabled) {
     core.savedObjects.registerType(caseTemplateSavedObjectType);
+  }
+  if (config.attachments?.enabled) {
+    core.savedObjects.registerType(createCaseAttachmentSavedObjectType());
   }
 };


### PR DESCRIPTION
## Summary

This PR added a saved object type called `cases-attachments`, and it will be registered when feature flag `xpack.cases.attachments.enabled` is on. 


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
- [x] This PR is assisted by Cursor and LLM

