### PR TITLE
[ResponseOps][Alerting] Dedicated user service

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/alert_actions_client/alert_actions_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/alert_actions_client/alert_actions_client.test.ts
@@ -26,7 +26,7 @@ describe('AlertActionsClient', () => {
   let client: AlertActionsClient;
 
   beforeEach(() => {
-    userService.getCurrentUserProfileUid.mockReturnValue('test-uid');
+    userService.getCurrentUserProfileUid.mockResolvedValue('test-uid');
     storageServiceEsClient.bulk.mockResolvedValueOnce({ items: [], errors: false, took: 1 });
     client = new AlertActionsClient(queryService, storageService, userService);
   });
@@ -107,7 +107,7 @@ describe('AlertActionsClient', () => {
     it('should handle null profile uid when security is not available', async () => {
       queryServiceEsClient.esql.query.mockResolvedValueOnce(getAlertEventESQLResponse());
 
-      userService.getCurrentUserProfileUid.mockReturnValueOnce(null);
+      userService.getCurrentUserProfileUid.mockResolvedValueOnce(null);
       const clientWithoutSecurity = new AlertActionsClient(
         queryService,
         storageService,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/alert_actions_client/alert_actions_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/alert_actions_client/alert_actions_client.ts
@@ -6,12 +6,8 @@
  */
 
 import Boom from '@hapi/boom';
-import { PluginStart } from '@kbn/core-di';
-import { Request } from '@kbn/core-di-server';
-import type { KibanaRequest } from '@kbn/core-http-server';
 import { esql } from '@kbn/esql-language';
-import type { SecurityPluginStart } from '@kbn/security-plugin/server';
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { groupBy, omit } from 'lodash';
 import { ALERT_ACTIONS_DATA_STREAM, type AlertAction } from '../../resources/alert_actions';
 import { ALERT_EVENTS_DATA_STREAM } from '../../resources/alert_events';
@@ -23,22 +19,23 @@ import { queryResponseToRecords } from '../services/query_service/query_response
 import { QueryService, type QueryServiceContract } from '../services/query_service/query_service';
 import type { StorageServiceContract } from '../services/storage_service/storage_service';
 import { StorageServiceScopedToken } from '../services/storage_service/tokens';
+import type { UserServiceContract } from '../services/user_service/user_service';
+import { UserService } from '../services/user_service/user_service';
 
 @injectable()
 export class AlertActionsClient {
   constructor(
-    @inject(Request) private readonly request: KibanaRequest,
     @inject(QueryService) private readonly queryService: QueryServiceContract,
     @inject(StorageServiceScopedToken) private readonly storageService: StorageServiceContract,
-    @optional() @inject(PluginStart('security')) private readonly security?: SecurityPluginStart
+    @inject(UserService) private readonly userService: UserServiceContract
   ) {}
 
   public async createAction(params: {
     groupHash: string;
     action: CreateAlertActionBody;
   }): Promise<void> {
-    const [username, alertEvent] = await Promise.all([
-      this.getUserName(),
+    const [userProfileUid, alertEvent] = await Promise.all([
+      this.getUserProfileUid(),
       this.findLastAlertEventRecordOrThrow({
         groupHash: params.groupHash,
         episodeId: 'episode_id' in params.action ? params.action.episode_id : undefined,
@@ -51,7 +48,7 @@ export class AlertActionsClient {
         this.buildAlertActionDocument({
           action: params.action,
           alertEvent,
-          username,
+          userProfileUid,
         }),
       ],
     });
@@ -60,8 +57,8 @@ export class AlertActionsClient {
   public async createBulkActions(
     actions: BulkCreateAlertActionItemBody[]
   ): Promise<{ processed: number; total: number }> {
-    const [username, records] = await Promise.all([
-      this.getUserName(),
+    const [userProfileUid, records] = await Promise.all([
+      this.getUserProfileUid(),
       this.fetchLastAlertEventRecordsForActions(actions),
     ]);
 
@@ -82,7 +79,7 @@ export class AlertActionsClient {
           return this.buildAlertActionDocument({
             action,
             alertEvent: matchingAlertEventRecord,
-            username,
+            userProfileUid,
           });
         }
       })
@@ -122,21 +119,21 @@ export class AlertActionsClient {
     );
   }
 
-  private async getUserName(): Promise<string | null> {
-    return this.security?.authc.getCurrentUser(this.request)?.username ?? null;
+  private async getUserProfileUid(): Promise<string | null> {
+    return this.userService.getCurrentUserProfileUid();
   }
 
   private buildAlertActionDocument(params: {
     action: CreateAlertActionBody;
     alertEvent: AlertEventRecord;
-    username: string | null;
+    userProfileUid: string | null;
   }): AlertAction {
-    const { action, alertEvent, username } = params;
+    const { action, alertEvent, userProfileUid } = params;
     const actionData = omit(action, ['episode_id', 'action_type']);
 
     return {
       '@timestamp': new Date().toISOString(),
-      actor: username,
+      actor: userProfileUid,
       action_type: action.action_type,
       last_series_event_timestamp: alertEvent['@timestamp'],
       rule_id: alertEvent.rule_id,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/fetch_rule_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/fetch_rule_step.test.ts
@@ -31,9 +31,9 @@ describe('FetchRuleStep', () => {
     timeField: '@timestamp',
     lookbackWindow: '1m',
     groupingKey: [],
-    createdBy: 'elastic',
+    createdBy: 'elastic_profile_uid',
     createdAt: '2025-01-01T00:00:00.000Z',
-    updatedBy: 'elastic',
+    updatedBy: 'elastic_profile_uid',
     updatedAt: '2025-01-01T00:00:00.000Z',
     ...overrides,
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.mock.ts
@@ -7,12 +7,10 @@
 
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { httpServerMock, httpServiceMock } from '@kbn/core-http-server-mocks';
-import { mockAuthenticatedUser } from '@kbn/core-security-common/mocks';
-import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { createUserService } from '../services/user_service/user_service.mock';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { RulesClient } from './rules_client';
 import { createRulesSavedObjectService } from '../services/rules_saved_object_service/rules_saved_object_service.mock';
-import { UserService } from '../services/user_service/user_service';
 
 export function createRulesClient(): {
   rulesClient: RulesClient;
@@ -22,14 +20,9 @@ export function createRulesClient(): {
   const request = httpServerMock.createKibanaRequest();
   const http = httpServiceMock.createStartContract();
   const taskManager = taskManagerMock.createStart();
-  const security = securityMock.createStart();
-  const userService = new UserService(request, security);
+  const userService = createUserService();
 
   http.basePath.get.mockReturnValue('/s/default');
-
-  security.authc.getCurrentUser.mockReturnValue(
-    mockAuthenticatedUser({ username: 'elastic', profile_uid: 'elastic_profile_uid' })
-  );
 
   const rulesClient = new RulesClient(
     request,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.mock.ts
@@ -20,7 +20,7 @@ export function createRulesClient(): {
   const request = httpServerMock.createKibanaRequest();
   const http = httpServiceMock.createStartContract();
   const taskManager = taskManagerMock.createStart();
-  const userService = createUserService();
+  const { userService } = createUserService();
 
   http.basePath.get.mockReturnValue('/s/default');
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.mock.ts
@@ -12,6 +12,7 @@ import { securityMock } from '@kbn/security-plugin/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { RulesClient } from './rules_client';
 import { createRulesSavedObjectService } from '../services/rules_saved_object_service/rules_saved_object_service.mock';
+import { UserService } from '../services/user_service/user_service';
 
 export function createRulesClient(): {
   rulesClient: RulesClient;
@@ -22,6 +23,7 @@ export function createRulesClient(): {
   const http = httpServiceMock.createStartContract();
   const taskManager = taskManagerMock.createStart();
   const security = securityMock.createStart();
+  const userService = new UserService(request, security);
 
   http.basePath.get.mockReturnValue('/s/default');
 
@@ -34,7 +36,7 @@ export function createRulesClient(): {
     http,
     rulesSavedObjectService,
     taskManager,
-    security
+    userService
   );
 
   return { rulesClient, mockSavedObjectsClient };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -7,15 +7,13 @@
 
 import { httpServerMock, httpServiceMock } from '@kbn/core-http-server-mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
-import { securityMock } from '@kbn/security-plugin/server/mocks';
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { AuthenticatedUser } from '@kbn/core/server';
-import { mockAuthenticatedUser } from '@kbn/core-security-common/mocks';
 
 import { RULE_SAVED_OBJECT_TYPE, type RuleSavedObjectAttributes } from '../../saved_objects';
 import { RulesClient } from './rules_client';
 import { createRulesSavedObjectService } from '../services/rules_saved_object_service/rules_saved_object_service.mock';
+import type { UserServiceContract } from '../services/user_service/user_service';
 
 import type { CreateRuleParams, UpdateRuleData } from './types';
 
@@ -37,7 +35,9 @@ describe('RulesClient', () => {
   const request: KibanaRequest = httpServerMock.createKibanaRequest();
   const http = httpServiceMock.createStartContract();
   const taskManager = taskManagerMock.createStart();
-  const security = securityMock.createStart();
+  const userService: jest.Mocked<UserServiceContract> = {
+    getCurrentUserProfileUid: jest.fn(),
+  };
   const { rulesSavedObjectService, mockSavedObjectsClient } = createRulesSavedObjectService();
 
   const baseCreateData: CreateRuleParams['data'] = {
@@ -60,13 +60,7 @@ describe('RulesClient', () => {
 
     // Default space
     http.basePath.get.mockReturnValue('/s/space-1');
-
-    const user: AuthenticatedUser = mockAuthenticatedUser({
-      username: 'elastic',
-      profile_uid: 'elastic_profile_uid',
-    });
-    security.authc.getCurrentUser.mockReturnValue(user);
-
+    userService.getCurrentUserProfileUid.mockReturnValue('elastic_profile_uid');
     mockSavedObjectsClient.create.mockResolvedValue({
       id: 'rule-id-default',
       type: RULE_SAVED_OBJECT_TYPE,
@@ -99,7 +93,7 @@ describe('RulesClient', () => {
   });
 
   function createClient() {
-    return new RulesClient(request, http, rulesSavedObjectService, taskManager, security);
+    return new RulesClient(request, http, rulesSavedObjectService, taskManager, userService);
   }
 
   describe('createRule', () => {
@@ -122,7 +116,7 @@ describe('RulesClient', () => {
         expect.objectContaining({
           name: 'rule-1',
           enabled: false,
-          createdBy: 'elastic',
+          createdBy: 'elastic_profile_uid',
         }),
         { id: 'rule-id-1', overwrite: false }
       );
@@ -134,8 +128,8 @@ describe('RulesClient', () => {
         expect.objectContaining({
           id: 'rule-id-1',
           enabled: false,
-          createdBy: 'elastic',
-          updatedBy: 'elastic',
+          createdBy: 'elastic_profile_uid',
+          updatedBy: 'elastic_profile_uid',
           createdAt: '2025-01-01T00:00:00.000Z',
           updatedAt: '2025-01-01T00:00:00.000Z',
         })
@@ -246,9 +240,9 @@ describe('RulesClient', () => {
       const existingAttributes: RuleSavedObjectAttributes = {
         ...baseCreateData,
         enabled: true,
-        createdBy: 'elastic',
+        createdBy: 'elastic_profile_uid',
         createdAt: '2025-01-01T00:00:00.000Z',
-        updatedBy: 'elastic',
+        updatedBy: 'elastic_profile_uid',
         updatedAt: '2025-01-01T00:00:00.000Z',
       };
       mockSavedObjectsClient.get.mockResolvedValueOnce({
@@ -283,9 +277,9 @@ describe('RulesClient', () => {
       const existingAttributes: RuleSavedObjectAttributes = {
         ...baseCreateData,
         enabled: false,
-        createdBy: 'elastic',
+        createdBy: 'elastic_profile_uid',
         createdAt: '2025-01-01T00:00:00.000Z',
-        updatedBy: 'elastic',
+        updatedBy: 'elastic_profile_uid',
         updatedAt: '2025-01-01T00:00:00.000Z',
       };
       mockSavedObjectsClient.get.mockResolvedValueOnce({
@@ -316,9 +310,9 @@ describe('RulesClient', () => {
       const existingAttributes: RuleSavedObjectAttributes = {
         ...baseCreateData,
         enabled: false,
-        createdBy: 'elastic',
+        createdBy: 'elastic_profile_uid',
         createdAt: '2025-01-01T00:00:00.000Z',
-        updatedBy: 'elastic',
+        updatedBy: 'elastic_profile_uid',
         updatedAt: '2025-01-01T00:00:00.000Z',
       };
       mockSavedObjectsClient.get.mockResolvedValueOnce({
@@ -348,9 +342,9 @@ describe('RulesClient', () => {
       const existingAttributes: RuleSavedObjectAttributes = {
         ...baseCreateData,
         enabled: true,
-        createdBy: 'elastic',
+        createdBy: 'elastic_profile_uid',
         createdAt: '2025-01-01T00:00:00.000Z',
-        updatedBy: 'elastic',
+        updatedBy: 'elastic_profile_uid',
         updatedAt: '2025-01-01T00:00:00.000Z',
       };
       mockSavedObjectsClient.get.mockResolvedValueOnce({
@@ -396,9 +390,9 @@ describe('RulesClient', () => {
       const existingAttributes: RuleSavedObjectAttributes = {
         ...baseCreateData,
         enabled: true,
-        createdBy: 'elastic',
+        createdBy: 'elastic_profile_uid',
         createdAt: '2025-01-01T00:00:00.000Z',
-        updatedBy: 'elastic',
+        updatedBy: 'elastic_profile_uid',
         updatedAt: '2025-01-01T00:00:00.000Z',
       };
       mockSavedObjectsClient.get.mockResolvedValueOnce({
@@ -451,9 +445,9 @@ describe('RulesClient', () => {
           ...baseCreateData,
           name: 'rule-1',
           enabled: true,
-          createdBy: 'elastic',
+          createdBy: 'elastic_profile_uid',
           createdAt: '2025-01-01T00:00:00.000Z',
-          updatedBy: 'elastic',
+          updatedBy: 'elastic_profile_uid',
           updatedAt: '2025-01-01T00:00:00.000Z',
         },
       };
@@ -466,9 +460,9 @@ describe('RulesClient', () => {
           ...baseCreateData,
           name: 'rule-2',
           enabled: false,
-          createdBy: 'elastic',
+          createdBy: 'elastic_profile_uid',
           createdAt: '2025-01-01T00:00:00.000Z',
-          updatedBy: 'elastic',
+          updatedBy: 'elastic_profile_uid',
           updatedAt: '2025-01-01T00:00:00.000Z',
         },
       };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -60,7 +60,7 @@ describe('RulesClient', () => {
 
     // Default space
     http.basePath.get.mockReturnValue('/s/space-1');
-    userService.getCurrentUserProfileUid.mockReturnValue('elastic_profile_uid');
+    userService.getCurrentUserProfileUid.mockResolvedValue('elastic_profile_uid');
     mockSavedObjectsClient.create.mockResolvedValue({
       id: 'rule-id-default',
       type: RULE_SAVED_OBJECT_TYPE,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -59,7 +59,7 @@ export class RulesClient {
       );
     }
 
-    const userProfileUid = this.userService.getCurrentUserProfileUid();
+    const userProfileUid = await this.userService.getCurrentUserProfileUid();
     const nowIso = new Date().toISOString();
 
     const ruleAttributes: RuleSavedObjectAttributes = {
@@ -128,7 +128,7 @@ export class RulesClient {
       );
     }
 
-    const userProfileUid = this.userService.getCurrentUserProfileUid();
+    const userProfileUid = await this.userService.getCurrentUserProfileUid();
     const nowIso = new Date().toISOString();
 
     let existingAttrs: RuleSavedObjectAttributes;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -11,7 +11,6 @@ import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import type { KibanaRequest as CoreKibanaRequest } from '@kbn/core/server';
 import type { HttpServiceStart, KibanaRequest } from '@kbn/core-http-server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
-import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { inject, injectable } from 'inversify';
 import { PluginStart } from '@kbn/core-di';
 import { CoreStart, Request } from '@kbn/core-di-server';
@@ -22,6 +21,8 @@ import { type RuleSavedObjectAttributes } from '../../saved_objects';
 import { ensureRuleExecutorTaskScheduled, getRuleExecutorTaskId } from '../rule_executor/schedule';
 import type { RulesSavedObjectServiceContract } from '../services/rules_saved_object_service/rules_saved_object_service';
 import { RulesSavedObjectService } from '../services/rules_saved_object_service/rules_saved_object_service';
+import type { UserServiceContract } from '../services/user_service/user_service';
+import { UserService } from '../services/user_service/user_service';
 import type {
   CreateRuleParams,
   FindRulesParams,
@@ -38,7 +39,7 @@ export class RulesClient {
     @inject(RulesSavedObjectService)
     private readonly rulesSavedObjectService: RulesSavedObjectServiceContract,
     @inject(PluginStart('taskManager')) private readonly taskManager: TaskManagerStartContract,
-    @inject(PluginStart('security')) private readonly security: SecurityPluginStart
+    @inject(UserService) private readonly userService: UserServiceContract
   ) {}
 
   private getSpaceContext(): { spaceId: string } {
@@ -46,10 +47,6 @@ export class RulesClient {
     const space = getSpaceIdFromPath(requestBasePath, this.http.basePath.serverBasePath);
     const spaceId = space?.spaceId || 'default';
     return { spaceId };
-  }
-
-  private async getUserName(): Promise<string | null> {
-    return this.security.authc.getCurrentUser(this.request)?.username ?? null;
   }
 
   public async createRule(params: CreateRuleParams): Promise<RuleResponse> {
@@ -62,7 +59,7 @@ export class RulesClient {
       );
     }
 
-    const username = await this.getUserName();
+    const userProfileUid = this.userService.getCurrentUserProfileUid();
     const nowIso = new Date().toISOString();
 
     const ruleAttributes: RuleSavedObjectAttributes = {
@@ -74,9 +71,9 @@ export class RulesClient {
       timeField: parsed.data.timeField,
       lookbackWindow: parsed.data.lookbackWindow,
       groupingKey: parsed.data.groupingKey,
-      createdBy: username,
+      createdBy: userProfileUid,
       createdAt: nowIso,
-      updatedBy: username,
+      updatedBy: userProfileUid,
       updatedAt: nowIso,
     };
 
@@ -131,7 +128,7 @@ export class RulesClient {
       );
     }
 
-    const username = await this.getUserName();
+    const userProfileUid = this.userService.getCurrentUserProfileUid();
     const nowIso = new Date().toISOString();
 
     let existingAttrs: RuleSavedObjectAttributes;
@@ -154,7 +151,7 @@ export class RulesClient {
     const nextAttrs: RuleSavedObjectAttributes = {
       ...existingAttrs,
       ...parsed.data,
-      updatedBy: username,
+      updatedBy: userProfileUid,
       updatedAt: nowIso,
     };
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.mock.ts
@@ -8,14 +8,8 @@
 import type { UserProfileWithSecurity } from '@kbn/core-user-profile-common';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-server';
 import { userProfileServiceMock } from '@kbn/core-user-profile-server-mocks';
-import type { KibanaRequest } from '@kbn/core-http-server';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { UserService } from './user_service';
-
-interface CreateUserServiceOptions {
-  request?: KibanaRequest;
-  uid?: string | null;
-}
 
 const mockProfile: UserProfileWithSecurity = {
   uid: 'elastic_profile_uid',
@@ -29,11 +23,11 @@ const mockProfile: UserProfileWithSecurity = {
   labels: {},
 };
 
-export function createUserService(options: CreateUserServiceOptions = {}): {
+export function createUserService(): {
   userService: UserService;
   userProfile: jest.Mocked<UserProfileServiceStart>;
 } {
-  const request = options.request ?? httpServerMock.createKibanaRequest();
+  const request = httpServerMock.createKibanaRequest();
   const userProfile = userProfileServiceMock.createStart();
 
   userProfile.getCurrent.mockResolvedValue(createUserProfile());

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.mock.ts
@@ -6,6 +6,7 @@
  */
 
 import type { UserProfileWithSecurity } from '@kbn/core-user-profile-common';
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-server';
 import { userProfileServiceMock } from '@kbn/core-user-profile-server-mocks';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
@@ -28,17 +29,19 @@ const mockProfile: UserProfileWithSecurity = {
   labels: {},
 };
 
-export function createUserService(options: CreateUserServiceOptions = {}): UserService {
+export function createUserService(options: CreateUserServiceOptions = {}): {
+  userService: UserService;
+  userProfile: jest.Mocked<UserProfileServiceStart>;
+} {
   const request = options.request ?? httpServerMock.createKibanaRequest();
   const userProfile = userProfileServiceMock.createStart();
 
-  if (options.uid !== undefined) {
-    userProfile.getCurrent.mockResolvedValue(createUserProfile(options.uid!));
-  } else {
-    userProfile.getCurrent.mockResolvedValue(createUserProfile());
-  }
+  userProfile.getCurrent.mockResolvedValue(createUserProfile());
 
-  return new UserService(request, userProfile);
+  return {
+    userService: new UserService(request, userProfile),
+    userProfile,
+  };
 }
 
 export function createUserProfile(uid?: string): UserProfileWithSecurity {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.mock.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UserProfileWithSecurity } from '@kbn/core-user-profile-common';
+import { userProfileServiceMock } from '@kbn/core-user-profile-server-mocks';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { UserService } from './user_service';
+
+interface CreateUserServiceOptions {
+  request?: KibanaRequest;
+  uid?: string | null;
+}
+
+const mockProfile: UserProfileWithSecurity = {
+  uid: 'elastic_profile_uid',
+  enabled: true,
+  user: {
+    username: 'elastic',
+    roles: [],
+    realm_name: 'realm',
+  },
+  data: {},
+  labels: {},
+};
+
+export function createUserService(options: CreateUserServiceOptions = {}): UserService {
+  const request = options.request ?? httpServerMock.createKibanaRequest();
+  const userProfile = userProfileServiceMock.createStart();
+
+  if (options.uid !== undefined) {
+    userProfile.getCurrent.mockResolvedValue(createUserProfile(options.uid!));
+  } else {
+    userProfile.getCurrent.mockResolvedValue(createUserProfile());
+  }
+
+  return new UserService(request, userProfile);
+}
+
+export function createUserProfile(uid?: string): UserProfileWithSecurity {
+  return {
+    ...mockProfile,
+    ...(uid ? { uid } : {}),
+  };
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.test.ts
@@ -10,38 +10,27 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0.
  */
-
-import { httpServerMock } from '@kbn/core-http-server-mocks';
-import { userProfileServiceMock } from '@kbn/core-user-profile-server-mocks';
-import { UserService } from './user_service';
-import { createUserProfile } from './user_service.mock';
+import { createUserService } from './user_service.mock';
 
 describe('UserService', () => {
-  const request = httpServerMock.createKibanaRequest();
-  const userProfile = userProfileServiceMock.createStart();
-  userProfile.getCurrent.mockResolvedValue(createUserProfile());
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('returns the current user profile uid when user profile service is available', async () => {
-    const service = new UserService(request, userProfile);
+    const { userService, userProfile } = createUserService();
 
-    await expect(service.getCurrentUserProfileUid()).resolves.toBe('elastic_profile_uid');
+    await expect(userService.getCurrentUserProfileUid()).resolves.toBe('elastic_profile_uid');
+
+    expect(userProfile.getCurrent).toHaveBeenCalledWith({
+      request: expect.anything(),
+    });
   });
 
-  it('returns null when UserService is not available', async () => {
-    const service = new UserService(request, undefined);
-
-    await expect(service.getCurrentUserProfileUid()).resolves.toBeNull();
-  });
-
-  it('returns null when the profile of current user is not available', async () => {
+  it('returns null when the profile is not found', async () => {
+    const { userService, userProfile } = createUserService();
     userProfile.getCurrent.mockResolvedValue(null);
 
-    const service = new UserService(request, userProfile);
-
-    await expect(service.getCurrentUserProfileUid()).resolves.toBeNull();
+    await expect(userService.getCurrentUserProfileUid()).resolves.toBeNull();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.test.ts
@@ -1,6 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
  * 2.0.
  */
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { mockAuthenticatedUser } from '@kbn/core-security-common/mocks';
+import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { UserService } from './user_service';
+
+describe('UserService', () => {
+  const request = httpServerMock.createKibanaRequest();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the current user profile uid when security is available', () => {
+    const security = securityMock.createStart();
+    security.authc.getCurrentUser.mockReturnValue(
+      mockAuthenticatedUser({ username: 'elastic', profile_uid: 'elastic_profile_uid' })
+    );
+
+    const service = new UserService(request, security);
+
+    expect(service.getCurrentUserProfileUid()).toBe('elastic_profile_uid');
+  });
+
+  it('returns null when security is not available', () => {
+    const service = new UserService(request, undefined);
+
+    expect(service.getCurrentUserProfileUid()).toBeNull();
+  });
+
+  it('returns null when current user is not available', () => {
+    const security = securityMock.createStart();
+    security.authc.getCurrentUser.mockReturnValue(null);
+
+    const service = new UserService(request, security);
+
+    expect(service.getCurrentUserProfileUid()).toBeNull();
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.ts
@@ -7,7 +7,7 @@
 
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-server';
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { CoreStart, Request } from '@kbn/core-di-server';
 
 export interface UserServiceContract {
@@ -18,16 +18,11 @@ export interface UserServiceContract {
 export class UserService implements UserServiceContract {
   constructor(
     @inject(Request) private readonly request: KibanaRequest,
-    @optional()
     @inject(CoreStart('userProfile'))
-    private readonly userProfile?: UserProfileServiceStart
+    private readonly userProfile: UserProfileServiceStart
   ) {}
 
   public async getCurrentUserProfileUid(): Promise<string | null> {
-    if (!this.userProfile) {
-      return null;
-    }
-
     const profile = await this.userProfile.getCurrent({ request: this.request });
     return profile?.uid ?? null;
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/user_service/user_service.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
+import { inject, injectable, optional } from 'inversify';
+import { PluginStart } from '@kbn/core-di';
+import { Request } from '@kbn/core-di-server';
+
+export interface UserServiceContract {
+  getCurrentUserProfileUid(): string | null;
+}
+
+@injectable()
+export class UserService implements UserServiceContract {
+  constructor(
+    @inject(Request) private readonly request: KibanaRequest,
+    @optional() @inject(PluginStart('security')) private readonly security?: SecurityPluginStart
+  ) {}
+
+  public getCurrentUserProfileUid(): string | null {
+    return this.security?.authc.getCurrentUser(this.request)?.profile_uid ?? null;
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/test_utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/test_utils.ts
@@ -47,9 +47,9 @@ export function createRuleResponse(overrides: Partial<RuleResponse> = {}): RuleR
     timeField: '@timestamp',
     lookbackWindow: '5m',
     groupingKey: [],
-    createdBy: 'elastic',
+    createdBy: 'elastic_profile_uid',
     createdAt: '2025-01-01T00:00:00.000Z',
-    updatedBy: 'elastic',
+    updatedBy: 'elastic_profile_uid',
     updatedAt: '2025-01-01T00:00:00.000Z',
     ...overrides,
   };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -29,6 +29,7 @@ import { DirectorService } from '../lib/director/director';
 import { TransitionStrategyFactory } from '../lib/director/strategies/strategy_resolver';
 import { BasicTransitionStrategy } from '../lib/director/strategies/basic_strategy';
 import { ResourceManager } from '../lib/services/resource_service/resource_manager';
+import { UserService } from '../lib/services/user_service/user_service';
 import {
   createTaskRunnerFactory,
   TaskRunnerFactoryToken,
@@ -37,6 +38,7 @@ import {
 export function bindServices({ bind }: ContainerModuleLoadOptions) {
   bind(AlertActionsClient).toSelf().inRequestScope();
   bind(RulesClient).toSelf().inRequestScope();
+  bind(UserService).toSelf().inRequestScope();
   bind(AlertingRetryService).toSelf().inSingletonScope();
   bind(RetryServiceToken).toService(AlertingRetryService);
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -8,21 +8,15 @@
 import { CoreStart, Request } from '@kbn/core-di-server';
 import type { ContainerModuleLoadOptions } from 'inversify';
 import { AlertActionsClient } from '../lib/alert_actions_client';
-import { DirectorService } from '../lib/director/director';
-import { BasicTransitionStrategy } from '../lib/director/strategies/basic_strategy';
-import { TransitionStrategyFactory } from '../lib/director/strategies/strategy_resolver';
 import { DispatcherService } from '../lib/dispatcher/dispatcher';
 import { RulesClient } from '../lib/rules_client';
-import { EsServiceInternalToken, EsServiceScopedToken } from '../lib/services/es_service/tokens';
 import { LoggerService, LoggerServiceToken } from '../lib/services/logger_service/logger_service';
 import { QueryService } from '../lib/services/query_service/query_service';
 import {
   QueryServiceInternalToken,
   QueryServiceScopedToken,
 } from '../lib/services/query_service/tokens';
-import { ResourceManager } from '../lib/services/resource_service/resource_manager';
 import { AlertingRetryService } from '../lib/services/retry_service';
-import { RetryServiceToken } from '../lib/services/retry_service/tokens';
 import { RulesSavedObjectService } from '../lib/services/rules_saved_object_service/rules_saved_object_service';
 import { StorageService } from '../lib/services/storage_service/storage_service';
 import {

--- a/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
@@ -34,7 +34,6 @@
     "@kbn/esql-types",
     "@kbn/yaml-rule-editor",
     "@kbn/core-http-server-mocks",
-    "@kbn/core-security-common",
     "@kbn/core-elasticsearch-server-mocks",
     "@kbn/logging-mocks",
     "@kbn/core-elasticsearch-client-server-mocks",
@@ -48,7 +47,10 @@
     "@kbn/core-test-helpers-kbn-server",
     "@kbn/test",
     "@kbn/esql-language",
-    "@kbn/core-saved-objects-api-server-mocks"
+    "@kbn/core-saved-objects-api-server-mocks",
+    "@kbn/core-user-profile-common",
+    "@kbn/core-user-profile-server-mocks",
+    "@kbn/core-user-profile-server"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/rna-program/issues/124

This PR creates a `UserService` class to abstract the internals of the security plugin when accessing user information.

Usages of `username` were replaced by `profile_uid`.
 


