### PR TITLE
[DevTools Console] Avoid editor freeze after pasting large JSON

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/language.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/language.test.ts
@@ -80,12 +80,7 @@ jest.mock('./console_worker_proxy', () => {
   return { ConsoleWorkerProxyService };
 });
 
-import {
-  ConsoleLang,
-  ConsoleOutputLang,
-  CONSOLE_TRIGGER_CHARS,
-  getParsedRequestsProvider,
-} from './language';
+import { ConsoleLang, CONSOLE_TRIGGER_CHARS, getParsedRequestsProvider } from './language';
 
 type ProvideCompletionItems = NonNullable<
   monaco.languages.CompletionItemProvider['provideCompletionItems']
@@ -414,13 +409,6 @@ describe('console language', () => {
     createdModels.push(model);
     getParsedRequestsProvider(model);
 
-    expect(mockConsoleParsedRequestsProvider).toHaveBeenCalledTimes(1);
-  });
-
-  it('exports ConsoleOutputLang', () => {
-    expect(ConsoleOutputLang.ID).toBeTruthy();
-    expect(ConsoleOutputLang.languageConfiguration).toBeTruthy();
-    expect(ConsoleOutputLang.lexerRules).toBeTruthy();
-    expect(ConsoleOutputLang.foldingRangeProvider).toBeTruthy();
+    expect(mockConsoleParsedRequestsProvider).toHaveBeenCalledWith(expect.anything(), model);
   });
 });

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/language.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/language.test.ts
@@ -1,0 +1,426 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { MutableRefObject } from 'react';
+import type { ESQLCallbacks } from '@kbn/esql-types';
+import type { suggest as suggestFn } from '@kbn/esql-language';
+import type { wrapAsMonacoSuggestions as wrapFn } from '../esql/lib/converters/suggestions';
+import type {
+  checkForTripleQuotesAndEsqlQuery as checkFn,
+  unescapeInvalidChars as unescapeFn,
+} from './utils';
+import type { setupConsoleErrorsProvider as setupErrorsProviderFn } from './console_errors_provider';
+import type { ConsoleParsedRequestsProvider as ParsedProviderCtor } from './console_parsed_requests_provider';
+
+import { monaco } from '../../monaco_imports';
+import { ESQL_AUTOCOMPLETE_TRIGGER_CHARS } from '../esql';
+
+const mockWorkerSetup = jest.fn<void, []>();
+
+const mockSuggest = jest.fn<ReturnType<typeof suggestFn>, Parameters<typeof suggestFn>>();
+const mockWrapAsMonacoSuggestions = jest.fn<ReturnType<typeof wrapFn>, Parameters<typeof wrapFn>>();
+const mockCheckForTripleQuotesAndEsqlQuery = jest.fn<
+  ReturnType<typeof checkFn>,
+  Parameters<typeof checkFn>
+>();
+const mockUnescapeInvalidChars = jest.fn<
+  ReturnType<typeof unescapeFn>,
+  Parameters<typeof unescapeFn>
+>();
+const mockSetupConsoleErrorsProvider = jest.fn<
+  ReturnType<typeof setupErrorsProviderFn>,
+  Parameters<typeof setupErrorsProviderFn>
+>();
+const mockConsoleParsedRequestsProvider = jest.fn<
+  InstanceType<typeof ParsedProviderCtor>,
+  ConstructorParameters<typeof ParsedProviderCtor>
+>();
+
+jest.mock('@kbn/esql-language', () => ({
+  suggest: (...args: Parameters<typeof mockSuggest>) => mockSuggest(...args),
+}));
+
+jest.mock('../esql/lib/converters/suggestions', () => ({
+  wrapAsMonacoSuggestions: (...args: Parameters<typeof mockWrapAsMonacoSuggestions>) =>
+    mockWrapAsMonacoSuggestions(...args),
+}));
+
+jest.mock('./utils', () => ({
+  checkForTripleQuotesAndEsqlQuery: (
+    ...args: Parameters<typeof mockCheckForTripleQuotesAndEsqlQuery>
+  ) => mockCheckForTripleQuotesAndEsqlQuery(...args),
+  unescapeInvalidChars: (...args: Parameters<typeof mockUnescapeInvalidChars>) =>
+    mockUnescapeInvalidChars(...args),
+}));
+
+jest.mock('./console_errors_provider', () => ({
+  setupConsoleErrorsProvider: (...args: Parameters<typeof mockSetupConsoleErrorsProvider>) =>
+    mockSetupConsoleErrorsProvider(...args),
+}));
+
+jest.mock('./console_parsed_requests_provider', () => {
+  function ConsoleParsedRequestsProvider(
+    ...args: ConstructorParameters<typeof ParsedProviderCtor>
+  ) {
+    mockConsoleParsedRequestsProvider(...args);
+  }
+  return { ConsoleParsedRequestsProvider };
+});
+
+jest.mock('./console_worker_proxy', () => {
+  function ConsoleWorkerProxyService(this: { setup: () => void }) {
+    this.setup = () => mockWorkerSetup();
+  }
+  return { ConsoleWorkerProxyService };
+});
+
+import {
+  ConsoleLang,
+  ConsoleOutputLang,
+  CONSOLE_TRIGGER_CHARS,
+  getParsedRequestsProvider,
+} from './language';
+
+type ProvideCompletionItems = NonNullable<
+  monaco.languages.CompletionItemProvider['provideCompletionItems']
+>;
+
+const createToken = (): { token: monaco.CancellationToken; dispose: () => void } => {
+  const source = new monaco.CancellationTokenSource();
+  return { token: source.token, dispose: () => source.dispose() };
+};
+
+const createActionsProvider = (): {
+  actionsProvider: MutableRefObject<{ provideCompletionItems: ProvideCompletionItems } | null>;
+  provideCompletionItems: jest.MockedFunction<ProvideCompletionItems>;
+} => {
+  const completionList: monaco.languages.CompletionList = { suggestions: [] };
+  const provideCompletionItems = jest.fn<
+    ReturnType<ProvideCompletionItems>,
+    Parameters<ProvideCompletionItems>
+  >(() => completionList);
+
+  const actionsProvider: MutableRefObject<{
+    provideCompletionItems: ProvideCompletionItems;
+  } | null> = {
+    current: { provideCompletionItems },
+  };
+
+  return { actionsProvider, provideCompletionItems };
+};
+
+const createProvider = (
+  esqlCallbacks: Pick<ESQLCallbacks, 'getSources' | 'getPolicies'> | undefined,
+  actionsProvider: MutableRefObject<{ provideCompletionItems: ProvideCompletionItems } | null>
+): monaco.languages.CompletionItemProvider => {
+  if (!ConsoleLang.getSuggestionProvider) {
+    throw new Error('expected ConsoleLang.getSuggestionProvider to be defined');
+  }
+  return ConsoleLang.getSuggestionProvider(esqlCallbacks, actionsProvider);
+};
+
+const createModel = (lines: string[]): monaco.editor.ITextModel => {
+  return monaco.editor.createModel(lines.join('\n'), 'plaintext');
+};
+
+describe('console language', () => {
+  const baseContext: monaco.languages.CompletionContext = {
+    triggerKind: monaco.languages.CompletionTriggerKind.Invoke,
+  };
+
+  const createEsqlCallbacks = (): Pick<ESQLCallbacks, 'getSources' | 'getPolicies'> => ({
+    getSources: async () => [],
+    getPolicies: async () => [],
+  });
+
+  const createdModels: monaco.editor.ITextModel[] = [];
+  afterEach(() => {
+    jest.restoreAllMocks();
+    while (createdModels.length) {
+      createdModels.pop()?.dispose();
+    }
+  });
+
+  beforeEach(() => {
+    // Global mocks stay, but each test starts from a clean slate:
+    // - clears call history
+    // - resets per-test stubbed implementations
+    jest.resetAllMocks();
+  });
+
+  it('exposes triggerCharacters including Console + ES|QL triggers', () => {
+    const { actionsProvider } = createActionsProvider();
+    const provider = createProvider(undefined, actionsProvider);
+    expect(provider.triggerCharacters).toEqual(
+      expect.arrayContaining([...CONSOLE_TRIGGER_CHARS, ...ESQL_AUTOCOMPLETE_TRIGGER_CHARS])
+    );
+  });
+
+  it('delegates to actions provider when no request line is found', async () => {
+    const { actionsProvider, provideCompletionItems } = createActionsProvider();
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    const model = createModel(['{ "not": "a request line" }']);
+    createdModels.push(model);
+
+    const getValueSpy = jest.spyOn(model, 'getValue');
+    const getValueInRangeSpy = jest.spyOn(model, 'getValueInRange');
+
+    await provider.provideCompletionItems!(model, new monaco.Position(1, 1), baseContext, token);
+
+    expect(provideCompletionItems).toHaveBeenCalledTimes(1);
+    expect(getValueSpy).not.toHaveBeenCalled();
+    expect(getValueInRangeSpy).not.toHaveBeenCalled();
+    expect(mockCheckForTripleQuotesAndEsqlQuery).not.toHaveBeenCalled();
+    expect(mockSuggest).not.toHaveBeenCalled();
+    expect(mockWrapAsMonacoSuggestions).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it('delegates to actions provider for non-_query request lines (e.g. GET _search)', async () => {
+    const { actionsProvider, provideCompletionItems } = createActionsProvider();
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    const model = createModel(['GET _search', '{ "query": { "match_all": {} } }']);
+    createdModels.push(model);
+
+    const getValueInRangeSpy = jest.spyOn(model, 'getValueInRange');
+
+    await provider.provideCompletionItems!(model, new monaco.Position(2, 5), baseContext, token);
+
+    expect(provideCompletionItems).toHaveBeenCalledTimes(1);
+    expect(getValueInRangeSpy).not.toHaveBeenCalled();
+    expect(mockCheckForTripleQuotesAndEsqlQuery).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it('does not treat GET _query as ES|QL request (POST-only) and delegates to actions provider', async () => {
+    const { actionsProvider, provideCompletionItems } = createActionsProvider();
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    const model = createModel(['GET _query', '{ "query": "FROM logs" }']);
+    createdModels.push(model);
+
+    await provider.provideCompletionItems!(model, new monaco.Position(2, 7), baseContext, token);
+
+    expect(provideCompletionItems).toHaveBeenCalledTimes(1);
+    expect(mockCheckForTripleQuotesAndEsqlQuery).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it('limits request-line lookback to 2000 lines and delegates when request line is beyond lookback', async () => {
+    const { actionsProvider, provideCompletionItems } = createActionsProvider();
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    const lines = ['POST _query', ...Array.from({ length: 2000 }, () => '')];
+    const model = createModel(lines);
+    createdModels.push(model);
+
+    const getValueInRangeSpy = jest.spyOn(model, 'getValueInRange');
+
+    await provider.provideCompletionItems!(model, new monaco.Position(2001, 1), baseContext, token);
+
+    expect(provideCompletionItems).toHaveBeenCalledTimes(1);
+    expect(getValueInRangeSpy).not.toHaveBeenCalled();
+    expect(mockCheckForTripleQuotesAndEsqlQuery).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it('runs _query detection via getValueInRange and delegates when not inside ES|QL', async () => {
+    const { actionsProvider, provideCompletionItems } = createActionsProvider();
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    mockCheckForTripleQuotesAndEsqlQuery.mockReturnValue({
+      insideTripleQuotes: false,
+      insideEsqlQuery: false,
+      esqlQueryIndex: -1,
+    });
+
+    const model = createModel(['POST _query', '{ "query": "FROM logs" }']);
+    createdModels.push(model);
+
+    const getValueInRangeSpy = jest.spyOn(model, 'getValueInRange');
+
+    await provider.provideCompletionItems!(model, new monaco.Position(2, 7), baseContext, token);
+
+    expect(getValueInRangeSpy).toHaveBeenCalledTimes(1);
+    expect(mockCheckForTripleQuotesAndEsqlQuery).toHaveBeenCalledTimes(1);
+    expect(provideCompletionItems).toHaveBeenCalledTimes(1);
+    expect(mockSuggest).not.toHaveBeenCalled();
+    expect(mockWrapAsMonacoSuggestions).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('delegates when inside ES|QL but esqlCallbacks are undefined', async () => {
+    const { actionsProvider, provideCompletionItems } = createActionsProvider();
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    mockCheckForTripleQuotesAndEsqlQuery.mockReturnValue({
+      insideTripleQuotes: false,
+      insideEsqlQuery: true,
+      esqlQueryIndex: 0,
+    });
+
+    const model = createModel(['POST _query', '{ "query": "FROM logs" }']);
+    createdModels.push(model);
+
+    await provider.provideCompletionItems!(model, new monaco.Position(2, 7), baseContext, token);
+
+    expect(provideCompletionItems).toHaveBeenCalledTimes(1);
+    expect(mockSuggest).not.toHaveBeenCalled();
+    expect(mockWrapAsMonacoSuggestions).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('returns empty suggestions when no actions provider is available and request line is not found', async () => {
+    const actionsProvider: MutableRefObject<{
+      provideCompletionItems: ProvideCompletionItems;
+    } | null> = {
+      current: null,
+    };
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    const model = createModel(['{ "no": "request line" }']);
+    createdModels.push(model);
+
+    const result = await provider.provideCompletionItems!(
+      model,
+      new monaco.Position(1, 1),
+      baseContext,
+      token
+    );
+
+    expect(result).toEqual({ suggestions: [] });
+    dispose();
+  });
+
+  it('returns empty suggestions when _query detection runs but actions provider is missing', async () => {
+    const actionsProvider: MutableRefObject<{
+      provideCompletionItems: ProvideCompletionItems;
+    } | null> = {
+      current: null,
+    };
+    const provider = createProvider(undefined, actionsProvider);
+    const { token, dispose } = createToken();
+
+    mockCheckForTripleQuotesAndEsqlQuery.mockReturnValue({
+      insideTripleQuotes: false,
+      insideEsqlQuery: false,
+      esqlQueryIndex: -1,
+    });
+
+    const model = createModel(['POST _query', '{ "query": "FROM logs" }']);
+    createdModels.push(model);
+
+    const result = await provider.provideCompletionItems!(
+      model,
+      new monaco.Position(2, 7),
+      baseContext,
+      token
+    );
+
+    expect(result).toEqual({ suggestions: [] });
+    dispose();
+  });
+
+  it('runs ES|QL suggestions and wraps them when inside ES|QL (single quoted)', async () => {
+    const { actionsProvider, provideCompletionItems } = createActionsProvider();
+    const esqlCallbacks = createEsqlCallbacks();
+    const provider = createProvider(esqlCallbacks, actionsProvider);
+    const { token, dispose } = createToken();
+
+    const wrapped: monaco.languages.CompletionList = { suggestions: [] };
+    mockWrapAsMonacoSuggestions.mockReturnValue(wrapped);
+
+    mockCheckForTripleQuotesAndEsqlQuery.mockReturnValue({
+      insideTripleQuotes: false,
+      insideEsqlQuery: true,
+      esqlQueryIndex: 0,
+    });
+
+    mockUnescapeInvalidChars.mockReturnValue('UNESCAPED_QUERY');
+    mockSuggest.mockResolvedValue([]);
+
+    const model = createModel(['POST _query', '{ "query": "FROM logs" }']);
+    createdModels.push(model);
+
+    const result = await provider.provideCompletionItems!(
+      model,
+      new monaco.Position(2, 7),
+      baseContext,
+      token
+    );
+
+    expect(mockSuggest).toHaveBeenCalledWith(
+      'UNESCAPED_QUERY',
+      'UNESCAPED_QUERY'.length,
+      esqlCallbacks
+    );
+    expect(mockWrapAsMonacoSuggestions).toHaveBeenCalledTimes(1);
+    expect(provideCompletionItems).not.toHaveBeenCalled();
+    expect(result).toBe(wrapped);
+    dispose();
+  });
+
+  it('passes allowSnippets=false when inside triple quotes (ES|QL)', async () => {
+    const { actionsProvider } = createActionsProvider();
+    const esqlCallbacks = createEsqlCallbacks();
+    const provider = createProvider(esqlCallbacks, actionsProvider);
+    const { token, dispose } = createToken();
+
+    mockCheckForTripleQuotesAndEsqlQuery.mockReturnValue({
+      insideTripleQuotes: true,
+      insideEsqlQuery: true,
+      esqlQueryIndex: 0,
+    });
+
+    mockUnescapeInvalidChars.mockReturnValue('UNESCAPED_QUERY');
+    mockSuggest.mockResolvedValue([]);
+    mockWrapAsMonacoSuggestions.mockReturnValue({ suggestions: [] });
+
+    const model = createModel(['POST _query', '{ "query": """FROM logs""" }']);
+    createdModels.push(model);
+
+    await provider.provideCompletionItems!(model, new monaco.Position(2, 7), baseContext, token);
+
+    // The 4th arg is `!insideTripleQuotes` -> false when inside triple quotes.
+    expect(mockWrapAsMonacoSuggestions.mock.calls[0][3]).toBe(false);
+    dispose();
+  });
+
+  it('wires onLanguage + parsed request provider', () => {
+    ConsoleLang.onLanguage?.();
+    expect(mockWorkerSetup).toHaveBeenCalledTimes(1);
+    expect(mockSetupConsoleErrorsProvider).toHaveBeenCalledTimes(1);
+
+    const model = createModel(['GET _search']);
+    createdModels.push(model);
+    getParsedRequestsProvider(model);
+
+    expect(mockConsoleParsedRequestsProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('exports ConsoleOutputLang', () => {
+    expect(ConsoleOutputLang.ID).toBeTruthy();
+    expect(ConsoleOutputLang.languageConfiguration).toBeTruthy();
+    expect(ConsoleOutputLang.lexerRules).toBeTruthy();
+    expect(ConsoleOutputLang.foldingRangeProvider).toBeTruthy();
+  });
+});

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.test.ts
@@ -7,7 +7,144 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Worker } from 'worker_threads';
 import { checkForTripleQuotesAndEsqlQuery, unescapeInvalidChars } from './autocomplete_utils';
+
+type QueryCheckResult = ReturnType<typeof checkForTripleQuotesAndEsqlQuery>;
+
+interface WorkerReadyMessage {
+  type: 'ready';
+}
+
+interface WorkerResultSuccessMessage {
+  type: 'result';
+  ok: true;
+  ms: number;
+  result: QueryCheckResult;
+}
+
+interface WorkerResultErrorMessage {
+  type: 'result';
+  ok: false;
+  error: string;
+  stack?: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isWorkerReadyMessage = (value: unknown): value is WorkerReadyMessage =>
+  isRecord(value) && value.type === 'ready';
+
+const isWorkerResultMessage = (
+  value: unknown
+): value is WorkerResultSuccessMessage | WorkerResultErrorMessage =>
+  isRecord(value) && value.type === 'result' && typeof value.ok === 'boolean';
+
+interface CheckForTripleQuotesPerfWorker {
+  measure(request: string, timeoutMs: number): Promise<{ ms: number; result: QueryCheckResult }>;
+  terminate(): Promise<void>;
+}
+
+const createCheckForTripleQuotesPerfWorker = async (): Promise<CheckForTripleQuotesPerfWorker> => {
+  const autocompleteUtilsPath = require.resolve('./autocomplete_utils');
+
+  const worker = new Worker(
+    `
+      const { parentPort } = require('worker_threads');
+      require('@kbn/setup-node-env');
+
+      const { performance } = require('perf_hooks');
+      const { checkForTripleQuotesAndEsqlQuery } = require(${JSON.stringify(
+        autocompleteUtilsPath
+      )});
+
+      parentPort.on('message', ({ request }) => {
+        try {
+          const t0 = performance.now();
+          const result = checkForTripleQuotesAndEsqlQuery(request);
+          const t1 = performance.now();
+          parentPort.postMessage({ type: 'result', ok: true, ms: t1 - t0, result });
+        } catch (e) {
+          parentPort.postMessage({
+            type: 'result',
+            ok: false,
+            error: e && e.message ? e.message : String(e),
+            stack: e && e.stack ? e.stack : undefined,
+          });
+        }
+      });
+
+      parentPort.postMessage({ type: 'ready' });
+    `,
+    { eval: true }
+  );
+
+  const waitForMessageOnce = async (timeoutMs: number, timeoutMessage: string) => {
+    return await new Promise<unknown>((resolve, reject) => {
+      let settled = false;
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        worker.off('message', onMessage);
+        worker.off('error', onError);
+      };
+
+      const onMessage = (msg: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(msg);
+      };
+
+      const onError = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      };
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        void worker.terminate();
+        reject(new Error(timeoutMessage));
+      }, timeoutMs);
+
+      worker.once('message', onMessage);
+      worker.once('error', onError);
+    });
+  };
+
+  const ready = await waitForMessageOnce(10_000, 'perf worker did not become ready after 10000ms');
+  if (!isWorkerReadyMessage(ready)) {
+    await worker.terminate();
+    throw new Error(`unexpected perf worker ready message: ${JSON.stringify(ready)}`);
+  }
+
+  return {
+    measure: async (request: string, timeoutMs: number) => {
+      worker.postMessage({ request });
+
+      const msg = await waitForMessageOnce(timeoutMs, `perf worker timed out after ${timeoutMs}ms`);
+      if (!isWorkerResultMessage(msg)) {
+        throw new Error(`unexpected perf worker response: ${JSON.stringify(msg)}`);
+      }
+
+      if (!msg.ok) {
+        const error = msg.error;
+        const stack = msg.stack;
+        throw new Error(stack ? `${error}\n${stack}` : error);
+      }
+
+      return { ms: msg.ms, result: msg.result };
+    },
+    terminate: async () => {
+      await worker.terminate();
+    },
+  };
+};
 
 describe('autocomplete_utils', () => {
   describe('checkForTripleQuotesAndQueries', () => {
@@ -73,6 +210,59 @@ describe('autocomplete_utils', () => {
         esqlQueryIndex: -1,
       });
     });
+
+    it('has roughly linear runtime scaling (performance regression)', async () => {
+      // NOTE: Absolute timing thresholds are flaky on shared CI. This test instead checks
+      // *relative scaling* on a constructed input that is adversarial for the old
+      // (regex-per-quote) implementation (many unescaped quotes), so accidental
+      // super-linear regressions are more likely to be caught.
+      //
+      // To keep this test preemptible (and avoid hanging Jest on a severe regression),
+      // it runs the measurement in a separate worker thread with a hard timeout.
+      const median = (values: number[]) => {
+        const sorted = [...values].sort((a, b) => a - b);
+        return sorted[Math.floor(sorted.length / 2)];
+      };
+
+      const buildManyJsonPairs = (pairCount: number) => {
+        const pairs: string[] = [];
+        for (let i = 0; i < pairCount; i++) {
+          pairs.push(`"k${i}":"v${i}"`);
+        }
+        return `{${pairs.join(',')}}`;
+      };
+
+      const perf = await createCheckForTripleQuotesPerfWorker();
+      const measure = async (pairCount: number) => {
+        // Building the string can be non-trivial; exclude it from the timed section.
+        const request = `POST _search\n${buildManyJsonPairs(pairCount)}`;
+        const { ms, result } = await perf.measure(request, 1_000);
+
+        // correctness (still important)
+        expect(result).toEqual({
+          insideTripleQuotes: false,
+          insideEsqlQuery: false,
+          esqlQueryIndex: -1,
+        });
+
+        return ms;
+      };
+
+      try {
+        // warmup (JIT)
+        await measure(250);
+
+        // Keep sizes small enough that the pre-optimization implementation fails fast (bad scaling)
+        // rather than effectively hanging the test runtime.
+        const tSmall = median([await measure(500), await measure(500), await measure(500)]);
+        const tLarge = median([await measure(1_000), await measure(1_000), await measure(1_000)]);
+
+        // Linear would be ~2x. Allow some noise/GC: fail only if it's far worse.
+        expect(tLarge / tSmall).toBeLessThan(3.25);
+      } finally {
+        await perf.terminate();
+      }
+    }, 20_000);
   });
 
   it('sets insideEsqlQuery for single quoted query after POST _query', () => {

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.test.ts
@@ -74,22 +74,17 @@ describe('autocomplete_utils', () => {
       });
     });
 
-    it('does not treat longer words as request methods (e.g. GETS)', () => {
-      const request = `GETS _query\n{\n  "query": "SELECT * FROM logs `;
-      expect(checkForTripleQuotesAndEsqlQuery(request)).toEqual({
-        insideTripleQuotes: false,
-        insideEsqlQuery: false,
-        esqlQueryIndex: -1,
-      });
-    });
-
-    it('does not treat longer words as request methods (e.g. POSTER)', () => {
-      const request = `POSTER _query\n{\n  "query": "SELECT * FROM logs `;
-      expect(checkForTripleQuotesAndEsqlQuery(request)).toEqual({
-        insideTripleQuotes: false,
-        insideEsqlQuery: false,
-        esqlQueryIndex: -1,
-      });
+    it('does not treat longer words as request methods (e.g. GETS, POSTER)', () => {
+      const methods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH'] as const;
+      for (const method of methods) {
+        const requestMethod = `${method}A`;
+        const request = `${requestMethod} _query\n{\n  "query": "SELECT * FROM logs `;
+        expect(checkForTripleQuotesAndEsqlQuery(request)).toEqual({
+          insideTripleQuotes: false,
+          insideEsqlQuery: false,
+          esqlQueryIndex: -1,
+        });
+      }
     });
   });
 

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.ts
@@ -9,10 +9,161 @@
 
 /**
  * This function takes a Console text up to the current position and determines whether
- * the current position is inside triple quotes, triple-quote or single-quote query,
- * and the start index of the current query.
+ * the current position is:
+ * - inside a `""" ... """` triple-quoted string
+ * - inside the JSON string value for the `"query"` key (either `"..."` or `"""..."""`)
+ * - and whether the surrounding request section is a POST /_query(/async) request.
+ *
+ * When inside an ES|QL query value, it returns the start index of the query text (the first
+ * character after the opening quote(s)).
  * @param text The text up to the current position
  */
+const TRIPLE_QUOTES = '"""';
+const QUERY_KEY = '"query"';
+const ESQL_QUERY_REQUEST_LINE_RE = /^post\s+\/?_query(?:\/async)?(?:\s|\?|$)/i;
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH'] as const;
+
+const ASCII = {
+  A_UPPER: 65,
+  Z_UPPER: 90,
+  A_LOWER: 97,
+  Z_LOWER: 122,
+} as const;
+
+const isWhitespace = (ch: string | undefined) =>
+  ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+
+/**
+ * Walks backwards from `fromIndex` until a non-whitespace character is found.
+ * Returns that index, or -1 if the scan runs past the beginning.
+ */
+const skipWhitespaceBackward = (text: string, fromIndex: number): number => {
+  for (let index = fromIndex; index >= 0; index--) {
+    if (!isWhitespace(text[index])) {
+      return index;
+    }
+  }
+  return -1;
+};
+
+const isAsciiLetter = (ch: string | undefined): boolean => {
+  if (!ch) return false;
+  const code = ch.charCodeAt(0);
+  return (
+    (code >= ASCII.A_UPPER && code <= ASCII.Z_UPPER) ||
+    (code >= ASCII.A_LOWER && code <= ASCII.Z_LOWER)
+  );
+};
+
+/**
+ * Returns true when `index` is positioned at the start of a line.
+ * In this file we treat `\n` as the line separator (Console input is normalized to `\n`).
+ */
+const isStartOfLine = (text: string, index: number): boolean => {
+  if (index === 0) {
+    return true;
+  }
+  const previousChar = text[index - 1];
+  return previousChar === '\n';
+};
+
+/**
+ * Checks whether `text[quoteIndex]` (the opening quote character of either `"` or `"""`) is the
+ * start of the JSON value for the `"query"` key, i.e. the preceding text ends with:
+ * `"query"\s*:\s*`.
+ *
+ * This is intentionally implemented without regexes and without creating large substrings.
+ */
+const isQueryValueStartAtQuote = (text: string, quoteIndex: number): boolean => {
+  // We expect the preceding text to end with: `"query"\s*:\s*`
+  const colonIndex = skipWhitespaceBackward(text, quoteIndex - 1);
+  if (colonIndex < 0 || text[colonIndex] !== ':') {
+    return false;
+  }
+
+  const keyEndIndex = skipWhitespaceBackward(text, colonIndex - 1);
+  const keyStartIndex = keyEndIndex - (QUERY_KEY.length - 1);
+  if (keyStartIndex < 0) {
+    return false;
+  }
+  return text.startsWith(QUERY_KEY, keyStartIndex);
+};
+
+/**
+ * Case-insensitive word match at `startIndex` for ASCII methods.
+ * Ensures we don't accidentally match longer identifiers (e.g. `GETS`).
+ */
+const matchesWordAt = (text: string, startIndex: number, word: string): boolean => {
+  for (let offset = 0; offset < word.length; offset++) {
+    const ch = text[startIndex + offset];
+    if (!ch || ch.toUpperCase() !== word[offset]) {
+      return false;
+    }
+  }
+  // Ensure we don't match a larger identifier (e.g. GETS).
+  return !isAsciiLetter(text[startIndex + word.length]);
+};
+
+/**
+ * Returns true when `text[startIndex...]` starts with an HTTP method token (GET/POST/...)
+ * and is not part of a longer word.
+ */
+const isRequestMethodAt = (text: string, startIndex: number): boolean => {
+  if (!isAsciiLetter(text[startIndex])) return false;
+  for (const method of HTTP_METHODS) {
+    if (matchesWordAt(text, startIndex, method)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Returns true if the given request line corresponds to an ES|QL request (`POST /_query` or
+ * `POST /_query/async`), allowing querystring suffixes.
+ */
+const isEsqlQueryRequestLine = (line: string): boolean => ESQL_QUERY_REQUEST_LINE_RE.test(line);
+
+/**
+ * Returns the index where query text begins if `quoteIndex` starts the `"query"` value.
+ * Otherwise returns -1.
+ */
+const getQueryValueStartIndex = (text: string, quoteIndex: number, quoteLen: 1 | 3): number => {
+  return isQueryValueStartAtQuote(text, quoteIndex) ? quoteIndex + quoteLen : -1;
+};
+
+/**
+ * Attempts to interpret the line starting at `lineStartIndex` as a Console request line
+ * (HTTP method + path). When a request line is found, returns:
+ * - `isEsqlQueryRequest`: whether this request line is a POST /_query(/async) request
+ * - `nextIndex`: where the main scan loop should continue (the beginning of the next line)
+ */
+const scanRequestLineFrom = (
+  text: string,
+  lineStartIndex: number
+): { nextIndex: number; isEsqlQueryRequest: boolean } | undefined => {
+  let scanIndex = lineStartIndex;
+  // Skip leading spaces/tabs on the request line.
+  while (scanIndex < text.length && (text[scanIndex] === ' ' || text[scanIndex] === '\t')) {
+    scanIndex++;
+  }
+
+  if (scanIndex >= text.length || !isRequestMethodAt(text, scanIndex)) {
+    return;
+  }
+
+  const newlineIndex = text.indexOf('\n', scanIndex);
+  const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
+
+  // The request line is typically short; substring allocation here is bounded.
+  const line = text.slice(scanIndex, lineEnd);
+  const isEsqlQueryRequest = isEsqlQueryRequestLine(line);
+
+  // Move the index past the current request line.
+  const nextIndex = newlineIndex === -1 ? text.length : newlineIndex + 1;
+  return { nextIndex, isEsqlQueryRequest };
+};
+
 export const checkForTripleQuotesAndEsqlQuery = (
   text: string
 ): {
@@ -20,149 +171,67 @@ export const checkForTripleQuotesAndEsqlQuery = (
   insideEsqlQuery: boolean;
   esqlQueryIndex: number;
 } => {
-  const tripleQuotes = '"""';
+  // Quote tracking for the JSON body:
+  // - inDoubleQuoteString: between unescaped `" ... "`
+  // - inTripleQuoteString: between `""" ... """` (only toggled when not already in double quotes)
+  let inDoubleQuoteString = false;
+  let inTripleQuoteString = false;
 
-  const isWhitespace = (ch: string | undefined) =>
-    ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+  // Tracks whether the *current* string (double or triple) is the value for `"query"`.
+  let inQueryValueString = false;
 
-  /**
-   * Checks whether `text[i]` (the opening quote character of either `"` or `"""`) is the start of
-   * the JSON value for the `"query"` key, i.e. the preceding text ends with `"query"\s*:\s*`.
-   *
-   * This is intentionally implemented without regexes or substring creation in the hot path.
-   */
-  const isQueryValueStart = (i: number): boolean => {
-    let j = i - 1;
-    while (j >= 0 && isWhitespace(text[j])) {
-      j--;
-    }
-    if (j < 0 || text[j] !== ':') {
-      return false;
-    }
-    j--;
-    while (j >= 0 && isWhitespace(text[j])) {
-      j--;
-    }
-    // We expect the key to end with: "query"
-    if (j < 6) {
-      return false;
-    }
-    return text.slice(j - 6, j + 1) === '"query"';
-  };
+  // Tracks whether the current request section is a POST /_query(/async) request.
+  let inEsqlQueryRequest = false;
 
-  const isLineStart = (i: number): boolean => i === 0 || text[i - 1] === '\n';
+  // Start index of the query text (first character after opening quote(s)) when inQueryValueString=true.
+  let esqlQueryStartIndex = -1;
 
-  const isRequestMethodAt = (i: number): boolean => {
-    const ch = text[i];
-    if (!ch) return false;
-    // Fast-path: methods always start with letters. Avoid work for most characters.
-    const code = ch.charCodeAt(0);
-    const isAlpha = (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
-    if (!isAlpha) return false;
-
-    // Case-insensitive check for supported methods.
-    const upper = (idx: number) => (text[idx] ?? '').toUpperCase();
-    const matches = (word: string) =>
-      word.split('').every((c, k) => upper(i + k) === c) &&
-      // ensure we don't match a larger identifier
-      !/[A-Z]/i.test(text[i + word.length] ?? '');
-
-    return (
-      matches('GET') ||
-      matches('POST') ||
-      matches('PUT') ||
-      matches('DELETE') ||
-      matches('HEAD') ||
-      matches('PATCH')
-    );
-  };
-
-  const isEsqlQueryRequestLine = (line: string): boolean => {
-    // Mirrors previous behavior:
-    // POST <spaces> /?_query(/async)? followed by newline/space/?/end
-    return /^post\s+\/?_query(?:\/async)?(?:\s|\?|$)/i.test(line);
-  };
-
-  let insideSingleQuotes = false;
-  let insideTripleQuotes = false;
-
-  let insideSingleQuotesQuery = false;
-  let insideTripleQuotesQuery = false;
-
-  let insideEsqlQueryRequest = false;
-
-  let currentQueryStartIndex = -1;
-  let i = 0;
-
-  const updateQueryStateOnQuoteToggle = (
-    isNowInsideQuotes: boolean,
-    quoteStartIndex: number,
-    quoteLen: 1 | 3
-  ): boolean => {
-    if (isNowInsideQuotes) {
-      const isQuery = isQueryValueStart(quoteStartIndex);
-      if (isQuery) {
-        currentQueryStartIndex = quoteStartIndex + quoteLen;
-      }
-      return isQuery;
-    }
-
-    currentQueryStartIndex = -1;
-    return false;
-  };
-
-  const scanRequestLineFrom = (lineStartIndex: number): number | undefined => {
-    // Skip leading spaces/tabs on the request line.
-    let k = lineStartIndex;
-    while (k < text.length && (text[k] === ' ' || text[k] === '\t')) {
-      k++;
-    }
-
-    if (k >= text.length || !isRequestMethodAt(k)) {
-      return;
-    }
-
-    const newlineIndex = text.indexOf('\n', k);
-    const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
-    // The request line is typically short; substring allocation here is bounded.
-    const line = text.slice(k, lineEnd);
-    insideEsqlQueryRequest = isEsqlQueryRequestLine(line);
-
-    // Move the index past the current request line.
-    return newlineIndex === -1 ? text.length : newlineIndex + 1;
-  };
-
-  while (i < text.length) {
+  for (let index = 0; index < text.length; ) {
     // Detect request boundaries (only meaningful outside quoted regions).
-    if (!insideSingleQuotes && !insideTripleQuotes && isLineStart(i)) {
-      const nextIndex = scanRequestLineFrom(i);
-      if (nextIndex !== undefined) {
-        i = nextIndex;
+    if (!inDoubleQuoteString && !inTripleQuoteString && isStartOfLine(text, index)) {
+      const requestLineScan = scanRequestLineFrom(text, index);
+      if (requestLineScan) {
+        inEsqlQueryRequest = requestLineScan.isEsqlQueryRequest;
+        index = requestLineScan.nextIndex;
         continue;
       }
     }
 
-    if (!insideSingleQuotes && text.startsWith(tripleQuotes, i)) {
-      insideTripleQuotes = !insideTripleQuotes;
-      insideTripleQuotesQuery = updateQueryStateOnQuoteToggle(insideTripleQuotes, i, 3);
-      i += 3; // Skip the triple quotes
+    // Triple quotes (only when we're not already inside a standard JSON string).
+    if (!inDoubleQuoteString && text.startsWith(TRIPLE_QUOTES, index)) {
+      inTripleQuoteString = !inTripleQuoteString;
+      if (inTripleQuoteString) {
+        esqlQueryStartIndex = getQueryValueStartIndex(text, index, 3);
+        inQueryValueString = esqlQueryStartIndex !== -1;
+      } else {
+        inQueryValueString = false;
+        esqlQueryStartIndex = -1;
+      }
+      index += 3;
       continue;
     }
 
-    if (!insideTripleQuotes && text[i] === '"' && text[i - 1] !== '\\') {
-      insideSingleQuotes = !insideSingleQuotes;
-      insideSingleQuotesQuery = updateQueryStateOnQuoteToggle(insideSingleQuotes, i, 1);
-      i++;
+    // Standard JSON string quotes (unescaped only, and only when not in triple quotes).
+    if (!inTripleQuoteString && text[index] === '"' && text[index - 1] !== '\\') {
+      inDoubleQuoteString = !inDoubleQuoteString;
+      if (inDoubleQuoteString) {
+        esqlQueryStartIndex = getQueryValueStartIndex(text, index, 1);
+        inQueryValueString = esqlQueryStartIndex !== -1;
+      } else {
+        inQueryValueString = false;
+        esqlQueryStartIndex = -1;
+      }
+      index++;
       continue;
     }
 
-    i++;
+    index++;
   }
 
   return {
-    insideTripleQuotes,
-    insideEsqlQuery: insideEsqlQueryRequest && (insideSingleQuotesQuery || insideTripleQuotesQuery),
-    esqlQueryIndex: insideEsqlQueryRequest ? currentQueryStartIndex : -1,
+    insideTripleQuotes: inTripleQuoteString,
+    insideEsqlQuery: inEsqlQueryRequest && inQueryValueString,
+    esqlQueryIndex: inEsqlQueryRequest ? esqlQueryStartIndex : -1,
   };
 };
 

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
@@ -9,8 +9,12 @@
 
 import React from 'react';
 import type { ComponentProps } from 'react';
-import { CODE_EDITOR_DEFAULT_THEME_ID, CODE_EDITOR_TRANSPARENT_THEME_ID } from '@kbn/monaco';
-import { render, screen } from '@testing-library/react';
+import {
+  CODE_EDITOR_DEFAULT_THEME_ID,
+  CODE_EDITOR_TRANSPARENT_THEME_ID,
+  monaco,
+} from '@kbn/monaco';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MonacoEditor, OVERFLOW_WIDGETS_TEST_ID } from './editor';
 import * as supportedLanguages from './languages/supported';
 
@@ -21,7 +25,87 @@ const defaultProps: Partial<ComponentProps<typeof MonacoEditor>> = {
   editorWillUnmount: jest.fn(),
 };
 
+const createEvent = (
+  changes: monaco.editor.IModelContentChange[]
+): monaco.editor.IModelContentChangedEvent => ({
+  changes,
+  eol: '\n',
+  versionId: 1,
+  isUndoing: false,
+  isRedoing: false,
+  isFlush: false,
+  isEolChange: false,
+});
+
+const createRange = (): monaco.IRange => ({
+  startLineNumber: 1,
+  startColumn: 1,
+  endLineNumber: 1,
+  endColumn: 1,
+});
+
+const createDisposable = (): monaco.IDisposable => ({ dispose: jest.fn() });
+
+const setupMonacoEditorHarness = (params: {
+  onDidChangeModelContent?: (cb: (e: monaco.editor.IModelContentChangedEvent) => void) => void;
+  onPushUndoStop: jest.Mock;
+  onCreateModel?: (model: monaco.editor.ITextModel) => void;
+}) => {
+  const disposable = createDisposable();
+
+  const createSpy = jest.spyOn(monaco.editor, 'create').mockImplementation((container, options) => {
+    if (!options?.model) {
+      throw new Error('expected create() to be called with a model');
+    }
+
+    const model = options.model;
+    params.onCreateModel?.(model);
+
+    const editor = {
+      onDidChangeModelContent: (cb: (e: monaco.editor.IModelContentChangedEvent) => void) => {
+        params.onDidChangeModelContent?.(cb);
+        return disposable;
+      },
+      getModel: () => model,
+      pushUndoStop: params.onPushUndoStop,
+      updateOptions: jest.fn(),
+      layout: jest.fn(),
+      dispose: jest.fn(),
+      getDomNode: () => null,
+    } as unknown as monaco.editor.IStandaloneCodeEditor;
+
+    return editor;
+  });
+
+  const markersSpy = jest
+    .spyOn(monaco.editor, 'onDidChangeMarkers')
+    .mockImplementation(() => disposable);
+  const getModelMarkersSpy = jest.spyOn(monaco.editor, 'getModelMarkers').mockReturnValue([]);
+
+  const cleanup = () => {
+    createSpy.mockRestore();
+    markersSpy.mockRestore();
+    getModelMarkersSpy.mockRestore();
+  };
+
+  return { cleanup };
+};
+
 describe('react monaco editor', () => {
+  let cleanupMonaco: (() => void) | undefined;
+
+  beforeEach(() => {
+    const { cleanup } = setupMonacoEditorHarness({
+      onPushUndoStop: jest.fn(),
+    });
+    cleanupMonaco = cleanup;
+  });
+
+  afterEach(() => {
+    cleanupMonaco?.();
+    cleanupMonaco = undefined;
+  });
+
   beforeAll(() => {
     jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
       (contextId, options) =>
@@ -50,17 +134,141 @@ describe('react monaco editor', () => {
 
     render(<MonacoEditor {...defaultProps} />);
 
-    expect(defineThemeSpy).toHaveBeenCalled();
-    expect(defineThemeSpy).toHaveBeenCalledWith(CODE_EDITOR_DEFAULT_THEME_ID, expect.any(Object));
-    expect(defineThemeSpy).toHaveBeenCalledWith(
-      CODE_EDITOR_TRANSPARENT_THEME_ID,
-      expect.any(Object)
-    );
+    return waitFor(() => {
+      expect(defineThemeSpy).toHaveBeenCalled();
+      expect(defineThemeSpy).toHaveBeenCalledWith(CODE_EDITOR_DEFAULT_THEME_ID, expect.any(Object));
+      expect(defineThemeSpy).toHaveBeenCalledWith(
+        CODE_EDITOR_TRANSPARENT_THEME_ID,
+        expect.any(Object)
+      );
+    });
   });
 
-  it('renders the overflow widgets into a portal', () => {
+  it('renders the overflow widgets into a portal', async () => {
     render(<MonacoEditor {...defaultProps} />);
 
-    expect(screen.getByTestId(OVERFLOW_WIDGETS_TEST_ID)).toBeDefined();
+    expect(await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID)).toBeDefined();
+  });
+});
+
+describe('react monaco editor onChange performance', () => {
+  let lastOnDidChangeModelContentCb:
+    | ((e: monaco.editor.IModelContentChangedEvent) => void)
+    | undefined;
+
+  beforeEach(() => {
+    lastOnDidChangeModelContentCb = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('computes the next value from event.changes (including multiple changes)', async () => {
+    const editorPushUndoStop = jest.fn();
+
+    let createdModel: monaco.editor.ITextModel | undefined;
+    const { cleanup } = setupMonacoEditorHarness({
+      onDidChangeModelContent: (cb) => {
+        lastOnDidChangeModelContentCb = cb;
+      },
+      onPushUndoStop: editorPushUndoStop,
+      onCreateModel: (model) => {
+        createdModel = model;
+      },
+    });
+
+    const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+
+    render(
+      <MonacoEditor value={null} defaultValue="abcdefghij" onChange={onChange} options={{}} />
+    );
+
+    await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID);
+    expect(typeof lastOnDidChangeModelContentCb).toBe('function');
+
+    // Two changes, deliberately provided out of order (ascending offsets) to ensure
+    // the implementation sorts descending to avoid offset shifting.
+    const range = createRange();
+    const event = createEvent([
+      { range, rangeOffset: 2, rangeLength: 2, text: 'XXXX' },
+      { range, rangeOffset: 7, rangeLength: 1, text: 'Y' },
+    ]);
+    lastOnDidChangeModelContentCb!(event);
+
+    expect(onChange).toHaveBeenCalledWith('abXXXXefgYij', event);
+    expect(createdModel).toBeDefined();
+
+    cleanup();
+  });
+
+  it('does not pushEditOperations for controlled rerenders when value matches last known value', async () => {
+    const originalCreateModel = monaco.editor.createModel.bind(monaco.editor);
+    let pushEditOperationsSpy: jest.SpyInstance | undefined;
+    const createModelSpy = jest
+      .spyOn(monaco.editor, 'createModel')
+      .mockImplementation((...args) => {
+        const model = originalCreateModel(...args);
+        pushEditOperationsSpy = jest.spyOn(model, 'pushEditOperations');
+        return model;
+      });
+
+    const editorPushUndoStop = jest.fn();
+    const { cleanup } = setupMonacoEditorHarness({
+      onDidChangeModelContent: (cb) => {
+        lastOnDidChangeModelContentCb = cb;
+      },
+      onPushUndoStop: editorPushUndoStop,
+    });
+
+    const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+    const { rerender } = render(
+      <MonacoEditor value="abcdefghij" onChange={onChange} options={{}} />
+    );
+
+    await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID);
+    expect(typeof lastOnDidChangeModelContentCb).toBe('function');
+
+    const range = createRange();
+    const event = createEvent([{ range, rangeOffset: 2, rangeLength: 2, text: 'XXXX' }]);
+    lastOnDidChangeModelContentCb!(event);
+
+    expect(onChange).toHaveBeenCalledWith('abXXXXefghij', event);
+
+    rerender(<MonacoEditor value="abXXXXefghij" onChange={onChange} options={{}} />);
+
+    expect(pushEditOperationsSpy).toBeDefined();
+    expect(pushEditOperationsSpy!).not.toHaveBeenCalled();
+    expect(editorPushUndoStop).not.toHaveBeenCalled();
+
+    createModelSpy.mockRestore();
+    cleanup();
+  });
+
+  it('pushes a full replace when controlled value changes externally', async () => {
+    const originalCreateModel = monaco.editor.createModel.bind(monaco.editor);
+    let pushEditOperationsSpy: jest.SpyInstance | undefined;
+    const createModelSpy = jest
+      .spyOn(monaco.editor, 'createModel')
+      .mockImplementation((...args) => {
+        const model = originalCreateModel(...args);
+        pushEditOperationsSpy = jest.spyOn(model, 'pushEditOperations');
+        return model;
+      });
+
+    const editorPushUndoStop = jest.fn();
+    const { cleanup } = setupMonacoEditorHarness({
+      onPushUndoStop: editorPushUndoStop,
+    });
+
+    const onChange = jest.fn<void, [string, monaco.editor.IModelContentChangedEvent]>();
+    const { rerender } = render(<MonacoEditor value="initial" onChange={onChange} options={{}} />);
+
+    await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID);
+    rerender(<MonacoEditor value="external update" onChange={onChange} options={{}} />);
+
+    expect(pushEditOperationsSpy).toBeDefined();
+    expect(pushEditOperationsSpy!).toHaveBeenCalledTimes(1);
+    expect(editorPushUndoStop).toHaveBeenCalledTimes(2);
+
+    createModelSpy.mockRestore();
+    cleanup();
   });
 });

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx
@@ -149,6 +149,24 @@ describe('react monaco editor', () => {
 
     expect(await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID)).toBeDefined();
   });
+
+  it('uses defaultValue when value is undefined (uncontrolled mode)', async () => {
+    const originalCreateModel = monaco.editor.createModel.bind(monaco.editor);
+    let firstArg: unknown;
+    const createModelSpy = jest
+      .spyOn(monaco.editor, 'createModel')
+      .mockImplementation((...args) => {
+        firstArg = args[0];
+        return originalCreateModel(...args);
+      });
+
+    render(<MonacoEditor {...defaultProps} value={undefined} defaultValue="fallback" />);
+
+    await screen.findByTestId(OVERFLOW_WIDGETS_TEST_ID);
+    expect(firstArg).toBe('fallback');
+
+    createModelSpy.mockRestore();
+  });
 });
 
 describe('react monaco editor onChange performance', () => {

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -132,15 +132,17 @@ const applyModelContentChanges = (
   prevValue: string,
   changes: monacoEditor.editor.IModelContentChange[]
 ): string => {
-  // Apply in descending order of offset so earlier edits don't shift later offsets.
+  // Monaco reports offsets and lengths relative to the *previous* value. When multiple changes are
+  // present (e.g. multi-cursor edits), apply them from the end of the string towards the start so
+  // earlier edits don't shift the offsets of later ones.
   const sortedChanges = [...changes].sort((a, b) => b.rangeOffset - a.rangeOffset);
-  let nextValue = prevValue;
-  for (const change of sortedChanges) {
+
+  return sortedChanges.reduce((acc, change) => {
     const start = change.rangeOffset;
+    // `rangeLength` is the number of chars to replace from the previous value.
     const end = change.rangeOffset + change.rangeLength;
-    nextValue = nextValue.slice(0, start) + change.text + nextValue.slice(end);
-  }
-  return nextValue;
+    return acc.slice(0, start) + change.text + acc.slice(end);
+  }, prevValue);
 };
 
 // initialize supported languages
@@ -250,7 +252,8 @@ export function MonacoEditor({
   }, [euiTheme]);
 
   const initMonaco = () => {
-    const finalValue = value !== null ? value : defaultValue;
+    // Treat `null`/`undefined` as uncontrolled, per the prop contract.
+    const finalValue = value ?? defaultValue;
 
     if (containerElement.current && overflowWidgetsDomNode.current) {
       // add the monaco class name to the overflow widgets dom node so that styles,

--- a/src/platform/test/functional/apps/console/quote_heavy_input.ts
+++ b/src/platform/test/functional/apps/console/quote_heavy_input.ts
@@ -1,0 +1,344 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * A quote-heavy payload that triggers super-linear ES|QL context detection
+ * before the fix in checkForTripleQuotesAndEsqlQuery. Used to verify the
+ * editor remains responsive after pasting large JSON with many escaped quotes.
+ */
+export const QUOTE_HEAVY_INPUT = String.raw`POST _ingest/pipeline/_simulate
+{
+  "docs": [
+    {
+      "_source": {
+        "@timestamp": "xQ9mP7vK2ZtR4nL1aB8cD6eF3gH0jS",
+        "eventData": {
+          "__original": "5\"wYxQ9mP7vK\"2Zt\"R4nL1aB8c\"D\"6eF3gH\"0\"jS5wYxQ9\"mP\"7vK2ZtR4n\"L1aB8cD\"6eF3gH0\"jS5wYxQ9m\"P7vK2ZtR4\"nL1aB8c\"D6eF3gH\"0jS5wYxQ9m\"P7vK2ZtR4\"nL1\"aB8cD6e\"F3g\"H0jS5wYx\"Q9m\"P7vK2Z\"tR4nL1\"aB8cD6e\"F3g\"H0jS5wYx\"Q9m\"P7vK2Zt\"R4nL1a\"B8cD6eF\"3gH0j\"S5wYxQ9\"m\"P7vK2ZtR4nL1aB8c\"D6\"eF3gH\"0jS5w\"YxQ9mP7v\"K2Z\"tR4\"n\"L1aB8\"c\"D6eF\"3gH\"0jS5wYxQ9\"mP7vK\"2ZtR4nL1a\"B8cD\"6eF3gH0jS5\"wYxQ9mP\"7vK2ZtR4nL\"1aB8cD6\"eF3g\"H0jS5\"wYxQ\"9\"mP7vK2ZtR4nL1aB8cD6eF3g\"H\"0jS5wYx\"Q9mP7v\"K2ZtR4n\"L1aB8c\"D6eF3gH\"0\"jS5wYxQ9mP7vK2Z\"t\"R4nL1aB8cD\"6eF3gH\"0jS5wYxQ9mP7v\"K2ZtR4n\"L1aB\"8\"cD6eF\"3\"gH0jS5wY\"x\"Q9mP7vK2ZtR4nL1aB8cD\"6\"eF3gH0jS5w\"Y\"xQ9mP7vK2ZtR4\"n\"L1aB8cD6e\"F3g\"H0jS5wYxQ9mP7vK2ZtR\"4nL1aB8cD\"6eF3gH0jS\"5w\"YxQ9mP7v\"K2ZtR\"4nL1aB8cD6eF3gH\"0jS\"5wY\"xQ9\"mP7vK\"2ZtR4\"nL1\"aB8c\"D6eF3\"gH0jS\"5wY\"xQ9m\"P7vK2\"ZtR4n\"L1a\"B8cD\"6eF3g\"H0jS5w\"YxQ\"9mP7\"vK2Zt\"R4nL1\"aB8\"cD6e\"F3gH0\"jS5wYxQ\"9mP\"7vK2Z\"tR4nL\"1aB8cD\"6eF\"3gH0j\"S5wYx\"Q9mP7\"vK2\"ZtR4n\"L1aB8\"cD6eF\"3gH\"0jS5wY\"xQ9mP\"7vK2Z\"tR4\"nL1aB8\"cD6eF\"3gH0j\"S5wYxQ9mP7vK2Zt\"R4n\"L1a\"B8c\"D6eF3\"gH0jS\"5wY\"xQ9m\"P7vK2\"ZtR4n\"L1a\"B8cD\"6eF3g\"H0jS5\"wYx\"Q9mP\"7vK2Z\"tR4nL\"1aB\"8cD6\"eF3gH\"0jS5w\"YxQ\"9mP7\"vK2Zt\"R4nL1\"aB8\"cD6eF\"3gH0j\"S5wYxQ9\"mP7\"vK2Zt\"R4nL1\"aB8cD\"6eF\"3gH0j\"S5wYx\"Q9mP7\"vK2\"ZtR4nL\"1aB8c\"D6eF3\"gH0\"jS5wYx\"Q9mP7\"vK2ZtR\"4nL1aB8cD\"6\"eF3gH0jS5wYxQ\"9\"mP7vK2ZtR\"4n\"L1aB8cD6\"eF3gH\"0jS5wYxQ9mP7v\"K2Z\"tR4\"nL1aB\"8cD6e\"F3gH0\"jS5\"wYxQ9\"mP7vK\"2ZtR4\"nL1\"aB8cD\"6eF3g\"H0jS5\"wYx\"Q9mP7\"vK2Zt\"R4nL1\"aB8\"cD6eF\"3gH0j\"S5wYxQ\"9mP\"7vK2Z\"tR4nL\"1aB8cD6\"eF3\"gH0jS\"5wYxQ\"9mP7v\"K2Z\"tR4nL\"1aB8c\"D6eF3\"gH0\"jS5wY\"xQ9mP\"7vK2Z\"tR4\"nL1\"aB8cD\"6eF3gH\"0jS5wY\"xQ9mP7\"vK2ZtR4nL\"1aB8c\"D6eF3gH\"0jS\"5wYxQ9mP7v\"K2Z\"tR4nL1aB8cD6e\"F3gH0jS\"5wY\"xQ9mP7vK2\"ZtR\"4\"nL\\1a\\\"\\B8cD6\"e\"F3gH\"0jS\"5wYxQ9mP7\"vK2Zt\"R4nL1aB8c\"D6eF3\"gH0jS5wYxQ\"9mP7vK2\"ZtR4nL1aB8\"cD6eF3g\"H0jS\"5wYxQ\"9mP7\"v\"K2ZtR4nL1aB8cD6\"e\"F3gH0jS\"5wYxQ9m\"P7vK2Zt\"R4nL1aB\"8cD6eF3\"g\"H0jS5wYxQ9mP7vK\"2\"ZtR4nL1aB8\"cD6eF3\"gH0jS5wYxQ9mP\"7vK2ZtR\"4nL1\"a\"B8cD6e\"F\"3gH0jS5w\"Y\"xQ9mP7vK2ZtR4nL1aB8c\"D\"6eF3gH0jS5\"w\"YxQ9mP7vK2ZtR\"4\"nL1aB8cD6\"eF3\"gH0jS5wYxQ9mP7vK2Zt\"R4nL1aB8c\"D6eF3gH0j\"S5\"wYxQ9mP7\"vK2Zt\"R4nL1aB8cD6eF3g\"H0j\"S5w\"YxQ\"9mP7v\"K2ZtR\"4nL\"1aB8\"cD6eF\"3gH0j\"S5w\"YxQ9\"mP7vK\"2ZtR4\"nL1\"aB8c\"D6eF3\"gH0jS\"5wY\"xQ9m\"P7vK2\"ZtR4n\"L1a\"B8cD\"6eF3g\"H0jS5\"wYx\"Q9mP7\"vK2Zt\"R4nL1aB\"8cD\"6eF3g\"H0jS5\"wYxQ9\"mP7\"vK2Zt\"R4nL1\"aB8cD\"6eF\"3gH0jS\"5wYxQ\"9mP7v\"K2Z\"tR4nL1\"aB8cD\"6eF3g\"H0jS5wYxQ9mP7vK\"2Zt\"R4n\"L1a\"B8cD6\"eF3gH0\"jS5\"wYxQ\"9mP7v\"K2ZtR\"4nL\"1aB8\"cD6eF\"3gH0j\"S5w\"YxQ9\"mP7vK\"2ZtR4\"nL1\"aB8c\"D6eF3\"gH0jS\"5wY\"xQ9m\"P7vK2\"ZtR4n\"L1a\"B8cD6\"eF3gH\"0jS5wYx\"Q9m\"P7vK2\"ZtR4n\"L1aB8\"cD6\"eF3gH\"0jS5w\"YxQ9m\"P7v\"K2ZtR4\"nL1aB\"8cD6e\"F3g\"H0jS5w\"YxQ9m\"P7vK2Z\"tR4nL1aB8\"c\"D6eF3gH0jS5wY\"x\"Q9mP7vK2Z\"tR\"4nL1aB8c\"D6eF3\"gH0jS5wYxQ9mP\"7vK\"2Zt\"R4nL1\"aB8cD\"6eF3g\"H0j\"S5wYx\"Q9mP7\"vK2Zt\"R4n\"L1aB8\"cD6eF\"3gH0j\"S5w\"YxQ9m\"P7vK2\"ZtR4n\"L1a\"B8cD6\"eF3gH\"0jS5w\"YxQ\"9mP7v\"K2ZtR\"4nL1a\"B8c\"D6eF3\"gH0jS\"5wYxQ9m\"P7v\"K2ZtR\"4nL1a\"B8cD6\"eF3\"gH0jS\"5wYxQ\"9mP7v\"K2Z\"tR4\"nL1aB\"8cD6eF\"3gH0jS\"5wYxQ9\"mP7vK2ZtR\"4nL1a\"B8cD6eF\"3gH\"0jS5wYxQ9m\"P7v\"K2Z\"tR4nL1\"aB8cD6eF3gH0j\"S5wYxQ9\"mP7\"vK2ZtR4n\"L1a\"B\"8cD6eF\"3\"gH0j\"S5w\"YxQ9mP7vK\"2ZtR4\"nL1aB8cD6\"eF3gH0j\"S5wYxQ9mP7\"vK2ZtR4\"nL1aB8cD6e\"F3gH0jS\"5wYx\"Q9mP7\"vK2Z\"t\"R4nL1aB8cD6eF3gH0jS5wYx\"Q\"9mP7vK2\"ZtR4nL1a\"B8cD6eF\"3gH0jS5wYx\"Q9mP7vK\"2\"ZtR4nL1aB8cD6eF\"3\"gH0jS5wYxQ\"9mP7vK\"2ZtR4nL1aB8cD\"6eF3gH0\"jS5w\"Y\"xQ9mP\"7\"vK2ZtR4n\"L\"1aB8cD6eF3gH0jS5wYxQ\"9\"mP7vK2ZtR4\"n\"L1aB8cD6eF3gH\"0\"jS5wYxQ9m\"P7v\"K2ZtR4nL1aB8cD6eF3g\"H0jS5wYxQ\"9mP7vK2Zt\"R4\"nL1aB8cD\"6eF3g\"H0jS5wYxQ9mP7vK\"2Zt\"R4n\"L1a\"B8cD6\"eF3gH\"0jS\"5wYx\"Q9mP7\"vK2Zt\"R4n\"L1aB\"8cD6e\"F3gH0\"jS5\"wYxQ\"9mP7v\"K2ZtR\"4nL\"1aB8\"cD6eF\"3gH0j\"S5w\"YxQ9\"mP7vK\"2ZtR4\"nL1\"aB8cD\"6eF3g\"H0jS5wY\"xQ9\"mP7vK\"2ZtR4\"nL1aB\"8cD\"6eF3g\"H0jS5\"wYxQ9\"mP7\"vK2ZtR\"4nL1a\"B8cD6\"eF3\"gH0jS5\"wYxQ9\"mP7vK\"2ZtR4nL1aB8cD6e\"F3g\"H0j\"S5w\"YxQ9m\"P7vK2Z\"tR4\"nL1a\"B8cD6\"eF3gH\"0jS\"5wYx\"Q9mP7\"vK2Zt\"R4n\"L1aB\"8cD6e\"F3gH0\"jS5\"wYxQ\"9mP7v\"K2ZtR\"4nL\"1aB8\"cD6eF\"3gH0j\"S5w\"YxQ9m\"P7vK2\"ZtR4nL1\"aB8\"cD6eF\"3gH0j\"S5wYx\"Q9m\"P7vK2\"ZtR4n\"L1aB8\"cD6\"eF3gH0\"jS5wY\"xQ9mP\"7vK\"2ZtR4n\"L1aB8\"cD6eF3\"gH0jS5wYx\"Q\"9mP7vK2ZtR4nL\"1\"aB8cD6eF3\"gH\"0jS5wYxQ\"9mP7v\"K2ZtR4nL1aB8c\"D6e\"F3g\"H0jS5\"wYxQ9\"mP7vK\"2Zt\"R4nL1\"aB8cD\"6eF3g\"H0j\"S5wYx\"Q9mP7\"vK2Zt\"R4n\"L1aB8\"cD6eF\"3gH0j\"S5w\"YxQ9m\"P7vK2\"ZtR4n\"L1a\"B8cD6\"eF3gH\"0jS5wYx\"Q9m\"P7vK2\"ZtR4n\"L1aB8c\"D6e\"F3gH0\"jS5wY\"xQ9mP\"7vK\"2ZtR4\"nL1aB\"8cD6e\"F3g\"H0j\"S5wYx\"Q9mP7v\"K2ZtR4\"nL1aB8\"cD6eF3gH0\"jS5wYxQ\"9mP7vK2\"ZtR\"4nL1aB8cD6\"eF3\"gH0jS5wYxQ9mP\"7vK2ZtR\"4nL\"1aB8cD6eF\"3gH\"0\"jS5wYx\"Q\"9mP7\"vK2\"ZtR4nL1aB\"8cD6e\"F3gH0jS5w\"YxQ9m\"P7vK2ZtR4n\"L1aB8cD6\"eF3gH0jS5w\"YxQ9mP7\"vK2Z\"tR4nL\"1aB8\"c\"D6eF3gH0jS5wYxQ9mP7vK2ZtR\"4\"nL1aB8c\"D6eF3gH0\"jS5wYxQ\"9mP7vK2\"ZtR4nL1\"a\"B8cD6eF3gH0jS5w\"Y\"xQ9mP7vK2Z\"tR4nL1\"aB8cD6eF3gH0j\"S5wYxQ9m\"P7vK\"2\"ZtR4n\"L\"1aB8cD6e\"F\"3gH0jS5wYxQ9mP7vK2Zt\"R\"4nL1aB8cD6\"e\"F3gH0jS5wYxQ9\"m\"P7vK2ZtR4\"nL1\"aB8cD6eF3gH0jS5wYxQ\"9mP7vK2Zt\"R4nL1aB8c\"D6\"eF3gH0jS\"5wYxQ\"9mP7vK2ZtR4nL1a\"B8c\"D6e\"F3g\"H0jS5\"wYxQ9\"mP7\"vK2Z\"tR4nL\"1aB8c\"D6e\"F3gH\"0jS5w\"YxQ9m\"P7v\"K2Zt\"R4nL1\"aB8cD\"6eF\"3gH0\"jS5wY\"xQ9mP\"7vK\"2ZtR\"4nL1a\"B8cD6\"eF3\"gH0jS\"5wYxQ\"9mP7vK\"2Zt\"R4nL1\"aB8cD\"6eF3gH\"0jS\"5wYxQ\"9mP7v\"K2ZtR\"4nL\"1aB8cD\"6eF3g\"H0jS5\"wYx\"Q9mP7v\"K2ZtR\"4nL1a\"B8cD6eF3gH0jS5w\"YxQ\"9mP\"7vK\"2ZtR4\"nL1aB\"8cD\"6eF3\"gH0jS\"5wYxQ\"9mP\"7vK2\"ZtR4n\"L1aB8\"cD6\"eF3g\"H0jS5\"wYxQ9\"mP7\"vK2Z\"tR4nL\"1aB8c\"D6e\"F3gH\"0jS5w\"YxQ9m\"P7v\"K2ZtR\"4nL1a\"B8cD6eF\"3gH\"0jS5w\"YxQ9m\"P7vK2\"ZtR\"4nL1a\"B8cD6\"eF3gH\"0jS\"5wYxQ9\"mP7vK\"2ZtR4\"nL1\"aB8cD6\"eF3gH\"0jS5wY\"xQ9mP7vK2\"Z\"tR4nL1aB8cD6e\"F\"3gH0jS5wY\"xQ\"9mP7vK2Z\"tR4nL\"1aB8cD6eF3gH0\"jS5\"wYx\"Q9mP7\"vK2Zt\"R4nL1\"aB8\"cD6eF\"3gH0j\"S5wYx\"Q9m\"P7vK2\"ZtR4n\"L1aB8cD\"6eF\"3gH0j\"S5wYx\"Q9mP7v\"K2Z\"tR4nL\"1aB8c\"D6eF3\"gH0\"jS5wY\"xQ9mP\"7vK2Z\"tR4\"nL1aB\"8cD6e\"F3gH0\"jS5\"wYxQ9\"mP7vK\"2ZtR4\"nL1\"aB8cD\"6eF3g\"H0jS5\"wYx\"Q9m\"P7vK2\"ZtR4nL\"1aB8cD\"6eF3gH0\"jS5wYxQ9m\"P7vK2\"ZtR4nL1\"aB8\"cD6eF3gH0j\"S5w\"YxQ\"9mP7vK\"2ZtR4nL1aB8cD\"6eF3gH0\"jS5\"wYxQ9mP7v\"K2ZtR4n\"L1\"aB8cD6e\"F3gH\"0jS5wYxQ9\"m\"P7vK2ZtR4nL\"1\"aB8cD6eF3gH0j\"S5wYxQ9\"mP7vK2Zt\"R4\"nL1aB\"8cD\"6eF3g\"H0j\"S5wYxQ9\"mP7v\"K2ZtR4nL\"1aB8c\"D6eF3gH0jS\"5wY\"xQ9mP7vK2Z\"tR4n\"L1aB8cD6eF3gH0jS\"5wY\"xQ9\"mP7v\"K2ZtR\"4nL1a\"B8c\"D6eF\"3gH0j\"S5wYx\"Q9m\"P7vK\"2ZtR4\"nL1aB\"8cD\"6eF3\"gH0jS\"5wYxQ\"9mP\"7vK2\"ZtR4n\"L1aB8\"cD6\"eF3g\"H0jS5\"wYxQ9\"mP7\"vK2Z\"tR4nL\"1aB8c\"D6e\"F3gH\"0jS5w\"YxQ9m\"P7v\"K2Zt\"R4nL1\"aB8cD\"6eF3gH0\"jS5\"wYxQ9mP\"7\"vK2ZtR4nL1aB8cD6\"e\"F3gH0jS5wYxQ9mP7\"vK2\"ZtR\"4nL1\"aB8cD\"6eF3g\"H0j\"S5wY\"xQ9mP\"7vK2Z\"tR4\"nL1a\"B8cD6\"eF3gH\"0jS\"5wYx\"Q9mP7\"vK2Zt\"R4n\"L1aB\"8cD6e\"F3gH0\"jS5\"wYxQ\"9mP7v\"K2ZtR\"4nL\"1aB8\"cD6eF\"3gH0j\"S5w\"YxQ9\"mP7vK\"2ZtR4\"nL1\"aB8c\"D6eF3\"gH0jS5\"wYxQ9mP7vK2ZtR4\"nL1a\"B8cD6eF3gH\"0jS5wY\"xQ9mP7vK2\"Z\"tR4nL1\"a\"B8cD6eF3\"gH\"0jS5wYxQ9\"mP7vK2Z\"tR4nL1a\"B8cD6eF3gH\"0jS5wYxQ9\"mP7vK2\"ZtR4nL1\"aB8cD6eF\"3gH0jS5wY\"xQ9\"mP7vK2Z\"tR4\"nL1aB8cD\"6eF\"3gH0jS\"5wYxQ9m\"P7vK2Zt\"R4nL1\"aB8cD6eF\"3gH0j\"S5wYxQ9\"mP7vK2\"ZtR4nL1\"aB8cD6\"eF3gH0j\"S\"5wYxQ9mP7vK2ZtR4\"nL\"1aB8c\"D6eF3\"gH0jS5wY\"xQ9\"mP7\"v\"K2ZtR4\"n\"L1aB\"8cD\"6eF3gH0jS\"5wYxQ\"9mP7vK2Zt\"R4nL1a\"B8cD6eF3gH\"0jS5wYxQ\"9mP7vK2ZtR\"4nL1aB8c\"D6eF\"3gH0j\"S5wY\"x\"Q9mP7vK2Zt\"R\"4nL1aB8\"cD6eF3gH0j\"S5wYxQ9\"mP7vK2Zt\"R4nL1aB\"8\"cD6eF3gH0jS5wYx\"Q\"9mP7vK2ZtR\"4nL1aB\"8cD6eF3gH0jS5\"wYxQ9mP7\"vK2Z\"t\"R4nL1a\"B\"8cD6eF3g\"H\"0jS5wYxQ9mP7vK2ZtR4n\"L\"1aB8cD6eF3\"g\"H0jS5wYxQ9mP7\"v\"K2ZtR4nL1\"aB8\"cD6eF3gH0jS5wYxQ9mP\"7vK2ZtR4n\"L1aB8cD6e\"F3\"gH0jS5wY\"xQ9mP\"7vK2ZtR4nL1aB8c\"D6e\"F3g\"H0j\"S5wYx\"Q9mP7\"vK2\"ZtR4\"nL1aB\"8cD6e\"F3g\"H0jS\"5wYxQ\"9mP7v\"K2Z\"tR4n\"L1aB8\"cD6eF\"3gH\"0jS5\"wYxQ9\"mP7vK\"2Zt\"R4nL\"1aB8c\"D6eF3\"gH0\"jS5wY\"xQ9mP\"7vK2Z\"tR4\"nL1aB\"8cD6e\"F3gH0\"jS5\"wYxQ9\"mP7vK\"2ZtR4nL\"1aB\"8cD6eF\"3gH0j\"S5wYxQ\"9mP\"7vK2Zt\"R4nL1\"aB8cD\"6eF3gH0jS5wYxQ9\"mP7\"vK2\"ZtR\"4nL1a\"B8cD6\"eF3\"gH0j\"S5wYx\"Q9mP7\"vK2\"ZtR4\"nL1aB\"8cD6e\"F3g\"H0jS\"5wYxQ\"9mP7v\"K2Z\"tR4n\"L1aB8\"cD6eF\"3gH\"0jS5\"wYxQ9\"mP7vK\"2Zt\"R4nL1\"aB8cD\"6eF3g\"H0j\"S5wYx\"Q9mP7\"vK2Zt\"R4n\"L1aB8\"cD6eF\"3gH0jS5\"wYx\"Q9mP7v\"K2ZtR\"4nL1a\"B8c\"D6eF3g\"H0jS5\"wYxQ9m\"P7vK2ZtR4\"n\"L1aB8cD6eF3gH\"0\"jS5wYxQ9m\"P7\"vK2ZtR4n\"L1aB8\"cD6eF3gH0jS5w\"YxQ\"9mP\"7vK2Z\"tR4nL\"1aB8c\"D6e\"F3gH0\"jS5wY\"xQ9mP\"7vK\"2ZtR4\"nL1aB\"8cD6e\"F3g\"H0jS5\"wYxQ9\"mP7vK\"2Zt\"R4nL1\"aB8cD\"6eF3g\"H0j\"S5wYx\"Q9mP7\"vK2ZtR4\"nL1\"aB8cD\"6eF3g\"H0jS5w\"YxQ\"9mP7v\"K2ZtR\"4nL1aB\"8cD\"6eF3g\"H0jS5\"wYxQ9\"mP7\"vK2\"ZtR4n\"L1aB8c\"D6eF3g\"H0jS5wY\"xQ9mP7vK2\"ZtR4nL\"1aB8cD6\"eF3\"gH0jS5wYxQ\"9mP\"7vK\"2ZtR4n\"L1aB8cD6eF3gH\"0jS5wYxQ\"9mP\"7vK2ZtR4n\"L1aB8cD\"6e\"F3gH0jS\"5wYx\"Q9mP7vK2Z\"t\"R4nL1aB8cD6\"e\"F3gH0jS5wYxQ9\"mP7vK2Z\"tR4nL1aB\"8c\"D6eF3\"gH0\"jS5wY\"xQ9\"mP7vK2Z\"tR4n\"L1aB8cD6\"eF3gH\"0jS5wYxQ9m\"P7v\"K2ZtR4nL1a\"B8cD\"6eF3gH0jS5wYxQ9m\"P7v\"K2Z\"tR4n\"L1aB8\"cD6eF\"3gH\"0jS5\"wYxQ9\"mP7vK\"2Zt\"R4nL\"1aB8c\"D6eF3\"gH0\"jS5w\"YxQ9m\"P7vK2\"ZtR\"4nL1\"aB8cD\"6eF3g\"H0j\"S5wY\"xQ9mP\"7vK2Z\"tR4\"nL1a\"B8cD6\"eF3gH\"0jS\"5wYx\"Q9mP7\"vK2Zt\"R4n\"L1aB\"8cD6e\"F3gH0\"jS5wYxQ\"9mP\"7vK2ZtR\"4\"nL1aB8cD6eF3gH0j\"S\"5wYxQ9mP7vK2ZtR4\"nL1\"aB8\"cD6e\"F3gH0\"jS5wY\"xQ9\"mP7v\"K2ZtR\"4nL1a\"B8c\"D6eF\"3gH0j\"S5wYx\"Q9m\"P7vK\"2ZtR4\"nL1aB\"8cD\"6eF3\"gH0jS\"5wYxQ\"9mP\"7vK2\"ZtR4n\"L1aB8\"cD6\"eF3g\"H0jS5\"wYxQ9\"mP7\"vK2Z\"tR4nL\"1aB8c\"D6e\"F3gH\"0jS5w\"YxQ9mP\"7vK2ZtR4nL1aB8c\"D6eF\"3gH0jS5wYx\"Q9mP7v\"K2ZtR4nL1\"a\"B8cD6eF3gH0jS\"5wY\"xQ9mP7vK2\"Z\"tR4nL1aB8cD6e\"F3g\"H0jS5wYxQ\"9\"mP7vK2ZtR4nL1\"aB8\"cD6eF3gH0\"j\"S5wYxQ9mP7vK2Zt\"R4n\"L1aB8cD6e\"F\"3gH0jS5wYxQ9mP7\"vK2\"ZtR4nL1aB\"8\"cD6eF3gH\"0jS\"5wYxQ9\"mP7vK2ZtR\"4nL1aB8cD\"6eF\"3gH0jS\"5w\"YxQ9\"mP7vK2ZtR4n\"L1aB8cD6eF3g\"H0jS5wYxQ\"9mP7vK2ZtR4n\"L1aB8cD6e\"F3gH0jS5wY\"x\"Q9mP7vK2ZtR4nL1aB8\"c\"D6eF3g\"H0jS5wYxQ9\"mP7vK\"2ZtR4nL1aB8\"cD6eF3gH0jS5wYxQ9m\"P7vK2ZtR4\"nL1aB8cD6\"eF3gH0jS5wYx\"Q9mP7vK2ZtR\"4nL\"1aB8cD6eF\"3\"gH0jS5\"w\"YxQ9mP7\"vK2\"ZtR4nL1aB\"8cD\"6eF3gH0j\"S5w\"YxQ9mP7vK\"2Zt\"R4nL1aB8cD6eF3g\"H0j\"S5wYxQ9mP7v\"K2Z\"tR4nL1a\"B8c\"D6eF3gH0j\"S5w\"YxQ9mP7v\"K2Z\"tR4nL1aB8\"cD6eF\"3gH0jS5wY\"x\"Q9mP7vK\"2\"ZtR4nL1\"aB8\"cD6eF3gH0\"jS5\"wYxQ9mP7\"vK2\"ZtR4nL1aB\"8cD\"6eF3gH0jS5wYxQ9\"mP7\"vK2ZtR4nL1a\"B8c\"D6eF3gH\"0jS\"5wYxQ9mP7\"vK2\"ZtR4nL1a\"B8c\"D6eF3gH0j\"S5wYx\"Q9mP7vK2Z\"t\"R4nL\"1\"aB8cD6e\"F3gH0jS5\"wYxQ9mP7v\"K2ZtR4\"nL1aB8cD\"6eF\"3gH0jS5wY\"xQ9\"mP7vK2ZtR4nL1aB\"8cD\"6eF3gH0jS5w\"YxQ\"9mP7vK2\"ZtR4nL1a\"B8cD6eF3g\"H0jS5w\"YxQ9mP7v\"K2Z\"tR4nL1aB8\"cD6eF\"3gH0jS5wY\"x\"Q9mP7vK\"2\"ZtR4nL1\"aB8\"cD6eF3gH0\"jS5\"wYxQ9mP7\"vK2\"ZtR4nL1aB\"8cD\"6eF3gH0jS5wYxQ9\"mP7\"vK2ZtR4nL1a\"B8c\"D6eF3gH\"0jS\"5wYxQ9mP7\"vK2\"ZtR4nL1a\"B8c\"D6eF3gH0j\"S5wYx\"Q9mP7vK2Z\"t\"R4nL1\"a\"B8cD6eF\"3gH\"0jS5wYxQ9\"mP7\"vK2ZtR4n\"L1a\"B8cD6eF3g\"H0j\"S5wYxQ9mP7vK2Zt\"R4n\"L1aB8cD6eF3\"gH0\"jS5wYxQ\"9mP\"7vK2ZtR4n\"L1a\"B8cD6eF3\"gH0\"jS5wYxQ9m\"P7vK2\"ZtR4nL1aB\"8\"cD6eF\"3\"gH0jS5w\"YxQ9mP7v\"K2ZtR4nL1\"aB8cD6\"eF3gH0jS\"5wY\"xQ9mP7vK2\"ZtR\"4nL1aB8cD6eF3gH\"0jS\"5wYxQ9mP7vK\"2ZtR\"4nL1aB8\"cD6eF3gH0j\"S5wYxQ9mP\"7vK2ZtR\"4nL1aB8c\"D6e\"F3gH0jS5w\"YxQ9m\"P7vK2ZtR4\"n\"L1aB8c\"D\"6eF3gH0\"jS5wYxQ9\"mP7vK2ZtR\"4nL1aB\"8cD6eF3g\"H0j\"S5wYxQ9mP\"7vK\"2ZtR4nL1aB8cD6e\"F3g\"H0jS5wYxQ9m\"P7v\"K2ZtR4n\"L1aB8cD6\"eF3gH0jS5\"wYxQ9m\"P7vK2ZtR\"4nL\"1aB8cD6eF\"3gH0j\"S5wYxQ9mP\"7\"vK2ZtR\"4\"nL1aB8c\"D6e\"F3gH0jS5w\"YxQ\"9mP7vK2Z\"tR4\"nL1aB8cD6\"eF3\"gH0jS5wYxQ9mP7v\"K2Z\"tR4nL1aB8cD\"6eF\"3gH0jS5\"wYx\"Q9mP7vK2Z\"tR4\"nL1aB8cD\"6eF\"3gH0jS5wY\"xQ9mP\"7vK2ZtR4n\"L\"1aB8cD6\"e\"F3gH0jS\"5wY\"xQ9mP7vK2\"ZtR\"4nL1aB8c\"D6e\"F3gH0jS5w\"YxQ\"9mP7vK2ZtR4nL1a\"B8c\"D6eF3gH0jS5\"wYx\"Q9mP7vK\"2Zt\"R4nL1aB8c\"D6e\"F3gH0jS5\"wYx\"Q9mP7vK2Z\"tR4nL\"1aB8cD6eF\"3\"gH0jS5\"w\"YxQ9mP7\"vK2\"ZtR4nL1aB\"8cD\"6eF3gH0j\"S5w\"YxQ9mP7vK\"2Zt\"R4nL1aB8cD6eF3g\"H0j\"S5wYxQ9mP7v\"K2Z\"tR4nL1a\"B8c\"D6eF3gH0j\"S5w\"YxQ9mP7v\"K2Z\"tR4nL1aB8\"cD6eF\"3gH0jS5wY\"x\"Q9mP7vK\"2\"ZtR4nL1\"aB8\"cD6eF3gH0\"jS5\"wYxQ9mP7\"vK2\"ZtR4nL1aB\"8cD\"6eF3gH0jS5wYxQ9\"mP7\"vK2ZtR4nL1a\"B8c\"D6eF3gH\"0jS\"5wYxQ9mP7\"vK2\"ZtR4nL1a\"B8c\"D6eF3gH0j\"S5wYx\"Q9mP7vK2Z\"t\"R4nL\"1\"aB8cD6e\"F3g\"H0jS5wYxQ\"9mP\"7vK2ZtR4\"nL1\"aB8cD6eF3\"gH0\"jS5wYxQ9mP7vK2Z\"tR4\"nL1aB8cD6eF\"3gH\"0jS5wYx\"Q9m\"P7vK2ZtR4\"nL1\"aB8cD6eF\"3gH\"0jS5wYxQ9\"mP7vK\"2ZtR4nL1a\"B\"8cD6e\"F\"3gH0jS5\"wYx\"Q9mP7vK2Z\"tR4\"nL1aB8cD\"6eF\"3gH0jS5wY\"xQ9\"mP7vK2ZtR4nL1aB\"8cD\"6eF3gH0jS5w\"YxQ\"9mP7vK2\"ZtR\"4nL1aB8cD\"6eF\"3gH0jS5w\"YxQ\"9mP7vK2Zt\"R4nL1\"aB8cD6eF3\"g\"H0jS5w\"Y\"xQ9mP7v\"K2ZtR4nL\"1aB8cD6eF\"3gH0jS\"5wYxQ9mP\"7vK\"2ZtR4nL1a\"B8c\"D6eF3gH0jS5wYxQ\"9mP\"7vK2ZtR4nL1\"aB8\"cD6eF3g\"H0jS5wYx\"Q9mP7vK2Z\"tR4nL1\"aB8cD6eF\"3gH\"0jS5wYxQ9\"mP7\"vK2ZtR4nL\"1a\"B8cD6eF3gH0\"jS5w\"YxQ9mP7vK\"2\"ZtR4nL\"1\"aB8cD6e\"F3g\"H0jS5wYxQ\"9mP\"7vK2ZtR4\"nL1\"aB8cD6eF3\"gH0\"jS5wYxQ9mP7vK2Z\"tR4\"nL1aB8cD6eF\"3gH\"0jS5wYx\"Q9m\"P7vK2ZtR4\"nL1\"aB8cD6eF\"3gH\"0jS5wYxQ9\"mP7vK\"2ZtR4nL1a\"B\"8cD6eF\"3\"gH0jS5w\"YxQ\"9mP7vK2Zt\"R4n\"L1aB8cD6\"eF3\"gH0jS5wYx\"Q9m\"P7vK2ZtR4nL1aB8\"cD6\"eF3gH0jS5wY\"xQ9\"mP7vK2Z\"tR4\"nL1aB8cD6\"eF3\"gH0jS5wY\"xQ9\"mP7vK2ZtR\"4nL1a\"B8cD6eF3g\"H\"0jS5wY\"x\"Q9mP7vK\"2Zt\"R4nL1aB8c\"D6e\"F3gH0jS5\"wYx\"Q9mP7vK2Z\"tR4\"nL1aB8cD6eF3gH0\"jS5\"wYxQ9mP7vK2\"ZtR\"4nL1aB8\"cD6\"eF3gH0jS5\"wYx\"Q9mP7vK2\"ZtR\"4nL1aB8cD\"6eF3g\"H0jS5wYxQ\"9\"mP7vK2Z\"t\"R4nL1aB\"8cD\"6eF3gH0jS\"5wY\"xQ9mP7vK\"2Zt\"R4nL1aB8c\"D6e\"F3gH0jS5wYxQ9mP\"7vK\"2ZtR4nL1aB8\"cD6\"eF3gH0j\"S5w\"YxQ9mP7vK\"2Zt\"R4nL1aB8\"cD6\"eF3gH0jS5\"wYxQ9\"mP7vK2ZtR\"4\"nL1aB8cD6\"e\"F3gH0jS\"5wYxQ9mP\"7vK2ZtR4n\"L1aB8c\"D6eF3gH0\"jS5\"wYxQ9mP7v\"K2Z\"tR4nL1aB8cD6eF3\"gH0\"jS5wYxQ9mP7\"vK2\"ZtR4nL1\"aB8cD6eF\"3gH0jS5wY\"xQ9mP7\"vK2ZtR4n\"L1a\"B8cD6eF3g\"H0j\"S5wYxQ9mP\"7v\"K2ZtR4nL1aB8c\"D6eF\"3gH0jS5wY\"x\"Q9mP7\"v\"K2ZtR4n\"L1aB8cD6eF\"3gH0jS5wY\"xQ9mP7v\"K2ZtR4nL\"1aB\"8cD6eF3gH\"0jS\"5wYxQ9mP7vK2ZtR\"4nL\"1aB8cD6eF3g\"H0jS5\"wYxQ9mP\"7vK2ZtR4n\"L1aB8cD6e\"F3gH0jS\"5wYxQ9mP\"7vK\"2ZtR4nL1a\"B8cD6\"eF3gH0jS5wY\"xQ9mP\"7vK2ZtR4nL1aB8\"cD\"6eF3g\"H0jS5\"wYxQ9mP7vK2\"ZtR4n\"L1aB8cD6eF3gH0\"jS5w\"YxQ9mP7vK2\"Zt\"R4nL1\"aB8cD6e\"F3gH0j\"S5wYx\"Q9mP7vK2\"ZtR\"4nL1aB8cD6eF\"3gH0\"jS5wYxQ9\"mP\"7vK2ZtR4\"nL1aB\"8cD6eF3gH0jS\"5wY\"xQ9\"mP7v\"K2ZtR\"4nL1a\"B8c\"D6eF\"3gH0j\"S5wYx\"Q9m\"P7vK\"2ZtR4\"nL1aB8c\"D6e\"F3gH\"0jS5w\"YxQ9mP\"7vK\"2Zt\"R4nL1\"aB8cD\"6eF3gH0\"jS5w\"YxQ9mP7v\"K2Z\"tR4nL1aB\"8cD\"6eF3gH0jS\"5wYx"
+        },
+        "ingest_lag_in_seconds": 1,
+        "kafka": {
+          "eventId": "Q9mP7vK2ZtR4nL1aB8cD6",
+          "moduleId": "eF3gH0jS5wY"
+        },
+        "customerInfo": {
+          "customerId": "xQ9mP7vK2Zt",
+          "deviceId": "R4nL1aB8cD6eF3gH0jS5w",
+          "lineId": "YxQ9mP7vK2ZtR4",
+          "publicIp": "nL1aB8cD6eF3"
+        }
+      }
+    },
+    {
+      "_index": "gH0jS5wYxQ9mP7vK2Zt",
+      "_source": {
+        "kafka": {
+          "eventId": "R4nL1aB8cD6e",
+          "moduleId": "F3gH0jS5w"
+        },
+        "customerInfo": {
+          "customerId": "YxQ9mP7vK2Z",
+          "deviceId": "tR4nL1aB8cD6eF3gH0jS5",
+          "lineId": "wYxQ9mP7vK2ZtR",
+          "publicIp": "4nL1aB8cD6eF"
+        },
+        "eventData": {
+          "__original": "3\"gH0jS5w\"Yx\"Q9m\"P\"7vK2ZtR4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0jS5\"w\"YxQ9mP7\"vK2\"ZtR4nL1aB8cD6e\"F3g\"H0jS5wYx\"Q9m\"P7vK2\"Z\"tR4nL1aB 8cD6eF 3g H0jS5wYx\"Q\"9mP7vK2ZtR4nL1aB8c\"D6eF3\"gH0jS5wY\"xQ9mP7\"vK2ZtR\"4nL1aB8\"cD6eF3gH0jS5wYxQ9mP7vK\"2ZtR\"4nL1aB8cD6eF3gH0j\"S5wYxQ9\"mP7vK2ZtR4n\"L1aB8cD\"6eF3gH\"0\"jS5wYxQ\"9\"mP7vK2ZtR4nL\"1aB8\"cD6eF3gH0\"j\"S5wYxQ9\"m\"P7vK2ZtR4nL1\"a\"B8cD6eF3g\"H\"0jS5wYxQ9mP7\"v\"K2ZtR4n\"L\"1aB8cD6eF3gH0\"jS5w\"YxQ9mP7vK2ZtR4nL1aB\"8cD6e\"F3gH0jS5wYx\"Q9mP7\"vK2ZtR4nL1\"aB8cD6"
+        }
+      }
+    },
+    {
+      "_source": {
+        "eventData": {
+          "__original": "e\"F3gH0jS\"5w\"YxQ\"9\"mP7vK2ZtR4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0jS5wYx\"Q\"9mP7vK2\"ZtR\"4nL1aB8cD6eF3g\"H0j\"S5wYxQ9m\"P7v\"K2ZtR\"4\"nL1aB8cD 6eF3gH 0j S5wYxQ9mP7v K\"2\"ZtR4nL1aB8cD6eF3gH\"0jS5w\"YxQ9mP7v\"K2ZtR4\"nL1aB8\"cD6eF3g\"H0jS5wYxQ9mP7vK2ZtR4nL\"1aB8\"cD6eF3gH0jS5wYxQ9\"mP7vK2Z\"tR4nL1aB8cD\"6eF3gH0\"jS5wYx\"Q\"9mP7vK2\"Z\"tR4nL1aB8cD6\"eF3g\"H0jS5wYxQ\"9\"mP7vK2ZtR4nL\"1\"aB8cD6eF3gH0\"j\"S5wYxQ9mP\"7\"vK2ZtR4nL1aB\"8\"cD6eF3gH0jS5w\"Y\"xQ9mP7vK2ZtR4\"nL1\"aB8cD6eF3gH0jS5wYxQ\"9mP7\"vK2ZtR4nL1a\"B8cD\"6eF3gH0jS5wY\"xQ\"9mP7vK2Z\"t\"R4n\"L\"1aB8cD6eF3gH0jS\"5wYxQ9mP\"7vK2ZtR4nL1aB8c\"D6eF3gH\"0jS5wYx\"Q9\"mP7vK2Zt\"R\"4nL1a\"B8c\"D6eF3gH0jS\"5wYxQ9m"
+        },
+        "customerInfo": {
+          "customerId": "P7vK2ZtR4nL",
+          "deviceId": "1aB8cD6eF3gH0jS5wYxQ9",
+          "lineId": "mP7vK2ZtR4nL1a",
+          "publicIp": "B8cD6eF3gH0j"
+        },
+        "kafka": {
+          "eventId": "S5wYxQ9mP7vK",
+          "moduleId": "2ZtR4nL1a"
+        }
+      }
+    },
+    {
+      "_source": {
+        "@timestamp": "B8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4n",
+        "eventData": {
+          "__original": "L\"1aB8cD6eF3gH0jS5w\"YxQ9m\"P7vK2ZtR4nL1aB8cD6e\"F3gH0jS\"5wYxQ9mP7vK2ZtR4n\"L1aB8\"cD6eF3gH0jS5wYxQ9mP\"7vK2Zt\"R4nL1aB8\"cD6eF"
+        },
+        "ingest_lag_in_seconds": 1,
+        "kafka": {
+          "eventId": "3gH0jS5w",
+          "moduleId": "YxQ9mP7vK"
+        },
+        "@version": "2",
+        "customerInfo": {
+          "customerId": "ZtR4nL1aB8c",
+          "deviceId": "D6eF3gH0jS5wYxQ9mP7vK",
+          "lineId": "2ZtR4nL1aB8cD6",
+          "publicIp": "eF3gH0jS5wYx"
+        }
+      }
+    }
+  ],
+  "pipeline": {
+    "processors": [
+      {
+        "rename": {
+          "field": "Q9mP7vK2ZtR4nL1aB8cD",
+          "target_field": "6eF3gH0jS5wYxQ"
+        }
+      },
+      {
+        "lowercase": {
+          "field": "9mP7vK2ZtR4nL1",
+          "target_field": "aB8cD6eF3gH",
+          "ignore_missing": true
+        }
+      },
+      {
+        "set": {
+          "field": "0jS5wYxQ9mP7",
+          "copy_from": "vK2ZtR4nL1aB8",
+          "ignore_empty_value": true
+        }
+      },
+      {
+        "set": {
+          "field": "cD6eF3gH0",
+          "copy_from": "jS5wYxQ9mP7vK2ZtR4nL1",
+          "ignore_empty_value": true
+        }
+      },
+      {
+        "script": {
+          "source": """
+                aB8 cD6eF3gH0j S 5wYxQ9mP7vK2ZtR4
+                nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0jS5wYxQ9mP""",
+          "if": "7vK2ZtR4nL1aB8cD 6e F3gH 0j S5wYxQ9mP7vK2ZtR4nL 1a B8cD"
+        }
+      },
+      {
+        "script": {
+          "description": "6eF3gH0 jS5wYxQ9 mP 7vK2ZtR4nL1 aB8cD6e F3gH 0jS",
+          "source": "5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0j",
+          "if": "S5wYxQ9mP7vK2ZtR4nL1aB8cD6 eF 3gH0 jS 5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3 gH0jS5wYxQ 9mP7vK2"
+        }
+      },
+      {
+        "set": {
+          "field": "ZtR4nL1aB8cD6e",
+          "copy_from": "F3gH0jS5wYxQ9mP7vK2",
+          "ignore_empty_value": true
+        }
+      },
+      {
+        "set": {
+          "field": "ZtR4nL1aB8cD6",
+          "copy_from": "eF3gH0jS5wYxQ9mP7vK2Zt",
+          "ignore_empty_value": true
+        }
+      },
+      {
+        "rename": {
+          "field": "R4nL1aB8cD6eF3gH0jS5w",
+          "target_field": "YxQ9mP7vK2Zt",
+          "ignore_missing": true
+        }
+      },
+      {
+        "script": {
+          "source": """
+                R4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0 jS5wYxQ9mP7v
+            """,
+          "if": "K2ZtR4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2Zt R4 nL1a"
+        }
+      },
+      {
+        "rename": {
+          "field": "B8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6",
+          "target_field": "eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF",
+          "target_field": "3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3",
+          "target_field": "gH0jS5wYxQ9mP7vK2ZtR4nL1aB8cD6",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "eF3gH0jS5wYxQ9mP7v",
+          "target_field": "K2ZtR4nL1aB8cD6eF3gH0jS5w",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "YxQ9mP7vK2ZtR4nL1aB8cD6eF3g",
+          "target_field": "H0jS5wYxQ9mP7vK2ZtR4nL1aB8cD",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1a",
+          "target_field": "B8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4n",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "L1aB8cD6eF3gH0jS5wYxQ9mP7vK",
+          "target_field": "2ZtR4nL1aB8cD6eF3gH0jS5wYxQ9",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "mP7vK2ZtR4nL1aB8cD6eF3gH0jS5w",
+          "target_field": "YxQ9mP7vK2ZtR4nL1aB8cD6eF3gH0j",
+          "ignore_missing": true
+        }
+      },
+      {
+      "script": {
+        "description": "S5wYxQ9mP 7vK2ZtR 4nL1aB8 cD6eF 3gH 0jS5wYx Q9mP7vK 2ZtR",
+        "lang": "4nL1aB8c",
+        "source": """
+            D6 eF3gH0jS5wYxQ9mP7vK2ZtR4nL 1a B8cD6 e
+                F3g H0j S 5wYxQ9mP7vK2ZtR4nL1aB8cD6
+                eF3gH0jS5w Y xQ9mP7vK2Z tR 4nL1 a B8c D 6eF3gH0jS5w
+
+                YxQ9mP7vK2ZtR4n L 1
+                aB8c D6eF3gH0jS5wYxQ9mP7vK
+                2ZtR 4nL1aB8cD6eF3gH0jS5wY
+                xQ9mP 7vK2ZtR4nL1aB8cD6eF3g
+                H0
+
+                jS 5wY xQ9mP7vK2ZtR4n L1 a B8cD6 eF3g H 0j S
+                5wYxQ9mP 7 vK2ZtR4n L1 aB8c D 6eF 3 gH0jS5wYx
+                Q9mP7vK2ZtR4 n L
+                1aB8cD6e F3gH0jS5wYxQ9mP7vK2 Z tR4nL
+                1a
+            B
+
+            8c D6 eF3gH0 jS5wYxQ
+            9m P7vK2ZtR4nL1aB8cD6eF3gH0 jS 5wYxQ 9
+                mP7 vK2 Z tR4nL1aB8cD6eF3gH0jS5wY
+                xQ9mP7vK2ZtR4nL1a B 8
+                cD6eF3gH 0jS5wYxQ9m
+                P7vK2Zt R4nL1aB8c
+                D6eF3gH0j S5wYxQ9m P7vK2ZtR4nL1aB8
+                cD6eF3g H
+                    0jS5wYxQ 9mP7vK2Zt R 4nL1aB8cD6eF3g
+                    H0jS5w YxQ9mP7vK2ZtR4nL1a B 8cD6eF3gH0jS5w Y xQ9mP7vK2
+                Z
+                tR
+            4
+
+            nL 1a B8c D6eF3gH 0jS5wYxQ9m P7vK2Z
+            tR 4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK 2Z tR4nL 1
+                aB8 cD6eF 3g H0jS5wYxQ9mP7vK2ZtR4nL1aB8cD 6
+                eF 3gH0jS5wYxQ9mP7 vK 2ZtR4nL1aB8c D
+                    6eF3gH0jS5w Y x
+                    Q9mP7vK2 ZtR4nL1aB8cD6 eF 3g H 0jS5wYxQ9mP7v K2 ZtR
+                    4nL1aB8 cD6eF3gH0jS5wY
+                    xQ
+                    9mP7vK2ZtR 4 nL1aB8cD6 eF3gH0jS5wYxQ9
+                    mP7vK2ZtR4nL1aB 8 cD6eF3gH0 jS5wYxQ9mP7vK2
+                    ZtR4nL1aB8cD6eF3gH0jS5wYxQ9mP7vK2ZtR4nL1a
+                    B8cD6e
+                F
+                3
+            g
+            H0 jS5wYxQ9mP7vK2ZtR4nL1aB8cD6e F3 gH0jS 5
+                wYx Q9m P 7vK2ZtR4nL1aB8cD6eF3gH0jS5w
+                YxQ9mP7vK2Z t R4nL1aB8cD6 eF 3gH0 j S5w Y xQ9mP7vK2ZtR
+
+                4nL1aB8cD6eF3g H 0jS5wYxQ9
+                mP7vK2ZtR4nL1aB8cD6 e F
+                    3gH0jS5wYxQ9 mP7vK2ZtR4
+                    nL1aB8cD6eF3g H0jS5wYxQ9m
+                    P7vK2ZtR4nL1aB8 cD6eF3gH0jS5w
+                    YxQ9mP7vK2ZtR4nL1aB8 cD6eF3gH0jS5wYxQ
+                9m
+
+                P7 vK2ZtR4nL 1aB8c D6eF 3gH 0jS5wY xQ9mP7vK2ZtR
+                4n L1aB8cD6eF 3 gH 0
+                    jS5wYxQ9mP7vK2ZtR4nL1aB8cD6eF3 g H0jS5wYxQ9mP7vK2Zt R 4nL1aB8cD6
+                e
+            F
+
+        """
+      }
+    },
+      {
+        "uri_parts": {
+          "field": "3gH0jS5wYxQ9",
+          "ignore_missing": true,
+          "ignore_failure": true
+        }
+      },
+      {
+        "append": {
+          "field": "mP7vK2ZtR4n",
+          "value": [
+            "L1aB8cD6eF3gH",
+            "0jS5wYxQ9mP7vK2ZtR",
+            "4nL1aB8cD6eF3",
+            "gH0jS5wYxQ9mP7vK2",
+            "ZtR4nL1aB8cD6"
+          ],
+          "allow_duplicates": false
+        }
+      },
+      {
+        "script": {
+          "description": "eF3gH0 jS5w YxQ9mP",
+          "source": """
+                7vK2ZtR 4nL1aB8cD6e F3 g
+                H0 jS 5w YxQ9 mP 7 vK 2Zt R
+                    4nL1aB 8cD6e
+                F 3gH0 jS 5w YxQ9mP7vK2 ZtR4 n
+                    L1aB8c D6eF3gH0jS5wYxQ9mP7vK2 Zt R4nL1aB8c
+                    D6eF3g H0jS5wY xQ9mP7vK2 Zt R4n
+                L 1aB8 cD 6e F3gH0jS5wY xQ9mP 7
+                    vK2ZtR4 nL1aB8cD6eF3g H0 jS5wYxQ9m
+                    P7vK2Z tR4nL1aB 8cD6eF3gH 0j S5w
+                Y
+                xQ9mP7 vK2ZtR
+                4
+                nL1aB8cD6e
+        """
+        }
+      },
+      {
+        "remove": {
+          "field": [
+            "F3gH"
+          ],
+          "ignore_missing": true
+        }
+      }
+    ]
+  }
+}`;


### PR DESCRIPTION
Closes #251172

## Summary
This PR fixes a DevTools Console editor freeze that occurs after pasting very large request payloads (notably JSON containing huge string fields) by removing expensive, full-buffer operations from keystroke-time paths and by preventing a super-linear ES|QL context scan from running on large inputs.

## DEMO (Before / After)
https://github.com/user-attachments/assets/54b90fdb-f0b0-4de0-ae53-6fa4a12a98d9

## Change 1: Console completion avoids full-buffer reads (`kbn-monaco` Console language)
**What changed**
- The Console completion provider no longer calls `model.getValue()` to compute `textBeforeCursor`.
- ES|QL context detection is only attempted when the cursor is within a `POST /_query` (or `POST _query/async`) request.
- When it *is* a `_query` request, the provider reads only the relevant slice via `model.getValueInRange()` (from the request line to the cursor).
- For all other requests (or when no request line is found within a bounded lookback), completion delegates to the existing actions provider.

**Why**
- `model.getValue()` materializes the entire document string, which becomes prohibitively expensive after users paste very large payloads; doing that on completion triggers (often on every keystroke) is enough to stall the UI.
- ES|QL completion only makes sense for `_query` requests; scoping the work avoids paying the cost for non-ES|QL traffic.

**Why this approach**
- We preserve existing completion behavior by delegating to the actions provider, but avoid the pathological cost by restricting work to a small, semantically relevant window.

## Change 2: ES|QL quote/query detection is linear-time (`checkForTripleQuotesAndEsqlQuery`)
**What changed**
- `checkForTripleQuotesAndEsqlQuery` was rewritten to scan the text once and avoid repeated substring+regex work inside the main loop.

**Why**
- The previous approach could become super-linear on adversarial inputs (many quotes / many potential toggles), which is exactly what large JSON payloads tend to contain.
- In the worst case, this turns “type one character” into “do a huge amount of CPU work”, producing the freeze.

**Why this approach**
- A single forward scan preserves semantics while making the runtime scale predictably with input size.

## Change 3: Monaco `onChange` no longer calls `editor.getValue()` per keystroke (`shared-ux` React Monaco editor)
**What changed**
- The `onDidChangeModelContent` handler computes the next value by applying `event.changes` to a shadow string (`lastKnownValueRef`) instead of calling `editor.getValue()`.
- Controlled-mode syncing (`useLayoutEffect`) first compares the incoming `value` against the shadow value to avoid unnecessary full-buffer reads.

**Why**
- `editor.getValue()` materializes the full buffer; doing it on every keystroke creates a hard O(N) cost per change, which is visible (and can be catastrophic) for large models.
- Applying incremental changes keeps the per-keystroke cost proportional to the change set, not the document size.

**Why this approach**
- Monaco already provides the exact edit deltas (`IModelContentChangedEvent.changes`). Applying those deltas is the cheapest way to keep React state in sync without forcing full-buffer reads.

## Tests (what they cover and why)
- **`language.test.ts`**: exercises the completion provider branching/delegation so we don’t regress behavior while tightening when/what we read from the model.
- **`autocomplete_utils.test.ts`**: focused behavioral coverage for ES|QL context detection edge cases (the perf-worker regression test was removed to keep the suite deterministic and low-maintenance).
- **`editor.test.tsx`**: verifies the incremental `onChange` value computation (including multi-change ordering) and controlled sync behavior.

## Test plan
- `node scripts/jest.js src/platform/packages/shared/kbn-monaco/src/languages/console/language.test.ts src/platform/packages/shared/kbn-monaco/src/languages/console/utils/autocomplete_utils.test.ts --config src/platform/packages/shared/kbn-monaco/jest.config.js`
- `node scripts/jest.js src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.test.tsx --config src/platform/packages/shared/shared-ux/code_editor/impl/jest.config.js`

### Manual UI verification (DevTools Console)
- Open `DevTools -> Console`.
- Open the sanitized reproduction payload gist (https://gist.github.com/kapral18/9e461b55238c15d949669dd62a851676) and paste the payload into the editor.
- Click at the very end of the pasted content and type a few characters.
- Verify the editor remains responsive (no multi-second freeze / hang), and typed characters appear immediately.
- Optional: place the cursor inside a `""" ... """` block and type to ensure autocomplete remains responsive.



Assisted by Cursor CLI using GPT-5.2-High model



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->


