### PR TITLE
[PoC] Associate a task cost per task

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/mappings.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/mappings.ts
@@ -68,6 +68,9 @@ export const taskMappings: SavedObjectsTypeMappingDefinition = {
     priority: {
       type: 'integer',
     },
+    cost: {
+      type: 'integer',
+    },
     // NO NEED TO BE INDEXED
     // apiKey: {
     //   type: 'binary',

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_model_versions.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_model_versions.ts
@@ -14,6 +14,7 @@ import {
   taskSchemaV5,
   taskSchemaV6,
   taskSchemaV7,
+  taskSchemaV8,
 } from '../schemas/task';
 
 // IMPORTANT!!!
@@ -98,6 +99,20 @@ export const taskModelVersions: SavedObjectsModelVersionMap = {
     schemas: {
       forwardCompatibility: taskSchemaV7.extends({}, { unknowns: 'ignore' }),
       create: taskSchemaV7,
+    },
+  },
+  '8': {
+    changes: [
+      {
+        type: 'mappings_addition',
+        addedMappings: {
+          cost: { type: 'integer' },
+        },
+      },
+    ],
+    schemas: {
+      forwardCompatibility: taskSchemaV8.extends({}, { unknowns: 'ignore' }),
+      create: taskSchemaV8,
     },
   },
 };

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task.ts
@@ -81,3 +81,7 @@ export const taskSchemaV6 = taskSchemaV5.extends({
 export const taskSchemaV7 = taskSchemaV6.extends({
   schedule: schema.maybe(schema.oneOf([scheduleIntervalSchema, scheduleRruleSchemaV3])),
 });
+
+export const taskSchemaV8 = taskSchemaV7.extends({
+  cost: schema.maybe(schema.number()),
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -429,6 +429,13 @@ export interface TaskInstance {
    * Optionally override the priority defined in the task type for this specific task instance
    */
   priority?: TaskPriority;
+
+  /**
+   * Optional cost for this task instance, overriding the task type's default cost.
+   * When set, must be one of the TaskCost enum values (Tiny, Normal, ExtraLarge).
+   * Used by the task selector and capacity logic to limit concurrent work.
+   */
+  cost?: number;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/task_selector_by_capacity.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/task_selector_by_capacity.ts
@@ -6,55 +6,77 @@
  */
 
 import type { ConcreteTaskInstance } from '../../task';
+import { TaskCost } from '../../task';
 import type { TaskClaimingBatches } from '../../queries/task_claiming';
 import { isLimited } from '../../queries/task_claiming';
 import { sharedConcurrencyTaskTypes, type TaskTypeDictionary } from '../../task_type_dictionary';
+
+/**
+ * Effective cost for a task: instance override, then task type definition, then Normal.
+ */
+export function getTaskCost(task: ConcreteTaskInstance, definitions: TaskTypeDictionary): number {
+  return task.cost ?? definitions.get(task.taskType)?.cost ?? TaskCost.Normal;
+}
 
 interface SelectTasksByCapacityOpts {
   definitions: TaskTypeDictionary;
   tasks: ConcreteTaskInstance[];
   batches: TaskClaimingBatches;
 }
-// given a list of tasks and capacity info, select the tasks that meet capacity
+
+// given a list of tasks and capacity info, select the tasks that meet capacity.
+// For limited task types, maxConcurrency is treated as a cost budget: each task
+// consumes its (instance or definition) cost from the budget.
 export function selectTasksByCapacity({
   definitions,
   tasks,
   batches,
 }: SelectTasksByCapacityOpts): ConcreteTaskInstance[] {
-  // create a map of task type - concurrency
   const limitedBatches = batches.filter(isLimited);
-  const limitedMap = new Map<string, number | null>();
+  // remaining cost budget per task type. For shared concurrency types, all share the same budget.
+  const remainingBudgetByType = new Map<string, number>();
+
   for (const limitedBatch of limitedBatches) {
     const { tasksTypes: taskType } = limitedBatch;
-
-    // get concurrency from task definition
     const taskDef = definitions.get(taskType);
-    limitedMap.set(taskType, taskDef?.maxConcurrency ?? null);
+    const defCost = taskDef?.cost ?? TaskCost.Normal;
+    const maxConcurrency = taskDef?.maxConcurrency ?? 0;
+    const budget = maxConcurrency * defCost;
+    remainingBudgetByType.set(taskType, budget);
+    const sharesConcurrencyWith = sharedConcurrencyTaskTypes(taskType);
+    if (sharesConcurrencyWith) {
+      const minBudget = Math.min(
+        budget,
+        ...sharesConcurrencyWith.map((t) => {
+          const d = definitions.get(t);
+          return (d?.maxConcurrency ?? 0) * (d?.cost ?? TaskCost.Normal);
+        })
+      );
+      for (const t of sharesConcurrencyWith) {
+        remainingBudgetByType.set(t, minBudget);
+      }
+    }
   }
 
-  // apply the limited concurrency
   const result: ConcreteTaskInstance[] = [];
   for (const task of tasks) {
-    // get concurrency of this task type
-    const concurrency = limitedMap.get(task.taskType);
-    if (concurrency == null) {
+    const remaining = remainingBudgetByType.get(task.taskType);
+    if (remaining == null) {
       result.push(task);
       continue;
     }
 
-    if (concurrency > 0) {
+    const taskCost = getTaskCost(task, definitions);
+    if (remaining >= taskCost) {
       result.push(task);
-
-      // get any shared concurrency task types
+      const newRemaining = remaining - taskCost;
       const sharesConcurrencyWith = sharedConcurrencyTaskTypes(task.taskType);
       if (sharesConcurrencyWith) {
         for (const taskType of sharesConcurrencyWith) {
-          if (limitedMap.has(taskType)) {
-            limitedMap.set(taskType, concurrency - 1);
-          }
+          remainingBudgetByType.set(taskType, newRemaining);
         }
       } else {
-        limitedMap.set(task.taskType, concurrency - 1);
+        remainingBudgetByType.set(task.taskType, newRemaining);
       }
     }
   }

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
@@ -46,7 +46,7 @@ import {
 
 import type { TaskStore, SearchOpts } from '../task_store';
 import { isOk, asOk } from '../lib/result_type';
-import { selectTasksByCapacity } from './lib/task_selector_by_capacity';
+import { selectTasksByCapacity, getTaskCost } from './lib/task_selector_by_capacity';
 import type { TaskPartitioner } from '../lib/task_partitioner';
 import { getRetryAt } from '../lib/get_retry_at';
 
@@ -153,7 +153,7 @@ async function claimAvailableTasks(opts: TaskClaimerOpts): Promise<ClaimOwnershi
 
   let capacityAccumulator = 0;
   for (const task of candidateTasks) {
-    const taskCost = definitions.get(task.taskType)?.cost ?? TaskCost.Normal;
+    const taskCost = getTaskCost(task, definitions);
     if (capacityAccumulator + taskCost <= initialCapacity) {
       tasksToRun.push(task);
       capacityAccumulator += taskCost;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/cost_capacity.ts
@@ -40,9 +40,7 @@ export class CostCapacity implements ICapacity {
   public usedCapacity(tasksInPool: Map<string, TaskRunner>) {
     let result = 0;
     tasksInPool.forEach((task) => {
-      if (task.definition?.cost) {
-        result += task.definition.cost;
-      }
+      result += task.cost;
     });
     return result;
   }
@@ -60,7 +58,7 @@ export class CostCapacity implements ICapacity {
   public getUsedCapacityByType(tasksInPool: TaskRunner[], type: string) {
     return tasksInPool.reduce(
       (count, runningTask) =>
-        runningTask.definition?.type === type ? count + runningTask.definition.cost : count,
+        runningTask.definition?.type === type ? count + runningTask.cost : count,
       0
     );
   }
@@ -95,7 +93,7 @@ export class CostCapacity implements ICapacity {
 
     let capacityAccumulator = 0;
     for (const task of tasks) {
-      const taskCost = task.definition?.cost ?? 0;
+      const taskCost = task.cost;
       if (capacityAccumulator + taskCost <= availableCapacity) {
         tasksToRun.push(task);
         capacityAccumulator += taskCost;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -61,7 +61,7 @@ import type {
   SuccessfulRunResult,
   TaskDefinition,
 } from '../task';
-import { isFailedRunResult, TaskStatus } from '../task';
+import { isFailedRunResult, TaskCost, TaskStatus } from '../task';
 import type { TaskTypeDictionary } from '../task_type_dictionary';
 import { isUnrecoverableError, isUserError } from './errors';
 import { CLAIM_STRATEGY_MGET, type TaskManagerConfig } from '../config';
@@ -84,6 +84,8 @@ export interface TaskRunner {
   expiration: Date;
   startedAt: Date | null;
   definition: TaskDefinition | undefined;
+  /** Effective cost for this task (instance override, then definition, then Normal). */
+  cost: number;
   cancel: CancelFunction;
   markTaskAsRunning: () => Promise<boolean>;
   run: () => Promise<Result<SuccessfulRunResult, FailedRunResult>>;
@@ -276,6 +278,13 @@ export class TaskManagerRunner implements TaskRunner {
    */
   public get definition(): TaskDefinition | undefined {
     return this.definitions.get(this.taskType);
+  }
+
+  /**
+   * Effective cost for this task (instance override, then definition, then Normal).
+   */
+  public get cost(): number {
+    return this.instance.task.cost ?? this.definition?.cost ?? TaskCost.Normal;
   }
 
   /**


### PR DESCRIPTION
WIP, perhaps instead of storing the numeric cost value we can store `tiny`, `normal`, `extralarge` because the numeric values may change over time..