### PR TITLE
[8.19] [Security Solution][A11Y] add aria labels to flyout panels to support screen readers (#250824)

### DIFF
--- a/x-pack/solutions/security/packages/expandable-flyout/src/components/container.tsx
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/components/container.tsx
@@ -169,6 +169,11 @@ export const Container: React.FC<ContainerProps> = memo(
       type,
     ]);
 
+    const flyoutAriaLabel = useMemo(() => {
+      const registeredPanel = registeredPanels.find((panel) => panel.key === right?.id);
+      return registeredPanel?.['aria-label'];
+    }, [registeredPanels, right?.id]);
+
     // callback function called when user changes the flyout's width
     const onResize = useCallback(
       (width: number) => {
@@ -218,6 +223,7 @@ export const Container: React.FC<ContainerProps> = memo(
         css={customStyles}
         onResize={onResize}
         minWidth={minFlyoutWidth}
+        aria-label={flyoutAriaLabel}
       >
         <ResizableContainer
           leftComponent={leftComponent as React.ReactElement}

--- a/x-pack/solutions/security/packages/expandable-flyout/src/types.ts
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/types.ts
@@ -85,6 +85,10 @@ export interface Panel {
    * Component to be rendered
    */
   component: (props: FlyoutPanelProps) => React.ReactElement;
+  /**
+   * Human-readable label for the panel
+   */
+  'aria-label'?: string;
 }
 
 export interface FlyoutPanelHistory {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/index.tsx
@@ -54,13 +54,35 @@ import type { ServicePanelExpandableFlyoutProps } from './entity_details/service
 import { ServicePanel } from './entity_details/service_right';
 import type { ServiceDetailsExpandableFlyoutProps } from './entity_details/service_details_left';
 import { ServiceDetailsPanel, ServiceDetailsPanelKey } from './entity_details/service_details_left';
+import {
+  DOCUMENT_DETAILS_ALERT_REASON_PANEL_ARIA_LABEL,
+  DOCUMENT_DETAILS_ANALYZER_PANEL_ARIA_LABEL,
+  DOCUMENT_DETAILS_ISOLATE_HOST_PANEL_ARIA_LABEL,
+  DOCUMENT_DETAILS_LEFT_PANEL_ARIA_LABEL,
+  DOCUMENT_DETAILS_PREVIEW_PANEL_ARIA_LABEL,
+  DOCUMENT_DETAILS_RIGHT_PANEL_ARIA_LABEL,
+  DOCUMENT_DETAILS_SESSION_VIEW_PANEL_ARIA_LABEL,
+  HOST_DETAILS_PANEL_ARIA_LABEL,
+  HOST_PANEL_ARIA_LABEL,
+  HOST_PREVIEW_PANEL_ARIA_LABEL,
+  IOC_RIGHT_PANEL_ARIA_LABEL,
+  NETWORK_PANEL_ARIA_LABEL,
+  NETWORK_PREVIEW_PANEL_ARIA_LABEL,
+  RULE_PANEL_ARIA_LABEL,
+  RULE_PREVIEW_PANEL_ARIA_LABEL,
+  SERVICE_DETAILS_PANEL_ARIA_LABEL,
+  SERVICE_PANEL_ARIA_LABEL,
+  USER_DETAILS_PANEL_ARIA_LABEL,
+  USER_PANEL_ARIA_LABEL,
+  USER_PREVIEW_PANEL_ARIA_LABEL,
+} from './panel_aria_labels';
 import { IOCPanelKey } from './ai_for_soc/constants/panel_keys';
 
 /**
  * List of all panels that will be used within the document details expandable flyout.
  * This needs to be passed to the expandable flyout registeredPanels property.
  */
-const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels'] = [
+export const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels'] = [
   {
     key: DocumentDetailsRightPanelKey,
     component: (props) => (
@@ -68,6 +90,7 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
         <RightPanel path={props.path as DocumentDetailsProps['path']} />
       </DocumentDetailsProvider>
     ),
+    'aria-label': DOCUMENT_DETAILS_RIGHT_PANEL_ARIA_LABEL,
   },
   {
     key: DocumentDetailsLeftPanelKey,
@@ -76,6 +99,7 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
         <LeftPanel path={props.path as DocumentDetailsProps['path']} />
       </DocumentDetailsProvider>
     ),
+    'aria-label': DOCUMENT_DETAILS_LEFT_PANEL_ARIA_LABEL,
   },
   {
     key: DocumentDetailsPreviewPanelKey,
@@ -84,6 +108,7 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
         <PreviewPanel path={props.path as DocumentDetailsProps['path']} />
       </DocumentDetailsProvider>
     ),
+    'aria-label': DOCUMENT_DETAILS_PREVIEW_PANEL_ARIA_LABEL,
   },
   {
     key: DocumentDetailsAlertReasonPanelKey,
@@ -92,16 +117,19 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
         <AlertReasonPanel />
       </AlertReasonPanelProvider>
     ),
+    'aria-label': DOCUMENT_DETAILS_ALERT_REASON_PANEL_ARIA_LABEL,
   },
   {
     key: RulePanelKey,
     component: (props) => <RulePanel {...(props as RulePanelExpandableFlyoutProps).params} />,
+    'aria-label': RULE_PANEL_ARIA_LABEL,
   },
   {
     key: RulePreviewPanelKey,
     component: (props) => (
       <RulePanel {...(props as RulePanelExpandableFlyoutProps).params} isPreviewMode />
     ),
+    'aria-label': RULE_PREVIEW_PANEL_ARIA_LABEL,
   },
   {
     key: DocumentDetailsIsolateHostPanelKey,
@@ -110,12 +138,14 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
         <IsolateHostPanel path={props.path as IsolateHostPanelProps['path']} />
       </IsolateHostPanelProvider>
     ),
+    'aria-label': DOCUMENT_DETAILS_ISOLATE_HOST_PANEL_ARIA_LABEL,
   },
   {
     key: DocumentDetailsAnalyzerPanelKey,
     component: (props) => (
       <AnalyzerPanel {...(props as AnalyzerPanelExpandableFlyoutProps).params} />
     ),
+    'aria-label': DOCUMENT_DETAILS_ANALYZER_PANEL_ARIA_LABEL,
   },
   {
     key: DocumentDetailsSessionViewPanelKey,
@@ -124,59 +154,70 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
         <SessionViewPanel path={props.path as SessionViewPanelProps['path']} />
       </SessionViewPanelProvider>
     ),
