### PR TITLE
Add workflow triggers for stream changes

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -128,16 +128,49 @@ export const ManualTriggerSchema = z.object({
   type: z.literal('manual'),
 });
 
+/**
+ * Stream change types that can trigger a workflow.
+ * These correspond to the different aspects of a stream that can be modified.
+ */
+export const StreamChangeTypeSchema = z.enum([
+  'mapping', // Field mappings changed
+  'processing', // Processing pipeline steps changed
+  'description', // Stream description changed
+  'settings', // Stream settings changed
+  'lifecycle', // Lifecycle policy changed
+  'failure_store', // Failure store configuration changed
+]);
+export type StreamChangeType = z.infer<typeof StreamChangeTypeSchema>;
+
+/**
+ * Trigger type for stream upsert (create/update) operations.
+ * Fires when a stream definition is created or updated.
+ */
+export const StreamsUpsertStreamTriggerSchema = z.object({
+  type: z.literal('streams.upsertStream'),
+  with: z
+    .object({
+      /** Stream name or pattern to watch. Supports wildcards (e.g., "logs-*") */
+      stream: z.string().min(1),
+      /** Optional array of change types to filter on. If empty, triggers on any change. */
+      changeTypes: z.array(StreamChangeTypeSchema).optional(),
+    })
+    .optional(),
+});
+export type StreamsUpsertStreamTrigger = z.infer<typeof StreamsUpsertStreamTriggerSchema>;
+
 export const TriggerSchema = z.discriminatedUnion('type', [
   AlertRuleTriggerSchema,
   ScheduledTriggerSchema,
   ManualTriggerSchema,
+  StreamsUpsertStreamTriggerSchema,
 ]);
 
 export const TriggerTypes = [
   AlertRuleTriggerSchema.shape.type.value,
   ScheduledTriggerSchema.shape.type.value,
   ManualTriggerSchema.shape.type.value,
+  StreamsUpsertStreamTriggerSchema.shape.type.value,
 ];
 export type TriggerType = (typeof TriggerTypes)[number];
 

--- a/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { z } from '@kbn/zod/v4';
+
+/**
+ * Common trigger definition fields shared between server and public.
+ * Config type is automatically inferred from the schema.
+ */
+export interface CommonTriggerDefinition<ConfigSchema extends z.ZodType = z.ZodType> {
+  /**
+   * Unique identifier for this trigger type.
+   * Should follow a namespaced format (e.g., "streams.upsertStream", "alerts.fired").
+   */
+  id: string;
+
+  /**
+   * Zod schema for validating trigger configuration (the `with` block).
+   * Defines the structure and validation rules for the trigger's parameters.
+   * The config type is automatically inferred from this schema.
+   */
+  configSchema: ConfigSchema;
+}

--- a/src/platform/plugins/shared/workflows_extensions/common/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/types.ts
@@ -8,12 +8,16 @@
  */
 
 import type { CommonStepDefinition } from './step_registry/types';
+import type { CommonTriggerDefinition } from './trigger_registry/types';
 
 /**
  * Common contract for workflows extensions start.
- * Exposes methods for retrieving registered step definitions.
+ * Exposes methods for retrieving registered step and trigger definitions.
  */
-export interface WorkflowsExtensionsStartContract<TStepDefinition extends CommonStepDefinition> {
+export interface WorkflowsExtensionsStartContract<
+  TStepDefinition extends CommonStepDefinition,
+  TTriggerDefinition extends CommonTriggerDefinition
+> {
   /**
    * Get all registered step definition.
    * @returns Array of all registered step definition
@@ -33,4 +37,24 @@ export interface WorkflowsExtensionsStartContract<TStepDefinition extends Common
    * @returns True if definition for the step type is registered, false otherwise
    */
   hasStepDefinition(stepTypeId: string): boolean;
+
+  /**
+   * Get all registered trigger definitions.
+   * @returns Array of all registered trigger definitions
+   */
+  getAllTriggerDefinitions(): TTriggerDefinition[];
+
+  /**
+   * Get definition for a specific trigger type.
+   * @param triggerTypeId - The trigger type identifier
+   * @returns The trigger definition, or undefined if not found
+   */
+  getTriggerDefinition(triggerTypeId: string): TTriggerDefinition | undefined;
+
+  /**
+   * Check if definition for a trigger type is registered.
+   * @param triggerTypeId - The trigger type identifier
+   * @returns True if definition for the trigger type is registered, false otherwise
+   */
+  hasTriggerDefinition(triggerTypeId: string): boolean;
 }

--- a/src/platform/plugins/shared/workflows_extensions/public/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/index.ts
@@ -23,3 +23,7 @@ export type { PublicStepDefinition, StepDocumentation } from './step_registry/ty
 export { ActionsMenuGroup } from './step_registry/types';
 
 export { createPublicStepDefinition } from './step_registry/types';
+
+export type { PublicTriggerDefinition, TriggerDocumentation } from './trigger_registry/types';
+
+export { createPublicTriggerDefinition } from './trigger_registry/types';

--- a/src/platform/plugins/shared/workflows_extensions/public/mocks.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/mocks.ts
@@ -8,22 +8,27 @@
  */
 
 import type { PublicStepDefinition } from './step_registry/types';
+import type { PublicTriggerDefinition } from './trigger_registry/types';
 import type { WorkflowsExtensionsPublicPluginSetup } from './types';
 import type { WorkflowsExtensionsStartContract } from '../common/types';
 
 const createSetupMock: () => jest.Mocked<WorkflowsExtensionsPublicPluginSetup> = () => {
   return {
     registerStepDefinition: jest.fn(),
+    registerTriggerDefinition: jest.fn(),
   };
 };
 
 const createStartMock: () => jest.Mocked<
-  WorkflowsExtensionsStartContract<PublicStepDefinition>
+  WorkflowsExtensionsStartContract<PublicStepDefinition, PublicTriggerDefinition>
 > = () => {
   return {
     getStepDefinition: jest.fn(),
     hasStepDefinition: jest.fn(),
     getAllStepDefinitions: jest.fn(() => []),
+    getTriggerDefinition: jest.fn(),
+    hasTriggerDefinition: jest.fn(),
+    getAllTriggerDefinitions: jest.fn(() => []),
   };
 };
 

--- a/src/platform/plugins/shared/workflows_extensions/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/plugin.ts
@@ -9,7 +9,9 @@
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import { PublicStepRegistry } from './step_registry';
+import { PublicTriggerRegistry } from './trigger_registry';
 import type { PublicStepDefinition } from './step_registry/types';
+import type { PublicTriggerDefinition } from './trigger_registry/types';
 import { registerInternalStepDefinitions } from './steps';
 import type {
   WorkflowsExtensionsPublicPluginSetup,
@@ -28,9 +30,11 @@ export class WorkflowsExtensionsPublicPlugin
     >
 {
   private readonly stepRegistry: PublicStepRegistry;
+  private readonly triggerRegistry: PublicTriggerRegistry;
 
   constructor(_initializerContext: PluginInitializerContext) {
     this.stepRegistry = new PublicStepRegistry();
+    this.triggerRegistry = new PublicTriggerRegistry();
   }
 
   public setup(
@@ -43,6 +47,10 @@ export class WorkflowsExtensionsPublicPlugin
       registerStepDefinition: (metadata) => {
         // Casting here to prevent type errors with a narrow type definition and to avoid forcing consumers to cast manually
         this.stepRegistry.register(metadata as PublicStepDefinition);
+      },
+      registerTriggerDefinition: (definition) => {
+        // Casting here to prevent type errors with a narrow type definition and to avoid forcing consumers to cast manually
+        this.triggerRegistry.register(definition as PublicTriggerDefinition);
       },
     };
   }
@@ -60,6 +68,15 @@ export class WorkflowsExtensionsPublicPlugin
       },
       hasStepDefinition: (stepTypeId: string) => {
         return this.stepRegistry.has(stepTypeId);
+      },
+      getAllTriggerDefinitions: () => {
+        return this.triggerRegistry.getAll();
+      },
+      getTriggerDefinition: (triggerTypeId: string) => {
+        return this.triggerRegistry.get(triggerTypeId);
+      },
+      hasTriggerDefinition: (triggerTypeId: string) => {
+        return this.triggerRegistry.has(triggerTypeId);
       },
     };
   }

