### PR TITLE
Use query service in dispatcher, update query to follow latest mappin…

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from '@kbn/core/server';
 import { inject, injectable } from 'inversify';
 import moment from 'moment';
 import { ALERT_ACTIONS_DATA_STREAM, type AlertAction } from '../../resources/alert_actions';
-import { EsServiceScopedToken } from '../services/es_service/tokens';
 import {
   LoggerServiceToken,
   type LoggerServiceContract,
 } from '../services/logger_service/logger_service';
 import { queryResponseToRecords } from '../services/query_service/query_response_to_records';
+import type { QueryServiceContract } from '../services/query_service/query_service';
+import { QueryServiceInternalToken } from '../services/query_service/tokens';
 import type { StorageServiceContract } from '../services/storage_service/storage_service';
 import { StorageServiceInternalToken } from '../services/storage_service/tokens';
 import { LOOKBACK_WINDOW_MINUTES } from './constants';
@@ -28,7 +28,7 @@ export interface DispatcherServiceContract {
 @injectable()
 export class DispatcherService implements DispatcherServiceContract {
   constructor(
-    @inject(EsServiceScopedToken) private readonly esClient: ElasticsearchClient,
+    @inject(QueryServiceInternalToken) private readonly queryService: QueryServiceContract,
     @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
     @inject(StorageServiceInternalToken) private readonly storageService: StorageServiceContract
   ) {}
@@ -37,8 +37,7 @@ export class DispatcherService implements DispatcherServiceContract {
     const startedAt = new Date();
     const { query } = getDispatchableAlertEventsQuery();
 
-    // TODO: Use QueryService as soon as it uses esClient instead of data plugin client
-    const result = await this.esClient.esql.query({
+    const result = await this.queryService.executeQuery({
       query,
       filter: {
         range: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
@@ -21,7 +21,11 @@ export const getDispatchableAlertEventsQuery = (): EsqlRequest => {
 
   return esql`FROM ${ALERT_EVENTS_DATA_STREAM},${ALERT_ACTIONS_DATA_STREAM} METADATA _index
       | WHERE (_index LIKE ${ALERT_ACTIONS_BACKING_INDEX}) OR (_index LIKE ${ALERT_EVENTS_BACKING_INDEX} and type == ${alertEventType})
-      | EVAL rule_id = COALESCE(rule.id, rule_id)
+      | EVAL 
+          rule_id = COALESCE(rule.id, rule_id),
+          episode_id = COALESCE(episode.id, episode_id),
+          episode_status = episode.status
+      | DROP episode.id, rule.id, episode.status
       | INLINE STATS last_fired = max(last_series_event_timestamp) WHERE _index LIKE ${ALERT_ACTIONS_BACKING_INDEX} AND action_type == "fire-event" BY rule_id, group_hash
       | WHERE (last_fired IS NULL OR last_fired < @timestamp) or (_index LIKE ${ALERT_ACTIONS_BACKING_INDEX})
       | STATS


### PR DESCRIPTION
resolves https://github.com/elastic/rna-program/issues/106

## Summary

Use QueryService in Dispatcher, and update query to use latest alert-event mapping (episode.id, episode.status). Updated integration tests accordingly.