+    'aria-label': DOCUMENT_DETAILS_SESSION_VIEW_PANEL_ARIA_LABEL,
   },
   {
     key: UserPanelKey,
     component: (props) => <UserPanel {...(props as UserPanelExpandableFlyoutProps).params} />,
+    'aria-label': USER_PANEL_ARIA_LABEL,
   },
   {
     key: UserDetailsPanelKey,
     component: (props) => (
       <UserDetailsPanel {...(props as UserDetailsExpandableFlyoutProps).params} />
     ),
+    'aria-label': USER_DETAILS_PANEL_ARIA_LABEL,
   },
   {
     key: UserPreviewPanelKey,
     component: (props) => (
       <UserPanel {...(props as UserPanelExpandableFlyoutProps).params} isPreviewMode />
     ),
+    'aria-label': USER_PREVIEW_PANEL_ARIA_LABEL,
   },
   {
     key: HostPanelKey,
     component: (props) => <HostPanel {...(props as HostPanelExpandableFlyoutProps).params} />,
+    'aria-label': HOST_PANEL_ARIA_LABEL,
   },
   {
     key: HostDetailsPanelKey,
     component: (props) => (
       <HostDetailsPanel {...(props as HostDetailsExpandableFlyoutProps).params} />
     ),
+    'aria-label': HOST_DETAILS_PANEL_ARIA_LABEL,
   },
   {
     key: HostPreviewPanelKey,
     component: (props) => (
       <HostPanel {...(props as HostPanelExpandableFlyoutProps).params} isPreviewMode />
     ),
+    'aria-label': HOST_PREVIEW_PANEL_ARIA_LABEL,
   },
   {
     key: NetworkPanelKey,
     component: (props) => <NetworkPanel {...(props as NetworkExpandableFlyoutProps).params} />,
+    'aria-label': NETWORK_PANEL_ARIA_LABEL,
   },
   {
     key: NetworkPreviewPanelKey,
     component: (props) => (
       <NetworkPanel {...(props as NetworkExpandableFlyoutProps).params} isPreviewMode />
     ),
+    'aria-label': NETWORK_PREVIEW_PANEL_ARIA_LABEL,
   },
 
   {
     key: ServicePanelKey,
     component: (props) => <ServicePanel {...(props as ServicePanelExpandableFlyoutProps).params} />,
+    'aria-label': SERVICE_PANEL_ARIA_LABEL,
   },
   {
     key: ServiceDetailsPanelKey,
     component: (props) => (
       <ServiceDetailsPanel {...(props as ServiceDetailsExpandableFlyoutProps).params} />
     ),
+    'aria-label': SERVICE_DETAILS_PANEL_ARIA_LABEL,
   },
   {
     key: IOCPanelKey,
@@ -185,6 +226,7 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
         <AIForSOCPanel />
       </AIForSOCDetailsProvider>
     ),
+    'aria-label': IOC_RIGHT_PANEL_ARIA_LABEL,
   },
 ];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/panel_aria_labels.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/panel_aria_labels.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const DOCUMENT_DETAILS_RIGHT_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.documentDetailsRight',
