### PR TITLE
[8.19] [CI] Increase artifacts disk to 180gb (#251774)

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -6,7 +6,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c2-standard-16
-      diskSizeGb: 150
+      diskSizeGb: 180
     timeout_in_minutes: 120
     retry:
       automatic:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Increase artifacts disk to 180gb (#251774)](https://github.com/elastic/kibana/pull/251774)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-04T23:09:44Z","message":"[CI] Increase artifacts disk to 180gb (#251774)\n\n## Summary\n\nWe're seeing intermittent failures due to disk space when building the\nartifacts:\n\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7926#019c2398-fae5-4dd1-811c-14cf8896ca4d/L6496\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7921#019c1e73-f465-48bf-af3d-8772e8b2300e/L6549","sha":"7ae3c6ebd0865dec6f227f5e9e5a504f1c966982","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","skip-ci","backport:all-open","v9.3.0","v9.4.0","v9.2.6"],"title":"[CI] Increase artifacts disk to 180gb","number":251774,"url":"https://github.com/elastic/kibana/pull/251774","mergeCommit":{"message":"[CI] Increase artifacts disk to 180gb (#251774)\n\n## Summary\n\nWe're seeing intermittent failures due to disk space when building the\nartifacts:\n\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7926#019c2398-fae5-4dd1-811c-14cf8896ca4d/L6496\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7921#019c1e73-f465-48bf-af3d-8772e8b2300e/L6549","sha":"7ae3c6ebd0865dec6f227f5e9e5a504f1c966982"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251777","number":251777,"state":"MERGED","mergeCommit":{"sha":"7d368d1457a3340f372e67d135f42e38d5eda4b8","message":"[9.3] [CI] Increase artifacts disk to 180gb (#251774) (#251777)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[CI] Increase artifacts disk to 180gb\n(#251774)](https://github.com/elastic/kibana/pull/251774)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Brad White <Ikuni17@users.noreply.github.com>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251774","number":251774,"mergeCommit":{"message":"[CI] Increase artifacts disk to 180gb (#251774)\n\n## Summary\n\nWe're seeing intermittent failures due to disk space when building the\nartifacts:\n\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7926#019c2398-fae5-4dd1-811c-14cf8896ca4d/L6496\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/7921#019c1e73-f465-48bf-af3d-8772e8b2300e/L6549","sha":"7ae3c6ebd0865dec6f227f5e9e5a504f1c966982"}},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251776","number":251776,"state":"MERGED","mergeCommit":{"sha":"3628387c2da9a579cf8c309b0a39572f0c6a8cd0","message":"[9.2] [CI] Increase artifacts disk to 180gb (#251774) (#251776)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[CI] Increase artifacts disk to 180gb\n(#251774)](https://github.com/elastic/kibana/pull/251774)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Brad White <Ikuni17@users.noreply.github.com>"}}]}] BACKPORT-->