### PR TITLE
POC Security Solution flyout in Discover - option 1

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/accessors/create_app_wrapper_accessor.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/accessors/create_app_wrapper_accessor.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SecuritySolutionAppWrapperFeature } from '@kbn/discover-shared-plugin/public';
+
+export const createAppWrapperAccessor = async (
+  appWrapperFeature?: SecuritySolutionAppWrapperFeature
+) => {
+  if (!appWrapperFeature) return undefined;
+  return appWrapperFeature.getWrapper();
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
@@ -7,150 +7,61 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useState } from 'react';
-import type { FC, PropsWithChildren } from 'react';
-import { fieldConstants, getFieldValue } from '@kbn/discover-utils';
+import React, { useEffect, useMemo, useState } from 'react';
+import { getFieldValue } from '@kbn/discover-utils';
 import type { DocViewerComponent } from '@kbn/unified-doc-viewer/types';
-import {
-  EuiTitle,
-  EuiSpacer,
-  EuiAccordion,
-  EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiSkeletonText,
-} from '@elastic/eui';
-import * as i18n from '../translations';
-import { getSecurityTimelineRedirectUrl } from '../utils';
-import { getEcsAllowedValueDescription } from '../utils/ecs_description';
+import { EuiSpacer } from '@elastic/eui';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 
-export const ExpandableSection: FC<PropsWithChildren<{ title: string }>> = ({
-  title,
-  children,
-}) => {
-  const [trigger, setTrigger] = useState<'open' | 'closed'>('open');
-
-  const onToggle = (isOpen: boolean) => {
-    const newState = isOpen ? 'open' : 'closed';
-    setTrigger(newState);
-  };
-
-  return (
-    <EuiAccordion
-      id={`accordion-${title}`}
-      forceState={trigger}
-      onToggle={onToggle}
-      buttonContent={
-        <EuiTitle size="xs" data-test-subj={`expandableHeader-${title}`}>
-          <h4>{title}</h4>
-        </EuiTitle>
-      }
-    >
-      <EuiSpacer size="m" />
-      <EuiFlexGroup
-        gutterSize={'m'}
-        direction="column"
-        data-test-subj={`expandableContent-${title}`}
-      >
-        {children}
-      </EuiFlexGroup>
-    </EuiAccordion>
-  );
-};
-
 export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
