### PR TITLE
[EDR Workflows] Unskip tests that failed on version conflict in after all

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_fleet_agent.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_fleet_agent.ts
@@ -205,6 +205,7 @@ export const deleteIndexedFleetAgents = async (
       .deleteByQuery({
         index: `${indexedData.fleetAgentsIndex}-*`,
         wait_for_completion: true,
+        conflicts: 'proceed',
         query: {
           bool: {
             filter: [

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/endpoint_details_complete.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/endpoint_details_complete.cy.ts
@@ -12,8 +12,7 @@ import { login, ROLE } from '../../../../tasks/login';
 
 const { insightsComponentExists, addConnectorButtonExists } = workflowInsightsSelectors;
 
-// FLAKY: https://github.com/elastic/kibana/issues/239216
-describe.skip(
+describe(
   'Endpoint details',
   {
     tags: [

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/authentication/trial_license_complete_tier/endpoint_authz.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/authentication/trial_license_complete_tier/endpoint_authz.ts
@@ -40,8 +40,7 @@ export default function ({ getService }: FtrProviderContext) {
   }
   // @skipInServerlessMKI - this test uses internal index manipulation in before/after hooks
   // @skipInServerlessMKI - if you are removing this annotation, make sure to add the test suite to the MKI pipeline in .buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
-  // Failing: See https://github.com/elastic/kibana/issues/236619
-  describe.skip('@ess @serverless @skipInServerlessMKI When attempting to call an endpoint api', function () {
+  describe('@ess @serverless @skipInServerlessMKI When attempting to call an endpoint api', function () {
     let indexedData: IndexedHostsAndAlertsResponse;
     let actionId = '';
     let agentId = '';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/policy_response/trial_license_complete_tier/policy_response.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/policy_response/trial_license_complete_tier/policy_response.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const utils = getService('securitySolutionUtils');
   const endpointTestresources = getService('endpointTestResources');
 
-  // Failing: See https://github.com/elastic/kibana/issues/236165
-  describe.skip('@ess @serverless @skipInServerlessMKI Endpoint policy response api', function () {
+  describe('@ess @serverless @skipInServerlessMKI Endpoint policy response api', function () {
     let adminSupertest: TestAgent;
 
     before(async () => {

--- a/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
@@ -40,8 +40,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     }
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/245458
-  describe.skip('For each artifact list under management', function () {
+  describe('For each artifact list under management', function () {
     targetTags(this, ['@ess', '@serverless']);
     this.timeout(60_000 * 5);
 

--- a/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/trusted_apps_list.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/trusted_apps_list.ts
@@ -17,8 +17,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const endpointTestResources = getService('endpointTestResources');
   const toasts = getService('toasts');
 
-  // Failing: See https://github.com/elastic/kibana/issues/236164
-  describe.skip('When on the Trusted Apps list', function () {
+  describe('When on the Trusted Apps list', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;


### PR DESCRIPTION
## Summary

Lot of our tests (cypress, FTRs) use in their `afterAll` hook the function `deleteIndexedEndpointHosts()`, which tries to delete Fleet agents in function `deleteIndexedFleetAgents()`.

There's some flakyness around this, which is most probably caused by a race condition, in which
- the `agent-status-change-task` updates the Agents' status every 60 second,
- we call the `deleteByQuery` ([docs](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query)), which first queries the documents, then deletes them - and if any of the docs' version changes between these 2 steps, we got the conflict error.

So, as a simple fix, I'm trying to add the `conflict: 'proceed'` option to the `deleteByQuery()` function call, let's see if it really helps.

Also, relevant tests are unskipped and the following issues can be closed:
closes #237393
closes #239216
closes #242204
closes #242863
closes #238454
closes #236842
closes #236061
closes #236344
closes #236687
closes #236165
closes #236198
closes #236619
closes #236164
closes #239731
closes #246101
closes #238720
closes #236862
closes #239558
closes #236075
closes #240968
closes #245458

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->