### PR TITLE
[ObsPresentation][APM] Handle malformed span.links data in trace samples

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import { getSpanLinksCountById, getLinkedChildrenOfSpan } from './get_linked_children';
+
+describe('get_linked_children', () => {
+  const mockApmEventClient = {
+    search: jest.fn(),
+  } as unknown as APMEventClient;
+
+  const defaultParams = {
+    traceId: 'test-trace-id',
+    apmEventClient: mockApmEventClient,
+    start: 0,
+    end: 1000,
+  };
+
+  const createHit = (
+    spanLinks: any,
+    fields: Record<string, string[]> = { 'trace.id': ['test-trace-id'], 'span.id': ['span-1'] }
+  ) => ({
+    _source: { span: { links: spanLinks } },
+    fields,
+  });
+
+  const createOtelHit = (fields: Record<string, string[]>) => ({
+    _source: {},
+    fields,
+  });
+
+  const mockSearchWith = (hits: any[]) => {
+    (mockApmEventClient.search as jest.Mock).mockResolvedValue({ hits: { hits } });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSpanLinksCountById', () => {
+    it('should return counts for span links grouped by span id', async () => {
+      mockSearchWith([
+        createHit([
+          { trace: { id: 'test-trace-id' }, span: { id: 'span-1' } },
+          { trace: { id: 'test-trace-id' }, span: { id: 'span-2' } },
+        ]),
+        createHit([{ trace: { id: 'test-trace-id' }, span: { id: 'span-1' } }]),
+      ]);
+
+      const result = await getSpanLinksCountById(defaultParams);
+
+      expect(result).toEqual({ 'span-1': 2, 'span-2': 1 });
+    });
+
+    it.each([
+      ['object', { trace: { id: 'test-trace-id' }, span: { id: 'span-1' } }],
+      ['null', null],
+      ['string', 'not-an-array'],
+    ])('should handle malformed span.links data (%s)', async (_, malformedData) => {
+      mockSearchWith([createHit(malformedData)]);
+
+      const result = await getSpanLinksCountById(defaultParams);
+
+      expect(result).toEqual({});
+    });
+
+    it('should use mapOtelToSpanLink for OTel data', async () => {
+      mockSearchWith([
+        createOtelHit({
+          'trace.id': ['test-trace-id'],
+          'span.id': ['otel-span-1'],
+          'links.trace_id': ['test-trace-id'],
+          'links.span_id': ['span-1'],
+        }),
+      ]);
+
+      const result = await getSpanLinksCountById(defaultParams);
+
+      expect(result).toEqual({ 'span-1': 1 });
+    });
+
+    it('should filter out span links from different traces', async () => {
+      mockSearchWith([
+        createHit([
+          { trace: { id: 'test-trace-id' }, span: { id: 'span-1' } },
+          { trace: { id: 'different-trace-id' }, span: { id: 'span-2' } },
+        ]),
+      ]);
+
+      const result = await getSpanLinksCountById(defaultParams);
+
+      expect(result).toEqual({ 'span-1': 1 });
+    });
+
+    it('should return empty object when no span links found', async () => {
+      mockSearchWith([]);
+
+      const result = await getSpanLinksCountById(defaultParams);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('getLinkedChildrenOfSpan', () => {
+    it('should return linked children for a specific span', async () => {
+      mockSearchWith([
+        createHit([{ trace: { id: 'test-trace-id' }, span: { id: 'target-span-id' } }], {
+          'trace.id': ['test-trace-id'],
+          'span.id': ['child-span-1'],
+        }),
+      ]);
+
+      const result = await getLinkedChildrenOfSpan({ ...defaultParams, spanId: 'target-span-id' });
+
+      expect(result).toEqual([{ trace: { id: 'test-trace-id' }, span: { id: 'child-span-1' } }]);
+    });
+
+    it('should handle malformed span.links data', async () => {
+      mockSearchWith([createHit('not-an-array')]);
+
+      const result = await getLinkedChildrenOfSpan({ ...defaultParams, spanId: 'target-span-id' });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should use transaction.id when span.id is not available', async () => {
+      mockSearchWith([
+        createHit([{ trace: { id: 'test-trace-id' }, span: { id: 'target-span-id' } }], {
+          'trace.id': ['test-trace-id'],
+          'transaction.id': ['transaction-1'],
+        }),
+      ]);
+
+      const result = await getLinkedChildrenOfSpan({ ...defaultParams, spanId: 'target-span-id' });
+
+      expect(result).toEqual([{ trace: { id: 'test-trace-id' }, span: { id: 'transaction-1' } }]);
+    });
+
+    it('should filter out links that do not match the target spanId', async () => {
+      mockSearchWith([
+        createHit([
+          { trace: { id: 'test-trace-id' }, span: { id: 'target-span-id' } },
+          { trace: { id: 'test-trace-id' }, span: { id: 'different-span-id' } },
+        ]),
+      ]);
+
+      const result = await getLinkedChildrenOfSpan({ ...defaultParams, spanId: 'target-span-id' });
+
+      expect(result).toEqual([{ trace: { id: 'test-trace-id' }, span: { id: 'child-span-1' } }]);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.ts
@@ -94,14 +94,19 @@ async function fetchLinkedChildrenOfSpan({
     const source = 'span' in hit._source ? hit._source : undefined;
     const event = accessKnownApmEventFields(hit.fields).requireFields(requiredFields).build();
 
+    const spanLinksArray = source?.span?.links
+      ? Array.isArray(source?.span?.links)
+        ? source.span.links
+        : [source.span.links]
+      : [];
     return {
       ...event,
-      [SPAN_LINKS]: Array.isArray(source?.span?.links)
-        ? source.span.links
-        : mapOtelToSpanLink({
-            trace_id: event[OTEL_SPAN_LINKS_TRACE_ID],
-            span_id: event[OTEL_SPAN_LINKS_SPAN_ID],
-          }),
+      [SPAN_LINKS]:
+        spanLinksArray ??
+        mapOtelToSpanLink({
+          trace_id: event[OTEL_SPAN_LINKS_TRACE_ID],
+          span_id: event[OTEL_SPAN_LINKS_SPAN_ID],
+        }),
     };
   });
   // Filter out documents that don't have any span.links that match the combination of traceId and spanId

--- a/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.ts
@@ -98,7 +98,7 @@ async function fetchLinkedChildrenOfSpan({
       ? Array.isArray(source?.span?.links)
         ? source.span.links
         : [source.span.links]
-      : [];
+      : undefined;
     return {
       ...event,
       [SPAN_LINKS]:

--- a/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/span_links/get_linked_children.ts
@@ -96,12 +96,12 @@ async function fetchLinkedChildrenOfSpan({
 
     return {
       ...event,
-      [SPAN_LINKS]:
-        source?.span?.links ??
-        mapOtelToSpanLink({
-          trace_id: event[OTEL_SPAN_LINKS_TRACE_ID],
-          span_id: event[OTEL_SPAN_LINKS_SPAN_ID],
-        }),
+      [SPAN_LINKS]: Array.isArray(source?.span?.links)
+        ? source.span.links
+        : mapOtelToSpanLink({
+            trace_id: event[OTEL_SPAN_LINKS_TRACE_ID],
+            span_id: event[OTEL_SPAN_LINKS_SPAN_ID],
+          }),
     };
   });
   // Filter out documents that don't have any span.links that match the combination of traceId and spanId


### PR DESCRIPTION
## Summary

Fixes an issue where span.links data that is not an array (e.g., null, object, or string) would cause trace sample requests to fail or return empty responses. This can occur with certain OTel data formats.

### Changes:
- Replace ?? operator with explicit `Array.isArray()` check to ensure `span.links` is always an array before calling `.filter()`
- Add comprehensive unit tests for malformed data scenarios
- Covers cases where `span.links` is null, object, string, or other non-array values

BEFORE

<img width="2880" height="2084" alt="image" src="https://github.com/user-attachments/assets/d853554d-0bb5-4451-bc8e-bea16f5560f8" />

AFTER

https://github.com/user-attachments/assets/8f3fb7b8-77e5-484f-bfbe-9ffed89c9f0c



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->