### PR TITLE
[Lens] [ES|QL] Use feature flag instead of dev flag for Lens ES|QL conversion.

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/feature_flags.ts
+++ b/x-pack/platform/plugins/shared/lens/common/feature_flags.ts
@@ -47,6 +47,24 @@ export const lensFeatureFlags = {
     type: 'boolean',
     fallback: false as boolean,
   },
+  /**
+   * Enables ES|QL mode for form-based datasources, allowing Lens to generate
+   * ES|QL queries instead of traditional DSL aggregations.
+   */
+  enableEsql: {
+    id: 'lens.enable_esql',
+    type: 'boolean',
+    fallback: false as boolean,
+  },
+  /**
+   * Enables the "Convert to ES|QL" button in the Lens inline editing flyout,
+   * allowing users to convert form-based visualizations to ES|QL queries.
+   */
+  enableEsqlConversion: {
+    id: 'lens.enable_esql_conversion',
+    type: 'boolean',
+    fallback: false as boolean,
+  },
 } satisfies Record<string, LensFeatureFlag>;
 
 export type LensFeatureFlags = GetFlagTypes<typeof lensFeatureFlags>;

--- a/x-pack/platform/plugins/shared/lens/moon.yml
+++ b/x-pack/platform/plugins/shared/lens/moon.yml
@@ -148,7 +148,6 @@ dependsOn:
   - '@kbn/cps'
   - '@kbn/kql'
   - '@kbn/controls-constants'
-  - '@kbn/react-env'
   - '@kbn/core-base-browser-mocks'
   - '@kbn/react-kibana-context-env'
 tags:

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -23,7 +23,7 @@ import {
 } from '@elastic/eui';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { TypedLensSerializedState, SupportedDatasourceId } from '@kbn/lens-common';
-import { useIsDevMode } from '@kbn/react-env';
+import { getLensFeatureFlags } from '../../../get_feature_flags';
 import { buildExpression } from '../../../editor_frame_service/editor_frame/expression_helpers';
 import {
   useLensSelector,
@@ -316,11 +316,9 @@ export function LensEditConfigurationFlyout({
       : [];
   }, [activeVisualization, visualization.state]);
 
-  const isDevMode = useIsDevMode();
-
   const showConvertToEsqlButton = useMemo(() => {
-    return isDevMode && !textBasedMode;
-  }, [isDevMode, textBasedMode]);
+    return getLensFeatureFlags().enableEsqlConversion && !textBasedMode;
+  }, [textBasedMode]);
 
   const {
     isConvertToEsqlButtonDisabled,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
@@ -237,7 +237,7 @@ export function getFormBasedDatasource({
   dataViewFieldEditor: IndexPatternFieldEditorStart;
   uiActions: UiActionsStart;
 }) {
-  const { uiSettings, featureFlags } = core;
+  const { uiSettings } = core;
 
   const DATASOURCE_ID = 'formBased';
   const ALIAS_IDS = ['indexpattern'];
@@ -494,7 +494,6 @@ export function getFormBasedDatasource({
         layerId,
         indexPatterns,
         uiSettings,
-        featureFlags,
         dateRange,
         nowInstant,
         searchSessionId,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/to_expression.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FeatureFlagsStart, IUiSettingsClient } from '@kbn/core/public';
+import type { IUiSettingsClient } from '@kbn/core/public';
 import { partition, uniq } from 'lodash';
 import seedrandom from 'seedrandom';
 import type {
@@ -35,6 +35,7 @@ import type {
 } from '@kbn/lens-common';
 import { isEsqlQuerySuccess, generateEsqlQuery } from './generate_esql_query';
 import { convertToAbsoluteDateRange } from '../../utils';
+import { getLensFeatureFlags } from '../../get_feature_flags';
 import { operationDefinitionMap } from './operations';
 import { isColumnFormatted, isColumnOfType } from './operations/definitions/helpers';
 import { dedupeAggs } from './dedupe_aggs';
@@ -75,7 +76,6 @@ function getExpressionForLayer(
   layer: FormBasedLayer,
   indexPattern: IndexPattern,
   uiSettings: IUiSettingsClient,
-  featureFlags: FeatureFlagsStart,
   dateRange: DateRange,
   nowInstant: Date,
   searchSessionId?: string,
@@ -176,7 +176,7 @@ function getExpressionForLayer(
     const aggExpressionToEsAggsIdMap: Map<ExpressionAstExpressionBuilder, string> = new Map();
 
     // esql mode variables
-    const lensESQLEnabled = featureFlags.getBooleanValue('lens.enable_esql', false);
+    const lensESQLEnabled = getLensFeatureFlags().enableEsql;
     const canUseESQL: boolean = lensESQLEnabled && uiSettings.get(ENABLE_ESQL) && !forceDSL;
 
     // Only generate ES|QL query when ES|QL mode is enabled
@@ -563,7 +563,6 @@ export function toExpression(
   layerId: string,
   indexPatterns: IndexPatternMap,
   uiSettings: IUiSettingsClient,
-  featureFlags: FeatureFlagsStart,
   dateRange: DateRange,
   nowInstant: Date,
   searchSessionId?: string,
@@ -574,7 +573,6 @@ export function toExpression(
       state.layers[layerId],
       indexPatterns[state.layers[layerId].indexPatternId],
       uiSettings,
-      featureFlags,
       dateRange,
       nowInstant,
       searchSessionId,

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -135,7 +135,6 @@
     "@kbn/cps",
     "@kbn/kql",
     "@kbn/controls-constants",
-    "@kbn/react-env",
     "@kbn/core-base-browser-mocks",
     "@kbn/react-kibana-context-env",
   ],


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana-team/issues/2740.

Replaces the `dev` flag with a feature flag for Lens ES|QL conversion, addressing the issue that testing the disabled state previously required building and testing a production build.

### Checklist

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] Used `cursor-cli` with `opus-4.5` to investigate and refactor.