### PR TITLE
POC using TOP_SNIPPETS to generate fragments for Agent Builder

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
@@ -31,6 +31,7 @@ const convertMatchResult = (result: MatchResult): ResourceResult => {
       partial: true,
       content: {
         highlights: result.highlights,
+        snippets: result.snippets,
       },
     },
   };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -8,11 +8,13 @@
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
 import type { MappingField } from '../utils/mappings';
+import { executeEsql, interpolateEsqlQuery } from '../utils/esql';
 
 export interface MatchResult {
   id: string;
   index: string;
   highlights: string[];
+  snippets: string[];
 }
 
 export interface PerformMatchSearchResponse {
@@ -73,16 +75,67 @@ export const performMatchSearch = async ({
     throw error;
   }
 
-  const results = response.hits.hits.map<MatchResult>((hit) => {
-    return {
-      id: hit._id!,
-      index: hit._index!,
-      highlights: Object.entries(hit.highlight ?? {}).reduce((acc, [field, highlights]) => {
-        acc.push(...highlights);
-        return acc;
-      }, [] as string[]),
-    };
-  });
+  const searchResults = response.hits.hits.map((hit) => ({
+    id: hit._id!,
+    index: hit._index!,
+    highlights: Object.entries(hit.highlight ?? {}).reduce((acc, [_field, highlights]) => {
+      acc.push(...highlights);
+      return acc;
+    }, [] as string[]),
+  }));
+
+  // TOP_SNIPPETS does not yet support multi-valued input. So here, we're hacking in
+  // snippet generation by calling `TOP_SNIPPETS` once for each searchable field in each 
+  // returned document. Yes, this is horribly inefficient, but this is a POC after all ;)
+  const results = await Promise.all(
+    searchResults.map(async (result) => {
+      const snippets: string[] = [];
+
+      for (const field of allSearchableFields) {
+        try {
+          const fieldName = field.path.includes(' ') ? `\`${field.path}\`` : field.path;
+          const indexName = result.index.includes(' ') ? `\`${result.index}\`` : result.index;
+          const esqlQuery = interpolateEsqlQuery(
+            `FROM ${indexName} METADATA _id | WHERE _id == ?docId | EVAL snippets = TOP_SNIPPETS(${fieldName}, ?term, {"num_snippets": 5}) | MV_EXPAND snippets | KEEP snippets`,
+            {
+              docId: result.id,
+              term,
+            }
+          );
+
+          logger.info(`Running TOP_SNIPPETS query: ${esqlQuery}`);
+
+          const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
+
+          logger.info(
+            `TOP_SNIPPETS response for doc="${result.id}", field="${field.path}": ${JSON.stringify(esqlResponse)}`
+          );
+
+          if (esqlResponse.values.length > 0 && esqlResponse.values[0][0] != null) {
+            const snippetValue = esqlResponse.values[0][0];
+            if (Array.isArray(snippetValue)) {
+              snippets.push(
+                ...snippetValue.filter((s): s is string => typeof s === 'string')
+              );
+            } else if (typeof snippetValue === 'string') {
+              snippets.push(snippetValue);
+            }
+          }
+        } catch (error) {
+          logger.info(
+            `TOP_SNIPPETS failed for document id="${result.id}", field="${field.path}": ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+
+      return {
+        ...result,
+        snippets,
+      };
+    })
+  );
 
   return { results };
 };


### PR DESCRIPTION
This is a POC that uses some hard coded variables to determine whether to return highlighted results, snippets via the `TOP_SNIPPETS` ES|QL function, or both when performing searches via the Agent Builder relevance tool. 

Additional customization is supported for playing with `numSnippets` and `numWords` options of `TOP_SNIPPETS`. 

Note - this POC still works on each individual result (hacked in very inefficiently has `TOP_SNIPPETS` does not yet have multi-value support. We could experiment with calling `TOP_SNIPPETS` across all documents for a given field like `contents` but since `TOP_SNIPPETS` only supports BM25 search over snippets this would likely not be worth doing for this use case at this time. 