### PR TITLE
Show Elastic heart logo during Valentine's period (Feb 1–14)

### DIFF
--- a/src/core/packages/rendering/server-internal/src/views/logo.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/logo.tsx
@@ -40,3 +40,43 @@ export const Logo: FC = () => (
     </g>
   </svg>
 );
+
+export const Heart: FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="32"
+    height="32"
+    viewBox="0 0 100 100"
+    shapeRendering="geometricPrecision"
+  >
+    <defs>
+      {/* Namespace the id to avoid collisions if multiple SVGs exist in DOM */}
+      <clipPath id="kbnElasticHeartClip" clipPathUnits="userSpaceOnUse">
+        {/* Classic heart silhouette: two rounded lobes, center notch, tapered point */}
+        <path d="M50 25 C50 12 42 4 30 4 C16 4 5 16 5 30 C12 48 28 72 50 95 C72 72 88 48 95 30 C95 16 84 4 70 4 C58 4 50 12 50 25 Z" />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#kbnElasticHeartClip)">
+      {/* Six segments tile the bounding box; the clip-path crops them to a heart. */}
+      {/* Layout mirrors the Elastic logo colour arrangement. */}
+
+      {/* Pink (small top-left accent) */}
+      <path fill="#EE5097" d="M0 0 L50 0 L33 20 L0 26 Z" />
+
+      {/* Yellow (top / right-lobe) */}
+      <path fill="#FDD009" d="M50 0 L100 0 L100 38 L58 38 L46 44 L33 20 Z" />
+
+      {/* Blue (left side) */}
+      <path fill="#17A7E0" d="M0 26 L33 20 L46 44 L0 56 Z" />
+
+      {/* Teal (large bottom-center) */}
+      <path fill="#23BAB1" d="M0 56 L46 44 L58 38 L64 66 L50 100 L0 100 Z" />
+
+      {/* Dark blue (right side) */}
+      <path fill="#0678A0" d="M100 38 L58 38 L64 66 L100 52 Z" />
+
+      {/* Green (bottom-right accent) */}
+      <path fill="#92C73D" d="M100 52 L64 66 L50 100 L100 100 Z" />
+    </g>
+  </svg>
+);

--- a/src/core/packages/rendering/server-internal/src/views/template.test.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/template.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { Template } from './template';
+import type { RenderingMetadata } from '../types';
+
+const createMockMetadata = (
+  overrides: Partial<RenderingMetadata> = {}
+): RenderingMetadata => ({
+  hardenPrototypes: false,
+  strictCsp: false,
+  uiPublicUrl: '/ui',
+  bootstrapScriptUrl: '/bootstrap.js',
+  locale: 'en',
+  themeVersion: 'v8',
+  darkMode: false,
+  stylesheetPaths: [],
+  scriptPaths: [],
+  injectedMetadata: {
+    theme: { name: 'amsterdam' },
+  } as any,
+  customBranding: {},
+  ...overrides,
+});
+
+describe('Template', () => {
+  describe('Valentine period logo', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('renders the Heart icon during Valentine period (Feb 1-14)', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2026, 1, 5)); // Feb 5
+
+      const markup = renderToStaticMarkup(
+        <Template metadata={createMockMetadata()} />
+      );
+
+      expect(markup).toContain('kbnElasticHeartClip');
+      expect(markup).not.toContain('logoElastic');
+
+      jest.useRealTimers();
+    });
+
+    it('renders the Heart icon on Feb 1 (start of period)', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2026, 1, 1)); // Feb 1
+
+      const markup = renderToStaticMarkup(
+        <Template metadata={createMockMetadata()} />
+      );
+
+      expect(markup).toContain('kbnElasticHeartClip');
+      jest.useRealTimers();
+    });
+
+    it('renders the Heart icon on Feb 14 (end of period)', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2026, 1, 14)); // Feb 14
+
+      const markup = renderToStaticMarkup(
+        <Template metadata={createMockMetadata()} />
+      );
+
+      expect(markup).toContain('kbnElasticHeartClip');
+      jest.useRealTimers();
+    });
+
+    it('renders the standard Logo outside Valentine period', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2026, 2, 1)); // Mar 1
+
+      const markup = renderToStaticMarkup(
+        <Template metadata={createMockMetadata()} />
+      );
+
+      expect(markup).not.toContain('kbnElasticHeartClip');
+      jest.useRealTimers();
+    });
+
+    it('renders the standard Logo on Feb 15 (day after period)', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2026, 1, 15)); // Feb 15
+
+      const markup = renderToStaticMarkup(
+        <Template metadata={createMockMetadata()} />
+      );
+
+      expect(markup).not.toContain('kbnElasticHeartClip');
+      jest.useRealTimers();
+    });
+
+    it('renders the standard Logo on Jan 31 (day before period)', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2026, 0, 31)); // Jan 31
+
+      const markup = renderToStaticMarkup(
+        <Template metadata={createMockMetadata()} />
+      );
+
+      expect(markup).not.toContain('kbnElasticHeartClip');
+      jest.useRealTimers();
+    });
+
+    it('uses custom branding logo over Heart icon even during Valentine period', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2026, 1, 10)); // Feb 10
+
+      const markup = renderToStaticMarkup(
+        <Template
+          metadata={createMockMetadata({ customBranding: { logo: 'https://example.com/logo.png' } })}
+        />
+      );
+
+      expect(markup).not.toContain('kbnElasticHeartClip');
+      expect(markup).toContain('https://example.com/logo.png');
+      jest.useRealTimers();
+    });
+  });
+});

