### PR TITLE
[Search] Fix FormIntoField style regression

### DIFF
--- a/x-pack/solutions/search/packages/shared-ui/src/form_info_field/form_info_field.tsx
+++ b/x-pack/solutions/search/packages/shared-ui/src/form_info_field/form_info_field.tsx
@@ -72,8 +72,6 @@ export const FormInfoField: React.FC<FormInfoFieldProps> = ({
       css={css({
         maxWidth: maxWidth ? `${maxWidth}px` : undefined,
         minWidth: minWidth ? `${minWidth}px` : undefined,
-        backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
-        borderRadius: `${euiTheme.border.radius.medium}`,
       })}
     >
       {label && (
@@ -83,69 +81,69 @@ export const FormInfoField: React.FC<FormInfoFieldProps> = ({
           </EuiTitle>
         </EuiFlexItem>
       )}
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup
-          css={css({
-            color: euiTheme.colors.textParagraph,
-            borderRadius: euiTheme.border.radius.small,
-          })}
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
-        >
-          <EuiFlexItem css={{ minWidth: 0, maxWidth: `${euiTheme.base * 18.75}px` }} grow={false}>
-            <code
-              data-test-subj={dataTestSubj}
-              style={{
-                textOverflow: 'ellipsis',
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                fontSize: euiTheme.size.m,
-                padding: `${euiTheme.size.s} ${euiTheme.size.s}`,
-              }}
-            >
-              {value}
-            </code>
+      <EuiFlexGroup
+        css={css({
+          color: euiTheme.colors.textParagraph,
+          borderRadius: `${euiTheme.border.radius.medium}`,
+          backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
+          maxWidth: 'fit-content',
+        })}
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+      >
+        <EuiFlexItem css={{ minWidth: 0, maxWidth: `${euiTheme.base * 18.75}px` }} grow={false}>
+          <code
+            data-test-subj={dataTestSubj}
+            style={{
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              fontSize: euiTheme.size.m,
+              padding: `${euiTheme.size.s} ${euiTheme.size.s}`,
+            }}
+          >
+            {value}
+          </code>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiCopy
+            textToCopy={copyValue ?? value}
+            afterMessage={i18n.translate('xpack.searchSharedUI.formInfoField.copyAfterMessage', {
+              defaultMessage: 'Copied',
+            })}
+          >
+            {(copy) => (
+              <EuiButtonIcon
+                size="s"
+                display="empty"
+                onClick={() => handleCopy(copy)}
+                iconType={isCopied ? 'check' : 'copy'}
+                color={isCopied ? 'success' : 'text'}
+                data-test-subj={
+                  isCopied && copyValueDataTestSubj
+                    ? `${copyValueDataTestSubj}-copied`
+                    : copyValueDataTestSubj
+                }
+                aria-label={
+                  isCopied
+                    ? i18n.translate('xpack.searchSharedUI.formInfoField.copiedAriaLabel', {
+                        defaultMessage: 'Copied',
+                      })
+                    : i18n.translate('xpack.searchSharedUI.formInfoField.copyAriaLabel', {
+                        defaultMessage: 'Copy to clipboard',
+                      })
+                }
+              />
+            )}
+          </EuiCopy>
+        </EuiFlexItem>
+        {actions.map((action, index) => (
+          <EuiFlexItem key={index} grow={false}>
+            {action}
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiCopy
-              textToCopy={copyValue ?? value}
-              afterMessage={i18n.translate('xpack.searchSharedUI.formInfoField.copyAfterMessage', {
-                defaultMessage: 'Copied',
-              })}
-            >
-              {(copy) => (
-                <EuiButtonIcon
-                  size="s"
-                  display="empty"
-                  onClick={() => handleCopy(copy)}
-                  iconType={isCopied ? 'check' : 'copy'}
-                  color={isCopied ? 'success' : 'text'}
-                  data-test-subj={
-                    isCopied && copyValueDataTestSubj
-                      ? `${copyValueDataTestSubj}-copied`
-                      : copyValueDataTestSubj
-                  }
-                  aria-label={
-                    isCopied
-                      ? i18n.translate('xpack.searchSharedUI.formInfoField.copiedAriaLabel', {
-                          defaultMessage: 'Copied',
-                        })
-                      : i18n.translate('xpack.searchSharedUI.formInfoField.copyAriaLabel', {
-                          defaultMessage: 'Copy to clipboard',
-                        })
-                  }
-                />
-              )}
-            </EuiCopy>
-          </EuiFlexItem>
-          {actions.map((action, index) => (
-            <EuiFlexItem key={index} grow={false}>
-              {action}
-            </EuiFlexItem>
-          ))}
-        </EuiFlexGroup>
-      </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
     </EuiFlexGroup>
   );
 };


### PR DESCRIPTION
## Summary

This PR fixes a style regression in the `FormInfoField` component. The background color and border radius style had been applied to the whole component, which meant that the those styles were also accidentally applied to the label.

On a smaller screen size, the component also stretched to 100% of the parent container, which meant that background color was extending beyond the content.

### Screenshots

**Index Details Page - Solution view - Mobile/Tablet screen size**

| Before    | After |
| -------- | ------- |
| <img width="752" height="393" alt="Screenshot 2026-02-03 at 13 34 45" src="https://github.com/user-attachments/assets/b01df6a0-2f76-458b-ad02-0fda42c5f859" /> | <img width="750" height="391" alt="Screenshot 2026-02-03 at 13 34 22" src="https://github.com/user-attachments/assets/906a63ed-3a39-42b1-b6ed-20ee06d5f94c" /> |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] I~f a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->