### PR TITLE
[9.1] Fix AI Connector form fields resetting to default value when cleared by user (#251095)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
@@ -1,0 +1,308 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfigInputField, ConfigNumberField } from './configuration_field';
+import { FieldType } from '../../types/types';
+import type { ConfigEntryView } from '../../types/types';
+
+describe('ConfigInputField', () => {
+  const createConfigEntry = (overrides: Partial<ConfigEntryView> = {}): ConfigEntryView => ({
+    key: 'url',
+    isValid: true,
+    label: 'URL',
+    description: 'The URL endpoint',
+    validationErrors: [],
+    required: false,
+    sensitive: false,
+    value: null,
+    default_value: 'https://api.example.com/v1',
+    updatable: true,
+    type: FieldType.STRING,
+    supported_task_types: ['text_embedding'],
+    ...overrides,
+  });
+
+  const defaultProps = {
+    isLoading: false,
+    validateAndSetConfigValue: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with default value when value is null', () => {
+    const configEntry = createConfigEntry({ value: null });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toHaveValue('https://api.example.com/v1');
+  });
+
+  it('renders with actual value when value is provided', () => {
+    const configEntry = createConfigEntry({ value: 'https://custom.url.com' });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toHaveValue('https://custom.url.com');
+  });
+
+  it('allows user to clear the field completely without resetting to default', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 'https://api.example.com/v1',
+    });
+
+    render(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('url-input');
+
+    // User clears the entire field
+    fireEvent.change(input, { target: { value: '' } });
+
+    // The input should be empty, not reset to default
+    expect(input).toHaveValue('');
+    expect(validateAndSetConfigValue).toHaveBeenCalledWith('');
+  });
+
+  it('does not reset to default after rerender when field is cleared', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 'https://api.example.com/v1',
+    });
+
+    const { rerender } = render(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('url-input');
+
+    // User clears the entire field
+    fireEvent.change(input, { target: { value: '' } });
+
+    // Simulate parent form updating value prop to null (as it converts '' to null)
+    rerender(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={{ ...configEntry, value: null }}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Should still be empty, not reset to default
+    expect(input).toHaveValue('');
+  });
+
+  it('allows user to type a new value after clearing', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 'https://api.example.com/v1',
+    });
+
+    render(
+      <ConfigInputField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('url-input');
+
+    // User clears and types new value
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, { target: { value: 'https://new.url.com' } });
+
+    expect(input).toHaveValue('https://new.url.com');
+    expect(validateAndSetConfigValue).toHaveBeenLastCalledWith('https://new.url.com');
+  });
+
+  it('is disabled when isLoading is true', () => {
+    const configEntry = createConfigEntry();
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} isLoading={true} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toBeDisabled();
+  });
+
+  it('is disabled in edit mode when field is not updatable', () => {
+    const configEntry = createConfigEntry({ updatable: false });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} isEdit={true} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toBeDisabled();
+  });
+
+  it('shows invalid state when isValid is false', () => {
+    const configEntry = createConfigEntry({ isValid: false });
+    render(<ConfigInputField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('url-input');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+});
+
+describe('ConfigNumberField', () => {
+  const createConfigEntry = (overrides: Partial<ConfigEntryView> = {}): ConfigEntryView => ({
+    key: 'max_tokens',
+    isValid: true,
+    label: 'Max Tokens',
+    description: 'Maximum number of tokens',
+    validationErrors: [],
+    required: false,
+    sensitive: false,
+    value: null,
+    default_value: 1024,
+    updatable: true,
+    type: FieldType.INTEGER,
+    supported_task_types: ['text_embedding'],
+    ...overrides,
+  });
+
+  const defaultProps = {
+    isLoading: false,
+    validateAndSetConfigValue: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with default value when value is null', () => {
+    const configEntry = createConfigEntry({ value: null });
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toHaveValue(1024);
+  });
+
+  it('renders with actual value when value is provided', () => {
+    const configEntry = createConfigEntry({ value: 2048 });
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toHaveValue(2048);
+  });
+
+  it('allows user to clear the field using the clear button', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 1024,
+    });
+
+    render(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Find and click the clear button
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    fireEvent.click(clearButton);
+
+    expect(validateAndSetConfigValue).toHaveBeenCalledWith('');
+  });
+
+  it('does not reset to default after rerender when field is cleared', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 1024,
+    });
+
+    const { rerender } = render(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Find and click the clear button
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    fireEvent.click(clearButton);
+
+    // Simulate parent form updating value prop to null (as it converts '' to null)
+    rerender(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={{ ...configEntry, value: null }}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    // Should still be empty, not reset to default
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toHaveValue(null);
+  });
+
+  it('allows user to change the value', () => {
+    const validateAndSetConfigValue = jest.fn();
+    const configEntry = createConfigEntry({
+      value: null,
+      default_value: 1024,
+    });
+
+    render(
+      <ConfigNumberField
+        {...defaultProps}
+        configEntry={configEntry}
+        validateAndSetConfigValue={validateAndSetConfigValue}
+      />
+    );
+
+    const input = screen.getByTestId('max_tokens-number');
+    fireEvent.change(input, { target: { value: '512' } });
+
+    expect(input).toHaveValue(512);
+    expect(validateAndSetConfigValue).toHaveBeenCalledWith('512');
+  });
+
+  it('is disabled when isLoading is true', () => {
+    const configEntry = createConfigEntry();
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} isLoading={true} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toBeDisabled();
+  });
+
+  it('is disabled when isPreconfigured is true', () => {
+    const configEntry = createConfigEntry();
+    render(
+      <ConfigNumberField {...defaultProps} configEntry={configEntry} isPreconfigured={true} />
+    );
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toBeDisabled();
+  });
+
+  it('is disabled in edit mode when field is not updatable', () => {
+    const configEntry = createConfigEntry({ updatable: false });
+    render(<ConfigNumberField {...defaultProps} configEntry={configEntry} isEdit={true} />);
+
+    const input = screen.getByTestId('max_tokens-number');
+    expect(input).toBeDisabled();
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.test.tsx
@@ -203,61 +203,6 @@ describe('ConfigNumberField', () => {
     expect(input).toHaveValue(2048);
   });
 
-  it('allows user to clear the field using the clear button', () => {
-    const validateAndSetConfigValue = jest.fn();
-    const configEntry = createConfigEntry({
-      value: null,
-      default_value: 1024,
-    });
-
-    render(
-      <ConfigNumberField
-        {...defaultProps}
-        configEntry={configEntry}
-        validateAndSetConfigValue={validateAndSetConfigValue}
-      />
-    );
-
-    // Find and click the clear button
-    const clearButton = screen.getByRole('button', { name: /clear/i });
-    fireEvent.click(clearButton);
-
-    expect(validateAndSetConfigValue).toHaveBeenCalledWith('');
-  });
-
-  it('does not reset to default after rerender when field is cleared', () => {
-    const validateAndSetConfigValue = jest.fn();
-    const configEntry = createConfigEntry({
-      value: null,
-      default_value: 1024,
-    });
-
-    const { rerender } = render(
-      <ConfigNumberField
-        {...defaultProps}
-        configEntry={configEntry}
-        validateAndSetConfigValue={validateAndSetConfigValue}
-      />
-    );
-
-    // Find and click the clear button
-    const clearButton = screen.getByRole('button', { name: /clear/i });
-    fireEvent.click(clearButton);
-
-    // Simulate parent form updating value prop to null (as it converts '' to null)
-    rerender(
-      <ConfigNumberField
-        {...defaultProps}
-        configEntry={{ ...configEntry, value: null }}
-        validateAndSetConfigValue={validateAndSetConfigValue}
-      />
-    );
-
-    // Should still be empty, not reset to default
-    const input = screen.getByTestId('max_tokens-number');
-    expect(input).toHaveValue(null);
-  });
-
   it('allows user to change the value', () => {
     const validateAndSetConfigValue = jest.fn();
     const configEntry = createConfigEntry({

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
@@ -47,8 +47,12 @@ export const ConfigInputField: React.FC<ConfigInputFieldProps> = ({
   );
 
   useEffect(() => {
-    setInnerValue(!value || value.toString().length === 0 ? defaultValue : value);
-  }, [defaultValue, value]);
+    // Only sync from external value if it has actual content
+    // Don't reset to default when user clears the field (value becomes null)
+    if (value != null && String(value).length > 0) {
+      setInnerValue(value);
+    }
+  }, [value]);
   return (
     <EuiFieldText
       disabled={isLoading || (isEdit && !updatable)}
@@ -124,8 +128,12 @@ export const ConfigNumberField: React.FC<ConfigInputFieldProps> = ({
   const { isValid, value, default_value: defaultValue, key, updatable } = configEntry;
   const [innerValue, setInnerValue] = useState(value ?? defaultValue);
   useEffect(() => {
-    setInnerValue(!value || value.toString().length === 0 ? defaultValue : value);
-  }, [defaultValue, value]);
+    // Only sync from external value if it has actual content
+    // Don't reset to default when user clears the field (value becomes null)
+    if (value != null && String(value).length > 0) {
+      setInnerValue(value);
+    }
+  }, [value]);
   return (
     <EuiFieldNumber
       fullWidth


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix AI Connector form fields resetting to default value when cleared by user (#251095)](https://github.com/elastic/kibana/pull/251095)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saikat Sarkar","email":"132922331+saikatsarkar056@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-30T23:06:22Z","message":"Fix AI Connector form fields resetting to default value when cleared by user (#251095)\n\n## Summary\n\nFixes #250953\n\nThis PR fixes a bug in the AI Connector creation flyout where fields\nwith default values (like URL, Model ID) would reset to their default\nvalue when the user tried to clear them completely using backspace.\n\n**Root cause:** The `useEffect` in `ConfigInputField` and\n`ConfigNumberField` was checking if the value was empty/null and\nresetting to `defaultValue`. When a user cleared a field, the form\nconverted the empty string to `null`, which triggered the effect to\nreset the field back to the default.\n\n**Fix:** Modified the `useEffect` to only sync when there's actual\nexternal content, preventing the reset when users intentionally clear\nthe field. The initial default is still applied via `useState`.\n\n### Changes\n- `ConfigInputField`: Updated `useEffect` to not reset to default when\nvalue is cleared\n- `ConfigNumberField`: Same fix applied\n- Added comprehensive unit tests for both components\n\n## Test plan\n\n1. Go to **Alerts and Insights > Connectors**\n2. Click **Create connector** → Select **AI Connector**\n3. Select **DeepSeek** as the provider\n4. Open **More Options** section\n5. Try to backspace/delete the URL field completely\n6. **Expected:** Field should clear and stay empty\n7. **Before fix:** Field would reset to default URL when last character\nwas deleted\n\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/cc8832f5-ca91-4270-825f-023dcbc34615\n\n\n\n\n### After\n\nhttps://github.com/user-attachments/assets/49a31906-6362-4f5d-aee1-bff10008aabd\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n### Release note\nFixes AI Connector form fields incorrectly resetting to default values\nwhen users clear them using backspace.","sha":"6c002da047e50b136402706afe740c992ab4239f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.3.0","v9.4.0","v9.3.1"],"title":"Fix AI Connector form fields resetting to default value when cleared by user","number":251095,"url":"https://github.com/elastic/kibana/pull/251095","mergeCommit":{"message":"Fix AI Connector form fields resetting to default value when cleared by user (#251095)\n\n## Summary\n\nFixes #250953\n\nThis PR fixes a bug in the AI Connector creation flyout where fields\nwith default values (like URL, Model ID) would reset to their default\nvalue when the user tried to clear them completely using backspace.\n\n**Root cause:** The `useEffect` in `ConfigInputField` and\n`ConfigNumberField` was checking if the value was empty/null and\nresetting to `defaultValue`. When a user cleared a field, the form\nconverted the empty string to `null`, which triggered the effect to\nreset the field back to the default.\n\n**Fix:** Modified the `useEffect` to only sync when there's actual\nexternal content, preventing the reset when users intentionally clear\nthe field. The initial default is still applied via `useState`.\n\n### Changes\n- `ConfigInputField`: Updated `useEffect` to not reset to default when\nvalue is cleared\n- `ConfigNumberField`: Same fix applied\n- Added comprehensive unit tests for both components\n\n## Test plan\n\n1. Go to **Alerts and Insights > Connectors**\n2. Click **Create connector** → Select **AI Connector**\n3. Select **DeepSeek** as the provider\n4. Open **More Options** section\n5. Try to backspace/delete the URL field completely\n6. **Expected:** Field should clear and stay empty\n7. **Before fix:** Field would reset to default URL when last character\nwas deleted\n\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/cc8832f5-ca91-4270-825f-023dcbc34615\n\n\n\n\n### After\n\nhttps://github.com/user-attachments/assets/49a31906-6362-4f5d-aee1-bff10008aabd\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n### Release note\nFixes AI Connector form fields incorrectly resetting to default values\nwhen users clear them using backspace.","sha":"6c002da047e50b136402706afe740c992ab4239f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251144","number":251144,"state":"OPEN"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251095","number":251095,"mergeCommit":{"message":"Fix AI Connector form fields resetting to default value when cleared by user (#251095)\n\n## Summary\n\nFixes #250953\n\nThis PR fixes a bug in the AI Connector creation flyout where fields\nwith default values (like URL, Model ID) would reset to their default\nvalue when the user tried to clear them completely using backspace.\n\n**Root cause:** The `useEffect` in `ConfigInputField` and\n`ConfigNumberField` was checking if the value was empty/null and\nresetting to `defaultValue`. When a user cleared a field, the form\nconverted the empty string to `null`, which triggered the effect to\nreset the field back to the default.\n\n**Fix:** Modified the `useEffect` to only sync when there's actual\nexternal content, preventing the reset when users intentionally clear\nthe field. The initial default is still applied via `useState`.\n\n### Changes\n- `ConfigInputField`: Updated `useEffect` to not reset to default when\nvalue is cleared\n- `ConfigNumberField`: Same fix applied\n- Added comprehensive unit tests for both components\n\n## Test plan\n\n1. Go to **Alerts and Insights > Connectors**\n2. Click **Create connector** → Select **AI Connector**\n3. Select **DeepSeek** as the provider\n4. Open **More Options** section\n5. Try to backspace/delete the URL field completely\n6. **Expected:** Field should clear and stay empty\n7. **Before fix:** Field would reset to default URL when last character\nwas deleted\n\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/cc8832f5-ca91-4270-825f-023dcbc34615\n\n\n\n\n### After\n\nhttps://github.com/user-attachments/assets/49a31906-6362-4f5d-aee1-bff10008aabd\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n### Release note\nFixes AI Connector form fields incorrectly resetting to default values\nwhen users clear them using backspace.","sha":"6c002da047e50b136402706afe740c992ab4239f"}}]}] BACKPORT-->