### PR TITLE
[Security solution][Attacks] Add cases action items

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
@@ -34,7 +34,7 @@ const mockAttack = getMockAttackDiscoveryAlerts()[0];
 function renderAttack(attack: AttackDiscoveryAlert) {
   return render(
     <TestProviders>
-      <AttacksGroupTakeActionItems attack={attack} />
+      <AttacksGroupTakeActionItems attack={attack} filters={[]} />
     </TestProviders>
   );
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
@@ -34,7 +34,7 @@ const mockAttack = getMockAttackDiscoveryAlerts()[0];
 function renderAttack(attack: AttackDiscoveryAlert) {
   return render(
     <TestProviders>
-      <AttacksGroupTakeActionItems attack={attack} filters={[]} />
+      <AttacksGroupTakeActionItems attack={attack} />
     </TestProviders>
   );
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -18,6 +18,7 @@ import { useAttackWorkflowStatusContextMenuItems } from '../../../hooks/attacks/
 import type { AttackWithWorkflowStatus } from '../../../hooks/attacks/bulk_actions/types';
 import { useAttackTagsContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_tags_context_menu_items';
 import { useAttackInvestigateInTimelineContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items';
+import { useAttackCaseContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items';
 
 interface AttacksGroupTakeActionItemsProps {
   attack: AttackDiscoveryAlert;
@@ -82,12 +83,20 @@ export function AttacksGroupTakeActionItems({
     closePopover,
   });
 
+  const { items: casesItems } = useAttackCaseContextMenuItems({ closePopover, attack });
+
   const defaultPanel: EuiContextMenuPanelDescriptor = useMemo(
     () => ({
       id: 0,
-      items: [...workflowItems, ...assignItems, ...tagsItems, ...investigateInTimelineItems],
+      items: [
+        ...workflowItems,
+        ...assignItems,
+        ...tagsItems,
+        ...investigateInTimelineItems,
+        ...casesItems,
+      ],
     }),
-    [workflowItems, assignItems, tagsItems, investigateInTimelineItems]
+    [workflowItems, assignItems, tagsItems, investigateInTimelineItems, casesItems]
   );
 
   const panels: EuiContextMenuPanelDescriptor[] = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -7,7 +7,11 @@
 
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiContextMenu } from '@elastic/eui';
-import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
+import {
+  getAttackDiscoveryMarkdown,
+  getOriginalAlertIds,
+  type AttackDiscoveryAlert,
+} from '@kbn/elastic-assistant-common';
 import React, { useCallback, useMemo } from 'react';
 import { useInvalidateFindAttackDiscoveries } from '../../../../attack_discovery/pages/use_find_attack_discoveries';
 import type { inputsModel } from '../../../../common/store';
@@ -37,9 +41,14 @@ export function AttacksGroupTakeActionItems({
     globalQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
   }, [globalQueries]);
 
+  const originalAlertIds = useMemo(
+    () => getOriginalAlertIds({ alertIds: attack.alertIds, replacements: attack.replacements }),
+    [attack.alertIds, attack.replacements]
+  );
+
   const baseAttackProps = useMemo(() => {
-    return { attackId: attack.id, relatedAlertIds: attack.alertIds };
-  }, [attack.alertIds, attack.id]);
+    return { attackId: attack.id, relatedAlertIds: originalAlertIds };
+  }, [attack.id, originalAlertIds]);
 
   const attacksWithAssignees = useMemo(() => {
     return [{ ...baseAttackProps, assignees: attack.assignees }];
@@ -78,12 +87,31 @@ export function AttacksGroupTakeActionItems({
     closePopover,
   });
 
+  const attacksWithTimelineAlerts = useMemo(() => [{ ...baseAttackProps }], [baseAttackProps]);
+
   const { items: investigateInTimelineItems } = useAttackInvestigateInTimelineContextMenuItems({
-    attack,
+    attacksWithTimelineAlerts,
     closePopover,
   });
 
-  const { items: casesItems } = useAttackCaseContextMenuItems({ closePopover, attack });
+  const attacksWithCase = useMemo(
+    () => [
+      {
+        ...baseAttackProps,
+        markdownComment: getAttackDiscoveryMarkdown({
+          attackDiscovery: attack,
+          replacements: attack.replacements,
+        }),
+      },
+    ],
+    [attack, baseAttackProps]
+  );
+
+  const { items: casesItems } = useAttackCaseContextMenuItems({
+    closePopover,
+    title: attack.title,
+    attacksWithCase,
+  });
 
   const defaultPanel: EuiContextMenuPanelDescriptor = useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import React from 'react';
+import { useBulkAttackCaseItems } from './use_bulk_attack_case_items';
+import {
+  ALERT_ATTACK_DISCOVERY_ALERT_IDS,
+  ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT,
+} from '../constants';
+
+jest.mock('../../../../../common/lib/kibana', () => ({
+  useKibana: jest.fn(),
+}));
+jest.mock(
+  '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case',
+  () => ({
+    useAddToExistingCase: jest.fn(),
+  })
+);
+jest.mock('../../../../../attack_discovery/pages/results/take_action/use_add_to_case', () => ({
+  useAddToNewCase: jest.fn(),
+}));
+
+const { useKibana } = jest.requireMock('../../../../../common/lib/kibana') as {
+  useKibana: jest.Mock;
+};
+const { useAddToExistingCase } = jest.requireMock(
+  '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case'
+) as { useAddToExistingCase: jest.Mock };
+const { useAddToNewCase } = jest.requireMock(
+  '../../../../../attack_discovery/pages/results/take_action/use_add_to_case'
+) as { useAddToNewCase: jest.Mock };
+
+let queryClient: QueryClient;
+
+function wrapper(props: { children: React.ReactNode }) {
+  return React.createElement(QueryClientProvider, { client: queryClient }, props.children);
+}
+
+describe('useBulkAttackCaseItems', () => {
+  const onAddToNewCase = jest.fn();
+  const onAddToExistingCase = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient();
+
+    useKibana.mockReturnValue({
+      services: {
+        cases: {
+          helpers: {
+            canUseCases: jest.fn().mockReturnValue({
+              createComment: true,
+              read: true,
+            }),
+          },
+        },
+      },
+    });
+
+    useAddToNewCase.mockReturnValue({
+      disabled: false,
+      onAddToNewCase,
+    });
+
+    useAddToExistingCase.mockReturnValue({
+      disabled: false,
+      onAddToExistingCase,
+    });
+  });
+
+  it('should return two case items when user has permissions', () => {
+    const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
+      wrapper,
+    });
+
+    expect(result.current.items).toHaveLength(2);
+  });
+
+  it('should return empty items when user lacks cases permissions', () => {
+    useKibana.mockReturnValue({
+      services: {
+        cases: {
+          helpers: {
+            canUseCases: jest.fn().mockReturnValue({
+              createComment: false,
+              read: true,
+            }),
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
+      wrapper,
+    });
+
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('should pass unique alert ids and markdown comments to onAddToNewCase', async () => {
+    const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
+      wrapper,
+    });
+
+    await result.current.items[0]?.onClick?.(
+      [
+        {
+          _id: 'attack-1',
+          data: [
+            { field: ALERT_ATTACK_DISCOVERY_ALERT_IDS, value: ['alert-1', 'alert-2'] },
+            { field: ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT, value: ['markdown 1'] },
+          ],
+          ecs: { _id: 'attack-1' },
+        },
+        {
+          _id: 'attack-2',
+          data: [
+            { field: ALERT_ATTACK_DISCOVERY_ALERT_IDS, value: ['alert-2', 'alert-3'] },
+            { field: ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT, value: ['markdown 2'] },
+          ],
+          ecs: { _id: 'attack-2' },
+        },
+      ],
+      false,
+      jest.fn(),
+      jest.fn(),
+      jest.fn()
+    );
+
+    expect(onAddToNewCase).toHaveBeenCalledWith({
+      alertIds: ['alert-1', 'alert-2', 'alert-3'],
+      markdownComments: ['markdown 1', 'markdown 2'],
+    });
+  });
+
+  it('should pass unique alert ids and markdown comments to onAddToExistingCase', async () => {
+    const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
+      wrapper,
+    });
+
+    await result.current.items[1]?.onClick?.(
+      [
+        {
+          _id: 'attack-1',
+          data: [
+            { field: ALERT_ATTACK_DISCOVERY_ALERT_IDS, value: ['alert-1'] },
+            { field: ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT, value: ['markdown 1'] },
+          ],
+          ecs: { _id: 'attack-1' },
+        },
+        {
+          _id: 'attack-2',
+          data: [
+            { field: ALERT_ATTACK_DISCOVERY_ALERT_IDS, value: ['alert-2'] },
+            { field: ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT, value: ['markdown 2'] },
+          ],
+          ecs: { _id: 'attack-2' },
+        },
+      ],
+      false,
+      jest.fn(),
+      jest.fn(),
+      jest.fn()
+    );
+
+    expect(onAddToExistingCase).toHaveBeenCalledWith({
+      alertIds: ['alert-1', 'alert-2'],
+      markdownComments: ['markdown 1', 'markdown 2'],
+    });
+  });
+
+  it('should return empty panels', () => {
+    const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
+      wrapper,
+    });
+
+    expect(result.current.panels).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
@@ -105,9 +105,13 @@ describe('useBulkAttackCaseItems', () => {
   });
 
   it('should pass unique alert ids and markdown comments to onAddToNewCase', async () => {
-    const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
-      wrapper,
-    });
+    const closePopover = jest.fn();
+    const { result } = renderHook(
+      () => useBulkAttackCaseItems({ title: 'attack title', closePopover }),
+      {
+        wrapper,
+      }
+    );
 
     await result.current.items[0]?.onClick?.(
       [
@@ -138,12 +142,17 @@ describe('useBulkAttackCaseItems', () => {
       alertIds: ['alert-1', 'alert-2', 'alert-3'],
       markdownComments: ['markdown 1', 'markdown 2'],
     });
+    expect(closePopover).toHaveBeenCalledTimes(1);
   });
 
   it('should pass unique alert ids and markdown comments to onAddToExistingCase', async () => {
-    const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
-      wrapper,
-    });
+    const closePopover = jest.fn();
+    const { result } = renderHook(
+      () => useBulkAttackCaseItems({ title: 'attack title', closePopover }),
+      {
+        wrapper,
+      }
+    );
 
     await result.current.items[1]?.onClick?.(
       [
@@ -174,6 +183,7 @@ describe('useBulkAttackCaseItems', () => {
       alertIds: ['alert-1', 'alert-2'],
       markdownComments: ['markdown 1', 'markdown 2'],
     });
+    expect(closePopover).toHaveBeenCalledTimes(1);
   });
 
   it('should return empty panels', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import type { BulkActionsConfig } from '@kbn/response-ops-alerts-table/types';
+import { uniq } from 'lodash';
+import { useAddToExistingCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case';
+import { useAddToNewCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_case';
+import { APP_ID } from '../../../../../../common';
+import { useKibana } from '../../../../../common/lib/kibana';
+import {
+  ADD_TO_EXISTING_CASE,
+  ADD_TO_NEW_CASE,
+} from '../../../../../common/components/visualization_actions/translations';
+import {
+  ALERT_ATTACK_DISCOVERY_ALERT_IDS,
+  ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT,
+} from '../constants';
+import type { BulkAttackActionItems } from '../types';
+
+export interface UseBulkAttackCaseItemsProps {
+  /** Title used to initialize "create case" flyout */
+  title: string;
+  /** Optional callback when add-to-case action is triggered */
+  onCasesAdd?: () => void;
+}
+
+/**
+ * Hook that provides bulk action items for adding attacks to a new or existing case.
+ */
+export const useBulkAttackCaseItems = ({
+  title,
+  onCasesAdd,
+}: UseBulkAttackCaseItemsProps): BulkAttackActionItems => {
+  const {
+    services: { cases },
+  } = useKibana();
+  const userCasesPermissions = cases.helpers.canUseCases([APP_ID]);
+  const canCreateAndReadCases = userCasesPermissions.createComment && userCasesPermissions.read;
+  const canUserCreateAndReadCases = useCallback(
+    () => canCreateAndReadCases,
+    [canCreateAndReadCases]
+  );
+
+  const { onAddToNewCase, disabled: isAddToNewCaseDisabled } = useAddToNewCase({
+    canUserCreateAndReadCases,
+    title,
+    onClick: onCasesAdd,
+  });
+
+  const { onAddToExistingCase, disabled: isAddToExistingCaseDisabled } = useAddToExistingCase({
+    canUserCreateAndReadCases,
+    onClick: onCasesAdd,
+  });
+
+  const onAddToNewCaseClick = useCallback<Required<BulkActionsConfig>['onClick']>(
+    async (alertItems) => {
+      const alertIds = uniq(
+        alertItems.flatMap((item) => {
+          const value = item.data.find(
+            (data) => data.field === ALERT_ATTACK_DISCOVERY_ALERT_IDS
+          )?.value;
+          return Array.isArray(value)
+            ? value.filter((id): id is string => typeof id === 'string')
+            : [];
+        })
+      );
+      const markdownComments = alertItems
+        .map((item) => {
+          const value = item.data.find(
+            (data) => data.field === ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT
+          )?.value;
+          if (!Array.isArray(value)) {
+            return undefined;
+          }
+          return typeof value[0] === 'string' ? value[0] : undefined;
+        })
+        .filter((comment): comment is string => comment != null);
+
+      onAddToNewCase({ alertIds, markdownComments });
+    },
+    [onAddToNewCase]
+  );
+
+  const onAddToExistingCaseClick = useCallback<Required<BulkActionsConfig>['onClick']>(
+    async (alertItems) => {
+      const alertIds = uniq(
+        alertItems.flatMap((item) => {
+          const value = item.data.find(
+            (data) => data.field === ALERT_ATTACK_DISCOVERY_ALERT_IDS
+          )?.value;
+          return Array.isArray(value)
+            ? value.filter((id): id is string => typeof id === 'string')
+            : [];
+        })
+      );
+      const markdownComments = alertItems
+        .map((item) => {
+          const value = item.data.find(
+            (data) => data.field === ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT
+          )?.value;
+          if (!Array.isArray(value)) {
+            return undefined;
+          }
+          return typeof value[0] === 'string' ? value[0] : undefined;
+        })
+        .filter((comment): comment is string => comment != null);
+
+      onAddToExistingCase({ alertIds, markdownComments });
+    },
+    [onAddToExistingCase]
+  );
+
+  const items = useMemo<BulkActionsConfig[]>(
+    () =>
+      canCreateAndReadCases
+        ? [
+            {
+              name: ADD_TO_NEW_CASE,
+              label: ADD_TO_NEW_CASE,
+              key: 'attack-add-to-new-case',
+              'data-test-subj': 'attack-add-to-new-case',
+              disableOnQuery: true,
+              disable: isAddToNewCaseDisabled,
+              onClick: onAddToNewCaseClick,
+            },
+            {
+              name: ADD_TO_EXISTING_CASE,
+              label: ADD_TO_EXISTING_CASE,
+              key: 'attack-add-to-existing-case',
+              'data-test-subj': 'attack-add-to-existing-case',
+              disableOnQuery: true,
+              disable: isAddToExistingCaseDisabled,
+              onClick: onAddToExistingCaseClick,
+            },
+          ]
+        : [],
+    [
+      canCreateAndReadCases,
+      isAddToExistingCaseDisabled,
+      isAddToNewCaseDisabled,
+      onAddToExistingCaseClick,
+      onAddToNewCaseClick,
+    ]
+  );
+
+  return useMemo(
+    () => ({
+      items,
+      panels: [],
+    }),
+    [items]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
@@ -12,10 +12,7 @@ import { useAddToExistingCase } from '../../../../../attack_discovery/pages/resu
 import { useAddToNewCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_case';
 import { APP_ID } from '../../../../../../common';
 import { useKibana } from '../../../../../common/lib/kibana';
-import {
-  ADD_TO_EXISTING_CASE,
-  ADD_TO_NEW_CASE,
-} from '../../../../../common/components/visualization_actions/translations';
+import { ADD_TO_EXISTING_CASE, ADD_TO_NEW_CASE } from '../translations';
 import {
   ALERT_ATTACK_DISCOVERY_ALERT_IDS,
   ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
@@ -27,6 +27,8 @@ export interface UseBulkAttackCaseItemsProps {
   title: string;
   /** Optional callback when add-to-case action is triggered */
   onCasesAdd?: () => void;
+  /** Optional callback to close the popover after triggering action */
+  closePopover?: () => void;
 }
 
 /**
@@ -35,6 +37,7 @@ export interface UseBulkAttackCaseItemsProps {
 export const useBulkAttackCaseItems = ({
   title,
   onCasesAdd,
+  closePopover,
 }: UseBulkAttackCaseItemsProps): BulkAttackActionItems => {
   const {
     services: { cases },
@@ -82,8 +85,9 @@ export const useBulkAttackCaseItems = ({
         .filter((comment): comment is string => comment != null);
 
       onAddToNewCase({ alertIds, markdownComments });
+      closePopover?.();
     },
-    [onAddToNewCase]
+    [closePopover, onAddToNewCase]
   );
 
   const onAddToExistingCaseClick = useCallback<Required<BulkActionsConfig>['onClick']>(
@@ -111,8 +115,9 @@ export const useBulkAttackCaseItems = ({
         .filter((comment): comment is string => comment != null);
 
       onAddToExistingCase({ alertIds, markdownComments });
+      closePopover?.();
     },
-    [onAddToExistingCase]
+    [closePopover, onAddToExistingCase]
   );
 
   const items = useMemo<BulkActionsConfig[]>(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
@@ -7,17 +7,14 @@
 
 import { useCallback, useMemo } from 'react';
 import type { BulkActionsConfig } from '@kbn/response-ops-alerts-table/types';
-import { uniq } from 'lodash';
 import { useAddToExistingCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case';
 import { useAddToNewCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_case';
 import { APP_ID } from '../../../../../../common';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { ADD_TO_EXISTING_CASE, ADD_TO_NEW_CASE } from '../translations';
-import {
-  ALERT_ATTACK_DISCOVERY_ALERT_IDS,
-  ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT,
-} from '../constants';
+import { ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT } from '../constants';
 import type { BulkAttackActionItems } from '../types';
+import { extractRelatedDetectionAlertIds } from '../utils/extract_related_detection_alert_ids';
 
 export interface UseBulkAttackCaseItemsProps {
   /** Title used to initialize "create case" flyout */
@@ -59,16 +56,7 @@ export const useBulkAttackCaseItems = ({
 
   const onAddToNewCaseClick = useCallback<Required<BulkActionsConfig>['onClick']>(
     async (alertItems) => {
-      const alertIds = uniq(
-        alertItems.flatMap((item) => {
-          const value = item.data.find(
-            (data) => data.field === ALERT_ATTACK_DISCOVERY_ALERT_IDS
-          )?.value;
-          return Array.isArray(value)
-            ? value.filter((id): id is string => typeof id === 'string')
-            : [];
-        })
-      );
+      const alertIds = extractRelatedDetectionAlertIds(alertItems);
       const markdownComments = alertItems
         .map((item) => {
           const value = item.data.find(
@@ -89,16 +77,7 @@ export const useBulkAttackCaseItems = ({
 
   const onAddToExistingCaseClick = useCallback<Required<BulkActionsConfig>['onClick']>(
     async (alertItems) => {
-      const alertIds = uniq(
-        alertItems.flatMap((item) => {
-          const value = item.data.find(
-            (data) => data.field === ALERT_ATTACK_DISCOVERY_ALERT_IDS
-          )?.value;
-          return Array.isArray(value)
-            ? value.filter((id): id is string => typeof id === 'string')
-            : [];
-        })
-      );
+      const alertIds = extractRelatedDetectionAlertIds(alertItems);
       const markdownComments = alertItems
         .map((item) => {
           const value = item.data.find(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import React from 'react';
+import { useBulkAttackInvestigateInTimelineItems } from './use_bulk_attack_investigate_in_timeline_items';
+import { useUserPrivileges } from '../../../../../common/components/user_privileges';
+import { useInvestigateInTimeline } from '../../../../../common/hooks/timeline/use_investigate_in_timeline';
+import { ALERT_ATTACK_DISCOVERY_ALERT_IDS } from '../constants';
+
+jest.mock('../../../../../common/components/user_privileges');
+jest.mock('../../../../../common/hooks/timeline/use_investigate_in_timeline');
+jest.mock('../../../../components/alerts_table/actions', () => ({
+  buildAlertsKqlFilter: jest.fn().mockReturnValue([]),
+}));
+
+const mockUseUserPrivileges = useUserPrivileges as jest.MockedFunction<typeof useUserPrivileges>;
+const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.MockedFunction<
+  typeof useInvestigateInTimeline
+>;
+
+let queryClient: QueryClient;
+
+function wrapper(props: { children: React.ReactNode }) {
+  return React.createElement(QueryClientProvider, { client: queryClient }, props.children);
+}
+
+describe('useBulkAttackInvestigateInTimelineItems', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient();
+
+    mockUseInvestigateInTimeline.mockReturnValue({
+      investigateInTimeline: jest.fn(),
+    } as unknown as ReturnType<typeof useInvestigateInTimeline>);
+
+    mockUseUserPrivileges.mockReturnValue({
+      timelinePrivileges: { read: true },
+    } as unknown as ReturnType<typeof useUserPrivileges>);
+  });
+
+  it('should return empty items if timeline read privileges are missing', () => {
+    mockUseUserPrivileges.mockReturnValue({
+      timelinePrivileges: { read: false },
+    } as unknown as ReturnType<typeof useUserPrivileges>);
+
+    const { result } = renderHook(() => useBulkAttackInvestigateInTimelineItems(), { wrapper });
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('should return one investigate item when user has privileges', () => {
+    const { result } = renderHook(() => useBulkAttackInvestigateInTimelineItems(), { wrapper });
+    expect(result.current.items).toHaveLength(1);
+  });
+
+  it('should call investigateInTimeline on click', async () => {
+    const investigateInTimeline = jest.fn();
+    mockUseInvestigateInTimeline.mockReturnValue({
+      investigateInTimeline,
+    } as unknown as ReturnType<typeof useInvestigateInTimeline>);
+
+    const { result } = renderHook(() => useBulkAttackInvestigateInTimelineItems(), { wrapper });
+    await result.current.items[0]?.onClick?.(
+      [
+        {
+          _id: 'attack-1',
+          data: [{ field: ALERT_ATTACK_DISCOVERY_ALERT_IDS, value: ['alert-1'] }],
+          ecs: { _id: 'attack-1' },
+        },
+      ],
+      false,
+      jest.fn(),
+      jest.fn(),
+      jest.fn()
+    );
+
+    expect(investigateInTimeline).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return empty panels', () => {
+    const { result } = renderHook(() => useBulkAttackInvestigateInTimelineItems(), { wrapper });
+    expect(result.current.panels).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.test.tsx
@@ -60,11 +60,14 @@ describe('useBulkAttackInvestigateInTimelineItems', () => {
 
   it('should call investigateInTimeline on click', async () => {
     const investigateInTimeline = jest.fn();
+    const closePopover = jest.fn();
     mockUseInvestigateInTimeline.mockReturnValue({
       investigateInTimeline,
     } as unknown as ReturnType<typeof useInvestigateInTimeline>);
 
-    const { result } = renderHook(() => useBulkAttackInvestigateInTimelineItems(), { wrapper });
+    const { result } = renderHook(() => useBulkAttackInvestigateInTimelineItems({ closePopover }), {
+      wrapper,
+    });
     await result.current.items[0]?.onClick?.(
       [
         {
@@ -80,6 +83,7 @@ describe('useBulkAttackInvestigateInTimelineItems', () => {
     );
 
     expect(investigateInTimeline).toHaveBeenCalledTimes(1);
+    expect(closePopover).toHaveBeenCalledTimes(1);
   });
 
   it('should return empty panels', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import type { BulkActionsConfig } from '@kbn/response-ops-alerts-table/types';
+import { uniq } from 'lodash';
+import { useUserPrivileges } from '../../../../../common/components/user_privileges';
+import { useInvestigateInTimeline } from '../../../../../common/hooks/timeline/use_investigate_in_timeline';
+import { buildAlertsKqlFilter } from '../../../../components/alerts_table/actions';
+import { ACTION_INVESTIGATE_IN_TIMELINE } from '../../../../components/alerts_table/translations';
+import { ALERT_ATTACK_DISCOVERY_ALERT_IDS } from '../constants';
+import type { BulkAttackActionItems } from '../types';
+
+/**
+ * Hook that provides bulk action items for investigating attacks in Timeline.
+ */
+export const useBulkAttackInvestigateInTimelineItems = (): BulkAttackActionItems => {
+  const { investigateInTimeline } = useInvestigateInTimeline();
+  const {
+    timelinePrivileges: { read: canUseTimeline },
+  } = useUserPrivileges();
+
+  const onInvestigateInTimelineClick = useCallback<Required<BulkActionsConfig>['onClick']>(
+    async (alertItems) => {
+      const alertIds = uniq(
+        alertItems.flatMap((item) => {
+          const value = item.data.find(
+            (data) => data.field === ALERT_ATTACK_DISCOVERY_ALERT_IDS
+          )?.value;
+          return Array.isArray(value)
+            ? value.filter((id): id is string => typeof id === 'string')
+            : [];
+        })
+      );
+      const alertIdFilters = buildAlertsKqlFilter('_id', alertIds);
+
+      investigateInTimeline({
+        filters: alertIdFilters,
+      });
+    },
+    [investigateInTimeline]
+  );
+
+  const items = useMemo<BulkActionsConfig[]>(
+    () =>
+      canUseTimeline
+        ? [
+            {
+              name: ACTION_INVESTIGATE_IN_TIMELINE,
+              label: ACTION_INVESTIGATE_IN_TIMELINE,
+              key: 'attack-investigate-in-timeline-action-item',
+              'data-test-subj': 'attack-investigate-in-timeline-action-item',
+              disableOnQuery: true,
+              onClick: onInvestigateInTimelineClick,
+            },
+          ]
+        : [],
+    [canUseTimeline, onInvestigateInTimelineClick]
+  );
+
+  return useMemo(
+    () => ({
+      items,
+      panels: [],
+    }),
+    [items]
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
@@ -15,10 +15,17 @@ import { ACTION_INVESTIGATE_IN_TIMELINE } from '../../../../components/alerts_ta
 import { ALERT_ATTACK_DISCOVERY_ALERT_IDS } from '../constants';
 import type { BulkAttackActionItems } from '../types';
 
+export interface UseBulkAttackInvestigateInTimelineItemsProps {
+  /** Optional callback to close the popover after triggering action */
+  closePopover?: () => void;
+}
+
 /**
  * Hook that provides bulk action items for investigating attacks in Timeline.
  */
-export const useBulkAttackInvestigateInTimelineItems = (): BulkAttackActionItems => {
+export const useBulkAttackInvestigateInTimelineItems = ({
+  closePopover,
+}: UseBulkAttackInvestigateInTimelineItemsProps = {}): BulkAttackActionItems => {
   const { investigateInTimeline } = useInvestigateInTimeline();
   const {
     timelinePrivileges: { read: canUseTimeline },
@@ -41,8 +48,9 @@ export const useBulkAttackInvestigateInTimelineItems = (): BulkAttackActionItems
       investigateInTimeline({
         filters: alertIdFilters,
       });
+      closePopover?.();
     },
-    [investigateInTimeline]
+    [closePopover, investigateInTimeline]
   );
 
   const items = useMemo<BulkActionsConfig[]>(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
@@ -7,13 +7,12 @@
 
 import { useCallback, useMemo } from 'react';
 import type { BulkActionsConfig } from '@kbn/response-ops-alerts-table/types';
-import { uniq } from 'lodash';
 import { useUserPrivileges } from '../../../../../common/components/user_privileges';
 import { useInvestigateInTimeline } from '../../../../../common/hooks/timeline/use_investigate_in_timeline';
 import { buildAlertsKqlFilter } from '../../../../components/alerts_table/actions';
 import { ACTION_INVESTIGATE_IN_TIMELINE } from '../../../../components/alerts_table/translations';
-import { ALERT_ATTACK_DISCOVERY_ALERT_IDS } from '../constants';
 import type { BulkAttackActionItems } from '../types';
+import { extractRelatedDetectionAlertIds } from '../utils/extract_related_detection_alert_ids';
 
 export interface UseBulkAttackInvestigateInTimelineItemsProps {
   /** Optional callback to close the popover after triggering action */
@@ -33,16 +32,7 @@ export const useBulkAttackInvestigateInTimelineItems = ({
 
   const onInvestigateInTimelineClick = useCallback<Required<BulkActionsConfig>['onClick']>(
     async (alertItems) => {
-      const alertIds = uniq(
-        alertItems.flatMap((item) => {
-          const value = item.data.find(
-            (data) => data.field === ALERT_ATTACK_DISCOVERY_ALERT_IDS
-          )?.value;
-          return Array.isArray(value)
-            ? value.filter((id): id is string => typeof id === 'string')
-            : [];
-        })
-      );
+      const alertIds = extractRelatedDetectionAlertIds(alertItems);
       const alertIdFilters = buildAlertsKqlFilter('_id', alertIds);
 
       investigateInTimeline({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/constants.ts
@@ -10,3 +10,10 @@
  * This field contains an array of alert IDs that are associated with the attack.
  */
 export const ALERT_ATTACK_DISCOVERY_ALERT_IDS = 'kibana.alert.attack_discovery.alert_ids' as const;
+
+/**
+ * Field name for markdown comment generated from an attack.
+ * This field is used to pass the precomputed markdown payload into bulk case actions.
+ */
+export const ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT =
+  'kibana.alert.attack_discovery.markdown_comment' as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
@@ -7,13 +7,17 @@
 
 import { renderHook } from '@testing-library/react';
 import { getMockAttackDiscoveryAlerts } from '../../../../../attack_discovery/pages/mock/mock_attack_discovery_alerts';
+import type { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
 
 jest.mock('../../../../../common/lib/kibana', () => ({
   useKibana: jest.fn(),
 }));
-jest.mock('../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case', () => ({
-  useAddToExistingCase: jest.fn(),
-}));
+jest.mock(
+  '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case',
+  () => ({
+    useAddToExistingCase: jest.fn(),
+  })
+);
 jest.mock('../../../../../attack_discovery/pages/results/take_action/use_add_to_case', () => ({
   useAddToNewCase: jest.fn(),
 }));
@@ -23,10 +27,9 @@ jest.mock('@kbn/elastic-assistant-common', () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { useAttackCaseContextMenuItems } = require('./use_attack_case_context_menu_items') as {
-  useAttackCaseContextMenuItems: (props: {
-    attack: unknown;
-    closePopover?: () => void;
-  }) => { items: Array<Record<string, unknown>> };
+  useAttackCaseContextMenuItems: (props: { attack: unknown; closePopover?: () => void }) => {
+    items: EuiContextMenuPanelItemDescriptorEntry[];
+  };
 };
 
 const { useKibana } = jest.requireMock('../../../../../common/lib/kibana') as {
@@ -177,4 +180,3 @@ describe('useAttackCaseContextMenuItems', () => {
     });
   });
 });
-

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
@@ -6,177 +6,138 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { getMockAttackDiscoveryAlerts } from '../../../../../attack_discovery/pages/mock/mock_attack_discovery_alerts';
-import type { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
+import type { MouseEvent } from 'react';
+import { useAttackCaseContextMenuItems } from './use_attack_case_context_menu_items';
+import { useBulkAttackCaseItems } from '../bulk_action_items/use_bulk_attack_case_items';
 
-jest.mock('../../../../../common/lib/kibana', () => ({
-  useKibana: jest.fn(),
-}));
-jest.mock(
-  '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case',
-  () => ({
-    useAddToExistingCase: jest.fn(),
-  })
-);
-jest.mock('../../../../../attack_discovery/pages/results/take_action/use_add_to_case', () => ({
-  useAddToNewCase: jest.fn(),
-}));
-jest.mock('@kbn/elastic-assistant-common', () => ({
-  getAttackDiscoveryMarkdown: jest.fn(),
-}));
+jest.mock('../bulk_action_items/use_bulk_attack_case_items');
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { useAttackCaseContextMenuItems } = require('./use_attack_case_context_menu_items') as {
-  useAttackCaseContextMenuItems: (props: { attack: unknown; closePopover?: () => void }) => {
-    items: EuiContextMenuPanelItemDescriptorEntry[];
-  };
-};
-
-const { useKibana } = jest.requireMock('../../../../../common/lib/kibana') as {
-  useKibana: jest.Mock;
-};
-const { useAddToExistingCase } = jest.requireMock(
-  '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case'
-) as { useAddToExistingCase: jest.Mock };
-const { useAddToNewCase } = jest.requireMock(
-  '../../../../../attack_discovery/pages/results/take_action/use_add_to_case'
-) as { useAddToNewCase: jest.Mock };
-const { getAttackDiscoveryMarkdown } = jest.requireMock('@kbn/elastic-assistant-common') as {
-  getAttackDiscoveryMarkdown: jest.Mock;
-};
-
-const mockUseKibana = useKibana as jest.Mock;
-const mockUseAddToNewCase = useAddToNewCase as jest.Mock;
-const mockUseAddToExistingCase = useAddToExistingCase as jest.Mock;
-const mockGetAttackDiscoveryMarkdown = getAttackDiscoveryMarkdown as jest.Mock;
+const mockUseBulkAttackCaseItems = useBulkAttackCaseItems as jest.MockedFunction<
+  typeof useBulkAttackCaseItems
+>;
 
 describe('useAttackCaseContextMenuItems', () => {
   const closePopover = jest.fn();
-  const mockAttack = getMockAttackDiscoveryAlerts()[0];
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockUseKibana.mockReturnValue({
-      services: {
-        cases: {
-          helpers: {
-            canUseCases: jest.fn().mockReturnValue({
-              createComment: true,
-              read: true,
-            }),
-          },
+    mockUseBulkAttackCaseItems.mockReturnValue({
+      items: [
+        {
+          label: 'Add to new case',
+          key: 'attack-add-to-new-case',
+          'data-test-subj': 'attack-add-to-new-case',
+          disableOnQuery: true,
+          onClick: jest.fn(),
         },
-      },
-    });
-
-    mockGetAttackDiscoveryMarkdown.mockReturnValue('mock-markdown');
-
-    mockUseAddToNewCase.mockReturnValue({
-      disabled: false,
-      onAddToNewCase: jest.fn(),
-    });
-
-    mockUseAddToExistingCase.mockReturnValue({
-      disabled: false,
-      onAddToExistingCase: jest.fn(),
+        {
+          label: 'Add to existing case',
+          key: 'attack-add-to-existing-case',
+          'data-test-subj': 'attack-add-to-existing-case',
+          disableOnQuery: true,
+          onClick: jest.fn(),
+        },
+      ],
+      panels: [],
     });
   });
 
-  it('should return two items matching the snapshot when user has permissions', () => {
+  it('should return items from transformed bulk hook', () => {
     const { result } = renderHook(() =>
-      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
+      useAttackCaseContextMenuItems({
+        attacksWithCase: [
+          {
+            attackId: 'attack-1',
+            relatedAlertIds: ['alert-1'],
+            markdownComment: 'markdown',
+          },
+        ],
+        title: 'Attack title',
+        closePopover,
+      })
     );
 
     expect(result.current.items).toMatchInlineSnapshot(`
       Array [
         Object {
           "data-test-subj": "attack-add-to-new-case",
-          "disabled": false,
           "key": "attack-add-to-new-case",
           "name": "Add to new case",
           "onClick": [Function],
+          "panel": undefined,
         },
         Object {
           "data-test-subj": "attack-add-to-existing-case",
-          "disabled": false,
           "key": "attack-add-to-existing-case",
           "name": "Add to existing case",
           "onClick": [Function],
+          "panel": undefined,
         },
       ]
     `);
   });
 
-  it('should return no items when user lacks permissions', () => {
-    mockUseKibana.mockReturnValue({
-      services: {
-        cases: {
-          helpers: {
-            canUseCases: jest.fn().mockReturnValue({
-              createComment: false,
-              read: true,
-            }),
+  it('should call useBulkAttackCaseItems with expected props', () => {
+    renderHook(() =>
+      useAttackCaseContextMenuItems({
+        attacksWithCase: [
+          {
+            attackId: 'attack-1',
+            relatedAlertIds: ['alert-1'],
+            markdownComment: 'markdown',
           },
+        ],
+        title: 'Attack title',
+      })
+    );
+
+    expect(mockUseBulkAttackCaseItems).toHaveBeenCalledWith({
+      title: 'Attack title',
+    });
+  });
+
+  it('should close popover on click', () => {
+    const onClick = jest.fn();
+    mockUseBulkAttackCaseItems.mockReturnValue({
+      items: [
+        {
+          label: 'Add to existing case',
+          key: 'attack-add-to-existing-case',
+          'data-test-subj': 'attack-add-to-existing-case',
+          disableOnQuery: true,
+          onClick,
         },
-      },
+      ],
+      panels: [],
     });
 
     const { result } = renderHook(() =>
-      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
+      useAttackCaseContextMenuItems({
+        attacksWithCase: [
+          {
+            attackId: 'attack-1',
+            relatedAlertIds: ['alert-1'],
+            markdownComment: 'markdown',
+          },
+        ],
+        title: 'Attack title',
+        closePopover,
+      })
     );
 
-    expect(result.current.items).toEqual([]);
-  });
-
-  it('should call `closePopover` and `onAddToNewCase` on click', () => {
-    const onAddToNewCase = jest.fn();
-    mockUseAddToNewCase.mockReturnValue({
-      disabled: false,
-      onAddToNewCase,
-    });
-
-    const { result } = renderHook(() =>
-      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
-    );
-
-    result.current.items[0]?.onClick?.({} as React.MouseEvent);
-
+    result.current.items[0]?.onClick?.({} as MouseEvent);
     expect(closePopover).toHaveBeenCalledTimes(1);
-    expect(onAddToNewCase).toHaveBeenCalledWith({
-      alertIds: mockAttack.alertIds,
-      replacements: mockAttack.replacements,
-      markdownComments: ['mock-markdown'],
-    });
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should call `closePopover` and `onAddToExistingCase` on click', () => {
-    const onAddToExistingCase = jest.fn();
-    mockUseAddToExistingCase.mockReturnValue({
-      disabled: false,
-      onAddToExistingCase,
-    });
-
+  it('should return empty panels', () => {
     const { result } = renderHook(() =>
-      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
+      useAttackCaseContextMenuItems({
+        attacksWithCase: [],
+        title: 'Attack title',
+      })
     );
 
-    result.current.items[1]?.onClick?.({} as React.MouseEvent);
-
-    expect(closePopover).toHaveBeenCalledTimes(1);
-    expect(onAddToExistingCase).toHaveBeenCalledWith({
-      alertIds: mockAttack.alertIds,
-      replacements: mockAttack.replacements,
-      markdownComments: ['mock-markdown'],
-    });
-  });
-
-  it('should build markdown using the attack + replacements', () => {
-    renderHook(() => useAttackCaseContextMenuItems({ attack: mockAttack, closePopover }));
-
-    expect(mockGetAttackDiscoveryMarkdown).toHaveBeenCalledWith({
-      attackDiscovery: mockAttack,
-      replacements: mockAttack.replacements,
-    });
+    expect(result.current.panels).toEqual([]);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { getMockAttackDiscoveryAlerts } from '../../../../../attack_discovery/pages/mock/mock_attack_discovery_alerts';
+
+jest.mock('../../../../../common/lib/kibana', () => ({
+  useKibana: jest.fn(),
+}));
+jest.mock('../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case', () => ({
+  useAddToExistingCase: jest.fn(),
+}));
+jest.mock('../../../../../attack_discovery/pages/results/take_action/use_add_to_case', () => ({
+  useAddToNewCase: jest.fn(),
+}));
+jest.mock('@kbn/elastic-assistant-common', () => ({
+  getAttackDiscoveryMarkdown: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useAttackCaseContextMenuItems } = require('./use_attack_case_context_menu_items') as {
+  useAttackCaseContextMenuItems: (props: {
+    attack: unknown;
+    closePopover?: () => void;
+  }) => { items: Array<Record<string, unknown>> };
+};
+
+const { useKibana } = jest.requireMock('../../../../../common/lib/kibana') as {
+  useKibana: jest.Mock;
+};
+const { useAddToExistingCase } = jest.requireMock(
+  '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case'
+) as { useAddToExistingCase: jest.Mock };
+const { useAddToNewCase } = jest.requireMock(
+  '../../../../../attack_discovery/pages/results/take_action/use_add_to_case'
+) as { useAddToNewCase: jest.Mock };
+const { getAttackDiscoveryMarkdown } = jest.requireMock('@kbn/elastic-assistant-common') as {
+  getAttackDiscoveryMarkdown: jest.Mock;
+};
+
+const mockUseKibana = useKibana as jest.Mock;
+const mockUseAddToNewCase = useAddToNewCase as jest.Mock;
+const mockUseAddToExistingCase = useAddToExistingCase as jest.Mock;
+const mockGetAttackDiscoveryMarkdown = getAttackDiscoveryMarkdown as jest.Mock;
+
+describe('useAttackCaseContextMenuItems', () => {
+  const closePopover = jest.fn();
+  const mockAttack = getMockAttackDiscoveryAlerts()[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        cases: {
+          helpers: {
+            canUseCases: jest.fn().mockReturnValue({
+              createComment: true,
+              read: true,
+            }),
+          },
+        },
+      },
+    });
+
+    mockGetAttackDiscoveryMarkdown.mockReturnValue('mock-markdown');
+
+    mockUseAddToNewCase.mockReturnValue({
+      disabled: false,
+      onAddToNewCase: jest.fn(),
+    });
+
+    mockUseAddToExistingCase.mockReturnValue({
+      disabled: false,
+      onAddToExistingCase: jest.fn(),
+    });
+  });
+
+  it('should return two items matching the snapshot when user has permissions', () => {
+    const { result } = renderHook(() =>
+      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
+    );
+
+    expect(result.current.items).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "data-test-subj": "attack-add-to-new-case",
+          "disabled": false,
+          "key": "attack-add-to-new-case",
+          "name": "Add to new case",
+          "onClick": [Function],
+        },
+        Object {
+          "data-test-subj": "attack-add-to-existing-case",
+          "disabled": false,
+          "key": "attack-add-to-existing-case",
+          "name": "Add to existing case",
+          "onClick": [Function],
+        },
+      ]
+    `);
+  });
+
+  it('should return no items when user lacks permissions', () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        cases: {
+          helpers: {
+            canUseCases: jest.fn().mockReturnValue({
+              createComment: false,
+              read: true,
+            }),
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
+    );
+
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('should call `closePopover` and `onAddToNewCase` on click', () => {
+    const onAddToNewCase = jest.fn();
+    mockUseAddToNewCase.mockReturnValue({
+      disabled: false,
+      onAddToNewCase,
+    });
+
+    const { result } = renderHook(() =>
+      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
+    );
+
+    result.current.items[0]?.onClick?.({} as React.MouseEvent);
+
+    expect(closePopover).toHaveBeenCalledTimes(1);
+    expect(onAddToNewCase).toHaveBeenCalledWith({
+      alertIds: mockAttack.alertIds,
+      replacements: mockAttack.replacements,
+      markdownComments: ['mock-markdown'],
+    });
+  });
+
+  it('should call `closePopover` and `onAddToExistingCase` on click', () => {
+    const onAddToExistingCase = jest.fn();
+    mockUseAddToExistingCase.mockReturnValue({
+      disabled: false,
+      onAddToExistingCase,
+    });
+
+    const { result } = renderHook(() =>
+      useAttackCaseContextMenuItems({ attack: mockAttack, closePopover })
+    );
+
+    result.current.items[1]?.onClick?.({} as React.MouseEvent);
+
+    expect(closePopover).toHaveBeenCalledTimes(1);
+    expect(onAddToExistingCase).toHaveBeenCalledWith({
+      alertIds: mockAttack.alertIds,
+      replacements: mockAttack.replacements,
+      markdownComments: ['mock-markdown'],
+    });
+  });
+
+  it('should build markdown using the attack + replacements', () => {
+    renderHook(() => useAttackCaseContextMenuItems({ attack: mockAttack, closePopover }));
+
+    expect(mockGetAttackDiscoveryMarkdown).toHaveBeenCalledWith({
+      attackDiscovery: mockAttack,
+      replacements: mockAttack.replacements,
+    });
+  });
+});
+

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.test.tsx
@@ -6,7 +6,6 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import type { MouseEvent } from 'react';
 import { useAttackCaseContextMenuItems } from './use_attack_case_context_menu_items';
 import { useBulkAttackCaseItems } from '../bulk_action_items/use_bulk_attack_case_items';
 
@@ -92,26 +91,13 @@ describe('useAttackCaseContextMenuItems', () => {
     );
 
     expect(mockUseBulkAttackCaseItems).toHaveBeenCalledWith({
+      closePopover: undefined,
       title: 'Attack title',
     });
   });
 
-  it('should close popover on click', () => {
-    const onClick = jest.fn();
-    mockUseBulkAttackCaseItems.mockReturnValue({
-      items: [
-        {
-          label: 'Add to existing case',
-          key: 'attack-add-to-existing-case',
-          'data-test-subj': 'attack-add-to-existing-case',
-          disableOnQuery: true,
-          onClick,
-        },
-      ],
-      panels: [],
-    });
-
-    const { result } = renderHook(() =>
+  it('should pass closePopover to useBulkAttackCaseItems', () => {
+    renderHook(() =>
       useAttackCaseContextMenuItems({
         attacksWithCase: [
           {
@@ -125,9 +111,10 @@ describe('useAttackCaseContextMenuItems', () => {
       })
     );
 
-    result.current.items[0]?.onClick?.({} as MouseEvent);
-    expect(closePopover).toHaveBeenCalledTimes(1);
-    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(mockUseBulkAttackCaseItems).toHaveBeenCalledWith({
+      closePopover,
+      title: 'Attack title',
+    });
   });
 
   it('should return empty panels', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
+import {
+  getAttackDiscoveryMarkdown,
+  type AttackDiscoveryAlert,
+} from '@kbn/elastic-assistant-common';
+import { useCallback, useMemo } from 'react';
+import { useAddToExistingCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case';
+import { APP_ID } from '../../../../../../common';
+import { useKibana } from '../../../../../common/lib/kibana';
+import {
+  ADD_TO_EXISTING_CASE,
+  ADD_TO_NEW_CASE,
+} from '../../../../../common/components/visualization_actions/translations';
+import { useAddToNewCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_case';
+
+interface UseAttackCaseContextMenuItemsProps {
+  attack: AttackDiscoveryAlert;
+  closePopover?: () => void;
+}
+
+export const useAttackCaseContextMenuItems = ({
+  attack,
+  closePopover,
+}: UseAttackCaseContextMenuItemsProps): {
+  items: EuiContextMenuPanelItemDescriptorEntry[];
+} => {
+  const {
+    services: { cases },
+  } = useKibana();
+  const userCasesPermissions = cases.helpers.canUseCases([APP_ID]);
+  const canCreateAndReadCases = userCasesPermissions.createComment && userCasesPermissions.read;
+  const canUserCreateAndReadCases = useCallback(() => canCreateAndReadCases, [canCreateAndReadCases]);
+
+  const { onAddToNewCase, disabled: isAddToNewCaseDisabled } = useAddToNewCase({
+    canUserCreateAndReadCases,
+    title: attack.title,
+  });
+
+  const { onAddToExistingCase, disabled: isAddToExistingCaseDisabled } = useAddToExistingCase({
+    canUserCreateAndReadCases,
+  });
+
+  const markdownComment = useMemo(
+    () =>
+      getAttackDiscoveryMarkdown({
+        attackDiscovery: attack,
+        replacements: attack.replacements,
+      }),
+    [attack]
+  );
+
+  const onAddToNewCaseClick = useCallback(() => {
+    closePopover?.();
+    onAddToNewCase({
+      alertIds: attack.alertIds,
+      replacements: attack.replacements,
+      markdownComments: [markdownComment],
+    });
+  }, [attack.alertIds, attack.replacements, closePopover, markdownComment, onAddToNewCase]);
+
+  const onAddToExistingCaseClick = useCallback(() => {
+    closePopover?.();
+    onAddToExistingCase({
+      alertIds: attack.alertIds,
+      replacements: attack.replacements,
+      markdownComments: [markdownComment],
+    });
+  }, [attack.alertIds, attack.replacements, closePopover, markdownComment, onAddToExistingCase]);
+
+  const items = useMemo<EuiContextMenuPanelItemDescriptorEntry[]>(
+    () =>
+      canCreateAndReadCases
+        ? [
+            {
+              name: ADD_TO_NEW_CASE,
+              key: 'attack-add-to-new-case',
+              'data-test-subj': 'attack-add-to-new-case',
+              disabled: isAddToNewCaseDisabled,
+              onClick: onAddToNewCaseClick,
+            },
+            {
+              name: ADD_TO_EXISTING_CASE,
+              key: 'attack-add-to-existing-case',
+              'data-test-subj': 'attack-add-to-existing-case',
+              disabled: isAddToExistingCaseDisabled,
+              onClick: onAddToExistingCaseClick,
+            },
+          ]
+        : [],
+    [
+      canCreateAndReadCases,
+      isAddToExistingCaseDisabled,
+      isAddToNewCaseDisabled,
+      onAddToExistingCaseClick,
+      onAddToNewCaseClick,
+    ]
+  );
+
+  return { items };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.tsx
@@ -36,7 +36,10 @@ export const useAttackCaseContextMenuItems = ({
   } = useKibana();
   const userCasesPermissions = cases.helpers.canUseCases([APP_ID]);
   const canCreateAndReadCases = userCasesPermissions.createComment && userCasesPermissions.read;
-  const canUserCreateAndReadCases = useCallback(() => canCreateAndReadCases, [canCreateAndReadCases]);
+  const canUserCreateAndReadCases = useCallback(
+    () => canCreateAndReadCases,
+    [canCreateAndReadCases]
+  );
 
   const { onAddToNewCase, disabled: isAddToNewCaseDisabled } = useAddToNewCase({
     canUserCreateAndReadCases,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_case_context_menu_items.tsx
@@ -35,6 +35,7 @@ export const useAttackCaseContextMenuItems = ({
 }: UseAttackCaseContextMenuItemsProps): BulkAttackContextMenuItems => {
   const bulkActionItems = useBulkAttackCaseItems({
     title,
+    closePopover,
   });
 
   const alertItems = useMemo(
@@ -63,20 +64,5 @@ export const useAttackCaseContextMenuItems = ({
     [bulkActionItems, alertItems, closePopover, clearSelection, setIsLoading, refresh]
   );
 
-  return useMemo(
-    () => ({
-      ...contextMenuItems,
-      // Add-to-case opens another flyout/modal so we close the current popover immediately.
-      items: contextMenuItems.items.map((item) => ({
-        ...item,
-        onClick: item.onClick
-          ? (event) => {
-              item.onClick?.(event);
-              closePopover?.();
-            }
-          : undefined,
-      })),
-    }),
-    [closePopover, contextMenuItems]
-  );
+  return contextMenuItems;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.test.tsx
@@ -7,54 +7,38 @@
 
 import { renderHook } from '@testing-library/react';
 import { useAttackInvestigateInTimelineContextMenuItems } from './use_attack_investigate_in_timeline_context_menu_items';
-import { getMockAttackDiscoveryAlerts } from '../../../../../attack_discovery/pages/mock/mock_attack_discovery_alerts';
-import { useUserPrivileges } from '../../../../../common/components/user_privileges';
-import { useInvestigateInTimeline } from '../../../../../common/hooks/timeline/use_investigate_in_timeline';
+import type { MouseEvent } from 'react';
+import { useBulkAttackInvestigateInTimelineItems } from '../bulk_action_items/use_bulk_attack_investigate_in_timeline_items';
 
-jest.mock('../../../../../common/components/user_privileges');
-jest.mock('../../../../../common/hooks/timeline/use_investigate_in_timeline');
-jest.mock('../../../../components/alerts_table/actions', () => ({
-  buildAlertsKqlFilter: jest.fn().mockReturnValue([]),
-}));
+jest.mock('../bulk_action_items/use_bulk_attack_investigate_in_timeline_items');
 
-const mockUseUserPrivileges = useUserPrivileges as jest.MockedFunction<typeof useUserPrivileges>;
-const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.MockedFunction<
-  typeof useInvestigateInTimeline
->;
-
-const mockAttack = getMockAttackDiscoveryAlerts()[0];
+const mockUseBulkAttackInvestigateInTimelineItems =
+  useBulkAttackInvestigateInTimelineItems as jest.MockedFunction<
+    typeof useBulkAttackInvestigateInTimelineItems
+  >;
 
 describe('useAttackInvestigateInTimelineContextMenuItems', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseInvestigateInTimeline.mockReturnValue({
-      investigateInTimeline: jest.fn(),
-    } as unknown as ReturnType<typeof useInvestigateInTimeline>);
-
-    mockUseUserPrivileges.mockReturnValue({
-      timelinePrivileges: { read: true },
-    } as unknown as ReturnType<typeof useUserPrivileges>);
-  });
-
-  it('should NOT return items if timeline read privileges are missing', () => {
-    mockUseUserPrivileges.mockReturnValue({
-      timelinePrivileges: { read: false },
-    } as unknown as ReturnType<typeof useUserPrivileges>);
-
-    const { result } = renderHook(() =>
-      useAttackInvestigateInTimelineContextMenuItems({
-        attack: mockAttack,
-      })
-    );
-
-    expect(result.current.items).toEqual([]);
+    mockUseBulkAttackInvestigateInTimelineItems.mockReturnValue({
+      items: [
+        {
+          label: 'Investigate in timeline',
+          key: 'attack-investigate-in-timeline-action-item',
+          'data-test-subj': 'attack-investigate-in-timeline-action-item',
+          disableOnQuery: true,
+          onClick: jest.fn(),
+        },
+      ],
+      panels: [],
+    });
   });
 
   it('should return one item matching the snapshot', () => {
     const { result } = renderHook(() =>
       useAttackInvestigateInTimelineContextMenuItems({
-        attack: mockAttack,
+        attacksWithTimelineAlerts: [{ attackId: 'attack-1', relatedAlertIds: ['alert-1'] }],
       })
     );
 
@@ -65,36 +49,57 @@ describe('useAttackInvestigateInTimelineContextMenuItems', () => {
           "key": "attack-investigate-in-timeline-action-item",
           "name": "Investigate in timeline",
           "onClick": [Function],
+          "panel": undefined,
         },
       ]
     `);
   });
 
-  it('should call `closePopover` on click', () => {
+  it('should call useBulkAttackInvestigateInTimelineItems', () => {
+    renderHook(() =>
+      useAttackInvestigateInTimelineContextMenuItems({
+        attacksWithTimelineAlerts: [{ attackId: 'attack-1', relatedAlertIds: ['alert-1'] }],
+      })
+    );
+
+    expect(mockUseBulkAttackInvestigateInTimelineItems).toHaveBeenCalled();
+  });
+
+  it('should call closePopover on click', () => {
     const closePopover = jest.fn();
+    const onClick = jest.fn();
+    mockUseBulkAttackInvestigateInTimelineItems.mockReturnValue({
+      items: [
+        {
+          label: 'Investigate in timeline',
+          key: 'attack-investigate-in-timeline-action-item',
+          'data-test-subj': 'attack-investigate-in-timeline-action-item',
+          disableOnQuery: true,
+          onClick,
+        },
+      ],
+      panels: [],
+    });
+
     const { result } = renderHook(() =>
       useAttackInvestigateInTimelineContextMenuItems({
-        attack: mockAttack,
+        attacksWithTimelineAlerts: [{ attackId: 'attack-1', relatedAlertIds: ['alert-1'] }],
         closePopover,
       })
     );
 
-    result.current.items[0]?.onClick?.({} as React.MouseEvent);
+    result.current.items[0]?.onClick?.({} as MouseEvent);
     expect(closePopover).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should call `investigateInTimeline` on click', () => {
-    const investigateInTimeline = jest.fn();
-    mockUseInvestigateInTimeline.mockReturnValue({
-      investigateInTimeline,
-    } as unknown as ReturnType<typeof useInvestigateInTimeline>);
+  it('should return empty panels', () => {
     const { result } = renderHook(() =>
       useAttackInvestigateInTimelineContextMenuItems({
-        attack: mockAttack,
+        attacksWithTimelineAlerts: [{ attackId: 'attack-1', relatedAlertIds: ['alert-1'] }],
       })
     );
 
-    result.current.items[0]?.onClick?.({} as React.MouseEvent);
-    expect(investigateInTimeline).toHaveBeenCalledTimes(1);
+    expect(result.current.panels).toEqual([]);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.test.tsx
@@ -7,7 +7,6 @@
 
 import { renderHook } from '@testing-library/react';
 import { useAttackInvestigateInTimelineContextMenuItems } from './use_attack_investigate_in_timeline_context_menu_items';
-import type { MouseEvent } from 'react';
 import { useBulkAttackInvestigateInTimelineItems } from '../bulk_action_items/use_bulk_attack_investigate_in_timeline_items';
 
 jest.mock('../bulk_action_items/use_bulk_attack_investigate_in_timeline_items');
@@ -62,35 +61,24 @@ describe('useAttackInvestigateInTimelineContextMenuItems', () => {
       })
     );
 
-    expect(mockUseBulkAttackInvestigateInTimelineItems).toHaveBeenCalled();
+    expect(mockUseBulkAttackInvestigateInTimelineItems).toHaveBeenCalledWith({
+      closePopover: undefined,
+    });
   });
 
-  it('should call closePopover on click', () => {
+  it('should pass closePopover to useBulkAttackInvestigateInTimelineItems', () => {
     const closePopover = jest.fn();
-    const onClick = jest.fn();
-    mockUseBulkAttackInvestigateInTimelineItems.mockReturnValue({
-      items: [
-        {
-          label: 'Investigate in timeline',
-          key: 'attack-investigate-in-timeline-action-item',
-          'data-test-subj': 'attack-investigate-in-timeline-action-item',
-          disableOnQuery: true,
-          onClick,
-        },
-      ],
-      panels: [],
-    });
 
-    const { result } = renderHook(() =>
+    renderHook(() =>
       useAttackInvestigateInTimelineContextMenuItems({
         attacksWithTimelineAlerts: [{ attackId: 'attack-1', relatedAlertIds: ['alert-1'] }],
         closePopover,
       })
     );
 
-    result.current.items[0]?.onClick?.({} as MouseEvent);
-    expect(closePopover).toHaveBeenCalledTimes(1);
-    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(mockUseBulkAttackInvestigateInTimelineItems).toHaveBeenCalledWith({
+      closePopover,
+    });
   });
 
   it('should return empty panels', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.tsx
@@ -5,67 +5,67 @@
  * 2.0.
  */
 
-import { useCallback, useMemo } from 'react';
-import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
-import type { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
-import { useUserPrivileges } from '../../../../../common/components/user_privileges';
-import { useInvestigateInTimeline } from '../../../../../common/hooks/timeline/use_investigate_in_timeline';
-import { buildAlertsKqlFilter } from '../../../../components/alerts_table/actions';
-import { ACTION_INVESTIGATE_IN_TIMELINE } from '../../../../components/alerts_table/translations';
+import { useMemo } from 'react';
+import { useBulkAttackInvestigateInTimelineItems } from '../bulk_action_items/use_bulk_attack_investigate_in_timeline_items';
+import { ALERT_ATTACK_DISCOVERY_ALERT_IDS } from '../constants';
+import { transformBulkActionsToContextMenuItems } from '../utils/transform_bulk_actions_to_context_menu_items';
+import type {
+  AttackWithTimelineAlerts,
+  BaseAttackContextMenuItemsProps,
+  BulkAttackContextMenuItems,
+} from '../types';
 
-export interface UseAttackInvestigateInTimelineContextMenuItemsProps {
-  /**
-   *  The attack discovery object
-   */
-  attack: AttackDiscoveryAlert;
-  /**
-   * Optional callback to close the containing popover menu
-   */
-  closePopover?: () => void;
+export interface UseAttackInvestigateInTimelineContextMenuItemsProps
+  extends BaseAttackContextMenuItemsProps {
+  /** Array of attacks with alert ids used to investigate in Timeline */
+  attacksWithTimelineAlerts: AttackWithTimelineAlerts[];
 }
 
 export const useAttackInvestigateInTimelineContextMenuItems = ({
-  attack,
+  attacksWithTimelineAlerts,
   closePopover,
-}: UseAttackInvestigateInTimelineContextMenuItemsProps): {
-  items: EuiContextMenuPanelItemDescriptorEntry[];
-} => {
-  const { investigateInTimeline } = useInvestigateInTimeline();
-  const {
-    timelinePrivileges: { read: canUseTimeline },
-  } = useUserPrivileges();
+  clearSelection,
+  setIsLoading,
+  refresh,
+}: UseAttackInvestigateInTimelineContextMenuItemsProps): BulkAttackContextMenuItems => {
+  const bulkActionItems = useBulkAttackInvestigateInTimelineItems();
 
-  const originalAlertIds = useMemo(
-    () => attack.alertIds.map((id) => attack.replacements?.[id] ?? id),
-    [attack.alertIds, attack.replacements]
-  );
-
-  const attackAlertIdFilters = useMemo(
-    () => buildAlertsKqlFilter('_id', originalAlertIds),
-    [originalAlertIds]
-  );
-
-  const onInvestigateInTimelineClick = useCallback(() => {
-    investigateInTimeline({
-      filters: attackAlertIdFilters,
-    });
-    closePopover?.();
-  }, [attackAlertIdFilters, closePopover, investigateInTimeline]);
-
-  const items = useMemo<EuiContextMenuPanelItemDescriptorEntry[]>(
+  const alertItems = useMemo(
     () =>
-      canUseTimeline
-        ? [
-            {
-              name: ACTION_INVESTIGATE_IN_TIMELINE,
-              key: 'attack-investigate-in-timeline-action-item',
-              'data-test-subj': 'attack-investigate-in-timeline-action-item',
-              onClick: onInvestigateInTimelineClick,
-            },
-          ]
-        : [],
-    [canUseTimeline, onInvestigateInTimelineClick]
+      attacksWithTimelineAlerts.map((attack) => ({
+        _id: attack.attackId,
+        data: [{ field: ALERT_ATTACK_DISCOVERY_ALERT_IDS, value: attack.relatedAlertIds }],
+        ecs: { _id: attack.attackId },
+      })),
+    [attacksWithTimelineAlerts]
   );
 
-  return { items };
+  const contextMenuItems = useMemo(
+    () =>
+      transformBulkActionsToContextMenuItems({
+        bulkActionItems,
+        alertItems,
+        closePopover,
+        clearSelection,
+        setIsLoading,
+        refresh,
+      }),
+    [bulkActionItems, alertItems, closePopover, clearSelection, setIsLoading, refresh]
+  );
+
+  return useMemo(
+    () => ({
+      ...contextMenuItems,
+      items: contextMenuItems.items.map((item) => ({
+        ...item,
+        onClick: item.onClick
+          ? (event) => {
+              item.onClick?.(event);
+              closePopover?.();
+            }
+          : undefined,
+      })),
+    }),
+    [closePopover, contextMenuItems]
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_investigate_in_timeline_context_menu_items.tsx
@@ -28,7 +28,7 @@ export const useAttackInvestigateInTimelineContextMenuItems = ({
   setIsLoading,
   refresh,
 }: UseAttackInvestigateInTimelineContextMenuItemsProps): BulkAttackContextMenuItems => {
-  const bulkActionItems = useBulkAttackInvestigateInTimelineItems();
+  const bulkActionItems = useBulkAttackInvestigateInTimelineItems({ closePopover });
 
   const alertItems = useMemo(
     () =>
@@ -53,19 +53,5 @@ export const useAttackInvestigateInTimelineContextMenuItems = ({
     [bulkActionItems, alertItems, closePopover, clearSelection, setIsLoading, refresh]
   );
 
-  return useMemo(
-    () => ({
-      ...contextMenuItems,
-      items: contextMenuItems.items.map((item) => ({
-        ...item,
-        onClick: item.onClick
-          ? (event) => {
-              item.onClick?.(event);
-              closePopover?.();
-            }
-          : undefined,
-      })),
-    }),
-    [closePopover, contextMenuItems]
-  );
+  return contextMenuItems;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/translations.ts
@@ -101,6 +101,20 @@ export const BULK_ACTION_CLOSE_SELECTED = i18n.translate(
   }
 );
 
+export const ADD_TO_NEW_CASE = i18n.translate(
+  'xpack.securitySolution.visualizationActions.addToNewCase',
+  {
+    defaultMessage: 'Add to new case',
+  }
+);
+
+export const ADD_TO_EXISTING_CASE = i18n.translate(
+  'xpack.securitySolution.visualizationActions.addToExistingCase',
+  {
+    defaultMessage: 'Add to existing case',
+  }
+);
+
 export const ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.alertTagsContextMenuItemTitle',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/types.ts
@@ -81,6 +81,20 @@ export interface AttackWithTags extends BaseAttackProps {
 }
 
 /**
+ * Represents an attack with markdown used for case attachments.
+ * The related alert IDs are used to attach alerts to a case.
+ */
+export interface AttackWithCase extends BaseAttackProps {
+  /** Markdown comment describing the attack */
+  markdownComment: string;
+}
+
+/**
+ * Represents an attack with alert IDs that should be investigated in Timeline.
+ */
+export type AttackWithTimelineAlerts = BaseAttackProps;
+
+/**
  * Extended content panel configuration for attack bulk actions.
  * Adds optional width property to support custom panel sizing (e.g., for assignees panel).
  */


### PR DESCRIPTION
> [!warning]
> This PR needs to be rebased with main after #251526 gets merged

## Summary

Closes #237378
Closes #237379

This PR adds the cases action items "add to existing case" and "add to new case" to the attack panel in the new attack discovery page.

## Screen-recording 🎬 


https://github.com/user-attachments/assets/3aa0ce79-e7e5-4375-b980-eeca3ec8195d

