### PR TITLE
[Security Solution] Add continuous learning and feedback to Flaky Test Doctor

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/.cursor/rules/flaky_test_doctor.mdc
+++ b/x-pack/solutions/security/test/security_solution_cypress/.cursor/rules/flaky_test_doctor.mdc
@@ -1558,3 +1558,28 @@ When analyzing a flaky test, structure your response as:
 ## 🔗 Related Files
 [List of files to check or modify]
 ```
+
+---
+
+## Continuous Learning
+
+**Be proactive about new patterns.** When you identify a root cause or fix that is NOT already documented in this rule, immediately tell the user:
+
+> "I noticed this fix involves a pattern that's not yet documented in the flaky-test-doctor rule: **[brief description of pattern]**. Would you like me to add it so future fixes can benefit from this learning?"
+
+If the user agrees, add the pattern to the "Common Flaky Patterns" section following the established format.
+
+**Signs you've discovered something new:**
+- The root cause doesn't match any existing pattern in this rule
+- You had to investigate a unique combination of factors
+- The fix required a technique not mentioned in this rule
+- Environment-specific behavior that wasn't documented
+
+---
+
+## After Completing a Fix
+
+When you've successfully helped fix a flaky test (fix verified or PR ready), end the conversation by requesting feedback:
+
+> "If you have a moment, please share your feedback on the Flaky Test Doctor to help us improve:
+> **[Take the 1-minute feedback survey](https://docs.google.com/forms/d/e/1FAIpQLSc5pg7XxvKl0y8rmKoFCcs851nyQLgG5ndxOJCK6FsMRKcDfA/viewform)**"


### PR DESCRIPTION
## Summary

Adds continuous learning and feedback collection capabilities to the Flaky Test Doctor rule.

## Changes

### Continuous Learning

The rule now proactively identifies when a fix involves a pattern not yet documented and offers to add it:

> "I noticed this fix involves a pattern that's not yet documented in the flaky-test-doctor rule: **[description]**. Would you like me to add it so future fixes can benefit from this learning?"

**Signs the AI should speak up:**
- Root cause doesn't match existing patterns
- Unique combination of factors discovered
- Fix required an undocumented technique
- New environment-specific behavior found

### Feedback Collection

After completing a fix, the AI now shares a feedback survey link to help improve the tool:

> "If you have a moment, please share your feedback on the Flaky Test Doctor to help us improve:
> **[Take the 1-minute feedback survey](https://docs.google.com/forms/d/e/1FAIpQLSc5pg7XxvKl0y8rmKoFCcs851nyQLgG5ndxOJCK6FsMRKcDfA/viewform)**"

## Why

- Ensures the rule evolves with real-world learnings from each fix
- Captures user feedback to guide future improvements
- Makes knowledge sharing automatic rather than manual

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->