### PR TITLE
[Dashboards] Update styles of floating actions in dashboards

### DIFF
--- a/examples/grid_example/public/use_layout_styles.tsx
+++ b/examples/grid_example/public/use_layout_styles.tsx
@@ -40,10 +40,6 @@ export const useLayoutStyles = () => {
       --dashboardHoverActionsActivePanelBoxShadow--singleWrapper: 0 0 0
         ${euiTheme.border.width.thin} ${euiTheme.colors.vis.euiColorVis0};
 
-      --dashboardHoverActionsActivePanelBoxShadow: -${euiTheme.border.width.thin} 0 ${euiTheme.colors.vis.euiColorVis0},
-        ${euiTheme.border.width.thin} 0 ${euiTheme.colors.vis.euiColorVis0},
-        0 -${euiTheme.border.width.thin} ${euiTheme.colors.vis.euiColorVis0};
-
       .kbnGridSection--targeted {
         background-position: top calc((var(--kbnGridGutterSize) / 2) * -1px) left
           calc((var(--kbnGridGutterSize) / 2) * -1px);
@@ -85,7 +81,6 @@ export const useLayoutStyles = () => {
       .kbnGridPanel--active {
         // overwrite the border style on panels + hover actions for active panels
         --hoverActionsBorderStyle: var(--dashboardActivePanelBorderStyle);
-        --hoverActionsBoxShadowStyle: var(--dashboardHoverActionsActivePanelBoxShadow);
         --hoverActionsSingleWrapperBoxShadowStyle: var(
           --dashboardHoverActionsActivePanelBoxShadow--singleWrapper
         );

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
@@ -87,7 +87,7 @@ export const useHoverActionStyles = (isEditMode: boolean, showBorder?: boolean) 
 
   const containerStyles = useMemo(() => {
     const editModeOutline = `${euiTheme.border.width.thin} dashed ${euiTheme.colors.borderBaseProminent}`;
-    const viewModeOutline = `${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBasePlain}`;
+    const viewModeOutline = `${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBaseSubdued}`;
 
     return css`
       // the border style can be overwritten by parents who define --hoverActionsBorderStyle; otherwise, default to either

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEuiTheme, highContrastModeStyles } from '@elastic/eui';
+import { useEuiTheme, highContrastModeStyles, euiShadow } from '@elastic/eui';
 import { css } from '@emotion/react';
 
 import { useMemo } from 'react';
@@ -64,17 +64,9 @@ export const useHoverActionStyles = (isEditMode: boolean, showBorder?: boolean) 
           flex: 0; // do not grow
           pointer-events: all; // re-enable pointer events for non-breakpoint children
           background-color: ${euiTheme.colors.backgroundBasePlain};
-          border: var(--internalBorderStyle);
-          border-width: ${euiTheme.border.width
-            .thin}; /* Prevents the element from resizing when dragged by keeping the border width constant (overriding the default change from 1px to 2px) */
-          box-shadow: var(
-            --hoverActionsBoxShadowStyle
-          ); /* Simulates a 2px 3-side border without affecting layout by using a box-shadow */
-          border-bottom: 0px;
+          ${euiShadow(euiThemeContext, 'xs')}
           padding: var(--paddingAroundAction);
-          padding-bottom: 0px;
-          border-top-left-radius: ${euiTheme.border.radius.medium};
-          border-top-right-radius: ${euiTheme.border.radius.medium};
+          border-radius: ${euiTheme.border.radius.medium};
         }
 
         // shrink down to single wrapped element with no breakpoint when panel gets small
@@ -157,7 +149,7 @@ export const useHoverActionStyles = (isEditMode: boolean, showBorder?: boolean) 
 
       .embPanel__hoverActions {
         position: absolute;
-        top: -${euiTheme.size.xl};
+        top: -${euiTheme.size.l};
         z-index: -1;
         opacity: 0;
         visibility: hidden;

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
@@ -83,7 +83,7 @@ export const useHoverActionStyles = (isEditMode: boolean, showBorder?: boolean) 
         }
       }
     `;
-  }, [euiTheme]);
+  }, [euiTheme, euiThemeContext]);
 
   const containerStyles = useMemo(() => {
     const editModeOutline = `${euiTheme.border.width.thin} dashed ${euiTheme.colors.borderBaseProminent}`;

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/use_layout_styles.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/use_layout_styles.tsx
@@ -36,10 +36,6 @@ export const useLayoutStyles = () => {
       --dashboardHoverActionsActivePanelBoxShadow--singleWrapper: 0 0 0
         ${euiTheme.border.width.thin} ${euiTheme.colors.vis.euiColorVis0};
 
-      --dashboardHoverActionsActivePanelBoxShadow: -${euiTheme.border.width.thin} 0 ${euiTheme.colors.vis.euiColorVis0},
-        ${euiTheme.border.width.thin} 0 ${euiTheme.colors.vis.euiColorVis0},
-        0 -${euiTheme.border.width.thin} ${euiTheme.colors.vis.euiColorVis0};
-
       .kbnGridSection--targeted {
         background-position: top calc((var(--kbnGridGutterSize) / 2) * -1px) left
           calc((var(--kbnGridGutterSize) / 2) * -1px);
@@ -92,7 +88,6 @@ export const useLayoutStyles = () => {
       .kbnGridPanel--active {
         // overwrite the border style on panels + hover actions for active panels
         --hoverActionsBorderStyle: var(--dashboardActivePanelBorderStyle);
-        --hoverActionsBoxShadowStyle: var(--dashboardHoverActionsActivePanelBoxShadow);
         --hoverActionsSingleWrapperBoxShadowStyle: var(
           --dashboardHoverActionsActivePanelBoxShadow--singleWrapper
         );


### PR DESCRIPTION
## Summary

- Updated styles of floating actions containers in dashboard to more closely match common design patterns.
- Removed the difference in style for these containers in Edit vs View modes.
- Pushed down the containers by 8px to achieve a position that feels more natural/common. This shouldn't affect usability of dashboard panels.
- Made the borders more subtle in view mode (for #250671)

<img width="1089" height="613" alt="Frame 2018777179" src="https://github.com/user-attachments/assets/963d0dd9-5469-43e9-be71-0073000e10ff" />

Closes #245125
Closes #250671



