### PR TITLE
[Discover][Metrics] Migrate metrics in discover flyout to the new flyout system

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_flyout_a11y.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_flyout_a11y.tsx
@@ -10,11 +10,9 @@
 import { EuiScreenReaderOnly, useGeneratedHtmlId } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useState } from 'react';
-import useUnmount from 'react-use/lib/useUnmount';
 
 export const useFlyoutA11y = ({ isXlScreen }: { isXlScreen: boolean }) => {
   const descriptionId = useGeneratedHtmlId();
-  const [triggerEl] = useState(document.activeElement);
   const [flyoutEl, setFlyoutEl] = useState<HTMLElement | null>(null);
 
   // Auto-focus push flyout on open or when switching to XL screen
@@ -25,13 +23,6 @@ export const useFlyoutA11y = ({ isXlScreen }: { isXlScreen: boolean }) => {
       setTimeout(() => flyoutEl.focus());
     }
   }, [flyoutEl, isXlScreen]);
-
-  // Return focus to the trigger element when the flyout is closed
-  useUnmount(() => {
-    if (triggerEl instanceof HTMLElement && document.contains(triggerEl)) {
-      triggerEl.focus();
-    }
-  });
 
   return {
     a11yProps: {

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MetricInsightsFlyout } from './metrics_insights_flyout';
+import type { MetricField } from '../../types';
+import { ES_FIELD_TYPES } from '@kbn/field-types';
+
+jest.mock('./metrics_flyout_body', () => ({
+  MetricFlyoutBody: jest.fn(() => <div data-test-subj="metricFlyoutBody" />),
+}));
+
+jest.mock('./hooks/use_flyout_a11y', () => ({
+  useFlyoutA11y: jest.fn(() => ({
+    a11yProps: {},
+    screenReaderDescription: null,
+  })),
+}));
+
+jest.mock('../../context/fields_metadata', () => ({
+  useFieldsMetadataContext: jest.fn(() => ({
+    fieldsMetadata: {},
+  })),
+}));
+
+jest.mock('react-use/lib/useLocalStorage', () => {
+  return jest.fn(() => [544, jest.fn()]);
+});
+
+describe('MetricInsightsFlyout', () => {
+  const mockMetricFlyoutBody = jest.requireMock('./metrics_flyout_body').MetricFlyoutBody;
+  const mockUseFlyoutA11y = jest.requireMock('./hooks/use_flyout_a11y').useFlyoutA11y;
+  const mockUseFieldsMetadataContext = jest.requireMock(
+    '../../context/fields_metadata'
+  ).useFieldsMetadataContext;
+
+  const createMockMetric = (overrides: Partial<MetricField> = {}): MetricField => ({
+    name: 'test.metric',
+    index: 'test-index',
+    type: ES_FIELD_TYPES.DOUBLE,
+    dimensions: [],
+    ...overrides,
+  });
+
+  const defaultProps = {
+    metric: createMockMetric(),
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseFieldsMetadataContext.mockReturnValue({ fieldsMetadata: {} });
+    mockUseFlyoutA11y.mockReturnValue({ a11yProps: {}, screenReaderDescription: null });
+  });
+
+  describe('rendering', () => {
+    it('renders the flyout with correct structure', () => {
+      render(<MetricInsightsFlyout {...defaultProps} />);
+
+      expect(screen.getByTestId('metricsExperienceFlyout')).toBeInTheDocument();
+      expect(screen.getByTestId('metricsExperienceFlyoutRowDetailsTitle')).toBeInTheDocument();
+      expect(screen.getByText('Metric')).toBeInTheDocument();
+    });
+
+    it('renders the flyout body with MetricFlyoutBody', () => {
+      render(<MetricInsightsFlyout {...defaultProps} />);
+
+      expect(screen.getByTestId('metricFlyoutBody')).toBeInTheDocument();
+    });
+  });
+
+  describe('keyboard interactions', () => {
+    it('calls onClose and prevents default when Escape key is pressed on the flyout', () => {
+      const onClose = jest.fn();
+      render(<MetricInsightsFlyout {...defaultProps} onClose={onClose} />);
+
+      const flyout = screen.getByTestId('metricsExperienceFlyout');
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+      const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+
+      fireEvent(flyout, event);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('does not call onClose for non-Escape keys', () => {
+      const onClose = jest.fn();
+      render(<MetricInsightsFlyout {...defaultProps} onClose={onClose} />);
+
+      const flyout = screen.getByTestId('metricsExperienceFlyout');
+      fireEvent.keyDown(flyout, { key: 'Enter', bubbles: true });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('prop handling', () => {
+    it('passes metric prop to MetricFlyoutBody', () => {
+      const metric = createMockMetric({ name: 'custom.metric' });
+
+      render(<MetricInsightsFlyout {...defaultProps} metric={metric} />);
+
+      expect(mockMetricFlyoutBody).toHaveBeenCalledWith(
+        expect.objectContaining({ metric }),
+        expect.anything()
+      );
+    });
+
+    it('passes esqlQuery prop to MetricFlyoutBody', () => {
+      const esqlQuery = 'FROM test | STATS avg(value)';
+
+      render(<MetricInsightsFlyout {...defaultProps} esqlQuery={esqlQuery} />);
+
+      expect(mockMetricFlyoutBody).toHaveBeenCalledWith(
+        expect.objectContaining({ esqlQuery }),
+        expect.anything()
+      );
+    });
+
+    it('passes description from fieldsMetadata to MetricFlyoutBody', () => {
+      mockUseFieldsMetadataContext.mockReturnValue({
+        fieldsMetadata: {
+          'test.metric': { description: 'Test metric description' },
+        },
+      });
+
+      render(<MetricInsightsFlyout {...defaultProps} />);
+
+      expect(mockMetricFlyoutBody).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Test metric description' }),
+        expect.anything()
+      );
+    });
+
+    it('passes undefined description when not in fieldsMetadata', () => {
+      mockUseFieldsMetadataContext.mockReturnValue({ fieldsMetadata: {} });
+
+      render(<MetricInsightsFlyout {...defaultProps} />);
+
+      expect(mockMetricFlyoutBody).toHaveBeenCalledWith(
+        expect.objectContaining({ description: undefined }),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('accessibility', () => {
+    it('renders the title as h2 with id for aria-labelledby', () => {
+      render(<MetricInsightsFlyout {...defaultProps} />);
+
+      const heading = screen.getByRole('heading', { level: 2 });
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent('Metric');
+      expect(heading).toHaveAttribute('id');
+      expect(heading.getAttribute('id')).toContain('metricFlyoutTitle');
+    });
+
+    it('renders screen reader description when provided by useFlyoutA11y', () => {
+      mockUseFlyoutA11y.mockReturnValue({
+        a11yProps: { role: 'dialog' },
+        screenReaderDescription: (
+          <p data-test-subj="metricsExperienceFlyoutScreenReaderDescription">
+            Screen reader description
+          </p>
+        ),
+      });
+
+      render(<MetricInsightsFlyout {...defaultProps} />);
+
+      expect(
+        screen.getByTestId('metricsExperienceFlyoutScreenReaderDescription')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.tsx
@@ -57,15 +57,21 @@ export const MetricInsightsFlyout = ({ metric, esqlQuery, onClose }: MetricInsig
     defaultMessage: 'Metric',
   });
 
+  // Only handle ESC in push mode (xl screen). In overlay mode, EUI handles ESC automatically.
   const onKeyDown = useCallback(
     (ev: React.KeyboardEvent) => {
-      if (isDOMNode(ev.target) && ev.currentTarget.contains(ev.target) && ev.key === keys.ESCAPE) {
+      if (
+        isXlScreen &&
+        isDOMNode(ev.target) &&
+        ev.currentTarget.contains(ev.target) &&
+        ev.key === keys.ESCAPE
+      ) {
         ev.preventDefault();
         ev.stopPropagation();
         onClose();
       }
     },
-    [onClose]
+    [onClose, isXlScreen]
   );
 
   const minWidth = euiTheme.base * 24;

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.tsx
@@ -103,7 +103,7 @@ export const MetricInsightsFlyout = ({ metric, esqlQuery, onClose }: MetricInsig
     >
       {screenReaderDescription}
       <EuiFlyoutHeader>
-        <EuiTitle size="s" data-test-subj="metricsExperienceFlyoutRowDetailsTitle">
+        <EuiTitle size="xs" data-test-subj="metricsExperienceFlyoutRowDetailsTitle">
           <h2 id={metricFlyoutTitleId}>{metricFlyoutTitle}</h2>
         </EuiTitle>
       </EuiFlyoutHeader>

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/metrics_insights_flyout.tsx
@@ -18,9 +18,10 @@ import {
   useGeneratedHtmlId,
   useIsWithinMinBreakpoint,
 } from '@elastic/eui';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
 import type { MetricField } from '../../types';
 import { MetricFlyoutBody } from './metrics_flyout_body';
 import { useFlyoutA11y } from './hooks/use_flyout_a11y';
@@ -43,6 +44,10 @@ export const MetricInsightsFlyout = ({ metric, esqlQuery, onClose }: MetricInsig
   const flyoutWidthRef = useRef(flyoutWidth ?? defaultWidth);
   const { a11yProps, screenReaderDescription } = useFlyoutA11y({ isXlScreen });
   const { fieldsMetadata = {} } = useFieldsMetadataContext();
+
+  useEffect(() => {
+    dismissAllFlyoutsExceptFor(DiscoverFlyouts.metricInsights);
+  }, []);
 
   const metricFlyoutTitleId = useGeneratedHtmlId({
     prefix: 'metricFlyoutTitle',

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.test.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.test.ts
@@ -9,6 +9,8 @@
 
 import { renderHook } from '@testing-library/react';
 import { useEuiTheme, useGeneratedHtmlId, useMutationObserver } from '@elastic/eui';
+import fs from 'fs';
+import path from 'path';
 import {
   useMetricsGridFullScreen,
   toggleMetricsGridFullScreen,
@@ -88,6 +90,26 @@ describe('useMetricsGridFullScreen', () => {
     expect(document.body.classList.remove).toHaveBeenCalledWith(
       expect.any(String),
       METRICS_GRID_WRAPPER_FULL_SCREEN_CLASS
+    );
+  });
+
+  it('fullscreen styles use EUI push flyout CSS variable to prevent overlap with push flyouts', () => {
+    // When the metrics grid is in fullscreen mode (position: fixed), it must respect
+    // the width of any open EUI push flyout. The --euiPushFlyoutOffsetInlineEnd CSS
+    // variable is set by EuiFlyout when type="push" and automatically updates when
+    // the flyout is opened, closed, or resized.
+    // See EUI docs: https://eui.elastic.co/docs/components/containers/flyout/#relative-positioning
+    //
+
+    // Since @emotion/css compiles CSS to hashed class names, we verify the source code
+    // directly to ensure the critical CSS variable is present and won't be accidentally removed.
+    const sourceCode = fs.readFileSync(
+      path.join(__dirname, 'use_metrics_grid_fullscreen.ts'),
+      'utf-8'
+    );
+
+    expect(sourceCode).toMatch(
+      /logicalCSS\s*\(\s*['"]right['"]\s*,\s*['"]var\(--euiPushFlyoutOffsetInlineEnd,\s*0px\)['"]\s*\)/
     );
   });
 });

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
@@ -80,6 +80,7 @@ export const useMetricsGridFullScreen = ({ prefix }: { prefix: string }) => {
         z-index: ${fullScreenZIndex} !important;
         position: fixed;
         inset: 0;
+        ${logicalCSS('right', 'var(--euiPushFlyoutOffsetInlineEnd, 0px)')}
         background-color: ${euiTheme.colors.backgroundBasePlain};
       `,
       [METRICS_GRID_RESTRICT_BODY_CLASS]: css`

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
@@ -187,83 +187,77 @@ interface ChartItemProps
 }
 
 const ChartItem = React.memo(
-  React.forwardRef<HTMLDivElement, ChartItemProps>(
-    (
-      {
-        id,
-        metric,
-        index,
-        size,
-        dimensions,
-        services,
-        onBrushEnd,
-        onFilter,
-        actions,
-        fetchParams,
-        discoverFetch$,
-        rowIndex,
-        colIndex,
-        isFocused,
-        searchTerm,
-        whereStatements,
-        onFocusCell,
-        onViewDetails,
-      }: ChartItemProps,
-      ref
-    ) => {
-      const { euiTheme } = useEuiTheme();
-      const colorPalette = useMemo(
-        () => Object.values(euiTheme.colors.vis).slice(0, 10),
-        [euiTheme.colors.vis]
-      );
+  ({
+    id,
+    metric,
+    index,
+    size,
+    dimensions,
+    services,
+    onBrushEnd,
+    onFilter,
+    actions,
+    fetchParams,
+    discoverFetch$,
+    rowIndex,
+    colIndex,
+    isFocused,
+    searchTerm,
+    whereStatements,
+    onFocusCell,
+    onViewDetails,
+  }: ChartItemProps) => {
+    const { euiTheme } = useEuiTheme();
+    const colorPalette = useMemo(
+      () => Object.values(euiTheme.colors.vis).slice(0, 10),
+      [euiTheme.colors.vis]
+    );
 
-      const esqlQuery = useMemo(() => {
-        const isSupported = metric.type !== 'unsigned_long';
-        return isSupported
-          ? createESQLQuery({
-              metric,
-              splitAccessors: dimensions.map((dim) => dim.name),
-              whereStatements,
-            })
-          : '';
-      }, [metric, dimensions, whereStatements]);
+    const esqlQuery = useMemo(() => {
+      const isSupported = metric.type !== 'unsigned_long';
+      return isSupported
+        ? createESQLQuery({
+            metric,
+            splitAccessors: dimensions.map((dim) => dim.name),
+            whereStatements,
+          })
+        : '';
+    }, [metric, dimensions, whereStatements]);
 
-      const color = useMemo(() => colorPalette[index % colorPalette.length], [index, colorPalette]);
-      const chartLayers = useChartLayers({ dimensions, metric, color });
-      const handleViewDetailsCallback = useCallback(
-        () => onViewDetails(index, esqlQuery, metric),
-        [index, esqlQuery, metric, onViewDetails]
-      );
+    const color = useMemo(() => colorPalette[index % colorPalette.length], [index, colorPalette]);
+    const chartLayers = useChartLayers({ dimensions, metric, color });
+    const handleViewDetailsCallback = useCallback(
+      () => onViewDetails(index, esqlQuery, metric),
+      [index, esqlQuery, metric, onViewDetails]
+    );
 
-      return (
-        <A11yGridCell
-          id={id}
-          ref={ref}
-          rowIndex={rowIndex}
-          colIndex={colIndex}
-          index={index}
-          isFocused={isFocused}
-          onFocus={onFocusCell}
-        >
-          <Chart
-            esqlQuery={esqlQuery}
-            size={size}
-            discoverFetch$={discoverFetch$}
-            fetchParams={fetchParams}
-            services={services}
-            onBrushEnd={onBrushEnd}
-            onFilter={onFilter}
-            onExploreInDiscoverTab={actions.openInNewTab}
-            onViewDetails={handleViewDetailsCallback}
-            title={metric.name}
-            chartLayers={chartLayers}
-            titleHighlight={searchTerm}
-            extraDisabledActions={[ACTION_OPEN_IN_DISCOVER]}
-          />
-        </A11yGridCell>
-      );
-    }
-  )
+    return (
+      <A11yGridCell
+        id={id}
+        rowIndex={rowIndex}
+        colIndex={colIndex}
+        index={index}
+        isFocused={isFocused}
+        onFocus={onFocusCell}
+      >
+        <Chart
+          esqlQuery={esqlQuery}
+          size={size}
+          discoverFetch$={discoverFetch$}
+          fetchParams={fetchParams}
+          services={services}
+          onBrushEnd={onBrushEnd}
+          onFilter={onFilter}
+          onExploreInDiscoverTab={actions.openInNewTab}
+          onViewDetails={handleViewDetailsCallback}
+          title={metric.name}
+          chartLayers={chartLayers}
+          titleHighlight={searchTerm}
+          extraDisabledActions={[ACTION_OPEN_IN_DISCOVER]}
+        />
+      </A11yGridCell>
+    );
+  }
 );
 
 ChartItem.displayName = 'ChartItem';

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
@@ -52,7 +52,6 @@ export const MetricsGrid = ({
   searchTerm,
 }: MetricsGridProps) => {
   const gridRef = useRef<HTMLDivElement>(null);
-  const chartRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const { euiTheme } = useEuiTheme();
 
   const [expandedMetric, setExpandedMetric] = useState<
@@ -75,14 +74,6 @@ export const MetricsGrid = ({
       gridRef,
     });
 
-  const setChartRef = useCallback((id: string, element: HTMLDivElement | null) => {
-    if (element) {
-      chartRefs.current.set(id, element);
-    } else {
-      chartRefs.current.delete(id);
-    }
-  }, []);
-
   const handleViewDetails = useCallback((index: number, esqlQuery: string, metric: MetricField) => {
     setExpandedMetric({ index, metric, esqlQuery });
   }, []);
@@ -99,17 +90,6 @@ export const MetricsGrid = ({
       focusCell(rowIndex, colIndex);
     });
   }, [expandedMetric, focusCell, getRowColFromIndex]);
-
-  const getChartRefForFocus = useCallback(() => {
-    if (expandedMetric !== undefined) {
-      const chartId = getItemKey(expandedMetric.metric, expandedMetric.index);
-      const chartElement = chartRefs.current.get(chartId);
-      if (chartElement) {
-        return { current: chartElement };
-      }
-    }
-    return { current: null };
-  }, [expandedMetric]);
 
   if (fields.length === 0) {
     return <EmptyState />;
@@ -153,7 +133,6 @@ export const MetricsGrid = ({
                 <ChartItem
                   id={id}
                   index={index}
-                  ref={(element) => setChartRef(id, element)}
                   metric={metric}
                   size="s"
                   dimensions={dimensions}
@@ -178,7 +157,6 @@ export const MetricsGrid = ({
       </A11yGridWrapper>
       {expandedMetric && (
         <MetricInsightsFlyout
-          chartRef={getChartRefForFocus()}
           metric={expandedMetric.metric}
           esqlQuery={expandedMetric.esqlQuery}
           onClose={handleCloseFlyout}


### PR DESCRIPTION
Closes: #234306

## Summary

Migrates the Metrics Insights flyout to EUI's new managed flyout system (`session="start"`) and cleans up redundant focus management code.

### Changes

**Core Migration**
- Replaced `EuiFlyoutResizable` with `EuiFlyout` + `session="start"` + `resizable={true}`
- Removed manual `EuiPortal` wrapper (now handled by EUI)
- Added `flyoutMenuProps` for managed flyout header/title
- Removed footer with "Close" button (EUI provides close via header)

**Focus Management Cleanup**
- Removed `useUnmount` hook that caused double focus return (parent component already handles focus return via `handleCloseFlyout`)
- Removed `chartRef` and related `focusTrapProps` (EUI's `EuiFocusTrap` handles this automatically in overlay mode)
- Removed `React.forwardRef` from `ChartItem` (dead code after `chartRef` removal)
- Conditioned `onKeyDown` ESC handler to only run in push mode (`isXlScreen`), since EUI handles ESC automatically in overlay mode

### Manual testing

- [ ] **Push mode (xl screen >1200px)**: Flyout opens as push, ESC closes it, focus returns to the correct metric cell
- [ ] **Overlay mode (<1200px)**: Flyout opens as overlay, ESC closes it (handled by EUI), focus returns correctly
- [ ] **Resize**: Resizing the flyout works correctly
- [ ] **Window resize transition**: Transitioning between push/overlay mode by resizing the window works correctly
- [ ] **Screen reader**: Description is announced correctly in push mode

### Demo

https://github.com/user-attachments/assets/e89e0588-335d-44dc-9a18-32d8684c3014

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



