### PR TITLE
[Agent Builder] Fix ESQL test tool fails when the numerical value is ZERO

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/execute/test_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/execute/test_tools.tsx
@@ -232,7 +232,7 @@ const renderFormField = ({
               data-test-subj={`agentBuilderToolTestInput-${name}`}
               value={(value as number) ?? ''}
               type="number"
-              onChange={(e) => onChange(e.target.valueAsNumber || e.target.value)}
+              onChange={(e) => onChange(e.target.valueAsNumber ?? e.target.value)}
               placeholder={i18nMessages.inputPlaceholder(label)}
               fullWidth
             />


### PR DESCRIPTION
closes: https://github.com/elastic/search-team/issues/12843

## Summary
Query fails when trying to input "0" and a numeric value. The error happened because `0 ?? "0" => "0"`

### Checklist

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
### Identify risks


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->