### PR TITLE
[9.1] chore(NA): use different gcp zones for spot instances (#248181)

### DIFF
--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -130,7 +130,8 @@ disabled:
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/basic_license_essentials_tier/configs/serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/sources/indices/trial_license_complete_tier/configs/serverless.config.ts
-  - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/serverless.config.ts
+  - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/serverless.config.ts:
+      queue: n2-4-spot
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/authentication/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/metadata/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/package/trial_license_complete_tier/configs/serverless.config.ts

--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -110,7 +110,8 @@ enabled:
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/basic_license_essentials_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/sources/indices/trial_license_complete_tier/configs/ess.config.ts
-  - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/ess.config.ts
+  - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/ess.config.ts:
+      queue: n2-4-spot
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/authentication/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/metadata/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/package/trial_license_complete_tier/configs/ess.config.ts

--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -81,10 +81,11 @@ function getAgentImageConfig({ returnYaml = false } = {}): string | BuildkiteAge
 
 const expandAgentQueue = (queueName: string = 'n2-4-spot', diskSizeGb?: number) => {
   const [kind, cores, addition] = queueName.split('-');
+  const zonesToUse = 'southamerica-east1-c,asia-south2-a,us-central1-f';
   const additionalProps =
     {
-      spot: { preemptible: true },
-      virt: { enableNestedVirtualization: true },
+      spot: { preemptible: true, zones: zonesToUse },
+      virt: { enableNestedVirtualization: true, spotZones: zonesToUse },
     }[addition] || {};
 
   return {

--- a/.buildkite/pipelines/build_api_docs.yml
+++ b/.buildkite/pipelines/build_api_docs.yml
@@ -10,6 +10,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 70
 
   - command: .buildkite/scripts/steps/api_docs/build_api_docs.sh
@@ -20,6 +21,7 @@ steps:
       provider: gcp
       machineType: n2-highmem-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     key: build_api_docs
     timeout_in_minutes: 50
     retry:
@@ -37,6 +39,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     key: publish_api_docs
     timeout_in_minutes: 50
     retry:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -38,6 +38,7 @@ steps:
       provider: gcp
       machineType: n2-standard-8
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
     key: build
     timeout_in_minutes: 60
     retry:
@@ -54,6 +55,7 @@ steps:
       machineType: n2-highcpu-8
       preemptible: true
       diskSizeGb: 105
+      spotZones: us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -68,6 +70,7 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -83,6 +86,7 @@ steps:
       provider: gcp
       machineType: n2-standard-16
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -98,6 +102,7 @@ steps:
       provider: gcp
       machineType: n2-standard-32
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -112,9 +117,9 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c4-standard-4
-      diskType: 'hyperdisk-balanced'
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-a,us-central1-b,us-central1-c
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -130,6 +135,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -147,6 +153,7 @@ steps:
       provider: gcp
       machineType: n2-highmem-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 80
     retry:
@@ -218,6 +225,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 4
     retry:
@@ -233,6 +241,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -248,6 +257,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -263,6 +273,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -278,6 +289,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -293,6 +305,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 5
     retry:
@@ -308,6 +321,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 3
     retry:
@@ -323,6 +337,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -338,6 +353,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -353,6 +369,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -368,6 +385,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 3
     retry:
@@ -383,6 +401,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 8
     retry:
@@ -398,6 +417,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     parallelism: 8
     retry:
@@ -413,6 +433,9 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      diskSizeGb: 105
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 75
     parallelism: 20
     retry:
@@ -427,9 +450,11 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
+      diskSizeGb: 105
       preemptible: true
-    timeout_in_minutes: 120
-    parallelism: 3
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
+    timeout_in_minutes: 75
+    parallelism: 14
     retry:
       automatic:
         - exit_status: '-1'
@@ -443,6 +468,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 120
     parallelism: 3
     retry:
@@ -467,6 +493,7 @@ steps:
       provider: gcp
       machineType: n2-standard-8
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     key: storybooks
     timeout_in_minutes: 80
     retry:
@@ -482,6 +509,7 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     timeout_in_minutes: 60
     soft_fail: true
     retry:
@@ -497,6 +525,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     artifact_paths: 'target/plugin_so_types_snapshot.json'
     timeout_in_minutes: 30
     retry:

--- a/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
+++ b/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
@@ -22,6 +22,7 @@ steps:
         agents:
           machineType: n2-standard-4
           preemptible: true
+          spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
         retry:
           automatic:
             - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/apm_cypress.yml
+++ b/.buildkite/pipelines/pull_request/apm_cypress.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -24,7 +24,8 @@ steps:
     agents:
       machineType: n2-standard-8
       preemptible: true
-      diskSizeGb: 150
+      spotZones: us-central1-c,us-central1-b,us-central1-a
+      diskSizeGb: 200
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
     timeout_in_minutes: 90
@@ -38,6 +39,7 @@ steps:
     agents:
       machineType: n2-highcpu-8
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     key: quick_checks
     timeout_in_minutes: 60
@@ -52,6 +54,7 @@ steps:
     agents:
       machineType: n2-standard-2
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -64,6 +67,7 @@ steps:
     agents:
       machineType: n2-standard-16
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     key: linting
     timeout_in_minutes: 60
@@ -77,6 +81,7 @@ steps:
     agents:
       machineType: n2-standard-32
       preemptible: true
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     key: linting_with_types
     timeout_in_minutes: 60
@@ -90,6 +95,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     key: check_oas_snapshot
     timeout_in_minutes: 60
     retry:
@@ -101,9 +107,9 @@ steps:
     label: 'Check Types'
     agents:
       machineType: c4-standard-4
-      diskType: 'hyperdisk-balanced'
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-a,us-central1-b,us-central1-c
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60
@@ -132,6 +138,7 @@ steps:
     agents:
       machineType: n2-highmem-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 105
     key: build_api_docs
     timeout_in_minutes: 90

--- a/.buildkite/pipelines/pull_request/base_merged_phases.yml
+++ b/.buildkite/pipelines/pull_request/base_merged_phases.yml
@@ -80,9 +80,9 @@ steps:
     label: 'Check Types'
     agents:
       machineType: c4-standard-4
-      diskType: 'hyperdisk-balanced'
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-a,us-central1-b,us-central1-c
+      spotZones: us-central1-c,us-central1-b,us-central1-a
       diskSizeGb: 115
     key: check_types
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/exploratory_view_plugin.yml
+++ b/.buildkite/pipelines/pull_request/exploratory_view_plugin.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/fips.yml
+++ b/.buildkite/pipelines/pull_request/fips.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-2
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/fleet_cypress.yml
+++ b/.buildkite/pipelines/pull_request/fleet_cypress.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/kbn_handlebars.yml
+++ b/.buildkite/pipelines/pull_request/kbn_handlebars.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-2
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/profiling_cypress.yml
+++ b/.buildkite/pipelines/pull_request/profiling_cypress.yml
@@ -4,6 +4,8 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
+    timeout_in_minutes: 15
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/renovate.yml
+++ b/.buildkite/pipelines/pull_request/renovate.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-highcpu-8
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     key: renovate_validation
     timeout_in_minutes: 60
     retry:

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -4,6 +4,8 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks
@@ -23,6 +25,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks
@@ -42,6 +45,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,6 +4,9 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      diskSizeGb: 105
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks
@@ -24,6 +25,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/explore.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/explore.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml
@@ -22,6 +22,7 @@ steps:
         agents:
           machineType: n2-standard-4
           preemptible: true
+          spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
         retry:
           automatic:
             - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/playwright.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/playwright.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks
@@ -24,6 +25,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks
@@ -44,6 +46,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks
@@ -64,6 +67,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks
@@ -84,6 +88,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/storybooks.yml
+++ b/.buildkite/pipelines/pull_request/storybooks.yml
@@ -4,5 +4,6 @@ steps:
     agents:
       machineType: n2-standard-8
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     key: storybooks
     timeout_in_minutes: 80

--- a/.buildkite/pipelines/pull_request/synthetics_plugin.yml
+++ b/.buildkite/pipelines/pull_request/synthetics_plugin.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/uptime_plugin.yml
+++ b/.buildkite/pipelines/pull_request/uptime_plugin.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/ux_plugin_e2e.yml
+++ b/.buildkite/pipelines/pull_request/ux_plugin_e2e.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: n2-standard-4
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/webpack_bundle_analyzer.yml
+++ b/.buildkite/pipelines/pull_request/webpack_bundle_analyzer.yml
@@ -4,5 +4,6 @@ steps:
     agents:
       machineType: n2-standard-8
       preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     key: webpack_bundle_analyzer
     timeout_in_minutes: 60


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [chore(NA): use different gcp zones for spot instances (#248181)](https://github.com/elastic/kibana/pull/248181)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2026-01-29T15:43:53Z","message":"chore(NA): use different gcp zones for spot instances (#248181)\n\nCloses https://github.com/elastic/kibana-operations/issues/414\n\nThis PR declares spotZones to be used on preemptible machine based jobs\naccording to data we have of zones that historically have been failing\nthe most over the past couple months.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"7c88eeec4f459a1af5515fbfbf7e1d38c5623acf","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v9.4.0"],"title":"chore(NA): use different gcp zones for spot instances","number":248181,"url":"https://github.com/elastic/kibana/pull/248181","mergeCommit":{"message":"chore(NA): use different gcp zones for spot instances (#248181)\n\nCloses https://github.com/elastic/kibana-operations/issues/414\n\nThis PR declares spotZones to be used on preemptible machine based jobs\naccording to data we have of zones that historically have been failing\nthe most over the past couple months.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"7c88eeec4f459a1af5515fbfbf7e1d38c5623acf"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248181","number":248181,"mergeCommit":{"message":"chore(NA): use different gcp zones for spot instances (#248181)\n\nCloses https://github.com/elastic/kibana-operations/issues/414\n\nThis PR declares spotZones to be used on preemptible machine based jobs\naccording to data we have of zones that historically have been failing\nthe most over the past couple months.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"7c88eeec4f459a1af5515fbfbf7e1d38c5623acf"}}]}] BACKPORT-->