### PR TITLE
[ES|QL] Fixes visor position

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -1189,6 +1189,17 @@ const ESQLEditorInternal = function ESQLEditor({
           </EuiFlexItem>
         </div>
       </EuiFlexGroup>
+      {!hideQuickSearch && (
+        <QuickSearchVisor
+          query={code}
+          isSpaceReduced={Boolean(editorIsInline) || measuredEditorWidth < BREAKPOINT_WIDTH}
+          isVisible={isVisorOpen}
+          onUpdateAndSubmitQuery={(newQuery) =>
+            onUpdateAndSubmitQuery(newQuery, QuerySource.QUICK_SEARCH)
+          }
+          onToggleVisor={onToggleVisor}
+        />
+      )}
       {(isHistoryOpen || (isLanguageComponentOpen && editorIsInline)) && (
         <ResizableButton
           onMouseDownResizeHandler={(mouseDownEvent) => {
@@ -1209,18 +1220,6 @@ const ESQLEditorInternal = function ESQLEditor({
               setResizableContainerHeight
             )
           }
-        />
-      )}
-      {!hideQuickSearch && (
-        <QuickSearchVisor
-          query={code}
-          isSpaceReduced={Boolean(editorIsInline) || measuredEditorWidth < BREAKPOINT_WIDTH}
-          isVisible={isVisorOpen}
-          onUpdateAndSubmitQuery={(newQuery) => {
-            onUpdateAndSubmitQuery(newQuery, QuerySource.QUICK_SEARCH);
-            editorRef.current?.focus();
-          }}
-          onToggleVisor={onToggleVisor}
         />
       )}
       <EditorFooter


### PR DESCRIPTION
## Summary

Moves the editor above the resizable button, otherwise it seems weird when the history and the visor are open.

Now

<img width="2425" height="636" alt="image" src="https://github.com/user-attachments/assets/869422c5-7a5f-4fe3-ac38-c93c47aaf6d5" />


