### PR TITLE
[Alerting v2] Simplify task registration pattern

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/index.ts
@@ -14,6 +14,7 @@ import { bindOnStart } from './setup/bind_on_start';
 import { bindRoutes } from './setup/bind_routes';
 import { bindServices } from './setup/bind_services';
 import { bindRuleExecutionServices } from './setup/bind_rule_executor';
+import { bindTasks } from './setup/bind_tasks';
 
 export const config: PluginConfigDescriptor<PluginConfig> = {
   schema: configSchema,
@@ -25,6 +26,7 @@ export const module = new ContainerModule((options) => {
   bindRoutes(options);
   bindServices(options);
   bindRuleExecutionServices(options);
+  bindTasks(options);
 });
 
 export type { PluginConfig as AlertingV2Config } from './config';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/index.ts
@@ -5,5 +5,4 @@
  * 2.0.
  */
 
-export { registerRuleExecutorTaskDefinition } from './task_definition';
-export { ALERTING_RULE_EXECUTOR_TASK_TYPE } from './task_definition';
+export { RuleExecutorTaskDefinition, ALERTING_RULE_EXECUTOR_TASK_TYPE } from './task_definition';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/task_definition.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/task_definition.ts
@@ -7,33 +7,23 @@
 
 import { schema } from '@kbn/config-schema';
 
-import type { AlertingServerSetupDependencies } from '../../types';
-import type { TaskRunnerFactory } from '../services/task_run_scope_service/create_task_runner';
+import type { AlertingTaskDefinition } from '../services/task_run_scope_service/create_task_runner';
 import { RuleExecutorTaskRunner } from './task_runner';
 
 export const ALERTING_RULE_EXECUTOR_TASK_TYPE = 'alerting_v2:rule_executor' as const;
 
-export function registerRuleExecutorTaskDefinition({
-  taskManager,
-  taskRunnerFactory,
-}: {
-  taskManager: AlertingServerSetupDependencies['taskManager'];
-  taskRunnerFactory: TaskRunnerFactory;
-}) {
-  const createTaskRunner = taskRunnerFactory({
-    taskRunnerClass: RuleExecutorTaskRunner,
-    taskType: ALERTING_RULE_EXECUTOR_TASK_TYPE,
-  });
-
-  taskManager.registerTaskDefinitions({
-    [ALERTING_RULE_EXECUTOR_TASK_TYPE]: {
-      title: 'Alerting v2 rule executor (ES|QL)',
-      timeout: '5m',
-      paramsSchema: schema.object({
-        ruleId: schema.string(),
-        spaceId: schema.string(),
-      }),
-      createTaskRunner,
-    },
-  });
-}
+/**
+ * Task definition for rule executor.
+ * Bound to TaskDefinition token and automatically registered with Task Manager on setup.
+ */
+export const RuleExecutorTaskDefinition: AlertingTaskDefinition<RuleExecutorTaskRunner> = {
+  taskType: ALERTING_RULE_EXECUTOR_TASK_TYPE,
+  title: 'Alerting v2 rule executor (ES|QL)',
+  timeout: '5m',
+  paramsSchema: schema.object({
+    ruleId: schema.string(),
+    spaceId: schema.string(),
+  }),
+  taskRunnerClass: RuleExecutorTaskRunner,
+  requiresFakeRequest: true,
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/task_run_scope_service/create_task_runner.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ObjectType } from '@kbn/config-schema';
 import type { CoreDiServiceStart } from '@kbn/core-di';
 import { Request } from '@kbn/core-di-server';
 import { Global } from '@kbn/core-di-internal';
@@ -24,35 +25,76 @@ export interface AlertingTaskRunner {
   }): Promise<RunResult>;
 }
 
