### PR TITLE
[Streams] Add unit tests for custom samples validation pattern

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/helpers.test.ts
@@ -5,10 +5,80 @@
  * 2.0.
  */
 
-import { shouldSuggestProcessorKey, detectProcessorContext } from './helpers';
+import { isSchema } from '@kbn/streams-schema';
+import { shouldSuggestProcessorKey, detectProcessorContext, deserializeJson } from './helpers';
+import { customSamplesDataSourceDocumentsSchema } from '../../../../common/url_schema';
 import type { monaco } from '@kbn/monaco';
 
 describe('helpers', () => {
+  describe('deserializeJson', () => {
+    it('returns parsed JSON for valid JSON input', () => {
+      const validJson = '[{"field": "value"}]';
+      const result = deserializeJson(validJson);
+      expect(result).toEqual([{ field: 'value' }]);
+    });
+
+    it('returns the raw string for invalid JSON input', () => {
+      const invalidJson = 'not valid json';
+      const result = deserializeJson(invalidJson);
+      expect(result).toBe('not valid json');
+    });
+
+    it('returns the raw string for incomplete JSON', () => {
+      const incompleteJson = '[{"field": "value"';
+      const result = deserializeJson(incompleteJson);
+      expect(result).toBe('[{"field": "value"');
+    });
+  });
+
+  /**
+   * These tests document the validation pattern used in custom_samples_data_source_card.tsx
+   * to ensure that invalid JSON from user editing never gets persisted to sessionStorage.
+   *
+   * The pattern: deserializeJson(value) + isSchema(customSamplesDataSourceDocumentsSchema, documents)
+   * - Invalid JSON causes deserializeJson to return a string
+   * - isSchema fails because the schema expects an array of objects, not a string
+   * - This prevents handleChange() from being called, so sessionStorage is never updated
+   */
+  describe('custom samples validation pattern', () => {
+    it('passes validation for valid JSON array of documents', () => {
+      const validInput = '[{"message": "test"}]';
+      const documents = deserializeJson(validInput);
+      expect(isSchema(customSamplesDataSourceDocumentsSchema, documents)).toBe(true);
+    });
+
+    it('fails validation when JSON is invalid - string returned by deserializeJson fails schema', () => {
+      const invalidJson = 'not valid json';
+      const documents = deserializeJson(invalidJson);
+      // deserializeJson returns the raw string for invalid JSON
+      expect(typeof documents).toBe('string');
+      // The schema expects an array, so validation fails
+      expect(isSchema(customSamplesDataSourceDocumentsSchema, documents)).toBe(false);
+    });
+
+    it('fails validation when JSON is incomplete', () => {
+      const incompleteJson = '[{"message": "test"';
+      const documents = deserializeJson(incompleteJson);
+      expect(typeof documents).toBe('string');
+      expect(isSchema(customSamplesDataSourceDocumentsSchema, documents)).toBe(false);
+    });
+
+    it('fails validation when JSON is valid but not an array', () => {
+      const validJsonButNotArray = '{"message": "test"}';
+      const documents = deserializeJson(validJsonButNotArray);
+      expect(typeof documents).toBe('object');
+      expect(Array.isArray(documents)).toBe(false);
+      expect(isSchema(customSamplesDataSourceDocumentsSchema, documents)).toBe(false);
+    });
+
+    it('fails validation when JSON is valid array but items are not objects', () => {
+      const validJsonButWrongShape = '["string1", "string2"]';
+      const documents = deserializeJson(validJsonButWrongShape);
+      expect(Array.isArray(documents)).toBe(true);
+      expect(isSchema(customSamplesDataSourceDocumentsSchema, documents)).toBe(false);
+    });
+  });
+
   describe('shouldSuggestProcessorKey', () => {
     it('returns true at start of key position', () => {
       const lineBefore = '  { "';


### PR DESCRIPTION
## Summary

This PR adds unit tests documenting the validation pattern used in `custom_samples_data_source_card.tsx` that prevents invalid JSON from being persisted to sessionStorage.

Related to #251875 - These tests confirm the analysis that the existing validation in `handleEditorChange` already prevents invalid JSON from being stored. The `safeParseSessionStorageItem` helper added in #251875 is a defensive measure for other potential corruption sources (browser storage issues, etc.), not for invalid user input.

### Tests added:

**`deserializeJson` function tests:**
- Returns parsed JSON for valid input
- Returns raw string for invalid JSON (parse errors)
- Returns raw string for incomplete JSON

**Custom samples validation pattern tests:**
- Passes validation for valid JSON array of documents
- Fails validation when JSON is invalid (string returned by deserializeJson fails schema)
- Fails validation when JSON is incomplete
- Fails validation when JSON is valid but not an array
- Fails validation when JSON is valid array but items are not objects

## Test plan

- [x] All new tests pass: `yarn test:jest x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/helpers.test.ts`

Made with [Cursor](https://cursor.com)