### PR TITLE
[Dashboards] Apply control filters to matching controls on navigation

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api/load_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api/load_dashboard_api.ts
@@ -90,7 +90,10 @@ export async function loadDashboardApi({
   // When overrideState.filters is defined (even if empty), we use the saved state
   // for pinned_panels rather than unsaved changes. This ensures that navigating
   // without filters doesn't retain control selections from previous navigations.
-  let controlFilterOverrides: { pinned_panels?: typeof lastSavedState.pinned_panels; filters?: Filter[] } = {};
+  const controlFilterOverrides: {
+    pinned_panels?: typeof lastSavedState.pinned_panels;
+    filters?: Filter[];
+  } = {};
 
   if (overrideState.filters !== undefined) {
     // Start with saved state for controls (not unsaved changes)

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api/load_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api/load_dashboard_api.ts
@@ -7,8 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Filter } from '@kbn/es-query';
 import { ContentInsightsClient } from '@kbn/content-management-content-insights-public';
 import { dashboardClient } from '../../dashboard_client';
+import { applyControlFiltersToPanels } from '../../dashboard_app/url/bwc/apply_control_filters_to_panels';
 import { getPanelSettings } from '../../panel_placement/get_panel_placement_settings';
 import { DEFAULT_PANEL_PLACEMENT_SETTINGS } from '../../plugin_constants';
 import { getAccessControlClient } from '../../services/access_control_service';
@@ -77,13 +79,43 @@ export async function loadDashboardApi({
     getDashboardBackupService().storeViewMode(viewMode);
   }
 
+  // Get the base state from saved dashboard
+  const lastSavedState = getLastSavedState(readResult);
+
+  // Apply control filters from navigation to matching controls on this dashboard.
+  // This allows control selections to persist when navigating between dashboards
+  // that have the same controls (same field and data view), rather than appearing
+  // as top-level filters in the filter bar.
+  //
+  // When overrideState.filters is defined (even if empty), we use the saved state
+  // for pinned_panels rather than unsaved changes. This ensures that navigating
+  // without filters doesn't retain control selections from previous navigations.
+  let controlFilterOverrides: { pinned_panels?: typeof lastSavedState.pinned_panels; filters?: Filter[] } = {};
+
+  if (overrideState.filters !== undefined) {
+    // Start with saved state for controls (not unsaved changes)
+    controlFilterOverrides.pinned_panels = lastSavedState?.pinned_panels;
+
+    // Apply any incoming filters to matching controls
+    if (overrideState.filters.length && lastSavedState?.pinned_panels?.length) {
+      const { updatedPinnedPanels, remainingFilters } = applyControlFiltersToPanels(
+        overrideState.filters as Filter[],
+        lastSavedState.pinned_panels
+      );
+      controlFilterOverrides.pinned_panels = updatedPinnedPanels;
+      controlFilterOverrides.filters = remainingFilters;
+    }
+  }
+
   const { api, cleanup, internalApi } = getDashboardApi({
     creationOptions,
     incomingEmbeddables,
     initialState: {
-      ...getLastSavedState(readResult),
+      ...lastSavedState,
       ...unsavedChanges,
       ...overrideState,
+      // Override with the merged values after applying control filters (only if we processed any)
+      ...controlFilterOverrides,
     },
     readResult,
     savedObjectId,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/apply_control_filters_to_panels.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/apply_control_filters_to_panels.test.ts
@@ -1,0 +1,583 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Filter } from '@kbn/es-query';
+import { FilterStateStore } from '@kbn/es-query';
+import { applyControlFiltersToPanels } from './apply_control_filters_to_panels';
+
+const DATA_VIEW_ID = '90943e30-9a47-11e8-b64d-95841ca0b247';
+const OTHER_DATA_VIEW_ID = 'other-data-view-id';
+
+// =============================================================================
+// FILTER FACTORIES
+// =============================================================================
+
+const createPhraseFilter = ({
+  key,
+  value,
+  index = DATA_VIEW_ID,
+  controlledBy,
+  pinned = false,
+}: {
+  key: string;
+  value: string | number;
+  index?: string;
+  controlledBy?: string;
+  pinned?: boolean;
+}): Filter => ({
+  meta: {
+    key,
+    index,
+    type: 'phrase',
+    ...(controlledBy && { controlledBy }),
+  },
+  query: {
+    match_phrase: {
+      [key]: value,
+    },
+  },
+  ...(pinned && { $state: { store: FilterStateStore.GLOBAL_STATE } }),
+});
+
+const createPhrasesFilter = ({
+  key,
+  values,
+  index = DATA_VIEW_ID,
+  controlledBy,
+}: {
+  key: string;
+  values: Array<string | number>;
+  index?: string;
+  controlledBy?: string;
+}): Filter => ({
+  meta: {
+    key,
+    index,
+    type: 'phrases',
+    params: values,
+    ...(controlledBy && { controlledBy }),
+  },
+  query: {
+    bool: {
+      should: values.map((v) => ({ match_phrase: { [key]: v } })),
+      minimum_should_match: 1,
+    },
+  },
+});
+
+const createExistsFilter = ({
+  key,
+  index = DATA_VIEW_ID,
+  controlledBy,
+  negate = false,
+}: {
+  key: string;
+  index?: string;
+  controlledBy?: string;
+  negate?: boolean;
+}): Filter => ({
+  meta: {
+    key,
+    index,
+    type: 'exists',
+    negate,
+    ...(controlledBy && { controlledBy }),
+  },
+  query: {
+    exists: {
+      field: key,
+    },
+  },
+});
+
+const createRangeFilter = ({
+  key,
+  gte,
+  lte,
+  index = DATA_VIEW_ID,
+  controlledBy,
+}: {
+  key: string;
+  gte?: number;
+  lte?: number;
+  index?: string;
+  controlledBy?: string;
+}): Filter => ({
+  meta: {
+    key,
+    index,
+    type: 'range',
+    params: { gte, lte },
+    ...(controlledBy && { controlledBy }),
+  },
+  query: {
+    range: {
+      [key]: { gte, lte },
+    },
+  },
+});
+
+// Filter without meta.type (like drill-down filters)
+const createDrilldownPhraseFilter = ({
+  key,
+  value,
+  index = DATA_VIEW_ID,
+}: {
+  key: string;
+  value: string | number;
+  index?: string;
+}): Filter => ({
+  meta: {
+    key,
+    index,
+  },
+  query: {
+    match_phrase: {
+      [key]: value,
+    },
+  },
+});
+
+const createDrilldownPhrasesFilter = ({
+  key,
+  values,
+  index = DATA_VIEW_ID,
+}: {
+  key: string;
+  values: Array<string | number>;
+  index?: string;
+}): Filter => ({
+  meta: {
+    key,
+    index,
+  },
+  query: {
+    bool: {
+      should: values.map((v) => ({ match_phrase: { [key]: v } })),
+      minimum_should_match: 1,
+    },
+  },
+});
+
+// =============================================================================
+// CONTROL PANEL FACTORIES
+// =============================================================================
+
+const createOptionsListPanel = ({
+  dataViewId = DATA_VIEW_ID,
+  fieldName,
+  selectedOptions,
+}: {
+  dataViewId?: string;
+  fieldName: string;
+  selectedOptions?: Array<string | number>;
+}) => ({
+  type: 'optionsListControl' as const,
+  config: {
+    dataViewId,
+    fieldName,
+    ...(selectedOptions && { selectedOptions }),
+  },
+});
+
+const createRangeSliderPanel = ({
+  dataViewId = DATA_VIEW_ID,
+  fieldName,
+  value,
+}: {
+  dataViewId?: string;
+  fieldName: string;
+  value?: [string, string];
+}) => ({
+  type: 'rangeSliderControl' as const,
+  config: {
+    dataViewId,
+    fieldName,
+    ...(value && { value }),
+  },
+});
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('applyControlFiltersToPanels', () => {
+  describe('edge cases', () => {
+    it('returns original values when filters is undefined', () => {
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+      const result = applyControlFiltersToPanels(undefined, panels);
+
+      expect(result.updatedPinnedPanels).toEqual(panels);
+      expect(result.remainingFilters).toBeUndefined();
+    });
+
+    it('returns original values when filters is empty', () => {
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+      const result = applyControlFiltersToPanels([], panels);
+
+      expect(result.updatedPinnedPanels).toEqual(panels);
+      expect(result.remainingFilters).toEqual([]);
+    });
+
+    it('returns original values when panels is undefined', () => {
+      const filters = [createPhraseFilter({ key: 'status', value: 'active' })];
+      const result = applyControlFiltersToPanels(filters, undefined);
+
+      expect(result.updatedPinnedPanels).toBeUndefined();
+      expect(result.remainingFilters).toEqual(filters);
+    });
+
+    it('returns original values when panels is empty', () => {
+      const filters = [createPhraseFilter({ key: 'status', value: 'active' })];
+      const result = applyControlFiltersToPanels(filters, []);
+
+      expect(result.updatedPinnedPanels).toEqual([]);
+      expect(result.remainingFilters).toEqual(filters);
+    });
+  });
+
+  describe('filter matching criteria', () => {
+    it('matches filter to control with same data view and field', () => {
+      const filters = [createPhraseFilter({ key: 'status', value: 'active' })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active'],
+      });
+      expect(result.remainingFilters).toBeUndefined();
+    });
+
+    it('does not match when data view differs', () => {
+      const filters = [
+        createPhraseFilter({ key: 'status', value: 'active', index: OTHER_DATA_VIEW_ID }),
+      ];
+      const panels = [createOptionsListPanel({ fieldName: 'status', dataViewId: DATA_VIEW_ID })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      // Panel unchanged, filter kept as pill
+      expect(result.updatedPinnedPanels?.[0].config).not.toHaveProperty('selectedOptions');
+      expect(result.remainingFilters).toHaveLength(1);
+    });
+
+    it('does not match when field name differs', () => {
+      const filters = [createPhraseFilter({ key: 'status', value: 'active' })];
+      const panels = [createOptionsListPanel({ fieldName: 'category' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).not.toHaveProperty('selectedOptions');
+      expect(result.remainingFilters).toHaveLength(1);
+    });
+  });
+
+  describe('filter type compatibility', () => {
+    it('matches phrase filter to options list control', () => {
+      const filters = [createPhraseFilter({ key: 'status', value: 'active' })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active'],
+      });
+    });
+
+    it('matches phrases filter to options list control', () => {
+      const filters = [createPhrasesFilter({ key: 'status', values: ['active', 'pending'] })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active', 'pending'],
+      });
+    });
+
+    it('matches exists filter to options list control', () => {
+      const filters = [createExistsFilter({ key: 'status' })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        existsSelected: true,
+      });
+    });
+
+    it('matches negated exists filter to options list control', () => {
+      const filters = [createExistsFilter({ key: 'status', negate: true })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        existsSelected: true,
+        exclude: true,
+      });
+    });
+
+    it('matches range filter to range slider control', () => {
+      const filters = [createRangeFilter({ key: 'price', gte: 10, lte: 100 })];
+      const panels = [createRangeSliderPanel({ fieldName: 'price' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        value: ['10', '100'],
+      });
+    });
+
+    it('does not match phrase filter to range slider control', () => {
+      const filters = [createPhraseFilter({ key: 'price', value: '50' })];
+      const panels = [createRangeSliderPanel({ fieldName: 'price' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).not.toHaveProperty('selectedOptions');
+      expect(result.remainingFilters).toHaveLength(1);
+    });
+
+    it('does not match range filter to options list control', () => {
+      const filters = [createRangeFilter({ key: 'status', gte: 1, lte: 5 })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).not.toHaveProperty('value');
+      expect(result.remainingFilters).toHaveLength(1);
+    });
+  });
+
+  describe('drill-down filters (no meta.type)', () => {
+    it('matches drill-down phrase filter by query structure', () => {
+      const filters = [createDrilldownPhraseFilter({ key: 'status', value: 'active' })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active'],
+      });
+      expect(result.remainingFilters).toBeUndefined();
+    });
+
+    it('matches drill-down phrases filter by query structure', () => {
+      const filters = [createDrilldownPhrasesFilter({ key: 'status', values: ['active', 'done'] })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active', 'done'],
+      });
+    });
+
+    it('keeps unmatched drill-down filter as pill', () => {
+      const filters = [createDrilldownPhraseFilter({ key: 'category', value: 'electronics' })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).not.toHaveProperty('selectedOptions');
+      expect(result.remainingFilters).toHaveLength(1);
+      expect(result.remainingFilters?.[0]).toEqual(filters[0]);
+    });
+  });
+
+  describe('pinned filters', () => {
+    it('keeps pinned filters as pills even when matching control exists', () => {
+      const filters = [createPhraseFilter({ key: 'status', value: 'active', pinned: true })];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      // Panel unchanged
+      expect(result.updatedPinnedPanels?.[0].config).not.toHaveProperty('selectedOptions');
+      // Filter kept as pill
+      expect(result.remainingFilters).toHaveLength(1);
+      expect(result.remainingFilters?.[0]).toEqual(filters[0]);
+    });
+  });
+
+  describe('control filters (with controlledBy)', () => {
+    it('applies matching control filter to control', () => {
+      const filters = [
+        createPhraseFilter({
+          key: 'status',
+          value: 'active',
+          controlledBy: 'some-control-id',
+        }),
+      ];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active'],
+      });
+      expect(result.remainingFilters).toBeUndefined();
+    });
+
+    it('removes unmatched control filter (does not keep as pill)', () => {
+      const filters = [
+        createPhraseFilter({
+          key: 'category',
+          value: 'electronics',
+          controlledBy: 'some-control-id',
+        }),
+      ];
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      // Panel unchanged
+      expect(result.updatedPinnedPanels?.[0].config).not.toHaveProperty('selectedOptions');
+      // Control filter removed, not kept as pill
+      expect(result.remainingFilters).toBeUndefined();
+    });
+  });
+
+  describe('mixed filter scenarios', () => {
+    it('handles mix of matching and non-matching filters correctly', () => {
+      const matchingControlFilter = createPhraseFilter({
+        key: 'status',
+        value: 'active',
+        controlledBy: 'ctrl-1',
+      });
+      const unmatchingControlFilter = createPhraseFilter({
+        key: 'region',
+        value: 'US',
+        controlledBy: 'ctrl-2',
+      });
+      const matchingDrilldownFilter = createDrilldownPhraseFilter({
+        key: 'category',
+        value: 'books',
+      });
+      const unmatchingDrilldownFilter = createDrilldownPhraseFilter({
+        key: 'brand',
+        value: 'acme',
+      });
+      const pinnedFilter = createPhraseFilter({
+        key: 'status',
+        value: 'closed',
+        pinned: true,
+      });
+
+      const filters = [
+        matchingControlFilter,
+        unmatchingControlFilter,
+        matchingDrilldownFilter,
+        unmatchingDrilldownFilter,
+        pinnedFilter,
+      ];
+      const panels = [
+        createOptionsListPanel({ fieldName: 'status' }),
+        createOptionsListPanel({ fieldName: 'category' }),
+      ];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      // Matching filters applied to controls
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active'],
+      });
+      expect(result.updatedPinnedPanels?.[1].config).toMatchObject({
+        selectedOptions: ['books'],
+      });
+
+      // Remaining filters should be:
+      // - pinnedFilter (always kept)
+      // - unmatchingDrilldownFilter (kept as pill)
+      // NOT: unmatchingControlFilter (removed)
+      expect(result.remainingFilters).toHaveLength(2);
+      expect(result.remainingFilters).toContainEqual(pinnedFilter);
+      expect(result.remainingFilters).toContainEqual(unmatchingDrilldownFilter);
+      expect(result.remainingFilters).not.toContainEqual(unmatchingControlFilter);
+    });
+
+    it('matches first compatible control when multiple exist', () => {
+      const filters = [createPhraseFilter({ key: 'status', value: 'active' })];
+      const panels = [
+        createOptionsListPanel({ fieldName: 'status' }),
+        createOptionsListPanel({ fieldName: 'status' }), // duplicate
+      ];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      // First panel gets the selection
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['active'],
+      });
+      // Second panel unchanged
+      expect(result.updatedPinnedPanels?.[1].config).not.toHaveProperty('selectedOptions');
+    });
+  });
+
+  describe('selection extraction', () => {
+    it('extracts numeric values correctly', () => {
+      const filters = [createPhrasesFilter({ key: 'count', values: [1, 2, 3] })];
+      const panels = [createOptionsListPanel({ fieldName: 'count' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: [1, 2, 3],
+      });
+    });
+
+    it('extracts partial range correctly (only gte)', () => {
+      const filters = [createRangeFilter({ key: 'price', gte: 10 })];
+      const panels = [createRangeSliderPanel({ fieldName: 'price' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        value: ['10', ''],
+      });
+    });
+
+    it('extracts partial range correctly (only lte)', () => {
+      const filters = [createRangeFilter({ key: 'price', lte: 100 })];
+      const panels = [createRangeSliderPanel({ fieldName: 'price' })];
+
+      const result = applyControlFiltersToPanels(filters, panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        value: ['', '100'],
+      });
+    });
+
+    it('preserves exclude flag from negated filter', () => {
+      const filter: Filter = {
+        meta: {
+          key: 'status',
+          index: DATA_VIEW_ID,
+          type: 'phrase',
+          negate: true,
+        },
+        query: {
+          match_phrase: {
+            status: 'inactive',
+          },
+        },
+      };
+      const panels = [createOptionsListPanel({ fieldName: 'status' })];
+
+      const result = applyControlFiltersToPanels([filter], panels);
+
+      expect(result.updatedPinnedPanels?.[0].config).toMatchObject({
+        selectedOptions: ['inactive'],
+        exclude: true,
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/apply_control_filters_to_panels.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/apply_control_filters_to_panels.ts
@@ -275,7 +275,7 @@ export function applyControlFiltersToPanels(
 
   // Track which filters successfully matched
   const matchedIndices = new Set<number>();
-  let updatedPanels = [...controlPanels];
+  const updatedPanels = [...controlPanels];
 
   // Try to match each filter to a control
   matchableFilters.forEach((filter, index) => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/apply_control_filters_to_panels.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/bwc/apply_control_filters_to_panels.ts
@@ -1,0 +1,307 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Filter, RangeFilterParams } from '@kbn/es-query';
+import { isFilterPinned } from '@kbn/es-query';
+import { OPTIONS_LIST_CONTROL, RANGE_SLIDER_CONTROL } from '@kbn/controls-constants';
+import type { DashboardState } from '../../../../common';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+type ControlPanel = NonNullable<DashboardState['pinned_panels']>[number];
+
+interface ControlConfig {
+  dataViewId?: string;
+  fieldName?: string;
+  selectedOptions?: Array<string | number>;
+  existsSelected?: boolean;
+  exclude?: boolean;
+  value?: [string, string]; // For range slider [min, max]
+}
+
+// =============================================================================
+// FILTER CLASSIFICATION
+// Determines how each filter type should be handled during navigation
+// =============================================================================
+
+/**
+ * Control filters have `controlledBy` set - they were created by a control on the source dashboard.
+ * These should be applied to matching controls, or REMOVED if no match (not kept as pills).
+ */
+const isControlFilter = (filter: Filter): boolean => {
+  return Boolean(filter.meta?.controlledBy);
+};
+
+/**
+ * Determines if a filter can potentially be matched to a control.
+ * Requires field name and data view info. Pinned filters are excluded since
+ * they must always persist as pills to avoid being lost on navigation.
+ */
+const canMatchToControl = (filter: Filter): boolean => {
+  if (isFilterPinned(filter)) return false;
+  return Boolean(filter.meta?.key && filter.meta?.index);
+};
+
+// =============================================================================
+// IDENTIFIER EXTRACTION
+// Extracts matching criteria from filters and controls
+// =============================================================================
+
+const getFilterFieldInfo = (filter: Filter) => ({
+  dataViewId: filter.meta?.index,
+  fieldName: filter.meta?.key,
+});
+
+const getControlFieldInfo = (panel: ControlPanel) => {
+  const config = panel.config as ControlConfig | undefined;
+  return {
+    dataViewId: config?.dataViewId,
+    fieldName: config?.fieldName,
+  };
+};
+
+// =============================================================================
+// MATCHING LOGIC
+// Determines if a filter can be applied to a specific control
+// =============================================================================
+
+/**
+ * Checks if filter and control have the same data view and field name
+ */
+const fieldInfoMatches = (filter: Filter, panel: ControlPanel): boolean => {
+  const filterInfo = getFilterFieldInfo(filter);
+  const controlInfo = getControlFieldInfo(panel);
+
+  if (!filterInfo.dataViewId || !filterInfo.fieldName) return false;
+  if (!controlInfo.dataViewId || !controlInfo.fieldName) return false;
+
+  return (
+    filterInfo.dataViewId === controlInfo.dataViewId &&
+    filterInfo.fieldName === controlInfo.fieldName
+  );
+};
+
+/**
+ * Checks if the filter type can be represented by the control type.
+ * We check both meta.type and query structure since meta.type isn't always set.
+ */
+const filterTypeCompatibleWithControl = (filter: Filter, panel: ControlPanel): boolean => {
+  const filterType = filter.meta?.type;
+
+  if (panel.type === OPTIONS_LIST_CONTROL) {
+    return (
+      filterType === 'phrase' ||
+      filterType === 'phrases' ||
+      filterType === 'exists' ||
+      Boolean(filter.query?.exists) ||
+      Boolean(filter.query?.match_phrase) ||
+      Boolean(filter.query?.bool?.should)
+    );
+  }
+
+  if (panel.type === RANGE_SLIDER_CONTROL) {
+    return filterType === 'range' || Boolean(filter.query?.range);
+  }
+
+  return false;
+};
+
+// =============================================================================
+// SELECTION EXTRACTION
+// Extracts the selected values from a filter to apply to a control
+// =============================================================================
+
+/**
+ * Extracts selection state from a filter for an options list control
+ */
+const extractOptionsListSelections = (
+  filter: Filter
+): { selectedOptions?: Array<string | number>; existsSelected?: boolean; exclude?: boolean } => {
+  const result: {
+    selectedOptions?: Array<string | number>;
+    existsSelected?: boolean;
+    exclude?: boolean;
+  } = {};
+
+  if (filter.meta?.negate) {
+    result.exclude = true;
+  }
+
+  // Exists filter
+  if (filter.query?.exists) {
+    result.existsSelected = true;
+    return result;
+  }
+
+  // Phrases filter (multiple values) - check meta.params first
+  if (filter.meta?.type === 'phrases' && Array.isArray(filter.meta?.params)) {
+    result.selectedOptions = filter.meta.params;
+    return result;
+  }
+
+  // Phrases filter via query structure (bool.should)
+  if (filter.query?.bool?.should && Array.isArray(filter.query.bool.should)) {
+    const values: Array<string | number> = [];
+    for (const clause of filter.query.bool.should) {
+      if (clause.match_phrase) {
+        const fieldName = Object.keys(clause.match_phrase)[0];
+        if (fieldName) {
+          values.push(clause.match_phrase[fieldName]);
+        }
+      }
+    }
+    if (values.length > 0) {
+      result.selectedOptions = values;
+      return result;
+    }
+  }
+
+  // Phrase filter (single value) - check query structure
+  if (filter.query?.match_phrase) {
+    const fieldName = filter.meta?.key ?? Object.keys(filter.query.match_phrase)[0];
+    if (fieldName && filter.query.match_phrase[fieldName] !== undefined) {
+      result.selectedOptions = [filter.query.match_phrase[fieldName]];
+      return result;
+    }
+  }
+
+  // Phrase filter via meta.params
+  if (filter.meta?.type === 'phrase' && filter.meta?.params) {
+    const params = filter.meta.params;
+    if (typeof params === 'object' && 'query' in params) {
+      result.selectedOptions = [(params as { query: string | number }).query];
+      return result;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Extracts range values from a filter for a range slider control
+ */
+const extractRangeSliderValues = (filter: Filter): { value?: [string, string] } => {
+  const params = filter.meta?.params as RangeFilterParams | undefined;
+  if (!params) return {};
+
+  const { gte, lte } = params;
+  const minValue = gte !== undefined && gte !== -Infinity ? String(gte) : '';
+  const maxValue = lte !== undefined && lte !== Infinity ? String(lte) : '';
+
+  if (minValue || maxValue) {
+    return { value: [minValue, maxValue] };
+  }
+
+  return {};
+};
+
+/**
+ * Applies filter selections to a control panel, returning the updated panel
+ */
+const applyFilterToControl = (filter: Filter, panel: ControlPanel): ControlPanel => {
+  const config = (panel.config ?? {}) as ControlConfig;
+
+  if (panel.type === OPTIONS_LIST_CONTROL) {
+    return {
+      ...panel,
+      config: { ...config, ...extractOptionsListSelections(filter) },
+    };
+  }
+
+  if (panel.type === RANGE_SLIDER_CONTROL) {
+    return {
+      ...panel,
+      config: { ...config, ...extractRangeSliderValues(filter) },
+    };
+  }
+
+  return panel;
+};
+
+// =============================================================================
+// MAIN EXPORT
+// =============================================================================
+
+/**
+ * Applies incoming navigation filters to matching controls on the destination dashboard.
+ *
+ * ## Filter Handling Rules
+ *
+ * | Filter Type          | Has Matching Control | No Matching Control |
+ * |----------------------|----------------------|---------------------|
+ * | Pinned filter        | Keep as pill         | Keep as pill        |
+ * | Control filter       | Apply to control     | REMOVE              |
+ * | Drill-down filter    | Apply to control     | Keep as pill        |
+ * | Regular filter pill  | Keep as pill         | Keep as pill        |
+ *
+ * ## Matching Criteria
+ * - Same data view ID
+ * - Same field name
+ * - Compatible filter type (phrase/phrases → options list, range → range slider)
+ */
+export function applyControlFiltersToPanels(
+  filters: Filter[] | undefined,
+  controlPanels: DashboardState['pinned_panels']
+): {
+  updatedPinnedPanels: DashboardState['pinned_panels'];
+  remainingFilters: Filter[] | undefined;
+} {
+  // Nothing to process
+  if (!filters?.length || !controlPanels?.length) {
+    return {
+      updatedPinnedPanels: controlPanels,
+      remainingFilters: filters,
+    };
+  }
+
+  // Separate filters that can potentially match controls from those that can't
+  const matchableFilters = filters.filter(canMatchToControl);
+  const unmatchableFilters = filters.filter((f) => !canMatchToControl(f));
+
+  if (!matchableFilters.length) {
+    return {
+      updatedPinnedPanels: controlPanels,
+      remainingFilters: filters,
+    };
+  }
+
+  // Track which filters successfully matched
+  const matchedIndices = new Set<number>();
+  let updatedPanels = [...controlPanels];
+
+  // Try to match each filter to a control
+  matchableFilters.forEach((filter, index) => {
+    const panelIndex = updatedPanels.findIndex(
+      (panel) => fieldInfoMatches(filter, panel) && filterTypeCompatibleWithControl(filter, panel)
+    );
+
+    if (panelIndex !== -1) {
+      updatedPanels[panelIndex] = applyFilterToControl(filter, updatedPanels[panelIndex]);
+      matchedIndices.add(index);
+    }
+  });
+
+  // Determine which unmatched filters to keep:
+  // - Control filters: remove (they shouldn't appear as pills)
+  // - Other filters (drill-down, etc.): keep as pills
+  const unmatchedFiltersToKeep = matchableFilters.filter((filter, index) => {
+    if (matchedIndices.has(index)) return false;
+    if (isControlFilter(filter)) return false; // Remove unmatched control filters
+    return true;
+  });
+
+  const remainingFilters = [...unmatchableFilters, ...unmatchedFiltersToKeep];
+
+  return {
+    updatedPinnedPanels: updatedPanels,
+    remainingFilters: remainingFilters.length ? remainingFilters : undefined,
+  };
+}


### PR DESCRIPTION


## Summary

Fixes an issue where control panel selections from one dashboard appear as filter pills when navigating to another dashboard with the same control. Now, matching control values are applied directly to the destination control.

Filter handling rules:

| Filter Type | Matching Control | No Match |
|------------|------------------|-----------|
| Control filter	| Apply to control | Remove |
| Drill-down filter | Apply to control | Keep as pill|
| Pinned filter	| Keep as pill | Keep as pill |

Matching criteria: Same data view ID + same field name + compatible filter type

![dashboard_controls](https://github.com/user-attachments/assets/2bbb506c-9c08-4152-b386-4c099363dde9)

Fixes #251481

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



