### PR TITLE
[9.2] [Fleet] Fix pkg reinstall installType when no version is provided (#250968)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -491,12 +491,6 @@ async function installPackageFromRegistry({
   try {
     // get the currently installed package
 
-    const installedPkg = await getInstallationObject({ savedObjectsClient, pkgName });
-    installType = getInstallType({ pkgVersion, installedPkg });
-
-    telemetryEvent.installType = installType;
-    telemetryEvent.currentVersion = installedPkg?.attributes.version || 'not_installed';
-
     const queryLatest = () =>
       Registry.fetchFindLatestPackageOrThrow(pkgName, {
         ignoreConstraints,
@@ -509,6 +503,12 @@ async function installPackageFromRegistry({
       latestPkg = await queryLatest();
       pkgVersion = latestPkg.version;
     }
+
+    const installedPkg = await getInstallationObject({ savedObjectsClient, pkgName });
+    installType = getInstallType({ pkgVersion, installedPkg });
+
+    telemetryEvent.installType = installType;
+    telemetryEvent.currentVersion = installedPkg?.attributes.version || 'not_installed';
 
     // get latest package version and requested version in parallel for performance
     const [latestPackage, { paths, packageInfo, archiveIterator, verificationResult }] =


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Fleet] Fix pkg reinstall installType when no version is provided (#250968)](https://github.com/elastic/kibana/pull/250968)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2026-01-30T13:20:32Z","message":"[Fleet] Fix pkg reinstall installType when no version is provided (#250968)","sha":"5ed7aab8ffaecbc4d5f9b4600e0dcda6068757b1","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Fleet","backport:all-open","v9.4.0"],"title":"[Fleet] Fix pkg reinstall installType when no version is provided","number":250968,"url":"https://github.com/elastic/kibana/pull/250968","mergeCommit":{"message":"[Fleet] Fix pkg reinstall installType when no version is provided (#250968)","sha":"5ed7aab8ffaecbc4d5f9b4600e0dcda6068757b1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250968","number":250968,"mergeCommit":{"message":"[Fleet] Fix pkg reinstall installType when no version is provided (#250968)","sha":"5ed7aab8ffaecbc4d5f9b4600e0dcda6068757b1"}},{"url":"https://github.com/elastic/kibana/pull/251274","number":251274,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->