+  { defaultMessage: 'Document details' }
+);
+
+export const DOCUMENT_DETAILS_LEFT_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.documentDetailsLeft',
+  { defaultMessage: 'Insights and investigation' }
+);
+
+export const DOCUMENT_DETAILS_PREVIEW_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.documentDetailsPreview',
+  { defaultMessage: 'Document preview' }
+);
+
+export const DOCUMENT_DETAILS_ALERT_REASON_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.documentDetailsAlertReason',
+  { defaultMessage: 'Alert reason' }
+);
+
+export const RULE_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.rule',
+  { defaultMessage: 'Rule details' }
+);
+
+export const RULE_PREVIEW_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.rulePreview',
+  { defaultMessage: 'Rule preview' }
+);
+
+export const DOCUMENT_DETAILS_ISOLATE_HOST_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.documentDetailsIsolateHost',
+  { defaultMessage: 'Isolate host' }
+);
+
+export const DOCUMENT_DETAILS_ANALYZER_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.documentDetailsAnalyzer',
+  { defaultMessage: 'Analyzer node details' }
+);
+
+export const DOCUMENT_DETAILS_SESSION_VIEW_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.documentDetailsSessionView',
+  { defaultMessage: 'Session view' }
+);
+
+export const USER_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.user',
+  { defaultMessage: 'User details' }
+);
+
+export const USER_DETAILS_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.userDetails',
+  { defaultMessage: 'User entity details' }
+);
+
+export const USER_PREVIEW_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.userPreview',
+  { defaultMessage: 'User preview' }
+);
+
+export const HOST_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.host',
+  { defaultMessage: 'Host details' }
+);
+
+export const HOST_DETAILS_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.hostDetails',
+  { defaultMessage: 'Host entity details' }
+);
+
+export const HOST_PREVIEW_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.hostPreview',
+  { defaultMessage: 'Host preview' }
+);
+
+export const NETWORK_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.network',
+  { defaultMessage: 'Network details' }
+);
+
+export const NETWORK_PREVIEW_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.networkPreview',
+  { defaultMessage: 'Network preview' }
+);
+
+export const SERVICE_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.service',
+  { defaultMessage: 'Service details' }
+);
+
+export const SERVICE_DETAILS_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.serviceDetails',
+  { defaultMessage: 'Service entity details' }
+);
+
+export const IOC_RIGHT_PANEL_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.panelAriaLabel.iocRight',
+  { defaultMessage: 'Indicator of compromise details' }
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][A11Y] add aria labels to flyout panels to support screen readers (#250824)](https://github.com/elastic/kibana/pull/250824)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-02T19:25:11Z","message":"[Security Solution][A11Y] add aria labels to flyout panels to support screen readers (#250824)\n\n## Summary\n\n[Issue 1](https://github.com/elastic/kibana/issues/250130)\n[Issue 2](https://github.com/elastic/kibana/issues/250337)\n\nThis is a partial fix for issue 1, and full fix for issue 2. It does not\naddress the history button popover (issue 1), which will be a separate\nPR. This PR adds an aria label to the the security solution flyout based\non the panel it hosts.\n\nUsed AI to generate the `panel_aria_labels.ts` file. It looks reasonable\nto me but not sure if the default descriptions are entirely correct\n(might be lacking some context).\n\n\nhttps://github.com/user-attachments/assets/0d1203e0-5f47-44dd-92c6-73b344bf816c\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cec25e5c2b7fd01ac16e19f3abc9b8784fb4802a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","fixed","Team: SecuritySolution","Team:Threat Hunting:Investigations","backport:all-open","a11y","v9.4.0"],"title":"[Security Solution][A11Y] add aria labels to flyout panels to support screen readers","number":250824,"url":"https://github.com/elastic/kibana/pull/250824","mergeCommit":{"message":"[Security Solution][A11Y] add aria labels to flyout panels to support screen readers (#250824)\n\n## Summary\n\n[Issue 1](https://github.com/elastic/kibana/issues/250130)\n[Issue 2](https://github.com/elastic/kibana/issues/250337)\n\nThis is a partial fix for issue 1, and full fix for issue 2. It does not\naddress the history button popover (issue 1), which will be a separate\nPR. This PR adds an aria label to the the security solution flyout based\non the panel it hosts.\n\nUsed AI to generate the `panel_aria_labels.ts` file. It looks reasonable\nto me but not sure if the default descriptions are entirely correct\n(might be lacking some context).\n\n\nhttps://github.com/user-attachments/assets/0d1203e0-5f47-44dd-92c6-73b344bf816c\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cec25e5c2b7fd01ac16e19f3abc9b8784fb4802a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250824","number":250824,"mergeCommit":{"message":"[Security Solution][A11Y] add aria labels to flyout panels to support screen readers (#250824)\n\n## Summary\n\n[Issue 1](https://github.com/elastic/kibana/issues/250130)\n[Issue 2](https://github.com/elastic/kibana/issues/250337)\n\nThis is a partial fix for issue 1, and full fix for issue 2. It does not\naddress the history button popover (issue 1), which will be a separate\nPR. This PR adds an aria label to the the security solution flyout based\non the panel it hosts.\n\nUsed AI to generate the `panel_aria_labels.ts` file. It looks reasonable\nto me but not sure if the default descriptions are entirely correct\n(might be lacking some context).\n\n\nhttps://github.com/user-attachments/assets/0d1203e0-5f47-44dd-92c6-73b344bf816c\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cec25e5c2b7fd01ac16e19f3abc9b8784fb4802a"}},{"url":"https://github.com/elastic/kibana/pull/251321","number":251321,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->