+/**
+ * Task definition interface for alerting tasks.
+ * Similar to Route definitions, task definitions are bound to the TaskDefinition token
+ * and automatically registered with Task Manager on setup.
+ */
+export interface AlertingTaskDefinition<TRunner extends AlertingTaskRunner = AlertingTaskRunner> {
+  taskType: string;
+  title: string;
+  timeout: string;
+  paramsSchema: ObjectType;
+  taskRunnerClass: TaskRunnerConstructor<TRunner>;
+  /**
+   * Whether this task requires a fakeRequest from Task Manager.
+   * Tasks scheduled with API keys have a fakeRequest that enables request-scoped services.
+   * Set to false for tasks that only use internal/singleton-scoped services.
+   * @default true
+   */
+  requiresFakeRequest?: boolean;
+}
+
+export const TaskDefinition = Symbol.for(
+  'alerting_v2.TaskDefinition'
+) as ServiceIdentifier<AlertingTaskDefinition>;
+
 export type TaskRunnerFactory = <TRunner extends AlertingTaskRunner>(params: {
   taskRunnerClass: TaskRunnerConstructor<TRunner>;
   taskType: string;
+  requiresFakeRequest?: boolean;
 }) => TaskRunCreatorFunction;
 
 export const TaskRunnerFactoryToken = Symbol.for(
   'alerting_v2.TaskRunnerFactory'
 ) as ServiceIdentifier<TaskRunnerFactory>;
 
