### PR TITLE
[Agent Builder] Default to Claude Sonnet 4.5 instead of 3.7

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/common/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/constants.ts
@@ -9,3 +9,5 @@ export const publicApiPath = `/api/agent_builder`;
 export const internalApiPath = `/internal/agent_builder`;
 
 export const AGENTBUILDER_PLUGIN_ID = 'agentBuilder';
+
+export const PREFERRED_DEFAULT_CONNECTOR_ID = 'Anthropic-Claude-Sonnet-4-5';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/chat/use_default_connector.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/chat/use_default_connector.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import type { AIConnector } from '@kbn/elastic-assistant';
+import { PREFERRED_DEFAULT_CONNECTOR_ID } from '../../../../common/constants';
 
 interface UseDefaultConnectorParams {
   connectors: AIConnector[];
@@ -27,13 +28,19 @@ export function useDefaultConnector({
       return defaultConnectorId;
     }
 
-    // 2. If no default, try to find a preconfigured connector (Elastic-managed LLM)
+    // 2. If no default, prefer the preconfigured Claude Sonnet 4.5 connector when available
+    const preferredConnector = connectors.find((c) => c.id === PREFERRED_DEFAULT_CONNECTOR_ID);
+    if (preferredConnector) {
+      return preferredConnector.id;
+    }
+
+    // 3. Otherwise use the first preconfigured connector (Elastic-managed LLM)
     const preconfiguredConnector = connectors.find((c) => c.isPreconfigured);
     if (preconfiguredConnector) {
       return preconfiguredConnector.id;
     }
 
-    // 3. If no preconfigured connector, use the first custom connector
+    // 4. If no preconfigured connector, use the first custom connector
     return connectors[0]?.id;
   }, [connectors, defaultConnectorId]);
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/chat/utils/resolve_selected_connector_id.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/chat/utils/resolve_selected_connector_id.ts
@@ -15,11 +15,17 @@ import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
 } from '@kbn/management-settings-ids';
+import { PREFERRED_DEFAULT_CONNECTOR_ID } from '../../../../common/constants';
 
 // TODO: Import from gen-ai-settings-plugin (package) once available
 const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
 
 const selectDefaultConnector = ({ connectors }: { connectors: InferenceConnector[] }) => {
+  const preferredConnector = connectors.find(
+    (connector) => connector.connectorId === PREFERRED_DEFAULT_CONNECTOR_ID
+  );
+  if (preferredConnector) return preferredConnector;
+
   const inferenceConnector = connectors.find(
     (connector) => connector.type === InferenceConnectorType.Inference
   );


### PR DESCRIPTION
## Summary

This PR updates the default connector selection logic for Agent Builder. We are implementing a short-term fix to prioritise Claude Sonnet 4.5 as the default fallback model.


## Changes
- Frontend: Updated `useDefaultConnector` hook to prioritise `PREFERRED_DEFAULT_CONNECTOR_ID`.
- Backend: Updated `resolveSelectedConnectorId` and `selectDefaultConnector` to align with the same prioritisation logic.
- Common: Added `PREFERRED_DEFAULT_CONNECTOR_ID` to shared constants.

## Manual Testing

- Confirmed Agent Builder automatically picks Sonnet 4.5 when no global default is set.
- `Inspected /api/agent_builder/converse/async` and verified the backend resolves the correct `connector_id`
- Confirmed the system correctly falls back to the next available model if Sonnet 4.5 is missing.

## Automated Tests
Updated resolveSelectedConnectorId tests to verify the new prioritisation logic.


<img width="1184" height="385" alt="Screenshot 2026-02-05 at 16 10 21" src="https://github.com/user-attachments/assets/9f9c6067-b57c-48be-a239-e4fc06e9e7fd" />
<img width="480" height="234" alt="Screenshot 2026-02-05 at 16 10 17" src="https://github.com/user-attachments/assets/55e6d294-0247-407c-a0ae-aed4574dcf7c" />
<img width="964" height="518" alt="Screenshot 2026-02-05 at 13 28 20" src="https://github.com/user-attachments/assets/8b0215d6-0145-4279-8fe8-ba2c28079626" />



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->