### PR TITLE
[One Workflow] skip existing scheduling check when workflow has concurrency strategy

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -311,16 +311,19 @@ export class WorkflowsExecutionEnginePlugin
               }
               logger.debug(`Running scheduled workflow task for workflow ${workflow.id}`);
 
-              // Guard check: Check if there's already a scheduled workflow execution in non-terminal state
-              const wasSkipped = await checkAndSkipIfExistingScheduledExecution(
-                workflow,
-                spaceId,
-                workflowExecutionRepository,
-                taskInstance,
-                logger
-              );
-              if (wasSkipped) {
-                return;
+              // Guard check: Check&Skip only when workflow has no concurrency strategy. When strategy is
+              // set, the concurrency check (later) governs the limit and strategy.
+              if (!workflow.definition?.settings?.concurrency?.strategy) {
+                const wasSkipped = await checkAndSkipIfExistingScheduledExecution(
+                  workflow,
+                  spaceId,
+                  workflowExecutionRepository,
+                  taskInstance,
+                  logger
+                );
+                if (wasSkipped) {
+                  return;
+                }
               }
 
               // Check for RRule triggers and log details


### PR DESCRIPTION
When a workflow has a concurrency strategy (e.g. `max: 2`, strategy `drop` or `cancel-in-progress`), the scheduled task runner was still running the "existing scheduled execution" guard first. That guard skips a new run whenever any other non-terminal scheduled execution exists, so the second run was always skipped and the concurrency check never got to allow it.

This change defers to workflow-level concurrency when it is set: we only run the existing-scheduled check when the workflow has **no** concurrency strategy (`!workflow.definition?.settings?.concurrency?.strategy`). When a strategy is set, we create the execution and let the concurrency check enforce the limit and strategy.

Fixes https://github.com/elastic/security-team/issues/15664