### PR TITLE
[9.2] [APM] Migrate Infra home page tests to Scout - Part II - Asset Details Flyout (#248997)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
@@ -57,6 +57,7 @@ describe('createPlaywrightConfig', () => {
       screenshot: 'only-on-failure',
       testIdAttribute: 'data-test-subj',
       trace: 'on-first-retry',
+      timezoneId: 'GMT',
     });
     expect(config.globalSetup).toBeUndefined();
     expect(config.globalTeardown).toBeUndefined();

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -97,6 +97,7 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
       screenshot: 'only-on-failure',
       // video: 'retain-on-failure',
       // storageState: './output/reports/state.json', // Store session state (like cookies)
+      timezoneId: 'GMT',
     },
 
     // Timeout for each test, includes test, hooks and fixtures

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/docker_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/docker_charts.tsx
@@ -37,6 +37,7 @@ export const DockerCharts = React.forwardRef<HTMLDivElement, Props>(
         title={
           <TitleWithTooltip
             title={CONTAINER_METRIC_GROUP_TITLES[metric]}
+            data-test-subj={`infraAssetDetailsDockerChartsSection${metric}Title`}
             tooltipContent={
               <EuiText size="xs">
                 <FormattedMessage
@@ -45,7 +46,7 @@ export const DockerCharts = React.forwardRef<HTMLDivElement, Props>(
                   values={{
                     link: (
                       <EuiLink
-                        data-test-subj="infraAssetDetailsViewContainerMetricsDocumentationLink"
+                        data-test-subj={`infraAssetDetailsDockerChartsSection${metric}DocumentationLink`}
                         href={`${CONTAINER_METRICS_DOC_HREF}#${FRAGMENT_BASE}-${metric}`}
                         target="_blank"
                         className={cx({

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/host_charts.tsx
@@ -40,6 +40,7 @@ export const HostCharts = React.forwardRef<HTMLDivElement, Props>(
       <Section
         title={
           <TitleWithTooltip
+            data-test-subj={`infraAssetDetailsHostChartsSection${metric}Title`}
             title={HOST_METRIC_GROUP_TITLES[metric]}
             tooltipContent={
               <EuiText size="xs">
@@ -49,7 +50,7 @@ export const HostCharts = React.forwardRef<HTMLDivElement, Props>(
                   values={{
                     link: (
                       <EuiLink
-                        data-test-subj="infraAssetDetailsViewHostMetricsDocumentationLink"
+                        data-test-subj={`infraAssetDetailsHostChartsSection${metric}DocumentationLink`}
                         href={`${HOST_METRICS_DOC_HREF}#${FRAGMENT_BASE}-${metric}`}
                         target="_blank"
                         className={cx({

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/kubernetes_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/charts/kubernetes_charts.tsx
@@ -44,7 +44,12 @@ export const KubernetesNodeCharts = React.forwardRef<HTMLDivElement, Props>(
 
     return (
       <Section
-        title={<SectionTitle title={HOST_METRIC_GROUP_TITLES.kubernetes} />}
+        title={
+          <SectionTitle
+            title={HOST_METRIC_GROUP_TITLES.kubernetes}
+            data-test-subj="infraAssetDetailsKubernetesChartsSectionTitle"
+          />
+        }
         data-test-subj="infraAssetDetailsKubernetesChartsSection"
         id="kubernetes"
         ref={ref}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/apis/inventory_views/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/apis/inventory_views/index.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KbnClient, ScoutLogger } from '@kbn/scout-oblt';
+import { measurePerformanceAsync } from '@kbn/scout-oblt';
+import type {
+  CreateInventoryViewAttributes,
+  FindInventoryViewResponse,
+  InventoryView,
+  InventoryViewResponse,
+  SingleInventoryView,
+} from './types';
+
+/**
+ * Inventory Views API Service
+ * Provides methods to interact with Kibana's Inventory Views API
+ */
+export interface InventoryViewApiService {
+  /**
+   * Retrieves all inventory views in a reduced version.
+   * @returns Promise with array of reduced inventory views
+   */
+  findAll: () => Promise<SingleInventoryView[]>;
+
+  /**
+   * Creates a new inventory view
+   * @param attributes - The inventory view attributes
+   * @returns Promise with the newly created inventory view
+   */
+  create: (attributes: CreateInventoryViewAttributes) => Promise<InventoryView>;
+
+  /**
+   * Deletes an inventory view by ID
+   * @param id - The id of the inventory view to delete
+   * @returns Promise with no content
+   */
+  deleteOne: (id: string) => Promise<void>;
+}
+
+/**
+ * Factory function to create an Inventory Views API service helper
+ * @param log - Scout logger instance
+ * @param kbnClient - Kibana client for making API requests
+ * @returns InventoryViewApiService instance
+ */
+export const getInventoryViewsApiService = ({
+  kbnClient,
+  log,
+}: {
+  kbnClient: KbnClient;
+  log: ScoutLogger;
+}): InventoryViewApiService => {
+  return {
+    findAll: async () => {
+      return await measurePerformanceAsync(
+        log,
+        'inventoryViews.findAll',
+        async (): Promise<SingleInventoryView[]> => {
+          const response = await kbnClient.request<FindInventoryViewResponse>({
+            method: 'GET',
+            path: '/api/infra/inventory_views',
+            retries: 3,
+          });
+
+          return response.data.data;
+        }
+      );
+    },
+    create: async (attributes: CreateInventoryViewAttributes) => {
+      return await measurePerformanceAsync(
+        log,
+        'inventoryViews.create',
+        async (): Promise<InventoryView> => {
+          const response = await kbnClient.request<InventoryViewResponse>({
+            method: 'POST',
+            path: '/api/infra/inventory_views',
+            retries: 3,
+            body: { attributes },
+          });
+
+          return response.data.data;
+        }
+      );
+    },
+    deleteOne: async (id: string): Promise<void> => {
+      return await measurePerformanceAsync(
+        log,
+        'inventoryViews.deleteOne',
+        async (): Promise<void> => {
+          await kbnClient.request({
+            method: 'DELETE',
+            path: `/api/infra/inventory_views/${id}`,
+            retries: 3,
+            ignoreErrors: [404],
+          });
+        }
+      );
+    },
+  };
+};

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/apis/inventory_views/types.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/apis/inventory_views/types.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Inventory view object returned by the Kibana API
+ */
+export interface InventoryView {
+  id: string;
+  attributes: InventoryViewAttributes;
+  updatedAt?: string;
+  version?: string;
+}
+
+interface InventoryViewAttributes {
+  name: string;
+  accountId: string;
+  autoBounds: boolean;
+  boundsOverride: {
+    min: number;
+    max: number;
+  };
+  customMetrics: Record<string, any>[];
+  customOptions: InventoryViewCustomOptions[];
+  groupBy: Record<string, any>[];
+  metric: { type: InventoryViewMetricType } & Record<string, any>;
+  nodeType: InventoryViewItemType;
+  region: string;
+  sort: InventoryViewSort;
+  view: InventoryViewViewType;
+  autoReload: boolean;
+  filterQuery: InventoryViewFilter;
+  legend?: InventoryViewLegend;
+  source?: string;
+  timelineOpen?: boolean;
+  preferredSchema?: InventoryViewPreferredSchema | null;
+  isDefault?: boolean;
+  isStatic?: boolean;
+  time?: number;
+}
+
+interface InventoryViewSort {
+  by: InventoryViewSortBy;
+  direction: InventoryViewSortDirection;
+}
+type InventoryViewSortBy = 'name' | 'value';
+type InventoryViewSortDirection = 'asc' | 'desc';
+
+type InventoryViewViewType = 'table' | 'map';
+
+interface InventoryViewLegend {
+  palette: InventoryViewLegendPalette;
+  steps: number;
+  reverseColors: boolean;
+}
+type InventoryViewLegendPalette =
+  | 'status'
+  | 'temperature'
+  | 'cool'
+  | 'warm'
+  | 'positive'
+  | 'negative';
+
+type InventoryViewPreferredSchema = 'ecs' | 'semconv';
+
+interface InventoryViewCustomOptions {
+  text: string;
+  field: string;
+}
+
+interface InventoryViewFilter {
+  kind: 'kuery';
+  expression: string;
+}
+
+type InventoryViewMetricType =
+  | 'count'
+  | 'cpuV2'
+  | 'cpu'
+  | 'diskLatency'
+  | 'diskSpaceUsage'
+  | 'load'
+  | 'memory'
+  | 'memoryFree'
+  | 'memoryTotal'
+  | 'normalizedLoad1m'
+  | 'tx'
+  | 'rx'
+  | 'txV2'
+  | 'rxV2'
+  | 'logRate'
+  | 'diskIOReadBytes'
+  | 'diskIOWriteBytes'
+  | 's3TotalRequests'
+  | 's3NumberOfObjects'
+  | 's3BucketSize'
+  | 's3DownloadBytes'
+  | 's3UploadBytes'
+  | 'rdsConnections'
+  | 'rdsQueriesExecuted'
+  | 'rdsActiveTransactions'
+  | 'rdsLatency'
+  | 'sqsMessagesVisible'
+  | 'sqsMessagesDelayed'
+  | 'sqsMessagesSent'
+  | 'sqsMessagesEmpty'
+  | 'sqsOldestMessage'
+  | 'custom';
+
+type InventoryViewItemType =
+  | 'host'
+  | 'pod'
+  | 'container'
+  | 'awsEC2'
+  | 'awsS3'
+  | 'awsSQS'
+  | 'host'
+  | 'pod'
+  | 'container'
+  | 'awsEC2'
+  | 'awsS3'
+  | 'awsSQS'
+  | 'awsRDS';
+
+/**
+ * Inventory view in a reduced form as returned by the findAll API
+ */
+export interface SingleInventoryView {
+  id: string;
+  attributes: {
+    name: string;
+    isDefault?: boolean;
+    isStatic?: boolean;
+  };
+  updatedAt?: string;
+  version?: string;
+}
+
+/**
+ * Response with an array of reduced inventory views
+ */
+export interface FindInventoryViewResponse {
+  data: SingleInventoryView[];
+}
+
+/**
+ * Response with a single, expanded inventory view
+ */
+export interface InventoryViewResponse {
+  data: InventoryView;
+}
+
+/**
+ * Attributes payload for creating a new inventory view
+ */
+export interface CreateInventoryViewAttributes
+  extends Omit<InventoryViewAttributes, 'isDefault' | 'isStatic'> {
+  isDefault?: undefined;
+  isStatic?: undefined;
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -5,9 +5,12 @@
  * 2.0.
  */
 
+import type { CreateInventoryViewAttributes } from './apis/inventory_views/types';
+
 export const DATE_WITH_HOSTS_DATA_FROM = '2023-03-28T18:20:00.000Z';
 export const DATE_WITH_HOSTS_DATA_TO = '2023-03-28T18:21:00.000Z';
 export const DATE_WITH_HOSTS_DATA = '03/28/2023 6:20:59 PM';
+export const DATE_WITH_HOSTS_DATA_TIMESTAMP = 1680027659000;
 
 export const HOST1_NAME = 'host-1';
 export const HOST2_NAME = 'host-2';
@@ -15,6 +18,14 @@ export const HOST3_NAME = 'host-3';
 export const HOST4_NAME = 'host-4';
 export const HOST5_NAME = 'host-5';
 export const HOST6_NAME = 'host-6';
+
+export const HOSTS_METADATA_FIELD = 'host.name';
+
+export const LOG_LEVELS = [
+  { message: 'A simple log', level: 'info' },
+  { message: 'Yet another debug log', level: 'debug' },
+  { message: 'Error with certificate: "ca_trusted_fingerprint"', level: 'error' },
+];
 
 export const HOST_NAME_WITH_SERVICES = HOST1_NAME;
 export const SERVICE_PER_HOST_COUNT = 3;
@@ -45,6 +56,7 @@ export const HOSTS = [
     cpuValue: 0.4,
   },
 ];
+export const DEFAULT_HOSTS_INVENTORY_VIEW_NAME = 'Hosts Default View';
 
 export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = '2023-03-29T18:20:00.000Z';
 export const DATE_WITH_HOSTS_WITHOUT_DATA_TO = '2023-03-29T18:21:00.000Z';
@@ -77,11 +89,17 @@ export const K8S_HOSTS = [
 export const DATE_WITH_DOCKER_DATA_FROM = '2023-03-31T18:20:00.000Z';
 export const DATE_WITH_DOCKER_DATA_TO = '2023-03-31T18:21:00.000Z';
 export const DATE_WITH_DOCKER_DATA = '03/31/2023 6:20:59 PM';
+export const DATE_WITH_DOCKER_DATA_TIMESTAMP = 1680286859000;
 export const CONTAINER_COUNT = 1;
+export const CONTAINER_IDS = Array.from({ length: CONTAINER_COUNT }, (_, i) => `cont-${i}`);
 export const CONTAINER_NAMES = Array.from(
   { length: CONTAINER_COUNT },
-  (_, i) => `container-container-${i}`
+  (_, i) => `container-cont-${i}`
 );
+
+export const CONTAINER_METADATA_FIELD = 'container.id';
+
+export const DEFAULT_CONTAINERS_INVENTORY_VIEW_NAME = 'Containers Default View';
 
 export const DATE_WITH_POD_DATA_FROM = '2023-04-01T18:20:00.000Z';
 export const DATE_WITH_POD_DATA_TO = '2023-04-01T18:21:00.000Z';
@@ -90,3 +108,40 @@ export const POD_COUNT = 1;
 export const POD_NAMES = Array.from({ length: POD_COUNT }, (_, i) => `pod-${i}`);
 
 export const DATE_WITHOUT_DATA = '04/01/2024 6:20:59 PM';
+
+export const EXTENDED_TIMEOUT = 45000; // 45 seconds
+
+export const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
+
+export const BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES: Omit<
+  CreateInventoryViewAttributes,
+  'nodeType' | 'name' | 'time' | 'metric'
+> = {
+  groupBy: [],
+  view: 'map',
+  customOptions: [],
+  customMetrics: [],
+  boundsOverride: {
+    max: 1,
+    min: 0,
+  },
+  autoBounds: true,
+  accountId: '',
+  region: '',
+  legend: {
+    palette: 'cool',
+    reverseColors: false,
+    steps: 10,
+  },
+  sort: {
+    by: 'name',
+    direction: 'desc',
+  },
+  timelineOpen: false,
+  autoReload: false,
+  filterQuery: {
+    expression: '',
+    kind: 'kuery',
+  },
+  preferredSchema: 'ecs',
+};

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
@@ -9,7 +9,7 @@ import type {
   ObltPageObjects,
   ObltTestFixtures,
   ObltWorkerFixtures,
-  KibanaUrl,
+  ObltApiServicesFixture,
 } from '@kbn/scout-oblt';
 import {
   test as base,
@@ -20,32 +20,48 @@ import {
 import type { InfraDocument, SynthtraceGenerator } from '@kbn/apm-synthtrace-client';
 import { Readable } from 'stream';
 import { InventoryPage } from './page_objects/inventory';
+import { AssetDetailsPage } from './page_objects/asset_details/asset_details';
+import { getInventoryViewsApiService, type InventoryViewApiService } from './apis/inventory_views';
 
 export interface ExtendedScoutTestFixtures extends ObltTestFixtures {
   pageObjects: ObltPageObjects & {
     inventoryPage: InventoryPage;
+    assetDetailsPage: AssetDetailsPage;
   };
 }
 
-export const test = base.extend<ExtendedScoutTestFixtures, ObltWorkerFixtures>({
+export interface ExtendedScoutWorkerFixtures extends ObltWorkerFixtures {
+  apiServices: ObltApiServicesFixture & {
+    inventoryViews: InventoryViewApiService;
+  };
+}
+
+export const test = base.extend<ExtendedScoutTestFixtures, ExtendedScoutWorkerFixtures>({
   pageObjects: async (
-    {
-      pageObjects,
-      page,
-      kbnUrl,
-    }: {
-      pageObjects: ExtendedScoutTestFixtures['pageObjects'];
-      page: ExtendedScoutTestFixtures['page'];
-      kbnUrl: KibanaUrl;
-    },
+    { pageObjects, page, kbnUrl },
     use: (pageObjects: ExtendedScoutTestFixtures['pageObjects']) => Promise<void>
   ) => {
     const extendedPageObjects = {
       ...pageObjects,
       inventoryPage: createLazyPageObject(InventoryPage, page, kbnUrl),
+      assetDetailsPage: createLazyPageObject(AssetDetailsPage, page, kbnUrl),
     };
 
     await use(extendedPageObjects);
+  },
+  apiServices: async (
+    { apiServices, kbnClient, log },
+    use: (apiServices: ExtendedScoutWorkerFixtures['apiServices']) => Promise<void>
+  ) => {
+    const extendedApiServices: ExtendedScoutWorkerFixtures['apiServices'] = {
+      ...apiServices,
+      inventoryViews: getInventoryViewsApiService({
+        kbnClient,
+        log,
+      }),
+    };
+
+    await use(extendedApiServices);
   },
 });
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator } from '@kbn/scout-oblt';
+import { createLazyPageObject, type KibanaUrl, type ScoutPage } from '@kbn/scout-oblt';
+import { OverviewTab } from './overview_tab';
+import { MetadataTab } from './metadata_tab';
+import { MetricsTab } from './metrics_tab';
+import { LogsTab } from './logs_tab';
+
+export class AssetDetailsPage {
+  public readonly hostOverviewTab: OverviewTab;
+  public readonly dockerOverviewTab: OverviewTab;
+
+  public readonly metadataTab: MetadataTab;
+
+  public readonly hostMetricsTab: MetricsTab;
+  public readonly dockerMetricsTab: MetricsTab;
+
+  public readonly logsTag: LogsTab;
+
+  public readonly openAsPageButton: Locator;
+  public readonly returnButton: Locator;
+
+  constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
+    this.hostOverviewTab = createLazyPageObject(OverviewTab, this.page, this.kbnUrl, 'Host');
+    this.dockerOverviewTab = createLazyPageObject(OverviewTab, this.page, this.kbnUrl, 'Docker');
+
+    this.metadataTab = createLazyPageObject(MetadataTab, this.page, this.kbnUrl);
+
+    this.hostMetricsTab = createLazyPageObject(MetricsTab, this.page, this.kbnUrl, 'Host');
+    this.dockerMetricsTab = createLazyPageObject(MetricsTab, this.page, this.kbnUrl, 'Docker');
+
+    this.logsTag = createLazyPageObject(LogsTab, this.page, this.kbnUrl);
+
+    this.openAsPageButton = this.page.getByTestId('infraAssetDetailsOpenAsPageButton');
+    this.returnButton = this.page.getByTestId('infraAssetDetailsReturnButton');
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details_tab.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+
+export type AssetDetailsPageTabName =
+  | 'Overview'
+  | 'Metadata'
+  | 'Metrics'
+  | 'Processes'
+  | 'Profiling'
+  | 'Logs'
+  | 'Anomalies'
+  | 'Osquery';
+
+export abstract class AssetDetailsTab {
+  public abstract readonly tabName: AssetDetailsPageTabName;
+  public abstract readonly tab: Locator;
+
+  constructor(protected readonly page: ScoutPage, protected readonly kbnUrl: KibanaUrl) {}
+
+  public getTab(): Locator {
+    return this.tab;
+  }
+
+  public async clickTab() {
+    await this.tab.click();
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/logs_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/logs_tab.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import type { AssetDetailsPageTabName } from './asset_details_tab';
+import { AssetDetailsTab } from './asset_details_tab';
+
+export class LogsTab extends AssetDetailsTab {
+  public readonly tabName: AssetDetailsPageTabName = 'Logs';
+  public readonly tab: Locator;
+
+  public readonly searchBar: Locator;
+  public readonly openInDiscoverButton: Locator;
+
+  public readonly table: Locator;
+  public readonly tableTotalDocumentsLabel: Locator;
+
+  constructor(page: ScoutPage, kbnUrl: KibanaUrl) {
+    super(page, kbnUrl);
+    this.tab = this.page.getByTestId(`infraAssetDetails${this.tabName}Tab`);
+
+    this.searchBar = this.page.getByTestId('infraAssetDetailsLogsTabFieldSearch');
+    this.openInDiscoverButton = this.page.getByTestId('infraAssetDetailsLogsTabOpenInLogsButton');
+
+    this.table = this.page.getByTestId('embeddedSavedSearchDocTable');
+    this.tableTotalDocumentsLabel = this.table.getByTestId('savedSearchTotalDocuments');
+  }
+
+  public async filterTable(searchTerm: string) {
+    await this.searchBar.pressSequentially(searchTerm);
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/metadata_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/metadata_tab.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import type { AssetDetailsPageTabName } from './asset_details_tab';
+import { AssetDetailsTab } from './asset_details_tab';
+
+export class MetadataTab extends AssetDetailsTab {
+  public readonly tabName: AssetDetailsPageTabName = 'Metadata';
+  public readonly tab: Locator;
+
+  public readonly searchBar: Locator;
+
+  public readonly table: Locator;
+  public readonly tableHeader: Locator;
+  public readonly tableRows: Locator;
+
+  constructor(page: ScoutPage, kbnUrl: KibanaUrl) {
+    super(page, kbnUrl);
+    this.tab = this.page.getByTestId(`infraAssetDetails${this.tabName}Tab`);
+
+    this.searchBar = this.page.getByTestId('infraAssetDetailsMetadataSearchBarInput');
+
+    this.table = this.page.getByTestId('infraAssetDetailsMetadataTable');
+    this.tableHeader = this.table.locator('thead tr');
+    this.tableRows = this.table.locator('tbody tr');
+  }
+
+  public getRowForField(fieldName: string) {
+    return this.tableRows.filter({ hasText: fieldName });
+  }
+
+  public getPinButtonsForField(fieldName: string) {
+    const row = this.getRowForField(fieldName);
+
+    const pin = row.getByTestId('infraAssetDetailsMetadataAddPin');
+    const unpin = row.getByTestId('infraAssetDetailsMetadataRemovePin');
+
+    return { pin, unpin };
+  }
+
+  public async pinField(fieldName: string) {
+    const pinButtons = this.getPinButtonsForField(fieldName);
+
+    await pinButtons.pin.click();
+    await pinButtons.unpin.focus();
+  }
+
+  public async unpinField(fieldName: string) {
+    const pinButtons = this.getPinButtonsForField(fieldName);
+
+    await pinButtons.unpin.click();
+    await pinButtons.pin.focus();
+  }
+
+  public async filterField(fieldName: string) {
+    await this.searchBar.pressSequentially(fieldName);
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/metrics_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/metrics_tab.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import type { AssetDetailsPageTabName } from './asset_details_tab';
+import { AssetDetailsTab } from './asset_details_tab';
+
+export type MetricsTabQuickAccessItem = 'CPU' | 'Memory' | 'Network' | 'Disk' | 'Log Rate';
+
+export class MetricsTab extends AssetDetailsTab {
+  public readonly tabName: AssetDetailsPageTabName = 'Metrics';
+  public readonly tab: Locator;
+
+  public readonly chartsContent: Locator;
+
+  public readonly quickAccessItems: Locator;
+
+  public readonly cpuSection: Locator;
+  public readonly cpuSectionTitle: Locator;
+  public readonly cpuUsageChart: Locator;
+  public readonly cpuUsageBreakdownChart: Locator;
+  public readonly cpuNormalizedLoadChart: Locator;
+  public readonly cpuLoadBreakdownChart: Locator;
+
+  public readonly memorySection: Locator;
+  public readonly memorySectionTitle: Locator;
+  public readonly memoryUsageChart: Locator;
+  public readonly memoryUsageBreakdownChart: Locator;
+
+  public readonly networkSection: Locator;
+  public readonly networkSectionTitle: Locator;
+  public readonly networkChart: Locator;
+
+  public readonly diskSection: Locator;
+  public readonly diskSectionTitle: Locator;
+  public readonly diskUsageChart: Locator;
+  public readonly diskIOChart: Locator;
+  public readonly diskThroughputChart: Locator;
+
+  public readonly logSection: Locator;
+  public readonly logSectionTitle: Locator;
+  public readonly logRateChart: Locator;
+
+  constructor(page: ScoutPage, kbnUrl: KibanaUrl, private readonly assetType: 'Host' | 'Docker') {
+    super(page, kbnUrl);
+    this.tab = this.page.getByTestId(`infraAssetDetails${this.tabName}Tab`);
+
+    this.chartsContent = this.page.getByTestId('infraAssetDetailsMetricChartsContent');
+
+    this.quickAccessItems = this.chartsContent
+      .getByRole('list')
+      .filter({ has: this.page.getByTestId('infraMetricsQuickAccessItemcpu') })
+      .locator('li');
+
+    this.cpuSection = this.chartsContent.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectioncpu`
+    );
+    this.cpuSectionTitle = this.cpuSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectioncpuTitle`
+    );
+    this.cpuUsageChart = this.cpuSection.getByTestId('infraAssetDetailsMetricChartcpuUsage');
+    this.cpuUsageBreakdownChart = this.cpuSection.getByTestId(
+      'infraAssetDetailsMetricChartcpuUsageBreakdown'
+    );
+    this.cpuNormalizedLoadChart = this.cpuSection.getByTestId(
+      'infraAssetDetailsMetricChartnormalizedLoad1m'
+    );
+    this.cpuLoadBreakdownChart = this.cpuSection.getByTestId(
+      'infraAssetDetailsMetricChartloadBreakdown'
+    );
+
+    this.memorySection = this.chartsContent.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionmemory`
+    );
+    this.memorySectionTitle = this.memorySection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionmemoryTitle`
+    );
+    this.memoryUsageChart = this.memorySection.getByTestId(
+      'infraAssetDetailsMetricChartmemoryUsage'
+    );
+    this.memoryUsageBreakdownChart = this.memorySection.getByTestId(
+      'infraAssetDetailsMetricChartmemoryUsageBreakdown'
+    );
+
+    this.networkSection = this.chartsContent.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionnetwork`
+    );
+    this.networkSectionTitle = this.networkSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionnetworkTitle`
+    );
+    this.networkChart = this.networkSection.getByTestId('infraAssetDetailsMetricChartrxTx');
+
+    this.diskSection = this.chartsContent.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectiondisk`
+    );
+    this.diskSectionTitle = this.diskSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectiondiskTitle`
+    );
+    this.diskUsageChart = this.diskSection.getByTestId(
+      'infraAssetDetailsMetricChartdiskUsageByMountPoint'
+    );
+    this.diskIOChart = this.diskSection.getByTestId('infraAssetDetailsMetricChartdiskIOReadWrite');
+    this.diskThroughputChart = this.diskSection.getByTestId(
+      'infraAssetDetailsMetricChartdiskThroughputReadWrite'
+    );
+
+    this.logSection = this.chartsContent.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionlog`
+    );
+    this.logSectionTitle = this.logSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionlogTitle`
+    );
+    this.logRateChart = this.logSection.getByTestId('infraAssetDetailsMetricChartlogRate');
+  }
+
+  public async clickQuickAccessItem(itemName: MetricsTabQuickAccessItem) {
+    const item = this.quickAccessItems.filter({ hasText: itemName });
+    await item.click();
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/overview_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/overview_tab.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import type { AssetDetailsPageTabName } from './asset_details_tab';
+import { AssetDetailsTab } from './asset_details_tab';
+
+export class OverviewTab extends AssetDetailsTab {
+  public readonly tabName: AssetDetailsPageTabName = 'Overview';
+  public readonly tab: Locator;
+
+  public readonly kpiCpuUsageChart: Locator;
+  public readonly kpiNormalizedLoadChart: Locator;
+  public readonly kpiMemoryUsageChart: Locator;
+  public readonly kpiDiskUsageChart: Locator;
+
+  public readonly metadataSection: Locator;
+  public readonly metadataSectionCollapsible: Locator;
+  public readonly metadataSectionGroup: Locator;
+  public readonly metadataShowAllButton: Locator;
+  public readonly metadataSummaryItems: Locator;
+
+  public readonly alertsSection: Locator;
+  public readonly alertsSectionCollapsible: Locator;
+  public readonly alertsSectionGroup: Locator;
+  public readonly alertsCreateRuleButton: Locator;
+  public readonly alertsShowAllButton: Locator;
+  public readonly alertsContent: Locator;
+
+  public readonly servicesSection: Locator;
+  public readonly servicesSectionCollapsible: Locator;
+  public readonly servicesSectionGroup: Locator;
+  public readonly servicesShowAllButton: Locator;
+  public readonly servicesContainer: Locator;
+
+  public readonly metricsSection: Locator;
+  public readonly metricsSectionCollapsible: Locator;
+  public readonly metricsSectionGroup: Locator;
+
+  public readonly metricsCpuSection: Locator;
+  public readonly metricsCpuSectionTitle: Locator;
+  public readonly metricsCpuShowAllButton: Locator;
+  public readonly metricsCpuUsageChart: Locator;
+  public readonly metricsCpuNormalizedLoadChart: Locator;
+
+  public readonly metricsMemorySection: Locator;
+  public readonly metricsMemorySectionTitle: Locator;
+  public readonly metricsMemoryShowAllButton: Locator;
+  public readonly metricsMemoryUsageChart: Locator;
+
+  public readonly metricsNetworkSection: Locator;
+  public readonly metricsNetworkSectionTitle: Locator;
+  public readonly metricsNetworkShowAllButton: Locator;
+  public readonly metricsNetworkChart: Locator;
+
+  public readonly metricsDiskSection: Locator;
+  public readonly metricsDiskSectionTitle: Locator;
+  public readonly metricsDiskShowAllButton: Locator;
+  public readonly metricsDiskUsageChart: Locator;
+  public readonly metricsDiskIOChart: Locator;
+
+  constructor(page: ScoutPage, kbnUrl: KibanaUrl, private readonly assetType: 'Host' | 'Docker') {
+    super(page, kbnUrl);
+    this.tab = this.page.getByTestId(`infraAssetDetails${this.tabName}Tab`);
+
+    this.kpiCpuUsageChart = this.page.getByTestId('infraAssetDetailsKPIcpuUsage');
+    this.kpiNormalizedLoadChart = this.page.getByTestId('infraAssetDetailsKPInormalizedLoad1m');
+    this.kpiMemoryUsageChart = this.page.getByTestId('infraAssetDetailsKPImemoryUsage');
+    this.kpiDiskUsageChart = this.page.getByTestId('infraAssetDetailsKPIdiskUsage');
+
+    this.metadataSection = this.page
+      .getByTestId('infraAssetDetailsCollapseExpandSection')
+      .filter({ hasText: 'Metadata' });
+    this.metadataSectionCollapsible = this.metadataSection.getByTestId(
+      'infraAssetDetailsMetadataCollapsible'
+    );
+    this.metadataSectionGroup = this.metadataSection.getByRole('group');
+    this.metadataShowAllButton = this.metadataSection.getByTestId(
+      'infraAssetDetailsMetadataShowAllButton'
+    );
+    this.metadataSummaryItems = this.metadataSection.getByTestId('infraMetadataSummaryItem');
+
+    this.alertsSection = this.page
+      .getByTestId('infraAssetDetailsCollapseExpandSection')
+      .filter({ hasText: 'Alerts' });
+    this.alertsSectionCollapsible = this.alertsSection.getByTestId(
+      'infraAssetDetailsAlertsCollapsible'
+    );
+    this.alertsSectionGroup = this.alertsSection
+      .getByRole('group')
+      .filter({ has: this.page.getByTestId('hostsView-alerts') });
+    this.alertsCreateRuleButton = this.alertsSection.getByTestId(
+      'infraAssetDetailsAlertsTabCreateAlertsRuleButton'
+    );
+    this.alertsShowAllButton = this.alertsSection.getByTestId(
+      'infraAssetDetailsAlertsTabAlertsShowAllButton'
+    );
+    this.alertsContent = this.alertsSection.getByTestId('hostsView-alerts');
+
+    this.servicesSection = this.page
+      .getByTestId('infraAssetDetailsCollapseExpandSection')
+      .filter({ hasText: 'Services' });
+    this.servicesSectionCollapsible = this.servicesSection.getByTestId(
+      'infraAssetDetailsServicesCollapsible'
+    );
+    this.servicesSectionGroup = this.servicesSection.getByRole('group');
+    this.servicesShowAllButton = this.servicesSection.getByTestId(
+      'infraAssetDetailsViewAPMShowAllServicesButton'
+    );
+    this.servicesContainer = this.servicesSection.getByTestId('infraAssetDetailsServicesContainer');
+
+    this.metricsSection = this.page
+      .getByTestId('infraAssetDetailsCollapseExpandSection')
+      .filter({ hasText: 'Metrics' });
+    this.metricsSectionCollapsible = this.metricsSection.getByTestId(
+      'infraAssetDetailsMetricsCollapsible'
+    );
+    this.metricsSectionGroup = this.metricsSection.getByRole('group');
+
+    this.metricsCpuSection = this.metricsSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectioncpu`
+    );
+    this.metricsCpuSectionTitle = this.metricsCpuSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectioncpuTitle`
+    );
+    this.metricsCpuShowAllButton = this.metricsCpuSection.getByRole('button', { name: 'Show all' });
+    this.metricsCpuUsageChart = this.metricsCpuSection.getByTestId(
+      'infraAssetDetailsMetricChartcpuUsage'
+    );
+    this.metricsCpuNormalizedLoadChart = this.metricsCpuSection.getByTestId(
+      'infraAssetDetailsMetricChartnormalizedLoad1m'
+    );
+
+    this.metricsMemorySection = this.metricsSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionmemory`
+    );
+    this.metricsMemorySectionTitle = this.metricsMemorySection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionmemoryTitle`
+    );
+    this.metricsMemoryShowAllButton = this.metricsMemorySection.getByRole('button', {
+      name: 'Show all',
+    });
+    this.metricsMemoryUsageChart = this.metricsMemorySection.getByTestId(
+      'infraAssetDetailsMetricChartmemoryUsage'
+    );
+
+    this.metricsNetworkSection = this.metricsSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionnetwork`
+    );
+    this.metricsNetworkSectionTitle = this.metricsNetworkSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectionnetworkTitle`
+    );
+    this.metricsNetworkShowAllButton = this.metricsNetworkSection.getByRole('button', {
+      name: 'Show all',
+    });
+    this.metricsNetworkChart = this.metricsNetworkSection.getByTestId(
+      'infraAssetDetailsMetricChartrxTx'
+    );
+
+    this.metricsDiskSection = this.metricsSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectiondisk`
+    );
+    this.metricsDiskSectionTitle = this.metricsDiskSection.getByTestId(
+      `infraAssetDetails${this.assetType}ChartsSectiondiskTitle`
+    );
+    this.metricsDiskShowAllButton = this.metricsDiskSection.getByRole('button', {
+      name: 'Show all',
+    });
+    this.metricsDiskUsageChart = this.metricsDiskSection.getByTestId(
+      'infraAssetDetailsMetricChartdiskUsageByMountPoint'
+    );
+    this.metricsDiskIOChart = this.metricsDiskSection.getByTestId(
+      'infraAssetDetailsMetricChartdiskIOReadWrite'
+    );
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -6,6 +6,7 @@
  */
 
 import { type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
+import { KUBERNETES_TOUR_STORAGE_KEY } from '../constants';
 
 export class InventoryPage {
   public readonly feedbackLink: Locator;
@@ -35,6 +36,8 @@ export class InventoryPage {
   public readonly noDataPage: Locator;
   public readonly noDataPageActionButton: Locator;
 
+  public readonly k8sPodWaffleContextMenu: Locator;
+
   constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
     this.feedbackLink = this.page.getByTestId('infraInventoryFeedbackLink');
     this.k8sFeedbackLink = this.page.getByTestId('infra-kubernetes-feedback-link');
@@ -62,6 +65,10 @@ export class InventoryPage {
 
     this.noDataPage = this.page.getByTestId('kbnNoDataPage');
     this.noDataPageActionButton = this.noDataPage.getByTestId('noDataDefaultActionButton');
+
+    this.k8sPodWaffleContextMenu = this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Kubernetes Pod details' });
   }
 
   private async waitForNodesToLoad(opts: { waitForSnapshotRequest?: boolean } = {}) {
@@ -82,6 +89,43 @@ export class InventoryPage {
 
   public async goToPage() {
     await this.page.goto(`${this.kbnUrl.app('metrics')}/inventory`);
+    await this.waitForPageToLoad();
+  }
+
+  public async goToPageWithSavedView(savedViewId: string) {
+    const appUrl = `${this.kbnUrl.app('metrics')}/inventory`;
+
+    const url = this.kbnUrl.get(appUrl, {
+      params: {
+        inventoryViewId: `'${savedViewId}'`,
+      },
+    });
+
+    await this.page.goto(url);
+
+    await this.waitForPageToLoad();
+  }
+
+  public async goToPageWithSavedViewAndAssetDetailsFlyout({
+    savedViewId,
+    assetId,
+    entityType,
+  }: {
+    savedViewId: string;
+    assetId: string;
+    entityType: 'host' | 'container';
+  }) {
+    const appUrl = `${this.kbnUrl.app('metrics')}/inventory`;
+
+    const url = this.kbnUrl.get(appUrl, {
+      params: {
+        assetDetailsFlyout: `(detailsItemId:${assetId},entityType:${entityType})`,
+        inventoryViewId: `'${savedViewId}'`,
+      },
+    });
+
+    await this.page.goto(url);
+
     await this.waitForPageToLoad();
   }
 
@@ -106,6 +150,16 @@ export class InventoryPage {
     await this.k8sTourDismissButton.click();
   }
 
+  public async addDismissK8sTourInitScript() {
+    // Dismiss k8s tour if it's present to avoid interference with other test assertions
+    await this.page.addInitScript(
+      ([k8sTourStorageKey]) => {
+        window.localStorage.setItem(k8sTourStorageKey, 'true');
+      },
+      [KUBERNETES_TOUR_STORAGE_KEY]
+    );
+  }
+
   public async goToTime(time: string) {
     await this.datePickerInput.focus();
     await this.datePickerInput.clear();
@@ -122,6 +176,11 @@ export class InventoryPage {
       name: container.getByTestId('nodeName'),
       value: container.getByTestId('nodeValue'),
     };
+  }
+
+  public async clickWaffleNode(nodeName: string) {
+    const node = await this.getWaffleNode(nodeName);
+    await node.container.click();
   }
 
   public async showHosts() {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/docker_containers_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/docker_containers_data.ts
@@ -20,7 +20,7 @@ export function generateDockerContainersData({
 
   const containers = Array(count)
     .fill(0)
-    .map((_, idx) => infra.dockerContainer(`container-${idx}`));
+    .map((_, idx) => infra.dockerContainer(`cont-${idx}`));
 
   return range
     .interval('30s')

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/logs_data_for_hosts_or_containers.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/logs_data_for_hosts_or_containers.ts
@@ -5,25 +5,26 @@
  * 2.0.
  */
 
+import type { LogDocument, SynthtraceGenerator } from '@kbn/apm-synthtrace-client';
 import { generateShortId, log, timerange } from '@kbn/apm-synthtrace-client';
+import { LOG_LEVELS } from '../constants';
 
-export function generateLogsDataForHosts({
+export function generateLogsDataForHostsOrContainers({
   from,
   to,
-  hosts,
-}: {
-  from: string;
-  to: string;
-  hosts: Array<{ hostName: string }>;
-}) {
+  hostNames,
+  containerIds,
+}:
+  | {
+      from: string;
+      to: string;
+    } & (
+      | { hostNames: string[]; containerIds?: undefined }
+      | { containerIds: string[]; hostNames?: undefined }
+    )): SynthtraceGenerator<LogDocument> {
   const range = timerange(from, to);
 
   // Logs Data logic
-  const MESSAGE_LOG_LEVELS = [
-    { message: 'A simple log', level: 'info' },
-    { message: 'Yet another debug log', level: 'debug' },
-    { message: 'Error with certificate: "ca_trusted_fingerprint"', level: 'error' },
-  ];
   const CLOUD_PROVIDERS = ['gcp', 'aws', 'azure'];
   const CLOUD_REGION = ['eu-central-1', 'us-east-1', 'area-51'];
 
@@ -34,25 +35,32 @@ export function generateLogsDataForHosts({
   ];
 
   return range
-    .interval('30s')
+    .interval('10s')
     .rate(1)
-    .generator((timestamp) =>
-      hosts.flatMap(({ hostName }) => {
-        const index = Math.floor(Math.random() * MESSAGE_LOG_LEVELS.length);
-        return log
+    .generator((timestamp, indx) =>
+      (hostNames ?? containerIds).flatMap((name) => {
+        const logIndex = indx % LOG_LEVELS.length;
+        const logConfig = log
           .create()
-          .message(MESSAGE_LOG_LEVELS[index].message)
-          .logLevel(MESSAGE_LOG_LEVELS[index].level)
-          .hostName(hostName)
+          .message(LOG_LEVELS[logIndex].message)
+          .logLevel(LOG_LEVELS[logIndex].level);
+
+        if (containerIds) {
+          logConfig.containerId(name);
+        } else {
+          logConfig.hostName(name);
+        }
+
+        return logConfig
           .defaults({
             'trace.id': generateShortId(),
             'agent.name': 'synth-agent',
-            'orchestrator.cluster.name': CLUSTER[index].clusterName,
-            'orchestrator.cluster.id': CLUSTER[index].clusterId,
+            'orchestrator.cluster.name': CLUSTER[logIndex].clusterName,
+            'orchestrator.cluster.id': CLUSTER[logIndex].clusterId,
             'orchestrator.resource.id': generateShortId(),
-            'cloud.provider': CLOUD_PROVIDERS[index],
-            'cloud.region': CLOUD_REGION[index],
-            'cloud.availability_zone': `${CLOUD_REGION[index]}a`,
+            'cloud.provider': CLOUD_PROVIDERS[logIndex],
+            'cloud.region': CLOUD_REGION[logIndex],
+            'cloud.availability_zone': `${CLOUD_REGION[logIndex]}a`,
             'cloud.project.id': generateShortId(),
             'cloud.instance.id': generateShortId(),
             'log.file.path': `/logs/${generateShortId()}/error.txt`,

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
@@ -8,6 +8,7 @@
 import { generateHostData } from '../fixtures/synthtrace/host_data';
 import {
   CONTAINER_COUNT,
+  CONTAINER_IDS,
   DATE_WITH_DOCKER_DATA_FROM,
   DATE_WITH_DOCKER_DATA_TO,
   DATE_WITH_HOSTS_DATA_FROM,
@@ -26,7 +27,7 @@ import {
 } from '../fixtures/constants';
 import { generateHostsWithK8sNodeData } from '../fixtures/synthtrace/hosts_with_k8s_node_data';
 import { generatePodsData } from '../fixtures/synthtrace/pods_data';
-import { generateLogsDataForHosts } from '../fixtures/synthtrace/logs_data_for_hosts';
+import { generateLogsDataForHostsOrContainers } from '../fixtures/synthtrace/logs_data_for_hosts_or_containers';
 import { generateAddServicesToExistingHost } from '../fixtures/synthtrace/add_services_to_existing_hosts';
 import { generateDockerContainersData } from '../fixtures/synthtrace/docker_containers_data';
 import { globalSetupHook } from '../fixtures';
@@ -45,10 +46,10 @@ globalSetupHook(
     log.info('Host data indexed');
 
     await logsSynthtraceEsClient.index(
-      generateLogsDataForHosts({
+      generateLogsDataForHostsOrContainers({
         from: DATE_WITH_HOSTS_DATA_FROM,
         to: DATE_WITH_HOSTS_DATA_TO,
-        hosts: HOSTS,
+        hostNames: HOSTS.map((host) => host.hostName),
       })
     );
     log.info('Logs data for hosts indexed');
@@ -97,5 +98,14 @@ globalSetupHook(
       })
     );
     log.info('Docker containers data indexed');
+
+    await logsSynthtraceEsClient.index(
+      generateLogsDataForHostsOrContainers({
+        from: DATE_WITH_DOCKER_DATA_FROM,
+        to: DATE_WITH_DOCKER_DATA_TO,
+        containerIds: CONTAINER_IDS,
+      })
+    );
+    log.info('Logs data for containers indexed');
   }
 );

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/container_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/container_asset_details_flyout.spec.ts
@@ -1,0 +1,397 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+import {
+  BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES,
+  CONTAINER_COUNT,
+  CONTAINER_IDS,
+  CONTAINER_METADATA_FIELD,
+  CONTAINER_NAMES,
+  DATE_WITH_DOCKER_DATA_TIMESTAMP,
+  DEFAULT_CONTAINERS_INVENTORY_VIEW_NAME,
+  EXTENDED_TIMEOUT,
+  LOG_LEVELS,
+} from '../../fixtures/constants';
+import type { MetricsTabQuickAccessItem } from '../../fixtures/page_objects/asset_details/metrics_tab';
+
+const CONTAINER_NAME = CONTAINER_NAMES[CONTAINER_COUNT - 1];
+const CONTAINER_ID = CONTAINER_IDS[CONTAINER_COUNT - 1];
+
+test.describe(
+  'Infrastructure Inventory - Container Asset Details Flyout',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    let savedViewId: string = '';
+
+    test.beforeAll(async ({ apiServices: { inventoryViews } }) => {
+      const createResult = await inventoryViews.create({
+        ...BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES,
+        name: DEFAULT_CONTAINERS_INVENTORY_VIEW_NAME,
+        nodeType: 'container',
+        time: DATE_WITH_DOCKER_DATA_TIMESTAMP,
+        metric: {
+          type: 'cpu',
+        },
+      });
+
+      savedViewId = createResult.id;
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+      await browserAuth.loginAsViewer();
+      await inventoryPage.addDismissK8sTourInitScript();
+      await inventoryPage.goToPageWithSavedViewAndAssetDetailsFlyout({
+        savedViewId,
+        assetId: CONTAINER_ID,
+        entityType: 'container',
+      });
+    });
+
+    test.afterAll(async ({ apiServices: { inventoryViews } }) => {
+      await inventoryViews.deleteOne(savedViewId);
+    });
+
+    test('Overview Tab', async ({ pageObjects: { assetDetailsPage } }) => {
+      await test.step('is selected as default tab', async () => {
+        await expect(assetDetailsPage.dockerOverviewTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
+
+      await test.step('renders KPI charts', async () => {
+        await expect(
+          assetDetailsPage.dockerOverviewTab.kpiCpuUsageChart.getByRole('heading', {
+            name: 'CPU Usage',
+          })
+        ).toBeVisible();
+        await expect(
+          assetDetailsPage.dockerOverviewTab.kpiMemoryUsageChart.getByRole('heading', {
+            name: 'Memory Usage',
+          })
+        ).toBeVisible();
+      });
+
+      await test.step('renders metadata section', async () => {
+        await expect(assetDetailsPage.dockerOverviewTab.metadataSection).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metadataSection).toHaveAttribute(
+          'data-section-state',
+          'open'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.metadataSectionGroup).not.toHaveAttribute(
+          'inert'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.metadataShowAllButton).toBeVisible();
+
+        await expect(assetDetailsPage.dockerOverviewTab.metadataSummaryItems).toHaveCount(3);
+        await expect(
+          assetDetailsPage.dockerOverviewTab.metadataSummaryItems.filter({
+            hasText: 'Container ID',
+          })
+        ).toBeVisible();
+        await expect(
+          assetDetailsPage.dockerOverviewTab.metadataSummaryItems.filter({
+            hasText: 'Container image name',
+          })
+        ).toBeVisible();
+        await expect(
+          assetDetailsPage.dockerOverviewTab.metadataSummaryItems.filter({
+            hasText: 'Host name',
+          })
+        ).toBeVisible();
+
+        await assetDetailsPage.dockerOverviewTab.metadataSectionCollapsible.click();
+        await expect(assetDetailsPage.dockerOverviewTab.metadataSection).toHaveAttribute(
+          'data-section-state',
+          'closed'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.metadataSectionGroup).toHaveAttribute(
+          'inert'
+        );
+      });
+
+      await test.step('renders alert section', async () => {
+        await expect(assetDetailsPage.dockerOverviewTab.alertsSection).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.alertsSection).toHaveAttribute(
+          'data-section-state',
+          'closed'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.alertsSectionGroup).toHaveAttribute(
+          'inert'
+        );
+        await assetDetailsPage.dockerOverviewTab.alertsSectionCollapsible.click();
+        await expect(assetDetailsPage.dockerOverviewTab.alertsSection).toHaveAttribute(
+          'data-section-state',
+          'open'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.alertsSectionGroup).not.toHaveAttribute(
+          'inert'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.alertsShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.alertsCreateRuleButton).toBeVisible();
+
+        await expect(assetDetailsPage.dockerOverviewTab.alertsContent).toBeVisible();
+      });
+
+      await test.step('renders metrics section', async () => {
+        await expect(assetDetailsPage.dockerOverviewTab.metricsSection).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsSection).toHaveAttribute(
+          'data-section-state',
+          'open'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.metricsSectionGroup).not.toHaveAttribute(
+          'inert'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.metricsCpuSection).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsCpuSectionTitle).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsCpuShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsCpuUsageChart).toBeVisible();
+
+        await expect(assetDetailsPage.dockerOverviewTab.metricsMemorySection).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsMemorySectionTitle).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsMemoryShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsMemoryUsageChart).toBeVisible();
+
+        await expect(assetDetailsPage.dockerOverviewTab.metricsNetworkSection).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsNetworkSectionTitle).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsNetworkShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsNetworkChart).toBeVisible();
+
+        await expect(assetDetailsPage.dockerOverviewTab.metricsDiskSection).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsDiskSectionTitle).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsDiskShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsDiskIOChart).toBeVisible();
+
+        await assetDetailsPage.dockerOverviewTab.metricsSectionCollapsible.click();
+        await expect(assetDetailsPage.dockerOverviewTab.metricsSection).toHaveAttribute(
+          'data-section-state',
+          'closed'
+        );
+        await expect(assetDetailsPage.dockerOverviewTab.metricsSectionGroup).toHaveAttribute(
+          'inert'
+        );
+      });
+    });
+
+    test('Metadata Tab', async ({ pageObjects: { assetDetailsPage } }) => {
+      await test.step('accessible from default tab', async () => {
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'false');
+        await assetDetailsPage.metadataTab.clickTab();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('render expected content', async () => {
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+        await expect(
+          assetDetailsPage.metadataTab.tableHeader.getByLabel('Pin fields')
+        ).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.tableHeader.getByText('Field')).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.tableHeader.getByText('Value')).toBeVisible();
+      });
+
+      await test.step('pin a metadata field row', async () => {
+        await assetDetailsPage.metadataTab.pinField(CONTAINER_METADATA_FIELD);
+        const pinButtons =
+          assetDetailsPage.metadataTab.getPinButtonsForField(CONTAINER_METADATA_FIELD);
+        await expect(pinButtons.pin).toBeHidden();
+        await expect(pinButtons.unpin).toBeVisible();
+      });
+
+      await test.step('unpin a metadata field row', async () => {
+        await assetDetailsPage.metadataTab.unpinField(CONTAINER_METADATA_FIELD);
+        const pinButtons =
+          assetDetailsPage.metadataTab.getPinButtonsForField(CONTAINER_METADATA_FIELD);
+        await expect(pinButtons.pin).toBeVisible();
+        await expect(pinButtons.unpin).toBeHidden();
+      });
+
+      await test.step('filter fields via search bar', async () => {
+        await assetDetailsPage.metadataTab.filterField(CONTAINER_METADATA_FIELD);
+        await expect(assetDetailsPage.metadataTab.tableRows).toHaveCount(1);
+        const row = assetDetailsPage.metadataTab.getRowForField(CONTAINER_METADATA_FIELD);
+        await expect(row).toBeVisible();
+      });
+    });
+
+    test('Metadata Tab - Is accessible from overview tab section show all', async ({
+      pageObjects: { assetDetailsPage },
+    }) => {
+      await assetDetailsPage.dockerOverviewTab.metadataShowAllButton.click();
+      await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('Metrics Tab', async ({ pageObjects: { assetDetailsPage } }) => {
+      await test.step('accessible from default tab', async () => {
+        await expect(assetDetailsPage.dockerMetricsTab.tab).toHaveAttribute(
+          'aria-selected',
+          'false'
+        );
+        await assetDetailsPage.dockerMetricsTab.clickTab();
+        await expect(assetDetailsPage.dockerMetricsTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
+
+      await test.step('quick access menu renders expected content', async () => {
+        const quickAccessItems: MetricsTabQuickAccessItem[] = ['CPU', 'Memory', 'Network', 'Disk'];
+
+        await expect(assetDetailsPage.dockerMetricsTab.quickAccessItems).toHaveText(
+          quickAccessItems
+        );
+      });
+
+      await test.step('navigate to CPU metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.dockerMetricsTab.clickQuickAccessItem('CPU');
+        await expect(assetDetailsPage.dockerMetricsTab.cpuSectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.dockerMetricsTab.cpuUsageChart).toBeVisible();
+      });
+
+      await test.step('navigate to Memory metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.dockerMetricsTab.clickQuickAccessItem('Memory');
+        await expect(assetDetailsPage.dockerMetricsTab.memorySectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.dockerMetricsTab.memoryUsageChart).toBeVisible();
+      });
+
+      await test.step('navigate to Network metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.dockerMetricsTab.clickQuickAccessItem('Network');
+        await expect(assetDetailsPage.dockerMetricsTab.networkSectionTitle).toBeInViewport();
+        await expect(assetDetailsPage.dockerMetricsTab.networkChart).toBeVisible();
+      });
+
+      await test.step('navigate to Disk metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.dockerMetricsTab.clickQuickAccessItem('Disk');
+        await expect(assetDetailsPage.dockerMetricsTab.diskSectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.dockerMetricsTab.diskIOChart).toBeVisible();
+      });
+    });
+
+    test('Metrics Tab - Sections are accessible from overview tab section show all', async ({
+      pageObjects: { assetDetailsPage },
+    }) => {
+      const goBackToOverviewTab = async () => {
+        await assetDetailsPage.dockerOverviewTab.tab.click();
+        await expect(assetDetailsPage.dockerOverviewTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      };
+
+      await test.step('cpu section', async () => {
+        await assetDetailsPage.dockerOverviewTab.metricsCpuShowAllButton.click();
+        await expect(assetDetailsPage.dockerMetricsTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+        await expect(assetDetailsPage.dockerMetricsTab.cpuSectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+
+      await test.step('memory section', async () => {
+        await assetDetailsPage.dockerOverviewTab.metricsMemoryShowAllButton.click();
+        await expect(assetDetailsPage.dockerMetricsTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+        await expect(assetDetailsPage.dockerMetricsTab.memorySectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+
+      await test.step('network section', async () => {
+        await assetDetailsPage.dockerOverviewTab.metricsNetworkShowAllButton.click();
+        await expect(assetDetailsPage.dockerMetricsTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+        await expect(assetDetailsPage.dockerMetricsTab.networkSectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+
+      await test.step('disk section', async () => {
+        await assetDetailsPage.dockerOverviewTab.metricsDiskShowAllButton.click();
+        await expect(assetDetailsPage.dockerMetricsTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+        await expect(assetDetailsPage.dockerMetricsTab.diskSectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+    });
+
+    test('Logs Tab', async ({ page, pageObjects: { assetDetailsPage } }) => {
+      await test.step('accessible from default tab', async () => {
+        await expect(assetDetailsPage.logsTag.tab).toHaveAttribute('aria-selected', 'false');
+        await assetDetailsPage.logsTag.clickTab();
+        await expect(assetDetailsPage.logsTag.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('render expected content', async () => {
+        await expect(assetDetailsPage.logsTag.searchBar).toBeVisible();
+        await expect(assetDetailsPage.logsTag.openInDiscoverButton).toBeVisible();
+        await expect(assetDetailsPage.logsTag.table).toBeVisible();
+        await expect(assetDetailsPage.logsTag.tableTotalDocumentsLabel).toBeVisible();
+      });
+
+      await test.step('filter logs via search bar and open the query in discover', async () => {
+        const totalDocumentsText =
+          await assetDetailsPage.logsTag.tableTotalDocumentsLabel.textContent();
+
+        await assetDetailsPage.logsTag.filterTable(`"${LOG_LEVELS[0].message}"`);
+        await expect(assetDetailsPage.logsTag.tableTotalDocumentsLabel).not.toHaveText(
+          totalDocumentsText!
+        );
+
+        const discoverQuery = `(container.id: ${CONTAINER_ID}) and ("${LOG_LEVELS[0].message}")`;
+
+        await assetDetailsPage.logsTag.openInDiscoverButton.click();
+
+        // Giving extended timeout to ensure Discover has enough time to load the page
+        await expect(page.getByTestId('queryInput')).toHaveValue(discoverQuery, {
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+    });
+
+    test('Open as page and return to flyout', async ({
+      page,
+      pageObjects: { assetDetailsPage },
+    }) => {
+      await test.step('go to metadata tab', async () => {
+        await assetDetailsPage.metadataTab.clickTab();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('open asset details as page keeping the selected tab', async () => {
+        await assetDetailsPage.openAsPageButton.click();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+
+        const url = new URL(page.url());
+        expect(url.pathname).toBe(
+          `/app/metrics/detail/container/${encodeURIComponent(CONTAINER_ID)}`
+        );
+      });
+
+      await test.step('return to flyout from asset details page', async () => {
+        await assetDetailsPage.returnButton.click();
+        await expect(
+          page.getByRole('dialog').getByRole('heading', { name: CONTAINER_NAME })
+        ).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
@@ -1,0 +1,408 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+import {
+  HOST1_NAME,
+  LOG_LEVELS,
+  EXTENDED_TIMEOUT,
+  HOSTS_METADATA_FIELD,
+  DEFAULT_HOSTS_INVENTORY_VIEW_NAME,
+  BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES,
+  DATE_WITH_HOSTS_DATA_TIMESTAMP,
+} from '../../fixtures/constants';
+import type { MetricsTabQuickAccessItem } from '../../fixtures/page_objects/asset_details/metrics_tab';
+
+test.describe(
+  'Infrastructure Inventory - Host Asset Details Flyout',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    let savedViewId: string = '';
+
+    test.beforeAll(async ({ apiServices: { inventoryViews } }) => {
+      const createResult = await inventoryViews.create({
+        ...BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES,
+        name: DEFAULT_HOSTS_INVENTORY_VIEW_NAME,
+        nodeType: 'host',
+        time: DATE_WITH_HOSTS_DATA_TIMESTAMP,
+        metric: {
+          type: 'cpuV2',
+        },
+      });
+
+      savedViewId = createResult.id;
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+      await browserAuth.loginAsViewer();
+      await inventoryPage.addDismissK8sTourInitScript();
+      await inventoryPage.goToPageWithSavedViewAndAssetDetailsFlyout({
+        savedViewId,
+        assetId: HOST1_NAME,
+        entityType: 'host',
+      });
+    });
+
+    test.afterAll(async ({ apiServices: { inventoryViews } }) => {
+      await inventoryViews.deleteOne(savedViewId);
+    });
+
+    test('Overview Tab', async ({ pageObjects: { assetDetailsPage } }) => {
+      await test.step('is selected as default tab', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('renders KPI charts', async () => {
+        await expect(
+          assetDetailsPage.hostOverviewTab.kpiCpuUsageChart.getByRole('heading', {
+            name: 'CPU Usage',
+          })
+        ).toBeVisible();
+        await expect(
+          assetDetailsPage.hostOverviewTab.kpiNormalizedLoadChart.getByRole('heading', {
+            name: 'Normalized Load',
+          })
+        ).toBeVisible();
+        await expect(
+          assetDetailsPage.hostOverviewTab.kpiMemoryUsageChart.getByRole('heading', {
+            name: 'Memory Usage',
+          })
+        ).toBeVisible();
+        await expect(
+          assetDetailsPage.hostOverviewTab.kpiDiskUsageChart.getByRole('heading', {
+            name: 'Disk Usage',
+          })
+        ).toBeVisible();
+      });
+
+      await test.step('renders metadata section', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.metadataSection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metadataSection).toHaveAttribute(
+          'data-section-state',
+          'open'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.metadataSectionGroup).not.toHaveAttribute(
+          'inert'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.metadataShowAllButton).toBeVisible();
+
+        await expect(assetDetailsPage.hostOverviewTab.metadataSummaryItems).toHaveCount(2);
+        await expect(
+          assetDetailsPage.hostOverviewTab.metadataSummaryItems.filter({ hasText: 'Host IP' })
+        ).toBeVisible();
+        await expect(
+          assetDetailsPage.hostOverviewTab.metadataSummaryItems.filter({
+            hasText: 'Host OS version',
+          })
+        ).toBeVisible();
+
+        await assetDetailsPage.hostOverviewTab.metadataSectionCollapsible.click();
+        await expect(assetDetailsPage.hostOverviewTab.metadataSection).toHaveAttribute(
+          'data-section-state',
+          'closed'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.metadataSectionGroup).toHaveAttribute(
+          'inert'
+        );
+      });
+
+      await test.step('renders alert section', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.alertsSection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.alertsSection).toHaveAttribute(
+          'data-section-state',
+          'closed'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.alertsSectionGroup).toHaveAttribute('inert');
+        await assetDetailsPage.hostOverviewTab.alertsSectionCollapsible.click();
+        await expect(assetDetailsPage.hostOverviewTab.alertsSection).toHaveAttribute(
+          'data-section-state',
+          'open'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.alertsSectionGroup).not.toHaveAttribute(
+          'inert'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.alertsShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.alertsCreateRuleButton).toBeVisible();
+
+        await expect(assetDetailsPage.hostOverviewTab.alertsContent).toBeVisible();
+      });
+
+      await test.step('renders services section', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.servicesSection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.servicesSection).toHaveAttribute(
+          'data-section-state',
+          'open'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.servicesSectionGroup).not.toHaveAttribute(
+          'inert'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.servicesShowAllButton).toBeVisible();
+
+        await expect(assetDetailsPage.hostOverviewTab.servicesContainer).toBeVisible();
+
+        await assetDetailsPage.hostOverviewTab.servicesSectionCollapsible.click();
+        await expect(assetDetailsPage.hostOverviewTab.servicesSection).toHaveAttribute(
+          'data-section-state',
+          'closed'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.servicesSectionGroup).toHaveAttribute(
+          'inert'
+        );
+      });
+
+      await test.step('renders metrics section', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.metricsSection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsSection).toHaveAttribute(
+          'data-section-state',
+          'open'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.metricsSectionGroup).not.toHaveAttribute(
+          'inert'
+        );
+
+        await expect(assetDetailsPage.hostOverviewTab.metricsCpuSection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsCpuSectionTitle).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsCpuShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsCpuUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsCpuNormalizedLoadChart).toBeVisible();
+
+        await expect(assetDetailsPage.hostOverviewTab.metricsMemorySection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsMemorySectionTitle).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsMemoryShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsMemoryUsageChart).toBeVisible();
+
+        await expect(assetDetailsPage.hostOverviewTab.metricsNetworkSection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsNetworkSectionTitle).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsNetworkShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsNetworkChart).toBeVisible();
+
+        await expect(assetDetailsPage.hostOverviewTab.metricsDiskSection).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsDiskSectionTitle).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsDiskShowAllButton).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsDiskUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsDiskIOChart).toBeVisible();
+
+        await assetDetailsPage.hostOverviewTab.metricsSectionCollapsible.click();
+        await expect(assetDetailsPage.hostOverviewTab.metricsSection).toHaveAttribute(
+          'data-section-state',
+          'closed'
+        );
+        await expect(assetDetailsPage.hostOverviewTab.metricsSectionGroup).toHaveAttribute('inert');
+      });
+    });
+
+    test('Metadata Tab', async ({ pageObjects: { assetDetailsPage } }) => {
+      await test.step('accessible from default tab', async () => {
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'false');
+        await assetDetailsPage.metadataTab.clickTab();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('render expected content', async () => {
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+        await expect(
+          assetDetailsPage.metadataTab.tableHeader.getByLabel('Pin fields')
+        ).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.tableHeader.getByText('Field')).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.tableHeader.getByText('Value')).toBeVisible();
+      });
+
+      await test.step('pin a metadata field row', async () => {
+        await assetDetailsPage.metadataTab.pinField(HOSTS_METADATA_FIELD);
+        const pinButtons = assetDetailsPage.metadataTab.getPinButtonsForField(HOSTS_METADATA_FIELD);
+        await expect(pinButtons.pin).toBeHidden();
+        await expect(pinButtons.unpin).toBeVisible();
+      });
+
+      await test.step('unpin a metadata field row', async () => {
+        await assetDetailsPage.metadataTab.unpinField(HOSTS_METADATA_FIELD);
+        const pinButtons = assetDetailsPage.metadataTab.getPinButtonsForField(HOSTS_METADATA_FIELD);
+        await expect(pinButtons.pin).toBeVisible();
+        await expect(pinButtons.unpin).toBeHidden();
+      });
+
+      await test.step('filter fields via search bar', async () => {
+        await assetDetailsPage.metadataTab.filterField(HOSTS_METADATA_FIELD);
+        await expect(assetDetailsPage.metadataTab.tableRows).toHaveCount(1);
+        const row = assetDetailsPage.metadataTab.getRowForField(HOSTS_METADATA_FIELD);
+        await expect(row).toBeVisible();
+      });
+    });
+
+    test('Metadata Tab - Is accessible from overview tab section show all', async ({
+      pageObjects: { assetDetailsPage },
+    }) => {
+      await assetDetailsPage.hostOverviewTab.metadataShowAllButton.click();
+      await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('Metrics Tab', async ({ pageObjects: { assetDetailsPage } }) => {
+      await test.step('accessible from default tab', async () => {
+        await expect(assetDetailsPage.hostMetricsTab.tab).toHaveAttribute('aria-selected', 'false');
+        await assetDetailsPage.hostMetricsTab.clickTab();
+        await expect(assetDetailsPage.hostMetricsTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('quick access menu renders expected content', async () => {
+        const quickAccessItems: MetricsTabQuickAccessItem[] = [
+          'CPU',
+          'Memory',
+          'Network',
+          'Disk',
+          'Log Rate',
+        ];
+
+        await expect(assetDetailsPage.hostMetricsTab.quickAccessItems).toHaveText(quickAccessItems);
+      });
+
+      await test.step('navigate to CPU metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.hostMetricsTab.clickQuickAccessItem('CPU');
+        await expect(assetDetailsPage.hostMetricsTab.cpuSectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.hostMetricsTab.cpuUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostMetricsTab.cpuUsageBreakdownChart).toBeVisible();
+        await expect(assetDetailsPage.hostMetricsTab.cpuNormalizedLoadChart).toBeVisible();
+        await expect(assetDetailsPage.hostMetricsTab.cpuLoadBreakdownChart).toBeVisible();
+      });
+
+      await test.step('navigate to Memory metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.hostMetricsTab.clickQuickAccessItem('Memory');
+        await expect(assetDetailsPage.hostMetricsTab.memorySectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.hostMetricsTab.memoryUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostMetricsTab.memoryUsageBreakdownChart).toBeVisible();
+      });
+
+      await test.step('navigate to Network metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.hostMetricsTab.clickQuickAccessItem('Network');
+        await expect(assetDetailsPage.hostMetricsTab.networkSectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.hostMetricsTab.networkChart).toBeVisible();
+      });
+
+      await test.step('navigate to Disk metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.hostMetricsTab.clickQuickAccessItem('Disk');
+        await expect(assetDetailsPage.hostMetricsTab.diskSectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.hostMetricsTab.diskUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostMetricsTab.diskIOChart).toBeVisible();
+        await expect(assetDetailsPage.hostMetricsTab.diskThroughputChart).toBeVisible();
+      });
+
+      await test.step('navigate to Log metrics via quick access menu and render expected content', async () => {
+        await assetDetailsPage.hostMetricsTab.clickQuickAccessItem('Log Rate');
+        await expect(assetDetailsPage.hostMetricsTab.logSectionTitle).toBeInViewport();
+
+        await expect(assetDetailsPage.hostMetricsTab.logRateChart).toBeVisible();
+      });
+    });
+
+    test('Metrics Tab - Sections are accessible from overview tab section show all', async ({
+      pageObjects: { assetDetailsPage },
+    }) => {
+      const goBackToOverviewTab = async () => {
+        await assetDetailsPage.hostOverviewTab.tab.click();
+        await expect(assetDetailsPage.hostOverviewTab.tab).toHaveAttribute('aria-selected', 'true');
+      };
+
+      await test.step('cpu section', async () => {
+        await assetDetailsPage.hostOverviewTab.metricsCpuShowAllButton.click();
+        await expect(assetDetailsPage.hostMetricsTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.hostMetricsTab.cpuSectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+
+      await test.step('memory section', async () => {
+        await assetDetailsPage.hostOverviewTab.metricsMemoryShowAllButton.click();
+        await expect(assetDetailsPage.hostMetricsTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.hostMetricsTab.memorySectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+
+      await test.step('network section', async () => {
+        await assetDetailsPage.hostOverviewTab.metricsNetworkShowAllButton.click();
+        await expect(assetDetailsPage.hostMetricsTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.hostMetricsTab.networkSectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+
+      await test.step('disk section', async () => {
+        await assetDetailsPage.hostOverviewTab.metricsDiskShowAllButton.click();
+        await expect(assetDetailsPage.hostMetricsTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.hostMetricsTab.diskSectionTitle).toBeInViewport();
+        await goBackToOverviewTab();
+      });
+    });
+
+    test('Logs Tab', async ({ page, pageObjects: { assetDetailsPage } }) => {
+      await test.step('accessible from default tab', async () => {
+        await expect(assetDetailsPage.logsTag.tab).toHaveAttribute('aria-selected', 'false');
+        await assetDetailsPage.logsTag.clickTab();
+        await expect(assetDetailsPage.logsTag.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('render expected content', async () => {
+        await expect(assetDetailsPage.logsTag.searchBar).toBeVisible();
+        await expect(assetDetailsPage.logsTag.openInDiscoverButton).toBeVisible();
+        await expect(assetDetailsPage.logsTag.table).toBeVisible();
+        await expect(assetDetailsPage.logsTag.tableTotalDocumentsLabel).toBeVisible();
+      });
+
+      await test.step('filter logs via search bar and open the query in discover', async () => {
+        const totalDocumentsText =
+          await assetDetailsPage.logsTag.tableTotalDocumentsLabel.textContent();
+
+        await assetDetailsPage.logsTag.filterTable(`"${LOG_LEVELS[0].message}"`);
+        await expect(assetDetailsPage.logsTag.tableTotalDocumentsLabel).not.toHaveText(
+          totalDocumentsText!
+        );
+
+        const discoverQuery = `(host.name: ${HOST1_NAME}) and ("${LOG_LEVELS[0].message}")`;
+
+        await assetDetailsPage.logsTag.openInDiscoverButton.click();
+
+        // Giving extended timeout to ensure Discover has enough time to load the page
+        await expect(page.getByTestId('queryInput')).toHaveValue(discoverQuery, {
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+    });
+
+    test('Open as page and return to flyout', async ({
+      page,
+      pageObjects: { assetDetailsPage },
+    }) => {
+      await test.step('go to metadata tab', async () => {
+        await assetDetailsPage.metadataTab.clickTab();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('open asset details as page keeping the selected tab', async () => {
+        await assetDetailsPage.openAsPageButton.click();
+
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+
+        const url = new URL(page.url());
+        expect(url.pathname).toBe(`/app/metrics/detail/host/${encodeURIComponent(HOST1_NAME)}`);
+      });
+
+      await test.step('return to flyout from asset details page', async () => {
+        await assetDetailsPage.returnButton.click();
+        await expect(
+          page.getByRole('dialog').getByRole('heading', { name: HOST1_NAME })
+        ).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -14,23 +14,17 @@ import {
   DATE_WITH_POD_DATA,
   DATE_WITHOUT_DATA,
   HOSTS,
+  POD_COUNT,
   POD_NAMES,
 } from '../../fixtures/constants';
 
-const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
-
-test.use({
-  timezoneId: 'GMT',
-});
+const POD_NAME = POD_NAMES[POD_COUNT - 1];
 
 test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
     await browserAuth.loginAsViewer();
+    await inventoryPage.addDismissK8sTourInitScript();
     await inventoryPage.goToPage();
-    // Dismiss k8s tour if it's present to avoid interference with other test assertions
-    // The k8s tour specific test will take care of adding it back during its own execution
-    await inventoryPage.dismissK8sTour();
-    await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
   });
 
   test('Render expected content', async ({ page, pageObjects: { inventoryPage } }) => {
@@ -44,6 +38,7 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
     });
 
     await test.step('display waffle map', async () => {
+      await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
       await expect(inventoryPage.mapViewButton).toHaveAttribute('aria-pressed', 'true');
       await expect(inventoryPage.waffleMap).toBeVisible();
     });
@@ -59,33 +54,6 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
       await inventoryPage.switchToTableView();
       await expect(inventoryPage.tableViewButton).toHaveAttribute('aria-pressed', 'true');
       await expect(inventoryPage.nodesOverviewTable).toBeVisible();
-    });
-  });
-
-  test('Render and dismiss k8s tour', async ({ page, pageObjects: { inventoryPage } }) => {
-    await test.step('reset k8s tour seen state', async () => {
-      await page.evaluate(
-        ([k8sTourStorageKey]) => localStorage.setItem(k8sTourStorageKey, 'false'),
-        [KUBERNETES_TOUR_STORAGE_KEY]
-      );
-      await inventoryPage.reload();
-    });
-
-    await test.step('display k8s tour with proper message', async () => {
-      await expect(inventoryPage.k8sTourText).toBeVisible();
-      await expect(inventoryPage.k8sTourText).toHaveText(
-        'Click here to see your infrastructure in different ways, including Kubernetes pods.'
-      );
-    });
-
-    await test.step('dismiss k8s tour', async () => {
-      await inventoryPage.dismissK8sTour();
-      await expect(inventoryPage.k8sTourText).toBeHidden();
-    });
-
-    await test.step('reload page and verify tour remains dismissed', async () => {
-      await inventoryPage.reload();
-      await expect(inventoryPage.k8sTourText).toBeHidden();
     });
   });
 
@@ -111,6 +79,7 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
 
   test('Inventory switcher changes node types', async ({ pageObjects: { inventoryPage } }) => {
     await test.step('show hosts by default', async () => {
+      await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
       await expect(inventoryPage.inventorySwitcherButton).toContainText('Hosts');
 
       const hostName = HOSTS[Math.floor(Math.random() * HOSTS.length)].hostName;
@@ -124,10 +93,9 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
       await inventoryPage.showPods();
       await expect(inventoryPage.inventorySwitcherButton).toContainText('Kubernetes Pods');
 
-      const podName = POD_NAMES[Math.floor(Math.random() * POD_NAMES.length)];
-      const waffleNode = await inventoryPage.getWaffleNode(podName);
+      const waffleNode = await inventoryPage.getWaffleNode(POD_NAME);
       await expect(waffleNode.container).toBeVisible();
-      await expect(waffleNode.name).toHaveText(podName);
+      await expect(waffleNode.name).toHaveText(POD_NAME);
 
       await expect(inventoryPage.k8sFeedbackLink).toBeVisible();
     });
@@ -144,7 +112,44 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
     });
   });
 
-  test('Has no detectable a11y violations on load', async ({ page }) => {
+  test('K8s pods waffle map node redirects to pod details page', async ({
+    page,
+    pageObjects: { inventoryPage },
+  }) => {
+    await test.step('switch to k8s pods', async () => {
+      await inventoryPage.goToTime(DATE_WITH_POD_DATA);
+      await inventoryPage.showPods();
+      await expect(inventoryPage.inventorySwitcherButton).toContainText('Kubernetes Pods');
+    });
+
+    await test.step('open pod waffle context menu', async () => {
+      const waffleNode = await inventoryPage.getWaffleNode(POD_NAME);
+      await waffleNode.container.click();
+
+      await expect(inventoryPage.k8sPodWaffleContextMenu).toBeVisible();
+      await expect(inventoryPage.k8sPodWaffleContextMenu).toContainText(
+        `View details for kubernetes.pod.uid ${POD_NAME}`
+      );
+    });
+
+    await test.step('click pod details link and verify redirection', async () => {
+      await inventoryPage.k8sPodWaffleContextMenu
+        .getByRole('link', {
+          name: 'Kubernetes Pod metrics',
+        })
+        .click();
+
+      const url = new URL(page.url());
+
+      expect(url.pathname).toBe(`/app/metrics/detail/pod/${encodeURIComponent(POD_NAME)}`);
+    });
+  });
+
+  test('Has no detectable a11y violations on load', async ({
+    page,
+    pageObjects: { inventoryPage },
+  }) => {
+    await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
     const { violations } = await page.checkA11y({ include: ['main'] });
     expect(violations).toHaveLength(0);
   });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -29,8 +29,9 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
 
   test('Render expected content', async ({ page, pageObjects: { inventoryPage } }) => {
     await test.step('set the correct browser page title', async () => {
-      const title = await page.title();
-      expect(title).toBe('Infrastructure inventory - Infrastructure - Observability - Elastic');
+      await expect(page).toHaveTitle(
+        'Infrastructure inventory - Infrastructure - Observability - Elastic'
+      );
     });
 
     await test.step('display inventory survey link', async () => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory_k8s_tour.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory_k8s_tour.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+import { DATE_WITH_HOSTS_DATA } from '../../fixtures/constants';
+
+test.describe('Infrastructure Inventory - K8s Tour', { tag: ['@ess', '@svlOblt'] }, () => {
+  test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+    await browserAuth.loginAsViewer();
+    await inventoryPage.goToPage();
+    await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
+  });
+
+  test('Render and dismiss k8s tour', async ({ pageObjects: { inventoryPage } }) => {
+    await test.step('display k8s tour with proper message', async () => {
+      await expect(inventoryPage.k8sTourText).toBeVisible();
+      await expect(inventoryPage.k8sTourText).toHaveText(
+        'Click here to see your infrastructure in different ways, including Kubernetes pods.'
+      );
+    });
+
+    await test.step('dismiss k8s tour', async () => {
+      await inventoryPage.dismissK8sTour();
+      await expect(inventoryPage.k8sTourText).toBeHidden();
+    });
+
+    await test.step('reload page and verify tour remains dismissed', async () => {
+      await inventoryPage.reload();
+      await expect(inventoryPage.k8sTourText).toBeHidden();
+    });
+  });
+});

--- a/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
@@ -192,7 +192,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.infraHome.getWaffleMap();
       });
 
-      describe('Asset Details flyout for a host', () => {
+      // Done
+      describe.skip('Asset Details flyout for a host', () => {
         before(async () => {
           await pageObjects.infraHome.goToTime(DATE_WITH_HOSTS_DATA);
           await pageObjects.infraHome.getWaffleMap();
@@ -276,6 +277,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
+      // Done
       describe('Asset Details flyout for a container', () => {
         before(async () => {
           await pageObjects.infraHome.goToContainer();
@@ -450,6 +452,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await pageObjects.infraHome.waitForLoading();
         });
 
+        // Done
         it('Should redirect to Host Details page', async () => {
           await pageObjects.infraHome.goToTime(DATE_WITH_HOSTS_DATA);
           await pageObjects.infraHome.goToHost();
@@ -466,6 +469,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await returnTo(INVENTORY_PATH);
         });
 
+        // Done
         describe('Redirect to Pod Details page', () => {
           it('should redirect to Pod Details page', async () => {
             await pageObjects.infraHome.goToPods();
@@ -488,6 +492,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           });
         });
 
+        // Done
         describe('Redirect to Container Details page', () => {
           it('should redirect to Container Details page', async () => {
             await pageObjects.infraHome.goToContainer();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[APM] Migrate Infra home page tests to Scout - Part II - Asset Details Flyout (#248997)](https://github.com/elastic/kibana/pull/248997)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-22T12:55:42Z","message":"[APM] Migrate Infra home page tests to Scout - Part II - Asset Details Flyout (#248997)\n\n## Summary\nPart of #246428\n\nThis PR is part II of the test migration effort to port infra home page\ntests from FTR to Scout. The original FTR file contains lots of tests\nthat I believe could be split into multiple separate suites following\nthe recommended approach of keeping 1 describe block per test file. The\nmigration will consist of these steps:\n\n- [X] Infra home page (this PR). Includes most of the standalone `it`\ntests inside the outter most describe block in the original FTR suite.\nIt tests the main home page contents, without opening any flyout pr\nnavigating away.\n- [X] **Asset details flyout**. Will cover the asset details flyout that\nopens up after clicking a node in the waffle map. Will in turn be split\ninto 2 separate files to cover the 2 distinct FTR describe blocks, one\nfor hosts and another for containers. This will also cover the \"Redirect\nto Node Details page\" block as the redirection occurs within the flyout.\n- [ ] Alert flyouts. Will cover the equivalent describe block around\nalerts from the infra home page\n- [ ] Saved views. Will cover the block around saved views functionality\n- [ ] React component test for waffle map. Will cover the outstanding\n`it` tests focused around waffle map functionality. As already specified\nin the FTR file, this are better suited as unit tests\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"ed76d0d863ccf3c803a8f8e2c28ad670c372b376","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.3.0","ci:beta-faster-pr-build","v9.4.0","Team:obs-presentation"],"title":"[APM] Migrate Infra home page tests to Scout - Part II - Asset Details Flyout","number":248997,"url":"https://github.com/elastic/kibana/pull/248997","mergeCommit":{"message":"[APM] Migrate Infra home page tests to Scout - Part II - Asset Details Flyout (#248997)\n\n## Summary\nPart of #246428\n\nThis PR is part II of the test migration effort to port infra home page\ntests from FTR to Scout. The original FTR file contains lots of tests\nthat I believe could be split into multiple separate suites following\nthe recommended approach of keeping 1 describe block per test file. The\nmigration will consist of these steps:\n\n- [X] Infra home page (this PR). Includes most of the standalone `it`\ntests inside the outter most describe block in the original FTR suite.\nIt tests the main home page contents, without opening any flyout pr\nnavigating away.\n- [X] **Asset details flyout**. Will cover the asset details flyout that\nopens up after clicking a node in the waffle map. Will in turn be split\ninto 2 separate files to cover the 2 distinct FTR describe blocks, one\nfor hosts and another for containers. This will also cover the \"Redirect\nto Node Details page\" block as the redirection occurs within the flyout.\n- [ ] Alert flyouts. Will cover the equivalent describe block around\nalerts from the infra home page\n- [ ] Saved views. Will cover the block around saved views functionality\n- [ ] React component test for waffle map. Will cover the outstanding\n`it` tests focused around waffle map functionality. As already specified\nin the FTR file, this are better suited as unit tests\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"ed76d0d863ccf3c803a8f8e2c28ad670c372b376"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248997","number":248997,"mergeCommit":{"message":"[APM] Migrate Infra home page tests to Scout - Part II - Asset Details Flyout (#248997)\n\n## Summary\nPart of #246428\n\nThis PR is part II of the test migration effort to port infra home page\ntests from FTR to Scout. The original FTR file contains lots of tests\nthat I believe could be split into multiple separate suites following\nthe recommended approach of keeping 1 describe block per test file. The\nmigration will consist of these steps:\n\n- [X] Infra home page (this PR). Includes most of the standalone `it`\ntests inside the outter most describe block in the original FTR suite.\nIt tests the main home page contents, without opening any flyout pr\nnavigating away.\n- [X] **Asset details flyout**. Will cover the asset details flyout that\nopens up after clicking a node in the waffle map. Will in turn be split\ninto 2 separate files to cover the 2 distinct FTR describe blocks, one\nfor hosts and another for containers. This will also cover the \"Redirect\nto Node Details page\" block as the redirection occurs within the flyout.\n- [ ] Alert flyouts. Will cover the equivalent describe block around\nalerts from the infra home page\n- [ ] Saved views. Will cover the block around saved views functionality\n- [ ] React component test for waffle map. Will cover the outstanding\n`it` tests focused around waffle map functionality. As already specified\nin the FTR file, this are better suited as unit tests\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"ed76d0d863ccf3c803a8f8e2c28ad670c372b376"}}]}] BACKPORT-->