### PR TITLE
[Cascade] Resolve issue that caused "stuttering" in cascade component

### DIFF
--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import type { Row } from '@tanstack/react-table';
 import { CascadeRowCellPrimitive } from './cascade_row_cell';
 import type { CascadeVirtualizerReturnValue } from '../../../lib/core/virtualizer';
@@ -60,6 +60,7 @@ describe('CascadeRowCellPrimitive', () => {
         scrollElement: null,
         activeStickyIndex: null,
         virtualizedRowComputedTranslateValue: new Map(),
+        preventRowSizeChangePropagation: jest.fn(() => jest.fn()),
       } as unknown as CascadeVirtualizerReturnValue)
   );
 
@@ -125,6 +126,165 @@ describe('CascadeRowCellPrimitive', () => {
       nodePath: [cascadeGroups[0]],
       nodePathMap: { group1: 0 },
       row: rowData,
+    });
+  });
+
+  describe('child component props', () => {
+    const mockLeafData = { items: [{ id: 'item-1' }] };
+
+    it('should pass all required methods and properties to the child component', async () => {
+      const cascadeGroups = ['group1', 'group2'];
+      const childPropsSpy = jest.fn();
+      const mockOnCascadeLeafNodeExpanded = jest.fn().mockResolvedValue(mockLeafData);
+
+      const rowData = cascadeGroups.reduce((acc, value, idx) => ({ ...acc, [value]: idx }), {
+        id: '1',
+        randomField: 'randomValue',
+      });
+
+      renderComponent({
+        cascadeGroups,
+        initialGroupColumn: [cascadeGroups[0]],
+        row: {
+          id: '1',
+          index: 0,
+          depth: 0,
+          original: rowData,
+          getToggleSelectedHandler: jest.fn(),
+          getToggleExpandedHandler: jest.fn(),
+        } as unknown as Row<any>,
+        children: (props) => {
+          childPropsSpy(props);
+          return <div>Test Child</div>;
+        },
+        onCascadeLeafNodeExpanded: mockOnCascadeLeafNodeExpanded,
+        getVirtualizer: mockVirtualizerGetter,
+      });
+
+      await waitFor(() => {
+        expect(childPropsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cellId: expect.any(String),
+            nodePath: expect.any(Array),
+            getScrollElement: expect.any(Function),
+            getScrollOffset: expect.any(Function),
+            getScrollMargin: expect.any(Function),
+            preventSizeChangePropagation: expect.any(Function),
+          })
+        );
+      });
+    });
+
+    it('should provide a working preventSizeChangePropagation function that calls the virtualizer method', async () => {
+      const cascadeGroups = ['group1', 'group2'];
+      let capturedPreventSizeChangePropagation: (() => () => void) | null = null;
+      const mockCleanup = jest.fn();
+      const mockPreventRowSizeChangePropagation = jest.fn(() => mockCleanup);
+      const mockOnCascadeLeafNodeExpanded = jest.fn().mockResolvedValue(mockLeafData);
+
+      const customMockVirtualizerGetter = jest.fn(
+        () =>
+          ({
+            getVirtualItems: jest.fn(() => []),
+            getTotalSize: jest.fn(() => 0),
+            isScrolling: false,
+            measureElement: jest.fn(),
+            scrollOffset: 0,
+            scrollElement: null,
+            activeStickyIndex: null,
+            virtualizedRowComputedTranslateValue: new Map(),
+            preventRowSizeChangePropagation: mockPreventRowSizeChangePropagation,
+          } as unknown as CascadeVirtualizerReturnValue)
+      );
+
+      const rowData = cascadeGroups.reduce((acc, value, idx) => ({ ...acc, [value]: idx }), {
+        id: '1',
+        randomField: 'randomValue',
+      });
+
+      const rowIndex = 5;
+
+      renderComponent({
+        cascadeGroups,
+        initialGroupColumn: [cascadeGroups[0]],
+        row: {
+          id: '1',
+          index: rowIndex,
+          depth: 0,
+          original: rowData,
+          getToggleSelectedHandler: jest.fn(),
+          getToggleExpandedHandler: jest.fn(),
+        } as unknown as Row<any>,
+        children: (props) => {
+          capturedPreventSizeChangePropagation = props.preventSizeChangePropagation;
+          return <div>Test Child</div>;
+        },
+        onCascadeLeafNodeExpanded: mockOnCascadeLeafNodeExpanded,
+        getVirtualizer: customMockVirtualizerGetter,
+      });
+
+      await waitFor(() => {
+        expect(capturedPreventSizeChangePropagation).not.toBeNull();
+      });
+
+      // Call the function and verify it delegates to the virtualizer
+      const cleanup = capturedPreventSizeChangePropagation!();
+      expect(mockPreventRowSizeChangePropagation).toHaveBeenCalledWith(rowIndex);
+
+      // Verify the cleanup function is returned
+      expect(cleanup).toBe(mockCleanup);
+    });
+
+    it('should provide getScrollElement that returns the virtualizer scrollElement', async () => {
+      const cascadeGroups = ['group1', 'group2'];
+      let capturedGetScrollElement: (() => Element | null) | null = null;
+      const mockScrollElement = document.createElement('div');
+      const mockOnCascadeLeafNodeExpanded = jest.fn().mockResolvedValue(mockLeafData);
+
+      const customMockVirtualizerGetter = jest.fn(
+        () =>
+          ({
+            getVirtualItems: jest.fn(() => []),
+            getTotalSize: jest.fn(() => 0),
+            isScrolling: false,
+            measureElement: jest.fn(),
+            scrollOffset: 0,
+            scrollElement: mockScrollElement,
+            activeStickyIndex: null,
+            virtualizedRowComputedTranslateValue: new Map(),
+            preventRowSizeChangePropagation: jest.fn(() => jest.fn()),
+          } as unknown as CascadeVirtualizerReturnValue)
+      );
+
+      const rowData = cascadeGroups.reduce((acc, value, idx) => ({ ...acc, [value]: idx }), {
+        id: '1',
+        randomField: 'randomValue',
+      });
+
+      renderComponent({
+        cascadeGroups,
+        initialGroupColumn: [cascadeGroups[0]],
+        row: {
+          id: '1',
+          index: 0,
+          depth: 0,
+          original: rowData,
+          getToggleSelectedHandler: jest.fn(),
+          getToggleExpandedHandler: jest.fn(),
+        } as unknown as Row<any>,
+        children: (props) => {
+          capturedGetScrollElement = props.getScrollElement;
+          return <div>Test Child</div>;
+        },
+        onCascadeLeafNodeExpanded: mockOnCascadeLeafNodeExpanded,
+        getVirtualizer: customMockVirtualizerGetter,
+      });
+
+      await waitFor(() => {
+        expect(capturedGetScrollElement).not.toBeNull();
+      });
+
+      expect(capturedGetScrollElement!()).toBe(mockScrollElement);
     });
   });
 });

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -60,6 +60,18 @@ export interface CascadeRowCellNestedVirtualizationAnchorProps<G extends GroupNo
   extends Pick<CascadeVirtualizerProps<G>, 'getScrollElement'> {
   getScrollOffset: () => number;
   getScrollMargin: () => number;
+  /**
+   * Function used to signal to the parent virtualizer that this row's size changes should not be propagated to it.
+   * This is only required if the nested virtualization implementation used here measures its rows.
+   */
+  preventSizeChangePropagation: () => () => void;
+}
+
+export interface CascadeRowCellRendererProps<G extends GroupNode, L extends LeafNode>
+  extends CascadeRowCellNestedVirtualizationAnchorProps<G> {
+  data: L[] | null;
+  cellId: string;
+  nodePath: string[];
 }
 
 export interface CascadeRowCellPrimitiveProps<G extends GroupNode, L extends LeafNode>
