### PR TITLE
[Metrics][Discover] Fix: pagination dimensions list in flyout 

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/overview_tab.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/overview_tab.test.tsx
@@ -169,6 +169,19 @@ describe('Metric Flyout Overview Tab', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('keeps pagination visible when on last page with fewer items than page size', () => {
+      const dimensions = Array.from({ length: 25 }, (_, i) => ({
+        name: `dimension.${String(i).padStart(2, '0')}`,
+        type: ES_FIELD_TYPES.KEYWORD,
+      }));
+      const metric = createMockMetric({ dimensions });
+      const { getByTestId } = render(<OverviewTab metric={metric} />);
+
+      expect(
+        getByTestId('metricsExperienceFlyoutOverviewTabDimensionsPagination')
+      ).toBeInTheDocument();
+    });
+
     it('sorts dimensions alphabetically', () => {
       const dimensions = [
         { name: 'zebra.field', type: ES_FIELD_TYPES.KEYWORD },

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/overview_tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/overview_tab.tsx
@@ -204,7 +204,7 @@ export const OverviewTab = ({ metric, description }: OverviewTabProps) => {
             `}
           />
           <EuiSpacer size="s" />
-          {dimensionListItems.length >= DEFAULT_PAGINATION_SIZE && (
+          {sortedDimensions.length >= DEFAULT_PAGINATION_SIZE && (
             <EuiTablePagination
               data-test-subj="metricsExperienceFlyoutOverviewTabDimensionsPagination"
               aria-label={i18n.translate(


### PR DESCRIPTION
Closes: #248425

## Summary

Fixes a bug where the dimensions pagination would disappear when navigating to the last page and then changing the "rows per page" value.

## Root Cause

The code uses two different lists:
1. `sortedDimensions` = full sorted list of ALL dimensions
2. `dimensionListItems` = paginated list (slice of current page only)

The pagination visibility condition was checking `dimensionListItems.length` (the current page's item count) instead of `sortedDimensions.length` (the total dimensions count).

**Example scenario:**
- 50 dimensions total
- User on page 3 (items 41-50, only 10 items on this page)
- `dimensionListItems.length` = 10 (current page items)
- Condition: `10 >= 20` = false → pagination disappears!

## Note

If you see the demo, you can notice the scroll behavior (where changing pages resets the scroll position). This will be addressed in a separate issue as part of the flyout redesign. See mention issue

## Demo

https://github.com/user-attachments/assets/a6ed5036-e6ef-495b-ba61-8307e1515c18

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



