### PR TITLE
[9.2] [Fleet] Use package policy input when available to retrieve agent health components  (#251093)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration.tsx
@@ -129,9 +129,11 @@ export const AgentDetailsIntegration: React.FunctionComponent<{
       if (!agent.components) {
         return [];
       }
-      return getInputUnitsByPackage(agent.components, packagePolicy).filter(
-        (u) => u.status === 'DEGRADED' || u.status === 'FAILED'
-      );
+      return packagePolicy.inputs
+        .flatMap((input) =>
+          getInputUnitsByPackage(agent.components ?? [], input.id ?? packagePolicy.id)
+        )
+        .filter((u) => u.status === 'DEGRADED' || u.status === 'FAILED');
     }, [agent.components, packagePolicy]);
 
     const showNeedsAttentionBadge =

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration_inputs.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration_inputs.tsx
@@ -82,9 +82,10 @@ export const AgentDetailsIntegrationInputs: React.FunctionComponent<{
           return new Map<string, InputStatusFormatter>();
         }
         if (current.enabled) {
-          const agentUnit = getInputUnitsByPackage(agent.components, packagePolicy)?.find((i) =>
-            i.id.match(new RegExp(current.type))
-          );
+          const agentUnit = getInputUnitsByPackage(
+            agent.components,
+            current.id ?? packagePolicy.id
+          )?.find((i) => i.id.match(new RegExp(current.type)));
           acc.set(
             current.type,
             agentUnit

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.test.ts
@@ -181,7 +181,7 @@ describe('getInputUnitsByPackage', () => {
 
   it('should return the agent component input units that belong to the package', () => {
     packageMock.id = 'df3a359d-9463-400c-8d8e-4d293ebf7821';
-    expect(getInputUnitsByPackage(agentComponents, packageMock)).toEqual([
+    expect(getInputUnitsByPackage(agentComponents, packageMock.id)).toEqual([
       {
         id: 'log-default-logfile-system-df3a359d-9463-400c-8d8e-4d293ebf7821',
         type: 'input',
@@ -198,7 +198,7 @@ describe('getInputUnitsByPackage', () => {
   });
 
   packageMock.id = '77fa4731-4502-4a44-bfbe-440b4662c08f';
-  expect(getInputUnitsByPackage(agentComponents, packageMock)).toEqual([
+  expect(getInputUnitsByPackage(agentComponents, packageMock.id)).toEqual([
     {
       id: 'log-default-logfile-apache-77fa4731-4502-4a44-bfbe-440b4662c08f',
       type: 'input',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.ts
@@ -54,4 +54,3 @@ export const getInputUnitsByPackage = (
     .flat()
     .filter((u) => !!u && u.id.match(re));
 };
-

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.ts
@@ -54,34 +54,4 @@ export const getInputUnitsByPackage = (
     .flat()
     .filter((u) => !!u && u.id.match(re));
 };
-<<<<<<< HEAD
-=======
 
-export const getOutputUnitsByPackage = (
-  agentComponents: FleetServerAgentComponent[],
-  inputOrPackagePolicyId: string
-): FleetServerAgentComponentUnit[] => {
-  const reId = new RegExp(inputOrPackagePolicyId);
-
-  return agentComponents
-    .filter((c) => (c.units ?? []).some((unit) => unit.id.match(reId)))
-    .map((c) => c.units || [])
-    .flat()
-    .filter((u) => !!u && u.type === 'output');
-};
-
-export const getOutputUnitsByPackageAndInputType = (
-  agentComponents: FleetServerAgentComponent[],
-  inputOrPackagePolicyId: string,
-  unitType: string
-): FleetServerAgentComponentUnit | undefined => {
-  const reId = new RegExp(inputOrPackagePolicyId);
-  const reUnitType = new RegExp(unitType);
-
-  return agentComponents
-    .filter((c) => (c.units ?? []).some((unit) => unit.id.match(reId) && unit.id.match(reUnitType)))
-    .map((c) => c.units || [])
-    .flat()
-    .find((u) => !!u && u.type === 'output');
-};
->>>>>>> 84b021818eb ([Fleet] Use package policy input when available to retrieve agent health components  (#251093))

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_status_utils.ts
@@ -7,7 +7,6 @@
 
 import { i18n } from '@kbn/i18n';
 
-import type { PackagePolicy } from '../../../../../types';
 import type {
   FleetServerAgentComponent,
   FleetServerAgentComponentStatus,
@@ -46,12 +45,43 @@ export class InputStatusFormatter {
 
 export const getInputUnitsByPackage = (
   agentComponents: FleetServerAgentComponent[],
-  packagePolicy: PackagePolicy
+  inputOrPackagePolicyId: string
 ): FleetServerAgentComponentUnit[] => {
-  const re = new RegExp(packagePolicy.id);
+  const re = new RegExp(inputOrPackagePolicyId);
 
   return agentComponents
     .map((c) => c?.units || [])
     .flat()
     .filter((u) => !!u && u.id.match(re));
 };
+<<<<<<< HEAD
+=======
+
+export const getOutputUnitsByPackage = (
+  agentComponents: FleetServerAgentComponent[],
+  inputOrPackagePolicyId: string
+): FleetServerAgentComponentUnit[] => {
+  const reId = new RegExp(inputOrPackagePolicyId);
+
+  return agentComponents
+    .filter((c) => (c.units ?? []).some((unit) => unit.id.match(reId)))
+    .map((c) => c.units || [])
+    .flat()
+    .filter((u) => !!u && u.type === 'output');
+};
+
+export const getOutputUnitsByPackageAndInputType = (
+  agentComponents: FleetServerAgentComponent[],
+  inputOrPackagePolicyId: string,
+  unitType: string
+): FleetServerAgentComponentUnit | undefined => {
+  const reId = new RegExp(inputOrPackagePolicyId);
+  const reUnitType = new RegExp(unitType);
+
+  return agentComponents
+    .filter((c) => (c.units ?? []).some((unit) => unit.id.match(reId) && unit.id.match(reUnitType)))
+    .map((c) => c.units || [])
+    .flat()
+    .find((u) => !!u && u.type === 'output');
+};
+>>>>>>> 84b021818eb ([Fleet] Use package policy input when available to retrieve agent health components  (#251093))


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Fleet] Use package policy input when available to retrieve agent health components  (#251093)](https://github.com/elastic/kibana/pull/251093)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2026-02-03T00:32:29Z","message":"[Fleet] Use package policy input when available to retrieve agent health components  (#251093)","sha":"84b021818ebd3329c788e142973a9bd0e5e031f4","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.4.0","v9.2.5","v9.3.1"],"title":"[Fleet] Use package policy input when available to retrieve agent health components ","number":251093,"url":"https://github.com/elastic/kibana/pull/251093","mergeCommit":{"message":"[Fleet] Use package policy input when available to retrieve agent health components  (#251093)","sha":"84b021818ebd3329c788e142973a9bd0e5e031f4"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251093","number":251093,"mergeCommit":{"message":"[Fleet] Use package policy input when available to retrieve agent health components  (#251093)","sha":"84b021818ebd3329c788e142973a9bd0e5e031f4"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->