-// Factory for task runners that depend on Task Manager fakeRequest.
-// It forks the DI container and overrides Request scope with the fake request.
+/**
+ * Factory for task runners that creates scoped DI containers for each task execution.
+ *
+ * For tasks with `requiresFakeRequest: true` (default):
+ * - Forks the DI container and binds the fakeRequest to Request scope
+ * - Enables request-scoped services (e.g., scoped ES clients)
+ * - Throws if no fakeRequest is available (task must be scheduled with API key)
+ *
+ * For tasks with `requiresFakeRequest: false`:
+ * - Forks the DI container for isolation
+ * - Does not bind Request scope
+ * - Task runner can only use internal/singleton-scoped services
+ */
 export function createTaskRunnerFactory({
   getInjection,
 }: {
   getInjection: () => CoreDiServiceStart;
 }): TaskRunnerFactory {
-  return ({ taskRunnerClass, taskType }) => {
+  return ({ taskRunnerClass, taskType, requiresFakeRequest = true }) => {
     return ({ taskInstance, abortController, fakeRequest }: RunContext) => ({
       run: async () => {
-        if (!fakeRequest) {
+        if (requiresFakeRequest && !fakeRequest) {
           throw new Error(
             `Cannot execute ${taskType} task without Task Manager fakeRequest. Ensure the task is scheduled with an API key (task id: ${taskInstance.id})`
           );
         }
 
         const scope = getInjection().fork();
-        scope.bind(Request).toConstantValue(fakeRequest);
-        scope.bind(Global).toConstantValue(Request);
-        scope.bind(taskRunnerClass).toSelf().inRequestScope();
+
+        if (fakeRequest) {
+          scope.bind(Request).toConstantValue(fakeRequest);
+          scope.bind(Global).toConstantValue(Request);
+          scope.bind(taskRunnerClass).toSelf().inRequestScope();
+        } else {
+          scope.bind(taskRunnerClass).toSelf().inTransientScope();
+        }
 
         try {
           const runner = scope.get(taskRunnerClass);

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_setup.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_setup.ts
@@ -8,11 +8,9 @@
 import type { ContainerModuleLoadOptions } from 'inversify';
 import { Logger, OnSetup, PluginSetup } from '@kbn/core-di';
 import { CoreSetup } from '@kbn/core-di-server';
-import { registerRuleExecutorTaskDefinition } from '../lib/rule_executor/task_definition';
 import { registerFeaturePrivileges } from '../lib/security/privileges';
 import { registerSavedObjects } from '../saved_objects';
-import { TaskRunnerFactoryToken } from '../lib/services/task_run_scope_service/create_task_runner';
-import type { AlertingServerSetupDependencies } from '../types';
+import { TaskDefinition } from '../lib/services/task_run_scope_service/create_task_runner';
 
 export function bindOnSetup({ bind }: ContainerModuleLoadOptions) {
   bind(OnSetup).toConstantValue((container) => {
@@ -25,11 +23,7 @@ export function bindOnSetup({ bind }: ContainerModuleLoadOptions) {
       logger,
     });
 
-    registerRuleExecutorTaskDefinition({
-      taskManager: container.get(
-        PluginSetup<AlertingServerSetupDependencies['taskManager']>('taskManager')
-      ),
-      taskRunnerFactory: container.get(TaskRunnerFactoryToken),
-    });
+    // Trigger task registration via onActivation callbacks
+    container.getAll(TaskDefinition);
   });
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_tasks.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_tasks.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ContainerModuleLoadOptions } from 'inversify';
+import { PluginSetup } from '@kbn/core-di';
+import {
+  TaskDefinition,
+  TaskRunnerFactoryToken,
+} from '../lib/services/task_run_scope_service/create_task_runner';
+import { RuleExecutorTaskDefinition } from '../lib/rule_executor/task_definition';
+import type { AlertingServerSetupDependencies } from '../types';
+
+export function bindTasks({ bind, onActivation }: ContainerModuleLoadOptions) {
+  // Register task with Task Manager when the binding is activated
+  onActivation(TaskDefinition, ({ get }, definition) => {
+    const taskManager = get(
+      PluginSetup<AlertingServerSetupDependencies['taskManager']>('taskManager')
+    );
+    const taskRunnerFactory = get(TaskRunnerFactoryToken);
+
+    const createTaskRunner = taskRunnerFactory({
+      taskRunnerClass: definition.taskRunnerClass,
+      taskType: definition.taskType,
+      requiresFakeRequest: definition.requiresFakeRequest,
+    });
+
+    taskManager.registerTaskDefinitions({
+      [definition.taskType]: {
+        title: definition.title,
+        timeout: definition.timeout,
+        paramsSchema: definition.paramsSchema,
+        createTaskRunner,
+      },
+    });
+
+    return definition;
+  });
+
+  // Bind task definitions - add more tasks here as needed
+  bind(TaskDefinition).toConstantValue(RuleExecutorTaskDefinition);
+}


### PR DESCRIPTION
## Summary

Refactors task registration to use a declarative binding pattern similar to route registration, making it easier to add new task types.

**Changes:**
- Add `TaskDefinition` token and `AlertingTaskDefinition` interface for task definitions
- Replace `registerRuleExecutorTaskDefinition()` function with `RuleExecutorTaskDefinition` constant object
- Create `bind_tasks.ts` with `onActivation` hook for automatic Task Manager registration
- Add `requiresFakeRequest` option to `TaskRunnerFactory` to support tasks that don't need API key authentication

### Before

```typescript
// Manual registration in bind_on_setup.ts
registerRuleExecutorTaskDefinition({
  taskManager: container.get(PluginSetup('taskManager')),
  taskRunnerFactory: container.get(TaskRunnerFactoryToken),
});
```

### After

```typescript
// Declarative binding in bind_tasks.ts
bind(TaskDefinition).toConstantValue(RuleExecutorTaskDefinition);
// Registration happens automatically via onActivation
```

### Adding new task types

```typescript
// 1. Define the task
export const MyTaskDefinition: AlertingTaskDefinition<MyTaskRunner> = {
  taskType: 'alerting_v2:my_task',
  title: 'My Task',
  timeout: '5m',
  paramsSchema: schema.object({ /* ... */ }),
  taskRunnerClass: MyTaskRunner,
  requiresFakeRequest: false, // optional, defaults to true
};

// 2. Bind it
bind(TaskDefinition).toConstantValue(MyTaskDefinition);
```
