### PR TITLE
chore(codeql): ignore `md` files

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,6 +8,7 @@ paths-ignore:
   - '**/.storybook/**'
   - '**/*-mocks/**'
   - '**/*.cy.*'
+  - '**/*.md'
   - '**/*.yaml'
   - '**/*.hbs'
   - '**/*.njk'


### PR DESCRIPTION
This PR updates the CodeQL configuration to exclude `.md` files from vulnerability scanning.

I noticed that the CodeQL check triggered for [this build](https://github.com/elastic/kibana/actions/runs/21710476400/job/62612468203?pr=251869), despite https://github.com/elastic/kibana/pull/251869 touching only a single Markdown file. The goal of this PR is to skip the check or shorten it to show the merge button quicker for PRs touching `.md` files. 