### PR TITLE
[Security Solution] Improve debugging capability of API integration tests that depend on `deleteAllRules` or `countDownTest` helpers

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/count_down_test.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/count_down_test.ts
@@ -33,8 +33,9 @@ export const countDownTest = async <T>(
     try {
       const testReturn = await functionToTest();
       if (!testReturn.passed) {
-        const error = testReturn.errorMessage != null ? ` error: ${testReturn.errorMessage},` : '';
-        log.error(`Failure trying to ${name},${error} retries left are: ${retryCount - 1}`);
+        log.error(`Failure trying to ${name}, retries left: ${retryCount - 1}`);
+        log.error(`Error message returned: "${testReturn.errorMessage}"`);
+
         // retry, counting down, and delay a bit before
         await new Promise((resolve) => setTimeout(resolve, timeoutWait));
         const returnValue = await countDownTest(
@@ -53,11 +54,9 @@ export const countDownTest = async <T>(
       if (ignoreThrow) {
         throw err;
       } else {
-        log.error(
-          `Failure trying to ${name}, with exception message of: ${
-            err.message
-          }, retries left are: ${retryCount - 1}`
-        );
+        log.error(`Failure trying to ${name}, retries left: ${retryCount - 1}`);
+        log.error(err);
+
         // retry, counting down, and delay a bit before
         await new Promise((resolve) => setTimeout(resolve, timeoutWait));
         const returnValue = await countDownTest(

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/moon.yml
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/moon.yml
@@ -25,6 +25,7 @@ dependsOn:
   - '@kbn/alerting-plugin'
   - '@kbn/task-manager-plugin'
   - '@kbn/test'
+  - '@kbn/spaces-plugin'
 tags:
   - test-helper
   - package

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/rules/delete_all_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/rules/delete_all_rules.ts
@@ -28,7 +28,7 @@ export const deleteAllRules = async (
   await countDownTest(
     async () => {
       await deleteAllRulesViaBulkAction(supertest, log, spaceId);
-      await verifyAllRulesWereDeleted(supertest, log, spaceId);
+      await verifyThereAreNoRules(supertest, log, spaceId);
 
       return { passed: true };
     },
@@ -72,7 +72,7 @@ async function deleteAllRulesViaBulkAction(
   log.debug('Delete all detection rules: action succeeded ✅', { space });
 }
 
-async function verifyAllRulesWereDeleted(
+async function verifyThereAreNoRules(
   supertest: SuperTest.Agent,
   log: ToolingLog,
   spaceId?: string

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/rules/delete_all_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/rules/delete_all_rules.ts
@@ -5,19 +5,20 @@
  * 2.0.
  */
 
+import expect from 'expect';
 import type { ToolingLog } from '@kbn/tooling-log';
 import type SuperTest from 'supertest';
 
 import {
   DETECTION_ENGINE_RULES_BULK_ACTION,
-  DETECTION_ENGINE_RULES_URL,
+  DETECTION_ENGINE_RULES_URL_FIND,
 } from '@kbn/security-solution-plugin/common/constants';
-import { withSpaceUrl } from '../spaces';
+import { getSpaceId, withSpaceUrl } from '../spaces';
 import { countDownTest } from '../count_down_test';
 
 /**
- * Removes all rules by looping over any found and removing them from REST.
- * @param supertest The supertest agent.
+ * Deletes all detection rules in a given Kibana space.
+ * Additionally, it double-checks that no rules remain after deletion.
  */
 export const deleteAllRules = async (
   supertest: SuperTest.Agent,
@@ -26,24 +27,10 @@ export const deleteAllRules = async (
 ): Promise<void> => {
   await countDownTest(
     async () => {
-      await supertest
-        .post(withSpaceUrl(DETECTION_ENGINE_RULES_BULK_ACTION, spaceId))
-        .send({ action: 'delete', query: '' })
-        .set('kbn-xsrf', 'true')
-        .set('elastic-api-version', '2023-10-31');
+      await deleteAllRulesViaBulkAction(supertest, log, spaceId);
+      await verifyAllRulesWereDeleted(supertest, log, spaceId);
 
-      const { body: finalCheck } = await supertest
-        .get(
-          spaceId
-            ? `/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_find`
-            : `${DETECTION_ENGINE_RULES_URL}/_find`
-        )
-        .set('kbn-xsrf', 'true')
-        .set('elastic-api-version', '2023-10-31')
-        .send();
-      return {
-        passed: finalCheck.data.length === 0,
-      };
+      return { passed: true };
     },
     'deleteAllRules',
     log,
@@ -51,3 +38,61 @@ export const deleteAllRules = async (
     1000
   );
 };
+
+async function deleteAllRulesViaBulkAction(
+  supertest: SuperTest.Agent,
+  log: ToolingLog,
+  spaceId?: string
+): Promise<void> {
+  const space = getSpaceId(spaceId);
+
+  log.debug(`Delete all detection rules: starting action...`, { space });
+
+  const response = await supertest
+    .post(withSpaceUrl(DETECTION_ENGINE_RULES_BULK_ACTION, spaceId))
+    .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
+    .send({ action: 'delete', query: '' })
+    .expect(200);
+
+  log.debug('Delete all detection rules: response received', { space, response: response.body });
+
+  expect(response.body).toHaveProperty('success', true);
+  expect(response.body).toHaveProperty('attributes.summary');
+
+  log.debug('Delete all detection rules: deletion summary', {
+    space,
+    summary: response.body.attributes.summary,
+  });
+
+  expect(response.body.attributes.summary.failed).toBe(0);
+  expect(response.body.attributes.summary.skipped).toBe(0);
+  expect(response.body.attributes.summary.succeeded).toBeGreaterThanOrEqual(0);
+
+  log.debug('Delete all detection rules: action succeeded ✅', { space });
+}
+
+async function verifyAllRulesWereDeleted(
+  supertest: SuperTest.Agent,
+  log: ToolingLog,
+  spaceId?: string
+): Promise<void> {
+  const space = getSpaceId(spaceId);
+
+  log.debug(`Verify all rules deleted: checking...`, { space });
+
+  const response = await supertest
+    .get(withSpaceUrl(DETECTION_ENGINE_RULES_URL_FIND, spaceId))
+    .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
+    .query({ page: 1, per_page: 1 }) // no need to request more data
+    .send()
+    .expect(200);
+
+  log.debug('Verify all rules deleted: response received', { space, response: response.body });
+
+  expect(response.body).toHaveProperty('total', 0);
+  expect(response.body).toHaveProperty('data', []);
+
+  log.debug(`Verify all rules deleted: checked ✅`, { space });
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/spaces.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/spaces.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-const DEFAULT_SPACE_ID = 'default';
+import { DEFAULT_SPACE_ID, getRouteUrlForSpace } from '@kbn/spaces-plugin/common';
+
+// TODO: Refactor and move this code to the spaces plugin's common folder
 
 /**
  * Returns a normalized space ID that can't be undefined.
@@ -23,7 +25,6 @@ export function getSpaceId(spaceId?: string): string {
  * - `withSpaceUrl('/api/some_endpoint', 'default')` returns `/api/some_endpoint`
  * - `withSpaceUrl('/api/some_endpoint', 'my_space') returns `/s/my_space/api/some_endpoint`
  */
-export function withSpaceUrl(url: string, spaceId = DEFAULT_SPACE_ID): string {
-  const normalizedSpaceId = getSpaceId(spaceId);
-  return normalizedSpaceId === DEFAULT_SPACE_ID ? url : `/s/${spaceId}${url}`;
+export function withSpaceUrl(routeUrl: string, spaceId?: string): string {
+  return getRouteUrlForSpace(routeUrl, spaceId);
 }

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/spaces.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/spaces.ts
@@ -5,6 +5,16 @@
  * 2.0.
  */
 
+const DEFAULT_SPACE_ID = 'default';
+
+/**
+ * Returns a normalized space ID that can't be undefined.
+ * The default space has an ID of 'default'.
+ */
+export function getSpaceId(spaceId?: string): string {
+  return spaceId ? String(spaceId) : DEFAULT_SPACE_ID;
+}
+
 /**
  * Wraps a provided URL with the space ID if it is not the default space.
  *
@@ -13,6 +23,7 @@
  * - `withSpaceUrl('/api/some_endpoint', 'default')` returns `/api/some_endpoint`
  * - `withSpaceUrl('/api/some_endpoint', 'my_space') returns `/s/my_space/api/some_endpoint`
  */
-export function withSpaceUrl(url: string, spaceId = 'default'): string {
-  return spaceId === 'default' ? url : `/s/${spaceId}${url}`;
+export function withSpaceUrl(url: string, spaceId = DEFAULT_SPACE_ID): string {
+  const normalizedSpaceId = getSpaceId(spaceId);
+  return normalizedSpaceId === DEFAULT_SPACE_ID ? url : `/s/${spaceId}${url}`;
 }

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/tsconfig.json
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response/tsconfig.json
@@ -19,6 +19,7 @@
     "@kbn/core-http-common",
     "@kbn/alerting-plugin",
     "@kbn/task-manager-plugin",
-    "@kbn/test"
+    "@kbn/test",
+    "@kbn/spaces-plugin"
   ]
 }


### PR DESCRIPTION
**Closes: https://github.com/elastic/kibana/issues/251098**

## Summary

This PR:

- [x] Improves debugging capability of the `deleteAllRules` helper by adding debug logs to it. This should make [failure logs like this](https://github.com/elastic/kibana/issues/251098#issuecomment-3828162634) clearer about what happened when this helper function fails again.
- [x] Improves debugging capability of the `countDownTest` helper by logging whole exception instead of its `message` only. An exception in JS doesn't have to have a `message` and doesn't even have to be an instance of `Error` or an object. One example is `AggregateError`.
- [x] Adds a tiny `getSpaceId` helper function which is useful for writing debug logs.

Also, the PR:

- [x] Makes minor improvements to the `resolve_read_rules` test that failed in [251098](https://github.com/elastic/kibana/issues/251098), particularly to its `beforeEach` and `afterEach` blocks. We don't need to do anything with alerts there - removing these actions should make the test more stable. I think we can close [251098](https://github.com/elastic/kibana/issues/251098) now - if the test fails again for the same reason, we'll have more data about why it failed.

## Improved test logs

When `deleteAllRules` succeeds, logs written from it will look like this:

```txt
           │ debg Delete all detection rules: starting action... { space: 'default' }
           │ debg Delete all detection rules: response received {
           │        space: 'default',
           │        response: {
           │          success: true,
           │          rules_count: 0,
           │          attributes: { results: [Object], summary: [Object] }
           │        }
           │      }
           │ debg Delete all detection rules: deletion summary {
           │        space: 'default',
           │        summary: { failed: 0, succeeded: 0, skipped: 0, total: 0 }
           │      }
           │ debg Delete all detection rules: action succeeded ✅ { space: 'default' }
           │ debg Verify all rules deleted: checking... { space: 'default' }
           │ debg Verify all rules deleted: response received {
           │        space: 'default',
           │        response: { page: 1, perPage: 1, total: 0, data: [] }
           │      }
           │ debg Verify all rules deleted: checked ✅ { space: 'default' }
```

When `deleteAllRules` fails, logs might look like this (error is being logged from `countDownTest`):

```
             │ debg Delete all detection rules: starting action... { space: 'default' }
             │ERROR Failure trying to deleteAllRules, retries left: 20
             │ERROR AggregateError:
             │          at internalConnectMultiple (node:net:1134:18)
             │          at afterConnectMultiple (node:net:1715:7)
             │      Error: connect ECONNREFUSED 127.0.0.1:5620
             │          at createConnectionError (node:net:1678:14)
             │          at afterConnectMultiple (node:net:1708:16)
             │      Error: connect ECONNREFUSED ::1:5620
             │          at createConnectionError (node:net:1678:14)
             │          at afterConnectMultiple (node:net:1708:16)
```

<details>
<summary>Full logs from beforeEach</summary>

### Before each

```txt
         └-> "before each" hook for "should create a "migrated" rule where querying for the new SO _id will resolve the new object and not return the outcome field when outcome === exactMatch"
           │ debg Delete all detection rules: starting action... { space: 'default' }
           │ debg Delete all detection rules: response received {
           │        space: 'default',
           │        response: {
           │          success: true,
           │          rules_count: 0,
           │          attributes: { results: [Object], summary: [Object] }
           │        }
           │      }
           │ debg Delete all detection rules: deletion summary {
           │        space: 'default',
           │        summary: { failed: 0, succeeded: 0, skipped: 0, total: 0 }
           │      }
           │ debg Delete all detection rules: action succeeded ✅ { space: 'default' }
           │ debg Verify all rules deleted: checking... { space: 'default' }
           │ debg Verify all rules deleted: response received {
           │        space: 'default',
           │        response: { page: 1, perPage: 1, total: 0, data: [] }
           │      }
           │ debg Verify all rules deleted: checked ✅ { space: 'default' }
           │ warn This test is using 'x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14' archive that contains saved object index definitions (in the 'mappings.json').
           │      This has proven to be a source of conflicts and flakiness, so the goal is to remove support for this feature ASAP. We kindly ask you to
           │      update your test archives and remove SO index definitions, so that tests use the official saved object indices created by Kibana at startup.
           │      You can achieve that by simply removing your saved object index definitions from 'mappings.json' (likely removing the file altogether).
           │      We also recommend migrating existing tests to 'kbnArchiver' whenever possible. After the fix please remove archive path from the exception list:
           │      /Users/georgii/Code/elastic/kibana-main/src/platform/packages/shared/kbn-es-archiver/src/fixtures/override_saved_objects_index/exception_list.json.
           │      Find more information here: https://github.com/elastic/kibana/issues/161882
           │ debg Requesting url (redacted): [http://localhost:5620/api/status]
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Loading "mappings.json"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Loading "data.json"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_usage_counters_9.4.0_001"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_search_solution_9.4.0_001"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_1"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_task_manager_9.4.0_001"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_security_solution_9.4.0_001"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_alerting_cases_9.4.0_001"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_analytics_9.4.0_001"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_ingest_9.4.0_001"
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_9.4.0_001"
           │ debg Deleted all saved object indices
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Created index ".kibana_1"
           │ debg [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] ".kibana_1" settings {"index":{"auto_expand_replicas":"0-1","number_of_replicas":"1","number_of_shards":"1"}}
           │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Indexed 2 docs into ".kibana_1"
           │ debg Migrating saved objects
           │ debg Requesting url (redacted): [http://localhost:5620/internal/saved_objects/_migrate]
           │ debg [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Migrated Kibana index after loading Kibana data
           │ debg [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Ensured that default space exists in .kibana
```

</details>

<details>
<summary>Full logs from afterEach</summary>

### After each

```txt
       └-> "after each" hook for "should create a "migrated" rule where querying for the new SO _id will resolve the new object and not return the outcome field when outcome === exactMatch"
         │ debg Delete all detection rules: starting action... { space: 'default' }
         │ debg Delete all detection rules: response received {
         │        space: 'default',
         │        response: {
         │          success: true,
         │          rules_count: 0,
         │          attributes: { results: [Object], summary: [Object] }
         │        }
         │      }
         │ debg Delete all detection rules: deletion summary {
         │        space: 'default',
         │        summary: { failed: 0, succeeded: 0, skipped: 0, total: 0 }
         │      }
         │ debg Delete all detection rules: action succeeded ✅ { space: 'default' }
         │ debg Verify all rules deleted: checking... { space: 'default' }
         │ debg Verify all rules deleted: response received {
         │        space: 'default',
         │        response: { page: 1, perPage: 1, total: 0, data: [] }
         │      }
         │ debg Verify all rules deleted: checked ✅ { space: 'default' }
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Unloading indices from "mappings.json"
         │ warn delete by query deleted 3 of 4 total documents, trying again
         │ warn since spaces are enabled, all objects other than the default space were deleted from .kibana rather than deleting the whole index
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_task_manager"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_alerting_cases"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_ingest"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_security_solution"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_analytics"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_usage_counters"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_search_solution"
         │ debg Cleaned all saved object indices
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Unloading indices from "data.json"
         │ warn since spaces are enabled, all objects other than the default space were deleted from .kibana rather than deleting the whole index
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_task_manager"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_alerting_cases"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_ingest"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_security_solution"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_analytics"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_usage_counters"
         │ info [x-pack/solutions/security/test/fixtures/es_archives/security_solution/resolve_read_rules/7_14] Deleted existing index ".kibana_search_solution"
         │ debg Cleaned all saved object indices
```

</details>

### Checklist

- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

For some reason Flaky Test Runner doesn't want to accept this PR:

<img width="1627" height="402" alt="Screenshot 2026-01-31 at 16 52 40" src="https://github.com/user-attachments/assets/23057e7b-210a-403e-8de2-c21c09175d5c" />


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->