### PR TITLE
[Streams] Add tooltip for disabled Create classic stream button

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/create_classic_stream_button.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/create_classic_stream_button.test.tsx
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '@kbn/i18n-react';
+import { StreamListView } from '.';
+import { useKibana } from '../../hooks/use_kibana';
+import { useStreamsPrivileges } from '../../hooks/use_streams_privileges';
+import { useStreamsAppFetch } from '../../hooks/use_streams_app_fetch';
+import { useStreamsAppRouter } from '../../hooks/use_streams_app_router';
+import { useTimefilter } from '../../hooks/use_timefilter';
+import { usePerformanceContext } from '@kbn/ebt-tools';
+
+jest.mock('../../hooks/use_kibana');
+jest.mock('../../hooks/use_streams_privileges');
+jest.mock('../../hooks/use_streams_app_fetch');
+jest.mock('../../hooks/use_streams_app_router');
+jest.mock('../../hooks/use_timefilter');
+jest.mock('@kbn/ebt-tools', () => ({
+  usePerformanceContext: jest.fn(),
+}));
+
+// Mock child components that are not relevant to this test
+jest.mock('../feedback_button', () => ({
+  FeedbackButton: () => <div data-testid="mockFeedbackButton">Feedback</div>,
+}));
+jest.mock('./streams_list_empty_prompt', () => ({
+  StreamsListEmptyPrompt: () => <div data-testid="mockEmptyPrompt">Empty</div>,
+}));
+jest.mock('../streams_tour', () => ({
+  WelcomeTourCallout: () => null,
+}));
+jest.mock('./tree_table', () => ({
+  StreamsTreeTable: () => <div data-testid="mockTreeTable">TreeTable</div>,
+}));
+jest.mock('./streams_settings_flyout', () => ({
+  StreamsSettingsFlyout: () => <div data-testid="mockSettingsFlyout">Settings</div>,
+}));
+jest.mock('./classic_stream_creation_flyout', () => ({
+  ClassicStreamCreationFlyout: () => <div data-testid="mockCreationFlyout">Creation</div>,
+}));
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<
+  typeof useStreamsPrivileges
+>;
+const mockUseStreamsAppFetch = useStreamsAppFetch as jest.MockedFunction<typeof useStreamsAppFetch>;
+const mockUseStreamsAppRouter = useStreamsAppRouter as jest.MockedFunction<
+  typeof useStreamsAppRouter
+>;
+const mockUseTimefilter = useTimefilter as jest.MockedFunction<typeof useTimefilter>;
+const mockUsePerformanceContext = usePerformanceContext as jest.MockedFunction<
+  typeof usePerformanceContext
+>;
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+describe('StreamListView - Create Classic Stream Button', () => {
+  const mockGetClassicStatus = jest.fn();
+  const mockAddError = jest.fn();
+
+  const defaultKibanaMock = {
+    isServerless: false,
+    dependencies: {
+      start: {
+        streams: {
+          streamsRepositoryClient: {
+            fetch: jest.fn().mockResolvedValue({ streams: [] }),
+          },
+          getClassicStatus: mockGetClassicStatus,
+        },
+        cloud: {
+          isCloudEnabled: false,
+        },
+      },
+    },
+    core: {
+      notifications: {
+        toasts: {
+          addError: mockAddError,
+        },
+      },
+    },
+    services: {
+      version: '8.0.0',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue(defaultKibanaMock as any);
+
+    mockUseStreamsAppRouter.mockReturnValue({
+      link: jest.fn((path) => path),
+    } as any);
+
+    mockUseTimefilter.mockReturnValue({
+      timeState: { start: 'now-15m', end: 'now' },
+    } as any);
+
+    mockUseStreamsAppFetch.mockReturnValue({
+      loading: false,
+      value: { streams: [], canReadFailureStore: false },
+      refresh: jest.fn(),
+    } as any);
+
+    mockUsePerformanceContext.mockReturnValue({
+      onPageReady: jest.fn(),
+    } as any);
+  });
+
+  describe('Button enabled state', () => {
+    it('should enable button when user has both Kibana and Elasticsearch permissions', async () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        ui: { manage: true },
+        features: {},
+      } as any);
+
+      mockGetClassicStatus.mockResolvedValue({
+        can_manage: true,
+      });
+
+      renderWithProviders(<StreamListView />);
+
+      await waitFor(() => {
+        expect(mockGetClassicStatus).toHaveBeenCalled();
+      });
+
+      const button = screen.getByTestId('streamsCreateClassicStreamButton');
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should disable button when user lacks Kibana manage permission', async () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        ui: { manage: false },
+        features: {},
+      } as any);
+
+      mockGetClassicStatus.mockResolvedValue({
+        can_manage: true,
+      });
+
+      renderWithProviders(<StreamListView />);
+
+      await waitFor(() => {
+        expect(mockGetClassicStatus).toHaveBeenCalled();
+      });
+
+      const button = screen.getByTestId('streamsCreateClassicStreamButton');
+      expect(button).toBeDisabled();
+    });
+
+    it('should disable button when user lacks Elasticsearch manage_index_templates privilege', async () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        ui: { manage: true },
+        features: {},
+      } as any);
+
+      mockGetClassicStatus.mockResolvedValue({
+        can_manage: false,
+      });
+
+      renderWithProviders(<StreamListView />);
+
+      await waitFor(() => {
+        expect(mockGetClassicStatus).toHaveBeenCalled();
+      });
+
+      const button = screen.getByTestId('streamsCreateClassicStreamButton');
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe('Tooltip behavior', () => {
+    it('should show Kibana permission tooltip when user lacks Kibana manage permission', async () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        ui: { manage: false },
+        features: {},
+      } as any);
+
+      mockGetClassicStatus.mockResolvedValue({
+        can_manage: true,
+      });
+
+      renderWithProviders(<StreamListView />);
+
+      await waitFor(() => {
+        expect(mockGetClassicStatus).toHaveBeenCalled();
+      });
+
+      const button = screen.getByTestId('streamsCreateClassicStreamButton');
+
+      // Use fireEvent for disabled buttons (which have pointer-events: none)
+      await act(async () => {
+        fireEvent.mouseOver(button);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'You need the Kibana manage streams privilege to create classic streams.'
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should show Elasticsearch permission tooltip when user has Kibana permission but lacks ES privilege', async () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        ui: { manage: true },
+        features: {},
+      } as any);
+
+      mockGetClassicStatus.mockResolvedValue({
+        can_manage: false,
+      });
+
+      renderWithProviders(<StreamListView />);
+
+      await waitFor(() => {
+        expect(mockGetClassicStatus).toHaveBeenCalled();
+      });
+
+      const button = screen.getByTestId('streamsCreateClassicStreamButton');
+
+      // Use fireEvent for disabled buttons (which have pointer-events: none)
+      await act(async () => {
+        fireEvent.mouseOver(button);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'You need the Elasticsearch manage_index_templates privilege to create classic streams.'
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should not show tooltip when user has all required permissions', async () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        ui: { manage: true },
+        features: {},
+      } as any);
+
+      mockGetClassicStatus.mockResolvedValue({
+        can_manage: true,
+      });
+
+      renderWithProviders(<StreamListView />);
+
+      await waitFor(() => {
+        expect(mockGetClassicStatus).toHaveBeenCalled();
+      });
+
+      const button = screen.getByTestId('streamsCreateClassicStreamButton');
+
+      // Hover over the button
+      await act(async () => {
+        await userEvent.hover(button);
+      });
+
+      // Wait a moment for any tooltip to appear
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Neither tooltip message should be visible
+      expect(
+        screen.queryByText(
+          'You need the Kibana manage streams privilege to create classic streams.'
+        )
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'You need the Elasticsearch manage_index_templates privilege to create classic streams.'
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingElastic,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -174,15 +175,38 @@ export function StreamListView() {
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
-                onClick={() => setIsClassicStreamCreationFlyoutOpen(true)}
-                size="s"
-                disabled={!(canManageStreamsKibana && canManageClassicElasticsearch)}
+              <EuiToolTip
+                content={
+                  !canManageStreamsKibana
+                    ? i18n.translate(
+                        'xpack.streams.streamsListView.createClassicStreamButtonDisabledKibanaTooltip',
+                        {
+                          defaultMessage:
+                            'You need the Kibana manage streams privilege to create classic streams.',
+                        }
+                      )
+                    : !canManageClassicElasticsearch
+                    ? i18n.translate(
+                        'xpack.streams.streamsListView.createClassicStreamButtonDisabledElasticsearchTooltip',
+                        {
+                          defaultMessage:
+                            'You need the Elasticsearch manage_index_templates privilege to create classic streams.',
+                        }
+                      )
+                    : undefined
+                }
               >
-                {i18n.translate('xpack.streams.streamsListView.createClassicStreamButtonLabel', {
-                  defaultMessage: 'Create classic stream',
-                })}
-              </EuiButton>
+                <EuiButton
+                  data-test-subj="streamsCreateClassicStreamButton"
+                  onClick={() => setIsClassicStreamCreationFlyoutOpen(true)}
+                  size="s"
+                  disabled={!(canManageStreamsKibana && canManageClassicElasticsearch)}
+                >
+                  {i18n.translate('xpack.streams.streamsListView.createClassicStreamButtonLabel', {
+                    defaultMessage: 'Create classic stream',
+                  })}
+                </EuiButton>
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         }

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/classic_stream_creation_permissions.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/classic_stream_creation_permissions.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRole } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../../fixtures';
+
+// Custom role that has Kibana manage_stream privilege but lacks ES manage_index_templates
+const STREAMS_MANAGER_WITHOUT_ES_TEMPLATES: KibanaRole = {
+  elasticsearch: {
+    cluster: ['monitor'], // Basic cluster privilege, but NOT manage_index_templates
+    indices: [
+      {
+        names: ['*'],
+        privileges: ['read', 'write', 'manage', 'view_index_metadata'],
+      },
+    ],
+  },
+  kibana: [
+    {
+      base: [],
+      feature: {
+        streams: ['all'], // Kibana manage_stream privilege
+        discover: ['all'],
+      },
+      spaces: ['*'],
+    },
+  ],
+};
+
+test.describe(
+  'Streams list view - classic stream creation permissions',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    test('should disable Create classic stream button when user lacks ES manage_index_templates privilege', async ({
+      browserAuth,
+      page,
+      pageObjects,
+    }) => {
+      // Login with custom role that has Kibana manage privilege but lacks ES manage_index_templates
+      await browserAuth.loginWithCustomRole(STREAMS_MANAGER_WITHOUT_ES_TEMPLATES);
+      await pageObjects.streams.gotoStreamMainPage();
+
+      // Find the Create classic stream button
+      const createButton = page.getByTestId('streamsCreateClassicStreamButton');
+      await expect(createButton).toBeVisible();
+
+      // Button should be disabled due to missing ES privilege
+      await expect(createButton).toBeDisabled();
+
+      // Hover over the button to show the tooltip
+      await createButton.hover({ force: true });
+
+      // Verify tooltip message about missing Elasticsearch privilege is shown
+      await expect(
+        page.getByText(
+          'You need the Elasticsearch manage_index_templates privilege to create classic streams.'
+        )
+      ).toBeVisible();
+    });
+
+    test('should disable Create classic stream button when user lacks Kibana manage privilege', async ({
+      browserAuth,
+      page,
+      pageObjects,
+    }) => {
+      // Login as viewer who lacks Kibana manage_stream privilege
+      await browserAuth.loginAsViewer();
+      await pageObjects.streams.gotoStreamMainPage();
+
+      // Find the Create classic stream button
+      const createButton = page.getByTestId('streamsCreateClassicStreamButton');
+      await expect(createButton).toBeVisible();
+
+      // Button should be disabled due to missing Kibana privilege
+      await expect(createButton).toBeDisabled();
+
+      // Hover over the button to show the tooltip
+      await createButton.hover({ force: true });
+
+      // Verify tooltip message about missing Kibana privilege is shown
+      await expect(
+        page.getByText('You need the Kibana manage streams privilege to create classic streams.')
+      ).toBeVisible();
+    });
+
+    test('should enable Create classic stream button when user has all required privileges', async ({
+      browserAuth,
+      page,
+      pageObjects,
+    }) => {
+      // Login as admin who has all privileges
+      await browserAuth.loginAsAdmin();
+      await pageObjects.streams.gotoStreamMainPage();
+
+      // Find the Create classic stream button
+      const createButton = page.getByTestId('streamsCreateClassicStreamButton');
+      await expect(createButton).toBeVisible();
+
+      // Button should be enabled
+      await expect(createButton).toBeEnabled();
+    });
+  }
+);


