### PR TITLE
[9.1] [Reporting] set zoom to 1 for long reports (#248785)

### DIFF
--- a/x-pack/platform/plugins/shared/screenshotting/server/layouts/create_layout.test.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/layouts/create_layout.test.ts
@@ -33,6 +33,7 @@ describe('Create Layout', () => {
         },
         "useReportingBranding": true,
         "width": 16,
+        "zoom": 2,
       }
     `);
   });

--- a/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.test.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.test.ts
@@ -56,3 +56,18 @@ it('preserve layout allows customizable selectors', () => {
     }
   `);
 });
+
+it('preserve layout use a default zoom of 2', () => {
+  const testPreserveLayout = new PreserveLayout({ width: 1000, height: 2000 });
+  expect(testPreserveLayout.getBrowserZoom()).toBe(2);
+  expect(testPreserveLayout.getBrowserViewport().height).toBe(4000);
+});
+
+it('preserve layout caps browser zoom for extremely large screenshots to avoid Chromium artifacts', () => {
+  // A very tall layout would exceed Chrome limits at zoom=2.
+  const testPreserveLayout = new PreserveLayout({ width: 1727, height: 15000 });
+
+  // The zoom should be reduced so that output height stays <= 16000 pixels.
+  expect(testPreserveLayout.getBrowserZoom()).toBe(1);
+  expect(testPreserveLayout.getBrowserViewport().height).toBeLessThanOrEqual(16000);
+});

--- a/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.ts
@@ -12,13 +12,18 @@ import type { Layout } from '.';
 import { BaseLayout } from './base_layout';
 import type { PageSizeParams } from './base_layout';
 
-// We use a zoom of two to bump up the resolution of the screenshot a bit.
-const ZOOM: number = 2;
+// We default to a zoom of two to bump up the resolution of the screenshot a bit.
+// However, Chromium/Skia has a height limit of 16384px, so for anything larger
+// than 8000, we should use a zoom of one.
+// https://github.com/puppeteer/puppeteer/issues/359
+const DEFAULT_ZOOM = 2;
+const MAX_HEIGHT_PX = 8000;
 
 export class PreserveLayout extends BaseLayout implements Layout {
   public readonly selectors: LayoutSelectorDictionary;
   public readonly height: number;
   public readonly width: number;
+  private readonly zoom: number;
   private readonly scaledHeight: number;
   private readonly scaledWidth: number;
 
@@ -26,8 +31,9 @@ export class PreserveLayout extends BaseLayout implements Layout {
     super('preserve_layout');
     this.height = size.height;
     this.width = size.width;
-    this.scaledHeight = size.height * ZOOM;
-    this.scaledWidth = size.width * ZOOM;
+    this.zoom = this.height <= MAX_HEIGHT_PX ? DEFAULT_ZOOM : 1;
+    this.scaledHeight = size.height * this.zoom;
+    this.scaledWidth = size.width * this.zoom;
 
     this.selectors = { ...DEFAULT_SELECTORS, ...selectors };
   }
@@ -45,14 +51,14 @@ export class PreserveLayout extends BaseLayout implements Layout {
   }
 
   public getBrowserZoom() {
-    return ZOOM;
+    return this.zoom;
   }
 
   public getViewport() {
     return {
       height: this.height,
       width: this.width,
-      zoom: ZOOM,
+      zoom: this.zoom,
     };
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Reporting] set zoom to 1 for long reports (#248785)](https://github.com/elastic/kibana/pull/248785)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2026-02-03T01:40:22Z","message":"[Reporting] set zoom to 1 for long reports (#248785)\n\nresolves https://github.com/elastic/kibana/issues/138812\n\n## Summary\n\nChrome has a hard limit of 16000 rows in a page screenshot. We currently\nset the zoom level to 2, which means any report > 8000 in height won't\nbe rendered correctly.\n\nAs a partial fix, we'll set zoom to 1 for any report that is > 8000\nheight.\n\nfor more info: https://github.com/puppeteer/puppeteer/issues/359","sha":"19df26274ac68e1401cfc2702fb7922c9fda7cdb","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:all-open","ci:cloud-deploy","Feature:Reporting:Screenshot","v9.3.0","v9.4.0"],"title":"[Reporting] set zoom to 1 for long reports","number":248785,"url":"https://github.com/elastic/kibana/pull/248785","mergeCommit":{"message":"[Reporting] set zoom to 1 for long reports (#248785)\n\nresolves https://github.com/elastic/kibana/issues/138812\n\n## Summary\n\nChrome has a hard limit of 16000 rows in a page screenshot. We currently\nset the zoom level to 2, which means any report > 8000 in height won't\nbe rendered correctly.\n\nAs a partial fix, we'll set zoom to 1 for any report that is > 8000\nheight.\n\nfor more info: https://github.com/puppeteer/puppeteer/issues/359","sha":"19df26274ac68e1401cfc2702fb7922c9fda7cdb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251365","number":251365,"state":"MERGED","mergeCommit":{"sha":"1ce95a5aa75b2fc1bbb716ff3854747a09e21d59","message":"[9.3] [Reporting] set zoom to 1 for long reports (#248785) (#251365)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Reporting] set zoom to 1 for long reports\n(#248785)](https://github.com/elastic/kibana/pull/248785)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Patrick Mueller <patrick.mueller@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248785","number":248785,"mergeCommit":{"message":"[Reporting] set zoom to 1 for long reports (#248785)\n\nresolves https://github.com/elastic/kibana/issues/138812\n\n## Summary\n\nChrome has a hard limit of 16000 rows in a page screenshot. We currently\nset the zoom level to 2, which means any report > 8000 in height won't\nbe rendered correctly.\n\nAs a partial fix, we'll set zoom to 1 for any report that is > 8000\nheight.\n\nfor more info: https://github.com/puppeteer/puppeteer/issues/359","sha":"19df26274ac68e1401cfc2702fb7922c9fda7cdb"}}]}] BACKPORT-->