--- a/src/core/packages/rendering/server-internal/src/views/template.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/template.tsx
@@ -13,12 +13,20 @@ import { EUI_STYLES_GLOBAL, EUI_STYLES_UTILS } from '@kbn/core-base-common';
 import { i18n } from '@kbn/i18n';
 import type { RenderingMetadata } from '../types';
 import { Fonts } from './fonts';
-import { Logo } from './logo';
+import { Logo, Heart } from './logo';
 import { Styles } from './styles';
 
 interface Props {
   metadata: RenderingMetadata;
 }
+
+// Helper function to check if current date is within Valentine's period (Feb 1-14)
+const isValentinesPeriod = (): boolean => {
+  const now = new Date();
+  const month = now.getMonth(); // 0-indexed (Jan = 0, Feb = 1)
+  const day = now.getDate();
+  return month === 1 && day >= 1 && day <= 14;
+};
 
 export const Template: FunctionComponent<Props> = ({
   metadata: {
@@ -37,10 +45,11 @@ export const Template: FunctionComponent<Props> = ({
   const title = customBranding.pageTitle ?? 'Elastic';
   const favIcon = customBranding.faviconSVG ?? `${uiPublicUrl}/favicons/favicon.svg`;
   const favIconPng = customBranding.faviconPNG ?? `${uiPublicUrl}/favicons/favicon.png`;
+  const DefaultIcon = isValentinesPeriod() ? Heart : Logo;
   const logo = customBranding.logo ? (
     <img src={customBranding.logo} width="64" height="64" alt="logo" />
   ) : (
-    <Logo />
+    <DefaultIcon />
   );
   return (
     <html lang={locale}>

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/__snapshots__/login_page.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/__snapshots__/login_page.test.tsx.snap
@@ -324,10 +324,54 @@ exports[`LoginPage page renders as expected 1`] = `
       >
         <span
           class="loginWelcome__logo"
+          style="padding: 0px;"
         >
-          <span
-            data-euiicon-type="logoElastic"
-          />
+          <svg
+            height="64"
+            shape-rendering="geometricPrecision"
+            viewBox="0 0 100 100"
+            width="64"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <defs>
+              <clippath
+                clipPathUnits="userSpaceOnUse"
+                id="loginHeartClip"
+              >
+                <path
+                  d="M50 25 C50 12 42 4 30 4 C16 4 5 16 5 30 C12 48 28 72 50 95 C72 72 88 48 95 30 C95 16 84 4 70 4 C58 4 50 12 50 25 Z"
+                />
+              </clippath>
+            </defs>
+            <g
+              clip-path="url(#loginHeartClip)"
+            >
+              <path
+                d="M0 0 L50 0 L33 20 L0 26 Z"
+                fill="#EE5097"
+              />
+              <path
+                d="M50 0 L100 0 L100 38 L58 38 L46 44 L33 20 Z"
+                fill="#FDD009"
+              />
+              <path
+                d="M0 26 L33 20 L46 44 L0 56 Z"
+                fill="#17A7E0"
+              />
+              <path
+                d="M0 56 L46 44 L58 38 L64 66 L50 100 L0 100 Z"
+                fill="#23BAB1"
+              />
+              <path
+                d="M100 38 L58 38 L64 66 L100 52 Z"
+                fill="#0678A0"
+              />
+              <path
+                d="M100 52 L64 66 L50 100 L100 100 Z"
+                fill="#92C73D"
+              />
+            </g>
+          </svg>
         </span>
         <h1
           class="euiTitle loginWelcome__title emotion-euiTitle-m"

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.test.tsx
@@ -426,6 +426,106 @@ describe('LoginPage', () => {
     });
   });
 
+  describe('Valentine period logo', () => {
+    const fakeTimerOptions = {
+      now: new Date(2026, 1, 5),
+      doNotFake: [
+        'setTimeout',
+        'setInterval',
+        'clearTimeout',
+        'clearInterval',
+        'setImmediate',
+        'clearImmediate',
+        'nextTick',
+        'queueMicrotask',
+      ] as const,
+    };
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('renders the HeartIcon during Valentine period (Feb 1-14)', async () => {
+      jest.useFakeTimers({ ...fakeTimerOptions, now: new Date(2026, 1, 5) });
+
+      const coreStartMock = coreMock.createStart();
+      customBrandingMock.customBranding$ = of({});
+      httpMock.get.mockResolvedValue(createLoginState());
+
+      const wrapper = shallow(
+        <LoginPage
+          http={httpMock}
+          notifications={coreStartMock.notifications}
+          fatalErrors={coreStartMock.fatalErrors}
+          loginAssistanceMessage=""
+          customBranding={customBrandingMock}
+        />
+      );
+
+      await act(async () => {
+        await nextTick();
+        wrapper.update();
+      });
+
+      expect(wrapper.find('HeartIcon').exists()).toBe(true);
+      expect(wrapper.find('EuiIcon[type="logoElastic"]').exists()).toBe(false);
+    });
+
+    it('renders the default EuiIcon outside Valentine period', async () => {
+      jest.useFakeTimers({ ...fakeTimerOptions, now: new Date(2026, 5, 15) });
+
+      const coreStartMock = coreMock.createStart();
+      customBrandingMock.customBranding$ = of({});
+      httpMock.get.mockResolvedValue(createLoginState());
+
+      const wrapper = shallow(
+        <LoginPage
+          http={httpMock}
+          notifications={coreStartMock.notifications}
+          fatalErrors={coreStartMock.fatalErrors}
+          loginAssistanceMessage=""
+          customBranding={customBrandingMock}
+        />
+      );
+
+      await act(async () => {
+        await nextTick();
+        wrapper.update();
+      });
+
+      expect(wrapper.find('HeartIcon').exists()).toBe(false);
+      expect(wrapper.find('EuiIcon[type="logoElastic"]').exists()).toBe(true);
+    });
+
+    it('uses custom branding logo over HeartIcon even during Valentine period', async () => {
+      jest.useFakeTimers({ ...fakeTimerOptions, now: new Date(2026, 1, 10) });
+
+      const coreStartMock = coreMock.createStart();
+      customBrandingMock.customBranding$ = of({ logo: 'https://example.com/logo.png' });
+      httpMock.get.mockResolvedValue(
+        createLoginState({ customBranding: { logo: 'https://example.com/logo.png' } })
+      );
+
+      const wrapper = shallow(
+        <LoginPage
+          http={httpMock}
+          notifications={coreStartMock.notifications}
+          fatalErrors={coreStartMock.fatalErrors}
+          loginAssistanceMessage=""
+          customBranding={customBrandingMock}
+        />
+      );
+
+      await act(async () => {
+        await nextTick();
+        wrapper.update();
+      });
+
+      expect(wrapper.find('HeartIcon').exists()).toBe(false);
+      expect(wrapper.find('EuiImage').exists()).toBe(true);
+    });
+  });
+
   describe('API calls', () => {
     it('GET login_state success', async () => {
       const coreStartMock = coreMock.createStart();

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.tsx
@@ -45,6 +45,39 @@ import type { LoginState } from '../../../common/login_state';
 import type { LogoutReason } from '../../../common/types';
 import type { ConfigType } from '../../config';
 
+// Check if current date is within Valentine's period (Feb 1-14)
+const isValentinesPeriod = (): boolean => {
+  const now = new Date();
+  const month = now.getMonth(); // 0-indexed (Jan = 0, Feb = 1)
+  const day = now.getDate();
+  return month === 1 && day >= 1 && day <= 14;
+};
+
+// Heart icon using Elastic brand colours, shown during Valentine's period
+const HeartIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="64"
+    height="64"
+    viewBox="0 0 100 100"
+    shapeRendering="geometricPrecision"
+  >
+    <defs>
+      <clipPath id="loginHeartClip" clipPathUnits="userSpaceOnUse">
+        <path d="M50 25 C50 12 42 4 30 4 C16 4 5 16 5 30 C12 48 28 72 50 95 C72 72 88 48 95 30 C95 16 84 4 70 4 C58 4 50 12 50 25 Z" />
+      </clipPath>
+    </defs>
+    <g clipPath="url(#loginHeartClip)">
+      <path fill="#EE5097" d="M0 0 L50 0 L33 20 L0 26 Z" />
+      <path fill="#FDD009" d="M50 0 L100 0 L100 38 L58 38 L46 44 L33 20 Z" />
+      <path fill="#17A7E0" d="M0 26 L33 20 L46 44 L0 56 Z" />
+      <path fill="#23BAB1" d="M0 56 L46 44 L58 38 L64 66 L50 100 L0 100 Z" />
+      <path fill="#0678A0" d="M100 38 L58 38 L64 66 L100 52 Z" />
+      <path fill="#92C73D" d="M100 52 L64 66 L50 100 L100 100 Z" />
+    </g>
+  </svg>
+);
+
 interface Props {
   http: HttpStart;
   notifications: NotificationsStart;
@@ -159,11 +192,13 @@ export class LoginPage extends Component<Props, State> {
     const customLogo = this.state.customBranding?.logo;
     const logo = customLogo ? (
       <EuiImage src={customLogo} size={40} alt="logo" />
+    ) : isValentinesPeriod() ? (
+      <HeartIcon />
     ) : (
       <EuiIcon type="logoElastic" size="xxl" />
     );
-    // custom logo needs to be centered
-    const logoStyle = customLogo ? { padding: 0 } : {};
+    // custom logo / heart icon needs to be centered
+    const logoStyle = customLogo || isValentinesPeriod() ? { padding: 0 } : {};
     return (
       <div data-test-subj="loginForm" css={kbnFullScreenBgCss}>
         <header


### PR DESCRIPTION
## Summary

- Adds a heart-shaped SVG icon composed of Elastic brand colours
- Swaps the default Elastic logo for the heart on the loading screen and login page during February 1–14
- Falls back to the standard logo outside the Valentine's window and when custom branding is configured

## Test plan

- [ ] Verify the heart icon appears on the loading/splash screen during Feb 1–14
- [ ] Verify the heart icon appears on the login page during Feb 1–14
- [ ] Verify the standard Elastic logo is shown outside the Valentine's period
- [ ] Verify custom branding logos still take precedence when configured