### PR TITLE
[ES|QL] Use generic fields definitions inside RERANK

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/fields_list.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/fields_list.ts
@@ -6,15 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0"async , the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
- */
 import { isFunctionExpression, within, isAssignment, isColumn } from '../../../../ast';
 import type { ESQLAstAllCommands, ESQLAstField } from '../../../../types';
 import {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/fields_list.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/fields_list.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"async , the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { isFunctionExpression, within, isAssignment, isColumn } from '../../../../ast';
+import type { ESQLAstAllCommands, ESQLAstField } from '../../../../types';
+import {
+  getNewUserDefinedColumnSuggestion,
+  pipeCompleteItem,
+  commaCompleteItem,
+  assignCompletionItem,
+} from '../../../registry/complete_items';
+import type { Location } from '../../../registry/types';
+import type { ICommandCallbacks, ICommandContext, ISuggestionItem } from '../../../registry/types';
+import { getAssignmentExpressionRoot } from '../expressions';
+import { suggestForExpression } from './expressions';
+import { withAutoSuggest } from './helpers';
+import type { ExpressionContextOptions } from './expressions/types';
+
+export async function suggestFieldsList(
+  query: string,
+  command: ESQLAstAllCommands,
+  fieldList: ESQLAstField[],
+  location: Location,
+  callbacks?: ICommandCallbacks,
+  context?: ICommandContext,
+  cursorPosition: number = query.length,
+  options?: {
+    /** Listed functions will not be suggested in expressions */
+    functionsToIgnore?: ExpressionContextOptions['functionsToIgnore'];
+    /** Suggestions to show after a complete field expression */
+    afterCompleteSuggestions?: ISuggestionItem[];
+    /** If true, consideres a single column as a completed field expression */
+    allowSingleColumnFields?: boolean;
+    /** the preferred field type */
+    preferredExpressionType?: ExpressionContextOptions['preferredExpressionType'];
+  }
+): Promise<ISuggestionItem[]> {
+  if (!callbacks?.getByType) {
+    return [];
+  }
+  const innerText = query.substring(0, cursorPosition);
+  const lastField = fieldList[fieldList.length - 1];
+
+  const endsWithComma = /,\s*$/.test(innerText);
+  const withinFunction =
+    lastField && isFunctionExpression(lastField) && within(innerText.length, lastField);
+  const startingNewExpression = endsWithComma && !withinFunction;
+
+  let expressionRoot = startingNewExpression ? undefined : lastField;
+  let insideAssignment = false;
+
+  if (expressionRoot && isAssignment(expressionRoot)) {
+    expressionRoot = getAssignmentExpressionRoot(expressionRoot);
+    insideAssignment = true;
+  }
+
+  const { suggestions, computed } = await suggestForExpression({
+    query,
+    expressionRoot,
+    command,
+    cursorPosition,
+    location,
+    context,
+    callbacks,
+    options: {
+      preferredExpressionType: options?.preferredExpressionType,
+      functionsToIgnore: options?.functionsToIgnore,
+    },
+  });
+
+  const { position, isComplete, insideFunction } = computed;
+
+  if (position === 'empty_expression' && !insideAssignment) {
+    suggestions.push(
+      getNewUserDefinedColumnSuggestion(callbacks?.getSuggestedUserDefinedColumnName?.() || '')
+    );
+  }
+
+  if (
+    isComplete &&
+    expressionRoot &&
+    (!isColumn(expressionRoot) || insideAssignment || options?.allowSingleColumnFields) &&
+    !insideFunction
+  ) {
+    suggestions.push(
+      withAutoSuggest(pipeCompleteItem),
+      withAutoSuggest({ ...commaCompleteItem, text: ', ' })
+    );
+    if (options?.afterCompleteSuggestions) {
+      suggestions.push(...options.afterCompleteSuggestions);
+    }
+  }
+
+  // After a new column definition col0 ^
+  if (
+    isColumn(expressionRoot) &&
+    !insideAssignment &&
+    !context?.columns?.has(expressionRoot.name)
+  ) {
+    suggestions.push(withAutoSuggest(assignCompletionItem));
+  }
+
+  return suggestions;
+}

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/eval/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/eval/autocomplete.ts
@@ -6,20 +6,12 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { isAssignment, isColumn, isFunctionExpression } from '../../../ast/is';
-import { within } from '../../../ast/location';
-import { suggestForExpression } from '../../definitions/utils';
-import { withAutoSuggest } from '../../definitions/utils/autocomplete/helpers';
-import { getAssignmentExpressionRoot } from '../../definitions/utils/expressions';
 import { FULL_TEXT_SEARCH_FUNCTIONS } from '../../definitions/constants';
-import type { ESQLAstAllCommands, ESQLSingleAstItem } from '../../../types';
-import {
-  commaCompleteItem,
-  getNewUserDefinedColumnSuggestion,
-  pipeCompleteItem,
-} from '../complete_items';
+import type { ESQLAstAllCommands, ESQLAstField } from '../../../types';
 import type { ICommandCallbacks } from '../types';
-import { Location, type ICommandContext, type ISuggestionItem } from '../types';
+import { type ICommandContext, type ISuggestionItem } from '../types';
+import { suggestFieldsList } from '../../definitions/utils/autocomplete/fields_list';
+import { Location } from '../types';
 
 export const FUNCTIONS_TO_IGNORE = {
   names: [...FULL_TEXT_SEARCH_FUNCTIONS],
@@ -35,58 +27,17 @@ export async function autocomplete(
   context?: ICommandContext,
   cursorPosition: number = query.length
 ): Promise<ISuggestionItem[]> {
-  if (!callbacks?.getByType) {
-    return [];
-  }
-  const innerText = query.substring(0, cursorPosition);
-  const lastArg = command.args[command.args.length - 1] as ESQLSingleAstItem | undefined;
-
-  const endsWithComma = /,\s*$/.test(innerText);
-  const withinFunction =
-    lastArg && isFunctionExpression(lastArg) && within(innerText.length, lastArg);
-  const startingNewExpression = endsWithComma && !withinFunction;
-
-  let expressionRoot = startingNewExpression ? undefined : lastArg;
-  let insideAssignment = false;
-
-  if (expressionRoot && isAssignment(expressionRoot)) {
-    expressionRoot = getAssignmentExpressionRoot(expressionRoot);
-    insideAssignment = true;
-  }
-
-  const { suggestions, computed } = await suggestForExpression({
+  return suggestFieldsList(
     query,
-    expressionRoot,
     command,
-    cursorPosition,
-    location: Location.EVAL,
-    context,
+    command.args as ESQLAstField[],
+    Location.EVAL,
     callbacks,
-    options: {
-      preferredExpressionType: 'any',
+    context,
+    cursorPosition,
+    {
       functionsToIgnore: FUNCTIONS_TO_IGNORE,
-    },
-  });
-
-  const { position, isComplete, insideFunction } = computed;
-
-  if (position === 'empty_expression' && !insideAssignment) {
-    suggestions.push(
-      getNewUserDefinedColumnSuggestion(callbacks?.getSuggestedUserDefinedColumnName?.() || '')
-    );
-  }
-
-  if (
-    isComplete &&
-    expressionRoot &&
-    (!isColumn(expressionRoot) || insideAssignment) &&
-    !insideFunction
-  ) {
-    suggestions.push(
-      withAutoSuggest(pipeCompleteItem),
-      withAutoSuggest({ ...commaCompleteItem, text: ', ' })
-    );
-  }
-
-  return suggestions;
+      preferredExpressionType: 'any',
+    }
+  );
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
@@ -19,7 +19,12 @@ import {
   withCompleteItem,
   assignCompletionItem,
 } from '../complete_items';
-import { expectSuggestions, suggest } from '../../../__tests__/commands/autocomplete';
+import { Location } from '../types';
+import {
+  expectSuggestions,
+  getFunctionSignaturesByReturnType,
+  suggest,
+} from '../../../__tests__/commands/autocomplete';
 import type { ICommandCallbacks } from '../types';
 import { buildConstantsDefinitions } from '../../definitions/utils/literals';
 import {
@@ -194,17 +199,29 @@ describe('RERANK Autocomplete', () => {
     test('suggests field continuations after selecting a field', async () => {
       const query = buildRerankQuery({ query: '"search query"', onClause: 'keywordField' });
 
-      await expectRerankSuggestions(query, [
-        'keywordField, ',
-        'keywordField WITH { $0 } ',
-        'keywordField | ',
-      ]);
+      await expectRerankSuggestions(query, {
+        contains: [', ', 'WITH { $0 }', '| '], // HD complete with the rest of items
+      });
     });
 
     test('suggests continuations after field with more trailing spaces', async () => {
       const query = buildRerankQuery({ query: '"search query"', onClause: 'keywordField' }) + ' ';
 
-      await expectRerankSuggestions(query, NEXT_ACTIONS);
+      await expectRerankSuggestions(query, [
+        ...NEXT_ACTIONS,
+        ...getFunctionSignaturesByReturnType(
+          Location.RERANK,
+          'any',
+          {
+            operators: true,
+            excludeOperatorGroups: [],
+            skipAssign: true,
+            agg: false,
+            scalar: false,
+          },
+          ['keyword']
+        ),
+      ]);
     });
   });
 
@@ -283,23 +300,6 @@ describe('RERANK Autocomplete', () => {
 
       await expectRerankSuggestions(query, NEXT_ACTIONS_EXPRESSIONS);
     });
-
-    test.each(OPERATOR_SUGGESTIONS.COMPARISON)(
-      'Incomplete %s operator shows other operators',
-      async (operator) => {
-        const operatorClause = `${operator} 10`;
-        const query =
-          buildRerankQuery({
-            query: '"search query"',
-            onClause: `textField = keywordField ${operatorClause}`,
-          }) + ' ';
-
-        await expectRerankSuggestions(query, {
-          contains: [...addPlaceholder(OPERATOR_SUGGESTIONS.COMPARISON.slice(0, 4))],
-          notContains: NEXT_ACTIONS_EXPRESSIONS,
-        });
-      }
-    );
 
     test('handles empty IN list as incomplete expression', async () => {
       const query =
@@ -403,31 +403,6 @@ describe('RERANK Autocomplete', () => {
   // ============================================================================
   // Edge Cases and Error Handling
   // ============================================================================
-
-  describe('Advanced boolean expressions', () => {
-    test('handles complex parenthesized expressions', async () => {
-      // Complex expressions ending with incomplete part show operators
-      const expression = '(textField = "value") AND NOT (keywordField';
-      const query =
-        buildRerankQuery({
-          query: '"search query"',
-          onClause: expression,
-        }) + ' ';
-
-      await expectRerankSuggestions(query, {
-        contains: [
-          addPlaceholder([OPERATOR_SUGGESTIONS.PATTERN[0]])[0],
-          ...addPlaceholder(OPERATOR_SUGGESTIONS.SET.slice(0, 1)),
-          OPERATOR_SUGGESTIONS.EXISTENCE[0],
-        ],
-        notContains: [
-          ...NEXT_ACTIONS_EXPRESSIONS,
-          ...addPlaceholder(OPERATOR_SUGGESTIONS.COMPARISON),
-        ],
-      });
-    });
-  });
-
   describe('Edge cases', () => {
     test('handles dotted field names correctly', async () => {
       const query =

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
@@ -22,6 +22,7 @@ import {
 import { Location } from '../types';
 import {
   expectSuggestions,
+  getFieldNamesByType,
   getFunctionSignaturesByReturnType,
   suggest,
 } from '../../../__tests__/commands/autocomplete';
@@ -200,7 +201,13 @@ describe('RERANK Autocomplete', () => {
       const query = buildRerankQuery({ query: '"search query"', onClause: 'keywordField' });
 
       await expectRerankSuggestions(query, {
-        contains: [', ', 'WITH { $0 }', '| '], // HD complete with the rest of items
+        contains: [
+          ', ',
+          'WITH { $0 }',
+          '| ',
+          ...getFieldNamesByType('any'),
+          ...getFunctionSignaturesByReturnType(Location.RERANK, 'any', { scalar: true }),
+        ],
       });
     });
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.ts
@@ -6,8 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { withAutoSuggest } from '../../definitions/utils/autocomplete/helpers';
-import type { ESQLAstRerankCommand, ESQLSingleAstItem, ESQLAstAllCommands } from '../../../types';
+import type { ESQLAstRerankCommand, ESQLAstAllCommands } from '../../../types';
 import type { ICommandCallbacks, ISuggestionItem, ICommandContext } from '../types';
 import { SuggestionCategory } from '../../../shared/sorting/types';
 import { Location } from '../types';
@@ -21,19 +20,15 @@ import {
 import {
   withinQuotes,
   createInferenceEndpointToCompletionItem,
-  handleFragment,
-  columnExists,
 } from '../../definitions/utils/autocomplete/helpers';
-import { suggestForExpression } from '../../definitions/utils';
 import { buildConstantsDefinitions } from '../../definitions/utils/literals';
 import type { MapParameters } from '../../definitions/utils/autocomplete/map_expression';
 import { getCommandMapExpressionSuggestions } from '../../definitions/utils/autocomplete/map_expression';
-import { pipeCompleteItem, commaCompleteItem, withCompleteItem } from '../complete_items';
+import { pipeCompleteItem, withCompleteItem } from '../complete_items';
+import { suggestFieldsList } from '../../definitions/utils/autocomplete/fields_list';
 
 export const QUERY_TEXT = 'Your search query' as const;
 export const QUERY_TEXT_SNIPPET = `"$\{0:${QUERY_TEXT}}"`;
-
-const FIELD_LIST_TYPES = ['keyword', 'text', 'boolean', 'integer', 'double', 'long'] as const;
 
 export async function autocomplete(
   query: string,
@@ -49,7 +44,7 @@ export async function autocomplete(
     return [];
   }
 
-  const { position, context: positionContext } = getPosition(innerText, command);
+  const position = getPosition(innerText, command);
 
   switch (position) {
     case CaretPosition.RERANK_KEYWORD: {
@@ -103,35 +98,28 @@ export async function autocomplete(
       return [onCompleteItem];
     }
 
-    case CaretPosition.ON_WITHIN_FIELD_LIST: {
-      return handleOnFieldList({
-        innerText,
-        callbacks,
-        context,
-        rerankCommand,
-      });
-    }
-
-    case CaretPosition.ON_KEEP_SUGGESTIONS_AFTER_TRAILING_SPACE: {
-      const lastOnField = rerankCommand.fields?.[rerankCommand.fields.length - 1];
-      const isAssignmentContext = !!(lastOnField && !context?.columns?.has(lastOnField.name));
-      // ON col0␣ → '=' suggestion using lastField from the ON clause
-      if (isAssignmentContext) {
-        return [assignCompletionItem];
-      }
-
-      return buildNextActions();
-    }
-
     case CaretPosition.ON_EXPRESSION: {
-      return handleOnExpression({
+      const afterCompleteSuggestions = [
+        {
+          ...withCompleteItem,
+          text: withCompleteItem.text,
+          sortText: '01',
+        },
+      ];
+      return suggestFieldsList(
         query,
         command,
-        cursorPosition,
+        rerankCommand.fields,
+        Location.RERANK,
         callbacks,
         context,
-        expressionRoot: positionContext?.expressionRoot,
-      });
+        cursorPosition,
+        {
+          afterCompleteSuggestions,
+          allowSingleColumnFields: true,
+          preferredExpressionType: 'text',
+        }
+      );
     }
 
     case CaretPosition.AFTER_WITH_KEYWORD:
@@ -157,117 +145,4 @@ export async function autocomplete(
       return [];
     }
   }
-}
-
-// ============================================================================
-// Suggestion Handlers
-// ============================================================================
-
-async function handleOnFieldList({
-  innerText,
-  callbacks,
-  context,
-}: {
-  innerText: string;
-  callbacks: ICommandCallbacks;
-  context: ICommandContext | undefined;
-  rerankCommand: ESQLAstRerankCommand;
-}): Promise<ISuggestionItem[]> {
-  const fieldSuggestions = (await callbacks.getByType?.(FIELD_LIST_TYPES)) ?? [];
-
-  const suggestions = await handleFragment(
-    innerText,
-    (fragment) => columnExists(fragment, context),
-    // incomplete: get available fields suggestions
-    (_: string, rangeToReplace?: { start: number; end: number }) => {
-      const customFieldSuggestion = getNewUserDefinedColumnSuggestion(
-        callbacks.getSuggestedUserDefinedColumnName?.() || ''
-      );
-
-      return [customFieldSuggestion, ...fieldSuggestions].map((suggestion) => {
-        return withAutoSuggest({
-          ...suggestion,
-          rangeToReplace,
-        });
-      });
-    },
-    // complete: get next actions suggestions for completed field
-    (fragment: string, rangeToReplace: { start: number; end: number }) => {
-      const results = buildNextActions({ withSpaces: true });
-
-      return results.map((suggestion) => ({
-        ...suggestion,
-        filterText: fragment,
-        text: fragment + suggestion.text,
-        rangeToReplace,
-      }));
-    }
-  );
-
-  return suggestions;
-}
-
-async function handleOnExpression({
-  query,
-  command,
-  cursorPosition,
-  callbacks,
-  context,
-  expressionRoot,
-}: {
-  query: string;
-  command: ESQLAstAllCommands;
-  cursorPosition: number;
-  callbacks: ICommandCallbacks;
-  context: ICommandContext | undefined;
-  expressionRoot: ESQLSingleAstItem | undefined;
-}): Promise<ISuggestionItem[]> {
-  const { suggestions, computed } = await suggestForExpression({
-    query,
-    expressionRoot,
-    command,
-    cursorPosition,
-    location: Location.RERANK,
-    context,
-    callbacks,
-    options: {
-      preferredExpressionType: 'boolean',
-    },
-  });
-
-  const { isComplete, insideFunction } = computed;
-
-  if (expressionRoot && isComplete && !insideFunction) {
-    suggestions.push(...buildNextActions());
-  }
-
-  return suggestions;
-}
-
-export function buildNextActions(options?: { withSpaces?: boolean }): ISuggestionItem[] {
-  const { withSpaces = false } = options || {};
-
-  const items: ISuggestionItem[] = [];
-
-  items.push({
-    ...withCompleteItem,
-    text: withSpaces ? ' ' + withCompleteItem.text + ' ' : withCompleteItem.text,
-    sortText: '01',
-  });
-
-  items.push(
-    withAutoSuggest({
-      ...commaCompleteItem,
-      text: commaCompleteItem.text + ' ',
-      sortText: '02',
-    })
-  );
-
-  items.push({
-    ...pipeCompleteItem,
-    text: withSpaces ? ' ' + pipeCompleteItem.text : pipeCompleteItem.text,
-    sortText: '03',
-  });
-
-  return items;
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.test.ts
@@ -323,6 +323,7 @@ describe('autocomplete', () => {
 
     // EVAL argument
     testSuggestions('FROM index1 | EVAL b/', [
+      '= ',
       'col0 = ',
       ...getFieldNamesByType('any').map((name) => `${name} `),
       ...getFunctionSignaturesByReturnType(Location.EVAL, 'any', { scalar: true }),

--- a/src/platform/packages/shared/kbn-esql-language/src/parser/__tests__/rerank.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/parser/__tests__/rerank.test.ts
@@ -132,10 +132,12 @@ describe('RERANK', () => {
             name: '=',
             args: [
               {},
-              {
-                type: 'function',
-                name: 'substring',
-              },
+              [
+                {
+                  type: 'function',
+                  name: 'substring',
+                },
+              ],
             ],
           },
         ],
@@ -244,12 +246,7 @@ describe('RERANK', () => {
       expect(rerankCmd).toMatchObject({
         type: 'command',
         name: 'rerank',
-        fields: [
-          expect.objectContaining({
-            type: 'column',
-            incomplete: true,
-          }),
-        ],
+        fields: [],
       });
 
       expect(errors).toHaveLength(1);

--- a/src/platform/packages/shared/kbn-esql-language/src/parser/core/cst_to_ast_converter.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/parser/core/cst_to_ast_converter.ts
@@ -1506,14 +1506,14 @@ export class CstToAstConverter {
     command: ast.ESQLAstRerankCommand
   ): void {
     const onToken = ctx.ON();
-    const rerankFieldsCtx = ctx.rerankFields();
+    const fieldsCtx = ctx.fields();
 
-    if (!onToken || !rerankFieldsCtx) {
+    if (!onToken || !fieldsCtx) {
       return;
     }
 
-    const onOption = this.toOption(onToken.getText().toLowerCase(), rerankFieldsCtx);
-    const fields = this.fromRerankFields(rerankFieldsCtx);
+    const onOption = this.toOption(onToken.getText().toLowerCase(), fieldsCtx);
+    const fields = this.fromFields(fieldsCtx);
 
     onOption.args.push(...fields);
     onOption.location.min = onToken.symbol.start;
@@ -1572,97 +1572,6 @@ export class CstToAstConverter {
         command.inferenceId.incomplete = inferenceIdParam.valueUnquoted?.length === 0;
       }
     }
-  }
-
-  /**
-   * Collects all ON fields for RERANK.
-   *
-   * - Accepts simple columns (e.g. `title`).
-   * - Accepts assignments (e.g. `title = X(title, 2)`).
-   * - Accepts expressions after a qualified name (e.g. `field < 10`).
-   */
-  private fromRerankFields(ctx: cst.RerankFieldsContext | undefined): ast.ESQLAstField[] {
-    const fields: ast.ESQLAstField[] = [];
-    if (!ctx) {
-      return fields;
-    }
-
-    try {
-      for (const fieldCtx of ctx.rerankField_list()) {
-        const field = this.fromRerankField(fieldCtx);
-
-        if (field) {
-          fields.push(field);
-        }
-      }
-    } catch (e) {
-      // do nothing
-    }
-    return fields;
-  }
-
-  /**
-   * Parses a single RERANK field entry.
-   *
-   * Supports three forms:
-   * 1) Assignment: qualifiedName '=' booleanExpression
-   * 2) Column only: qualifiedName
-   */
-  private fromRerankField(ctx: cst.RerankFieldContext): ast.ESQLAstField | undefined {
-    try {
-      const qualifiedNameCtx = ctx.qualifiedName();
-
-      if (!qualifiedNameCtx) {
-        return undefined;
-      }
-
-      // 1) field assignment: <col> = <booleanExpression>
-      if (ctx.ASSIGN()) {
-        const left = this.toColumn(qualifiedNameCtx);
-        const assignment = this.toFunction(
-          ctx.ASSIGN().getText(),
-          ctx,
-          undefined,
-          'binary-expression'
-        ) as ast.ESQLBinaryExpression;
-
-        if (ctx.booleanExpression()) {
-          const right = this.fromBooleanExpression(ctx.booleanExpression());
-          const hasIncompleteItem = !!right?.incomplete;
-          const hasException = !!ctx.booleanExpression()?.exception;
-
-          if (!right || hasIncompleteItem || hasException) {
-            assignment.incomplete = true;
-          }
-
-          assignment.args.push(left);
-
-          if (right) {
-            assignment.args.push(right);
-          }
-
-          assignment.location = this.extendLocationToArgs(assignment);
-        } else {
-          // User typed something like `ON col0 =` and stopped.
-          // Build an assignment with only the left operand, mark it as incomplete,
-          assignment.args.push(left, []);
-          assignment.incomplete = true;
-          assignment.location = {
-            min: left.location.min,
-            max: ctx.ASSIGN()!.symbol.stop,
-          };
-        }
-
-        return assignment;
-      }
-
-      // 2) simple column reference
-      return this.toColumn(qualifiedNameCtx);
-    } catch (e) {
-      // do nothing
-    }
-
-    return undefined;
   }
 
   // --------------------------------------------------------------------- FUSE

--- a/src/platform/packages/shared/kbn-esql-language/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/types.ts
@@ -63,7 +63,7 @@ export type ESQLSingleAstItem =
  * EVAL ?param = 123
  * ```
  */
-export type ESQLAstField = ESQLColumn | ESQLBinaryExpression | ESQLParam;
+export type ESQLAstField = ESQLColumn | ESQLBinaryExpression | ESQLAstExpression | ESQLParam;
 
 /**
  * An array of AST nodes represents different things in different contexts.


### PR DESCRIPTION
## Summary
`RERANK` can now accept expressions within the `ON` option without assigning it a name.
`| RERANK "my query" ON SUBSTRING(description, 0, 100)`

It no longer uses `RerankFields` but the same `Fields` context as `EVAL`.

To have a consistent behaviour with EVAL and avoid code duplication extracted the code used to autocomplete a `field` and used it in `EVAL` and `RERANK`.
This helper might be useful  also for `STATS` and `ROW` fields (needs a quick analysis), but it's outside the scope of the PR.

Note: Rerank expression should be a text one, but `suggestForExpression` does not handle gracefully the `preferredType` when outside a function. I think we should handle that separately https://github.com/elastic/kibana/issues/251246.