### PR DESCRIPTION
## 🍒 Summary

When users lack the Elasticsearch `manage_index_templates` cluster privilege, the "Create classic stream" button in the Streams app is correctly disabled but there's no feedback explaining why. This change adds a tooltip to the button that explains the missing privilege requirement.

Fixes https://github.com/elastic/observability-error-backlog/issues/458

## 🛠️ Changes

- Added `EuiToolTip` wrapper around the "Create classic stream" button in `stream_list_view/index.tsx`
- Tooltip shows "You need the Kibana manage streams privilege to create classic streams." when the Kibana permission is missing
- Tooltip shows "You need the Elasticsearch manage_index_templates privilege to create classic streams." when the ES privilege is missing
- No tooltip is displayed when the user has all required permissions
- Added unit tests (`create_classic_stream_button.test.tsx`) covering:
  - Button enabled/disabled states based on permissions
  - Tooltip display for missing Kibana permission
  - Tooltip display for missing Elasticsearch permission
  - No tooltip when all permissions present
- Added Scout UI integration test (`classic_stream_creation_permissions.spec.ts`) verifying the disabled button and tooltip behavior with insufficient privileges

## 🎙️ Prompts

- Fix the missing user feedback when "Create classic stream" button is disabled due to insufficient Elasticsearch privileges
- Add tests for the tooltip behavior

🤖 This pull request was assisted by Cursor
