### PR TITLE
[8.19] [SLO] Fix SLO filter containing space and wildcard (#251033)

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/common/parse_kuery.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/parse_kuery.ts
@@ -6,23 +6,33 @@
  */
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import { kqlQuerySchema, QuerySchema } from '@kbn/slo-schema';
-import { buildEsQuery, fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
+import type { QuerySchema } from '@kbn/slo-schema';
+import { kqlQuerySchema } from '@kbn/slo-schema';
+import { buildEsQuery } from '@kbn/es-query';
+import type { DataViewBase } from '@kbn/es-query';
+import { isEmpty } from 'lodash';
 
-export function getElasticsearchQueryOrThrow(kuery: QuerySchema = ''): QueryDslQueryContainer {
+export function getElasticsearchQueryOrThrow(
+  kuery: QuerySchema = '',
+  dataView?: DataViewBase
+): QueryDslQueryContainer {
   try {
-    if (kqlQuerySchema.is(kuery)) {
-      return toElasticsearchQuery(fromKueryExpression(kuery));
-    } else {
-      return buildEsQuery(
-        undefined,
-        {
-          query: kuery?.kqlQuery,
-          language: 'kuery',
-        },
-        kuery?.filters
-      );
+    if (isEmpty(kuery)) {
+      return { match_all: {} };
     }
+    const kqlQuery = kqlQuerySchema.is(kuery) ? kuery : kuery.kqlQuery;
+    const filters = kqlQuerySchema.is(kuery) ? [] : kuery.filters;
+    return buildEsQuery(
+      dataView,
+      {
+        query: kqlQuery,
+        language: 'kuery',
+      },
+      filters,
+      {
+        allowLeadingWildcards: true,
+      }
+    );
   } catch (err) {
     return [] as QueryDslQueryContainer;
   }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/data_preview_chart.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/data_preview_chart.tsx
@@ -299,7 +299,7 @@ export function DataPreviewChart({
                 yAccessors={['value']}
                 data={(previewData?.results ?? []).map((datum) => ({
                   date: new Date(datum.date).getTime(),
-                  value: datum.sliValue && datum.sliValue >= 0 ? datum.sliValue : null,
+                  value: datum.sliValue != null && datum.sliValue >= 0 ? datum.sliValue : null,
                   events: datum.events,
                 }))}
               />
@@ -315,7 +315,7 @@ export function DataPreviewChart({
                   yAccessors={['value']}
                   data={data.map((datum) => ({
                     date: new Date(datum.date).getTime(),
-                    value: datum.sliValue && datum.sliValue >= 0 ? datum.sliValue : null,
+                    value: datum.sliValue != null && datum.sliValue >= 0 ? datum.sliValue : null,
                     events: datum.events,
                   }))}
                 />

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/use_table_docs.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/use_table_docs.tsx
@@ -28,7 +28,7 @@ export const useTableDocs = ({
   const errorMessages = getFieldState(name).error?.message;
   const filter = watch(name) as QuerySchema;
 
-  const esFilter = getElasticsearchQueryOrThrow(filter);
+  const esFilter = getElasticsearchQueryOrThrow(filter, dataView);
 
   const { data, loading, error } = useEsSearch(
     {

--- a/x-pack/solutions/observability/plugins/slo/server/services/aggregations/get_custom_metric_indicator_aggregation.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/aggregations/get_custom_metric_indicator_aggregation.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import { metricCustomDocCountMetric, MetricCustomIndicator } from '@kbn/slo-schema';
+import type { MetricCustomIndicator } from '@kbn/slo-schema';
+import { metricCustomDocCountMetric } from '@kbn/slo-schema';
+import type { DataView } from '@kbn/data-views-plugin/common';
 import { getElasticsearchQueryOrThrow } from '../transform_generators';
 
 type MetricCustomMetricDef =
@@ -13,12 +15,12 @@ type MetricCustomMetricDef =
   | MetricCustomIndicator['params']['total'];
 
 export class GetCustomMetricIndicatorAggregation {
-  constructor(private indicator: MetricCustomIndicator) {}
+  constructor(private indicator: MetricCustomIndicator, private dataView?: DataView) {}
 
   private buildMetricAggregations(type: 'good' | 'total', metricDef: MetricCustomMetricDef) {
     return metricDef.metrics.reduce((acc, metric) => {
       const filter = metric.filter
-        ? getElasticsearchQueryOrThrow(metric.filter)
+        ? getElasticsearchQueryOrThrow(metric.filter, this.dataView)
         : { match_all: {} };
 
       if (metricCustomDocCountMetric.is(metric)) {

--- a/x-pack/solutions/observability/plugins/slo/server/services/aggregations/get_histogram_indicator_aggregation.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/aggregations/get_histogram_indicator_aggregation.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { HistogramIndicator } from '@kbn/slo-schema';
-import { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { HistogramIndicator } from '@kbn/slo-schema';
+import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { DataView } from '@kbn/data-views-plugin/common';
 import { getElasticsearchQueryOrThrow } from '../transform_generators/common';
 
 type HistogramIndicatorDef =
@@ -14,11 +14,11 @@ type HistogramIndicatorDef =
   | HistogramIndicator['params']['total'];
 
 export class GetHistogramIndicatorAggregation {
-  constructor(private indicator: HistogramIndicator) {}
+  constructor(private indicator: HistogramIndicator, private dataView?: DataView) {}
 
   private buildAggregation(indicator: HistogramIndicatorDef): AggregationsAggregationContainer {
     const filter = indicator.filter
-      ? getElasticsearchQueryOrThrow(indicator.filter)
+      ? getElasticsearchQueryOrThrow(indicator.filter, this.dataView)
       : { match_all: {} };
     if (indicator.aggregation === 'value_count') {
       return {

--- a/x-pack/solutions/observability/plugins/slo/server/services/aggregations/get_timeslice_metric_indicator_aggregation.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/aggregations/get_timeslice_metric_indicator_aggregation.ts
@@ -8,6 +8,7 @@
 import { TimesliceMetricIndicator, timesliceMetricMetricDef } from '@kbn/slo-schema';
 import * as t from 'io-ts';
 import { assertNever } from '@kbn/std';
+import type { DataView } from '@kbn/data-views-plugin/common';
 
 import { getElasticsearchQueryOrThrow } from '../transform_generators';
 
@@ -15,7 +16,7 @@ type TimesliceMetricDef = TimesliceMetricIndicator['params']['metric'];
 type TimesliceMetricMetricDef = t.TypeOf<typeof timesliceMetricMetricDef>;
 
 export class GetTimesliceMetricIndicatorAggregation {
-  constructor(private indicator: TimesliceMetricIndicator) {}
+  constructor(private indicator: TimesliceMetricIndicator, private dataView?: DataView) {}
 
   private buildAggregation(metric: TimesliceMetricMetricDef) {
     const { aggregation } = metric;
@@ -85,7 +86,7 @@ export class GetTimesliceMetricIndicatorAggregation {
   private buildMetricAggregations(metricDef: TimesliceMetricDef) {
     return metricDef.metrics.reduce((acc, metric) => {
       const filter = metric.filter
-        ? getElasticsearchQueryOrThrow(metric.filter)
+        ? getElasticsearchQueryOrThrow(metric.filter, this.dataView)
         : { match_all: {} };
       const aggs = { metric: this.buildAggregation(metric) };
       return {

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_preview_data.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_preview_data.test.ts
@@ -10,14 +10,56 @@ import { dataViewsService } from '@kbn/data-views-plugin/server/mocks';
 import { GetPreviewDataParams } from '@kbn/slo-schema';
 import { GetPreviewData } from './get_preview_data';
 import { oneMinute } from './fixtures/duration';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import type { DataViewsService } from '@kbn/data-views-plugin/common';
 
 describe('GetPreviewData', () => {
   let esClientMock: ElasticsearchClientMock;
   let service: GetPreviewData;
+  let mockDataViewsService: jest.Mocked<DataViewsService>;
 
   beforeEach(() => {
     esClientMock = elasticsearchServiceMock.createElasticsearchClient();
-    service = new GetPreviewData(esClientMock, 'default', dataViewsService);
+    mockDataViewsService = {
+      ...dataViewsService,
+      get: jest.fn().mockImplementation((dataViewId: string) => {
+        if (dataViewId === 'e7744dbe-a7a4-457b-83aa-539e9c88764c') {
+          return Promise.resolve(
+            createStubDataView({
+              spec: {
+                id: dataViewId,
+                title: 'kbn-data-forge-fake_stack.admin-console-*',
+                timeFieldName: '@timestamp',
+                fields: {
+                  'http.response.status_code': {
+                    name: 'http.response.status_code',
+                    type: 'number',
+                    esTypes: ['long'],
+                    searchable: true,
+                    aggregatable: true,
+                    readFromDocValues: true,
+                  },
+                },
+              },
+            })
+          );
+        }
+        if (dataViewId === '593f894a-3378-42cc-bafc-61b4877b64b0') {
+          return Promise.resolve(
+            createStubDataView({
+              spec: {
+                id: dataViewId,
+                title: 'kbn-data-forge-fake_stack.message_processor-*',
+                timeFieldName: '@timestamp',
+                fields: {},
+              },
+            })
+          );
+        }
+        return Promise.reject(new Error('Data view not found'));
+      }),
+    } as any;
+    service = new GetPreviewData(esClientMock, 'default', mockDataViewsService);
   });
 
   describe("for 'Custom KQL' indicator type", () => {

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/histogram.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/histogram.ts
@@ -40,7 +40,7 @@ export class HistogramTransformGenerator extends TransformGenerator {
       await this.buildSource(slo, slo.indicator),
       this.buildDestination(slo),
       this.buildCommonGroupBy(slo, slo.indicator.params.timestampField),
-      this.buildAggregations(slo, slo.indicator),
+      await this.buildAggregations(slo, slo.indicator),
       this.buildSettings(slo, slo.indicator.params.timestampField),
       slo
     );
@@ -74,8 +74,12 @@ export class HistogramTransformGenerator extends TransformGenerator {
     };
   }
 
-  private buildAggregations(slo: SLODefinition, indicator: HistogramIndicator) {
-    const getHistogramIndicatorAggregations = new GetHistogramIndicatorAggregation(indicator);
+  private async buildAggregations(slo: SLODefinition, indicator: HistogramIndicator) {
+    const dataView = await this.getIndicatorDataView(indicator.params.dataViewId);
+    const getHistogramIndicatorAggregations = new GetHistogramIndicatorAggregation(
+      indicator,
+      dataView
+    );
 
     return {
       ...getHistogramIndicatorAggregations.execute({

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/kql_custom.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/kql_custom.ts
@@ -54,7 +54,7 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
         bool: {
           filter: [
             getFilterRange(slo, indicator.params.timestampField, this.isServerless),
-            getElasticsearchQueryOrThrow(indicator.params.filter),
+            getElasticsearchQueryOrThrow(indicator.params.filter, dataView),
           ],
         },
       },

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/metric_custom.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/metric_custom.ts
@@ -39,7 +39,7 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
       await this.buildSource(slo, slo.indicator),
       this.buildDestination(slo),
       this.buildCommonGroupBy(slo, slo.indicator.params.timestampField),
-      this.buildAggregations(slo, slo.indicator),
+      await this.buildAggregations(slo, slo.indicator),
       this.buildSettings(slo, slo.indicator.params.timestampField),
       slo
     );
@@ -72,7 +72,7 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
     };
   }
 
-  private buildAggregations(slo: SLODefinition, indicator: MetricCustomIndicator) {
+  private async buildAggregations(slo: SLODefinition, indicator: MetricCustomIndicator) {
     if (indicator.params.good.equation.match(INVALID_EQUATION_REGEX)) {
       throw new Error(`Invalid equation: ${indicator.params.good.equation}`);
     }
@@ -81,7 +81,11 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
       throw new Error(`Invalid equation: ${indicator.params.total.equation}`);
     }
 
-    const getCustomMetricIndicatorAggregation = new GetCustomMetricIndicatorAggregation(indicator);
+    const dataView = await this.getIndicatorDataView(indicator.params.dataViewId);
+    const getCustomMetricIndicatorAggregation = new GetCustomMetricIndicatorAggregation(
+      indicator,
+      dataView
+    );
     return {
       ...getCustomMetricIndicatorAggregation.execute({
         type: 'good',

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/synthetics_availability.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/synthetics_availability.ts
@@ -108,6 +108,7 @@ export class SyntheticsAvailabilityTransformGenerator extends TransformGenerator
   }
 
   private async buildSource(slo: SLODefinition, indicator: SyntheticsAvailabilityIndicator) {
+    const dataView = await this.getIndicatorDataView(indicator.params.dataViewId);
     const queryFilter: estypes.QueryDslQueryContainer[] = [
       { term: { 'summary.final_attempt': true } },
       { term: { 'meta.space_id': this.spaceId } },
@@ -144,10 +145,8 @@ export class SyntheticsAvailabilityTransformGenerator extends TransformGenerator
     }
 
     if (!!indicator.params.filter) {
-      queryFilter.push(getElasticsearchQueryOrThrow(indicator.params.filter));
+      queryFilter.push(getElasticsearchQueryOrThrow(indicator.params.filter, dataView));
     }
-
-    const dataView = await this.getIndicatorDataView(indicator.params.dataViewId);
 
     return {
       index: SYNTHETICS_INDEX_PATTERN,

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/timeslice_metric.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/timeslice_metric.ts
@@ -43,7 +43,7 @@ export class TimesliceMetricTransformGenerator extends TransformGenerator {
       await this.buildSource(slo, slo.indicator),
       this.buildDestination(slo),
       this.buildCommonGroupBy(slo, slo.indicator.params.timestampField),
-      this.buildAggregations(slo, slo.indicator),
+      await this.buildAggregations(slo, slo.indicator),
       this.buildSettings(slo, slo.indicator.params.timestampField),
       slo
     );
@@ -77,7 +77,7 @@ export class TimesliceMetricTransformGenerator extends TransformGenerator {
     };
   }
 
-  private buildAggregations(slo: SLODefinition, indicator: TimesliceMetricIndicator) {
+  private async buildAggregations(slo: SLODefinition, indicator: TimesliceMetricIndicator) {
     if (indicator.params.metric.equation.match(INVALID_EQUATION_REGEX)) {
       throw new Error(`Invalid equation: ${indicator.params.metric.equation}`);
     }
@@ -86,7 +86,8 @@ export class TimesliceMetricTransformGenerator extends TransformGenerator {
       throw new Error('The sli.metric.timeslice indicator MUST have a timeslice budgeting method.');
     }
 
-    const getIndicatorAggregation = new GetTimesliceMetricIndicatorAggregation(indicator);
+    const dataView = await this.getIndicatorDataView(indicator.params.dataViewId);
+    const getIndicatorAggregation = new GetTimesliceMetricIndicatorAggregation(indicator, dataView);
     const comparator = timesliceMetricComparatorMapping[indicator.params.metric.comparator];
     return {
       ...getIndicatorAggregation.execute('_metric'),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[SLO] Fix SLO filter containing space and wildcard (#251033)](https://github.com/elastic/kibana/pull/251033)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Panagiota Mitsopoulou","email":"panagiota.mitsopoulou@elastic.co"},"sourceCommit":{"committedDate":"2026-02-02T09:17:02Z","message":"[SLO] Fix SLO filter containing space and wildcard (#251033)\n\nFixes https://github.com/elastic/kibana/issues/250781\nFixes https://github.com/elastic/kibana/issues/251039\n\n## Summary\n\nCurrently in SLO edit/create form when user uses a filter query that\ncontains a space followed by a wildcard character (`tags: hello *`), it\nbehaves as if it's using Lucene syntax instead of KQL (generates\n`query_string` queries instead of `wildcard` queries for keyword\nfields). `query_string` uses Lucene syntax which handles spaces and\nwildcards differently than KQL, leading to queries matching all\ndocuments or no documents instead of the intended subset.\n\n## Root cause\nThe `getElasticsearchQueryOrThrow` function accepts an optional\n`dataView` parameter that is required for `buildEsQuery` to determine\nfield types (keyword vs text vs other types). With a missing dataView\n[getFields](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es-query/src/kuery/functions/utils/get_fields.ts#L14)()\ncan't find the field in the dataView, so it falls back to a field with\nno type info, causing `query_string` instead of `wildcard`\n\n\nThis PR fixes various calls to `getElasticsearchQueryOrThrow` to include\na `dataView`. It also fixes a visual issue with the preview chart, where\nit appeared to be empty where sliValue = 0. Now it shows a line at the\n0% level for those time intervals where good events might be 0.\n\n## After, tags: hello *, only hello all documents returned\n\n\n<img width=\"1126\" height=\"465\"\nalt=\"542489023-4f0a0439-3615-436b-a265-132a929563f9\"\nsrc=\"https://github.com/user-attachments/assets/48267637-2b8d-48ae-ac41-bf452804ab7e\"\n/>\n\n## SLO documents flyout showing only documents with hello all tag\n\n<img width=\"1308\" height=\"528\" alt=\"Screenshot 2026-01-30 at 01 43 04\"\nsrc=\"https://github.com/user-attachments/assets/dc880ca9-6baa-4a72-a8be-0d6e0a52fcda\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"96eb62cfbe06cf210adf56ed71b70d5e618b87ec","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:actionable-obs","backport:version","v9.4.0","author:actionable-obs","Team:obs-ux-management","v9.2.5","v8.19.11","v9.3.1"],"title":"[SLO] Fix SLO filter containing space and wildcard","number":251033,"url":"https://github.com/elastic/kibana/pull/251033","mergeCommit":{"message":"[SLO] Fix SLO filter containing space and wildcard (#251033)\n\nFixes https://github.com/elastic/kibana/issues/250781\nFixes https://github.com/elastic/kibana/issues/251039\n\n## Summary\n\nCurrently in SLO edit/create form when user uses a filter query that\ncontains a space followed by a wildcard character (`tags: hello *`), it\nbehaves as if it's using Lucene syntax instead of KQL (generates\n`query_string` queries instead of `wildcard` queries for keyword\nfields). `query_string` uses Lucene syntax which handles spaces and\nwildcards differently than KQL, leading to queries matching all\ndocuments or no documents instead of the intended subset.\n\n## Root cause\nThe `getElasticsearchQueryOrThrow` function accepts an optional\n`dataView` parameter that is required for `buildEsQuery` to determine\nfield types (keyword vs text vs other types). With a missing dataView\n[getFields](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es-query/src/kuery/functions/utils/get_fields.ts#L14)()\ncan't find the field in the dataView, so it falls back to a field with\nno type info, causing `query_string` instead of `wildcard`\n\n\nThis PR fixes various calls to `getElasticsearchQueryOrThrow` to include\na `dataView`. It also fixes a visual issue with the preview chart, where\nit appeared to be empty where sliValue = 0. Now it shows a line at the\n0% level for those time intervals where good events might be 0.\n\n## After, tags: hello *, only hello all documents returned\n\n\n<img width=\"1126\" height=\"465\"\nalt=\"542489023-4f0a0439-3615-436b-a265-132a929563f9\"\nsrc=\"https://github.com/user-attachments/assets/48267637-2b8d-48ae-ac41-bf452804ab7e\"\n/>\n\n## SLO documents flyout showing only documents with hello all tag\n\n<img width=\"1308\" height=\"528\" alt=\"Screenshot 2026-01-30 at 01 43 04\"\nsrc=\"https://github.com/user-attachments/assets/dc880ca9-6baa-4a72-a8be-0d6e0a52fcda\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"96eb62cfbe06cf210adf56ed71b70d5e618b87ec"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251033","number":251033,"mergeCommit":{"message":"[SLO] Fix SLO filter containing space and wildcard (#251033)\n\nFixes https://github.com/elastic/kibana/issues/250781\nFixes https://github.com/elastic/kibana/issues/251039\n\n## Summary\n\nCurrently in SLO edit/create form when user uses a filter query that\ncontains a space followed by a wildcard character (`tags: hello *`), it\nbehaves as if it's using Lucene syntax instead of KQL (generates\n`query_string` queries instead of `wildcard` queries for keyword\nfields). `query_string` uses Lucene syntax which handles spaces and\nwildcards differently than KQL, leading to queries matching all\ndocuments or no documents instead of the intended subset.\n\n## Root cause\nThe `getElasticsearchQueryOrThrow` function accepts an optional\n`dataView` parameter that is required for `buildEsQuery` to determine\nfield types (keyword vs text vs other types). With a missing dataView\n[getFields](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es-query/src/kuery/functions/utils/get_fields.ts#L14)()\ncan't find the field in the dataView, so it falls back to a field with\nno type info, causing `query_string` instead of `wildcard`\n\n\nThis PR fixes various calls to `getElasticsearchQueryOrThrow` to include\na `dataView`. It also fixes a visual issue with the preview chart, where\nit appeared to be empty where sliValue = 0. Now it shows a line at the\n0% level for those time intervals where good events might be 0.\n\n## After, tags: hello *, only hello all documents returned\n\n\n<img width=\"1126\" height=\"465\"\nalt=\"542489023-4f0a0439-3615-436b-a265-132a929563f9\"\nsrc=\"https://github.com/user-attachments/assets/48267637-2b8d-48ae-ac41-bf452804ab7e\"\n/>\n\n## SLO documents flyout showing only documents with hello all tag\n\n<img width=\"1308\" height=\"528\" alt=\"Screenshot 2026-01-30 at 01 43 04\"\nsrc=\"https://github.com/user-attachments/assets/dc880ca9-6baa-4a72-a8be-0d6e0a52fcda\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"96eb62cfbe06cf210adf56ed71b70d5e618b87ec"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251197","number":251197,"state":"OPEN"},{"branch":"8.19","label":"v8.19.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251198","number":251198,"state":"OPEN"}]}] BACKPORT-->