### PR TITLE
[Fleet] POC composable package installation

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -668,6 +668,7 @@ export interface CustomAssetFailedAttempt extends FailedAttempt {
 }
 
 export enum INSTALL_STATES {
+  RESOLVE_DEPENDENCIES = 'resolve_dependencies',
   CREATE_RESTART_INSTALLATION = 'create_restart_installation',
   INSTALL_PRECHECK = 'install_precheck',
   INSTALL_ESQL_VIEWS = 'install_esql_views',
@@ -728,6 +729,10 @@ export interface Installation {
   previous_version?: string | null;
   rolled_back?: boolean;
   is_rollback_ttl_expired?: boolean;
+  dependencies?: Array<{
+    name: string;
+    version: string;
+  }> | null;
 }
 
 export interface PackageUsageStats {

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
@@ -37,6 +37,12 @@ export interface PackageSpecManifest {
   source?: {
     license: string;
   };
+  requires?: {
+    content?: {
+      package: string;
+      version: string;
+    }[];
+  };
   type?: PackageSpecPackageType;
   release?: 'experimental' | 'beta' | 'ga';
   categories?: Array<PackageSpecCategory | undefined>;

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/epm.ts
@@ -42,6 +42,8 @@ export interface GetPackagesRequest {
     excludeInstallStatus?: boolean;
     withPackagePoliciesCount?: boolean;
     type?: string;
+    package?: string;
+    all?: boolean;
   };
 }
 

--- a/x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts
@@ -1168,6 +1168,13 @@ export const getSavedObjectTypes = (
           name: { type: 'keyword' },
           version: { type: 'keyword' },
           internal: { type: 'boolean' },
+          dependencies: {
+            type: 'nested',
+            properties: {
+              name: { type: 'keyword' },
+              version: { type: 'keyword' },
+            },
+          },
           keep_policies_up_to_date: { type: 'boolean', index: false },
           es_index_patterns: {
             dynamic: false,
@@ -1266,6 +1273,22 @@ export const getSavedObjectTypes = (
               type: 'mappings_addition',
               addedMappings: {
                 previous_version: { type: 'keyword' },
+              },
+            },
+          ],
+        },
+        '6': {
+          changes: [
+            {
+              type: 'mappings_addition',
+              addedMappings: {
+                dependencies: {
+                  type: 'nested',
+                  properties: {
+                    name: { type: 'keyword' },
+                    version: { type: 'keyword' },
+                  },
+                },
               },
             },
           ],

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
@@ -119,6 +119,7 @@ const optionalArchivePackageProps: readonly OptionalPackageProp[] = [
   'assets',
   'data_streams',
   'license',
+  'requires',
   'type',
   'categories',
   'conditions',

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -1218,6 +1218,7 @@ export async function restartInstallation(options: {
     install_started_at: new Date().toISOString(),
     install_source: installSource,
     previous_version: previousVersion,
+    // TODO dependencies should be updated there too
   };
 
   if (verificationResult) {
@@ -1275,6 +1276,12 @@ export async function createInstallation(options: {
     install_format_schema_version: FLEET_INSTALL_FORMAT_VERSION,
     keep_policies_up_to_date: defaultKeepPoliciesUpToDate,
     verification_status: 'unknown',
+    // TODO put behind a feature flag
+    dependencies:
+      packageInfo.requires?.content?.map((pkg) => ({
+        name: pkg.package,
+        version: pkg.version,
+      })) ?? null,
   };
 
   if (verificationResult) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/_state_machine_package_install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/_state_machine_package_install.ts
@@ -62,6 +62,7 @@ import type { StateMachineDefinition, StateMachineStates } from './state_machine
 import { handleState } from './state_machine';
 import { stepCreateAlertingRules } from './steps/step_create_alerting_rules';
 import { cleanupEsqlViewsStep, stepInstallEsqlViews } from './steps/step_install_esql_views';
+import { stepResolveDependencies } from './steps/step_resolve_dependencies';
 
 export interface InstallContext extends StateContext<StateNames> {
   savedObjectsClient: SavedObjectsClientContract;
@@ -92,8 +93,14 @@ export interface InstallContext extends StateContext<StateNames> {
  */
 const regularStatesDefinition: StateMachineStates<StateNames> = {
   create_restart_installation: {
-    nextState: INSTALL_STATES.INSTALL_PRECHECK,
+    nextState: INSTALL_STATES.RESOLVE_DEPENDENCIES,
     onTransition: stepCreateRestartInstallation,
+    onPostTransition: updateLatestExecutedState,
+  },
+  // TODO Put that step behind a feature flag
+  resolve_dependencies: {
+    onTransition: stepResolveDependencies,
+    nextState: INSTALL_STATES.INSTALL_PRECHECK,
     onPostTransition: updateLatestExecutedState,
   },
   install_precheck: {
@@ -244,6 +251,7 @@ export async function _stateMachineInstallPackage(
     // we need to clean up latest_executed_state or it won't be refreshed
     await cleanupLatestExecutedState(context);
   }
+
   const installStates: StateMachineDefinition<StateNames> = {
     // inject initial state inside context
     context: { ...context, initialState },

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_resolve_dependencies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_resolve_dependencies.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import pMap from 'p-map';
+import semverSatisfies from 'semver/functions/satisfies';
+import semverRcompare from 'semver/functions/rcompare';
+import semverGt from 'semver/functions/gt';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+
+import { type InstallablePackage, SO_SEARCH_LIMIT } from '../../../../../../common';
+import { getInstallation, getInstalledPackageSavedObjects } from '../../get';
+import { installPackage } from '../../install';
+import type { InstallContext } from '../_state_machine_package_install';
+import { fetchList, pkgToPkgKey } from '../../../registry';
+import { withPackageSpan } from '../../utils';
+
+export async function stepResolveDependencies(context: InstallContext) {
+  const { logger } = context;
+
+  const isPrerelease = true; // TODO Should probably come from install context
+
+  // if install request and not install dependencies Query dependendant packages
+  await withPackageSpan('Resolving dependencies', async () => {
+    // Check dependants package TODO allow flag to skip dependency check for now use force
+    if (!context.force) {
+      const dependants = await getDependantsPackages(
+        context.savedObjectsClient,
+        context.packageInstallContext.packageInfo.name
+      );
+
+      for (const dependant of dependants) {
+        const dependencyRequiredVersion = dependant.attributes.dependencies?.find(
+          (d) => d.name === context.packageInstallContext.packageInfo.name
+        )?.version;
+
+        if (
+          dependencyRequiredVersion &&
+          !semverSatisfies(
+            context.packageInstallContext.packageInfo.version,
+            dependencyRequiredVersion
+          )
+        ) {
+          throw new Error(
+            `Package ${context.packageInstallContext.packageInfo.name}@${context.packageInstallContext.packageInfo.version} is not compatible with dependant ${dependant.attributes.name}@${dependant.attributes.version}`
+          );
+        }
+      }
+    }
+
+    // Check dependencies
+    const resolvedDependencies = await buildDependencies(
+      context.savedObjectsClient,
+      context.packageInstallContext.packageInfo,
+      { prerelease: isPrerelease }
+    );
+
+    for (const dependency of resolvedDependencies) {
+      if (dependency.status === 'installed') {
+        logger.info(
+          `stepResolveDependencies: dependency ${dependency.name}@${dependency.resolvedVersion} is already installed`
+        );
+        continue;
+      } else if (dependency.status === 'to_install') {
+        logger.info(
+          `stepResolveDependencies: installing dependency ${dependency.name}@${dependency.resolvedVersion}`
+        );
+        await installPackage({
+          installSource: 'registry',
+          savedObjectsClient: context.savedObjectsClient,
+          esClient: context.esClient,
+          pkgkey: pkgToPkgKey({ name: dependency.name, version: dependency.resolvedVersion }),
+          spaceId: context.spaceId,
+          force: context.force,
+          prerelease: isPrerelease,
+          // TODO pass some flag to say it's install from dependency resolution
+        });
+      } else if (dependency.status === 'to_update') {
+        logger.info(
+          `stepResolveDependencies: updating dependency ${dependency.name}@${dependency.resolvedVersion}`
+        );
+        await installPackage({
+          installSource: 'registry',
+          savedObjectsClient: context.savedObjectsClient,
+          esClient: context.esClient,
+          pkgkey: pkgToPkgKey({ name: dependency.name, version: dependency.resolvedVersion }),
+          spaceId: context.spaceId,
+          force: context.force,
+          prerelease: isPrerelease,
+          // TODO pass some flag to say it's install from dependency resolution
+        });
+      }
+    }
+  });
+}
+
+interface ResolvedDependency {
+  name: string;
+  requiredVersion: string;
+  resolvedVersion: string;
+  status: 'installed' | 'to_update' | 'to_install';
+}
+
+async function buildDependencies(
+  soClient: SavedObjectsClientContract,
+  packageInfo: InstallablePackage,
+  opts?: { prerelease?: boolean }
+): Promise<ResolvedDependency[]> {
+  const requiredContentPackages =
+    packageInfo.requires?.content?.map((pkg) => ({
+      name: pkg.package,
+      requiredVersion: pkg.version,
+    })) ?? [];
+
+  if (!requiredContentPackages.length) {
+    return [];
+  }
+  // Retrieve installed packages
+  const dependenciesWithInstalledPackage = await pMap(
+    requiredContentPackages,
+    async (pkg) => {
+      const installation = await getInstallation({
+        savedObjectsClient: soClient,
+        pkgName: pkg.name,
+      });
+      return { installation, requiredPackage: pkg };
+    },
+    { concurrency: 10 }
+  );
+
+  const resolvedDependencies: ResolvedDependency[] = [];
+
+  for (const {
+    installation,
+    requiredPackage: { name, requiredVersion },
+  } of dependenciesWithInstalledPackage) {
+    if (!installation) {
+      const resolvedVersion = await getCompatibleVersion(name, [requiredVersion], {
+        prerelease: opts?.prerelease,
+      });
+      resolvedDependencies.push({
+        name,
+        requiredVersion,
+        resolvedVersion,
+        status: 'to_install',
+      });
+    } else if (!semverSatisfies(installation.version, requiredVersion)) {
+      // Package installed but version doesn't satisfy constraint - need to update
+      // Get all dependants to collect their version constraints
+      const dependants = await getDependantsPackages(soClient, name);
+
+      const versionConstraints = dependants.reduce(
+        (acc, curr) => {
+          const versionConstraint = curr.attributes.dependencies?.find(
+            (d) => d.name === name
+          )?.version;
+          if (versionConstraint) {
+            acc.push(versionConstraint);
+          }
+          return acc;
+        },
+        [requiredVersion]
+      );
+
+      const resolvedVersion = await getCompatibleVersion(name, versionConstraints, {
+        prerelease: opts?.prerelease,
+      });
+      if (semverGt(installation.version, resolvedVersion)) {
+        // TODO create proper Fleet error with metadata to handle this case in the UI
+        throw new Error(
+          `Required package ${name}@${requiredVersion} is not compatible with installed version ${installation.version}, you need to downgrade that package first.`
+        );
+      }
+      resolvedDependencies.push({
+        name,
+        requiredVersion,
+        resolvedVersion,
+        status: 'to_update',
+      });
+    } else {
+      resolvedDependencies.push({
+        name,
+        requiredVersion,
+        resolvedVersion: installation.version,
+        status: 'installed',
+      });
+    }
+  }
+
+  return resolvedDependencies;
+}
+
+/**
+ * Return compatible version for given package and version constraints, throw on error
+ */
+async function getCompatibleVersion(
+  pkgName: string,
+  versionConstrains: string[],
+  opts?: { prerelease?: boolean }
+) {
+  const res = await fetchList({
+    all: true,
+    package: pkgName,
+    prerelease: opts?.prerelease,
+  });
+
+  const allAvailableVersions = res.sort((a, b) => semverRcompare(a.version, b.version));
+
+  for (const registryPackage of allAvailableVersions) {
+    if (
+      versionConstrains.every((constrain) => semverSatisfies(registryPackage.version, constrain))
+    ) {
+      return registryPackage.version;
+    }
+  }
+
+  // TODO create proper Fleet error with metadata to handle this case in the UI
+  throw new Error(
+    `No compatible version found for ${pkgName} with constraints ${versionConstrains.join(', ')}`
+  );
+}
+
+async function getDependantsPackages(soClient: SavedObjectsClientContract, pkgName: string) {
+  const dependants = (
+    await getInstalledPackageSavedObjects(soClient, {
+      dependencyPackageName: pkgName,
+      perPage: SO_SEARCH_LIMIT,
+      sortOrder: 'asc',
+    })
+  ).saved_objects.filter((obj) => obj.attributes.name !== pkgName);
+
+  return dependants;
+}

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/index.ts
@@ -95,6 +95,12 @@ export async function fetchList(
     if (params.type) {
       url.searchParams.set('type', params.type);
     }
+    if (params.package) {
+      url.searchParams.set('package', params.package);
+    }
+    if (params.all) {
+      url.searchParams.set('all', params.all.toString());
+    }
   }
 
   setConstraints(url);


### PR DESCRIPTION
## Summary

POC of composable package installation 

## Assumptions

* We only support content package as dependencies
* We could only have one level of dependency

## What's next

- Server
  - [ ] global lock for package installation => to avoid conflict in dependencies resolution, we should allow to install only one package at the same time, we could use kbn-lock-manager for that
  - [x] Check dependant package one installing any content package.
  - [ ] Improve Dependencies error to have handleable error for the UI
- UI
  - [ ]  handle conflict
  - [ ] Show dependencies 
  - [ ] Allow to discover dependencies assets? probably need some design for that.
- Registry
  -  [ ] dependencies should be returned from registry endpoints

## Test instructions 

With integrations from that PR https://github.com/elastic/integrations/pull/17232
* go the apache package and build it `elastic-package build --skip-validation` than run the package registry from there 
*  Run kibana with a custom package registry 
kibana.dev.yml
```
xpack.fleet.registryUrl: https://127.0.0.1:8080
```
```
eval "$(elastic-package stack shellinit)"
NODE_EXTRA_CA_CERTS=$ELASTIC_PACKAGE_CA_CERT yarn start --no-base-path
```

## Examples

#### Install a incompatible package that will require a downgrade of installed package 

<img width="900" h alt="Screenshot 2026-02-04 at 10 31 16 AM" src="https://github.com/user-attachments/assets/1b1f08e9-e3db-46d0-bfaa-b109565459b6" />

#### Install package install required dependency if not installed 

<img width="900" alt="Screenshot 2026-02-04 at 10 32 07 AM" src="https://github.com/user-attachments/assets/5e35c364-a96b-4834-8d49-b84eb010a50a" />

#### Install package do not install required dependency if a compatible version is installed 

<img width="900" alt="Screenshot 2026-02-04 at 10 33 28 AM" src="https://github.com/user-attachments/assets/6fa6abbb-3e46-4389-9ecf-4e8df459a4d6" />


#### Install package that will not satisfy a dependant package requirements 


<img width="900" alt="Screenshot 2026-02-04 at 10 52 35 AM" src="https://github.com/user-attachments/assets/174af967-b743-4be9-858e-01be75c2ebc2" />






