### PR TITLE
[search_homepage][scout] fetch full name instead of hardcoded value

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_viewer.spec.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_viewer.spec.ts
@@ -17,10 +17,11 @@ test.describe('Homepage - Viewer', { tag: ['@svlSearch', '@ess'] }, () => {
     await pageObjects.homepage.goto();
   });
 
-  test('should not be able to see manage button', async ({ pageObjects }) => {
+  test('should not be able to see manage button', async ({ pageObjects, samlAuth }) => {
     const headerLeftGroup = await pageObjects.homepage.getHeaderLeftGroup();
+    const userData = await samlAuth.session.getUserData('viewer');
 
-    await expect(headerLeftGroup).toContainText('Welcome, test viewer');
+    await expect(headerLeftGroup).toContainText(`Welcome, ${userData?.full_name}`);
     await expect(headerLeftGroup).not.toContainText('Manage');
   });
 


### PR DESCRIPTION
## Summary

This PR fixes tests consistently failing on MKI.

Please make sure to run Scout tests against ECH/MKI before merging PRs with new or updated tests, they may affect the next round of Cloud testing.

Setting Cloud runs locally is quite simple and take <10 mins, all the instructions are available [here](https://docs.elastic.dev/appex-qa/scout/run-tests#run-scout-tests-on-elastic-cloud) 🙇 

Failure screenshot:

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/1a23dfcc-f5fa-4a41-b777-9a37029d2f83" />
