### PR TITLE
[APM] Skip flaky tests on cloud

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
@@ -235,6 +235,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     });
 
     describe('create rule for opbeans-node using kql filter', () => {
+      this.tags('skipCloud');
+
       let ruleId: string;
       let alerts: ApmAlertFields[];
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
@@ -234,7 +234,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
     });
 
-    describe('create rule for opbeans-node using kql filter', () => {
+    describe('create rule for opbeans-node using kql filter', function () {
       this.tags('skipCloud');
 
       let ruleId: string;

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_error_rate.spec.ts
@@ -244,6 +244,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     });
 
     describe('create rule with kql query', () => {
+      this.tags('skipCloud');
+
       let ruleId: string;
       let alerts: ApmAlertFields[];
 
@@ -319,7 +321,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         );
       });
 
-      it.skip('shows alert count=1 for opbeans-node on service inventory', async () => {
+      it('shows alert count=1 for opbeans-node on service inventory', async () => {
         const serviceInventoryAlertCounts = await fetchServiceInventoryAlertCounts(apmApiClient);
         expect(serviceInventoryAlertCounts).to.eql({
           'opbeans-node': 1,

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_error_rate.spec.ts
@@ -243,7 +243,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
     });
 
-describe('create rule with kql query', function () {
+    describe('create rule with kql query', function () {
       this.tags('skipCloud');
 
       let ruleId: string;

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_error_rate.spec.ts
@@ -243,7 +243,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
     });
 
-    describe('create rule with kql query', () => {
+describe('create rule with kql query', function () {
       this.tags('skipCloud');
 
       let ruleId: string;


### PR DESCRIPTION
## Summary

This PR skips tests on cloud only instead of skipping individual tests entirely


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->