### PR TITLE
[9.0] [Search] Fix wrapping of Index Details header buttons (#251543)

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
@@ -216,10 +216,10 @@ export const SearchIndexDetailsPage = () => {
             pageTitle={index?.name}
             bottomBorder={false}
             rightSideItems={[
-              <EuiFlexGroup gutterSize="m">
-                {hasDocuments ? (
-                  <>
-                    <EuiFlexItem>
+              {
+                ...(hasDocuments ? (
+                  <EuiFlexGroup>
+                    <div>
                       <EuiButtonEmpty
                         isLoading={isInitialLoading}
                         data-test-subj="viewInDiscoverLink"
@@ -230,8 +230,8 @@ export const SearchIndexDetailsPage = () => {
                           defaultMessage="View in Discover"
                         />
                       </EuiButtonEmpty>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
+                    </div>
+                    <EuiFlexGroup>
                       <EuiButton
                         isLoading={isInitialLoading}
                         data-test-subj="useInPlaygroundLink"
@@ -244,10 +244,15 @@ export const SearchIndexDetailsPage = () => {
                           defaultMessage="Search in Playground"
                         />
                       </EuiButton>
-                    </EuiFlexItem>
-                  </>
+                      <SearchIndexDetailsPageMenuItemPopover
+                        handleDeleteIndexModal={handleDeleteIndexModal}
+                        showApiReference={hasDocuments}
+                        userPrivileges={userPrivileges}
+                      />
+                    </EuiFlexGroup>
+                  </EuiFlexGroup>
                 ) : (
-                  <EuiFlexItem>
+                  <EuiFlexGroup>
                     <EuiButtonEmpty
                       href={docLinks.links.apiReference}
                       target="_blank"
@@ -260,16 +265,14 @@ export const SearchIndexDetailsPage = () => {
                         defaultMessage="API Reference"
                       />
                     </EuiButtonEmpty>
-                  </EuiFlexItem>
-                )}
-                <EuiFlexItem>
-                  <SearchIndexDetailsPageMenuItemPopover
-                    handleDeleteIndexModal={handleDeleteIndexModal}
-                    showApiReference={hasDocuments}
-                    userPrivileges={userPrivileges}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>,
+                    <SearchIndexDetailsPageMenuItemPopover
+                      handleDeleteIndexModal={handleDeleteIndexModal}
+                      showApiReference={hasDocuments}
+                      userPrivileges={userPrivileges}
+                    />
+                  </EuiFlexGroup>
+                )),
+              },
             ]}
           />
           <EuiPageTemplate.Section


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Search] Fix wrapping of Index Details header buttons (#251543)](https://github.com/elastic/kibana/pull/251543)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2026-02-04T15:13:30Z","message":"[Search] Fix wrapping of Index Details header buttons (#251543)\n\n## Summary\n\nOn smaller screen sizes, the Index Details (solution space) page header\nwould wrap in a way that pushed the three-dot menu onto its own row.\nThis change groups the three-dot menu with the adjacent action button,\nensuring that when wrapping occurs, the menu is not left isolated on a\nseparate line.\n\n| Before | After |\n| ------ | ------ |\n| <img width=\"200\" height=\"668\" alt=\"Screenshot 2026-02-03 at 17 56 50\"\nsrc=\"https://github.com/user-attachments/assets/26e5aeab-64fe-498f-82c7-fb0d006c1bf5\"\n/> | <img width=\"200\" height=\"671\" alt=\"Screenshot 2026-02-03 at 17 57\n27\"\nsrc=\"https://github.com/user-attachments/assets/78bbb661-bd8e-41dd-aeca-9f8469d32915\"\n/> |\n\n| Before | After |\n| ------ | ------ |\n| <img width=\"200\" height=\"667\" alt=\"Screenshot 2026-02-03 at 17 55 43\"\nsrc=\"https://github.com/user-attachments/assets/42a3b609-1ea2-4434-a814-af18c7ac40f9\"\n/> | <img width=\"200\" height=\"671\" alt=\"Screenshot 2026-02-03 at 17 55\n02\"\nsrc=\"https://github.com/user-attachments/assets/4a13638c-8bee-4767-9959-b919f8ed2cee\"\n/> |\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"0bb08947c6ecc51637673d69b3eafccfbc65dcc5","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:version","v9.4.0","v9.2.5","v9.1.11","v9.3.1"],"title":"[Search] Fix wrapping of Index Details header buttons","number":251543,"url":"https://github.com/elastic/kibana/pull/251543","mergeCommit":{"message":"[Search] Fix wrapping of Index Details header buttons (#251543)\n\n## Summary\n\nOn smaller screen sizes, the Index Details (solution space) page header\nwould wrap in a way that pushed the three-dot menu onto its own row.\nThis change groups the three-dot menu with the adjacent action button,\nensuring that when wrapping occurs, the menu is not left isolated on a\nseparate line.\n\n| Before | After |\n| ------ | ------ |\n| <img width=\"200\" height=\"668\" alt=\"Screenshot 2026-02-03 at 17 56 50\"\nsrc=\"https://github.com/user-attachments/assets/26e5aeab-64fe-498f-82c7-fb0d006c1bf5\"\n/> | <img width=\"200\" height=\"671\" alt=\"Screenshot 2026-02-03 at 17 57\n27\"\nsrc=\"https://github.com/user-attachments/assets/78bbb661-bd8e-41dd-aeca-9f8469d32915\"\n/> |\n\n| Before | After |\n| ------ | ------ |\n| <img width=\"200\" height=\"667\" alt=\"Screenshot 2026-02-03 at 17 55 43\"\nsrc=\"https://github.com/user-attachments/assets/42a3b609-1ea2-4434-a814-af18c7ac40f9\"\n/> | <img width=\"200\" height=\"671\" alt=\"Screenshot 2026-02-03 at 17 55\n02\"\nsrc=\"https://github.com/user-attachments/assets/4a13638c-8bee-4767-9959-b919f8ed2cee\"\n/> |\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"0bb08947c6ecc51637673d69b3eafccfbc65dcc5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251543","number":251543,"mergeCommit":{"message":"[Search] Fix wrapping of Index Details header buttons (#251543)\n\n## Summary\n\nOn smaller screen sizes, the Index Details (solution space) page header\nwould wrap in a way that pushed the three-dot menu onto its own row.\nThis change groups the three-dot menu with the adjacent action button,\nensuring that when wrapping occurs, the menu is not left isolated on a\nseparate line.\n\n| Before | After |\n| ------ | ------ |\n| <img width=\"200\" height=\"668\" alt=\"Screenshot 2026-02-03 at 17 56 50\"\nsrc=\"https://github.com/user-attachments/assets/26e5aeab-64fe-498f-82c7-fb0d006c1bf5\"\n/> | <img width=\"200\" height=\"671\" alt=\"Screenshot 2026-02-03 at 17 57\n27\"\nsrc=\"https://github.com/user-attachments/assets/78bbb661-bd8e-41dd-aeca-9f8469d32915\"\n/> |\n\n| Before | After |\n| ------ | ------ |\n| <img width=\"200\" height=\"667\" alt=\"Screenshot 2026-02-03 at 17 55 43\"\nsrc=\"https://github.com/user-attachments/assets/42a3b609-1ea2-4434-a814-af18c7ac40f9\"\n/> | <img width=\"200\" height=\"671\" alt=\"Screenshot 2026-02-03 at 17 55\n02\"\nsrc=\"https://github.com/user-attachments/assets/4a13638c-8bee-4767-9959-b919f8ed2cee\"\n/> |\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"0bb08947c6ecc51637673d69b3eafccfbc65dcc5"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251689","number":251689,"state":"OPEN"},{"branch":"9.1","label":"v9.1.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251688","number":251688,"state":"OPEN"},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251690","number":251690,"state":"OPEN"}]}] BACKPORT-->