### PR TITLE
Add CLAUDE.md -> AGENTS.md symlink

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3238,6 +3238,7 @@ x-pack/solutions/security/test/moon.yml @elastic/kibana-operations
 
 # Leads approval
 /AGENTS.md @elastic/kibana-tech-leads
+/.claude/ @elastic/kibana-tech-leads
 
 ####
 ## These rules are always last so they take ultimate priority over everything else

--- a/.gitignore
+++ b/.gitignore
@@ -19,11 +19,10 @@ target
 /build
 .jruby
 .idea
-.claude
+.claude/*.local.json
 .cursor
 !x-pack/solutions/security/test/security_solution_cypress/.cursor/
 .windsurf
-claude.md
 *.iml
 *.log
 types.eslint.config.js


### PR DESCRIPTION
Add support for Claude system rules by symlinking to AGENTS.md

https://code.claude.com/docs/en/memory

Until Claude supports AGENTS.md directly: https://github.com/anthropics/claude-code/issues/6235

Alternative is to have it reference the AGENTS.md, but that would result in a separate tool call loop.

We don't have any direct Windows development, as anyone on Windows should be using WSL. So the symlink should be fine.