### PR TITLE
[CI] Increase artifacts disk to 180gb

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -6,7 +6,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c2-standard-16
-      diskSizeGb: 160
+      diskSizeGb: 180
     timeout_in_minutes: 120
     retry:
       automatic:


### PR DESCRIPTION
## Summary

We're seeing intermittent failures due to disk space when building the artifacts:

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7926#019c2398-fae5-4dd1-811c-14cf8896ca4d/L6496 
https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7921#019c1e73-f465-48bf-af3d-8772e8b2300e/L6549





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->