### PR TITLE
updating the description for the index parameter: search tool to avoid errors

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/search.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/search.ts
@@ -14,9 +14,10 @@ const searchSchema = z.object({
   query: z.string().describe('A natural language query expressing the search request'),
   index: z
     .string()
+    .min(1)
     .optional()
     .describe(
-      '(optional) Index to search against. If not provided, will automatically select the best index to use based on the query.'
+      'Index to search against. Omit this parameter entirely to let the tool automatically select the best index based on the query.'
     ),
 });
 


### PR DESCRIPTION
## Context 
I've noticed repeated tool errors with the search tool, which primarily occur when GPT-5.2 calls it. 
The errors occurs when the llm call the search tool and pass "" empty string for index parameter.
Since GPT-5.2 is one of our recommended models, I've implemented this fix.

Error trace: https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDoxNzEy/spans/32fb03babd83aff62395e359d6dd2758?selectedSpanNodeId=U3Bhbjo0MDcxNzU%3D

After Fix: https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDoxNzEy/spans/9a3bcf12e0fb42e5d4bc495cbca34911?selectedSpanNodeId=U3Bhbjo0MDcyNTA=

## Summary

This pull request makes a improvement to the validation and documentation of the `index` parameter in the `searchSchema` within `search.ts`. The change enforces that if an index is provided, it must be a non-empty string, and clarifies the documentation to encourage omitting the parameter for automatic selection.

Tested this on a test dataset of text retrieval and analytical queries containing 20 queries
gpt-5.2
Control: Tool Call Error: 13/20
Variant: Tool Call Error: 2/20

Claude-4.5
Control: Tool Call Error: 0/20
Variant: Tool Call Error: 0/20