--- a/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/index.ts
@@ -7,6 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { CommonStepDefinition } from './step_registry/types';
-export type { CommonTriggerDefinition } from './trigger_registry/types';
-export { DataMapStepTypeId } from './steps/data';
+export { PublicTriggerRegistry } from './trigger_registry';
+export type { PublicTriggerDefinition, TriggerDocumentation } from './types';
+export { createPublicTriggerDefinition } from './types';

--- a/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/trigger_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/trigger_registry.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod/v4';
+import { PublicTriggerRegistry } from './trigger_registry';
+import type { PublicTriggerDefinition } from './types';
+
+const triggerId = 'streams.upsertStream';
+const defaultDefinition: PublicTriggerDefinition = {
+  id: triggerId,
+  configSchema: z.object({ stream: z.string(), changeTypes: z.array(z.string()).optional() }),
+  label: 'Stream Upsert Trigger',
+  description: 'Triggers when a stream is created or updated',
+};
+
+describe('PublicTriggerRegistry', () => {
+  let registry: PublicTriggerRegistry;
+
+  beforeEach(() => {
+    registry = new PublicTriggerRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a trigger definition', () => {
+      registry.register(defaultDefinition);
+
+      expect(registry.has(triggerId)).toBe(true);
+      expect(registry.get(triggerId)).toBe(defaultDefinition);
+    });
+
+    it('should throw an error if a trigger with the same ID is already registered', () => {
+      registry.register(defaultDefinition);
+
+      expect(() => {
+        registry.register(defaultDefinition);
+      }).toThrow('Trigger definition for type "streams.upsertStream" is already registered');
+    });
+  });
+
+  describe('get', () => {
+    it('should return the definition for a registered trigger', () => {
+      registry.register(defaultDefinition);
+
+      const definition = registry.get(triggerId);
+      expect(definition?.label).toBe('Stream Upsert Trigger');
+      expect(definition?.description).toBe('Triggers when a stream is created or updated');
+    });
+
+    it('should return undefined for an unregistered trigger', () => {
+      expect(registry.get('unknown.trigger')).toBeUndefined();
+    });
+  });
+
+  describe('has', () => {
+    it('should return true for a registered trigger', () => {
+      registry.register(defaultDefinition);
+
+      expect(registry.has(triggerId)).toBe(true);
+    });
+
+    it('should return false for an unregistered trigger', () => {
+      expect(registry.has('unknown.trigger')).toBe(false);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all registered trigger definitions', () => {
+      registry.register({ ...defaultDefinition, id: 'streams.trigger1', label: 'Trigger 1' });
+      registry.register({ ...defaultDefinition, id: 'streams.trigger2', label: 'Trigger 2' });
+      registry.register({ ...defaultDefinition, id: 'custom.trigger3', label: 'Trigger 3' });
+
+      const allTriggers = registry.getAll();
+      const allIds = allTriggers.map((trigger) => trigger.id);
+
+      expect(allIds).toHaveLength(3);
+      expect(allIds[0]).toBe('streams.trigger1');
+      expect(allIds[1]).toBe('streams.trigger2');
+      expect(allIds[2]).toBe('custom.trigger3');
+    });
+
+    it('should return an empty array when no triggers are registered', () => {
+      const allTriggers = registry.getAll();
+      expect(allTriggers).toEqual([]);
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/trigger_registry.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/trigger_registry.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PublicTriggerDefinition } from './types';
+
+/**
+ * Registry for public-side workflow trigger definitions.
+ * Stores UI-related information (label, description, icon) for trigger types.
+ */
+export class PublicTriggerRegistry {
+  private readonly registry = new Map<string, PublicTriggerDefinition>();
+
+  /**
+   * Register trigger definition.
+   * @param definition - The trigger definition to register
+   * @throws Error if definition for the same trigger type ID is already registered
+   */
+  public register(definition: PublicTriggerDefinition): void {
+    const triggerTypeId = String(definition.id);
+    if (this.registry.has(triggerTypeId)) {
+      throw new Error(
+        `Trigger definition for type "${triggerTypeId}" is already registered. Each trigger type must have unique definition.`
+      );
+    }
+    this.registry.set(triggerTypeId, definition);
+  }
+
+  /**
+   * Get definition for a specific trigger type.
+   * @param triggerTypeId - The trigger type identifier
+   * @returns The trigger definition, or undefined if not found
+   */
+  public get(triggerTypeId: string): PublicTriggerDefinition | undefined {
+    return this.registry.get(triggerTypeId);
+  }
+
+  /**
+   * Check if definition for a trigger type is registered.
+   * @param triggerTypeId - The trigger type identifier
+   * @returns True if definition for the trigger type is registered, false otherwise
+   */
+  public has(triggerTypeId: string): boolean {
+    return this.registry.has(triggerTypeId);
+  }
+
+  /**
+   * Get all registered trigger definitions.
+   * @returns Array of all registered trigger definitions
+   */
+  public getAll(): PublicTriggerDefinition[] {
+    return Array.from(this.registry.values());
+  }
+}

--- a/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/types.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { z } from '@kbn/zod/v4';
+import type { CommonTriggerDefinition } from '../../common/trigger_registry/types';
+
+/**
+ * Helper function to create a PublicTriggerDefinition with automatic type inference.
+ * This ensures that the config type is correctly inferred from the configSchema
+ * without needing explicit type annotations.
+ */
+export function createPublicTriggerDefinition<Config extends z.ZodType = z.ZodType>(
+  definition: PublicTriggerDefinition<Config>
+): PublicTriggerDefinition<Config> {
+  return definition;
+}
+
+/**
+ * User-facing metadata for a workflow trigger.
+ * This is used by the UI to display trigger information (label, description, icon, schemas, documentation).
+ */
+export interface PublicTriggerDefinition<Config extends z.ZodType = z.ZodType>
+  extends CommonTriggerDefinition<Config> {
+  /**
+   * User-facing label/title for this trigger type.
+   * Displayed in the UI when selecting or viewing triggers.
+   */
+  label: string;
+
+  /**
+   * User-facing description of what this trigger does.
+   * Displayed as help text or in tooltips.
+   */
+  description?: string;
+
+  /**
+   * Icon type from EUI icon library.
+   * Used to visually represent this trigger type in the UI.
+   * Kibana icon will be used if not provided.
+   */
+  icon?: React.ComponentType;
+
+  /**
+   * Documentation for the trigger, including details and examples.
+   */
+  documentation?: TriggerDocumentation;
+}
+
+/**
+ * Documentation information for a workflow trigger.
+ */
+export interface TriggerDocumentation {
+  /**
+   * Detailed description with usage examples (markdown supported)
+   * @example "This trigger fires when a stream definition is created or updated."
+   */
+  details?: string;
+
+  /**
+   * External documentation URL
+   * @example "https://docs.example.com/triggers/stream-change"
+   */
+  url?: string;
+
+  /**
+   * Usage examples in YAML format
+   * @example
+   * ```yaml
+   * triggers:
+   *   - type: streams.upsertStream
+   *     with:
+   *       stream: "logs-*"
+   *       changeTypes: ["mapping", "processing"]
+   * ```
+   */
+  examples?: string[];
+}

--- a/src/platform/plugins/shared/workflows_extensions/public/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/types.ts
@@ -9,11 +9,12 @@
 
 import type { z } from '@kbn/zod/v4';
 import type { PublicStepDefinition } from './step_registry/types';
+import type { PublicTriggerDefinition } from './trigger_registry/types';
 import type { WorkflowsExtensionsStartContract } from '../common/types';
 
 /**
  * Public-side plugin setup contract.
- * Exposes methods for other plugins to register public-side step definition.
+ * Exposes methods for other plugins to register public-side step and trigger definitions.
  */
 
 export interface WorkflowsExtensionsPublicPluginSetup {
@@ -31,14 +32,27 @@ export interface WorkflowsExtensionsPublicPluginSetup {
   >(
     definition: PublicStepDefinition<Input, Output, Config>
   ): void;
+
+  /**
+   * Register user-facing definition for a workflow trigger.
+   * This should be called during the plugin's setup phase.
+   *
+   * @param definition - The public-side trigger definition
+   * @throws Error if definition for the same trigger type ID is already registered
+   */
+  registerTriggerDefinition<Config extends z.ZodType = z.ZodType>(
+    definition: PublicTriggerDefinition<Config>
+  ): void;
 }
 
 /**
  * Public-side plugin start contract.
- * Exposes methods for retrieving registered public-side step definition.
+ * Exposes methods for retrieving registered public-side step and trigger definitions.
  */
-export type WorkflowsExtensionsPublicPluginStart =
-  WorkflowsExtensionsStartContract<PublicStepDefinition>;
+export type WorkflowsExtensionsPublicPluginStart = WorkflowsExtensionsStartContract<
+  PublicStepDefinition,
+  PublicTriggerDefinition
+>;
 
 /**
  * Dependencies for the public plugin setup phase.

--- a/src/platform/plugins/shared/workflows_extensions/server/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/index.ts
@@ -33,3 +33,14 @@ export type {
 } from './step_registry/types';
 
 export { createServerStepDefinition } from './step_registry/types';
+
+export type {
+  ServerTriggerDefinition,
+  TriggerEventData,
+  TriggerMatchResult,
+  TriggerMatcher,
+} from './trigger_registry/types';
+
+export { createServerTriggerDefinition } from './trigger_registry/types';
+
+export type { StreamsUpsertStreamEventPayload } from './triggers';

--- a/src/platform/plugins/shared/workflows_extensions/server/mocks.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/mocks.ts
@@ -8,22 +8,27 @@
  */
 
 import type { ServerStepDefinition } from './step_registry/types';
+import type { ServerTriggerDefinition } from './trigger_registry/types';
 import type { WorkflowsExtensionsServerPluginSetup } from './types';
 import type { WorkflowsExtensionsStartContract } from '../common/types';
 
 const createSetupMock: () => jest.Mocked<WorkflowsExtensionsServerPluginSetup> = () => {
   return {
     registerStepDefinition: jest.fn(),
+    registerTriggerDefinition: jest.fn(),
   };
 };
 
 const createStartMock: () => jest.Mocked<
-  WorkflowsExtensionsStartContract<ServerStepDefinition>
+  WorkflowsExtensionsStartContract<ServerStepDefinition, ServerTriggerDefinition>
 > = () => {
   return {
     getStepDefinition: jest.fn(),
     hasStepDefinition: jest.fn(),
     getAllStepDefinitions: jest.fn(),
+    getTriggerDefinition: jest.fn(),
+    hasTriggerDefinition: jest.fn(),
+    getAllTriggerDefinitions: jest.fn(),
   };
 };
 

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/index.ts
@@ -7,6 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { CommonStepDefinition } from './step_registry/types';
-export type { CommonTriggerDefinition } from './trigger_registry/types';
-export { DataMapStepTypeId } from './steps/data';
+export { ServerTriggerRegistry } from './trigger_registry';
+export type {
+  ServerTriggerDefinition,
+  TriggerEventData,
+  TriggerMatchResult,
+  TriggerMatcher,
+} from './types';
+export { createServerTriggerDefinition } from './types';

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ServerTriggerRegistry } from './trigger_registry';
+import type { ServerTriggerDefinition, TriggerEventData, TriggerMatchResult } from './types';
+
+const triggerId = 'streams.upsertStream';
+const mockMatcher = jest.fn(
+  (_config: unknown, _event: TriggerEventData): TriggerMatchResult => ({
+    matches: true,
+    workflowInputs: {},
+  })
+);
+const defaultDefinition: ServerTriggerDefinition = {
+  id: triggerId,
+  configSchema: z.object({ stream: z.string(), changeTypes: z.array(z.string()).optional() }),
+  matches: mockMatcher,
+};
+
+describe('ServerTriggerRegistry', () => {
+  let registry: ServerTriggerRegistry;
+
+  beforeEach(() => {
+    registry = new ServerTriggerRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a trigger definition', () => {
+      registry.register(defaultDefinition);
+
+      expect(registry.has(triggerId)).toBe(true);
+      expect(registry.get(triggerId)).toBe(defaultDefinition);
+    });
+
+    it('should throw an error if a trigger with the same ID is already registered', () => {
+      registry.register(defaultDefinition);
+
+      expect(() => {
+        registry.register(defaultDefinition);
+      }).toThrow('Trigger type "streams.upsertStream" is already registered');
+    });
+  });
+
+  describe('get', () => {
+    it('should return the definition for a registered trigger', () => {
+      registry.register(defaultDefinition);
+
+      expect(registry.get(triggerId)).toBe(defaultDefinition);
+    });
+
+    it('should return undefined for an unregistered trigger', () => {
+      expect(registry.get('unknown.trigger')).toBeUndefined();
+    });
+  });
+
+  describe('has', () => {
+    it('should return true for a registered trigger', () => {
+      registry.register(defaultDefinition);
+
+      expect(registry.has(triggerId)).toBe(true);
+    });
+
+    it('should return false for an unregistered trigger', () => {
+      expect(registry.has('unknown.trigger')).toBe(false);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all registered trigger definitions', () => {
+      registry.register({ ...defaultDefinition, id: 'streams.trigger1' });
+      registry.register({ ...defaultDefinition, id: 'streams.trigger2' });
+      registry.register({ ...defaultDefinition, id: 'custom.trigger3' });
+
+      const allTriggers = registry.getAll();
+      const allIds = allTriggers.map((trigger) => trigger.id);
+
+      expect(allIds).toHaveLength(3);
+      expect(allIds[0]).toBe('streams.trigger1');
+      expect(allIds[1]).toBe('streams.trigger2');
+      expect(allIds[2]).toBe('custom.trigger3');
+    });
+
+    it('should return an empty array when no triggers are registered', () => {
+      const allTriggers = registry.getAll();
+      expect(allTriggers).toEqual([]);
+    });
+  });
+
+  describe('trigger matcher', () => {
+    it('should allow invoking the matches function on a registered trigger', () => {
+      registry.register(defaultDefinition);
+
+      const trigger = registry.get(triggerId);
+      expect(trigger).toBeDefined();
+
+      const eventData: TriggerEventData = {
+        type: triggerId,
+        payload: { streamName: 'logs-test', changeTypes: ['mapping'] },
+      };
+
+      const result = trigger!.matches({ stream: 'logs-*' }, eventData);
+      expect(mockMatcher).toHaveBeenCalledWith({ stream: 'logs-*' }, eventData);
+      expect(result.matches).toBe(true);
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ServerTriggerDefinition } from './types';
+
+/**
+ * Registry for server-side workflow trigger implementations.
+ * Stores trigger definitions and configurations.
+ */
+export class ServerTriggerRegistry {
+  private readonly registry = new Map<string, ServerTriggerDefinition>();
+
+  /**
+   * Register a trigger definition.
+   * @param definition - The trigger definition to register
+   * @throws Error if a trigger with the same ID is already registered
+   */
+  public register(definition: ServerTriggerDefinition): void {
+    const triggerTypeId = String(definition.id);
+    if (this.registry.has(triggerTypeId)) {
+      throw new Error(
+        `Trigger type "${triggerTypeId}" is already registered. Each trigger type must have a unique identifier.`
+      );
+    }
+    this.registry.set(triggerTypeId, definition);
+  }
+
+  /**
+   * Get a trigger definition for a given trigger type ID.
+   * @param triggerTypeId - The trigger type identifier
+   * @returns The trigger definition, or undefined if not found
+   */
+  public get(triggerTypeId: string): ServerTriggerDefinition | undefined {
+    return this.registry.get(triggerTypeId);
+  }
+
+  /**
+   * Check if a trigger type is registered.
+   * @param triggerTypeId - The trigger type identifier
+   * @returns True if the trigger type is registered, false otherwise
+   */
+  public has(triggerTypeId: string): boolean {
+    return this.registry.has(triggerTypeId);
+  }
+
+  /**
+   * Get all registered trigger definitions.
+   * @returns Array of registered trigger definitions
+   */
+  public getAll(): ServerTriggerDefinition[] {
+    return Array.from(this.registry.values());
+  }
+}

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/types.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { z } from '@kbn/zod/v4';
+import type { CommonTriggerDefinition } from '../../common/trigger_registry/types';
+
+/**
+ * Event data passed to trigger handlers when evaluating matches.
+ * This is a generic interface that can be extended for specific trigger types.
+ */
+export interface TriggerEventData {
+  /** The type of event (should match the trigger type, e.g., 'streams.upsertStream') */
+  type: string;
+  /** Event-specific payload data */
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Result of a trigger match evaluation.
+ */
+export interface TriggerMatchResult {
+  /** Whether the trigger matches the event */
+  matches: boolean;
+  /** Optional inputs to pass to the workflow when it runs */
+  workflowInputs?: Record<string, unknown>;
+}
+
+/**
+ * Function type for evaluating if an event matches a trigger configuration.
+ */
+export type TriggerMatcher<Config = unknown> = (
+  triggerConfig: Config | undefined,
+  eventData: TriggerEventData
+) => TriggerMatchResult;
+
+/**
+ * Definition of a server-side workflow trigger extension.
+ * Contains the technical/behavioral implementation of a trigger.
+ *
+ * The config type is automatically inferred from the configSchema,
+ * so you don't need to specify it explicitly. Use `createServerTriggerDefinition` helper function
+ * for the best type inference experience.
+ *
+ * @example
+ * ```typescript
+ * // Using the helper function (recommended for best type inference)
+ * const myTriggerDefinition = createServerTriggerDefinition({
+ *   id: 'streams.upsertStream',
+ *   configSchema: z.object({ stream: z.string(), changeTypes: z.array(z.string()).optional() }),
+ *   matches: (config, event) => {
+ *     // Evaluate if the event matches this trigger's configuration
+ *     return { matches: true, workflowInputs: { stream: event.payload.streamName } };
+ *   },
+ * });
+ * ```
+ */
+export interface ServerTriggerDefinition<Config extends z.ZodType = z.ZodType>
+  extends CommonTriggerDefinition<Config> {
+  /**
+   * Function to evaluate if an event matches this trigger's configuration.
+   * Called when a trigger event occurs to determine which workflows should run.
+   *
+   * @param triggerConfig - The parsed trigger configuration from the workflow definition (the `with` block)
+   * @param eventData - The event data that triggered the evaluation
+   * @returns Whether the trigger matches and optional workflow inputs
+   */
+  matches: TriggerMatcher<z.infer<Config>>;
+}
+
+/**
+ * Helper function to create a ServerTriggerDefinition with automatic type inference.
+ * This ensures that the config type is correctly inferred from the configSchema
+ * without needing explicit type annotations.
+ *
+ * @example
+ * ```typescript
+ * const myTriggerDefinition = createServerTriggerDefinition({
+ *   id: 'streams.upsertStream',
+ *   configSchema: z.object({ stream: z.string() }),
+ *   matches: (config, event) => ({ matches: true }),
+ * });
+ * ```
+ */
+export function createServerTriggerDefinition<Config extends z.ZodType = z.ZodType>(
+  definition: ServerTriggerDefinition<Config>
+): ServerTriggerDefinition<Config> {
+  return definition;
+}

--- a/src/platform/plugins/shared/workflows_extensions/server/triggers/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/triggers/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { streamsUpsertStreamTriggerDefinition } from './streams_upsert_stream_trigger';
+import type { ServerTriggerRegistry } from '../trigger_registry';
+
+/**
+ * Register all internal trigger definitions.
+ */
+export function registerInternalTriggerDefinitions(triggerRegistry: ServerTriggerRegistry): void {
+  triggerRegistry.register(streamsUpsertStreamTriggerDefinition);
+}
+
+export { streamsUpsertStreamTriggerDefinition };
+export type { StreamsUpsertStreamEventPayload } from './streams_upsert_stream_trigger';

--- a/src/platform/plugins/shared/workflows_extensions/server/triggers/streams_upsert_stream_trigger.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/triggers/streams_upsert_stream_trigger.test.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  type StreamsUpsertStreamEventPayload,
+  streamsUpsertStreamTriggerDefinition,
+} from './streams_upsert_stream_trigger';
+import type { TriggerEventData } from '../trigger_registry/types';
+
+describe('streamsUpsertStreamTriggerDefinition', () => {
+  const createEventData = (
+    payload: Partial<StreamsUpsertStreamEventPayload>
+  ): TriggerEventData => ({
+    type: 'streams.upsertStream',
+    payload: {
+      streamName: 'logs-test',
+      changeTypes: ['mapping'],
+      isCreated: false,
+      ...payload,
+    } as unknown as Record<string, unknown>,
+  });
+
+  describe('id and configSchema', () => {
+    it('should have the correct trigger id', () => {
+      expect(streamsUpsertStreamTriggerDefinition.id).toBe('streams.upsertStream');
+    });
+
+    it('should have a valid configSchema', () => {
+      expect(streamsUpsertStreamTriggerDefinition.configSchema).toBeDefined();
+    });
+  });
+
+  describe('matches function', () => {
+    describe('without configuration', () => {
+      it('should match all stream upsert events when no config is provided', () => {
+        const eventData = createEventData({ streamName: 'any-stream' });
+        const result = streamsUpsertStreamTriggerDefinition.matches(undefined, eventData);
+
+        expect(result.matches).toBe(true);
+        expect(result.workflowInputs).toEqual({
+          stream: {
+            name: 'any-stream',
+            changeTypes: ['mapping'],
+            isCreated: false,
+            definition: undefined,
+          },
+        });
+      });
+    });
+
+    describe('stream pattern matching', () => {
+      it('should match exact stream name', () => {
+        const config = { stream: 'logs-test' };
+        const eventData = createEventData({ streamName: 'logs-test' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should not match different stream name', () => {
+        const config = { stream: 'logs-production' };
+        const eventData = createEventData({ streamName: 'logs-test' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(false);
+      });
+
+      it('should match wildcard pattern at the end', () => {
+        const config = { stream: 'logs-*' };
+        const eventData = createEventData({ streamName: 'logs-test' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should match wildcard pattern at the beginning', () => {
+        const config = { stream: '*-production' };
+        const eventData = createEventData({ streamName: 'logs-production' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should match wildcard pattern in the middle', () => {
+        const config = { stream: 'logs-*-production' };
+        const eventData = createEventData({ streamName: 'logs-web-production' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should match multiple wildcards', () => {
+        const config = { stream: '*-*-*' };
+        const eventData = createEventData({ streamName: 'logs-web-production' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should match single wildcard for all streams', () => {
+        const config = { stream: '*' };
+        const eventData = createEventData({ streamName: 'anything-goes' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should not match partial wildcard incorrectly', () => {
+        const config = { stream: 'logs-*' };
+        const eventData = createEventData({ streamName: 'metrics-test' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(false);
+      });
+
+      it('should escape regex special characters in pattern', () => {
+        const config = { stream: 'logs.test' };
+        const eventData = createEventData({ streamName: 'logs.test' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should not match when pattern has special chars but stream does not', () => {
+        const config = { stream: 'logs.test' };
+        const eventData = createEventData({ streamName: 'logsXtest' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(false);
+      });
+    });
+
+    describe('changeTypes filtering', () => {
+      it('should match when change type matches', () => {
+        const config = { stream: 'logs-*', changeTypes: ['mapping' as const] };
+        const eventData = createEventData({
+          streamName: 'logs-test',
+          changeTypes: ['mapping'],
+        });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should match when any change type matches', () => {
+        const config = {
+          stream: 'logs-*',
+          changeTypes: ['mapping' as const, 'processing' as const],
+        };
+        const eventData = createEventData({
+          streamName: 'logs-test',
+          changeTypes: ['processing', 'description'],
+        });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should not match when no change type matches', () => {
+        const config = { stream: 'logs-*', changeTypes: ['mapping' as const] };
+        const eventData = createEventData({
+          streamName: 'logs-test',
+          changeTypes: ['processing', 'description'],
+        });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(false);
+      });
+
+      it('should match any change when changeTypes is empty', () => {
+        const config = { stream: 'logs-*', changeTypes: [] };
+        const eventData = createEventData({
+          streamName: 'logs-test',
+          changeTypes: ['processing'],
+        });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+
+      it('should match any change when changeTypes is not specified', () => {
+        const config = { stream: 'logs-*' };
+        const eventData = createEventData({
+          streamName: 'logs-test',
+          changeTypes: ['description', 'settings'],
+        });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+      });
+    });
+
+    describe('workflow inputs', () => {
+      it('should include stream information in workflow inputs', () => {
+        const streamDefinition = { name: 'logs-test', ingest: { processing: [] } };
+        const config = { stream: 'logs-*' };
+        const eventData = createEventData({
+          streamName: 'logs-test',
+          changeTypes: ['mapping', 'processing'],
+          isCreated: true,
+          streamDefinition,
+        });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(true);
+        expect(result.workflowInputs).toEqual({
+          stream: {
+            name: 'logs-test',
+            changeTypes: ['mapping', 'processing'],
+            isCreated: true,
+            definition: streamDefinition,
+          },
+        });
+      });
+
+      it('should not include workflow inputs when match fails', () => {
+        const config = { stream: 'other-*' };
+        const eventData = createEventData({ streamName: 'logs-test' });
+
+        const result = streamsUpsertStreamTriggerDefinition.matches(config, eventData);
+
+        expect(result.matches).toBe(false);
+        expect(result.workflowInputs).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/server/triggers/streams_upsert_stream_trigger.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/triggers/streams_upsert_stream_trigger.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { StreamChangeTypeSchema } from '@kbn/workflows';
+import { StreamsUpsertStreamTriggerSchema } from '@kbn/workflows';
+import type { z } from '@kbn/zod/v4';
+import { createServerTriggerDefinition } from '../trigger_registry/types';
+import type { TriggerEventData, TriggerMatchResult } from '../trigger_registry/types';
+
+/**
+ * Event payload for stream upsert events.
+ */
+export interface StreamsUpsertStreamEventPayload {
+  /** The name of the stream that was changed */
+  streamName: string;
+  /** The types of changes that occurred */
+  changeTypes: string[];
+  /** Whether the stream was created (true) or updated (false) */
+  isCreated: boolean;
+  /** The stream definition after the change */
+  streamDefinition?: Record<string, unknown>;
+}
+
+/**
+ * Get the config schema from the workflow schema.
+ * This extracts the `with` property schema from StreamsUpsertStreamTriggerSchema.
+ */
+const configSchema = StreamsUpsertStreamTriggerSchema.shape.with.unwrap();
+
+/**
+ * Type for the trigger configuration.
+ */
+type StreamsUpsertStreamConfig = z.infer<typeof configSchema>;
+
+/**
+ * Check if a stream name matches a pattern.
+ * Supports wildcards (*) for pattern matching.
+ *
+ * @param pattern - The pattern to match against (e.g., "logs-*", "metrics-*-production")
+ * @param streamName - The stream name to check
+ * @returns Whether the stream name matches the pattern
+ */
+function matchesStreamPattern(pattern: string, streamName: string): boolean {
+  // Escape regex special characters except *
+  const escapedPattern = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  // Convert * to regex wildcard
+  const regexPattern = escapedPattern.replace(/\*/g, '.*');
+  const regex = new RegExp(`^${regexPattern}$`);
+  return regex.test(streamName);
+}
+
+/**
+ * Matcher function for streams.upsertStream trigger.
+ * Evaluates if an event matches the trigger configuration.
+ */
+function matchesStreamsUpsertStreamTrigger(
+  triggerConfig: StreamsUpsertStreamConfig | undefined,
+  eventData: TriggerEventData
+): TriggerMatchResult {
+  const payload = eventData.payload as unknown as StreamsUpsertStreamEventPayload;
+
+  // If no config is provided, match all stream upsert events
+  if (!triggerConfig) {
+    return {
+      matches: true,
+      workflowInputs: {
+        stream: {
+          name: payload.streamName,
+          changeTypes: payload.changeTypes,
+          isCreated: payload.isCreated,
+          definition: payload.streamDefinition,
+        },
+      },
+    };
+  }
+
+  // Check if stream name matches the pattern
+  if (triggerConfig.stream && !matchesStreamPattern(triggerConfig.stream, payload.streamName)) {
+    return { matches: false };
+  }
+
+  // Check if change types match (if specified)
+  const configChangeTypes = triggerConfig.changeTypes;
+  if (configChangeTypes && configChangeTypes.length > 0) {
+    const hasMatchingChangeType = payload.changeTypes.some((changeType) =>
+      configChangeTypes.includes(changeType as z.infer<typeof StreamChangeTypeSchema>)
+    );
+
+    if (!hasMatchingChangeType) {
+      return { matches: false };
+    }
+  }
+
+  // All conditions match
+  return {
+    matches: true,
+    workflowInputs: {
+      stream: {
+        name: payload.streamName,
+        changeTypes: payload.changeTypes,
+        isCreated: payload.isCreated,
+        definition: payload.streamDefinition,
+      },
+    },
+  };
+}
+
+/**
+ * Server-side trigger definition for streams.upsertStream.
+ * This trigger fires when a stream is created or updated.
+ */
+export const streamsUpsertStreamTriggerDefinition = createServerTriggerDefinition({
+  id: 'streams.upsertStream',
+  configSchema,
+  matches: matchesStreamsUpsertStreamTrigger,
+});

--- a/src/platform/plugins/shared/workflows_extensions/server/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/types.ts
@@ -10,11 +10,12 @@
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { ServerStepDefinition } from './step_registry/types';
+import type { ServerTriggerDefinition } from './trigger_registry/types';
 import type { WorkflowsExtensionsStartContract } from '../common/types';
 
 /**
  * Server-side plugin setup contract.
- * Exposes methods for other plugins to register server-side custom workflow steps.
+ * Exposes methods for other plugins to register server-side custom workflow steps and triggers.
  */
 export interface WorkflowsExtensionsServerPluginSetup {
   /**
@@ -25,14 +26,25 @@ export interface WorkflowsExtensionsServerPluginSetup {
    * @throws Error if definition for the same step type ID is already registered
    */
   registerStepDefinition(definition: ServerStepDefinition): void;
+
+  /**
+   * Register server-side definition for a workflow trigger.
+   * This should be called during the plugin's setup phase.
+   *
+   * @param definition - The trigger server-side definition
+   * @throws Error if definition for the same trigger type ID is already registered
+   */
+  registerTriggerDefinition(definition: ServerTriggerDefinition): void;
 }
 
 /**
  * Server-side plugin start contract.
- * Exposes methods for retrieving registered server-side step implementations.
+ * Exposes methods for retrieving registered server-side step and trigger implementations.
  */
-export type WorkflowsExtensionsServerPluginStart =
-  WorkflowsExtensionsStartContract<ServerStepDefinition>;
+export type WorkflowsExtensionsServerPluginStart = WorkflowsExtensionsStartContract<
+  ServerStepDefinition,
+  ServerTriggerDefinition
+>;
 
 /**
  * Dependencies for the server plugin setup phase.

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
@@ -54,6 +54,9 @@ describe('getActionOptions', () => {
       getStepDefinition: jest.fn(),
       getAllStepDefinitions: jest.fn(),
       hasStepDefinition: jest.fn(),
+      getTriggerDefinition: jest.fn(),
+      getAllTriggerDefinitions: jest.fn().mockReturnValue([]),
+      hasTriggerDefinition: jest.fn().mockReturnValue(false),
     };
 
     (getAllConnectors as jest.Mock).mockReturnValue([]);

--- a/src/platform/plugins/shared/workflows_management/server/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/index.ts
@@ -19,3 +19,5 @@ export async function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export type { WorkflowsServerPluginSetup, WorkflowsServerPluginStart } from './types';
+export type { FireTriggerOptions, FireTriggerResult } from './trigger_service';
+export type { TriggerService } from './trigger_service';

--- a/src/platform/plugins/shared/workflows_management/server/lib/schedule_utils.ts
+++ b/src/platform/plugins/shared/workflows_management/server/lib/schedule_utils.ts
@@ -10,10 +10,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, complexity */
 
 import { Frequency } from '@kbn/rrule';
+import type { TriggerType } from '@kbn/workflows';
 
-// Define the trigger type based on the schema
+/**
+ * Workflow trigger type - represents any trigger type with optional config.
+ * Uses TriggerType from @kbn/workflows for the type field to ensure
+ * consistency with all registered trigger types (alert, scheduled, manual,
+ * streams.upsertStream, etc.).
+ */
 export interface WorkflowTrigger {
-  type: 'alert' | 'scheduled' | 'manual';
+  type: TriggerType;
   with?: Record<string, any>;
 }
 

--- a/src/platform/plugins/shared/workflows_management/server/trigger_service/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/trigger_service/index.ts
@@ -7,6 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { CommonStepDefinition } from './step_registry/types';
-export type { CommonTriggerDefinition } from './trigger_registry/types';
-export { DataMapStepTypeId } from './steps/data';
+export { TriggerService } from './trigger_service';
+export type { FireTriggerOptions, FireTriggerResult } from './trigger_service';

--- a/src/platform/plugins/shared/workflows_management/server/trigger_service/trigger_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/trigger_service/trigger_service.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { TriggerType, WorkflowYaml } from '@kbn/workflows';
+import type { WorkflowExecutionEngineModel } from '@kbn/workflows/types/latest';
+import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
+import type {
+  TriggerEventData,
+  WorkflowsExtensionsServerPluginStart,
+} from '@kbn/workflows-extensions/server';
+import type { WorkflowProperties, WorkflowStorage } from '../storage/workflow_storage';
+
+/**
+ * Result of firing a trigger.
+ */
+export interface FireTriggerResult {
+  /** Number of workflows that matched the trigger */
+  matchedWorkflows: number;
+  /** Number of workflows that were successfully scheduled */
+  scheduledWorkflows: number;
+  /** IDs of workflows that were scheduled */
+  scheduledWorkflowIds: string[];
+  /** Any errors that occurred during scheduling */
+  errors: Array<{ workflowId: string; error: string }>;
+}
+
+/**
+ * Options for firing a trigger.
+ */
+export interface FireTriggerOptions {
+  /** The event data that triggered the fire */
+  eventData: TriggerEventData;
+  /** The Kibana request context (for authorization) */
+  request: KibanaRequest;
+  /** The space ID where workflows should be searched */
+  spaceId: string;
+}
+
+/**
+ * Service for firing triggers and scheduling matching workflows.
+ */
+export class TriggerService {
+  private readonly logger: Logger;
+  private workflowStorage: WorkflowStorage | null = null;
+  private workflowsExtensions: WorkflowsExtensionsServerPluginStart | null = null;
+  private workflowsExecutionEngine: WorkflowsExecutionEnginePluginStart | null = null;
+
+  constructor(logger: Logger) {
+    this.logger = logger.get('trigger-service');
+  }
+
+  /**
+   * Initialize the service with required dependencies.
+   * Must be called during plugin start phase.
+   */
+  public initialize(deps: {
+    workflowStorage: WorkflowStorage;
+    workflowsExtensions: WorkflowsExtensionsServerPluginStart;
+    workflowsExecutionEngine: WorkflowsExecutionEnginePluginStart;
+  }): void {
+    this.workflowStorage = deps.workflowStorage;
+    this.workflowsExtensions = deps.workflowsExtensions;
+    this.workflowsExecutionEngine = deps.workflowsExecutionEngine;
+    this.logger.debug('TriggerService initialized');
+  }
+
+  /**
+   * Fire a trigger and schedule any matching workflows.
+   *
+   * @param options - The trigger firing options
+   * @returns Result of the trigger fire operation
+   */
+  public async fireTrigger(options: FireTriggerOptions): Promise<FireTriggerResult> {
+    const { eventData, request, spaceId } = options;
+
+    if (!this.workflowStorage || !this.workflowsExtensions || !this.workflowsExecutionEngine) {
+      throw new Error('TriggerService not initialized');
+    }
+
+    this.logger.debug(`Firing trigger: ${eventData.type} in space ${spaceId}`);
+
+    // Get the registered trigger definition
+    const triggerDefinition = this.workflowsExtensions.getTriggerDefinition(eventData.type);
+    if (!triggerDefinition) {
+      this.logger.debug(`No trigger definition registered for type: ${eventData.type}`);
+      return {
+        matchedWorkflows: 0,
+        scheduledWorkflows: 0,
+        scheduledWorkflowIds: [],
+        errors: [],
+      };
+    }
+
+    // Find all enabled workflows in the space
+    const workflows = await this.findEnabledWorkflows(spaceId);
+    this.logger.debug(`Found ${workflows.length} enabled workflows in space ${spaceId}`);
+
+    const matchedWorkflows: Array<{
+      id: string;
+      workflow: WorkflowProperties;
+      inputs: Record<string, unknown>;
+    }> = [];
+    const errors: Array<{ workflowId: string; error: string }> = [];
+
+    // Evaluate each workflow's triggers
+    for (const { id, workflow } of workflows) {
+      if (workflow.definition) {
+        const triggers = workflow.definition.triggers || [];
+        for (const trigger of triggers) {
+          if (trigger.type === eventData.type) {
+            try {
+              // Use the registered trigger definition's matcher
+              // Access `with` property safely since some triggers (like manual) don't have it
+              const triggerConfig = 'with' in trigger ? trigger.with : undefined;
+              const matchResult = triggerDefinition.matches(triggerConfig, eventData);
+
+              if (matchResult.matches) {
+                this.logger.debug(`Workflow ${id} matched trigger ${eventData.type}`);
+                matchedWorkflows.push({
+                  id,
+                  workflow,
+                  inputs: matchResult.workflowInputs || {},
+                });
+                break; // Only match once per workflow
+              }
+            } catch (error) {
+              this.logger.warn(`Error evaluating trigger for workflow ${id}: ${error.message}`);
+              errors.push({ workflowId: id, error: error.message });
+            }
+          }
+        }
+      }
+    }
+
+    this.logger.debug(`${matchedWorkflows.length} workflows matched trigger ${eventData.type}`);
+
+    // Schedule matched workflows
+    const scheduledWorkflowIds: string[] = [];
+
+    for (const { id, workflow, inputs } of matchedWorkflows) {
+      try {
+        const workflowModel: WorkflowExecutionEngineModel = {
+          id,
+          name: workflow.name,
+          enabled: workflow.enabled,
+          definition: workflow.definition as WorkflowYaml,
+          yaml: workflow.yaml,
+        };
+
+        const context = {
+          event: eventData.payload,
+          spaceId,
+          inputs,
+          triggeredBy: eventData.type as TriggerType,
+        };
+
+        await this.workflowsExecutionEngine.scheduleWorkflow(workflowModel, context, request);
+        scheduledWorkflowIds.push(id);
+        this.logger.debug(`Scheduled workflow ${id} for trigger ${eventData.type}`);
+      } catch (error) {
+        this.logger.error(`Failed to schedule workflow ${id}: ${error.message}`);
+        errors.push({ workflowId: id, error: error.message });
+      }
+    }
+
+    return {
+      matchedWorkflows: matchedWorkflows.length,
+      scheduledWorkflows: scheduledWorkflowIds.length,
+      scheduledWorkflowIds,
+      errors,
+    };
+  }
+
+  /**
+   * Find all enabled workflows in a space.
+   */
+  private async findEnabledWorkflows(
+    spaceId: string
+  ): Promise<Array<{ id: string; workflow: WorkflowProperties }>> {
+    if (!this.workflowStorage) {
+      throw new Error('TriggerService not initialized');
+    }
+
+    const response = await this.workflowStorage.getClient().search({
+      query: {
+        bool: {
+          must: [{ term: { spaceId } }, { term: { enabled: true } }, { term: { valid: true } }],
+          must_not: {
+            exists: { field: 'deleted_at' },
+          },
+        },
+      },
+      size: 10000, // Fetch all enabled workflows
+      track_total_hits: false,
+    });
+
+    return response.hits.hits.flatMap((hit) => {
+      const id = hit._id;
+      const source = hit._source;
+      if (id && source) {
+        return [{ id, workflow: source }];
+      }
+      return [];
+    });
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -32,13 +32,20 @@ import type {
   WorkflowsExtensionsServerPluginSetup,
   WorkflowsExtensionsServerPluginStart,
 } from '@kbn/workflows-extensions/server';
+import type { TriggerService } from './trigger_service';
 import type { WorkflowsManagementApi } from './workflows_management/workflows_management_api';
 
 export interface WorkflowsServerPluginSetup {
   management: WorkflowsManagementApi;
 }
 
-export type WorkflowsServerPluginStart = Record<string, never>;
+export interface WorkflowsServerPluginStart {
+  /**
+   * Service for firing triggers and scheduling matching workflows.
+   * Use this to trigger workflows when events occur (e.g., stream changes).
+   */
+  triggerService: TriggerService;
+}
 
 export interface WorkflowsServerPluginSetupDeps {
   features?: FeaturesPluginSetup;

--- a/x-pack/platform/plugins/shared/streams/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams/kibana.jsonc
@@ -25,7 +25,7 @@
       "usageCollection",
       "fieldsMetadata"
     ],
-    "optionalPlugins": ["cloud", "serverless", "globalSearch", "spaces"],
+    "optionalPlugins": ["cloud", "serverless", "globalSearch", "spaces", "workflowsManagement"],
     "requiredBundles": [],
     "extraPublicDirs": ["common"]
   }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
@@ -14,13 +14,18 @@ import { StreamsClient } from './client';
 import type { AttachmentClient } from './attachments/attachment_client';
 import type { SystemClient } from './system/system_client';
 import type { FeatureClient } from './feature';
+import { WorkflowTriggerService } from './workflow_triggers';
 
 export class StreamsService {
+  private readonly workflowTriggerService: WorkflowTriggerService;
+
   constructor(
     private readonly coreSetup: CoreSetup<StreamsPluginStartDependencies>,
     private readonly logger: Logger,
     private readonly isDev: boolean
-  ) {}
+  ) {
+    this.workflowTriggerService = new WorkflowTriggerService(coreSetup, logger);
+  }
 
   async getClientWithRequest({
     request,
@@ -54,6 +59,7 @@ export class StreamsService {
       request,
       isServerless,
       isDev: this.isDev,
+      workflowTriggerService: this.workflowTriggerService,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/workflow_triggers/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/workflow_triggers/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { WorkflowTriggerService } from './workflow_trigger_service';
+export type { StreamChangeType, StreamUpsertEvent } from './workflow_trigger_service';

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/workflow_triggers/workflow_trigger_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/workflow_triggers/workflow_trigger_service.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, KibanaRequest, Logger } from '@kbn/core/server';
+import type { TriggerEventData } from '@kbn/workflows-extensions/server';
+import type { Streams } from '@kbn/streams-schema';
+import type { StreamsPluginStartDependencies } from '../../../types';
+
+/**
+ * Change types that can occur when a stream is upserted.
+ */
+export type StreamChangeType =
+  | 'mapping'
+  | 'processing'
+  | 'description'
+  | 'settings'
+  | 'lifecycle'
+  | 'failure_store';
+
+/**
+ * Information about a stream upsert event.
+ */
+export interface StreamUpsertEvent {
+  /** The name of the stream */
+  streamName: string;
+  /** The types of changes that occurred */
+  changeTypes: StreamChangeType[];
+  /** Whether this is a new stream or an update to an existing one */
+  isCreated: boolean;
+  /** The stream definition after the change */
+  streamDefinition?: Streams.all.Definition;
+  /** The space ID where the change occurred */
+  spaceId: string;
+  /** The request context (for authorization) */
+  request: KibanaRequest;
+}
+
+/**
+ * Service for firing workflow triggers when stream changes occur.
+ */
+export class WorkflowTriggerService {
+  private readonly logger: Logger;
+  private readonly core: CoreSetup<StreamsPluginStartDependencies>;
+
+  constructor(core: CoreSetup<StreamsPluginStartDependencies>, logger: Logger) {
+    this.core = core;
+    this.logger = logger.get('workflow-triggers');
+  }
+
+  /**
+   * Fire workflow triggers when a stream is upserted (created or updated).
+   *
+   * @param event - The stream upsert event
+   */
+  public async onStreamUpsert(event: StreamUpsertEvent): Promise<void> {
+    try {
+      const [, plugins] = await this.core.getStartServices();
+
+      if (!plugins.workflowsManagement) {
+        this.logger.debug(
+          'Workflows management plugin not available, skipping trigger for stream upsert'
+        );
+        return;
+      }
+
+      const { triggerService } = plugins.workflowsManagement;
+
+      const eventData: TriggerEventData = {
+        type: 'streams.upsertStream',
+        payload: {
+          streamName: event.streamName,
+          changeTypes: event.changeTypes,
+          isCreated: event.isCreated,
+          streamDefinition: event.streamDefinition,
+        },
+      };
+
+      this.logger.debug(
+        `Firing streams.upsertStream trigger for stream "${
+          event.streamName
+        }" with changes: ${event.changeTypes.join(', ')}`
+      );
+
+      const result = await triggerService.fireTrigger({
+        eventData,
+        request: event.request,
+        spaceId: event.spaceId,
+      });
+
+      if (result.matchedWorkflows > 0) {
+        this.logger.info(
+          `Stream "${event.streamName}" triggered ${result.scheduledWorkflows}/${result.matchedWorkflows} workflows`
+        );
+      }
+
+      if (result.errors.length > 0) {
+        this.logger.warn(
+          `Errors firing triggers for stream "${event.streamName}": ${result.errors
+            .map((e: { workflowId: string; error: string }) => `${e.workflowId}: ${e.error}`)
+            .join(', ')}`
+        );
+      }
+    } catch (error) {
+      // Don't let trigger failures affect the stream operation
+      this.logger.error(
+        `Failed to fire workflow triggers for stream "${event.streamName}": ${error.message}`
+      );
+    }
+  }
+
+  /**
+   * Determine what types of changes occurred between an old and new stream definition.
+   *
+   * @param oldDefinition - The previous stream definition (undefined for new streams)
+   * @param newDefinition - The new stream definition
+   * @returns Array of change types
+   */
+  public static detectChangeTypes(
+    oldDefinition: Streams.all.Definition | undefined,
+    newDefinition: Streams.all.Definition
+  ): StreamChangeType[] {
+    const changes: StreamChangeType[] = [];
+
+    // If no old definition, this is a create - all aspects are "changed"
+    if (!oldDefinition) {
+      // For new streams, report all present aspects as changes
+      if (newDefinition.description) {
+        changes.push('description');
+      }
+      if ('wired' in newDefinition.ingest && newDefinition.ingest.wired?.fields) {
+        changes.push('mapping');
+      }
+      if (newDefinition.ingest.processing?.steps?.length) {
+        changes.push('processing');
+      }
+      if (newDefinition.ingest.settings && Object.keys(newDefinition.ingest.settings).length > 0) {
+        changes.push('settings');
+      }
+      if (newDefinition.ingest.lifecycle) {
+        changes.push('lifecycle');
+      }
+      if (newDefinition.ingest.failure_store) {
+        changes.push('failure_store');
+      }
+      return changes;
+    }
+
+    // Compare description
+    if (oldDefinition.description !== newDefinition.description) {
+      changes.push('description');
+    }
+
+    // Compare mapping (fields) for wired streams
+    if ('wired' in oldDefinition.ingest && 'wired' in newDefinition.ingest) {
+      const oldFields = JSON.stringify(oldDefinition.ingest.wired?.fields || {});
+      const newFields = JSON.stringify(newDefinition.ingest.wired?.fields || {});
+      if (oldFields !== newFields) {
+        changes.push('mapping');
+      }
+    }
+
+    // Compare processing
+    const oldProcessing = JSON.stringify(oldDefinition.ingest.processing || {});
+    const newProcessing = JSON.stringify(newDefinition.ingest.processing || {});
+    if (oldProcessing !== newProcessing) {
+      changes.push('processing');
+    }
+
+    // Compare settings
+    const oldSettings = JSON.stringify(oldDefinition.ingest.settings || {});
+    const newSettings = JSON.stringify(newDefinition.ingest.settings || {});
+    if (oldSettings !== newSettings) {
+      changes.push('settings');
+    }
+
+    // Compare lifecycle
+    const oldLifecycle = JSON.stringify(oldDefinition.ingest.lifecycle || {});
+    const newLifecycle = JSON.stringify(newDefinition.ingest.lifecycle || {});
+    if (oldLifecycle !== newLifecycle) {
+      changes.push('lifecycle');
+    }
+
+    // Compare failure_store
+    const oldFailureStore = JSON.stringify(oldDefinition.ingest.failure_store || {});
+    const newFailureStore = JSON.stringify(newDefinition.ingest.failure_store || {});
+    if (oldFailureStore !== newFailureStore) {
+      changes.push('failure_store');
+    }
+
+    return changes;
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/types.ts
@@ -30,6 +30,7 @@ import type { FieldsMetadataServerStart } from '@kbn/fields-metadata-plugin/serv
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { ConsoleStart as ConsoleServerStart } from '@kbn/console-plugin/server';
+import type { WorkflowsServerPluginStart } from '@kbn/workflows-management-plugin/server';
 import type { StreamsConfig } from '../common/config';
 
 export interface StreamsServer {
@@ -70,4 +71,5 @@ export interface StreamsPluginStartDependencies {
   fieldsMetadata: FieldsMetadataServerStart;
   console: ConsoleServerStart;
   spaces?: SpacesPluginStart;
+  workflowsManagement?: WorkflowsServerPluginStart;
 }


### PR DESCRIPTION
## 🍒 Summary

This PR implements workflow triggers for stream changes, enabling automated workflows to be triggered when streams are created or updated. This addresses [elastic/streams-program#781](https://github.com/elastic/streams-program/issues/781).

## 🛠️ Changes

### Trigger Registry Infrastructure (`workflows_extensions`)
- Added `TriggerRegistry` class (server + public) following the same pattern as the existing step registry
- Defined `CommonTriggerDefinition`, `ServerTriggerDefinition`, and `PublicTriggerDefinition` interfaces
- Server trigger definitions include a `matches` function for evaluating whether an event should trigger a workflow
- Updated plugin contracts to expose `registerTriggerDefinition` and `getTriggerDefinitions` methods
- Added comprehensive documentation to README.md

### Trigger Schema (`@kbn/workflows`)
- Added `StreamsUpsertStreamTriggerSchema` with type `streams.upsertStream`
- Added `StreamChangeTypeSchema` enum for change types: `mapping`, `processing`, `description`, `settings`, `lifecycle`, `failure_store`
- Trigger config includes `stream` (pattern with wildcard support) and optional `changeTypes` array

### Stream Change Detection (`streams` plugin)
- Created `WorkflowTriggerService` that fires triggers when streams are upserted
- Hooked into `StreamsClient.upsertStream()` and `StreamsClient.bulkUpsert()` to fire triggers after successful operations
- Added `workflowsManagement` as an optional dependency

### Trigger Execution (`workflows_management`)
- Created `TriggerService` that searches for enabled workflows with matching triggers and schedules them
- Integrated with `workflowsExtensions` to get trigger definitions and evaluate matches
- Integrated with `workflowsExecutionEngine` to schedule matching workflows

### Pattern Matching
- Implemented wildcard pattern matching for stream names (e.g., `logs-*`, `*-production`, `logs-*-debug`)
- Change type filtering - workflows can optionally filter on specific change types

## 🎙️ Prompts

- Research how this should be done (also take into account workflows_extensions README) and create a PR for it. Do not do the "Significant event rule spiked" trigger one for now.

🤖 This pull request was assisted by Cursor
