### PR TITLE
[8.19] use shared package registry docker config in dataset_quality tests

### DIFF
--- a/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
+++ b/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
@@ -17,12 +17,8 @@ import {
   DatasetQualityUsername,
 } from '@kbn/dataset-quality-plugin/server/test_helpers/create_dataset_quality_users/authentication';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
-import {
-  fleetPackageRegistryDockerImage,
-  FtrConfigProviderContext,
-  defineDockerServersConfig,
-} from '@kbn/test';
-import path from 'path';
+import type { FtrConfigProviderContext } from '@kbn/test';
+import { packageRegistryDocker, defineDockerServersConfig } from '@kbn/test';
 import supertest from 'supertest';
 import { UrlObject, format } from 'url';
 import { DatasetQualityFtrConfigName } from '../configs';
@@ -96,12 +92,9 @@ export function createTestConfig(
   const { license, name, kibanaConfig } = config;
 
   return async ({ readConfigFile }: FtrConfigProviderContext) => {
-    const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
     const xPackAPITestsConfig = await readConfigFile(
       require.resolve('../../api_integration/config.ts')
     );
-
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
 
     const services = xPackAPITestsConfig.get('services');
     const servers = xPackAPITestsConfig.get('servers');
@@ -122,16 +115,7 @@ export function createTestConfig(
       testFiles: [require.resolve('../tests')],
       servers,
       dockerServers: defineDockerServersConfig({
-        registry: {
-          enabled: !!dockerRegistryPort,
-          image: fleetPackageRegistryDockerImage,
-          portInContainer: 8080,
-          port: dockerRegistryPort,
-          args: dockerArgs,
-          waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
-          preferCached: true,
-        },
+        registry: packageRegistryDocker,
       }),
       servicesRequiredForTestAnalysis: ['datasetQualityFtrConfig', 'registry'],
       services: {


### PR DESCRIPTION
## Summary
This PR aims to fix unwanted docker-pulls on the `docker.elastic.co/kibana-ci/package-registry-distribution:lite` image.

As a followup to https://github.com/elastic/kibana/pull/250040 - this PR uses the shared package-registry config in the dataset_quality tests too. This test config didn't receive the shared config because this test was not present in main, also it was never updated to use `preferCached=true`. 
