### PR TITLE
[8.19] Disable AIOps log rate analysis journey

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -49,6 +49,9 @@ disabled:
   # Gen AI suites, running with their own pipeline
   - x-pack/platform/test/functional_gen_ai/inference/config.ts
 
+  # Not required in 8.19 anymore
+  - x-pack/performance/journeys_e2e/aiops_log_rate_analysis.ts
+
 defaultQueue: 'n2-4-spot'
 enabled:
   - src/platform/test/accessibility/config.ts
@@ -325,7 +328,6 @@ enabled:
   - x-pack/platform/test/ui_capabilities/spaces_only/config.ts
   - x-pack/platform/test/upgrade_assistant_integration/config.ts
   - x-pack/platform/test/usage_collection/config.ts
-  - x-pack/performance/journeys_e2e/aiops_log_rate_analysis.ts
   - x-pack/performance/journeys_e2e/ecommerce_dashboard.ts
   - x-pack/performance/journeys_e2e/ecommerce_dashboard_http2.ts
   - x-pack/performance/journeys_e2e/ecommerce_dashboard_map_only.ts


### PR DESCRIPTION
## Summary

This PR disables the AIOps log rate analysis performance journey in the 8.19 branch to avoid an issue with forward compatibility testing, where behavior changed with 9.3.0.
After discussing this internally, we've decided that we don't actually need this journey in 8.19 anymore, so the most practical solution is to disable it.