### PR TITLE
fix(stack_connectors): add optional indicator to fields i openai connector

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/genai_connectors/index.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/genai_connectors/index.tsx
@@ -11,6 +11,12 @@ import type { ConfigFieldSchema } from '@kbn/triggers-actions-ui-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as i18n from './translations';
 
+export const OptionalFieldLabel = (
+  <EuiText size="xs" color="subdued" data-test-subj="optional-label">
+    {i18n.OPTIONAL_LABEL}
+  </EuiText>
+);
+
 export const temperatureField: ConfigFieldSchema = {
   id: 'temperature',
   label: i18n.TEMPERATURE_LABEL,
@@ -21,14 +27,9 @@ export const temperatureField: ConfigFieldSchema = {
       id="xpack.stackConnectors.components.temperature"
     />
   ),
-  euiFieldProps: {
-    append: (
-      <EuiText size="xs" color="subdued">
-        {i18n.OPTIONAL_LABEL}
-      </EuiText>
-    ),
-  },
+  labelAppend: OptionalFieldLabel,
 };
+
 export const contextWindowLengthField: ConfigFieldSchema = {
   id: 'contextWindowLength',
   label: i18n.CONTEXT_WINDOW_LABEL,
@@ -39,11 +40,5 @@ export const contextWindowLengthField: ConfigFieldSchema = {
       id="xpack.stackConnectors.components.bedrock.contextWindowLength"
     />
   ),
-  euiFieldProps: {
-    append: (
-      <EuiText size="xs" color="subdued">
-        {i18n.OPTIONAL_LABEL}
-      </EuiText>
-    ),
-  },
+  labelAppend: OptionalFieldLabel,
 };

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.test.tsx
@@ -92,6 +92,7 @@ describe('ConnectorFields renders', () => {
     expect(getAllByTestId('config.projectId-input')[0]).toBeInTheDocument();
     expect(getAllByTestId('open-ai-api-doc')[0]).toBeInTheDocument();
     expect(getAllByTestId('open-ai-api-keys-doc')[0]).toBeInTheDocument();
+    expect(getAllByTestId('optional-label')).toHaveLength(4);
   });
 
   test('azure ai connector fields are rendered', async () => {
@@ -383,7 +384,7 @@ describe('ConnectorFields renders', () => {
       expect(queryByTestId('link-gen-ai-token-dashboard')).not.toBeInTheDocument();
     });
     it('Does not render if isEdit is true and dashboardUrl is null', async () => {
-      mockDashboard.mockImplementation((id: string) => ({
+      mockDashboard.mockImplementation(() => ({
         dashboardUrl: null,
       }));
       const { queryByTestId } = render(

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.tsx
@@ -6,7 +6,10 @@
  */
 
 import React, { useMemo } from 'react';
-import type { ActionConnectorFieldsProps } from '@kbn/triggers-actions-ui-plugin/public';
+import type {
+  ActionConnectorFieldsProps,
+  ConnectorFormSchema,
+} from '@kbn/triggers-actions-ui-plugin/public';
 import { SimpleConnectorForm } from '@kbn/triggers-actions-ui-plugin/public';
 import {
   FilePickerField,
@@ -34,6 +37,7 @@ import { OpenAiProviderType } from '@kbn/connector-schemas/openai/constants';
 import * as i18nAuth from '../../common/auth/translations';
 import DashboardLink from './dashboard_link';
 import * as i18n from './translations';
+import type { Config, Secrets } from './types';
 import {
   azureAiConfig,
   azureAiSecrets,
@@ -45,12 +49,19 @@ import {
 } from './constants';
 import { CRT_REQUIRED, KEY_REQUIRED } from '../../common/auth/translations';
 
+interface OpenAIConnectorFormData extends ConnectorFormSchema<Config, Secrets> {
+  __internal__?: {
+    hasHeaders?: boolean;
+    hasPKI?: boolean;
+  };
+}
+
 const { emptyField } = fieldValidators;
 
 const ConnectorFields: React.FC<ActionConnectorFieldsProps> = ({ readOnly, isEdit }) => {
   const { euiTheme } = useEuiTheme();
   const { getFieldDefaultValue } = useFormContext();
-  const [{ config, __internal__, id, name }] = useFormData({
+  const [{ config, __internal__, id, name }] = useFormData<OpenAIConnectorFormData>({
     watch: ['config.apiProvider', '__internal__.hasHeaders', '__internal__.hasPKI'],
   });
   const hasHeaders = __internal__ != null ? __internal__.hasHeaders : false;
@@ -65,7 +76,6 @@ const ConnectorFields: React.FC<ActionConnectorFieldsProps> = ({ readOnly, isEdi
       getFieldDefaultValue<OpenAiProviderType>('config.apiProvider') ?? OpenAiProviderType.OpenAi,
     [getFieldDefaultValue]
   );
-
   const verificationModeOptions = [
     { value: 'full', text: i18n.VERIFICATION_MODE_FULL },
     { value: 'certificate', text: i18n.VERIFICATION_MODE_CERTIFICATE },
@@ -329,7 +339,7 @@ const ConnectorFields: React.FC<ActionConnectorFieldsProps> = ({ readOnly, isEdi
           }}
         </UseArray>
       )}
-      {isEdit && (
+      {isEdit && id && name && (
         <DashboardLink
           connectorId={id}
           connectorName={name}

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/constants.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/constants.tsx
@@ -8,10 +8,13 @@
 import React from 'react';
 import type { ConfigFieldSchema, SecretsFieldSchema } from '@kbn/triggers-actions-ui-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiLink, EuiText } from '@elastic/eui';
+import { EuiLink } from '@elastic/eui';
 import { DEFAULT_MODEL, OpenAiProviderType } from '@kbn/connector-schemas/openai/constants';
-import { contextWindowLengthField, temperatureField } from '../../common/genai_connectors';
-import * as commonI18n from '../../common/genai_connectors/translations';
+import {
+  contextWindowLengthField,
+  temperatureField,
+  OptionalFieldLabel,
+} from '../../common/genai_connectors';
 import * as i18n from './translations';
 import type { Config } from './types';
 
@@ -98,24 +101,19 @@ export const openAiConfig: ConfigFieldSchema[] = [
     id: 'organizationId',
     label: i18n.ORG_ID_LABEL,
     isRequired: false,
+    labelAppend: OptionalFieldLabel,
     helpText: (
       <FormattedMessage
         defaultMessage="For users who belong to multiple organizations. Organization IDs can be found on your Organization settings page."
         id="xpack.stackConnectors.components.genAi.openAiOrgId"
       />
     ),
-    euiFieldProps: {
-      append: (
-        <EuiText size="xs" color="subdued">
-          {commonI18n.OPTIONAL_LABEL}
-        </EuiText>
-      ),
-    },
   },
   {
     id: 'projectId',
     label: i18n.PROJECT_ID_LABEL,
     isRequired: false,
+    labelAppend: OptionalFieldLabel,
     helpText: (
       <FormattedMessage
         defaultMessage="For users who are accessing their projects through their legacy user API key. Project IDs can be found on your General settings page by selecting the specific project."
@@ -128,11 +126,6 @@ export const openAiConfig: ConfigFieldSchema[] = [
       onFocus: (event: React.FocusEvent<HTMLInputElement>) => {
         event.target.setAttribute('autocomplete', 'new-password');
       },
-      append: (
-        <EuiText size="xs" color="subdued">
-          {commonI18n.OPTIONAL_LABEL}
-        </EuiText>
-      ),
     },
   },
 ];

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/simple_connector_form.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/simple_connector_form.tsx
@@ -23,6 +23,7 @@ type Validations<T = any> = Array<ValidationConfig<FormData, string, T>>;
 export interface CommonFieldSchema<T = any> {
   id: string;
   label: string;
+  labelAppend?: ReactNode;
   helpText?: string | ReactNode;
   isRequired?: boolean;
   type?: keyof typeof FIELD_TYPES;
@@ -55,6 +56,7 @@ const { emptyField, urlField } = fieldValidators;
 
 const getFieldConfig = <T,>({
   label,
+  labelAppend,
   isRequired = true,
   isUrlField = false,
   requireTld = true,
@@ -63,6 +65,7 @@ const getFieldConfig = <T,>({
   validations = [],
 }: {
   label: string;
+  labelAppend?: ReactNode;
   isRequired?: boolean;
   isUrlField?: boolean;
   requireTld?: boolean;
@@ -71,6 +74,7 @@ const getFieldConfig = <T,>({
   validations?: Validations<T>;
 }) => ({
   label,
+  labelAppend,
   validations: [
     ...(isRequired
       ? [
@@ -125,6 +129,7 @@ const FormRow: React.FC<FormRowProps> = ({
   isPasswordField,
   isRequired = true,
   isUrlField,
+  labelAppend,
   helpText,
   defaultValue,
   euiFieldProps = {},
@@ -149,6 +154,7 @@ const FormRow: React.FC<FormRowProps> = ({
                 isRequired,
                 requireTld,
                 validations,
+                labelAppend,
               })}
               helpText={helpText}
               componentProps={{
@@ -163,7 +169,7 @@ const FormRow: React.FC<FormRowProps> = ({
           ) : (
             <UseField
               path={id}
-              config={getFieldConfig({ label, type, isRequired, validations })}
+              config={getFieldConfig({ label, type, isRequired, validations, labelAppend })}
               helpText={helpText}
               component={PasswordField}
               componentProps={{


### PR DESCRIPTION
## Summary

This PR updates the OpenAI connector to use @MichaelMarcialis suggested pattern for how to handle optional input fields. 

See: https://github.com/elastic/kibana/issues/195048#issuecomment-2393788073

Closes https://github.com/elastic/kibana/issues/195048

### Implementation

The OpenAI connector is updated to use `labelAppend` to indicate optional fields. Existing solution using `append` has been replaced by `labelAppend` to align with how optional input fields are handled in other places (which also aligns with the recommended pattern). 


<img width="1657" height="1250" alt="Screenshot 2026-02-05 at 14 35 30" src="https://github.com/user-attachments/assets/ca445b8f-d143-46a6-bc90-066071d6c961" />
<img width="1659" height="1255" alt="Screenshot 2026-02-05 at 14 35 45" src="https://github.com/user-attachments/assets/82e232cc-847e-44a8-ab9c-e21d2e9f7d18" />
<img width="1657" height="1251" alt="Screenshot 2026-02-05 at 14 36 02" src="https://github.com/user-attachments/assets/f09f3d88-ba3d-4557-abaa-37662f7aef23" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->