### PR TITLE
Increase reporting default CSV scroll timeout

### DIFF
--- a/src/platform/packages/private/kbn-reporting/server/__snapshots__/config_schema.test.ts.snap
+++ b/src/platform/packages/private/kbn-reporting/server/__snapshots__/config_schema.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       "valueInBytes": 262144000,
     },
     "scroll": Object {
-      "duration": "30s",
+      "duration": "120s",
       "size": 500,
       "strategy": "pit",
     },
@@ -71,7 +71,7 @@ Object {
       "valueInBytes": 262144000,
     },
     "scroll": Object {
-      "duration": "30s",
+      "duration": "120s",
       "size": 500,
       "strategy": "pit",
     },

--- a/src/platform/packages/private/kbn-reporting/server/config_schema.ts
+++ b/src/platform/packages/private/kbn-reporting/server/config_schema.ts
@@ -75,7 +75,7 @@ const CsvSchema = schema.object({
       { defaultValue: 'pit' }
     ),
     duration: schema.string({
-      defaultValue: '30s', // values other than "auto" are passed directly to ES, so string only format is preferred
+      defaultValue: '120s', // values other than "auto" are passed directly to ES, so string only format is preferred
       validate(value) {
         if (!/(^[0-9]+(d|h|m|s|ms|micros|nanos)|auto)$/.test(value)) {
           return 'must be either "auto" or a duration string';


### PR DESCRIPTION
This PR increases the default 30s timeout to 120s for the scroll requests during CSV reports generation.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->