### PR TITLE
[9.3] [Infra] Fix inventory home page tests (#249330)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/toolbar_control.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/toolbar_control.tsx
@@ -110,7 +110,9 @@ export function SavedViewsToolbarControls<TSingleSavedViewState extends SavedVie
           <EuiButton
             size="s"
             onClick={togglePopoverAndLoad}
-            data-test-subj="savedViews-openPopover"
+            data-test-subj={`savedViews-openPopover-${
+              isFetchingCurrentView ? 'loading' : 'loaded'
+            }`}
             buttonRef={openPopoverButtonRef}
             iconType="arrowDown"
             iconSide="right"

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -71,25 +71,21 @@ export class InventoryPage {
       .filter({ hasText: 'Kubernetes Pod details' });
   }
 
-  private async waitForNodesToLoad(opts: { waitForSnapshotRequest?: boolean } = {}) {
-    if (opts.waitForSnapshotRequest) {
-      // Wait for successful API completion
-      await this.page.waitForResponse(
-        (resp) => resp.url().includes('/api/metrics/snapshot') && resp.status() === 200
-      );
-    }
-
+  private async waitForNodesToLoad() {
     await this.page.getByTestId('infraNodesOverviewLoadingPanel').waitFor({ state: 'hidden' });
   }
 
   private async waitForPageToLoad() {
     await this.page.getByTestId('infraMetricsPage').waitFor();
     await this.waitForNodesToLoad();
+    await this.page.getByTestId('savedViews-openPopover-loaded').waitFor();
   }
 
-  public async goToPage() {
+  public async goToPage(opts: { skipLoadWait?: boolean } = {}) {
     await this.page.goto(`${this.kbnUrl.app('metrics')}/inventory`);
-    await this.waitForPageToLoad();
+    if (!opts.skipLoadWait) {
+      await this.waitForPageToLoad();
+    }
   }
 
   public async goToPageWithSavedView(savedViewId: string) {
@@ -161,11 +157,9 @@ export class InventoryPage {
   }
 
   public async goToTime(time: string) {
-    await this.datePickerInput.focus();
-    await this.datePickerInput.clear();
     await this.datePickerInput.fill(time);
-    await this.datePickerInput.press('Enter');
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.datePickerInput.press('Escape');
+    await this.waitForNodesToLoad();
   }
 
   public async getWaffleNode(nodeName: string) {
@@ -186,19 +180,19 @@ export class InventoryPage {
   public async showHosts() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherHostsButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.waitForNodesToLoad();
   }
 
   public async showPods() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherPodsButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.waitForNodesToLoad();
   }
 
   public async showContainers() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherContainersButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.waitForNodesToLoad();
   }
 
   public async clickNoDataPageAddDataButton() {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
@@ -11,7 +11,8 @@ import { test } from '../../fixtures';
 test.describe('Infrastructure Inventory - Onboarding', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
     await browserAuth.loginAsViewer();
-    await inventoryPage.goToPage();
+    // Skip load wait as there is no data to load in empty data test cases
+    await inventoryPage.goToPage({ skipLoadWait: true });
   });
 
   test('Renders no data page and redirects to onboarding page when no data is present', async ({

--- a/x-pack/solutions/observability/test/functional/page_objects/infra_saved_views.ts
+++ b/x-pack/solutions/observability/test/functional/page_objects/infra_saved_views.ts
@@ -17,7 +17,7 @@ export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
 
   return {
     async clickSavedViewsButton() {
-      const button = await testSubjects.find('savedViews-openPopover');
+      const button = await testSubjects.find('savedViews-openPopover-loaded');
 
       await retry.waitFor('Wait for button to be enabled', async () => {
         const isDisabled = Boolean(await button.getAttribute('disabled'));
@@ -75,7 +75,7 @@ export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
 
     async ensureViewIsLoaded(name: string) {
       await retry.tryForTime(config.get('timeouts.try'), async () => {
-        const subject = await testSubjects.find('savedViews-openPopover');
+        const subject = await testSubjects.find('savedViews-openPopover-loaded');
         expect(await subject.getVisibleText()).to.be(name);
       });
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Infra] Fix inventory home page tests (#249330)](https://github.com/elastic/kibana/pull/249330)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-19T14:47:51Z","message":"[Infra] Fix inventory home page tests (#249330)\n\n## Summary\n\nCloses #249003\n\nThis PR addresses the flakiness detected in infrastructure inventory\ntests. The problem originated from an incorrect handling of the loading\nstate of the page during the first load. Previously, the page object for\nthe home page was simply waiting for the waffle chart loading state to\ngo away. The assumption was that, once the chart had loaded the data\n(even if it was empty) the page was fully loaded and ready to be\ninteracted with. But, this is not entirely the case as there is another\ncomponent in the page that interacts with the waffle chart that should\nbe awaited as well.\n\nSaid component is the saved views selector (which will have a whole test\nsuite for itself coming soon) that is capable of interacting with the\nselected waffle time. Upon page load, this component starts fetching\nsaved views in the background. Once that process finishes, the selected\nsaved view will update the waffle time. In these test cases, as saved\nviews aren't being tested, the saved views selector will set a default\nview by omission. The timeframe of this default view that will be\napplied by default sets the date to the current time.\n\nSo, knowing that behaviour for saved views the issue is now clear.\nBecause the test wasn't properly waiting for saved views to be loaded,\nsometimes the waffle chart could load faster than saved views. When this\nhappened, the test case would continue running while saved views were\nstill being fetched. Tests would set their desired date during the\nbeforeEach block. But, by the time test assertions started, the default\nviews would have finished loading and acted on the waffle time date.\nThis caused chart data to be fetched again targeting the current date\nwhich would result in an empty waffle chart, which would in turn lead\nthe test assertions to failed. Flakiness comes from the fact that the\nissue depended on requests timing relative to each other, thus why it\ncouldn't be reliably reproduced.\n\nThe changes included in the PR will make sure that saved views are\nproperly awaited while setting the stage for test runs.\nAlso, following the recommended best practices, the saved views\ncomponent's test id has been updated to reflect it's loading state\n(loading vs loaded) so we can confidently have a marker for when saved\nviews have fully loaded.\n\n\n### Checklist\n\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"df085303036e7632b8c1ab83a3d9e11c56ed372f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.3.0","ci:beta-faster-pr-build","v9.4.0","Team:obs-presentation"],"title":"[Infra] Fix inventory home page tests","number":249330,"url":"https://github.com/elastic/kibana/pull/249330","mergeCommit":{"message":"[Infra] Fix inventory home page tests (#249330)\n\n## Summary\n\nCloses #249003\n\nThis PR addresses the flakiness detected in infrastructure inventory\ntests. The problem originated from an incorrect handling of the loading\nstate of the page during the first load. Previously, the page object for\nthe home page was simply waiting for the waffle chart loading state to\ngo away. The assumption was that, once the chart had loaded the data\n(even if it was empty) the page was fully loaded and ready to be\ninteracted with. But, this is not entirely the case as there is another\ncomponent in the page that interacts with the waffle chart that should\nbe awaited as well.\n\nSaid component is the saved views selector (which will have a whole test\nsuite for itself coming soon) that is capable of interacting with the\nselected waffle time. Upon page load, this component starts fetching\nsaved views in the background. Once that process finishes, the selected\nsaved view will update the waffle time. In these test cases, as saved\nviews aren't being tested, the saved views selector will set a default\nview by omission. The timeframe of this default view that will be\napplied by default sets the date to the current time.\n\nSo, knowing that behaviour for saved views the issue is now clear.\nBecause the test wasn't properly waiting for saved views to be loaded,\nsometimes the waffle chart could load faster than saved views. When this\nhappened, the test case would continue running while saved views were\nstill being fetched. Tests would set their desired date during the\nbeforeEach block. But, by the time test assertions started, the default\nviews would have finished loading and acted on the waffle time date.\nThis caused chart data to be fetched again targeting the current date\nwhich would result in an empty waffle chart, which would in turn lead\nthe test assertions to failed. Flakiness comes from the fact that the\nissue depended on requests timing relative to each other, thus why it\ncouldn't be reliably reproduced.\n\nThe changes included in the PR will make sure that saved views are\nproperly awaited while setting the stage for test runs.\nAlso, following the recommended best practices, the saved views\ncomponent's test id has been updated to reflect it's loading state\n(loading vs loaded) so we can confidently have a marker for when saved\nviews have fully loaded.\n\n\n### Checklist\n\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"df085303036e7632b8c1ab83a3d9e11c56ed372f"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249330","number":249330,"mergeCommit":{"message":"[Infra] Fix inventory home page tests (#249330)\n\n## Summary\n\nCloses #249003\n\nThis PR addresses the flakiness detected in infrastructure inventory\ntests. The problem originated from an incorrect handling of the loading\nstate of the page during the first load. Previously, the page object for\nthe home page was simply waiting for the waffle chart loading state to\ngo away. The assumption was that, once the chart had loaded the data\n(even if it was empty) the page was fully loaded and ready to be\ninteracted with. But, this is not entirely the case as there is another\ncomponent in the page that interacts with the waffle chart that should\nbe awaited as well.\n\nSaid component is the saved views selector (which will have a whole test\nsuite for itself coming soon) that is capable of interacting with the\nselected waffle time. Upon page load, this component starts fetching\nsaved views in the background. Once that process finishes, the selected\nsaved view will update the waffle time. In these test cases, as saved\nviews aren't being tested, the saved views selector will set a default\nview by omission. The timeframe of this default view that will be\napplied by default sets the date to the current time.\n\nSo, knowing that behaviour for saved views the issue is now clear.\nBecause the test wasn't properly waiting for saved views to be loaded,\nsometimes the waffle chart could load faster than saved views. When this\nhappened, the test case would continue running while saved views were\nstill being fetched. Tests would set their desired date during the\nbeforeEach block. But, by the time test assertions started, the default\nviews would have finished loading and acted on the waffle time date.\nThis caused chart data to be fetched again targeting the current date\nwhich would result in an empty waffle chart, which would in turn lead\nthe test assertions to failed. Flakiness comes from the fact that the\nissue depended on requests timing relative to each other, thus why it\ncouldn't be reliably reproduced.\n\nThe changes included in the PR will make sure that saved views are\nproperly awaited while setting the stage for test runs.\nAlso, following the recommended best practices, the saved views\ncomponent's test id has been updated to reflect it's loading state\n(loading vs loaded) so we can confidently have a marker for when saved\nviews have fully loaded.\n\n\n### Checklist\n\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"df085303036e7632b8c1ab83a3d9e11c56ed372f"}}]}] BACKPORT-->