### PR TITLE
[APM] a11y support of the service map with react flow

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/constants.ts
@@ -53,3 +53,6 @@ export const EDGE_OFFSET_DIVISOR = 4;
 
 /** Duration of the center animation in milliseconds */
 export const CENTER_ANIMATION_DURATION_MS = 200;
+
+/** Minimum distance threshold for directional keyboard navigation (in pixels) */
+export const DIRECTION_THRESHOLD = 50;

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/diamond_node.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/diamond_node.tsx
@@ -10,6 +10,7 @@ import { Handle, Position } from '@xyflow/react';
 import { useEuiTheme, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { getSpanIcon } from '@kbn/apm-ui-shared';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import {
   DEPENDENCY_NODE_DIAMOND_SIZE,
   DEPENDENCY_NODE_DIAMOND_CONTAINER_SIZE,
@@ -27,6 +28,8 @@ interface DiamondNodeProps {
   testSubjPrefix: string;
   iconAltFallback: string;
   badge?: ReactNode;
+  ariaLabel?: string;
+  groupedCount?: number;
 }
 
 export const DiamondNode = memo(
@@ -41,6 +44,8 @@ export const DiamondNode = memo(
     testSubjPrefix,
     iconAltFallback,
     badge,
+    ariaLabel: customAriaLabel,
+    groupedCount,
   }: DiamondNodeProps) => {
     const { euiTheme } = useEuiTheme();
 
@@ -52,6 +57,62 @@ export const DiamondNode = memo(
       }
       return null;
     }, [spanType, spanSubtype]);
+
+    const ariaLabel = useMemo(() => {
+      if (customAriaLabel) {
+        return customAriaLabel;
+      }
+
+      const parts = [
+        i18n.translate('xpack.apm.serviceMap.dependencyNode.ariaLabel', {
+          defaultMessage: 'Dependency: {dependencyName}',
+          values: { dependencyName: label },
+        }),
+      ];
+
+      if (groupedCount && groupedCount > 1) {
+        parts.push(
+          i18n.translate('xpack.apm.serviceMap.dependencyNode.groupedCount', {
+            defaultMessage: 'Contains {count} resources',
+            values: { count: groupedCount },
+          })
+        );
+      }
+
+      if (spanType) {
+        parts.push(
+          i18n.translate('xpack.apm.serviceMap.dependencyNode.typeInfo', {
+            defaultMessage: 'Type: {spanType}',
+            values: { spanType },
+          })
+        );
+      }
+
+      if (spanSubtype) {
+        parts.push(
+          i18n.translate('xpack.apm.serviceMap.dependencyNode.subtypeInfo', {
+            defaultMessage: 'Subtype: {spanSubtype}',
+            values: { spanSubtype },
+          })
+        );
+      }
+
+      if (selected) {
+        parts.push(
+          i18n.translate('xpack.apm.serviceMap.dependencyNode.selected', {
+            defaultMessage: 'Selected',
+          })
+        );
+      }
+
+      parts.push(
+        i18n.translate('xpack.apm.serviceMap.dependencyNode.instructions', {
+          defaultMessage: 'Press Enter or Space to view details',
+        })
+      );
+
+      return parts.join('. ');
+    }, [customAriaLabel, label, spanType, spanSubtype, selected, groupedCount]);
 
     const containerStyles = css`
       position: relative;
@@ -79,6 +140,17 @@ export const DiamondNode = memo(
       box-sizing: border-box;
       cursor: pointer;
       pointer-events: all;
+
+      &:focus-visible {
+        outline: ${euiTheme.border.width.thick} solid ${euiTheme.colors.primary};
+        outline-offset: ${euiTheme.size.xxs};
+      }
+
+      [data-id]:focus &,
+      [data-id]:focus-visible & {
+        outline: ${euiTheme.border.width.thick} solid ${euiTheme.colors.primary};
+        outline-offset: ${euiTheme.size.xxs};
+      }
     `;
 
     const iconContainerStyles = css`
@@ -107,13 +179,20 @@ export const DiamondNode = memo(
         <EuiFlexItem grow={false} css={containerStyles}>
           <Handle type="target" position={targetPosition ?? Position.Left} css={handleStyles} />
           {badge}
-          <div css={diamondStyles}>
+          <div
+            css={diamondStyles}
+            role="button"
+            tabIndex={0}
+            aria-label={ariaLabel}
+            aria-pressed={selected}
+          >
             <div css={iconContainerStyles}>
               {iconUrl && (
                 <img
                   src={iconUrl}
                   alt={spanType || spanSubtype || iconAltFallback}
                   css={iconStyles}
+                  aria-hidden="true"
                 />
               )}
             </div>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/grouped_resources_node.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/grouped_resources_node.tsx
@@ -38,6 +38,7 @@ export const GroupedResourcesNode = memo(
         targetPosition={targetPosition}
         testSubjPrefix="groupedResources"
         iconAltFallback="grouped resources"
+        groupedCount={data.count}
         badge={
           <EuiBadge color="hollow" css={badgeStyles}>
             {data.count}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/node_label.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/node_label.tsx
@@ -33,7 +33,7 @@ export const NodeLabel = memo(({ label, selected = false }: NodeLabelProps) => {
   `;
 
   return (
-    <EuiFlexItem grow={false} css={labelStyles}>
+    <EuiFlexItem grow={false} css={labelStyles} aria-hidden="true">
       {label}
     </EuiFlexItem>
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/react_flow_popover.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/react_flow_popover.tsx
@@ -10,6 +10,7 @@ import type { MouseEvent } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ReactFlowInstance, Viewport } from '@xyflow/react';
 import { useReactFlow } from '@xyflow/react';
+import { i18n } from '@kbn/i18n';
 import {
   DEFAULT_NODE_SIZE,
   OFFSCREEN_POSITION,
@@ -252,8 +253,25 @@ export function ReactFlowPopover({
 
   const trigger = <div style={{ width: 1, height: 1, visibility: 'hidden' }} aria-hidden="true" />;
 
+  // Build accessible label for the popover
+  const popoverAriaLabel = useMemo(() => {
+    if (selectedEdge) {
+      return i18n.translate('xpack.apm.serviceMap.popover.edgeAriaLabel', {
+        defaultMessage: 'Details for connection from {source} to {target}. Press Escape to close.',
+        values: { source: selectedEdge.source, target: selectedEdge.target },
+      });
+    }
+    if (selectedNode) {
+      return i18n.translate('xpack.apm.serviceMap.popover.nodeAriaLabel', {
+        defaultMessage: 'Details for {nodeName}. Press Escape to close.',
+        values: { nodeName: selectedNode.data.label || selectedNode.id },
+      });
+    }
+    return '';
+  }, [selectedNode, selectedEdge]);
+
   return (
-    <div style={popoverStyle} role="presentation">
+    <div style={popoverStyle} role="presentation" aria-hidden={!isOpen}>
       <EuiPopover
         anchorPosition="upCenter"
         button={trigger}
@@ -262,6 +280,12 @@ export function ReactFlowPopover({
         ref={popoverRef}
         zIndex={Number(euiTheme.levels.menu)}
         data-test-subj="serviceMapPopover"
+        aria-label={popoverAriaLabel}
+        panelProps={{
+          'aria-live': 'polite',
+          role: 'dialog',
+          'aria-modal': 'false',
+        }}
       >
         {elementData && (
           <PopoverContent

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/use_keyboard_navigation.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/use_keyboard_navigation.test.ts
@@ -1,0 +1,443 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { MarkerType } from '@xyflow/react';
+import { useKeyboardNavigation } from './use_keyboard_navigation';
+import type { ServiceMapNode, ServiceMapEdge } from '../../../../../common/service_map';
+import { DIRECTION_THRESHOLD } from './constants';
+import { DEFAULT_EDGE_COLOR } from '../../../../../common/service_map/constants';
+
+function createNode(id: string, x: number, y: number, label?: string): ServiceMapNode {
+  return {
+    id,
+    position: { x, y },
+    data: {
+      id,
+      label: label || id,
+    },
+    type: 'service',
+  } as ServiceMapNode;
+}
+
+function createEdge(source: string, target: string): ServiceMapEdge {
+  return {
+    id: `${source}->${target}`,
+    source,
+    target,
+    type: 'default',
+    style: { stroke: DEFAULT_EDGE_COLOR, strokeWidth: 1 },
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 12,
+      height: 12,
+      color: DEFAULT_EDGE_COLOR,
+    },
+    data: {
+      isBidirectional: false,
+      sourceData: { label: source, id: source },
+      targetData: { label: target, id: target },
+    },
+  };
+}
+
+const defaultProps = {
+  nodes: [] as ServiceMapNode[],
+  edges: [] as ServiceMapEdge[],
+  selectedNodeId: null,
+  selectedNodeForPopover: null,
+  selectedEdgeForPopover: null,
+  onNodeSelect: jest.fn(),
+  onEdgeSelect: jest.fn(),
+  onPopoverClose: jest.fn(),
+};
+
+describe('useKeyboardNavigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findNodeInDirection', () => {
+    describe('with no nodes', () => {
+      it('returns null when nodes array is empty', () => {
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes: [],
+          })
+        );
+
+        expect(result.current.findNodeInDirection('nonexistent', 'ArrowRight')).toBeNull();
+      });
+    });
+
+    describe('with single node', () => {
+      it('returns null when only one node exists', () => {
+        const nodes = [createNode('a', 100, 100)];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        expect(result.current.findNodeInDirection('a', 'ArrowRight')).toBeNull();
+        expect(result.current.findNodeInDirection('a', 'ArrowLeft')).toBeNull();
+        expect(result.current.findNodeInDirection('a', 'ArrowUp')).toBeNull();
+        expect(result.current.findNodeInDirection('a', 'ArrowDown')).toBeNull();
+      });
+
+      it('returns null when current node does not exist', () => {
+        const nodes = [createNode('a', 100, 100)];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        expect(result.current.findNodeInDirection('nonexistent', 'ArrowRight')).toBeNull();
+      });
+    });
+
+    describe('horizontal navigation (ArrowRight/ArrowLeft)', () => {
+      it('finds node to the right', () => {
+        const nodes = [
+          createNode('a', 0, 100),
+          createNode('b', 200, 100), // To the right of 'a'
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowRight');
+        expect(nextNode?.id).toBe('b');
+      });
+
+      it('finds node to the left', () => {
+        const nodes = [
+          createNode('a', 200, 100),
+          createNode('b', 0, 100), // To the left of 'a'
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowLeft');
+        expect(nextNode?.id).toBe('b');
+      });
+
+      it('does not find node when horizontal distance is below threshold', () => {
+        const nodes = [
+          createNode('a', 100, 100),
+          createNode('b', 100 + DIRECTION_THRESHOLD - 1, 100), // Just below threshold
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        expect(result.current.findNodeInDirection('a', 'ArrowRight')).toBeNull();
+      });
+
+      it('finds node when horizontal distance is at threshold', () => {
+        const nodes = [
+          createNode('a', 100, 100),
+          createNode('b', 100 + DIRECTION_THRESHOLD + 1, 100), // Just above threshold
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowRight');
+        expect(nextNode?.id).toBe('b');
+      });
+
+      it('prefers horizontal movement over diagonal when dx > dy', () => {
+        const nodes = [
+          createNode('a', 0, 100),
+          createNode('b', 200, 120), // Slightly down and to the right
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        // Should find 'b' when going right because dx (200) > dy (20)
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowRight');
+        expect(nextNode?.id).toBe('b');
+      });
+
+      it('does not find node horizontally when dy >= dx', () => {
+        const nodes = [
+          createNode('a', 0, 0),
+          createNode('b', 100, 150), // More vertical than horizontal
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        expect(result.current.findNodeInDirection('a', 'ArrowRight')).toBeNull();
+      });
+    });
+
+    describe('vertical navigation (ArrowUp/ArrowDown)', () => {
+      it('finds node below', () => {
+        const nodes = [
+          createNode('a', 100, 0),
+          createNode('b', 100, 200), // Below 'a'
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowDown');
+        expect(nextNode?.id).toBe('b');
+      });
+
+      it('finds node above', () => {
+        const nodes = [
+          createNode('a', 100, 200),
+          createNode('b', 100, 0), // Above 'a'
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowUp');
+        expect(nextNode?.id).toBe('b');
+      });
+
+      it('does not find node when vertical distance is below threshold', () => {
+        const nodes = [
+          createNode('a', 100, 100),
+          createNode('b', 100, 100 + DIRECTION_THRESHOLD - 1), // Just below threshold
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        expect(result.current.findNodeInDirection('a', 'ArrowDown')).toBeNull();
+      });
+
+      it('prefers vertical movement over diagonal when dy > dx', () => {
+        const nodes = [
+          createNode('a', 100, 0),
+          createNode('b', 120, 200), // Slightly right and below
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        // Should find 'b' when going down because dy (200) > dx (20)
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowDown');
+        expect(nextNode?.id).toBe('b');
+      });
+    });
+
+    describe('distance-based selection', () => {
+      it('selects the closest node in the direction', () => {
+        const nodes = [
+          createNode('a', 0, 100),
+          createNode('b', 150, 100), // Closer
+          createNode('c', 300, 100), // Further
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        const nextNode = result.current.findNodeInDirection('a', 'ArrowRight');
+        expect(nextNode?.id).toBe('b');
+      });
+
+      it('navigates through multiple nodes correctly', () => {
+        const nodes = [
+          createNode('a', 0, 100),
+          createNode('b', 200, 100),
+          createNode('c', 400, 100),
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        // From 'a', go right to 'b'
+        let nextNode = result.current.findNodeInDirection('a', 'ArrowRight');
+        expect(nextNode?.id).toBe('b');
+
+        // From 'b', go right to 'c'
+        nextNode = result.current.findNodeInDirection('b', 'ArrowRight');
+        expect(nextNode?.id).toBe('c');
+
+        // From 'c', go left to 'b'
+        nextNode = result.current.findNodeInDirection('c', 'ArrowLeft');
+        expect(nextNode?.id).toBe('b');
+      });
+    });
+
+    describe('complex graph navigation', () => {
+      it('navigates in a grid-like layout', () => {
+        //  A --- B
+        //  |     |
+        //  C --- D
+        const nodes = [
+          createNode('a', 0, 0),
+          createNode('b', 200, 0),
+          createNode('c', 0, 200),
+          createNode('d', 200, 200),
+        ];
+
+        const { result } = renderHook(() =>
+          useKeyboardNavigation({
+            ...defaultProps,
+            nodes,
+          })
+        );
+
+        // From A
+        expect(result.current.findNodeInDirection('a', 'ArrowRight')?.id).toBe('b');
+        expect(result.current.findNodeInDirection('a', 'ArrowDown')?.id).toBe('c');
+        expect(result.current.findNodeInDirection('a', 'ArrowLeft')).toBeNull();
+        expect(result.current.findNodeInDirection('a', 'ArrowUp')).toBeNull();
+
+        // From D
+        expect(result.current.findNodeInDirection('d', 'ArrowLeft')?.id).toBe('c');
+        expect(result.current.findNodeInDirection('d', 'ArrowUp')?.id).toBe('b');
+        expect(result.current.findNodeInDirection('d', 'ArrowRight')).toBeNull();
+        expect(result.current.findNodeInDirection('d', 'ArrowDown')).toBeNull();
+      });
+    });
+  });
+
+  describe('screen reader announcements', () => {
+    it('initializes with empty announcement', () => {
+      const { result } = renderHook(() => useKeyboardNavigation(defaultProps));
+
+      expect(result.current.screenReaderAnnouncement).toBe('');
+    });
+  });
+
+  describe('keyboard event handling', () => {
+    it('calls onPopoverClose when Escape is pressed with open node popover', () => {
+      const onPopoverClose = jest.fn();
+      const selectedNode = createNode('a', 100, 100);
+
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...defaultProps,
+          selectedNodeForPopover: selectedNode,
+          onPopoverClose,
+        })
+      );
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Escape' });
+        document.dispatchEvent(event);
+      });
+
+      expect(onPopoverClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onPopoverClose when Escape is pressed with open edge popover', () => {
+      const onPopoverClose = jest.fn();
+      const selectedEdge = createEdge('a', 'b');
+
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...defaultProps,
+          selectedEdgeForPopover: selectedEdge,
+          onPopoverClose,
+        })
+      );
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Escape' });
+        document.dispatchEvent(event);
+      });
+
+      expect(onPopoverClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onPopoverClose when Escape is pressed without open popover', () => {
+      const onPopoverClose = jest.fn();
+
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...defaultProps,
+          onPopoverClose,
+        })
+      );
+
+      act(() => {
+        const event = new KeyboardEvent('keydown', { key: 'Escape' });
+        document.dispatchEvent(event);
+      });
+
+      expect(onPopoverClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes event listener on unmount', () => {
+      const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+
+      const { unmount } = renderHook(() => useKeyboardNavigation(defaultProps));
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/use_keyboard_navigation.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/use_keyboard_navigation.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useCallback, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { ServiceMapNode, ServiceMapEdge } from '../../../../../common/service_map';
+import { DIRECTION_THRESHOLD } from './constants';
+
+type ArrowDirection = 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight';
+
+interface UseKeyboardNavigationOptions {
+  nodes: ServiceMapNode[];
+  edges: ServiceMapEdge[];
+  selectedNodeId: string | null;
+  selectedNodeForPopover: ServiceMapNode | null;
+  selectedEdgeForPopover: ServiceMapEdge | null;
+  onNodeSelect: (node: ServiceMapNode | null) => void;
+  onEdgeSelect: (edge: ServiceMapEdge | null) => void;
+  onPopoverClose: () => void;
+}
+
+interface UseKeyboardNavigationResult {
+  screenReaderAnnouncement: string;
+  findNodeInDirection: (currentNodeId: string, direction: ArrowDirection) => ServiceMapNode | null;
+}
+
+/**
+ * Hook that provides keyboard navigation for the service map.
+ *
+ * Supports:
+ * - Arrow keys: Spatial navigation between nodes
+ * - Enter/Space: Open popover for focused node
+ * - Escape: Close popover
+ *
+ * Also manages screen reader announcements for navigation events.
+ */
+export function useKeyboardNavigation({
+  nodes,
+  edges,
+  selectedNodeId,
+  selectedNodeForPopover,
+  selectedEdgeForPopover,
+  onNodeSelect,
+  onEdgeSelect,
+  onPopoverClose,
+}: UseKeyboardNavigationOptions): UseKeyboardNavigationResult {
+  const [screenReaderAnnouncement, setScreenReaderAnnouncement] = useState<string>('');
+
+  /**
+   * Find the closest node in a given direction from the current node.
+   * Uses spatial positioning and distance calculation.
+   */
+  const findNodeInDirection = useCallback(
+    (currentNodeId: string, direction: ArrowDirection): ServiceMapNode | null => {
+      const currentNode = nodes.find((n) => n.id === currentNodeId);
+      if (!currentNode) return null;
+
+      const current = currentNode.position;
+      const candidates: Array<{ node: ServiceMapNode; distance: number }> = [];
+
+      nodes.forEach((node) => {
+        if (node.id === currentNodeId) return;
+
+        const pos = node.position;
+        const dx = pos.x - current.x;
+        const dy = pos.y - current.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        const isInDirection =
+          (direction === 'ArrowRight' && dx > DIRECTION_THRESHOLD && Math.abs(dy) < Math.abs(dx)) ||
+          (direction === 'ArrowLeft' && dx < -DIRECTION_THRESHOLD && Math.abs(dy) < Math.abs(dx)) ||
+          (direction === 'ArrowDown' && dy > DIRECTION_THRESHOLD && Math.abs(dx) < Math.abs(dy)) ||
+          (direction === 'ArrowUp' && dy < -DIRECTION_THRESHOLD && Math.abs(dx) < Math.abs(dy));
+
+        if (isInDirection) {
+          candidates.push({ node, distance });
+        }
+      });
+
+      candidates.sort((a, b) => a.distance - b.distance);
+      return candidates[0]?.node || null;
+    },
+    [nodes]
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && (selectedNodeForPopover || selectedEdgeForPopover)) {
+        event.preventDefault();
+        onPopoverClose();
+        setScreenReaderAnnouncement(
+          i18n.translate('xpack.apm.serviceMap.popoverClosed', {
+            defaultMessage: 'Popover closed',
+          })
+        );
+        return;
+      }
+      if (event.key === 'Enter' || event.key === ' ') {
+        const activeElement = document.activeElement;
+        const edgeElement = activeElement?.closest('.react-flow__edge');
+        if (edgeElement) {
+          const edgeElementId = edgeElement.getAttribute('data-id');
+          if (!edgeElementId) return;
+          const focusedEdge = edges.find((e) => e.id === edgeElementId);
+          if (!focusedEdge) return;
+          event.preventDefault();
+
+          if (selectedEdgeForPopover?.id === edgeElementId) {
+            onPopoverClose();
+          } else {
+            onEdgeSelect(focusedEdge);
+            const sourceLabel = String(focusedEdge.data?.sourceData?.label || focusedEdge.source);
+            const targetLabel = String(focusedEdge.data?.targetData?.label || focusedEdge.target);
+            setScreenReaderAnnouncement(
+              i18n.translate('xpack.apm.serviceMap.edgeSelected', {
+                defaultMessage:
+                  'Selected connection from {source} to {target}. Press Escape to close.',
+                values: { source: sourceLabel, target: targetLabel },
+              })
+            );
+          }
+          return;
+        }
+        const nodeElement = activeElement?.closest('[data-id]');
+        if (nodeElement && !edgeElement) {
+          const nodeId = nodeElement.getAttribute('data-id');
+          const focusedNode = nodes.find((n) => n.id === nodeId);
+          if (!focusedNode) return;
+
+          event.preventDefault();
+
+          if (selectedNodeId === nodeId) {
+            onPopoverClose();
+          } else {
+            onNodeSelect(focusedNode);
+            setScreenReaderAnnouncement(
+              i18n.translate('xpack.apm.serviceMap.nodeSelected', {
+                defaultMessage: 'Selected {nodeLabel}. Press Escape to close.',
+                values: { nodeLabel: focusedNode.data.label || nodeId },
+              })
+            );
+          }
+        }
+      }
+      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+        const activeElement = document.activeElement;
+        const currentNodeElement = activeElement?.closest('[data-id]');
+        if (currentNodeElement && !event.shiftKey && !event.ctrlKey && !event.metaKey) {
+          const currentNodeId = currentNodeElement.getAttribute('data-id');
+          if (!currentNodeId) return null;
+
+          const nextNode = findNodeInDirection(currentNodeId, event.key as ArrowDirection);
+          if (!nextNode) return null;
+
+          event.preventDefault();
+
+          const nextElement = document.querySelector(`[data-id="${nextNode.id}"]`);
+          if (nextElement instanceof HTMLElement) {
+            nextElement.focus();
+            setScreenReaderAnnouncement(
+              i18n.translate('xpack.apm.serviceMap.nodeFocused', {
+                defaultMessage: 'Focused on {nodeLabel}',
+                values: { nodeLabel: nextNode.data.label || nextNode.id },
+              })
+            );
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    nodes,
+    edges,
+    selectedNodeId,
+    selectedNodeForPopover,
+    selectedEdgeForPopover,
+    onNodeSelect,
+    onEdgeSelect,
+    onPopoverClose,
+    findNodeInDirection,
+  ]);
+
+  return {
+    screenReaderAnnouncement,
+    findNodeInDirection,
+  };
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/use_reduced_motion.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/react_flow_service_map/use_reduced_motion.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Hook that detects and responds to user's reduced motion preferences.
+ * Listens for changes to the prefers-reduced-motion media query.
+ *
+ * @returns Object containing:
+ * - prefersReducedMotion: boolean indicating if reduced motion is preferred
+ * - getAnimationDuration: function to get 0 or the provided duration based on preference
+ */
+export function useReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  const getAnimationDuration = useCallback(
+    (duration: number): number => {
+      return prefersReducedMotion ? 0 : duration;
+    },
+    [prefersReducedMotion]
+  );
+
+  return {
+    prefersReducedMotion,
+    getAnimationDuration,
+  };
+}

--- a/x-pack/solutions/observability/plugins/apm/test/scout_react_flow_service_map/ui/fixtures/page_objects/react_flow_service_map.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout_react_flow_service_map/ui/fixtures/page_objects/react_flow_service_map.ts
@@ -116,4 +116,23 @@ export class ReactFlowServiceMapPage {
   async getPopoverTitle() {
     return this.serviceMapPopoverTitle.textContent();
   }
+
+  /* Accessibility helpers */
+  async focusNode(nodeId: string) {
+    const node = this.getNodeById(nodeId);
+    await node.focus();
+  }
+
+  async isNodeFocused(nodeId: string): Promise<boolean> {
+    return this.page.evaluate((id) => {
+      const nodeEl = document.querySelector(`[data-id="${id}"]`);
+      return nodeEl === document.activeElement || nodeEl?.contains(document.activeElement) || false;
+    }, nodeId);
+  }
+
+  async getNodeAriaLabel(nodeId: string): Promise<string | null> {
+    const node = this.getNodeById(nodeId);
+    const interactiveElement = node.locator('[role="button"]');
+    return interactiveElement.getAttribute('aria-label');
+  }
 }

--- a/x-pack/solutions/observability/plugins/apm/test/scout_react_flow_service_map/ui/parallel_tests/service_map/react_flow_service_map_a11y.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout_react_flow_service_map/ui/parallel_tests/service_map/react_flow_service_map_a11y.spec.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test, testData } from '../../fixtures';
+import { SERVICE_OPBEANS_JAVA, SERVICE_OPBEANS_NODE } from '../../fixtures/constants';
+
+/**
+ * Accessibility tests for React Flow Service Map
+ *
+ * These tests verify that the service map meets accessibility requirements:
+ * - axe-core automated checks pass (WCAG 2.1 AA compliance)
+ * - Keyboard navigation works correctly
+ * - Focus management is proper
+ * - Screen reader support through ARIA attributes
+ *
+ * Tests run with the serviceMapUseReactFlow feature flag enabled.
+ */
+test.describe('React Flow Service Map Accessibility', { tag: ['@ess', '@svlOblt'] }, () => {
+  test.beforeEach(async ({ browserAuth, pageObjects: { reactFlowServiceMapPage } }) => {
+    await browserAuth.loginAsViewer();
+    await reactFlowServiceMapPage.gotoWithDateSelected(testData.START_DATE, testData.END_DATE);
+    await reactFlowServiceMapPage.waitForReactFlowServiceMapToLoad();
+  });
+
+  test('axe-core automated accessibility checks pass', async ({
+    page,
+    pageObjects: { reactFlowServiceMapPage },
+  }) => {
+    await test.step('service map container has no accessibility violations', async () => {
+      await page.testSubj.locator('reactFlowServiceMap').waitFor({ state: 'visible' });
+
+      const { violations } = await page.checkA11y({
+        include: ['[data-test-subj="reactFlowServiceMap"]'],
+      });
+
+      expect(violations).toHaveLength(0);
+    });
+
+    await test.step('service map controls have no accessibility violations', async () => {
+      const { violations } = await page.checkA11y({
+        include: ['[data-testid="rf__controls"]'],
+      });
+
+      expect(violations).toHaveLength(0);
+    });
+
+    await test.step('service node popover has no accessibility violations', async () => {
+      await reactFlowServiceMapPage.waitForNodeToLoad(SERVICE_OPBEANS_JAVA);
+      await reactFlowServiceMapPage.clickNode(SERVICE_OPBEANS_JAVA);
+      await reactFlowServiceMapPage.waitForPopoverToBeVisible();
+
+      const { violations } = await page.checkA11y({
+        include: ['[data-test-subj="serviceMapPopoverContent"]'],
+      });
+
+      expect(violations).toHaveLength(0);
+    });
+  });
+
+  test('keyboard navigation works correctly', async ({
+    page,
+    pageObjects: { reactFlowServiceMapPage },
+  }) => {
+    await test.step('service map nodes are focusable with Tab key', async () => {
+      await reactFlowServiceMapPage.waitForNodeToLoad(SERVICE_OPBEANS_JAVA);
+
+      const serviceMap = page.testSubj.locator('reactFlowServiceMap');
+      await serviceMap.focus();
+      await page.keyboard.press('Tab');
+
+      const focusedElement = await page.evaluate(() => document.activeElement?.tagName);
+      expect(focusedElement).toBeTruthy();
+    });
+
+    await test.step('pressing Enter on a focused node opens the popover', async () => {
+      await reactFlowServiceMapPage.waitForNodeToLoad(SERVICE_OPBEANS_JAVA);
+
+      const node = reactFlowServiceMapPage.getNodeById(SERVICE_OPBEANS_JAVA);
+      await node.focus();
+      await page.keyboard.press('Enter');
+
+      await reactFlowServiceMapPage.waitForPopoverToBeVisible();
+      await expect(reactFlowServiceMapPage.serviceMapPopoverContent).toBeVisible();
+    });
+
+    await test.step('pressing Escape closes the popover', async () => {
+      await page.keyboard.press('Escape');
+
+      await reactFlowServiceMapPage.waitForPopoverToBeHidden();
+      await expect(reactFlowServiceMapPage.serviceMapPopoverContent).toBeHidden();
+    });
+
+    await test.step('pressing Space on a focused node opens the popover', async () => {
+      const node = reactFlowServiceMapPage.getNodeById(SERVICE_OPBEANS_JAVA);
+      await node.focus();
+      await page.keyboard.press(' ');
+
+      await reactFlowServiceMapPage.waitForPopoverToBeVisible();
+      await expect(reactFlowServiceMapPage.serviceMapPopoverContent).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await reactFlowServiceMapPage.waitForPopoverToBeHidden();
+    });
+
+    await test.step('arrow keys navigate between nodes', async () => {
+      await reactFlowServiceMapPage.waitForNodeToLoad(SERVICE_OPBEANS_NODE);
+
+      const javaNode = reactFlowServiceMapPage.getNodeById(SERVICE_OPBEANS_JAVA);
+      await javaNode.focus();
+
+      const originalFocusedId = await page.evaluate(() => {
+        const el = document.activeElement?.closest('[data-id]');
+        return el?.getAttribute('data-id');
+      });
+
+      await page.keyboard.press('ArrowRight');
+
+      const newFocusedId = await page.evaluate(() => {
+        const el = document.activeElement?.closest('[data-id]');
+        return el?.getAttribute('data-id');
+      });
+
+      expect(newFocusedId || originalFocusedId).toBeTruthy();
+    });
+  });
+
+  test('focus management and visible indicators work correctly', async ({
+    page,
+    pageObjects: { reactFlowServiceMapPage },
+  }) => {
+    await test.step('nodes have visible focus indicators when focused', async () => {
+      await reactFlowServiceMapPage.waitForNodeToLoad(SERVICE_OPBEANS_JAVA);
+
+      const node = reactFlowServiceMapPage.getNodeById(SERVICE_OPBEANS_JAVA);
+      await node.focus();
+
+      const isFocused = await page.evaluate((nodeId) => {
+        const nodeEl = document.querySelector(`[data-id="${nodeId}"]`);
+        return nodeEl === document.activeElement || nodeEl?.contains(document.activeElement);
+      }, SERVICE_OPBEANS_JAVA);
+
+      expect(isFocused).toBe(true);
+    });
+
+    await test.step('zoom controls are keyboard accessible', async () => {
+      await expect(reactFlowServiceMapPage.reactFlowZoomInBtn).toBeVisible();
+      await expect(reactFlowServiceMapPage.reactFlowZoomOutBtn).toBeVisible();
+      await expect(reactFlowServiceMapPage.reactFlowFitViewBtn).toBeVisible();
+
+      await reactFlowServiceMapPage.reactFlowZoomInBtn.focus();
+      await page.keyboard.press('Enter');
+
+      await expect(reactFlowServiceMapPage.reactFlowControls).toBeVisible();
+    });
+  });
+
+  test('ARIA attributes are properly set for screen readers', async ({
+    page,
+    pageObjects: { reactFlowServiceMapPage },
+  }) => {
+    await test.step('service map container has aria-label describing the content', async () => {
+      const serviceMapContainer = page.testSubj.locator('reactFlowServiceMap');
+      await expect(serviceMapContainer).toBeVisible();
+
+      await expect(serviceMapContainer).toHaveAttribute('aria-label', /Service map/);
+    });
+
+    await test.step('service nodes have proper role and aria-label', async () => {
+      await reactFlowServiceMapPage.waitForNodeToLoad(SERVICE_OPBEANS_JAVA);
+
+      const nodeContainer = reactFlowServiceMapPage.getNodeById(SERVICE_OPBEANS_JAVA);
+      const interactiveElement = nodeContainer.locator('[role="button"]');
+
+      await expect(interactiveElement).toHaveAttribute('role', 'button');
+      await expect(interactiveElement).toHaveAttribute('aria-label', /service/i);
+      await expect(interactiveElement).toHaveAttribute(
+        'aria-label',
+        new RegExp(SERVICE_OPBEANS_JAVA, 'i')
+      );
+    });
+
+    await test.step('screen reader announcement region exists within service map', async () => {
+      const serviceMapContainer = page.testSubj.locator('reactFlowServiceMap');
+      const liveRegion = serviceMapContainer.locator('[aria-live="polite"]');
+      await expect(liveRegion).toHaveCount(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #250215
## Summary
This PR adds a11y support including: 

### Keyboard Navigation
- **Tab navigation**: Users can tab through the service map container and nodes
- **Arrow key navigation**: Spatial navigation between nodes (up/down/left/right) based on node positions
- **Enter/Space**: Opens the details popover for the focused node
- **Escape**: Closes the popover


https://github.com/user-attachments/assets/d8ae5ac8-cb84-4d80-874e-f1c99fb307ba


https://github.com/user-attachments/assets/b9498736-00b5-4595-9c3c-985e654e8d72



### Screen Reader Support
- **Container announcement**: Service map container has `role="group"` with descriptive `aria-label` including navigation instructions
- **Node labels**: Each node has comprehensive `aria-label` with service name, agent type, and health status
- **Dynamic announcements**: `aria-live` region announces selection changes and navigation events
- **Hidden instructions**: Full navigation instructions available via `aria-describedby`


https://github.com/user-attachments/assets/9d6d4a1a-8d84-41de-8a91-8eb2027ae7dd

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/4267515f-8190-43c7-87e2-e803fb47276c" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/06372384-fe5f-4283-ab2b-86cc84e6c899" />


### Visual Accessibility
- **Focus indicators**: Clear focus outlines on nodes using EUI theme colors
- **Reduced motion support**: `useReducedMotion` hook respects `prefers-reduced-motion` media query


https://github.com/user-attachments/assets/e67e3d86-0e3f-4712-9aa1-411f23d5f652


## How to test

- Verify that the Cytoscape service map is visible berfore adding the
feature flag
- Add 
```
feature_flags.overrides:
   apm.serviceMapUseReactFlow: true
```
to the `kibana.dev.yml`
- Verify the react flow service map is visible and accessible using:
   - [x] VoiceOver (macOS) - Navigation and announcements
   - [x] Keyboard-only navigation
   - [x] Reduced motion preference

## How to run the scout tests
- Start the server with the React Flow feature flag enabled:

   `node scripts/scout.js start-server --serverless=oblt --config-dir
react_flow_service_map`

- Run the React Flow tests:

   `npx playwright test
--config=x-pack/solutions/observability/plugins/apm/test/scout_react_flow_service_map/ui/parallel.playwright.config.ts
--grep=@svlOblt --project=local `