### PR TITLE
[a11y][Infra] Fix Switch not being announced on change

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_sort_controls.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_sort_controls.tsx
@@ -56,8 +56,7 @@ export const WaffleSortControls = ({ sort, onChange }: Props) => {
       ...sort,
       direction: sort.direction === 'asc' ? 'desc' : 'asc',
     });
-    closePopover();
-  }, [closePopover, sort, onChange]);
+  }, [sort, onChange]);
 
   const panels = useMemo<EuiContextMenuPanelDescriptor[]>(
     () => [


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/212668


This PR fixes Switch not being announced on change, this was due to the `closePopover()` call, we don't need it for the Switch, but we keep it for Name and Metric Value buttons.

https://github.com/user-attachments/assets/5f2b6f4f-52b3-47f7-aab6-cd211d82cf59



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->