### PR TITLE
[Search] Reduce polling on Index Details page

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/components/api_key_form.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/components/api_key_form.tsx
@@ -25,9 +25,10 @@ const API_KEY_MASK = '•'.repeat(60);
 
 interface ApiKeyFormProps {
   hasTitle?: boolean;
+  minWidth?: number;
 }
 
-export const ApiKeyForm: React.FC<ApiKeyFormProps> = ({ hasTitle = true }) => {
+export const ApiKeyForm: React.FC<ApiKeyFormProps> = ({ hasTitle = true, minWidth }) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const { apiKey, status, updateApiKey, toggleApiKeyVisibility } = useSearchApiKey();
 
@@ -43,6 +44,7 @@ export const ApiKeyForm: React.FC<ApiKeyFormProps> = ({ hasTitle = true }) => {
         copyValue={apiKey}
         dataTestSubj="apiKeyFormAPIKey"
         copyValueDataTestSubj="APIKeyButtonCopy"
+        minWidth={minWidth}
         actions={[
           <EuiButtonIcon
             iconType={status === Status.showPreviewKey ? 'eyeClosed' : 'eye'}

--- a/x-pack/solutions/search/plugins/search_indices/public/components/connection_details/connection_details.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/connection_details/connection_details.tsx
@@ -24,6 +24,7 @@ export const ConnectionDetails: React.FC = () => {
       copyValue={elasticsearchUrl}
       dataTestSubj="connectionDetailsEndpoint"
       copyValueDataTestSubj="connectionDetailsEndpointCopy"
+      minWidth={400}
     />
   );
 };

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
@@ -58,19 +58,23 @@ export const SearchIndexDetailsPage = () => {
   } = useKibana().services;
   const {
     data: index,
-    refetch,
+    refetch: refetchIndex,
     isError: isIndexError,
     isInitialLoading,
     error: indexLoadingError,
   } = useIndex(indexName);
   const {
     data: mappings,
+    refetch: refetchMappings,
     isError: isMappingsError,
     isInitialLoading: isMappingsInitialLoading,
     error: mappingsError,
   } = useIndexMapping(indexName);
-  const { data: indexDocuments, isInitialLoading: indexDocumentsIsInitialLoading } =
-    useIndexDocumentSearch(indexName);
+  const {
+    data: indexDocuments,
+    refetch: refetchIndexDocuments,
+    isInitialLoading: indexDocumentsIsInitialLoading,
+  } = useIndexDocumentSearch(indexName);
   const { data: userPrivileges } = useUserPrivilegesQuery(indexName);
 
   const navigateToPlayground = useCallback(async () => {
@@ -112,6 +116,7 @@ export const SearchIndexDetailsPage = () => {
             isInitialLoading={indexDocumentsIsInitialLoading}
             userPrivileges={userPrivileges}
             navigateToPlayground={navigateToPlayground}
+            mappingData={mappings}
           />
         ),
         'data-test-subj': `${SearchIndexDetailsTabs.DATA}Tab`,
@@ -141,6 +146,7 @@ export const SearchIndexDetailsPage = () => {
     indexDocuments,
     indexDocumentsIsInitialLoading,
     userPrivileges,
+    mappings,
     navigateToPlayground,
   ]);
   const [selectedTab, setSelectedTab] = useState(detailsPageTabs[0]);
@@ -175,9 +181,12 @@ export const SearchIndexDetailsPage = () => {
     application.navigateToApp('management', { deepLinkId: 'index_management' });
   }, [application]);
 
-  const refetchIndex = useCallback(() => {
-    refetch();
-  }, [refetch]);
+  const refetchAllData = useCallback(() => {
+    refetchIndex();
+    refetchMappings();
+    refetchIndexDocuments();
+  }, [refetchIndex, refetchMappings, refetchIndexDocuments]);
+
   const indexError = useMemo(
     () =>
       isIndexError
@@ -197,7 +206,10 @@ export const SearchIndexDetailsPage = () => {
   }, [isShowingDeleteModal]);
   const { euiTheme } = useEuiTheme();
 
-  if (isInitialLoading || isMappingsInitialLoading || indexDocumentsIsInitialLoading) {
+  const pageDataLoading =
+    isInitialLoading || isMappingsInitialLoading || indexDocumentsIsInitialLoading;
+
+  if (pageDataLoading) {
     return (
       <SectionLoading>
         {i18n.translate('xpack.searchIndices.loadingDescription', {
@@ -221,7 +233,7 @@ export const SearchIndexDetailsPage = () => {
         <IndexloadingError
           error={indexError}
           navigateToIndexListPage={navigateToIndexListPage}
-          reloadFunction={refetchIndex}
+          reloadFunction={refetchAllData}
         />
       ) : (
         <>
@@ -295,12 +307,27 @@ export const SearchIndexDetailsPage = () => {
             <EuiFlexGroup direction="column">
               <EuiFlexGroup direction="column">
                 <EuiFlexItem>
-                  <EuiFlexGroup css={{ overflow: 'auto' }} wrap>
-                    <EuiFlexItem grow={false} css={{ minWidth: 400 }}>
-                      <ConnectionDetails />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false} css={{ minWidth: 400 }}>
-                      <ApiKeyForm />
+                  <EuiFlexGroup justifyContent="spaceBetween" alignItems="flexEnd">
+                    <EuiFlexGroup css={{ overflow: 'auto' }} wrap>
+                      <EuiFlexItem grow={false}>
+                        <ConnectionDetails />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <ApiKeyForm minWidth={400} />
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                    <EuiFlexItem css={{ maxWidth: 'fit-content' }}>
+                      <EuiButton
+                        data-test-subj="SearchIndexDetailsPageRefreshDataButton"
+                        isLoading={pageDataLoading}
+                        onClick={refetchAllData}
+                        iconType="refresh"
+                        color="success"
+                      >
+                        {i18n.translate('xpack.searchIndices.indexAction.refreshDataButtonLabel', {
+                          defaultMessage: 'Refresh data',
+                        })}
+                      </EuiButton>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
@@ -20,7 +20,6 @@ import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
 import { useKibana } from '../../hooks/use_kibana';
-import { useIndexMapping } from '../../hooks/api/use_index_mappings';
 import type { IndexDocuments as IndexDocumentsType } from '../../hooks/api/use_document_search';
 import { IndexDocuments } from '../index_documents/index_documents';
 import { IndexSearchExample } from './details_search_example';
@@ -29,6 +28,7 @@ import { UpdateElserMappingsModal } from '../update_elser_mappings/update_elser_
 import { flattenMappings, hasElserOnMlNodeSemanticTextField } from '../update_elser_mappings/utils';
 import type { NormalizedFields } from '../update_elser_mappings/types';
 import { useLicense } from '../../hooks/use_license';
+import type { Mappings } from '../../types';
 
 interface IndexDetailsDataProps {
   indexName: string;
@@ -36,6 +36,7 @@ interface IndexDetailsDataProps {
   isInitialLoading: boolean;
   navigateToPlayground: () => void;
   userPrivileges?: UserStartPrivilegesResponse;
+  mappingData: Mappings | undefined;
 }
 
 export const IndexDetailsData = ({
@@ -44,9 +45,9 @@ export const IndexDetailsData = ({
   isInitialLoading,
   navigateToPlayground,
   userPrivileges,
+  mappingData,
 }: IndexDetailsDataProps) => {
   const { application, cloud } = useKibana().services;
-  const { data: mappingData } = useIndexMapping(indexName);
   const { isAtLeastEnterprise } = useLicense();
   const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
 

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_delete_document.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_delete_document.ts
@@ -11,7 +11,8 @@ import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { MutationKeys, QueryKeys } from '../../constants';
 import { useKibana } from '../use_kibana';
 import type { IndexDocuments } from './use_document_search';
-import { INDEX_SEARCH_POLLING } from './use_document_search';
+
+const INDEX_SEARCH_POLLING = 30000;
 
 interface DeleteDocumentParams {
   id: string;

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_document_search.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_document_search.ts
@@ -23,15 +23,12 @@ const DEFAULT_PAGINATION = {
   size: DEFAULT_DOCUMENT_PAGE_SIZE,
   total: 0,
 };
-export const INDEX_SEARCH_POLLING = 30000;
 export const useIndexDocumentSearch = (indexName: string) => {
   const {
     services: { http },
   } = useKibana();
-  const { data, isInitialLoading } = useQuery({
+  const { data, isInitialLoading, refetch } = useQuery({
     queryKey: [QueryKeys.SearchDocuments, indexName],
-    refetchInterval: INDEX_SEARCH_POLLING,
-    refetchIntervalInBackground: true,
     refetchOnWindowFocus: 'always',
     queryFn: async ({ signal }) =>
       http.post<IndexDocuments>(`/internal/search_indices/${indexName}/documents/search`, {
@@ -48,6 +45,7 @@ export const useIndexDocumentSearch = (indexName: string) => {
   });
   return {
     data,
+    refetch,
     isInitialLoading,
     meta: pageToPagination(data?.results?._meta?.page ?? DEFAULT_PAGINATION),
   };

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index.ts
@@ -10,14 +10,11 @@ import { useQuery } from '@kbn/react-query';
 import { QueryKeys } from '../../constants';
 import { useKibana } from '../use_kibana';
 
-const POLLING_INTERVAL = 15 * 1000;
 export const useIndex = (indexName: string) => {
   const { http } = useKibana().services;
   const queryKey = [QueryKeys.FetchIndex, indexName];
   return useQuery<Index, { body: { statusCode: number; message: string; error: string } }>({
     queryKey,
-    refetchInterval: POLLING_INTERVAL,
-    refetchIntervalInBackground: true,
     refetchOnWindowFocus: 'always',
     retry: (failureCount, error) => {
       return !(error?.body?.statusCode === 404 || failureCount === 3);

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index_mappings.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index_mappings.ts
@@ -10,14 +10,11 @@ import { useKibana } from '../use_kibana';
 import type { Mappings } from '../../types';
 import { QueryKeys } from '../../constants';
 
-const POLLING_INTERVAL = 15 * 1000;
 export const useIndexMapping = (indexName: string) => {
   const { http } = useKibana().services;
   const queryKey = [QueryKeys.FetchMapping, indexName];
   return useQuery<Mappings, { body: { message: string; error: string } }>({
     queryKey,
-    refetchInterval: POLLING_INTERVAL,
-    refetchIntervalInBackground: true,
     refetchOnWindowFocus: 'always',
     queryFn: () =>
       http.fetch<Mappings>(`/api/index_management/mapping/${encodeURIComponent(indexName)}`),

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_user_permissions.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_user_permissions.ts
@@ -15,7 +15,8 @@ import { useKibana } from '../use_kibana';
 export const useUserPrivilegesQuery = (indexName: string) => {
   const { http } = useKibana().services;
   return useQuery({
-    queryKey: [QueryKeys.FetchUserStartPrivileges],
+    queryKey: [QueryKeys.FetchUserStartPrivileges, indexName],
+    refetchOnWindowFocus: false,
     queryFn: () =>
       http.get<UserStartPrivilegesResponse>(
         `/internal/search_indices/start_privileges/${indexName}`


### PR DESCRIPTION
## Summary

This change improves how the Index Details page fetches data by reducing unnecessary polling to backend APIs. Previously, the page repeatedly polled two endpoints to keep index metadata up to date, even when the data was not actively changing or required for user interaction.

As part of this update, we reviewed the polling strategy used for:

`GET /api/index_management/mapping/{index_name}`
`GET /internal/index_management/indices/{index_name}`
`POST /internal/search_indices/${indexName}/documents/search`

and adjusted the behavior to better align with how the data is used on the page.

### What changed
- Polling behavior has been reduced or scoped so that requests are only made on initial load, on window focus, and when requested.
- A `Refresh data` button was added to allow users to request up to date data.
- `useUserPrivilegesQuery` no longer refetches on window focus, which is the default behavior.
-  The `queryKey` in `useUserPrivilegesQuery` has been updated to add the `indexName`.

### Screenshots

**Index with documents**
<img width="700" height="828" alt="Screenshot 2026-02-03 at 13 24 12" src="https://github.com/user-attachments/assets/c8a99e1e-4f67-4bfd-9b7a-4c7490f8cb7d" />

**Index without documents**
<img width="700" height="829" alt="Screenshot 2026-02-03 at 13 24 26" src="https://github.com/user-attachments/assets/8d752199-2ecf-47e6-b47e-f1966590f0c2" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note

Reduced background polling on the Index Details page to avoid unnecessary API requests.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->