### PR TITLE
[One Workflow] Fix email connector documentation: to field

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/generic_monaco_connector_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/generic_monaco_connector_handler.ts
@@ -145,7 +145,7 @@ ${Object.entries(connectorInfo.examples.params || {})
         documentation: 'Configure recipient, subject, and message content',
         examples: {
           params: {
-            to: 'user@example.com',
+            to: ['user@example.com', 'other@example.com'],
             subject: 'Workflow Notification',
             message: 'Your workflow has completed successfully.',
           },


### PR DESCRIPTION
<img width="2182" height="544" alt="CleanShot 2026-02-01 at 11 37 35@2x" src="https://github.com/user-attachments/assets/8876c5e9-001a-4a73-92fb-c9389ebeed39" />


More details in the issue.