### PR TITLE
[SharedUX] Enforce tours enablement check for search

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
@@ -15,6 +15,7 @@ import { EisCloudConnectPromoTour } from './eis_ccm_promotional_tour';
 import { useKibana } from '../hooks/use_kibana';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
 import * as i18n from '../translations';
+import { notificationServiceMock } from '@kbn/core/public/mocks';
 
 jest.mock('../hooks/use_show_eis_promotional_content');
 jest.mock('../hooks/use_kibana');
@@ -37,6 +38,7 @@ const mockUseKibana = (overrides?: Partial<any>) => {
           },
         },
       },
+      notifications: notificationServiceMock.createStartContract(),
       ...overrides,
     },
   });
@@ -98,6 +100,25 @@ describe('EisCloudConnectPromoTour', () => {
     });
 
     renderComponent({ isSelfManaged: false });
+
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('renders children and does not render the tour when tours is disabled', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true,
+      onDismissPromo: jest.fn(),
+    });
+    mockUseKibana({
+      notifications: {
+        tours: {
+          isEnabled: jest.fn().mockReturnValue(false),
+        },
+      },
+    });
+
+    renderComponent();
 
     expect(screen.getByTestId(childTestId)).toBeInTheDocument();
     expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
@@ -70,8 +70,9 @@ export const EisCloudConnectPromoTour = ({
 }: EisCloudConnectPromoTourProps) => {
   const { euiTheme } = useEuiTheme();
   const {
-    services: { application, uiSettings },
+    services: { application, notifications, uiSettings },
   } = useKibana();
+  const userAllowsTours = notifications?.tours?.isEnabled() ?? true;
   // Setting to enable hiding the tour for FTR tests
   const isEISTourEnabled = uiSettings?.get<boolean>(EIS_TOUR_ENABLED_FEATURE_FLAG_ID, true);
   const { isPromoVisible, onDismissPromo } = useShowEisPromotionalContent({
@@ -89,7 +90,8 @@ export const EisCloudConnectPromoTour = ({
     !isReady ||
     !isSelfManaged ||
     !hasCloudConnectPermission ||
-    !isEISTourEnabled
+    !isEISTourEnabled ||
+    !userAllowsTours
   ) {
     return children;
   }

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.test.tsx
@@ -17,6 +17,19 @@ import { EIS_PROMO_TOUR_TITLE, TOUR_CTA } from '../translations';
 
 jest.mock('../hooks/use_show_eis_promotional_content');
 
+const mockToursIsEnabled = jest.fn(() => true);
+jest.mock('../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    services: {
+      notifications: {
+        tours: {
+          isEnabled: mockToursIsEnabled,
+        },
+      },
+    },
+  }),
+}));
+
 describe('EisPromotionalTour', () => {
   const promoId = 'testPromo';
   const dataId = `${promoId}-eis-promo-tour`;
@@ -33,6 +46,7 @@ describe('EisPromotionalTour', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockToursIsEnabled.mockReturnValue(true);
   });
 
   it('renders children only when promo is not visible', () => {
@@ -40,6 +54,22 @@ describe('EisPromotionalTour', () => {
       isPromoVisible: false,
       onDismissPromo: jest.fn(),
     });
+
+    renderEisPromotionalTour();
+
+    // Child should render
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+
+    // Tour should not render
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('renders children and does not render the tour when tours is disabled', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true,
+      onDismissPromo: jest.fn(),
+    });
+    mockToursIsEnabled.mockReturnValue(false);
 
     renderEisPromotionalTour();
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
@@ -23,6 +23,7 @@ import {
   EIS_PROMO_TOUR_TITLE,
 } from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
+import { useKibana } from '../hooks/use_kibana';
 
 export interface EisPromotionalTourProps {
   anchorPosition?: EuiTourStepProps['anchorPosition'];
@@ -44,8 +45,12 @@ export const EisPromotionalTour = ({
     promoId: `${promoId}EisPromoTour`,
   });
   const dataId = `${promoId}-eis-promo-tour`;
+  const {
+    services: { notifications },
+  } = useKibana();
+  const isTourEnabled = notifications?.tours?.isEnabled() ?? true;
 
-  if (!isPromoVisible || !isCloudEnabled) {
+  if (!isPromoVisible || !isCloudEnabled || !isTourEnabled) {
     return children;
   }
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.test.tsx
@@ -17,6 +17,19 @@ import * as i18n from '../translations';
 
 jest.mock('../hooks/use_show_eis_promotional_content');
 
+const mockToursIsEnabled = jest.fn(() => true);
+jest.mock('../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    services: {
+      notifications: {
+        tours: {
+          isEnabled: mockToursIsEnabled,
+        },
+      },
+    },
+  }),
+}));
+
 describe('EisTokenCostTour', () => {
   const promoId = 'tokenPromo';
   const dataId = `${promoId}-eis-costs-tour`;
@@ -31,6 +44,7 @@ describe('EisTokenCostTour', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockToursIsEnabled.mockReturnValue(true);
   });
 
   it('renders children only when promo is not visible', () => {
@@ -60,6 +74,22 @@ describe('EisTokenCostTour', () => {
     expect(screen.getByTestId(childTestId)).toBeInTheDocument();
 
     // Tour should NOT be rendered even though promo is visible
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('renders children and does not render the tour when tours is disabled', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true, // would normally show the tour
+      onDismissPromo: jest.fn(),
+    });
+    mockToursIsEnabled.mockReturnValue(false);
+
+    renderComponent();
+
+    // Child should be rendered
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+
+    // Tour should NOT be rendered
     expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
   });
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import type { EuiTourStepProps } from '@elastic/eui';
 import { EuiButton, EuiButtonEmpty, EuiText, EuiTourStep, useEuiTheme } from '@elastic/eui';
+import { useKibana } from '../hooks/use_kibana';
 import * as i18n from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
 
@@ -59,8 +60,12 @@ export const EisTokenCostTour = ({
     promoId: `${promoId}EisCostsTour`,
   });
   const dataId = `${promoId}-eis-costs-tour`;
+  const {
+    services: { notifications },
+  } = useKibana();
+  const isTourEnabled = notifications?.tours?.isEnabled() ?? true;
 
-  if (!isPromoVisible || !isReady || !isCloudEnabled) {
+  if (!isPromoVisible || !isReady || !isCloudEnabled || !isTourEnabled) {
     return children;
   }
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/inference_costs_transparency_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/inference_costs_transparency_tour.test.tsx
@@ -17,6 +17,19 @@ import * as i18n from '../translations';
 
 jest.mock('../hooks/use_show_eis_promotional_content');
 
+const mockToursIsEnabled = jest.fn(() => true);
+jest.mock('../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    services: {
+      notifications: {
+        tours: {
+          isEnabled: mockToursIsEnabled,
+        },
+      },
+    },
+  }),
+}));
+
 describe('InferenceCostsTransparencyTour', () => {
   const promoId = 'tokenPromo';
   const dataId = `${promoId}-inference-costs-tour`;
@@ -33,6 +46,7 @@ describe('InferenceCostsTransparencyTour', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockToursIsEnabled.mockReturnValue(true);
   });
 
   it('renders children only when promo is not visible', () => {
@@ -62,6 +76,22 @@ describe('InferenceCostsTransparencyTour', () => {
     expect(screen.getByTestId(childTestId)).toBeInTheDocument();
 
     // Tour should NOT be rendered even though promo is visible
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('renders children and does not render the tour when tours is disabled', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true,
+      onDismissPromo: jest.fn(),
+    });
+    mockToursIsEnabled.mockReturnValue(false);
+
+    renderComponent();
+
+    // Child should be rendered
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+
+    // Tour should NOT be rendered
     expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
   });
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/inference_costs_transparency_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/inference_costs_transparency_tour.tsx
@@ -20,6 +20,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as i18n from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
+import { useKibana } from '../hooks/use_kibana';
 
 /**
  * Props for the InferenceCostsTransparencyTour component.
@@ -67,8 +68,12 @@ export const InferenceCostsTransparencyTour = ({
     promoId: `${promoId}InferenceCostsTransparencyTour`,
   });
   const dataId = `${promoId}-inference-costs-tour`;
+  const {
+    services: { notifications },
+  } = useKibana();
+  const isTourEnabled = notifications?.tours?.isEnabled() ?? true;
 
-  if (!isPromoVisible || !isReady || !isCloudEnabled) {
+  if (!isPromoVisible || !isReady || !isCloudEnabled || !isTourEnabled) {
     return children;
   }
 

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.test.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.test.tsx
@@ -36,15 +36,19 @@ jest.mock('@kbn/search-api-keys-components', () => ({
   useSearchApiKey: jest.fn().mockReturnValue({ apiKey: 'test-api-key' }),
 }));
 
-jest.mock('../../hooks/use_kibana', () => ({
-  useKibana: jest.fn().mockReturnValue({
-    services: {
-      application: {},
-      share: {},
-      console: {},
-    },
-  }),
-}));
+jest.mock('../../hooks/use_kibana', () => {
+  const { notificationServiceMock } = jest.requireActual('@kbn/core/public/mocks');
+  return {
+    useKibana: jest.fn().mockReturnValue({
+      services: {
+        application: {},
+        share: {},
+        console: {},
+        notifications: notificationServiceMock.createStartContract(),
+      },
+    }),
+  };
+});
 
 jest.mock('../../contexts/usage_tracker_context', () => ({
   useUsageTracker: jest.fn().mockReturnValue({

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/hooks/use_guide_tour.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/hooks/use_guide_tour.tsx
@@ -6,14 +6,17 @@
  */
 
 import { useState } from 'react';
+import { useKibana } from '../../../hooks/use_kibana';
 
 const GUIDE_TOUR_KEY = 'searchIndicesIngestDataGuideTour';
 
 export const useGuideTour = () => {
+  const { notifications } = useKibana().services;
+  const isTourEnabled = notifications.tours.isEnabled();
   const hasDismissedGuide = localStorage.getItem(GUIDE_TOUR_KEY) === 'dismissed';
   const [tourIsOpen, setTourIsOpen] = useState(!hasDismissedGuide);
   return {
-    tourIsOpen,
+    tourIsOpen: tourIsOpen && isTourEnabled,
     setTourIsOpen: (isOpen: boolean) => {
       setTourIsOpen(isOpen);
       localStorage.setItem(GUIDE_TOUR_KEY, isOpen ? '' : 'dismissed');

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_show_managed_llm_cost_tour.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_show_managed_llm_cost_tour.ts
@@ -13,23 +13,24 @@ import { AnalyticsEvents } from '../analytics/constants';
 
 export const useShowManagedLLMCostTour = () => {
   const usageTracker = useUsageTracker();
-  const { cloud } = useKibana().services;
+  const { cloud, notifications } = useKibana().services;
   const [isTourVisible, setIsTourVisible] = useState<boolean>(false);
   const onSkipTour = useCallback(() => {
     localStorage.setItem(ELASTIC_LLM_COST_TOUR_SKIP_KEY, 'true');
     setIsTourVisible(false);
     usageTracker?.click(AnalyticsEvents.closedCostTransparencyTour);
   }, [usageTracker]);
+  const isTourEnabled = notifications.tours.isEnabled();
 
   useEffect(() => {
     const isTourSkipped = localStorage.getItem(ELASTIC_LLM_COST_TOUR_SKIP_KEY) === 'true';
     const isCloud = cloud?.isServerlessEnabled ?? false;
 
-    if (!isTourSkipped && isCloud && !isTourVisible) {
+    if (!isTourSkipped && isCloud && !isTourVisible && isTourEnabled) {
       setIsTourVisible(true);
       usageTracker?.click(AnalyticsEvents.viewCostTransparencyTour);
     }
-  }, [cloud, isTourVisible, usageTracker]);
+  }, [cloud, isTourVisible, usageTracker, isTourEnabled]);
 
   return { isTourVisible, onSkipTour };
 };

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.test.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.test.tsx
@@ -50,30 +50,34 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn(() => ({ rulesetId: MOCK_QUERY_RULESET_RESPONSE_FIXTURE.ruleset_id })),
 }));
 
-jest.mock('../../hooks/use_kibana', () => ({
-  useKibana: () => ({
-    services: {
-      application: {
-        navigateToUrl: jest.fn(),
-        getUrlForApp: jest.fn().mockReturnValue('/app/test'),
-      },
-      http: {
-        basePath: {
-          prepend: jest.fn().mockImplementation((path) => `/base${path}`),
+jest.mock('../../hooks/use_kibana', () => {
+  const { notificationServiceMock } = jest.requireActual('@kbn/core/public/mocks');
+  return {
+    useKibana: () => ({
+      services: {
+        application: {
+          navigateToUrl: jest.fn(),
+          getUrlForApp: jest.fn().mockReturnValue('/app/test'),
         },
+        http: {
+          basePath: {
+            prepend: jest.fn().mockImplementation((path) => `/base${path}`),
+          },
+        },
+        overlays: {
+          openConfirm: jest.fn().mockResolvedValue(true),
+        },
+        history: {
+          block: jest.fn().mockReturnValue(jest.fn()),
+          listen: jest.fn().mockReturnValue(jest.fn()),
+        },
+        console: {},
+        share: {},
+        notifications: notificationServiceMock.createStartContract(),
       },
-      overlays: {
-        openConfirm: jest.fn().mockResolvedValue(true),
-      },
-      history: {
-        block: jest.fn().mockReturnValue(jest.fn()),
-        listen: jest.fn().mockReturnValue(jest.fn()),
-      },
-      console: {},
-      share: {},
-    },
-  }),
-}));
+    }),
+  };
+});
 
 jest.mock('@kbn/unsaved-changes-prompt', () => ({
   useUnsavedChangesPrompt: jest.fn(),

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.tsx
@@ -51,7 +51,7 @@ export interface QueryRulesetDetailProps {
 export const QueryRulesetDetail: React.FC<QueryRulesetDetailProps> = ({ createMode = false }) => {
   const { euiTheme } = useEuiTheme();
   const {
-    services: { application, http, history, overlays },
+    services: { application, http, history, notifications, overlays },
   } = useKibana();
   const { rulesetId = '' } = useParams<{
     rulesetId?: string;
@@ -102,6 +102,7 @@ export const QueryRulesetDetail: React.FC<QueryRulesetDetailProps> = ({ createMo
   const splitButtonPopoverActionsId = useGeneratedHtmlId({
     prefix: 'splitButtonPopoverActionsId',
   });
+  const isTourEnabled = notifications.tours.isEnabled();
   const TOUR_QUERY_RULES_STORAGE_KEY = 'queryRules.tour';
 
   const tourConfig = {
@@ -285,7 +286,9 @@ export const QueryRulesetDetail: React.FC<QueryRulesetDetailProps> = ({ createMo
               <EuiFlexItem grow={false}>
                 <EuiTourStep
                   content={<p>{tourStepsInfo[0].content}</p>}
-                  isStepOpen={tourState.isTourActive && tourState.currentTourStep === 1}
+                  isStepOpen={
+                    isTourEnabled && tourState.isTourActive && tourState.currentTourStep === 1
+                  }
                   minWidth={tourState.tourPopoverWidth}
                   onFinish={finishTour}
                   step={1}
@@ -425,7 +428,9 @@ export const QueryRulesetDetail: React.FC<QueryRulesetDetailProps> = ({ createMo
               <EuiTourStep
                 anchor={() => tourStepsInfo[1]?.tourTargetRef?.current || document.body}
                 content={<p>{tourStepsInfo[1].content}</p>}
-                isStepOpen={tourState.isTourActive && tourState.currentTourStep === 2}
+                isStepOpen={
+                  isTourEnabled && tourState.isTourActive && tourState.currentTourStep === 2
+                }
                 maxWidth={tourState.tourPopoverWidth}
                 onFinish={finishTour}
                 step={1}

--- a/x-pack/solutions/search/test/functional_search/tests/search_index_details.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/search_index_details.ts
@@ -71,7 +71,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           await searchSpace.navigateTo(spaceCreated.id);
           await pageObjects.searchNavigation.navigateToIndexDetailPage(indexWithoutDataName);
           await pageObjects.searchIndexDetailsPage.expectIndexDetailsPageIsLoaded();
-          await pageObjects.searchIndexDetailsPage.dismissIngestTourIfShown();
         });
         it('can load index detail page', async () => {
           await pageObjects.searchIndexDetailsPage.expectIndexDetailPageHeader();

--- a/x-pack/solutions/search/test/page_objects/search_index_details_page.ts
+++ b/x-pack/solutions/search/test/page_objects/search_index_details_page.ts
@@ -364,12 +364,5 @@ export function SearchIndexDetailPageProvider({ getService }: FtrProviderContext
       const isMappingsFieldEnabled = await testSubjects.isEnabled('indexDetailsMappingsAddField');
       expect(isMappingsFieldEnabled).to.be(true);
     },
-
-    async dismissIngestTourIfShown() {
-      if (await testSubjects.isDisplayed('searchIngestTourCloseButton')) {
-        await testSubjects.click('searchIngestTourCloseButton');
-        await testSubjects.missingOrFail('searchIngestTourCloseButton', { timeout: 2000 });
-      }
-    },
   };
 }

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/search_index_detail.ts
@@ -71,7 +71,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         it('can load index detail page', async () => {
           await pageObjects.searchIndexDetailsPage.expectIndexDetailPageHeader();
           await pageObjects.searchIndexDetailsPage.expectSearchIndexDetailsTabsExists();
-          await pageObjects.searchIndexDetailsPage.dismissIngestTourIfShown();
           await pageObjects.searchIndexDetailsPage.expectAPIReferenceDocLinkExists();
           await pageObjects.searchIndexDetailsPage.expectAPIReferenceDocLinkMissingInMoreOptions();
         });


### PR DESCRIPTION
## Summary

As part of [[Epic] Setting to disable feedback snippets, guided tours and announcements in Kibana](https://github.com/elastic/kibana/issues/234771) SharedUX has added two new `core.notifications` services for `feedback` and `tours`. Their `isEnabled()` API verifies if users should be shown that kind of elements by reading their preferences from global UI settings (`hideFeedback` and `hideAnnouncements`).

From now on, every feedback or tour component should call `isEnabled()` before rendering to honor user preferences. 

> [!IMPORTANT]
SharedUX will be opening PRs for existing occurrences per team. Each team should manually test their PR to verify toggling those settings results in the expected behavior. If your team owns more `feedback` or `tours` occurrences or are planning on doing so, this check needs to be added to honor user preferences.
>  

### Testing

**Feedback elements**
- This is a read-only setting, you need to override it via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`.
- Verify changing the setting value hides/render the element as expected.

**Tours/announcements elements**
- Toggle either the deprecated `hideAnnouncements` space setting or the global one on the Stack Management > Advanced Settings UI.
- Verify toggling the setting hides/render the element as expected.

Related PR: [[SharedUX] Add feedback and tours to core notifications](https://github.com/elastic/kibana/pull/248248)