### PR TITLE
fix(kbn-elastic-assistant): make the confirm delete modal accessible

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/system_prompt_settings_management/index.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiText,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 
@@ -78,6 +79,8 @@ const SystemPromptSettingsManagementComponent = ({ connectors, defaultConnector 
     closeFlyout: closeConfirmModal,
   } = useFlyoutModalVisibility();
   const [deletedPrompt, setDeletedPrompt] = useState<PromptResponse | null>();
+  const confirmModalTitleId = useGeneratedHtmlId();
+  const confirmModalDescriptionId = useGeneratedHtmlId();
 
   const {
     conversationsSettingsBulkActions,
@@ -258,9 +261,10 @@ const SystemPromptSettingsManagementComponent = ({ connectors, defaultConnector 
       </Flyout>
       {deleteConfirmModalVisibility && deletedPrompt?.name && (
         <EuiConfirmModal
-          aria-labelledby={confirmationTitle}
+          aria-labelledby={confirmModalTitleId}
+          aria-describedby={confirmModalDescriptionId}
           title={confirmationTitle}
-          titleProps={{ id: deletedPrompt?.id ?? undefined }}
+          titleProps={{ id: confirmModalTitleId }}
           onCancel={onDeleteCancelled}
           onConfirm={onDeleteConfirmed}
           cancelButtonText={CANCEL}
@@ -268,7 +272,7 @@ const SystemPromptSettingsManagementComponent = ({ connectors, defaultConnector 
           buttonColor="danger"
           defaultFocusedButton="confirm"
         >
-          <p>{i18n.DELETE_SYSTEM_PROMPT_MODAL_DESCRIPTION}</p>
+          <p id={confirmModalDescriptionId}>{i18n.DELETE_SYSTEM_PROMPT_MODAL_DESCRIPTION}</p>
         </EuiConfirmModal>
       )}
     </>


### PR DESCRIPTION
## Add missing aria-* attributes

Add missing `aria-labelledby` and `aria-describedby` attributes to the delete confirmation modal and fix the `id` wiring.

Closes https://github.com/elastic/kibana/issues/231494

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


*PR developed with Cursor CLI GPT Codex 5.2 Hight Fast*


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->