### PR TITLE
fix: stabilize close PIT tests by writing to index after closePit()

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -1337,6 +1337,14 @@ describe('migration actions', () => {
       const pitId = pitResponse.right.pitId;
       await closePit({ client, pitId })();
 
+      await client.bulk({
+        refresh: 'wait_for',
+        operations: [
+          { index: { _index: 'existing_index_with_docs', _id: 'pit-invalidation-doc' } },
+          { type: 'test', value: 1 },
+        ],
+      });
+
       const searchTask = client.search({ pit: { id: pitId } });
 
       await expect(searchTask).rejects.toThrow('search_phase_execution_exception');

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -1361,6 +1361,29 @@ describe('migration actions', () => {
       }
     });
 
+    it('rejects search with closed PIT when allow_partial_search_results is false', async () => {
+      const openPitTask = openPit({ client, index: 'existing_index_with_docs' });
+      const pitResponse = (await openPitTask()) as Either.Right<OpenPitResponse>;
+
+      const pitId = pitResponse.right.pitId;
+      await closePit({ client, pitId })();
+
+      await client.bulk({
+        refresh: 'wait_for',
+        operations: [
+          { index: { _index: 'existing_index_with_docs', _id: 'pit-invalidation-doc-2' } },
+          { type: 'test', value: 2 },
+        ],
+      });
+
+      const searchTask = client.search({
+        pit: { id: pitId },
+        allow_partial_search_results: false,
+      });
+
+      await expect(searchTask).rejects.toThrow('search_phase_execution_exception');
+    });
+
     it('rejects if PIT does not exist', async () => {
       const closePitTask = closePit({ client, pitId: 'no_such_pit' });
       await expect(closePitTask()).rejects.toThrow('illegal_argument_exception');

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1379,13 +1379,20 @@ export const runActionTestSuite = ({
   });
 
   describe('closePit', () => {
-    // temporarily skipped, see https://elastic.slack.com/archives/C5TQ33ND8/p1769442067974589
-    it.skip('closes PointInTime', async () => {
+    it('closes PointInTime', async () => {
       const openPitTask = openPit({ client, index: 'existing_index_with_docs' });
       const pitResponse = (await openPitTask()) as Either.Right<OpenPitResponse>;
 
       const pitId = pitResponse.right.pitId;
       await closePit({ client, pitId })();
+
+      await client.bulk({
+        refresh: 'wait_for',
+        operations: [
+          { index: { _index: 'existing_index_with_docs', _id: 'pit-invalidation-doc' } },
+          { type: 'test', value: 1 },
+        ],
+      });
 
       const searchTask = client.search({ pit: { id: pitId } });
 

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1394,9 +1394,20 @@ export const runActionTestSuite = ({
         ],
       });
 
-      const searchTask = client.search({ pit: { id: pitId } });
-
-      await expect(searchTask).rejects.toThrow('search_phase_execution_exception');
+      try {
+        const response = await client.search({ pit: { id: pitId } });
+        expect(response._shards?.failed).toBeGreaterThanOrEqual(1);
+        const failureReason =
+          response._shards?.failures?.[0]?.reason?.reason ??
+          response._shards?.failures?.[0]?.reason?.type ??
+          '';
+        expect(failureReason).toMatch(
+          /No search context found for id|search_context_missing_exception/
+        );
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).toContain('search_phase_execution_exception');
+      }
     });
 
     it('rejects if PIT does not exist', async () => {


### PR DESCRIPTION
ES can keep a PIT valid after `close_pit` if there are no further writes to the index, which made these tests flaky (e.g. in serverless). This change adds a bulk index of one document to `existing_index_with_docs` after `closePit()` so the PIT is invalidated and a search with the closed PIT id consistently fails with `search_phase_execution_exception`. The previously skipped test in `actions_test_suite.ts` is re-enabled with the same fix.

Closes https://github.com/elastic/kibana-team/issues/2737