-  const {
-    application: { getUrlForApp },
-    fieldsMetadata,
-  } = useDiscoverServices();
-
-  const timelinesURL = getUrlForApp('securitySolutionUI', {
-    path: 'alerts',
-  });
-
-  const result = fieldsMetadata?.useFieldsMetadata({
-    attributes: ['allowed_values', 'name', 'flat_name'],
-    fieldNames: [fieldConstants.EVENT_CATEGORY_FIELD],
-  });
-
-  const reason = useMemo(() => getFieldValue(hit, 'kibana.alert.reason') as string, [hit]);
-  const description = useMemo(
-    () => getFieldValue(hit, 'kibana.alert.rule.description') as string,
-    [hit]
+  const { discoverShared } = useDiscoverServices();
+  const discoverFeaturesRegistry = discoverShared.features.registry;
+  const alertFlyoutOverviewTabComponent = discoverFeaturesRegistry.getById(
+    'security-solution-alert-flyout-overview-tab'
   );
-  const alertURL = useMemo(() => getFieldValue(hit, 'kibana.alert.url') as string, [hit]);
-  const eventKind = useMemo(() => getFieldValue(hit, 'event.kind') as string, [hit]);
-  const isAlert = useMemo(() => eventKind === 'signal', [eventKind]);
-  const eventId = useMemo(() => getFieldValue(hit, '_id') as string, [hit]);
-  const eventURL = useMemo(
-    () =>
-      getSecurityTimelineRedirectUrl({
-        from: getFieldValue(hit, '@timestamp') as string,
-        to: getFieldValue(hit, '@timestamp') as string,
-        eventId: eventId as string,
-        index: getFieldValue(hit, '_index') as string,
-        baseURL: timelinesURL,
-      }),
-    [hit, eventId, timelinesURL]
-  );
+  const alertFlyoutOverviewTabComponentRender = alertFlyoutOverviewTabComponent?.render;
 
-  const eventCategory = useMemo(() => getFieldValue(hit, 'event.category') as string, [hit]);
+  const [ResolvedAlertFlyoutOverviewTabComponent, setResolvedAlertFlyoutOverviewTabComponent] =
+    useState<(() => Element) | null>(null);
+
+  const id = useMemo(() => getFieldValue(hit, '_id') as string, [hit]);
+  const indexName = useMemo(() => getFieldValue(hit, '_index') as string, [hit]);
+  const scopeId = 'discover';
+
+  useEffect(() => {
+    let mounted = true;
+    if (!alertFlyoutOverviewTabComponentRender) {
+      setResolvedAlertFlyoutOverviewTabComponent(null);
+      return;
+    }
+
+    alertFlyoutOverviewTabComponentRender({ id, indexName, scopeId })
+      .then((Comp) => {
+        if (!mounted) return;
+        setResolvedAlertFlyoutOverviewTabComponent(() => Comp);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setResolvedAlertFlyoutOverviewTabComponent(null);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [id, indexName, alertFlyoutOverviewTabComponentRender]);
 
   return (
-    <EuiFlexGroup
-      data-test-subj={isAlert ? 'alertOverview' : 'eventOverview'}
-      gutterSize="m"
-      direction="column"
-      style={{ paddingBlock: '20px' }}
-    >
-      <EuiFlexItem>
-        <ExpandableSection title={i18n.aboutSectionTitle}>
-          {result?.loading ? (
-            <EuiSkeletonText
-              lines={2}
-              size={'s'}
-              isLoading={result?.loading}
-              contentAriaLabel={i18n.ecsDescriptionLoadingAriaLable}
-            />
-          ) : (
-            <EuiText size="s" data-test-subj="about">
-              {getEcsAllowedValueDescription(result?.fieldsMetadata, eventCategory)}
-            </EuiText>
-          )}
-        </ExpandableSection>
-      </EuiFlexItem>
-      {description ? (
-        <EuiFlexItem>
-          <ExpandableSection title={i18n.descriptionSectionTitle}>
-            <EuiText size="s" data-test-subj="description">
-              {description}
-            </EuiText>
-          </ExpandableSection>
-        </EuiFlexItem>
+    <>
+      {ResolvedAlertFlyoutOverviewTabComponent ? (
+        <>
+          <EuiSpacer size="m" />
+          <ResolvedAlertFlyoutOverviewTabComponent
+            id={id}
+            indexName={indexName}
+            scopeId={scopeId}
+          />
+        </>
       ) : null}
-      {isAlert ? (
-        <EuiFlexItem>
-          <ExpandableSection title={i18n.reasonSectionTitle}>
-            <EuiText size="s" data-test-subj="reason">
-              {reason}
-            </EuiText>
-          </ExpandableSection>
-        </EuiFlexItem>
-      ) : null}
-      <EuiFlexItem grow={false}>
-        <EuiButton
-          data-test-subj="exploreSecurity"
-          href={isAlert && alertURL ? alertURL : eventURL}
-          target="_blank"
-          iconType="link"
-          fill
-          aria-label={i18n.overviewExploreButtonLabel(isAlert)}
-        >
-          {i18n.overviewExploreButtonLabel(isAlert)}
-        </EuiButton>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    </>
   );
 };

--- a/src/platform/plugins/shared/discover_shared/public/index.ts
+++ b/src/platform/plugins/shared/discover_shared/public/index.ts
@@ -22,6 +22,7 @@ export type {
   ObservabilityStreamsFeatureRenderDeps,
   ObservabilityStreamsFeature,
   SecuritySolutionCellRendererFeature,
+  SecuritySolutionAlertFlyoutOverviewTabFeature,
   SecuritySolutionAppWrapperFeature,
   DiscoverFeature,
   DiscoverFeaturesServiceSetup,

--- a/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
+++ b/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
@@ -8,20 +8,19 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
-import type { FunctionComponent, PropsWithChildren } from 'react';
+import type React, { FunctionComponent, PropsWithChildren } from 'react';
 import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
 import type { Query, TimeRange } from '@kbn/es-query';
 import type {
-  SpanLinks,
   ErrorsByTraceId,
-  TraceRootSpan,
-  UnifiedSpanDocument,
   FocusedTraceWaterfallProps,
   FullTraceWaterfallProps,
+  SpanLinks,
+  TraceRootSpan,
+  UnifiedSpanDocument,
 } from '@kbn/apm-types';
 import type { HistogramItem, ProcessorEvent } from '@kbn/apm-types-shared';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import type React from 'react';
 import type { IndicatorType } from '@kbn/slo-schema';
 import type { FeaturesRegistry } from '../../../common';
 
@@ -114,6 +113,11 @@ export interface SecuritySolutionCellRendererFeature {
   >;
 }
 
+export interface SecuritySolutionAlertFlyoutOverviewTabFeature {
+  id: 'security-solution-alert-flyout-overview-tab';
+  render: (props: { id: string; indexName: string; scopeId: string }) => Promise<() => Element>;
+}
+
 export interface SecuritySolutionAppWrapperFeature {
   id: 'security-solution-app-wrapper';
   getWrapper: () => Promise<() => FunctionComponent<PropsWithChildren<{}>>>;
@@ -121,6 +125,7 @@ export interface SecuritySolutionAppWrapperFeature {
 
 export type SecuritySolutionFeature =
   | SecuritySolutionCellRendererFeature
+  | SecuritySolutionAlertFlyoutOverviewTabFeature
   | SecuritySolutionAppWrapperFeature;
 
 /** ****************************************************************************************/

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { OverviewTab } from '../../flyout/document_details/right/tabs/overview_tab';
+import { DocumentDetailsProvider } from '../../flyout/document_details/shared/context';
+
+export const getAlertFlyoutOverviewTabComponent = ({
+  id,
+  indexName,
+  scopeId,
+}: {
+  id: string;
+  indexName: string;
+  scopeId: string;
+}) => {
+  return (
+    <DocumentDetailsProvider id={id} indexName={indexName} scopeId={scopeId}>
+      <OverviewTab />
+    </DocumentDetailsProvider>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/app_wrapper/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/app_wrapper/index.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
+import { Provider as ReduxStoreProvider } from 'react-redux';
+import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
+import { KibanaContextProvider, useKibana } from '@kbn/kibana-react-plugin/public';
+import { NavigationProvider } from '@kbn/security-solution-navigation';
+import type { CoreStart } from '@kbn/core/public';
+import type { SecuritySolutionAppWrapperFeature } from '@kbn/discover-shared-plugin/public';
+import type { DiscoverServices } from '@kbn/discover-plugin/public';
+import { CellActionsProvider } from '@kbn/cell-actions';
+import { APP_ID } from '../../../common';
+import { SecuritySolutionFlyout } from '../../flyout';
+import { StatefulEventContext } from '../../common/components/events_viewer/stateful_event_context';
+import type { SecurityAppStore } from '../../common/store';
+import { ReactQueryClientProvider } from '../../common/containers/query_client/query_client_provider';
+import type { StartPluginsDependencies, StartServices } from '../../types';
+import { MlCapabilitiesProvider } from '../../common/components/ml/permissions/ml_capabilities_provider';
+import { UserPrivilegesProvider } from '../../common/components/user_privileges/user_privileges_context';
+import { DiscoverInTimelineContextProvider } from '../../common/components/discover_in_timeline/provider';
+import { UpsellingProvider } from '../../common/components/upselling_provider';
+import { ConsoleManager } from '../../management/components/console';
+import { AssistantProvider } from '../../assistant/provider';
+import { ONE_DISCOVER_SCOPE_ID } from '../constants';
+
+export const createSecuritySolutionDiscoverAppWrapperGetter = ({
+  core,
+  services,
+  plugins,
+  store,
+}: {
+  core: CoreStart;
+  services: StartServices;
+  plugins: StartPluginsDependencies;
+  /**
+   * instance of Security App store that should be used in Discover
+   */
+  store: SecurityAppStore;
+}) => {
+  const getSecuritySolutionDiscoverAppWrapper: Awaited<
+    ReturnType<SecuritySolutionAppWrapperFeature['getWrapper']>
+  > = () => {
+    return function SecuritySolutionDiscoverAppWrapper({ children }) {
+      const { services: discoverServices } = useKibana<DiscoverServices>();
+      const CasesContext = useMemo(() => plugins.cases.ui.getCasesContext(), []);
+
+      const userCasesPermissions = useMemo(() => plugins.cases.helpers.canUseCases([APP_ID]), []);
+
+      /**
+       *
+       * Since this component is meant to be used only in the context of Discover,
+       * these services are appended/overwritten to the existing services object
+       * provided by the Discover plugin.
+       *
+       */
+      const securitySolutionServices: StartServices = useMemo(
+        () => ({
+          ...services,
+          /* Helps with getting correct instance of query, timeFilter and filterManager instances from discover */
+          data: discoverServices.data,
+        }),
+        [discoverServices]
+      );
+
+      const statefulEventContextValue = useMemo(
+        () => ({
+          // timelineId acts as scopeId
+          timelineID: ONE_DISCOVER_SCOPE_ID,
+          enableHostDetailsFlyout: true,
+          /* behaviour similar to query tab */
+          tabType: 'query',
+          enableIpDetailsFlyout: true,
+        }),
+        []
+      );
+
+      return (
+        <KibanaContextProvider services={securitySolutionServices}>
+          <EuiThemeProvider>
+            <MlCapabilitiesProvider>
+              <CasesContext owner={[APP_ID]} permissions={userCasesPermissions}>
+                <UserPrivilegesProvider kibanaCapabilities={services.application.capabilities}>
+                  {/* ^_^ Needed for notes addition */}
+                  <NavigationProvider core={core}>
+                    <CellActionsProvider
+                      getTriggerCompatibleActions={services.uiActions.getTriggerCompatibleActions}
+                    >
+                      {/* ^_^ Needed for Cell Actions since it gives errors when CellActionsContext is used */}
+                      <UpsellingProvider upsellingService={services.upselling}>
+                        {/* ^_^ Needed for Alert Preview from Expanded Section of Entity Flyout */}
+                        <ReduxStoreProvider store={store}>
+                          <ReactQueryClientProvider>
+                            <ConsoleManager>
+                              {/* ^_^ Needed for AlertPreview -> Alert Details Flyout Action */}
+                              <AssistantProvider>
+                                {/* ^_^ Needed for AlertPreview -> Alert Details Flyout Action */}
+                                <DiscoverInTimelineContextProvider>
+                                  {/* ^_^ Needed for Add to Timeline action by `useRiskInputActions`*/}
+                                  <ExpandableFlyoutProvider>
+                                    <SecuritySolutionFlyout />
+                                    {/* vv below context should not be here and should be removed */}
+                                    <StatefulEventContext.Provider
+                                      value={statefulEventContextValue}
+                                    >
+                                      {children}
+                                    </StatefulEventContext.Provider>
+                                  </ExpandableFlyoutProvider>
+                                </DiscoverInTimelineContextProvider>
+                              </AssistantProvider>
+                            </ConsoleManager>
+                          </ReactQueryClientProvider>
+                        </ReduxStoreProvider>
+                      </UpsellingProvider>
+                    </CellActionsProvider>
+                  </NavigationProvider>
+                </UserPrivilegesProvider>
+              </CasesContext>
+            </MlCapabilitiesProvider>
+          </EuiThemeProvider>
+        </KibanaContextProvider>
+      );
+    };
+  };
+
+  return getSecuritySolutionDiscoverAppWrapper;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/index.tsx
@@ -6,3 +6,5 @@
  */
 
 export { getCellRendererForGivenRecord } from './cell_renderers';
+export { createSecuritySolutionDiscoverAppWrapperGetter } from './app_wrapper';
+export { getAlertFlyoutOverviewTabComponent } from './alert_flyout_overview_tab_component';

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -21,7 +21,11 @@ import { AppStatus, DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { Logger } from '@kbn/logging';
 import { uiMetricService } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
-import type { SecuritySolutionCellRendererFeature } from '@kbn/discover-shared-plugin/public/services/discover_features';
+import type {
+  SecuritySolutionAlertFlyoutOverviewTabFeature,
+  SecuritySolutionAppWrapperFeature,
+  SecuritySolutionCellRendererFeature,
+} from '@kbn/discover-shared-plugin/public/services/discover_features';
 import { ProductFeatureSecurityKey } from '@kbn/security-solution-features/keys';
 import { ProductFeatureAssistantKey } from '@kbn/security-solution-features/src/product_features_keys';
 import type { ExternalReferenceAttachmentType } from '@kbn/cases-plugin/public/client/attachment_framework/types';
@@ -84,6 +88,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
   // Lazily instantiated dependencies
   private _subPlugins?: SubPlugins;
   private _store?: SecurityAppStore;
+  private _securityStoreForDiscover?: SecurityAppStore;
   private _actionsRegistered?: boolean = false;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
@@ -265,7 +270,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     const externalAttachmentType: ExternalReferenceAttachmentType = generateAttachmentType();
     cases?.attachmentFramework?.registerExternalReference(externalAttachmentType);
 
-    this.registerDiscoverSharedFeatures(plugins);
+    this.registerDiscoverSharedFeatures(core, plugins);
 
     return this.contract.getSetupContract();
   }
@@ -288,7 +293,10 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     this.services.stop();
   }
 
-  public async registerDiscoverSharedFeatures(plugins: SetupPlugins) {
+  public async registerDiscoverSharedFeatures(
+    core: CoreSetup<StartPluginsDependencies, PluginStart>,
+    plugins: SetupPlugins
+  ) {
     const { discoverShared } = plugins;
     const discoverFeatureRegistry = discoverShared.features.registry;
     const cellRendererFeature: SecuritySolutionCellRendererFeature = {
@@ -299,7 +307,42 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       },
     };
 
+    const testFeature: SecuritySolutionAlertFlyoutOverviewTabFeature = {
+      id: 'security-solution-alert-flyout-overview-tab',
+      render: async () => {
+        const { getAlertFlyoutOverviewTabComponent } = await this.getLazyDiscoverSharedDeps();
+        return getAlertFlyoutOverviewTabComponent;
+      },
+    };
+
+    const appWrapperFeature: SecuritySolutionAppWrapperFeature = {
+      id: 'security-solution-app-wrapper',
+      getWrapper: async () => {
+        const [coreStart, startPlugins] = await core.getStartServices();
+
+        const services = await this.services.generateServices(coreStart, startPlugins);
+        const subPlugins = await this.startSubPlugins(this.storage, coreStart, startPlugins);
+        const securityStoreForDiscover = await this.getStoreForDiscover(
+          coreStart,
+          startPlugins,
+          subPlugins
+        );
+
+        const { createSecuritySolutionDiscoverAppWrapperGetter } =
+          await this.getLazyDiscoverSharedDeps();
+
+        return createSecuritySolutionDiscoverAppWrapperGetter({
+          core: coreStart,
+          services,
+          plugins: startPlugins,
+          store: securityStoreForDiscover,
+        });
+      },
+    };
+
     discoverFeatureRegistry.register(cellRendererFeature);
+    discoverFeatureRegistry.register(testFeature);
+    discoverFeatureRegistry.register(appWrapperFeature);
   }
 
   public async getLazyDiscoverSharedDeps() {
@@ -311,6 +354,31 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       /* webpackChunkName: "one_discover_shared_deps" */
       './one_discover'
     );
+  }
+
+  /**
+   * Lazily instantiate a `SecurityAppStore` for discover.
+   */
+  private async getStoreForDiscover(
+    coreStart: CoreStart,
+    startPlugins: StartPlugins,
+    subPlugins: StartedSubPlugins
+  ): Promise<SecurityAppStore> {
+    if (!this._securityStoreForDiscover) {
+      const { createStoreFactory } = await this.lazyApplicationDependencies();
+
+      this._securityStoreForDiscover = await createStoreFactory(
+        coreStart,
+        startPlugins,
+        subPlugins,
+        this.storage,
+        this.experimentalFeatures
+      );
+    }
+    if (startPlugins.timelines) {
+      startPlugins.timelines.setTimelineEmbeddedStore(this._securityStoreForDiscover);
+    }
+    return this._securityStoreForDiscover;
   }
 
   /**


### PR DESCRIPTION
## Summary

This draft POC PR demonstrate how we could load the alert details overview tab content in the Discover application, just by registering the main component in Security Solution `plugin.tsx` file.

### Advantages of this approach:
- fastest implementation: we can basically register entire components in Security Solution `plugin.tsx` file, using the `discoverShared.features.registry` functionality
- very little files impacted
- lowest risk of breaking existing functionality (at least at first): as we're not modifying many files, that should lower the risk of breaking the current expandable flyout in Security Solution

### Disadvantages of this approach:
- it goes against plugin code separation that we have in Kibana
- it will require a lot of if/else conditions in the Security Solution to support the different behaviors:
  - at first, because we'll be using the expandable flyout pacckage in Security Solution but the new EUI flyout system in Discover, all the interactions (openRight, openLeft, openParent, openChild) will be different. The content will have to be aware of where it's being rendered and change accordingly
  - a lot of the code in the flyout relies on the fact that we have the Security Solution app setup. This means for example that our Redux store is available and populated. This might be more difficult in Discover. While we can have the Redux store setup, we can't guarantee that it will be populated. For example, dataViews are handled differently between the 2 plugins, and some of the flyout components need dataViews to properly function.
- it will not work when Discover is loaded outside of Security context (for example in Classic nav). We will have to have a separate implementation for that.
- there will be a high risk of breaking Discover experience as we’re bypassing the plugin separation. This can be limited with extensive UI integration tests, but still…
- it will require having the entire Discover application wrapped with pretty much all the context providers from Security Solution, which may introduce performance issues
- it requires the same data to be fetched twice (one time by Discover, then a second time in Security Solution)
- we're building tech debt, as this solution is definitely not the long term desired one

### Example of it partially working

<img width="1413" height="840" alt="Screenshot 2026-02-02 at 3 51 30 PM" src="https://github.com/user-attachments/assets/391b35ca-8b9d-4fa5-84fa-6217a594a132" />