@@ -80,13 +92,7 @@ export interface CascadeRowCellPrimitiveProps<G extends GroupNode, L extends Lea
   /**
    * Render prop function that provides the leaf node data when available, which can be used to render the content we'd to display with the data received.
    */
-  children: (
-    args: {
-      data: L[] | null;
-      cellId: string;
-      nodePath: string[];
-    } & CascadeRowCellNestedVirtualizationAnchorProps<G>
-  ) => React.ReactNode;
+  children: (args: CascadeRowCellRendererProps<G, L>) => React.ReactNode;
 }
 
 type OnCascadeGroupNodeExpandedArgs<G extends GroupNode> = CascadeGroupNodeUIInteraction<G>;

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.styles.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.styles.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { css } from '@emotion/react';
+import type { UseEuiTheme } from '@elastic/eui';
+
+export const getCustomCascadeGridBodyStyle = (euiTheme: UseEuiTheme['euiTheme']) => ({
+  wrapper: css({
+    overflow: 'hidden',
+    position: 'relative',
+    height: '100%',
+    '& .euiDataGridHeader': {
+      backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    },
+    '& .euiDataGridRow': {
+      backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    },
+    '.unifiedDataTableToolbar:has(+ .euiDataGrid__content &)': {
+      backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    },
+    '.unifiedDataTableToolbar:has(+ .euiDataGrid__content &) .unifiedDataTableToolbarControlGroup':
+      {
+        backgroundColor: euiTheme.colors.backgroundBasePlain,
+      },
+  }),
+  virtualizerContainer: css({
+    width: '100%',
+    height: '100%',
+    overflowY: 'auto',
+    position: 'relative',
+    scrollbarWidth: 'thin',
+  }),
+  virtualizerInner: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    overflowAnchor: 'none',
+    // Promote to GPU layer for smoother transform animations
+    willChange: 'transform',
+
+    '& > .euiDataGridRow:last-child .euiDataGridRowCell:not(.euiDataGridFooterCell)': {
+      borderBlockEnd: 'none',
+    },
+  }),
+  displayFlex: css({ display: 'flex' }),
+});

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -116,7 +116,14 @@ const ESQLDataCascade = React.memo(
     const cascadeLeafRowRenderer = useCallback<
       DataCascadeRowCellProps<ESQLDataGroupNode, DataTableRecord>['children']
     >(
-      ({ data: cellData, cellId, getScrollElement, getScrollOffset, getScrollMargin }) => (
+      ({
+        data: cellData,
+        cellId,
+        getScrollElement,
+        getScrollOffset,
+        getScrollMargin,
+        preventSizeChangePropagation,
+      }) => (
         <ESQLDataCascadeLeafCell
           {...props}
           dataView={dataView}
@@ -125,6 +132,7 @@ const ESQLDataCascade = React.memo(
           getScrollElement={getScrollElement}
           getScrollOffset={getScrollOffset}
           getScrollMargin={getScrollMargin}
+          preventSizeChangePropagation={preventSizeChangePropagation}
         />
       ),
       [dataView, props]


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/246949

Previously scrolling through the nested list when its length exceeds the visible viewport, we'd notice an effect after scroll where the rendered items would shift around, this PR fixes this issue. 

### Context; 
This happened because in discover determining the size of the element rendering the content of the nested virtualized list happens by measured the row items, so when content is rendered, given that it is contained in another virtual list that is also measured, the changes in the nested list would in turn cause a measurement to be triggered in the parent, causing the `scrolloffset` value with which the inner virtualized list was initialised with to be invalid, so the jank we see is the readjustment to the new `scrollOffset`, what we've opted for is to provide a way to disable propagating these changes to the parent whilst the user is interacting with the nested list.

#### Visuals

![Untitledstutterfixed-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/8d4fdb7c-25c1-482e-b4e0-557f056659d2)

#### How to test

- Navigate to discover, switch to ES|QL mode
- Make sure to select a large enough time range, so we are returned quite an handful of documents
- Provide the following query `FROM kibana_sample_data_ecommerce | STATS count = COUNT(*), PERCENTILE(products.price, 95), AVG(products.tax_amount), SUM(total_quantity) BY products.manufacturer` or yours
- Select a row that has quite an extensive number of documents, attempt scrolling through the documents in the row, there should be no jank (aka. stutter).

### Checklist

<!--
Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials -->
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->

