### PR TITLE
[Agent Builder] [PoC] Semantic Metadata Layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,5 @@ src/platform/plugins/shared/console/packaging/react/translations
 
 # Batched commits marker, e.g.: from quick checks
 .collect_commits_marker
+claude.md
+.claude

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
@@ -28,6 +28,7 @@ export const platformCoreTools = {
   productDocumentation: platformCoreTool('product_documentation'),
   cases: platformCoreTool('cases'),
   integrationKnowledge: platformCoreTool('integration_knowledge'),
+  smlSearch: platformCoreTool('sml_search'),
   // Attachment tools
   attachmentRead: platformCoreTool('attachment_read'),
   attachmentUpdate: platformCoreTool('attachment_update'),
@@ -59,6 +60,7 @@ export const defaultAgentToolIds = [
   platformCoreTools.getIndexMapping,
   platformCoreTools.getDocumentById,
   platformCoreTools.getWorkflowExecutionStatus,
+  platformCoreTools.smlSearch,
 ];
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
@@ -29,6 +29,7 @@ export const platformCoreTools = {
   cases: platformCoreTool('cases'),
   integrationKnowledge: platformCoreTool('integration_knowledge'),
   smlSearch: platformCoreTool('sml_search'),
+  smlAttach: platformCoreTool('sml_attach'),
   // Attachment tools
   attachmentRead: platformCoreTool('attachment_read'),
   attachmentUpdate: platformCoreTool('attachment_update'),
@@ -61,6 +62,7 @@ export const defaultAgentToolIds = [
   platformCoreTools.getDocumentById,
   platformCoreTools.getWorkflowExecutionStatus,
   platformCoreTools.smlSearch,
+  platformCoreTools.smlAttach,
 ];
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
@@ -23,6 +23,8 @@ export type {
   SmlAttachmentListContext,
   SmlAttachmentListItem,
   SmlAttachmentPermissions,
+  SmlAttachmentSearchItem,
+  SmlAttachmentToAttachmentContext,
   SmlAttachmentTypeDefinition,
   SmlUpdateAction,
 } from './sml';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
@@ -20,6 +20,7 @@ export type {
   SmlAttachmentChunk,
   SmlAttachmentData,
   SmlAttachmentDataContext,
+  SmlAttachmentFromIdContext,
   SmlAttachmentListContext,
   SmlAttachmentListItem,
   SmlAttachmentPermissions,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
@@ -7,6 +7,8 @@
 
 export type {
   AttachmentTypeDefinition,
+  AttachmentFindQuery,
+  AttachmentFindResult,
   AttachmentRepresentation,
   TextAttachmentRepresentation,
   AttachmentValidationResult,
@@ -14,6 +16,16 @@ export type {
   AttachmentFormatContext,
   AttachmentResolveContext,
 } from './type_definition';
+export type {
+  SmlAttachmentChunk,
+  SmlAttachmentData,
+  SmlAttachmentDataContext,
+  SmlAttachmentListContext,
+  SmlAttachmentListItem,
+  SmlAttachmentPermissions,
+  SmlAttachmentTypeDefinition,
+  SmlUpdateAction,
+} from './sml';
 export type {
   AttachmentBoundedTool,
   BuiltinAttachmentBoundedTool,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/sml.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/sml.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/logging';
+import type { MaybePromise } from '@kbn/utility-types';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+
+export type SmlUpdateAction = 'create' | 'update' | 'delete';
+
+export interface SmlAttachmentListItem {
+  attachmentId: string;
+  attachmentType: string;
+  createdAt?: string;
+  updatedAt: string;
+  spaceId?: string;
+}
+
+export interface SmlAttachmentListContext {
+  esClient: ElasticsearchClient;
+  savedObjectsClient: SavedObjectsClientContract;
+  logger: Logger;
+}
+
+export interface SmlAttachmentChunk {
+  id?: string;
+  type: string;
+  title?: string;
+  fields?: string[];
+  indexPatterns?: string[];
+  tags?: string[];
+  content: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SmlAttachmentData {
+  chunks: SmlAttachmentChunk[];
+}
+
+export interface SmlAttachmentPermissions {
+  spaces: string[];
+}
+
+export interface SmlAttachmentDataContext {
+  request?: KibanaRequest;
+  savedObjectsClient: SavedObjectsClientContract;
+  spaceId: string;
+}
+
+export interface SmlAttachmentTypeDefinition<TType extends string = string, TContent = unknown> {
+  list: (context: SmlAttachmentListContext) => MaybePromise<SmlAttachmentListItem[]>;
+  fetchFrequency?: () => string;
+  getSmlData: (
+    attachment: Attachment<TType, TContent>,
+    context: SmlAttachmentDataContext
+  ) => MaybePromise<SmlAttachmentData>;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/sml.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/sml.ts
@@ -10,7 +10,7 @@ import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
 import type { MaybePromise } from '@kbn/utility-types';
-import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
 
 export type SmlUpdateAction = 'create' | 'update' | 'delete';
 
@@ -48,7 +48,22 @@ export interface SmlAttachmentPermissions {
   spaces: string[];
 }
 
+export interface SmlAttachmentSearchItem {
+  chunkId?: string;
+  attachmentId: string;
+  attachmentType: string;
+  title?: string;
+  content: string;
+  spaces?: string[];
+}
+
 export interface SmlAttachmentDataContext {
+  request?: KibanaRequest;
+  savedObjectsClient: SavedObjectsClientContract;
+  spaceId: string;
+}
+
+export interface SmlAttachmentToAttachmentContext {
   request?: KibanaRequest;
   savedObjectsClient: SavedObjectsClientContract;
   spaceId: string;
@@ -61,4 +76,8 @@ export interface SmlAttachmentTypeDefinition<TType extends string = string, TCon
     attachment: Attachment<TType, TContent>,
     context: SmlAttachmentDataContext
   ) => MaybePromise<SmlAttachmentData>;
+  toAttachment?: (
+    item: SmlAttachmentSearchItem,
+    context: SmlAttachmentToAttachmentContext
+  ) => MaybePromise<AttachmentInput<TType, TContent> | null>;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/sml.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/sml.ts
@@ -48,6 +48,13 @@ export interface SmlAttachmentPermissions {
   spaces: string[];
 }
 
+export interface SmlAttachmentFromIdContext {
+  esClient: ElasticsearchClient;
+  savedObjectsClient: SavedObjectsClientContract;
+  spaceId: string;
+  request?: KibanaRequest;
+}
+
 export interface SmlAttachmentSearchItem {
   chunkId?: string;
   attachmentId: string;
@@ -72,6 +79,10 @@ export interface SmlAttachmentToAttachmentContext {
 export interface SmlAttachmentTypeDefinition<TType extends string = string, TContent = unknown> {
   list: (context: SmlAttachmentListContext) => MaybePromise<SmlAttachmentListItem[]>;
   fetchFrequency?: () => string;
+  toAttachmentFromId?: (
+    attachmentId: string,
+    context: SmlAttachmentFromIdContext
+  ) => MaybePromise<Attachment<TType, TContent> | null>;
   getSmlData: (
     attachment: Attachment<TType, TContent>,
     context: SmlAttachmentDataContext

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts
@@ -10,6 +10,7 @@ import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import type { AttachmentBoundedTool } from './tools';
+import type { SmlAttachmentTypeDefinition } from './sml';
 
 /**
  * Server-side definition of an attachment type.
@@ -62,6 +63,17 @@ export interface AttachmentTypeDefinition<TType extends string = string, TConten
    * Whether attachments of this type are read-only. Defaults to true.
    */
   isReadonly?: boolean;
+  /**
+   * Optional search hook for by-reference attachments (e.g., saved objects).
+   */
+  find?: (
+    query: AttachmentFindQuery,
+    context: AttachmentResolveContext
+  ) => MaybePromise<AttachmentFindResult<TType, TContent>[]>;
+  /**
+   * Optional SML capabilities for indexing attachments into the semantic metadata layer.
+   */
+  sml?: SmlAttachmentTypeDefinition<TType, TContent>;
 }
 
 /**
@@ -81,6 +93,20 @@ export interface AttachmentResolveContext extends AttachmentFormatContext {
    * Optional to keep the core attachment contract generic and allow non-Kibana environments.
    */
   savedObjectsClient?: SavedObjectsClientContract;
+}
+
+export interface AttachmentFindQuery {
+  search?: string;
+  page?: number;
+  perPage?: number;
+}
+
+export interface AttachmentFindResult<TType extends string = string, TContent = unknown> {
+  id: string;
+  type: TType;
+  title: string;
+  description?: string;
+  data: TContent;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/sml.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SmlUpdateAction } from '@kbn/agent-builder-server/attachments';
+
+export interface SmlIndexerRequestBody {
+  attachment_type: string;
+  attachment_id: string;
+  action: SmlUpdateAction;
+  space_id?: string;
+}
+
+export interface SmlIndexerResponse {
+  ack: boolean;
+}
+
+export interface SmlSearchRequestQuery {
+  query: string;
+  size?: number;
+}
+
+export interface SmlSearchResult {
+  chunk_id: string;
+  attachment_id: string;
+  attachment_type: string;
+  type: string;
+  title?: string;
+  content: string;
+  spaces: string[];
+}
+
+export interface SmlSearchResponse {
+  results: SmlSearchResult[];
+  total: number;
+}

--- a/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
@@ -25,6 +25,7 @@
       "lens",
       "licensing",
       "management",
+      "taskManager",
       "share",
       "spaces",
       "stackConnectors",

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -24,6 +24,7 @@ import { getRunAgentStepDefinition } from './step_types';
 import type { AgentBuilderHandlerContext } from './request_handler_context';
 import { registerAgentBuilderHandlerContext } from './request_handler_context';
 import { createSmlSearchTool } from './services/tools/builtin/sml/sml_search';
+import { createSmlAttachTool } from './services/tools/builtin/sml/sml_attach';
 import { registerSmlCrawlerTask } from './services/sml/task';
 import { createAgentBuilderUsageCounter } from './telemetry/usage_counters';
 import { TrackingService } from './telemetry/tracking_service';
@@ -87,6 +88,11 @@ export class AgentBuilderPlugin
     serviceSetups.tools.register(
       createSmlSearchTool({
         getSmlService: () => this.serviceManager.internalStart?.sml,
+      })
+    );
+    serviceSetups.tools.register(
+      createSmlAttachTool({
+        getAttachmentsService: () => this.serviceManager.internalStart?.attachments,
       })
     );
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -23,6 +23,7 @@ import { registerUISettings } from './ui_settings';
 import { getRunAgentStepDefinition } from './step_types';
 import type { AgentBuilderHandlerContext } from './request_handler_context';
 import { registerAgentBuilderHandlerContext } from './request_handler_context';
+import { getCurrentSpaceId } from './utils/spaces';
 import { createSmlSearchTool } from './services/tools/builtin/sml/sml_search';
 import { createSmlAttachTool } from './services/tools/builtin/sml/sml_attach';
 import { registerSmlCrawlerTask } from './services/sml/task';
@@ -173,6 +174,17 @@ export class AgentBuilderPlugin
       tools: {
         getRegistry: ({ request }) => tools.getRegistry({ request }),
         execute: runner.runTool.bind(runner),
+      },
+      sml: {
+        indexAttachment: async ({ request, attachmentId, attachmentType, action, spaceId }) => {
+          const resolvedSpaceId = spaceId ?? getCurrentSpaceId({ request, spaces });
+          await startServices.sml.indexAttachment({
+            attachmentId,
+            attachmentType,
+            action,
+            spaceId: resolvedSpaceId,
+          });
+        },
       },
     };
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
@@ -16,6 +16,7 @@ import { registerConversationRoutes } from './conversations';
 import { registerAttachmentRoutes } from './attachments';
 import { registerMCPRoutes } from './mcp';
 import { registerA2ARoutes } from './a2a';
+import { registerSmlRoutes } from './sml';
 
 export const registerRoutes = (dependencies: RouteDependencies) => {
   registerToolsRoutes(dependencies);
@@ -28,4 +29,5 @@ export const registerRoutes = (dependencies: RouteDependencies) => {
   registerAttachmentRoutes(dependencies);
   registerMCPRoutes(dependencies);
   registerA2ARoutes(dependencies);
+  registerSmlRoutes(dependencies);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/sml.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { RouteDependencies } from './types';
+import { getHandlerWrapper } from './wrap_handler';
+import { apiPrivileges } from '../../common/features';
+import { internalApiPath, publicApiPath } from '../../common/constants';
+import type { SmlIndexerResponse, SmlSearchResponse } from '../../common/http_api/sml';
+
+export function registerSmlRoutes({ router, getInternalServices, logger }: RouteDependencies) {
+  const wrapHandler = getHandlerWrapper({ logger });
+
+  router.post(
+    {
+      path: `${internalApiPath}/sml/indexer`,
+      validate: {
+        body: schema.object({
+          attachment_type: schema.string(),
+          attachment_id: schema.string(),
+          action: schema.oneOf([
+            schema.literal('create'),
+            schema.literal('update'),
+            schema.literal('delete'),
+          ]),
+          space_id: schema.maybe(schema.string()),
+        }),
+      },
+      options: { access: 'internal' },
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.manageAgentBuilder] },
+      },
+    },
+    wrapHandler(async (ctx, request, response) => {
+      const { sml } = getInternalServices();
+      const {
+        attachment_id: attachmentId,
+        attachment_type: attachmentType,
+        action,
+        space_id,
+      } = request.body;
+
+      const currentSpace = (await ctx.agentBuilder).spaces.getSpaceId();
+      const spaceId = space_id ?? currentSpace;
+
+      await sml.indexAttachment({ attachmentId, attachmentType, action, spaceId });
+
+      return response.ok<SmlIndexerResponse>({
+        body: { ack: true },
+      });
+    })
+  );
+
+  router.versioned
+    .get({
+      path: `${publicApiPath}/_sml`,
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.readAgentBuilder] },
+      },
+      access: 'public',
+      summary: 'Search the semantic metadata layer',
+      description: 'Search the semantic metadata layer for attachments with permission checks.',
+      options: {
+        tags: ['sml', 'attachment', 'oas-tag:agent builder'],
+        availability: {
+          stability: 'experimental',
+          since: '9.3.0',
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            query: schema.object({
+              query: schema.string(),
+              size: schema.maybe(schema.number({ min: 1, max: 100 })),
+            }),
+          },
+        },
+      },
+      wrapHandler(async (ctx, request, response) => {
+        const { sml } = getInternalServices();
+        const currentSpace = (await ctx.agentBuilder).spaces.getSpaceId();
+
+        const { results, total } = await sml.search({
+          request,
+          query: request.query.query,
+          size: request.query.size,
+          spaceId: currentSpace,
+        });
+
+        return response.ok<SmlSearchResponse>({
+          body: {
+            results: results.map((result) => ({
+              chunk_id: result.chunkId,
+              attachment_id: result.attachmentId,
+              attachment_type: result.attachmentType,
+              type: result.type,
+              title: result.title,
+              content: result.content,
+              spaces: result.spaces,
+            })),
+            total,
+          },
+        });
+      })
+    );
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
@@ -42,6 +42,9 @@ export class AttachmentServiceImpl implements AttachmentService {
       getTypeDefinition: (attachment) => {
         return this.attachmentTypeRegistry.get(attachment);
       },
+      listTypeDefinitions: () => {
+        return this.attachmentTypeRegistry.list();
+      },
     };
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
@@ -18,4 +18,5 @@ export interface AttachmentServiceStart {
     attachment: AttachmentInput<Type, Data>
   ): Promise<ValidateAttachmentResult<Type, Data>>;
   getTypeDefinition(type: string): AttachmentTypeDefinition | undefined;
+  listTypeDefinitions(): AttachmentTypeDefinition[];
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/attachment_lookup.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/attachment_lookup.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Attachment, VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { getLatestVersion, isAttachmentActive } from '@kbn/agent-builder-common/attachments';
+import { conversationIndexName } from '../conversation/client/storage';
+import { createSpaceDslFilter } from '../../utils/spaces';
+
+export const resolveAttachmentForSpace = async ({
+  esClient,
+  attachmentId,
+  attachmentType,
+  spaceId,
+}: {
+  esClient: ElasticsearchClient;
+  attachmentId: string;
+  attachmentType: string;
+  spaceId: string;
+}): Promise<Attachment | undefined> => {
+  const response = await esClient.search<{
+    attachments?: VersionedAttachment[];
+  }>({
+    index: conversationIndexName,
+    size: 1,
+    _source: ['attachments'],
+    query: {
+      bool: {
+        filter: [
+          createSpaceDslFilter(spaceId),
+          { term: { 'attachments.id': attachmentId } },
+          { term: { 'attachments.type': attachmentType } },
+        ],
+      },
+    },
+  });
+
+  const hit = response.hits.hits[0]?._source;
+  if (!hit?.attachments) {
+    return undefined;
+  }
+
+  const attachment = hit.attachments.find(
+    (candidate) => candidate.id === attachmentId && candidate.type === attachmentType
+  );
+  if (!attachment || !isAttachmentActive(attachment)) {
+    return undefined;
+  }
+
+  const latestVersion = getLatestVersion(attachment);
+  if (!latestVersion) {
+    return undefined;
+  }
+
+  return {
+    id: attachment.id,
+    type: attachment.type,
+    data: latestVersion.data as Record<string, unknown>,
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/attachment_lookup.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/attachment_lookup.ts
@@ -6,48 +6,22 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import type { Attachment, VersionedAttachment } from '@kbn/agent-builder-common/attachments';
-import {
-  AttachmentType,
-  getLatestVersion,
-  isAttachmentActive,
-} from '@kbn/agent-builder-common/attachments';
+import { getLatestVersion, isAttachmentActive } from '@kbn/agent-builder-common/attachments';
 import { conversationIndexName } from '../conversation/client/storage';
 import { createSpaceDslFilter } from '../../utils/spaces';
 
 export const resolveAttachmentForSpace = async ({
   esClient,
-  savedObjectsClient,
   attachmentId,
   attachmentType,
   spaceId,
 }: {
   esClient: ElasticsearchClient;
-  savedObjectsClient?: SavedObjectsClientContract;
   attachmentId: string;
   attachmentType: string;
   spaceId: string;
 }): Promise<Attachment | undefined> => {
-  if (attachmentType === AttachmentType.visualizationRef && savedObjectsClient) {
-    const scopedClient = savedObjectsClient.asScopedToNamespace(spaceId);
-    const savedObject = await scopedClient.get('lens', attachmentId);
-    const attributes = savedObject.attributes as Record<string, unknown>;
-    const title = typeof attributes.title === 'string' ? attributes.title : undefined;
-    const description =
-      typeof attributes.description === 'string' ? attributes.description : undefined;
-
-    return {
-      id: attachmentId,
-      type: attachmentType,
-      data: {
-        saved_object_id: attachmentId,
-        ...(title ? { title } : {}),
-        ...(description ? { description } : {}),
-      },
-    };
-  }
-
   const response = await esClient.search<{
     attachments?: VersionedAttachment[];
   }>({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/constants.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const smlIndexAlias = '.sml-attachments';
+export const smlWriteAlias = '.sml-attachments-write';
+export const smlIndexPrefix = '.sml-attachments-';
+export const smlCrawlerStateIndex = '.sml-crawler-state';
+
+export const smlDefaultFetchInterval = '10m';
+export const smlSearchDefaultSize = 25;
+export const smlCrawlerTaskType = 'agent_builder:sml_crawler';
+export const smlTaskScope = ['agent_builder'];

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/constants.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-export const smlIndexAlias = '.sml-attachments';
-export const smlWriteAlias = '.sml-attachments-write';
-export const smlIndexPrefix = '.sml-attachments-';
-export const smlCrawlerStateIndex = '.sml-crawler-state';
+import { chatSystemIndex } from '@kbn/agent-builder-server';
+
+export const smlIndexAlias = chatSystemIndex('sml-attachments');
+export const smlWriteAlias = chatSystemIndex('sml-attachments-write');
+export const smlIndexPrefix = chatSystemIndex('sml-attachments-');
+export const smlCrawlerStateIndex = chatSystemIndex('sml-crawler-state');
 
 export const smlDefaultFetchInterval = '10m';
 export const smlSearchDefaultSize = 25;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_service.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type { Logger } from '@kbn/logging';
+import { SmlCrawlerService } from './crawler_service';
+
+const createLogger = (): Logger =>
+  ({
+    debug: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logger);
+
+describe('SmlCrawlerService', () => {
+  it('indexes new attachments', async () => {
+    const list = jest
+      .fn()
+      .mockResolvedValue([
+        { attachmentId: 'a1', attachmentType: 'text', updatedAt: '2025-01-01T00:00:00Z' },
+      ]);
+    const definition = {
+      id: 'text',
+      sml: {
+        list,
+      },
+    } as unknown as AttachmentTypeDefinition;
+
+    const indexer = { indexAttachment: jest.fn().mockResolvedValue(undefined) };
+    const crawlerState = {
+      listByType: jest.fn().mockResolvedValue([]),
+      upsert: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const crawler = new SmlCrawlerService({
+      esClient: {} as any,
+      savedObjectsClient: {} as any,
+      attachmentsService: {
+        listTypeDefinitions: () => [definition],
+      } as any,
+      logger: createLogger(),
+      crawlerState: crawlerState as any,
+      indexerService: indexer as any,
+    });
+
+    await crawler.crawlAttachmentType('text');
+
+    expect(indexer.indexAttachment).toHaveBeenCalledWith({
+      attachmentId: 'a1',
+      attachmentType: 'text',
+      action: 'create',
+      spaceId: 'default',
+    });
+  });
+
+  it('deletes missing attachments', async () => {
+    const definition = {
+      id: 'text',
+      sml: {
+        list: jest.fn().mockResolvedValue([]),
+      },
+    } as unknown as AttachmentTypeDefinition;
+
+    const indexer = { indexAttachment: jest.fn().mockResolvedValue(undefined) };
+    const crawlerState = {
+      listByType: jest.fn().mockResolvedValue([
+        {
+          id: 'text:a1:default',
+          attachment_id: 'a1',
+          attachment_type: 'text',
+          space_id: 'default',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          update_action: null,
+        },
+      ]),
+      upsert: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const crawler = new SmlCrawlerService({
+      esClient: {} as any,
+      savedObjectsClient: {} as any,
+      attachmentsService: {
+        listTypeDefinitions: () => [definition],
+      } as any,
+      logger: createLogger(),
+      crawlerState: crawlerState as any,
+      indexerService: indexer as any,
+    });
+
+    await crawler.crawlAttachmentType('text');
+
+    expect(indexer.indexAttachment).toHaveBeenCalledWith({
+      attachmentId: 'a1',
+      attachmentType: 'text',
+      action: 'delete',
+      spaceId: 'default',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_service.ts
@@ -35,11 +35,15 @@ export class SmlCrawlerService {
 
     await this.deps.crawlerState.ensureIndex();
 
+    this.deps.logger.debug(`SML crawler listing attachments for "${attachmentType}"`);
     const listItems = await smlDefinition.list({
       esClient: this.deps.esClient,
       savedObjectsClient: this.deps.savedObjectsClient,
       logger: this.deps.logger,
     });
+    this.deps.logger.error(
+      `SML crawler found ${listItems.length} attachment candidates for "${attachmentType}"`
+    );
 
     const stateItems = await this.deps.crawlerState.listByType(attachmentType);
     const stateById = new Map(stateItems.map((item) => [item.id, item]));

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_service.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/logging';
+import type { SmlAttachmentListItem, SmlUpdateAction } from '@kbn/agent-builder-server/attachments';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-utils';
+import type { AttachmentServiceStart } from '../attachments';
+import type { CrawlerStateItem, CrawlerStateService } from './crawler_state_service';
+import type { SmlIndexerService } from './indexer_service';
+
+interface SmlCrawlerDeps {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  savedObjectsClient: SavedObjectsClientContract;
+  crawlerState: CrawlerStateService;
+  indexerService: SmlIndexerService;
+  attachmentsService: AttachmentServiceStart;
+}
+
+export class SmlCrawlerService {
+  constructor(private readonly deps: SmlCrawlerDeps) {}
+
+  async crawlAttachmentType(attachmentType: string): Promise<void> {
+    const definition = this.deps.attachmentsService.getTypeDefinition(attachmentType);
+    const smlDefinition = definition?.sml;
+    if (!smlDefinition) {
+      return;
+    }
+
+    await this.deps.crawlerState.ensureIndex();
+
+    const listItems = await smlDefinition.list({
+      esClient: this.deps.esClient,
+      savedObjectsClient: this.deps.savedObjectsClient,
+      logger: this.deps.logger,
+    });
+
+    const stateItems = await this.deps.crawlerState.listByType(attachmentType);
+    const stateById = new Map(stateItems.map((item) => [item.id, item]));
+
+    const seenIds = new Set<string>();
+    for (const listItem of listItems) {
+      const stateId = buildCrawlerStateId(listItem);
+      seenIds.add(stateId);
+
+      const updatedAt = listItem.updatedAt ?? new Date().toISOString();
+      const existing = stateById.get(stateId);
+      if (!existing) {
+        await this.deps.crawlerState.upsert({
+          id: stateId,
+          attachment_id: listItem.attachmentId,
+          attachment_type: listItem.attachmentType,
+          space_id: listItem.spaceId,
+          created_at: listItem.createdAt ?? updatedAt,
+          updated_at: updatedAt,
+          update_action: 'create',
+        });
+        continue;
+      }
+
+      if (updatedAt > existing.updated_at) {
+        await this.deps.crawlerState.upsert({
+          ...existing,
+          updated_at: updatedAt,
+          update_action: 'update',
+        });
+      }
+    }
+
+    for (const item of stateItems) {
+      if (!seenIds.has(item.id) && item.update_action !== 'delete') {
+        await this.deps.crawlerState.setUpdateAction(item.id, 'delete');
+      }
+    }
+
+    const queued = await this.deps.crawlerState.listQueued();
+    for (const item of queued) {
+      if (item.attachment_type !== attachmentType || !item.update_action) {
+        continue;
+      }
+
+      await this.processQueueItem(item, item.update_action);
+    }
+  }
+
+  private async processQueueItem(item: CrawlerStateItem, action: SmlUpdateAction): Promise<void> {
+    const spaceId = item.space_id ?? DEFAULT_SPACE_ID;
+
+    await this.deps.indexerService.indexAttachment({
+      attachmentId: item.attachment_id,
+      attachmentType: item.attachment_type,
+      action,
+      spaceId,
+    });
+
+    if (action === 'delete') {
+      await this.deps.crawlerState.delete(item.id);
+    } else {
+      await this.deps.crawlerState.clearUpdateAction(item.id);
+    }
+  }
+}
+
+const buildCrawlerStateId = (item: SmlAttachmentListItem): string => {
+  const spaceId = item.spaceId ?? DEFAULT_SPACE_ID;
+  return `${item.attachmentType}:${item.attachmentId}:${spaceId}`;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_state_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/crawler_state_service.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+import type { SmlUpdateAction } from '@kbn/agent-builder-server/attachments';
+import { smlCrawlerStateIndex } from './constants';
+import { smlCrawlerStateMappings } from './mappings';
+
+export interface CrawlerStateItem {
+  id: string;
+  attachment_id: string;
+  attachment_type: string;
+  space_id?: string;
+  created_at: string;
+  updated_at: string;
+  update_action?: SmlUpdateAction | null;
+}
+
+export class CrawlerStateService {
+  constructor(private readonly esClient: ElasticsearchClient, private readonly logger: Logger) {}
+
+  async ensureIndex(): Promise<void> {
+    const exists = await this.esClient.indices.exists({ index: smlCrawlerStateIndex });
+    if (exists) {
+      return;
+    }
+
+    this.logger.debug(`Creating crawler state index "${smlCrawlerStateIndex}"`);
+    await this.esClient.indices.create({
+      index: smlCrawlerStateIndex,
+      settings: {
+        auto_expand_replicas: '0-1',
+        hidden: true,
+      },
+      mappings: smlCrawlerStateMappings,
+    });
+  }
+
+  async resetIndex(): Promise<void> {
+    const exists = await this.esClient.indices.exists({ index: smlCrawlerStateIndex });
+    if (exists) {
+      await this.esClient.indices.delete({ index: smlCrawlerStateIndex });
+    }
+    await this.ensureIndex();
+  }
+
+  async listByType(attachmentType: string): Promise<CrawlerStateItem[]> {
+    const results: CrawlerStateItem[] = [];
+    let searchAfter: unknown[] | undefined;
+
+    while (true) {
+      const response = await this.esClient.search<CrawlerStateItem>({
+        index: smlCrawlerStateIndex,
+        size: 1000,
+        sort: [{ updated_at: 'asc' }, { id: 'asc' }],
+        search_after: searchAfter,
+        query: {
+          bool: {
+            filter: [{ term: { attachment_type: attachmentType } }],
+          },
+        },
+      });
+
+      const hits = response.hits.hits;
+      if (hits.length === 0) {
+        break;
+      }
+
+      for (const hit of hits) {
+        if (hit._source) {
+          results.push(hit._source);
+        }
+      }
+
+      searchAfter = hits[hits.length - 1].sort;
+    }
+
+    return results;
+  }
+
+  async listQueued(): Promise<CrawlerStateItem[]> {
+    const results: CrawlerStateItem[] = [];
+    let searchAfter: unknown[] | undefined;
+
+    while (true) {
+      const response = await this.esClient.search<CrawlerStateItem>({
+        index: smlCrawlerStateIndex,
+        size: 1000,
+        sort: [{ updated_at: 'asc' }, { id: 'asc' }],
+        search_after: searchAfter,
+        query: {
+          bool: {
+            filter: [{ exists: { field: 'update_action' } }],
+          },
+        },
+      });
+
+      const hits = response.hits.hits;
+      if (hits.length === 0) {
+        break;
+      }
+
+      for (const hit of hits) {
+        if (hit._source) {
+          results.push(hit._source);
+        }
+      }
+
+      searchAfter = hits[hits.length - 1].sort;
+    }
+
+    return results;
+  }
+
+  async upsert(item: CrawlerStateItem): Promise<void> {
+    await this.esClient.index({
+      index: smlCrawlerStateIndex,
+      id: item.id,
+      document: item,
+      refresh: false,
+    });
+  }
+
+  async setUpdateAction(id: string, action: SmlUpdateAction): Promise<void> {
+    await this.esClient.update({
+      index: smlCrawlerStateIndex,
+      id,
+      doc: {
+        update_action: action,
+      },
+      doc_as_upsert: false,
+    });
+  }
+
+  async clearUpdateAction(id: string): Promise<void> {
+    await this.esClient.update({
+      index: smlCrawlerStateIndex,
+      id,
+      doc: {
+        update_action: null,
+      },
+      doc_as_upsert: false,
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.esClient.delete({
+      index: smlCrawlerStateIndex,
+      id,
+      refresh: false,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { SmlIndexerService } from './indexer_service';
+export { CrawlerStateService } from './crawler_state_service';
+export { SmlCrawlerService } from './crawler_service';
+export { SmlIndexManager } from './index_manager';
+export { SmlService } from './sml_service';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/index_manager.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/index_manager.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+import { smlIndexAlias, smlIndexPrefix, smlWriteAlias } from './constants';
+import { getSmlIndexMappings } from './mappings';
+import { pickEmbeddingInferenceId } from './utils';
+import type { CrawlerStateService } from './crawler_state_service';
+
+const isMappingCompatible = (
+  currentMappings: Record<string, unknown>,
+  expectedMappings: Record<string, unknown>
+): boolean => {
+  const currentProps =
+    (currentMappings as { properties?: Record<string, unknown> }).properties ?? {};
+  const expectedProps =
+    (expectedMappings as { properties?: Record<string, unknown> }).properties ?? {};
+
+  return Object.keys(expectedProps).every((key) => {
+    const current = currentProps[key] as { type?: string } | undefined;
+    const expected = expectedProps[key] as { type?: string } | undefined;
+    return current?.type === expected?.type;
+  });
+};
+
+export class SmlIndexManager {
+  constructor(
+    private readonly esClient: ElasticsearchClient,
+    private readonly logger: Logger,
+    private readonly crawlerState: CrawlerStateService
+  ) {}
+
+  async ensureIndex(): Promise<{ indexName: string; inferenceId: string }> {
+    const inferenceId = await pickEmbeddingInferenceId({
+      esClient: this.esClient,
+      logger: this.logger,
+    });
+    const mappings = getSmlIndexMappings(inferenceId);
+
+    const aliasExists = await this.esClient.indices.existsAlias({ name: smlIndexAlias });
+    if (!aliasExists) {
+      const indexName = `${smlIndexPrefix}${Date.now()}`;
+      await this.createIndex(indexName, mappings);
+      await this.esClient.indices.updateAliases({
+        actions: [
+          { add: { index: indexName, alias: smlIndexAlias } },
+          { add: { index: indexName, alias: smlWriteAlias, is_write_index: true } },
+        ],
+      });
+
+      return { indexName, inferenceId };
+    }
+
+    const aliasInfo = await this.esClient.indices.getAlias({ name: smlIndexAlias });
+    const indexName = Object.keys(aliasInfo)[0];
+
+    const currentMappingsResponse = await this.esClient.indices.getMapping({ index: indexName });
+    const currentMappings = currentMappingsResponse[indexName]?.mappings ?? {};
+
+    if (!isMappingCompatible(currentMappings, mappings)) {
+      this.logger.warn(
+        `SML mappings incompatible for "${indexName}". Creating a fresh index and resetting crawler state.`
+      );
+      const newIndexName = `${smlIndexPrefix}${Date.now()}`;
+      await this.createIndex(newIndexName, mappings);
+      await this.esClient.indices.updateAliases({
+        actions: [
+          { remove: { index: indexName, alias: smlIndexAlias } },
+          { remove: { index: indexName, alias: smlWriteAlias } },
+          { add: { index: newIndexName, alias: smlIndexAlias } },
+          { add: { index: newIndexName, alias: smlWriteAlias, is_write_index: true } },
+        ],
+      });
+      await this.crawlerState.resetIndex();
+      return { indexName: newIndexName, inferenceId };
+    }
+
+    return { indexName, inferenceId };
+  }
+
+  private async createIndex(indexName: string, mappings: Record<string, unknown>): Promise<void> {
+    this.logger.debug(`Creating SML index "${indexName}"`);
+    await this.esClient.indices.create({
+      index: indexName,
+      settings: {
+        auto_expand_replicas: '0-1',
+        hidden: true,
+      },
+      mappings,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/indexer_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/indexer_service.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/logging';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { SmlAttachmentChunk, SmlUpdateAction } from '@kbn/agent-builder-server/attachments';
+import { smlIndexAlias, smlWriteAlias } from './constants';
+import type { AttachmentServiceStart } from '../attachments';
+import { resolveAttachmentForSpace } from './attachment_lookup';
+
+export interface IndexerRequest {
+  attachmentId: string;
+  attachmentType: string;
+  action: SmlUpdateAction;
+  spaceId: string;
+}
+
+interface IndexerDeps {
+  esClient: ElasticsearchClient;
+  savedObjectsClient: SavedObjectsClientContract;
+  attachmentsService: AttachmentServiceStart;
+  logger: Logger;
+}
+
+export class SmlIndexerService {
+  constructor(private readonly deps: IndexerDeps) {}
+
+  async indexAttachment({ attachmentId, attachmentType, action, spaceId }: IndexerRequest) {
+    if (action === 'delete') {
+      await this.deleteAttachmentDocs({ attachmentId, attachmentType, spaceId });
+      return;
+    }
+
+    const attachment = await resolveAttachmentForSpace({
+      esClient: this.deps.esClient,
+      attachmentId,
+      attachmentType,
+      spaceId,
+    });
+    if (!attachment) {
+      throw new Error(`Attachment "${attachmentType}:${attachmentId}" not found`);
+    }
+
+    const definition = this.deps.attachmentsService.getTypeDefinition(attachmentType);
+    if (!definition) {
+      throw new Error(`Attachment type "${attachmentType}" not registered`);
+    }
+
+    const smlData =
+      (await definition.sml?.getSmlData(attachment, {
+        savedObjectsClient: this.deps.savedObjectsClient,
+        spaceId,
+      })) ?? this.getDefaultSmlData(attachment, attachmentType);
+
+    await this.deleteAttachmentDocs({ attachmentId, attachmentType, spaceId });
+    await this.indexChunks({
+      attachmentId,
+      attachmentType,
+      chunks: smlData.chunks,
+      spaceId,
+    });
+  }
+
+  private getDefaultSmlData(attachment: Attachment, attachmentType: string) {
+    const now = new Date().toISOString();
+    return {
+      chunks: [
+        {
+          type: attachmentType,
+          content: JSON.stringify(attachment.data),
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+    };
+  }
+
+  private async indexChunks({
+    attachmentId,
+    attachmentType,
+    chunks,
+    spaceId,
+  }: {
+    attachmentId: string;
+    attachmentType: string;
+    chunks: SmlAttachmentChunk[];
+    spaceId: string;
+  }) {
+    if (chunks.length === 0) {
+      return;
+    }
+
+    const operations = chunks.flatMap((chunk, index) => {
+      const chunkId = chunk.id ?? `${attachmentId}:${index}`;
+      const createdAt = chunk.createdAt ?? new Date().toISOString();
+      const updatedAt = chunk.updatedAt ?? createdAt;
+
+      return [
+        { index: { _index: smlWriteAlias, _id: chunkId } },
+        {
+          id: chunkId,
+          type: chunk.type,
+          title: chunk.title,
+          fields: chunk.fields,
+          index_patterns: chunk.indexPatterns,
+          tags: chunk.tags,
+          attachment_id: attachmentId,
+          attachment_type: attachmentType,
+          content: chunk.content,
+          content_embedding: chunk.content,
+          created_at: createdAt,
+          updated_at: updatedAt,
+          spaces: [spaceId],
+        },
+      ];
+    });
+
+    const response = await this.deps.esClient.bulk({
+      index: smlIndexAlias,
+      operations,
+      refresh: false,
+    });
+
+    if (response.errors) {
+      const failures = response.items.filter((item) => item.index?.error);
+      this.deps.logger.error(
+        `Failed to index ${failures.length} SML chunks for attachment "${attachmentId}".`
+      );
+      throw new Error('SML indexing failed');
+    }
+  }
+
+  private async deleteAttachmentDocs({
+    attachmentId,
+    attachmentType,
+    spaceId,
+  }: {
+    attachmentId: string;
+    attachmentType: string;
+    spaceId: string;
+  }) {
+    await this.deps.esClient.deleteByQuery({
+      index: smlIndexAlias,
+      refresh: false,
+      query: {
+        bool: {
+          filter: [
+            { term: { attachment_id: attachmentId } },
+            { term: { attachment_type: attachmentType } },
+            { term: { spaces: spaceId } },
+          ],
+        },
+      },
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/mappings.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/mappings.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+
+const keyword = { type: 'keyword' as const };
+const date = { type: 'date' as const };
+const text = { type: 'text' as const };
+
+export const getSmlIndexMappings = (inferenceId: string): MappingTypeMapping => ({
+  dynamic: false,
+  properties: {
+    id: keyword,
+    type: keyword,
+    title: keyword,
+    fields: keyword,
+    index_patterns: keyword,
+    tags: keyword,
+    attachment_id: keyword,
+    attachment_type: keyword,
+    content: text,
+    content_embedding: {
+      type: 'semantic_text',
+      inference_id: inferenceId,
+    },
+    created_at: date,
+    updated_at: date,
+    spaces: keyword,
+  },
+});
+
+export const smlCrawlerStateMappings: MappingTypeMapping = {
+  dynamic: false,
+  properties: {
+    id: keyword,
+    attachment_id: keyword,
+    attachment_type: keyword,
+    space_id: keyword,
+    created_at: date,
+    updated_at: date,
+    update_action: keyword,
+  },
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_service.ts
@@ -175,6 +175,7 @@ export class SmlService {
 
       const attachment = await resolveAttachmentForSpace({
         esClient,
+        savedObjectsClient,
         attachmentId: source.attachment_id,
         attachmentType: source.attachment_type,
         spaceId,
@@ -211,11 +212,6 @@ export class SmlService {
       });
     }
 
-    const total =
-      typeof response.hits.total === 'number'
-        ? response.hits.total
-        : response.hits.total?.value ?? results.length;
-
-    return { results, total };
+    return { results, total: results.length };
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_service.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { ElasticsearchServiceStart } from '@kbn/core-elasticsearch-server';
+import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
+import type { Logger } from '@kbn/logging';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { AttachmentServiceStart } from '../attachments';
+import {
+  smlCrawlerTaskType,
+  smlDefaultFetchInterval,
+  smlIndexAlias,
+  smlSearchDefaultSize,
+  smlTaskScope,
+} from './constants';
+import { SmlIndexManager } from './index_manager';
+import { CrawlerStateService } from './crawler_state_service';
+import { SmlIndexerService } from './indexer_service';
+import { SmlCrawlerService } from './crawler_service';
+import { resolveAttachmentForSpace } from './attachment_lookup';
+import { normalizeTaskInterval } from './utils';
+
+interface SmlServiceDeps {
+  logger: Logger;
+  elasticsearch: ElasticsearchServiceStart;
+  savedObjects: SavedObjectsServiceStart;
+  attachmentsService: AttachmentServiceStart;
+}
+
+export interface SmlIndexerParams {
+  attachmentId: string;
+  attachmentType: string;
+  action: 'create' | 'update' | 'delete';
+  spaceId: string;
+}
+
+export interface SmlSearchResult {
+  chunkId: string;
+  attachmentId: string;
+  attachmentType: string;
+  type: string;
+  title?: string;
+  content: string;
+  spaces: string[];
+}
+
+export class SmlService {
+  private readonly crawlerState: CrawlerStateService;
+  private readonly indexManager: SmlIndexManager;
+  private readonly indexer: SmlIndexerService;
+  private readonly crawler: SmlCrawlerService;
+
+  constructor(private readonly deps: SmlServiceDeps) {
+    const esClient = this.deps.elasticsearch.client.asInternalUser;
+    const savedObjectsClient = this.deps.savedObjects.createInternalRepository();
+
+    this.crawlerState = new CrawlerStateService(esClient, this.deps.logger.get('crawler_state'));
+    this.indexer = new SmlIndexerService({
+      esClient,
+      savedObjectsClient,
+      attachmentsService: this.deps.attachmentsService,
+      logger: this.deps.logger.get('indexer'),
+    });
+    this.indexManager = new SmlIndexManager(
+      esClient,
+      this.deps.logger.get('index_manager'),
+      this.crawlerState
+    );
+    this.crawler = new SmlCrawlerService({
+      esClient,
+      savedObjectsClient,
+      attachmentsService: this.deps.attachmentsService,
+      logger: this.deps.logger.get('crawler'),
+      crawlerState: this.crawlerState,
+      indexerService: this.indexer,
+    });
+  }
+
+  async start(taskManager: TaskManagerStartContract): Promise<void> {
+    await this.indexManager.ensureIndex();
+    await this.crawlerState.ensureIndex();
+    await this.scheduleCrawlerTasks(taskManager);
+  }
+
+  stop(): void {}
+
+  async indexAttachment(params: SmlIndexerParams): Promise<void> {
+    await this.indexManager.ensureIndex();
+    await this.crawlerState.ensureIndex();
+    await this.indexer.indexAttachment(params);
+  }
+
+  async runCrawlerForType(attachmentType: string): Promise<void> {
+    await this.indexManager.ensureIndex();
+    await this.crawlerState.ensureIndex();
+    await this.crawler.crawlAttachmentType(attachmentType);
+  }
+
+  private async scheduleCrawlerTasks(taskManager: TaskManagerStartContract): Promise<void> {
+    const definitions = this.deps.attachmentsService
+      .listTypeDefinitions()
+      .filter((definition) => definition.sml?.list);
+
+    await Promise.all(
+      definitions.map(async (definition) => {
+        const interval = normalizeTaskInterval(
+          definition.sml?.fetchFrequency?.() ?? smlDefaultFetchInterval
+        );
+        const taskId = `${smlCrawlerTaskType}:${definition.id}`;
+
+        await taskManager.ensureScheduled({
+          id: taskId,
+          taskType: smlCrawlerTaskType,
+          schedule: { interval },
+          params: { attachment_type: definition.id },
+          state: {},
+          scope: smlTaskScope,
+        });
+      })
+    );
+  }
+
+  async search({
+    request,
+    query,
+    size = smlSearchDefaultSize,
+    spaceId,
+  }: {
+    request: KibanaRequest;
+    query: string;
+    size?: number;
+    spaceId: string;
+  }): Promise<{ results: SmlSearchResult[]; total: number }> {
+    await this.indexManager.ensureIndex();
+    const esClient = this.deps.elasticsearch.client.asInternalUser;
+    const savedObjectsClient = this.deps.savedObjects.getScopedClient(request);
+
+    const response = await esClient.search<{
+      attachment_id: string;
+      attachment_type: string;
+      type: string;
+      title?: string;
+      content: string;
+      spaces?: string[];
+    }>({
+      index: smlIndexAlias,
+      size,
+      query: {
+        bool: {
+          filter: [{ terms: { spaces: [spaceId, '*'] } }],
+          must: [
+            {
+              semantic: {
+                field: 'content_embedding',
+                query,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const results: SmlSearchResult[] = [];
+
+    for (const hit of response.hits.hits) {
+      const source = hit._source;
+      if (!source) {
+        continue;
+      }
+
+      const attachment = await resolveAttachmentForSpace({
+        esClient,
+        attachmentId: source.attachment_id,
+        attachmentType: source.attachment_type,
+        spaceId,
+      });
+
+      if (!attachment) {
+        continue;
+      }
+
+      const definition = this.deps.attachmentsService.getTypeDefinition(source.attachment_type);
+      if (!definition?.sml) {
+        continue;
+      }
+
+      const hasPermissions =
+        (await definition.sml.hasPermissions?.(attachment, {
+          request,
+          spaceId,
+          savedObjectsClient,
+        })) ?? true;
+
+      if (!hasPermissions) {
+        continue;
+      }
+
+      results.push({
+        chunkId: hit._id ?? '',
+        attachmentId: source.attachment_id,
+        attachmentType: source.attachment_type,
+        type: source.type,
+        title: source.title,
+        content: source.content,
+        spaces: source.spaces ?? [],
+      });
+    }
+
+    const total =
+      typeof response.hits.total === 'number'
+        ? response.hits.total
+        : response.hits.total?.value ?? results.length;
+
+    return { results, total };
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/task.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/task.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { Logger } from '@kbn/logging';
+import type {
+  RunContext,
+  TaskManagerSetupContract,
+} from '@kbn/task-manager-plugin/server';
+import { smlCrawlerTaskType } from './constants';
+import type { SmlService } from './sml_service';
+
+export const registerSmlCrawlerTask = ({
+  taskManager,
+  logger,
+  getSmlService,
+}: {
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+  getSmlService: () => SmlService | undefined;
+}) => {
+  taskManager.registerTaskDefinitions({
+    [smlCrawlerTaskType]: {
+      title: 'Agent Builder SML crawler',
+      timeout: '5m',
+      maxAttempts: 3,
+      paramsSchema: schema.object({
+        attachment_type: schema.string(),
+      }),
+      stateSchemaByVersion: {
+        1: {
+          schema: schema.object({}),
+          up: (state: Record<string, unknown>) => state,
+        },
+      },
+      createTaskRunner: ({ taskInstance }: RunContext) => ({
+        run: async () => {
+          const smlService = getSmlService();
+          if (!smlService) {
+            throw new Error('SML service is not available for crawler task execution.');
+          }
+
+          const { attachment_type: attachmentType } = taskInstance.params as {
+            attachment_type: string;
+          };
+          logger.debug(`Running SML crawler task for "${attachmentType}".`);
+          await smlService.runCrawlerForType(attachmentType);
+
+          return {
+            state: {},
+            schedule: taskInstance.schedule,
+          };
+        },
+      }),
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/utils.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { normalizeTaskInterval, parseDurationToMs } from './utils';
+
+describe('parseDurationToMs', () => {
+  it('parses milliseconds', () => {
+    expect(parseDurationToMs('250ms')).toBe(250);
+  });
+
+  it('parses seconds', () => {
+    expect(parseDurationToMs('10s')).toBe(10_000);
+  });
+
+  it('parses minutes', () => {
+    expect(parseDurationToMs('2m')).toBe(120_000);
+  });
+
+  it('parses hours', () => {
+    expect(parseDurationToMs('1h')).toBe(3_600_000);
+  });
+
+  it('parses days', () => {
+    expect(parseDurationToMs('1d')).toBe(86_400_000);
+  });
+
+  it('rejects invalid duration', () => {
+    expect(() => parseDurationToMs('abc')).toThrow('Invalid duration');
+  });
+
+  it('normalizes task manager intervals', () => {
+    expect(normalizeTaskInterval('30s')).toBe('30s');
+    expect(normalizeTaskInterval('90s')).toBe('2m');
+    expect(normalizeTaskInterval('2h')).toBe('120m');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/utils.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+
+const durationMatcher = /^(?<value>\d+)(?<unit>ms|s|m|h|d)$/;
+
+export const parseDurationToMs = (duration: string): number => {
+  const match = durationMatcher.exec(duration);
+  if (!match || !match.groups) {
+    throw new Error(`Invalid duration "${duration}". Expected format like 10m or 1h.`);
+  }
+
+  const value = Number(match.groups.value);
+  const unit = match.groups.unit;
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid duration "${duration}". Value must be > 0.`);
+  }
+
+  switch (unit) {
+    case 'ms':
+      return value;
+    case 's':
+      return value * 1000;
+    case 'm':
+      return value * 60 * 1000;
+    case 'h':
+      return value * 60 * 60 * 1000;
+    case 'd':
+      return value * 24 * 60 * 60 * 1000;
+    default:
+      throw new Error(`Unsupported duration unit "${unit}".`);
+  }
+};
+
+export const normalizeTaskInterval = (duration: string): string => {
+  const ms = parseDurationToMs(duration);
+  const seconds = Math.round(ms / 1000);
+  if (seconds <= 59 && seconds >= 1) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.max(1, Math.round(ms / (60 * 1000)));
+  return `${minutes}m`;
+};
+
+export const pickEmbeddingInferenceId = async ({
+  esClient,
+  logger,
+}: {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<string> => {
+  const { endpoints } = await esClient.inference.get({ inference_id: '_all' });
+  const embeddingEndpoints = endpoints.filter((endpoint) =>
+    ['text_embedding', 'sparse_embedding'].includes(endpoint.task_type)
+  );
+
+  if (embeddingEndpoints.length === 0) {
+    throw new Error('No embedding inference endpoints available for semantic_text fields.');
+  }
+
+  const inferenceId = embeddingEndpoints[0].inference_id;
+  logger.debug(`Using inference endpoint "${inferenceId}" for SML semantic_text mappings.`);
+  return inferenceId;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { ToolType } from '@kbn/agent-builder-common';
+import { platformCoreTools } from '@kbn/agent-builder-common/tools';
+import { ATTACHMENT_REF_ACTOR } from '@kbn/agent-builder-common/attachments';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import { createErrorResult, getToolResultId } from '@kbn/agent-builder-server';
+import type { AttachmentServiceStart, SmlAttachmentSearchItem } from '../../../attachments';
+
+const smlAttachSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        attachment_id: z.string().describe('Attachment identifier from SML search'),
+        attachment_type: z.string().describe('Attachment type from SML search'),
+        title: z.string().optional().describe('Optional title from SML search'),
+        content: z.string().optional().describe('Optional content from SML search'),
+        spaces: z.array(z.string()).optional(),
+      })
+    )
+    .min(1)
+    .describe('SML results to convert into attachments'),
+});
+
+export const createSmlAttachTool = ({
+  getAttachmentsService,
+}: {
+  getAttachmentsService: () => AttachmentServiceStart | undefined;
+}): BuiltinToolDefinition<typeof smlAttachSchema> => ({
+  id: platformCoreTools.smlAttach,
+  type: ToolType.builtin,
+  description: 'Convert SML search results into conversation attachments.',
+  schema: smlAttachSchema,
+  tags: ['sml', 'attachment'],
+  handler: async ({ items }, context) => {
+    const attachmentsService = getAttachmentsService();
+    if (!attachmentsService) {
+      return {
+        results: [
+          createErrorResult({
+            message: 'Attachments service is not available',
+          }),
+        ],
+      };
+    }
+
+    const results = [];
+
+    for (const item of items) {
+      const definition = attachmentsService.getTypeDefinition(item.attachment_type);
+      if (!definition?.sml?.toAttachment) {
+        results.push(
+          createErrorResult({
+            message: `Attachment type "${item.attachment_type}" does not support SML attachment conversion`,
+            metadata: { attachment_type: item.attachment_type },
+          })
+        );
+        continue;
+      }
+
+      const smlItem: SmlAttachmentSearchItem = {
+        attachmentId: item.attachment_id,
+        attachmentType: item.attachment_type,
+        title: item.title,
+        content: item.content ?? '',
+        spaces: item.spaces,
+      };
+
+      const attachmentInput = await definition.sml.toAttachment(smlItem, {
+        request: context.request,
+        savedObjectsClient: context.savedObjectsClient,
+        spaceId: context.spaceId,
+      });
+
+      if (!attachmentInput) {
+        results.push(
+          createErrorResult({
+            message: `Failed to convert SML result for "${item.attachment_type}:${item.attachment_id}"`,
+            metadata: { attachment_id: item.attachment_id },
+          })
+        );
+        continue;
+      }
+
+      const created = await context.attachments.add(attachmentInput, ATTACHMENT_REF_ACTOR.agent);
+
+      results.push({
+        tool_result_id: getToolResultId(),
+        type: ToolResultType.other,
+        data: {
+          attachment_id: created.id,
+          type: created.type,
+          source_attachment_id: item.attachment_id,
+          source_attachment_type: item.attachment_type,
+        },
+      });
+    }
+
+    return { results };
+  },
+});
+

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { platformCoreTools, ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import { createErrorResult, getToolResultId } from '@kbn/agent-builder-server';
+import type { SmlService } from '../../../sml';
+
+const smlSearchSchema = z.object({
+  query: z.string().describe('Semantic query to search the semantic metadata layer'),
+  size: z.number().min(1).max(100).optional().describe('Maximum number of results to return'),
+});
+
+export const createSmlSearchTool = ({
+  getSmlService,
+}: {
+  getSmlService: () => SmlService | undefined;
+}): BuiltinToolDefinition<typeof smlSearchSchema> => ({
+  id: platformCoreTools.smlSearch,
+  type: ToolType.builtin,
+  description:
+    'Search the Semantic Metadata Layer (SML) for indexed attachments. Results are permission-checked for the current user.',
+  schema: smlSearchSchema,
+  tags: ['sml', 'attachment'],
+  handler: async ({ query, size }, context) => {
+    const smlService = getSmlService();
+    if (!smlService) {
+      return {
+        results: [
+          createErrorResult({
+            message: 'Semantic metadata search is not available yet.',
+          }),
+        ],
+      };
+    }
+
+    const { results, total } = await smlService.search({
+      request: context.request,
+      query,
+      size,
+      spaceId: context.spaceId,
+    });
+
+    return {
+      results: [
+        {
+          tool_result_id: getToolResultId(),
+          type: ToolResultType.other,
+          data: {
+            total,
+            results,
+          },
+        },
+      ],
+    };
+  },
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
@@ -14,12 +14,14 @@ import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { ToolsServiceSetup, ToolsServiceStart } from './tools';
 import type { RunnerFactory } from './runner';
 import type { AgentsServiceSetup, AgentsServiceStart } from './agents';
 import type { ConversationService } from './conversation';
 import type { ChatService } from './chat';
 import type { AttachmentServiceSetup, AttachmentServiceStart } from './attachments';
+import type { SmlService } from './sml';
 import type { TrackingService } from '../telemetry/tracking_service';
 import type { AnalyticsService } from '../telemetry';
 
@@ -36,6 +38,7 @@ export interface InternalStartServices {
   conversations: ConversationService;
   chat: ChatService;
   runnerFactory: RunnerFactory;
+  sml: SmlService;
 }
 
 export interface ServiceSetupDeps {
@@ -53,6 +56,7 @@ export interface ServicesStartDeps {
   savedObjects: SavedObjectsServiceStart;
   // plugin deps
   inference: InferenceServerStart;
+  taskManager: TaskManagerStartContract;
   spaces?: SpacesPluginStart;
   actions: ActionsPluginStart;
   trackingService?: TrackingService;

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -120,4 +120,16 @@ export interface AgentBuilderPluginStart {
    * Tools service, to manage or execute tools.
    */
   tools: ToolsStart;
+  /**
+   * SML service helpers for producers to trigger updates.
+   */
+  sml: {
+    indexAttachment: (params: {
+      request: KibanaRequest;
+      attachmentId: string;
+      attachmentType: string;
+      action: 'create' | 'update' | 'delete';
+      spaceId?: string;
+    }) => Promise<void>;
+  };
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -16,6 +16,10 @@ import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugi
 import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type {
   PluginSetupContract as ActionsPluginSetup,
   PluginStartContract as ActionsPluginStart,
 } from '@kbn/actions-plugin/server';
@@ -29,6 +33,7 @@ export interface AgentBuilderSetupDependencies {
   workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
   workflowsManagement?: WorkflowsServerPluginSetup;
   inference: InferenceServerSetup;
+  taskManager: TaskManagerSetupContract;
   spaces?: SpacesPluginSetup;
   features: FeaturesPluginSetup;
   usageCollection?: UsageCollectionSetup;
@@ -42,6 +47,7 @@ export interface AgentBuilderStartDependencies {
   cloud?: CloudStart;
   spaces?: SpacesPluginStart;
   actions: ActionsPluginStart;
+  taskManager: TaskManagerStartContract;
 }
 
 export interface AttachmentsSetup {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/sml_helpers.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/sml_helpers.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { SmlAttachmentListItem } from '@kbn/agent-builder-server/attachments';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { getLatestVersion } from '@kbn/agent-builder-common/attachments';
+import { chatSystemIndex } from '@kbn/agent-builder-server';
+
+export const listConversationAttachmentsForType = async ({
+  esClient,
+  attachmentType,
+}: {
+  esClient: ElasticsearchClient;
+  attachmentType: string;
+}): Promise<SmlAttachmentListItem[]> => {
+  const results = new Map<string, SmlAttachmentListItem>();
+  let searchAfter: unknown[] | undefined;
+
+  while (true) {
+    const response = await esClient.search<{
+      attachments?: VersionedAttachment[];
+      space?: string;
+    }>({
+      index: chatSystemIndex('conversations'),
+      size: 1000,
+      _source: ['attachments', 'space'],
+      sort: [{ _id: 'asc' }],
+      search_after: searchAfter,
+      query: {
+        bool: {
+          filter: [{ term: { 'attachments.type': attachmentType } }],
+        },
+      },
+    });
+
+    const hits = response.hits.hits;
+    if (hits.length === 0) {
+      break;
+    }
+
+    for (const hit of hits) {
+      const attachments = hit._source?.attachments ?? [];
+      const spaceId = hit._source?.space;
+
+      for (const attachment of attachments) {
+        if (attachment.type !== attachmentType) {
+          continue;
+        }
+
+        const latest = getLatestVersion(attachment);
+        const updatedAt = latest?.created_at ?? new Date().toISOString();
+        const id = `${attachment.id}:${spaceId ?? 'default'}`;
+
+        const existing = results.get(id);
+        if (!existing || existing.updatedAt < updatedAt) {
+          results.set(id, {
+            attachmentId: attachment.id,
+            attachmentType,
+            updatedAt,
+            createdAt: attachment.versions[0]?.created_at,
+            spaceId,
+          });
+        }
+      }
+    }
+
+    searchAfter = hits[hits.length - 1].sort;
+  }
+
+  return [...results.values()];
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/sml_helpers.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/sml_helpers.ts
@@ -29,7 +29,10 @@ export const listConversationAttachmentsForType = async ({
       index: chatSystemIndex('conversations'),
       size: 1000,
       _source: ['attachments', 'space'],
-      sort: [{ _id: 'asc' }],
+      sort: [
+        { updated_at: { order: 'asc', missing: '_last' } },
+        { space: { order: 'asc', missing: '_first' } },
+      ],
       search_after: searchAfter,
       query: {
         bool: {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/visualization_ref.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/visualization_ref.ts
@@ -13,6 +13,7 @@ import {
 import type {
   AttachmentResolveContext,
   AttachmentTypeDefinition,
+  SmlAttachmentFromIdContext,
   SmlAttachmentListItem,
   SmlAttachmentSearchItem,
 } from '@kbn/agent-builder-server/attachments';
@@ -131,6 +132,15 @@ export const createVisualizationRefAttachmentType = (): AttachmentTypeDefinition
         return results;
       },
       fetchFrequency: () => '1m',
+      toAttachmentFromId: async (attachmentId: string, context: SmlAttachmentFromIdContext) => {
+        return {
+          id: attachmentId,
+          type: AttachmentType.visualizationRef,
+          data: {
+            saved_object_id: attachmentId,
+          },
+        };
+      },
       getSmlData: (attachment) => {
         const now = new Date().toISOString();
         return {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/visualization_ref.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/visualization_ref.ts
@@ -19,6 +19,7 @@ import {
   type LensApiSchemaType,
   type LensAttributes,
 } from '@kbn/lens-embeddable-utils/config_builder';
+import { listConversationAttachmentsForType } from './sml_helpers';
 
 /**
  * Creates the definition for the `visualization_ref` attachment type.
@@ -78,6 +79,27 @@ export const createVisualizationRefAttachmentType = (): AttachmentTypeDefinition
       return `A visualization_ref attachment contains a reference to a saved Lens visualization. The reference includes the saved object ID and type. Use attachment_read to resolve the referenced content when needed.`;
     },
     getTools: () => [],
+    sml: {
+      list: ({ esClient }) =>
+        listConversationAttachmentsForType({
+          esClient,
+          attachmentType: AttachmentType.visualizationRef,
+        }),
+      fetchFrequency: () => '10m',
+      getSmlData: (attachment) => {
+        const now = new Date().toISOString();
+        return {
+          chunks: [
+            {
+              type: AttachmentType.visualizationRef,
+              content: JSON.stringify(attachment.data),
+              createdAt: now,
+              updatedAt: now,
+            },
+          ],
+        };
+      },
+    },
   };
 };
 

--- a/x-pack/platform/plugins/shared/lens/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/lens/kibana.jsonc
@@ -38,6 +38,7 @@
       "contentManagement"
     ],
     "optionalPlugins": [
+      "agentBuilder",
       "expressionLegacyMetricVis",
       "expressionPartitionVis",
       "usageCollection",

--- a/x-pack/platform/plugins/shared/lens/server/api/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/types.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import type { HttpServiceSetup, Logger, RequestHandlerContext } from '@kbn/core/server';
+import type { CoreStart, HttpServiceSetup, Logger, RequestHandlerContext } from '@kbn/core/server';
 import type { ContentManagementServerSetup } from '@kbn/content-management-plugin/server';
 import type { VersionedRouter } from '@kbn/core-http-server';
 import type { LensConfigBuilder } from '@kbn/lens-embeddable-utils/config_builder';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/server';
 
 export type * from './routes/types';
 
@@ -17,6 +18,7 @@ export interface RegisterAPIRoutesArgs {
   contentManagement: ContentManagementServerSetup;
   builder: LensConfigBuilder;
   logger: Logger;
+  getStartServices: () => Promise<[CoreStart, { agentBuilder?: AgentBuilderPluginStart }]>;
 }
 
 export type RegisterAPIRouteFn = (

--- a/x-pack/platform/plugins/shared/lens/server/plugin.tsx
+++ b/x-pack/platform/plugins/shared/lens/server/plugin.tsx
@@ -21,6 +21,7 @@ import type { ExpressionsServerSetup } from '@kbn/expressions-plugin/server';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/server';
 import type { MigrateFunctionsObject } from '@kbn/kibana-utils-plugin/common';
 import type { ContentManagementServerSetup } from '@kbn/content-management-plugin/server';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/server';
 
 import type {
   TaskManagerSetupContract,
@@ -59,6 +60,7 @@ export interface PluginStartContract {
   fieldFormats: FieldFormatsStart;
   data: DataPluginStart;
   dataViews: DataViewsServerPluginStart;
+  agentBuilder?: AgentBuilderPluginStart;
 }
 
 export interface LensServerPluginSetup {
@@ -101,6 +103,7 @@ export class LensServerPlugin
       storage: new LensStorage({
         throwOnResultValidationError: this.initializerContext.env.mode.dev,
         logger: this.initializerContext.logger.get('storage'),
+        getStartServices: core.getStartServices,
       }),
       version: {
         latest: LENS_ITEM_LATEST_VERSION,
@@ -123,6 +126,7 @@ export class LensServerPlugin
       contentManagement: plugins.contentManagement,
       builder,
       logger: this.logger,
+      getStartServices: core.getStartServices,
     });
 
     core

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -6,6 +6,7 @@
   "include": ["*.ts", "common/**/*", "public/**/*", "server/**/*", "../../../../../typings/**/*"],
   "kbn_references": [
     "@kbn/spaces-plugin",
+    "@kbn/agent-builder-plugin",
     "@kbn/core",
     "@kbn/task-manager-plugin",
     "@kbn/global-search-plugin",


### PR DESCRIPTION
## Summary

implements semantic metadata layer:
- indexer service: responsible for indexing elastic 'elements' into SML index
-- exposes API for internal and external consumption, allows on event updates to SML index by attachment authors
- crawler service: responsible for periodically discovering new/changed/deleted elements and uses indexer to do updates
- attachment registry updates: attachment authors can provide method to fetch the elements for indexing into SML, a method to convert their element into SML representation and a method to convert SML representation back into their element.
- sml_search tool: allows LLM to run semantic search on objects indexed in SML index to discoer elastic 'elements'
- sml_attach_tool: allows LLM to attach specific item from the sml_search results to the attachment

