### PR TITLE
[9.2] use shared package registry docker config in dataset_quality tests

### DIFF
--- a/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
+++ b/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
@@ -13,8 +13,7 @@ import {
 } from '@kbn/dataset-quality-plugin/server/test_helpers/create_dataset_quality_users/authentication';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import type { FtrConfigProviderContext } from '@kbn/test';
-import { fleetPackageRegistryDockerImage, defineDockerServersConfig } from '@kbn/test';
-import path from 'path';
+import { packageRegistryDocker, defineDockerServersConfig } from '@kbn/test';
 import supertest from 'supertest';
 import type { UrlObject } from 'url';
 import { format } from 'url';
@@ -89,12 +88,9 @@ export function createTestConfig(
   const { license, name, kibanaConfig } = config;
 
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
-    const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
     const xPackAPITestsConfig = await readConfigFile(
       require.resolve('../../api_integration/config.ts')
     );
-
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
 
     const services = xPackAPITestsConfig.get('services');
     const servers = xPackAPITestsConfig.get('servers');
@@ -115,15 +111,7 @@ export function createTestConfig(
       testFiles: [require.resolve('../tests')],
       servers,
       dockerServers: defineDockerServersConfig({
-        registry: {
-          enabled: !!dockerRegistryPort,
-          image: fleetPackageRegistryDockerImage,
-          portInContainer: 8080,
-          port: dockerRegistryPort,
-          args: dockerArgs,
-          waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
-        },
+        registry: packageRegistryDocker,
       }),
       servicesRequiredForTestAnalysis: ['datasetQualityFtrConfig', 'registry'],
       services: {


### PR DESCRIPTION
## Summary
This PR aims to fix unwanted docker-pulls on the `docker.elastic.co/kibana-ci/package-registry-distribution:lite` image.

As a followup to https://github.com/elastic/kibana/pull/250040 - this PR uses the shared package-registry config in the dataset_quality tests too. This test config didn't receive the shared config because this test was not present in main, also it was never updated to use `preferCached=true`. 
