### PR TITLE
Change default maxScheduledPerMinute to 32000

### DIFF
--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -889,7 +889,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
 :   Specifies the maximum number of rules to run per minute.
 
     Data type: `int`
-    Default: `10000`
+    Default: `32000`
     
     :::{note}
     :applies_to: serverless:


### PR DESCRIPTION
Updated the default value for maxScheduledPerMinute from 10000 to 32000.

Default value is 32000 since 8.16.

Relates to https://github.com/elastic/docs-content/issues/5002