### PR TITLE
[ResponseOps] Skip director on non alertable rules

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -33,9 +33,14 @@ const scheduleSchema = z
   .strict()
   .describe('Schedule configuration for the rule.');
 
+export const ruleKindSchema = z.enum(['alert', 'signal']).describe('The kind of rule.');
+
+export type RuleKind = z.infer<typeof ruleKindSchema>;
+
 export const createRuleDataSchema = z
   .object({
     name: z.string().min(1).max(64).describe('Human-readable rule name.'),
+    kind: ruleKindSchema,
     tags: z
       .array(z.string().max(64).describe('Rule tag.'))
       .max(100)

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/create_rule_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/create_rule_page.tsx
@@ -30,6 +30,7 @@ import { YamlRuleEditor } from '@kbn/yaml-rule-editor';
 import { RulesApi } from '../services/rules_api';
 
 const DEFAULT_RULE_YAML = `name: Example rule
+kind: alert
 tags: []
 schedule:
   custom: 1m
@@ -41,6 +42,7 @@ groupingKey: []`;
 
 const DEFAULT_RULE_VALUES: CreateRuleData = {
   name: 'Example rule',
+  kind: 'alert',
   tags: [],
   schedule: { custom: '1m' },
   enabled: true,
@@ -114,6 +116,7 @@ export const CreateRulePage = () => {
         const nextPayload: CreateRuleData = {
           ...DEFAULT_RULE_VALUES,
           name: rule.name,
+          kind: rule.kind ?? DEFAULT_RULE_VALUES.kind,
           tags: rule.tags ?? DEFAULT_RULE_VALUES.tags,
           schedule: rule.schedule?.custom
             ? { custom: rule.schedule.custom }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
@@ -8,12 +8,13 @@
 import { inject, injectable } from 'inversify';
 import type { HttpStart } from '@kbn/core/public';
 import { CoreStart } from '@kbn/core-di-browser';
-import type { CreateRuleData } from '@kbn/alerting-v2-schemas';
+import type { CreateRuleData, RuleKind } from '@kbn/alerting-v2-schemas';
 import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
 
 export interface RuleListItem {
   id: string;
   name: string;
+  kind: RuleKind;
   enabled?: boolean;
   query?: string;
   schedule?: { custom?: string };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/director.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/director.mock.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { DeeplyMockedApi } from '@kbn/core-elasticsearch-client-server-mocks';
+import { createLoggerService } from '../services/logger_service/logger_service.mock';
+import { createQueryService } from '../services/query_service/query_service.mock';
+import { BasicTransitionStrategy } from './strategies/basic_strategy';
+import { TransitionStrategyFactory } from './strategies/strategy_resolver';
+import { DirectorService } from './director';
+
+export function createDirectorService(): {
+  directorService: DirectorService;
+  mockEsClient: DeeplyMockedApi<ElasticsearchClient>;
+} {
+  const { queryService, mockEsClient } = createQueryService();
+  const { loggerService } = createLoggerService();
+
+  const basicStrategy = new BasicTransitionStrategy();
+  const strategyFactory = new TransitionStrategyFactory(basicStrategy);
+  const directorService = new DirectorService(strategyFactory, queryService, loggerService);
+
+  return {
+    directorService,
+    mockEsClient,
+  };
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/build_alert_events.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/build_alert_events.test.ts
@@ -22,6 +22,7 @@ describe('buildAlertEventsFromEsqlResponse', () => {
   it('transforms ES|QL response rows into alert documents', () => {
     const ruleAttributes: RuleSavedObjectAttributes = {
       name: 'My ES|QL Rule',
+      kind: 'alert',
       tags: ['esql', 'test'],
       schedule: { custom: '1m' },
       enabled: true,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/director_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/director_step.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DirectorStep } from './director_step';
+import { createRulePipelineState, createAlertEvent, createRuleResponse } from '../test_utils';
+import { createLoggerService } from '../../services/logger_service/logger_service.mock';
+import { createDirectorService } from '../../director/director.mock';
+
+describe('DirectorStep', () => {
+  const { loggerService } = createLoggerService();
+
+  const createEmptyEsqlResponse = () => ({
+    columns: [
+      { name: 'group_hash', type: 'keyword' },
+      { name: 'last_episode_id', type: 'keyword' },
+      { name: 'last_episode_status', type: 'keyword' },
+    ],
+    values: [],
+  });
+
+  it('runs the director for alertable rules', async () => {
+    const { directorService, mockEsClient } = createDirectorService();
+    const step = new DirectorStep(loggerService, directorService);
+
+    mockEsClient.esql.query.mockResolvedValue(createEmptyEsqlResponse());
+
+    const alertEvents = [createAlertEvent({ group_hash: 'hash-1' })];
+
+    const state = createRulePipelineState({
+      rule: createRuleResponse({ kind: 'alert' }),
+      alertEvents,
+    });
+
+    const result = await step.execute(state);
+
+    expect(mockEsClient.esql.query).toHaveBeenCalled();
+    expect(result.type).toBe('continue');
+    expect(result).toHaveProperty('data.alertEvents');
+  });
+
+  it('skips episode tracking for signal rules', async () => {
+    const { directorService, mockEsClient } = createDirectorService();
+    const step = new DirectorStep(loggerService, directorService);
+
+    const alertEvents = [createAlertEvent({ group_hash: 'hash-1' })];
+
+    const state = createRulePipelineState({
+      rule: createRuleResponse({ kind: 'signal' }),
+      alertEvents,
+    });
+
+    const result = await step.execute(state);
+
+    expect(mockEsClient.esql.query).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'continue',
+      data: { alertEvents },
+    });
+  });
+
+  it('handles empty alert events', async () => {
+    const { directorService, mockEsClient } = createDirectorService();
+    const step = new DirectorStep(loggerService, directorService);
+
+    const state = createRulePipelineState({
+      rule: createRuleResponse({ kind: 'alert' }),
+      alertEvents: [],
+    });
+
+    const result = await step.execute(state);
+
+    expect(mockEsClient.esql.query).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'continue',
+      data: { alertEvents: [] },
+    });
+  });
+
+  it('propagates errors from elasticsearch', async () => {
+    const { directorService, mockEsClient } = createDirectorService();
+    const step = new DirectorStep(loggerService, directorService);
+
+    const alertEvents = [createAlertEvent()];
+    mockEsClient.esql.query.mockRejectedValue(new Error('ES query failed'));
+
+    const state = createRulePipelineState({
+      rule: createRuleResponse({ kind: 'alert' }),
+      alertEvents,
+    });
+
+    await expect(step.execute(state)).rejects.toThrow('ES query failed');
+  });
+
+  it('halts with state_not_ready when rule is missing from state', async () => {
+    const { directorService } = createDirectorService();
+    const step = new DirectorStep(loggerService, directorService);
+    const state = createRulePipelineState();
+
+    const result = await step.execute(state);
+
+    expect(result).toEqual({ type: 'halt', reason: 'state_not_ready' });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/fetch_rule_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/fetch_rule_step.test.ts
@@ -24,6 +24,7 @@ describe('FetchRuleStep', () => {
     overrides: Partial<RuleSavedObjectAttributes> = {}
   ): RuleSavedObjectAttributes => ({
     name: 'test-rule',
+    kind: 'alert',
     tags: [],
     schedule: { custom: '1m' },
     enabled: true,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -42,6 +42,7 @@ describe('RulesClient', () => {
 
   const baseCreateData: CreateRuleParams['data'] = {
     name: 'rule-1',
+    kind: 'alert',
     tags: [],
     schedule: { custom: '1m' },
     enabled: true,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -67,6 +67,7 @@ export class RulesClient {
 
     const ruleAttributes: RuleSavedObjectAttributes = {
       name: parsed.data.name,
+      kind: parsed.data.kind,
       tags: parsed.data.tags,
       schedule: parsed.data.schedule,
       enabled: parsed.data.enabled,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/test_utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/test_utils.ts
@@ -40,6 +40,7 @@ export function createRuleResponse(overrides: Partial<RuleResponse> = {}): RuleR
   return {
     id: 'rule-1',
     name: 'test-rule',
+    kind: 'alert',
     tags: [],
     schedule: { custom: '1m' },
     enabled: true,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/rule_mappings.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/rule_mappings.ts
@@ -14,6 +14,7 @@ export const ruleMappings: SavedObjectsTypeMappingDefinition = {
   dynamic: false,
   properties: {
     name: { type: 'text' },
+    kind: { type: 'keyword' },
     tags: { type: 'keyword' },
     enabled: { type: 'boolean' },
     schedule: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_saved_object_attributes/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_saved_object_attributes/v1.ts
@@ -13,6 +13,7 @@ import { schema } from '@kbn/config-schema';
  */
 export const ruleSavedObjectAttributesSchema = schema.object({
   name: schema.string(),
+  kind: schema.oneOf([schema.literal('alert'), schema.literal('signal')]),
   tags: schema.arrayOf(schema.string(), { defaultValue: [] }),
   schedule: schema.object({
     custom: schema.string(),


### PR DESCRIPTION
## Summary

This PR skips running the director if the rule is not alertable.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios