### PR TITLE
[Connectors] Fix: Unbounded array in schema validation

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/server/routes/connectors.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/routes/connectors.ts
@@ -552,7 +552,8 @@ export function registerConnectorRoutes({
               rule: schema.string(),
               updated_at: schema.string(),
               value: schema.string(),
-            })
+            }),
+            { maxSize: 1000 }
           ),
         }),
         params: schema.object({
@@ -597,7 +598,8 @@ export function registerConnectorRoutes({
                 rule: schema.string(),
                 updated_at: schema.string(),
                 value: schema.string(),
-              })
+              }),
+              { maxSize: 1000 }
             ),
           })
         ),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -538,7 +538,8 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
               rule: schema.string(),
               updated_at: schema.string(),
               value: schema.string(),
-            })
+            }),
+            { maxSize: 1000 }
           ),
         }),
         params: schema.object({
@@ -583,7 +584,8 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
                 rule: schema.string(),
                 updated_at: schema.string(),
                 value: schema.string(),
-              })
+              }),
+              { maxSize: 1000 }
             ),
           })
         ),


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/12759 and https://github.com/elastic/search-team/issues/12760

Added `maxSize (1000)` to filtering_rules schema validation to prevent DoS attacks.

The limit of `1000` aligns with Elasticsearch connector API capabilities and similar Kibana patterns (Fleet plugin), balancing security with practical use cases where users may configure extensive filtering rules.



