### PR TITLE
[Search Homepage] Added license check for the agent badges

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
@@ -9,11 +9,16 @@ import React from 'react';
 
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { useKibana } from '../use_kibana';
+import { useGetLicenseInfo } from '../use_get_license_info';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useAgentCount } from './use_agent_count';
 
 jest.mock('../use_kibana');
+jest.mock('../use_get_license_info');
+
 const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseGetLicenseInfo = useGetLicenseInfo as jest.MockedFunction<typeof useGetLicenseInfo>;
+
 const mockToolsService = {
   list: jest.fn().mockReturnValue(Promise.resolve([])),
 };
@@ -35,40 +40,102 @@ describe('useAgentCount', () => {
     jest.clearAllMocks();
     queryClient.clear();
 
-    // look for better typecasting
     mockUseKibana.mockReturnValue({
       services: {
         agentBuilder: mockAgentBuilderService,
       } as any,
     } as any);
+
+    mockUseGetLicenseInfo.mockReturnValue({
+      hasEnterpriseLicense: true,
+      isTrial: false,
+      licenseType: 'enterprise',
+    });
   });
 
-  it('should fetch the agent count', async () => {
-    mockAgentsService.list.mockReturnValue(
-      Promise.resolve([
-        {
-          agent: 'fake-agent',
-        },
-        {
-          agent: 'fake-agent2',
-        },
-      ])
-    );
-    const { result } = renderHook(() => useAgentCount(), { wrapper });
+  describe('with enterprise license', () => {
+    it('should fetch the agent count', async () => {
+      mockAgentsService.list.mockReturnValue(
+        Promise.resolve([
+          {
+            agent: 'fake-agent',
+          },
+          {
+            agent: 'fake-agent2',
+          },
+        ])
+      );
+      const { result } = renderHook(() => useAgentCount(), { wrapper });
 
-    await waitFor(() => expect(result.current.isLoading).toBeFalsy());
-    await waitFor(() => expect(result.current.isError).toBeFalsy());
-    await waitFor(() => expect(result.current.agents).toBe(2));
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+      await waitFor(() => expect(result.current.isError).toBeFalsy());
+      await waitFor(() => expect(result.current.agents).toBe(2));
+    });
+
+    it('should fetch the tools count', async () => {
+      mockToolsService.list.mockReturnValue(
+        Promise.resolve([{ tool: 'fake-tool' }, { tool: 'fake-tool2' }])
+      );
+      const { result } = renderHook(() => useAgentCount(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+      await waitFor(() => expect(result.current.isError).toBeFalsy());
+      await waitFor(() => expect(result.current.tools).toBe(2));
+    });
   });
 
-  it('should fetch the tools count', async () => {
-    mockToolsService.list.mockReturnValue(
-      Promise.resolve([{ tool: 'fake-tool' }, { tool: 'fake-tool2' }])
-    );
-    const { result } = renderHook(() => useAgentCount(), { wrapper });
+  describe('without enterprise license', () => {
+    beforeEach(() => {
+      mockUseGetLicenseInfo.mockReturnValue({
+        hasEnterpriseLicense: false,
+        isTrial: false,
+        licenseType: 'basic',
+      });
+    });
 
-    await waitFor(() => expect(result.current.isLoading).toBeFalsy());
-    await waitFor(() => expect(result.current.isError).toBeFalsy());
-    await waitFor(() => expect(result.current.tools).toBe(2));
+    it('should not fetch data and return zero values with isError true', async () => {
+      const { result } = renderHook(() => useAgentCount(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+      expect(result.current.agents).toBe(0);
+      expect(result.current.tools).toBe(0);
+      expect(result.current.isError).toBe(true);
+      expect(mockAgentsService.list).not.toHaveBeenCalled();
+      expect(mockToolsService.list).not.toHaveBeenCalled();
+    });
+
+    it('should return isError true for platinum license', async () => {
+      mockUseGetLicenseInfo.mockReturnValue({
+        hasEnterpriseLicense: false,
+        isTrial: false,
+        licenseType: 'platinum',
+      });
+      const { result } = renderHook(() => useAgentCount(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  describe('with trial license', () => {
+    beforeEach(() => {
+      mockUseGetLicenseInfo.mockReturnValue({
+        hasEnterpriseLicense: true,
+        isTrial: true,
+        licenseType: 'trial',
+      });
+    });
+
+    it('should fetch data with trial license (has at least enterprise)', async () => {
+      mockAgentsService.list.mockReturnValue(Promise.resolve([{ agent: 'fake-agent' }]));
+      mockToolsService.list.mockReturnValue(Promise.resolve([{ tool: 'fake-tool' }]));
+
+      const { result } = renderHook(() => useAgentCount(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+      expect(result.current.isError).toBeFalsy();
+      expect(result.current.agents).toBe(1);
+      expect(result.current.tools).toBe(1);
+    });
   });
 });

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.ts
@@ -7,11 +7,14 @@
 
 import { useQuery } from '@kbn/react-query';
 import { useKibana } from '../use_kibana';
+import { useGetLicenseInfo } from '../use_get_license_info';
 
 export const useAgentCount = () => {
   const {
     services: { agentBuilder },
   } = useKibana();
+
+  const { hasEnterpriseLicense } = useGetLicenseInfo();
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['fetchAgentCount'],
@@ -25,7 +28,13 @@ export const useAgentCount = () => {
         tools: tools?.length ?? 0,
       };
     },
+    enabled: hasEnterpriseLicense && !!agentBuilder,
   });
 
-  return { tools: data?.tools ?? 0, agents: data?.agents ?? 0, isLoading, isError };
+  return {
+    tools: data?.tools ?? 0,
+    agents: data?.agents ?? 0,
+    isLoading: hasEnterpriseLicense ? isLoading : false,
+    isError: isError || !hasEnterpriseLicense,
+  };
 };

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/use_get_license_info.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/use_get_license_info.ts
@@ -16,10 +16,16 @@ export const useGetLicenseInfo = () => {
 
   const license = useObservable(licensing.license$, null);
 
-  const { isTrial, licenseType } = useMemo(
+  const { isTrial, licenseType, hasEnterpriseLicense } = useMemo(
     () => ({
       isTrial: license && license.isAvailable && license.isActive && license.type === 'trial',
       licenseType: license?.type,
+      hasEnterpriseLicense: !!(
+        license &&
+        license.isAvailable &&
+        license.isActive &&
+        license.hasAtLeast('enterprise')
+      ),
     }),
     [license]
   );
@@ -27,5 +33,6 @@ export const useGetLicenseInfo = () => {
   return {
     isTrial,
     licenseType,
+    hasEnterpriseLicense,
   };
 };


### PR DESCRIPTION
## Summary

Adds license check to the homepage agent builder badge.
Instead of throwing error it will show - now.



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note
Homepage doesn't throw errors when license level is less than Enterprise.




<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->