### PR TITLE
[Kibana Log] Failed to load current Streams state

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/storage/migrate_on_read.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/storage/migrate_on_read.test.ts
@@ -402,4 +402,14 @@ describe('migrateOnRead', () => {
       expect(() => migrateOnRead(groupStreamDefinition)).not.toThrow();
     });
   });
+
+  describe('ingest migration', () => {
+    it('should add ingest if missing', () => {
+      const definition = { name: 'test-stream' };
+
+      const result = migrateOnRead(definition);
+      expect(result.ingest).toBeDefined();
+      expect(mockStreamsAsserts).toHaveBeenCalled();
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/storage/migrate_on_read.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/storage/migrate_on_read.ts
@@ -29,6 +29,13 @@ export function migrateOnRead(definition: Record<string, unknown>): Streams.all.
     };
     hasBeenMigrated = true;
   }
+
+  // Add ingest
+  if (!('ingest' in migratedDefinition)) {
+    set(migratedDefinition, 'ingest', {});
+    hasBeenMigrated = true;
+  }
+
   // Rename unwired to classic
   if (
     isObject(migratedDefinition.ingest) &&


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/observability-error-backlog/issues/429

This PR adds a migration step that adds a default `ingest` structure for legacy definitions