### PR TITLE
[Fleet] Apply advanced YAML from ES output to OTel exporter

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { load } from 'js-yaml';
+
 import type { Output, TemplateAgentPolicyInput } from '../../types';
 import type {
   FullAgentPolicyInput,
@@ -319,12 +321,18 @@ function attachOtelcolExporter(
 }
 
 function generateOtelcolExporter(dataOutput: Output): Record<OTelCollectorComponentID, any> {
+  // Parse config_yaml if present, similar to transformOutputToFullPolicyOutput
+  const advancedYamlConfig = dataOutput.config_yaml
+    ? (load(dataOutput.config_yaml) as Record<string, any>)
+    : {};
+
   switch (dataOutput.type) {
     case outputType.Elasticsearch:
       const outputID = getOutputIdForAgentPolicy(dataOutput);
       return {
         [`elasticsearch/${outputID}`]: {
-          endpoints: dataOutput.hosts,
+          ...advancedYamlConfig, // Apply advanced YAML config first
+          endpoints: dataOutput.hosts, // Explicit properties override config_yaml
         },
       };
     default:


### PR DESCRIPTION
## Summary

Allow baseline configuration of the ES exporter used by OTel input packages via the advanced YML box on the default ES output. 

- Introduced parsing of `config_yaml` in the `generateOtelcolExporter` function to allow advanced YAML configurations.
- Updated tests to validate the application of `config_yaml` settings, including handling of explicit property overrides and SSL settings.
- Added multiple test cases to ensure correct behavior with various `config_yaml` scenarios, including empty and null values.

## Screenshots

<img width="769" height="164" alt="image" src="https://github.com/user-attachments/assets/55632851-ef6e-429f-9d80-d65cdadae538" />

<img width="341" height="175" alt="image" src="https://github.com/user-attachments/assets/6f6bd673-591b-4afb-8d84-728180d317ad" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Generated w/ Cursor


