### PR TITLE
[Search][Inference Endpoints] fix: return focus to actions button

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
@@ -10,6 +10,7 @@ import {
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
+  type EuiFlyoutProps,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -103,6 +104,7 @@ interface InferenceFlyoutWrapperProps {
   onSubmitSuccess?: (inferenceId: string) => void;
   inferenceEndpoint?: InferenceEndpoint;
   enableEisPromoTour?: boolean;
+  focusTrapProps?: EuiFlyoutProps['focusTrapProps'];
 }
 
 export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
@@ -114,6 +116,7 @@ export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
   onSubmitSuccess,
   inferenceEndpoint,
   enableEisPromoTour,
+  focusTrapProps,
 }) => {
   const inferenceCreationFlyoutId = useGeneratedHtmlId({
     prefix: 'InferenceFlyoutId',
@@ -160,6 +163,7 @@ export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
     <EuiFlyout
       ownFocus
       onClose={onFlyoutClose}
+      focusTrapProps={focusTrapProps}
       aria-labelledby={inferenceCreationFlyoutId}
       data-test-subj="inference-flyout"
     >

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -94,8 +94,8 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
   );
 
   const displayInferenceFlyout = useCallback((selectedEndpoint: InferenceInferenceEndpointInfo) => {
-    setShowInferenceFlyout(true);
     setSelectedInferenceEndpoint(selectedEndpoint);
+    setShowInferenceFlyout(true);
   }, []);
 
   const onCloseInferenceFlyout = useCallback(() => {
@@ -269,7 +269,7 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
         <EuiFlexItem>
           <EuiBasicTable
             columns={tableColumns}
-            itemId="id"
+            itemId="inference_id"
             items={paginatedSortedTableData}
             onChange={handleTableChange}
             pagination={pagination}

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/edit_inference_endpoints/edit_inference_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/edit_inference_endpoints/edit_inference_flyout.tsx
@@ -33,6 +33,21 @@ export const EditInferenceFlyout: React.FC<EditInterfaceFlyoutProps> = ({
   const onEditSuccess = useCallback(() => {
     refetch();
   }, [refetch]);
+  const onFocusReturn = useCallback(() => {
+    // Defer focus until after any closing animations complete
+    requestAnimationFrame(() => {
+      const actionsButtonParent = document.getElementById(
+        `${selectedInferenceEndpoint.inference_id}-actions`
+      );
+      if (actionsButtonParent) {
+        const actionsButton = actionsButtonParent.querySelector('button');
+        if (actionsButton) {
+          actionsButton.focus();
+        }
+      }
+    });
+    return false;
+  }, [selectedInferenceEndpoint.inference_id]);
 
   const inferenceEndpoint: InferenceEndpoint = {
     config: {
@@ -65,6 +80,9 @@ export const EditInferenceFlyout: React.FC<EditInterfaceFlyoutProps> = ({
       enforceAdaptiveAllocations={!!serverless}
       onSubmitSuccess={onEditSuccess}
       inferenceEndpoint={inferenceEndpoint}
+      focusTrapProps={{
+        returnFocus: onFocusReturn,
+      }}
     />
   );
 };


### PR DESCRIPTION
## Summary

When closing the View Inference Endpoint flyout this change ensures focus is returned to the all actions button of the endpoint's table row. This has to be done manually because the button that opened the flyout is in a context menu and no longer visible when the flyout closes.

- Closes #233338

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
