### PR TITLE
[Agent Builder] model provider: fix default connector logic

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -96,6 +96,8 @@ export class ServiceManager {
       logger: logger.get('runnerFactory'),
       security,
       elasticsearch,
+      uiSettings,
+      savedObjects,
       inference,
       spaces,
       actions,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/model_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/model_provider.ts
@@ -6,6 +6,8 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
+import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type {
   ModelProvider,
   ScopedModel,
@@ -17,12 +19,15 @@ import { getConnectorProvider, getConnectorModel } from '@kbn/inference-common';
 import type { InferenceCompleteCallbackHandler } from '@kbn/inference-common/src/chat_complete';
 import type { TrackingService } from '../../telemetry';
 import { MODEL_TELEMETRY_METADATA } from '../../telemetry';
+import { resolveSelectedConnectorId } from '../chat/utils/resolve_selected_connector_id';
 
 export interface CreateModelProviderOpts {
   inference: InferenceServerStart;
   request: KibanaRequest;
   defaultConnectorId?: string;
   trackingService?: TrackingService;
+  uiSettings: UiSettingsServiceStart;
+  savedObjects: SavedObjectsServiceStart;
 }
 
 export type CreateModelProviderFactoryFn = (
@@ -51,13 +56,21 @@ export const createModelProvider = ({
   request,
   defaultConnectorId,
   trackingService,
+  uiSettings,
+  savedObjects,
 }: CreateModelProviderOpts): ModelProvider => {
   const getDefaultConnectorId = async () => {
-    if (defaultConnectorId) {
-      return defaultConnectorId;
+    const resolvedConnectorId = await resolveSelectedConnectorId({
+      uiSettings,
+      savedObjects,
+      request,
+      connectorId: defaultConnectorId,
+      inference,
+    });
+    if (!resolvedConnectorId) {
+      throw new Error('No connector available');
     }
-    const defaultConnector = await inference.getDefaultConnector(request);
-    return defaultConnector.connectorId;
+    return resolvedConnectorId;
   };
 
   const completedCalls: ModelCallInfo[] = [];

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/runner_factory.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/runner_factory.ts
@@ -22,11 +22,16 @@ export class RunnerFactoryImpl implements RunnerFactory {
   }
 
   private createRunnerDeps(): CreateRunnerDeps {
-    const { inference, trackingService, ...otherDeps } = this.deps;
+    const { inference, trackingService, uiSettings, savedObjects, ...otherDeps } = this.deps;
     return {
       ...otherDeps,
       trackingService,
-      modelProviderFactory: createModelProviderFactory({ inference, trackingService }),
+      modelProviderFactory: createModelProviderFactory({
+        inference,
+        trackingService,
+        uiSettings,
+        savedObjects,
+      }),
     };
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/types.ts
@@ -8,6 +8,8 @@
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchServiceStart } from '@kbn/core-elasticsearch-server';
 import type { SecurityServiceStart } from '@kbn/core-security-server';
+import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
+import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
@@ -22,6 +24,8 @@ export interface RunnerFactoryDeps {
   logger: Logger;
   elasticsearch: ElasticsearchServiceStart;
   security: SecurityServiceStart;
+  uiSettings: UiSettingsServiceStart;
+  savedObjects: SavedObjectsServiceStart;
   // plugin deps
   inference: InferenceServerStart;
   spaces: SpacesPluginStart | undefined;


### PR DESCRIPTION
## Summary

`createModelProvider` was still using the old default connector selection logic, instead of the one implemented in `resolveSelectedConnectorId`. In practice, it means in some scenarios (such as calling tools via the Kibana AB MCP server), the default connector uiSetting (`genAiSettings:defaultAIConnector`) was being ignored.

This PR addresses it, by properly using `resolveSelectedConnectorId` within `createModelProvider`

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->