### PR TITLE
[Automatic Migrations] Adds the feature flag to disable Dashboard v2 parsing

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -214,7 +214,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the Automatic Migration of Splunk dashboards in Security Solution
    */
-  splunkV2DashboardsEnabled: true,
+  splunkV2DashboardsEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -210,6 +210,11 @@ export const allowedExperimentalValues = Object.freeze({
    * When disabled, DNS field is not added to Linux policies and not shown in UI.
    */
   linuxDnsEvents: true,
+
+  /**
+   * Enables the Automatic Migration of Splunk dashboards in Security Solution
+   */
+  splunkV2DashboardsEnabled: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/dashboards/resources/resource_identifier.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/dashboards/resources/resource_identifier.ts
@@ -17,7 +17,9 @@ export class DashboardResourceIdentifier extends ResourceIdentifier<OriginalDash
     if (!originalDashboardXMLString) {
       return [];
     }
-    const splunkDashboardXMLPaser = await getSplunkDashboardXmlParser(originalDashboardXMLString);
+    const splunkDashboardXMLPaser = await getSplunkDashboardXmlParser(originalDashboardXMLString, {
+      experimentalFeatures: this.deps.experimentalFeatures,
+    });
     const queries: string[] = await splunkDashboardXMLPaser.extractQueries();
     const resources = await Promise.all(queries.map((query) => this.identifier(query)));
     return resources.flat();

--- a/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/parsers/splunk/dashboard_xml.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/parsers/splunk/dashboard_xml.ts
@@ -263,8 +263,22 @@ export class SplunkXmlDashboardParser extends XmlParser implements SplunkXmlDash
       };
     }
 
-    return {
-      isSupported: true,
-    };
+    // Check if rootTag has an attribute `version=1.1`
+    const versionMatch = xmlContent.match(/<\s*([a-zA-Z0-9_:]+)\s*.*version=['"]?1\.1['"]?/);
+    if (!versionMatch) {
+      return {
+        isSupported: false,
+        reason: `Unsupported version. Only version 1.1 is supported.`,
+      };
+    }
+
+    // Ensure it's a dashboard with rows
+    const hasRows = xmlContent.includes('<row');
+    return hasRows
+      ? { isSupported: true }
+      : {
+          isSupported: false,
+          reason: 'No <row> elements found in the provided Dashboard XML.',
+        };
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/parsers/splunk/get_dashboard_xml_parser.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/parsers/splunk/get_dashboard_xml_parser.ts
@@ -5,13 +5,26 @@
  * 2.0.
  */
 
+import type { ExperimentalFeatures } from '../../../experimental_features';
 import { SplunkXmlDashboardParser } from './dashboard_xml';
 import { SplunkXmlDashboardV2Parser } from './dashboard_xml_v2';
 
-export const getSplunkDashboardXmlParser = async (xml: string) => {
+interface SplunkDashboardXmlParserDeps {
+  experimentalFeatures: ExperimentalFeatures;
+}
+
+export const getSplunkDashboardXmlParser = async (
+  xml: string,
+  deps: SplunkDashboardXmlParserDeps
+) => {
   const dashboardParser = new SplunkXmlDashboardParser(xml);
+  const { splunkV2DashboardsEnabled } = deps.experimentalFeatures;
 
   const version = await dashboardParser.getVersion();
+  if (!splunkV2DashboardsEnabled) {
+    // always return old parser if V2 is not supported
+    return dashboardParser;
+  }
 
   if (version === '2') {
     return new SplunkXmlDashboardV2Parser(xml);

--- a/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/resources/resource_identifier_base.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/siem_migrations/resources/resource_identifier_base.ts
@@ -16,10 +16,15 @@ import type { ItemDocument, OriginalItem } from '../types';
 import type { SplunkResourceType } from '../model/vendor/common/splunk.gen';
 import type { QradarResourceType } from '../model/vendor/common/qradar.gen';
 import { qradarResourceIdentifier } from './qradar';
+import type { ExperimentalFeatures } from '../../experimental_features';
 
 export interface SiemMigrationResourceTypeByVendor {
   splunk: SplunkResourceType;
   qradar: QradarResourceType;
+}
+
+export interface ResourceIdentifierDeps {
+  experimentalFeatures: ExperimentalFeatures;
 }
 
 /** Currently resource identification is only needed for Splunk since this for Qradar we identify resources by LLM */
@@ -30,7 +35,8 @@ const identifiers: Record<ResourceSupportedVendor, VendorResourceIdentifier> = {
 
 // Type for a class that extends the ResourceIdentifier abstract class
 export type ResourceIdentifierConstructor<I extends ItemDocument = ItemDocument> = new (
-  vendor: ResourceSupportedVendor
+  vendor: ResourceSupportedVendor,
+  deps: ResourceIdentifierDeps
 ) => ResourceIdentifier<I>;
 
 export abstract class ResourceIdentifier<I> {
@@ -38,7 +44,10 @@ export abstract class ResourceIdentifier<I> {
 
   protected identifier: VendorResourceIdentifier;
 
-  constructor(protected readonly vendor: ResourceSupportedVendor) {
+  constructor(
+    protected readonly vendor: ResourceSupportedVendor,
+    protected readonly deps: ResourceIdentifierDeps
+  ) {
     // The constructor may need query_language as an argument for other vendors
     if (!isResourceSupportedVendor(this.vendor)) {
       throw new Error(`Resource identification is not supported for vendor: ${this.vendor}`);

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/data_input_flyout/steps/macros/macros_data_input.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/data_input_flyout/steps/macros/macros_data_input.test.tsx
@@ -41,6 +41,13 @@ jest.mock('../../../../../../common/lib/kibana/kibana_react', () => ({
   }),
 }));
 jest.mock('../../../../../../common/hooks/use_app_toasts');
+jest.mock('../../../../../../common/experimental_features_service', () => ({
+  ExperimentalFeaturesService: {
+    get: () => ({
+      splunkV2DashboardsEnabled: false,
+    }),
+  },
+}));
 
 describe('MacrosDataInput', () => {
   let appToastsMock: jest.Mocked<ReturnType<typeof useAppToastsMock.create>>;

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/data_input_flyout/steps/macros/sub_steps/macros_file_upload/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/data_input_flyout/steps/macros/sub_steps/macros_file_upload/index.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useMemo } from 'react';
 import type { EuiStepProps, EuiStepStatus } from '@elastic/eui';
+import { ExperimentalFeaturesService } from '../../../../../../../../common/experimental_features_service';
 import { useAppToasts } from '../../../../../../../../common/hooks/use_app_toasts';
 import type { SiemMigrationResourceData } from '../../../../../../../../../common/siem_migrations/model/common.gen';
 import { DashboardResourceIdentifier } from '../../../../../../../../../common/siem_migrations/dashboards/resources';
@@ -36,7 +37,9 @@ export const useMacrosFileUploadStep = ({
       const macrosIndexed: Record<string, SiemMigrationResourceData> = Object.fromEntries(
         macrosFromFile.map((macro) => [macro.name, macro])
       );
-      const resourceIdentifier = new DashboardResourceIdentifier('splunk');
+      const resourceIdentifier = new DashboardResourceIdentifier('splunk', {
+        experimentalFeatures: ExperimentalFeaturesService.get(),
+      });
       const macrosToUpsert: SiemMigrationResourceData[] = [];
       let missingMacrosIt: string[] = missingMacros;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/macros/macros_data_input.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/macros/macros_data_input.test.tsx
@@ -52,6 +52,14 @@ jest.mock('../../../../../common/hooks/use_missing_resources', () => ({
   }),
 }));
 
+jest.mock('../../../../../../common/experimental_features_service', () => ({
+  ExperimentalFeaturesService: {
+    get: () => ({
+      splunkV2DashboardsEnabled: false,
+    }),
+  },
+}));
+
 describe('MacrosDataInput', () => {
   let appToastsMock: jest.Mocked<ReturnType<typeof useAppToastsMock.create>>;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/macros/sub_steps/macros_file_upload/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/macros/sub_steps/macros_file_upload/index.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useMemo } from 'react';
 import type { EuiStepProps, EuiStepStatus } from '@elastic/eui';
+import { ExperimentalFeaturesService } from '../../../../../../../../common/experimental_features_service';
 import { useAppToasts } from '../../../../../../../../common/hooks/use_app_toasts';
 import type { SiemMigrationResourceData } from '../../../../../../../../../common/siem_migrations/model/common.gen';
 import { RuleResourceIdentifier } from '../../../../../../../../../common/siem_migrations/rules/resources';
@@ -36,7 +37,9 @@ export const useMacrosFileUploadStep = ({
       const macrosIndexed: Record<string, SiemMigrationResourceData> = Object.fromEntries(
         macrosFromFile.map((macro) => [macro.name, macro])
       );
-      const resourceIdentifier = new RuleResourceIdentifier('splunk');
+      const resourceIdentifier = new RuleResourceIdentifier('splunk', {
+        experimentalFeatures: ExperimentalFeaturesService.get(),
+      });
       const macrosToUpsert: SiemMigrationResourceData[] = [];
       let missingMacrosIt: string[] = missingMacros;
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/langgraph/draw_graphs_script.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/langgraph/draw_graphs_script.ts
@@ -19,6 +19,7 @@ import type {
 import type { RulesClient } from '@kbn/alerting-plugin/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { InferenceChatModel } from '@kbn/inference-langchain';
+import type { ExperimentalFeatures } from '../../common';
 import { getRulesMigrationTools } from '../../server/lib/siem_migrations/rules/task/agent/tools';
 import type { DashboardMigrationsRetriever } from '../../server/lib/siem_migrations/dashboards/task/retrievers';
 import { getDashboardMigrationAgent } from '../../server/lib/siem_migrations/dashboards/task/agent';
@@ -81,6 +82,7 @@ async function getSiemDashboardMigrationGraph(logger: Logger): Promise<Drawable>
     inference: {} as InferenceServerStart,
     request: {} as KibanaRequest,
     connectorId: 'test-connector-id',
+    experimentalFeatures: {} as unknown as ExperimentalFeatures,
   });
   return graph.getGraphAsync({ xray: true });
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/retrievers/resource_retriever.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/retrievers/resource_retriever.test.ts
@@ -11,6 +11,7 @@ import { ResourceIdentifier } from '../../../../../../common/siem_migrations/res
 import type { SiemMigrationsDataResourcesClient } from '../../data/siem_migrations_data_resources_client';
 import type { RuleMigrationRule } from '../../../../../../common/siem_migrations/model/rule_migration.gen';
 import type { ItemDocument } from '../../types';
+import type { ExperimentalFeatures } from '../../../../../../common';
 
 jest.mock('../../data/siem_migrations_data_resources_client');
 jest.mock('../../../../../../common/siem_migrations/resources');
@@ -27,6 +28,10 @@ const MockResourceIdentifierClass =
 class TestResourceRetriever extends ResourceRetriever {
   protected ResourceIdentifierClass = MockResourceIdentifierClass;
 }
+
+const mockExperimentalFeatures = {
+  splunkV2DashboardsEnabled: false,
+} as unknown as ExperimentalFeatures;
 
 const defaultResourceIdentifier = () =>
   ({
@@ -45,15 +50,14 @@ describe('ResourceRetriever', () => {
     } as unknown as jest.Mocked<SiemMigrationsDataResourcesClient>;
 
     MockResourceIdentifierClass.mockImplementation(defaultResourceIdentifier);
-    mockResourceIdentifier = new MockResourceIdentifierClass('splunk') as jest.Mocked<
-      ResourceIdentifier<ItemDocument>
-    >;
+    mockResourceIdentifier = new MockResourceIdentifierClass('splunk', {
+      experimentalFeatures: mockExperimentalFeatures,
+    }) as jest.Mocked<ResourceIdentifier<ItemDocument>>;
 
-    retriever = new TestResourceRetriever(
-      'mockMigrationId',
-      mockDataClient,
-      MockResourceIdentifierClass
-    );
+    retriever = new TestResourceRetriever('mockMigrationId', MockResourceIdentifierClass, {
+      resourcesDataClient: mockDataClient,
+      experimentalFeatures: mockExperimentalFeatures,
+    });
   });
 
   it('throws an error if initialize is not called before getResources', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/retrievers/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/retrievers/types.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ExperimentalFeatures } from '../../../../../../common';
+import type { SiemMigrationsDataResourcesClient } from '../../data/siem_migrations_data_resources_client';
+
+export interface ResourceRetrieverDeps {
+  experimentalFeatures: ExperimentalFeatures;
+  resourcesDataClient: SiemMigrationsDataResourcesClient;
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/types.ts
@@ -14,6 +14,7 @@ import type {
 import type { PackageService } from '@kbn/fleet-plugin/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { RulesClient } from '@kbn/alerting-plugin/server';
+import type { ExperimentalFeatures } from '../../../../common';
 import type {
   DashboardMigration,
   DashboardMigrationDashboard,
@@ -30,6 +31,7 @@ export interface SiemMigrationsClientDependencies {
   savedObjectsClient: SavedObjectsClientContract;
   packageService?: PackageService;
   telemetry: AnalyticsServiceSetup;
+  experimentalFeatures: ExperimentalFeatures;
 }
 
 export interface SiemMigrationsCreateClientParams {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/api/dashboards/create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/api/dashboards/create.ts
@@ -87,7 +87,10 @@ export const registerSiemDashboardMigrationsCreateDashboardsRoute = (
             );
 
             const resourceIdentifier = new DashboardResourceIdentifier(
-              items[0].original_dashboard.vendor
+              items[0].original_dashboard.vendor,
+              {
+                experimentalFeatures: ctx.securitySolution.getConfig().experimentalFeatures,
+              }
             );
 
             const [, extractedResources] = await Promise.all([

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/api/resources/upsert.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/api/resources/upsert.ts
@@ -62,6 +62,8 @@ export const registerSiemDashboardMigrationsResourceUpsertRoute = (
               const dashboardMigrationsClient =
                 ctx.securitySolution.siemMigrations.getDashboardsClient();
 
+              const { experimentalFeatures } = ctx.securitySolution.getConfig();
+
               await siemMigrationAuditLogger.logUploadResources({ migrationId });
 
               const [lookups, macros] = partition(resources, { type: 'lookup' });
@@ -76,7 +78,9 @@ export const registerSiemDashboardMigrationsResourceUpsertRoute = (
               }));
 
               // Create identified resource documents to keep track of them (without content)
-              const resourceIdentifier = new DashboardResourceIdentifier('splunk');
+              const resourceIdentifier = new DashboardResourceIdentifier('splunk', {
+                experimentalFeatures,
+              });
               const identifiedResources = await resourceIdentifier.fromResources(resources);
               const resourcesToCreate = identifiedResources.map<CreateSiemMigrationResourceInput>(
                 (resource) => ({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.test.ts
@@ -16,6 +16,7 @@ import { getDashboardMigrationAgent } from './graph';
 import type { OriginalDashboard } from '../../../../../../common/siem_migrations/model/dashboard_migration.gen';
 import { elasticsearchServiceMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { IScopedClusterClient } from '@kbn/core/server';
+import type { ExperimentalFeatures } from '../../../../../../common';
 
 jest.mock(
   '../../../../../assistant/tools/esql/graphs/select_index_pattern/select_index_pattern',
@@ -66,6 +67,7 @@ const setupAgent = (responses: NodeResponse[]) => {
     },
     request: httpServerMock.createKibanaRequest(),
     connectorId: 'test-connector',
+    experimentalFeatures: { splunkV2DashboardsEnabled: false } as unknown as ExperimentalFeatures,
   });
   return graph;
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.ts
@@ -15,7 +15,7 @@ import { getAggregateDashboardNode } from './nodes/aggregate_dashboard';
 import { RETRY_POLICY } from './constants';
 
 export function getDashboardMigrationAgent(params: MigrateDashboardGraphParams) {
-  const parseOriginalDashboardNode = getParseOriginalDashboardNode();
+  const parseOriginalDashboardNode = getParseOriginalDashboardNode(params);
   const createDescriptionsNode = getCreateDescriptionsNode(params);
   const translatePanel = getTranslatePanelNode(params);
   const aggregateDashboardNode = getAggregateDashboardNode();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/nodes/parse_original_dashboard/parse_original_dashboard.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/nodes/parse_original_dashboard/parse_original_dashboard.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { getParseOriginalDashboardNode } from './parse_original_dashboard';
-import type { MigrateDashboardState } from '../../types';
+import type { MigrateDashboardGraphParams, MigrateDashboardState } from '../../types';
 import { SplunkXmlDashboardParser } from '../../../../../../../../common/siem_migrations/parsers/splunk/dashboard_xml';
 import { MigrationTranslationResult } from '../../../../../../../../common/siem_migrations/constants';
 
@@ -14,6 +14,13 @@ import { MigrationTranslationResult } from '../../../../../../../../common/siem_
 jest.mock('../../../../../../../../common/siem_migrations/parsers/splunk/dashboard_xml');
 
 const mockSplunkXmlDashboardParser = SplunkXmlDashboardParser;
+
+const getTestNode = () =>
+  getParseOriginalDashboardNode({
+    experimentalFeatures: {
+      splunkV2DashboardsEnabled: false,
+    },
+  } as unknown as MigrateDashboardGraphParams);
 
 describe('getParseOriginalDashboardNode', () => {
   const mockState = {
@@ -67,7 +74,7 @@ describe('getParseOriginalDashboardNode', () => {
       .mocked(mockSplunkXmlDashboardParser)
       .mockImplementation(() => mockParserInstance as unknown as SplunkXmlDashboardParser);
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
     const result = await node(mockState, mockConfig);
 
     expect(mockSplunkXmlDashboardParser.isSupportedSplunkXml).toHaveBeenCalledWith(
@@ -93,7 +100,7 @@ describe('getParseOriginalDashboardNode', () => {
       },
     };
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
 
     await expect(node(unsupportedState as MigrateDashboardState, mockConfig)).rejects.toThrow(
       'Unsupported dashboard vendor'
@@ -106,7 +113,7 @@ describe('getParseOriginalDashboardNode', () => {
       reason: 'Unsupported root tag: form',
     });
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
     const result = await node(mockState, mockConfig);
 
     expect(mockSplunkXmlDashboardParser.isSupportedSplunkXml).toHaveBeenCalledWith(
@@ -134,7 +141,7 @@ describe('getParseOriginalDashboardNode', () => {
       reason: 'Unsupported version. Only version 1.1 is supported.',
     });
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
     const result = await node(mockState, mockConfig);
 
     expect(mockSplunkXmlDashboardParser.isSupportedSplunkXml).toHaveBeenCalledWith(
@@ -162,7 +169,7 @@ describe('getParseOriginalDashboardNode', () => {
       reason: 'No <row> elements found in the provided Dashboard XML.',
     });
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
     const result = await node(mockState, mockConfig);
 
     expect(mockSplunkXmlDashboardParser.isSupportedSplunkXml).toHaveBeenCalledWith(
@@ -197,7 +204,7 @@ describe('getParseOriginalDashboardNode', () => {
       .mocked(mockSplunkXmlDashboardParser)
       .mockImplementation(() => mockParserInstance as unknown as SplunkXmlDashboardParser);
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
 
     await expect(node(mockState, mockConfig)).rejects.toThrow('Parser error');
     expect(mockSplunkXmlDashboardParser.isSupportedSplunkXml).toHaveBeenCalledWith(
@@ -218,7 +225,7 @@ describe('getParseOriginalDashboardNode', () => {
       .mocked(mockSplunkXmlDashboardParser)
       .mockImplementation(() => mockParserInstance as unknown as SplunkXmlDashboardParser);
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
     const result = await node(mockState, mockConfig);
 
     expect(mockSplunkXmlDashboardParser.isSupportedSplunkXml).toHaveBeenCalledWith(
@@ -262,7 +269,7 @@ describe('getParseOriginalDashboardNode', () => {
       .mocked(mockSplunkXmlDashboardParser)
       .mockImplementation(() => mockParserInstance as unknown as SplunkXmlDashboardParser);
 
-    const node = getParseOriginalDashboardNode();
+    const node = getTestNode();
     const result = await node(mockState, mockConfig);
 
     expect(mockSplunkXmlDashboardParser.isSupportedSplunkXml).toHaveBeenCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/nodes/parse_original_dashboard/parse_original_dashboard.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/nodes/parse_original_dashboard/parse_original_dashboard.ts
@@ -9,30 +9,35 @@ import { getSplunkDashboardXmlParser } from '../../../../../../../../common/siem
 import { MigrationTranslationResult } from '../../../../../../../../common/siem_migrations/constants';
 import { generateAssistantComment } from '../../../../../common/task/util/comments';
 import { SplunkXmlDashboardParser } from '../../../../../../../../common/siem_migrations/parsers/splunk/dashboard_xml';
-import type { GraphNode } from '../../types';
+import type { GraphNode, MigrateDashboardGraphParams } from '../../types';
 
-export const getParseOriginalDashboardNode = (): GraphNode => {
+export const getParseOriginalDashboardNode = (params: MigrateDashboardGraphParams): GraphNode => {
   return async (state) => {
     if (state.original_dashboard.vendor !== 'splunk') {
       throw new Error('Unsupported dashboard vendor');
     }
 
-    // Check if the XML content is supported
-    const supportCheck = SplunkXmlDashboardParser.isSupportedSplunkXml(
-      state.original_dashboard.data
-    );
-    if (!supportCheck.isSupported) {
-      return {
-        parsed_original_dashboard: {
-          title: state.original_dashboard.title,
-          panels: [],
-        },
-        translation_result: MigrationTranslationResult.UNTRANSLATABLE,
-        comments: [generateAssistantComment(`Unsupported Splunk XML: ${supportCheck.reason}`)],
-      };
+    if (!params.experimentalFeatures.splunkV2DashboardsEnabled) {
+      // Check if the XML content is supported only if Splunk V2 dashboards is not enabled
+      // otherwise, all splunk dashboards are supported
+      const supportCheck = SplunkXmlDashboardParser.isSupportedSplunkXml(
+        state.original_dashboard.data
+      );
+      if (!supportCheck.isSupported) {
+        return {
+          parsed_original_dashboard: {
+            title: state.original_dashboard.title,
+            panels: [],
+          },
+          translation_result: MigrationTranslationResult.UNTRANSLATABLE,
+          comments: [generateAssistantComment(`Unsupported Splunk XML: ${supportCheck.reason}`)],
+        };
+      }
     }
 
-    const parser = await getSplunkDashboardXmlParser(state.original_dashboard.data);
+    const parser = await getSplunkDashboardXmlParser(state.original_dashboard.data, {
+      experimentalFeatures: params.experimentalFeatures,
+    });
     const panels = await parser.extractPanels();
 
     return {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/types.ts
@@ -9,6 +9,7 @@ import type { Logger, IScopedClusterClient } from '@kbn/core/server';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { ExperimentalFeatures } from '../../../../../../common';
 import type { MigrationComments } from '../../../../../../common/siem_migrations/model/common.gen';
 import type { ParsedPanel } from '../../../../../../common/siem_migrations/parsers/types';
 import type { MigrationTranslationResult } from '../../../../../../common/siem_migrations/constants';
@@ -42,6 +43,7 @@ export interface MigrateDashboardGraphParams {
   inference: InferenceServerStart;
   request: KibanaRequest;
   connectorId: string;
+  experimentalFeatures: ExperimentalFeatures;
 }
 
 export interface ParsedOriginalDashboard {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/dashboard_migrations_task_runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/dashboard_migrations_task_runner.ts
@@ -53,6 +53,7 @@ export class DashboardMigrationTaskRunner extends SiemMigrationTaskRunner<
     super(migrationId, vendor, request, startedBy, abortController, data, logger, dependencies);
     this.retriever = new DashboardMigrationsRetriever(this.migrationId, {
       data: this.data,
+      experimentalFeatures: this.dependencies.experimentalFeatures,
     });
   }
 
@@ -93,6 +94,7 @@ export class DashboardMigrationTaskRunner extends SiemMigrationTaskRunner<
       inference: inferenceService,
       request: this.request,
       connectorId,
+      experimentalFeatures: this.dependencies.experimentalFeatures,
     });
 
     this.telemetry = telemetryClient;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/retrievers/dashboard_migrations_retriever.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/retrievers/dashboard_migrations_retriever.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
+import type { ExperimentalFeatures } from '../../../../../../common';
 import type { DashboardMigrationsDataClient } from '../../data/dashboard_migrations_data_client';
 import { DashboardResourceRetriever } from './dashboard_resource_retriever';
 
-export interface DashboardMigrationsRetrieverClients {
+export interface DashboardMigrationsRetrieverDeps {
   data: DashboardMigrationsDataClient;
+  experimentalFeatures: ExperimentalFeatures;
 }
 
 /**
@@ -20,8 +22,11 @@ export interface DashboardMigrationsRetrieverClients {
 export class DashboardMigrationsRetriever {
   public readonly resources: DashboardResourceRetriever;
 
-  constructor(migrationId: string, clients: DashboardMigrationsRetrieverClients) {
-    this.resources = new DashboardResourceRetriever(migrationId, clients.data.resources);
+  constructor(migrationId: string, deps: DashboardMigrationsRetrieverDeps) {
+    this.resources = new DashboardResourceRetriever(migrationId, {
+      experimentalFeatures: deps.experimentalFeatures,
+      resourcesDataClient: deps.data.resources,
+    });
   }
 
   public async initialize() {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/retrievers/dashboard_resource_retriever.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/retrievers/dashboard_resource_retriever.ts
@@ -7,14 +7,14 @@
 
 import { DashboardResourceIdentifier } from '../../../../../../common/siem_migrations/dashboards/resources';
 import type { DashboardMigrationDashboard } from '../../../../../../common/siem_migrations/model/dashboard_migration.gen';
-import type { SiemMigrationsDataResourcesClient } from '../../../common/data/siem_migrations_data_resources_client';
 import { ResourceRetriever } from '../../../common/task/retrievers/resource_retriever';
+import type { ResourceRetrieverDeps } from '../../../common/task/retrievers/types';
 
 export class DashboardResourceRetriever extends ResourceRetriever<DashboardMigrationDashboard> {
   constructor(
     protected readonly migrationId: string,
-    protected readonly resourcesDataClient: SiemMigrationsDataResourcesClient
+    protected readonly deps: ResourceRetrieverDeps
   ) {
-    super(migrationId, resourcesDataClient, DashboardResourceIdentifier);
+    super(migrationId, DashboardResourceIdentifier, deps);
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/resources/upsert.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/resources/upsert.ts
@@ -59,6 +59,7 @@ export const registerSiemRuleMigrationsResourceUpsertRoute = (
           try {
             const ctx = await context.resolve(['securitySolution']);
             const ruleMigrationsClient = ctx.securitySolution.siemMigrations.getRulesClient();
+            const { experimentalFeatures } = ctx.securitySolution.getConfig();
 
             await siemMigrationAuditLogger.logUploadResources({ migrationId });
 
@@ -90,7 +91,9 @@ export const registerSiemRuleMigrationsResourceUpsertRoute = (
             }
 
             if (rule.original_rule.vendor === 'splunk') {
-              const resourceIdentifier = new RuleResourceIdentifier(rule.original_rule.vendor);
+              const resourceIdentifier = new RuleResourceIdentifier(rule.original_rule.vendor, {
+                experimentalFeatures,
+              });
               const identifiedMissingResources = await resourceIdentifier.fromResources(resources);
               const resourcesToCreate =
                 identifiedMissingResources.map<CreateSiemMigrationResourceInput>((resource) => ({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/rules/create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/rules/create.ts
@@ -59,6 +59,7 @@ export const registerSiemRuleMigrationsCreateRulesRoute = (
               }
               const ctx = await context.resolve(['securitySolution']);
               const ruleMigrationsClient = ctx.securitySolution.siemMigrations.getRulesClient();
+              const { experimentalFeatures } = ctx.securitySolution.getConfig();
               await siemMigrationAuditLogger.logAddRules({
                 migrationId,
                 count: rulesCount,
@@ -75,7 +76,10 @@ export const registerSiemRuleMigrationsCreateRulesRoute = (
 
               // Create identified resource documents without content to keep track of them
               const resourceIdentifier = new RuleResourceIdentifier(
-                firstOriginalRule.vendor as ResourceSupportedVendor
+                firstOriginalRule.vendor as ResourceSupportedVendor,
+                {
+                  experimentalFeatures,
+                }
               );
               const extractedResources = await resourceIdentifier.fromOriginals(originalRules);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/rules/qradar/create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/rules/qradar/create.ts
@@ -55,6 +55,7 @@ export const registerSiemRuleMigrationsCreateQRadarRulesRoute = (
           try {
             const ctx = await context.resolve(['securitySolution']);
             const ruleMigrationsClient = ctx.securitySolution.siemMigrations.getRulesClient();
+            const { experimentalFeatures } = ctx.securitySolution.getConfig();
 
             // Parse QRadar XML
             const parser = new QradarRulesXmlParser(xml);
@@ -125,7 +126,9 @@ export const registerSiemRuleMigrationsCreateQRadarRulesRoute = (
 
             // Identify reference sets from rule data and create resource records without content
             // This allows tracking missing resources that need to be uploaded
-            const resourceIdentifier = new RuleResourceIdentifier('qradar');
+            const resourceIdentifier = new RuleResourceIdentifier('qradar', {
+              experimentalFeatures,
+            });
             const extractedResources = await resourceIdentifier.fromOriginals(
               rulesToBeCreated.map((r) => r.original_rule)
             );

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/integration_retriever.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/integration_retriever.test.ts
@@ -7,7 +7,7 @@
 
 import { MockRuleMigrationsDataClient } from '../../data/__mocks__/mocks';
 import { IntegrationRetriever } from './integration_retriever';
-import type { RuleMigrationsRetrieverClients } from './rule_migrations_retriever';
+import type { RuleMigrationsRetrieverDeps } from './rule_migrations_retriever';
 
 describe('IntegrationRetriever', () => {
   let integrationRetriever: IntegrationRetriever;
@@ -22,7 +22,7 @@ describe('IntegrationRetriever', () => {
   beforeEach(() => {
     integrationRetriever = new IntegrationRetriever({
       data: mockRuleMigrationsDataClient,
-    } as RuleMigrationsRetrieverClients);
+    } as RuleMigrationsRetrieverDeps);
     mockRuleMigrationsDataClient.integrations.semanticSearch.mockImplementation(
       async (_: string) => {
         return mockIntegrationItem;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/integration_retriever.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/integration_retriever.ts
@@ -6,10 +6,10 @@
  */
 
 import type { RuleMigrationIntegration } from '../../types';
-import type { RuleMigrationsRetrieverClients } from './rule_migrations_retriever';
+import type { RuleMigrationsRetrieverDeps } from './rule_migrations_retriever';
 
 export class IntegrationRetriever {
-  constructor(private readonly clients: RuleMigrationsRetrieverClients) {}
+  constructor(private readonly clients: RuleMigrationsRetrieverDeps) {}
 
   public async populateIndex() {
     return this.clients.data.integrations.populate();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/prebuilt_rules_retriever.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/prebuilt_rules_retriever.ts
@@ -7,12 +7,12 @@
 
 import type { PrebuildRuleVersionsMap } from '../../data/rule_migrations_data_prebuilt_rules_client';
 import type { RuleSemanticSearchResult } from '../../types';
-import type { RuleMigrationsRetrieverClients } from './rule_migrations_retriever';
+import type { RuleMigrationsRetrieverDeps } from './rule_migrations_retriever';
 
 export class PrebuiltRulesRetriever {
   private rulesMap?: PrebuildRuleVersionsMap;
 
-  constructor(private readonly clients: RuleMigrationsRetrieverClients) {}
+  constructor(private readonly clients: RuleMigrationsRetrieverDeps) {}
 
   public async populateIndex() {
     if (!this.rulesMap) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_resource_retriever.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_resource_retriever.test.ts
@@ -9,6 +9,7 @@ import { RuleResourceRetriever } from './rule_resource_retriever'; // Adjust pat
 import type { RuleMigrationsDataClient } from '../../data/rule_migrations_data_client';
 import type { RuleMigrationRule } from '../../../../../../common/siem_migrations/model/rule_migration.gen';
 import { RuleResourceIdentifier } from '../../../../../../common/siem_migrations/rules/resources';
+import type { ExperimentalFeatures } from '../../../../../../common';
 
 jest.mock('../../data/rule_migrations_data_service');
 jest.mock('../../../../../../common/siem_migrations/rules/resources');
@@ -27,7 +28,12 @@ describe('RuleResourceRetriever', () => {
       resources: { searchBatches: jest.fn().mockReturnValue({ next: jest.fn(() => []) }) },
     } as unknown as jest.Mocked<RuleMigrationsDataClient>;
 
-    retriever = new RuleResourceRetriever('mockMigrationId', mockDataClient.resources);
+    retriever = new RuleResourceRetriever('mockMigrationId', {
+      resourcesDataClient: mockDataClient.resources,
+      experimentalFeatures: {
+        splunkV2DashboardsEnabled: false,
+      } as unknown as ExperimentalFeatures,
+    });
 
     MockResourceIdentifier.mockImplementation(() => ({
       fromOriginal: jest.fn().mockReturnValue([]),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_resource_retriever.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_resource_retriever.ts
@@ -8,13 +8,13 @@
 import { RuleResourceIdentifier } from '../../../../../../common/siem_migrations/rules/resources';
 import type { RuleMigrationRule } from '../../../../../../common/siem_migrations/model/rule_migration.gen';
 import { ResourceRetriever } from '../../../common/task/retrievers/resource_retriever';
-import type { SiemMigrationsDataResourcesClient } from '../../../common/data/siem_migrations_data_resources_client';
+import type { ResourceRetrieverDeps } from '../../../common/task/retrievers/types';
 
 export class RuleResourceRetriever extends ResourceRetriever<RuleMigrationRule> {
   constructor(
     protected readonly migrationId: string,
-    protected readonly resourcesDataClient: SiemMigrationsDataResourcesClient
+    protected readonly deps: ResourceRetrieverDeps
   ) {
-    super(migrationId, resourcesDataClient, RuleResourceIdentifier);
+    super(migrationId, RuleResourceIdentifier, deps);
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.ts
@@ -53,6 +53,7 @@ export class RuleMigrationTaskRunner extends SiemMigrationTaskRunner<
       data: this.data,
       rules: this.dependencies.rulesClient,
       savedObjects: this.dependencies.savedObjectsClient,
+      experimentalFeatures: this.dependencies.experimentalFeatures,
     });
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -259,6 +259,7 @@ export class RequestContextFactory implements IRequestContextFactory {
           savedObjectsClient: coreContext.savedObjects.client,
           packageService: startPlugins.fleet?.packageService,
           telemetry: core.analytics,
+          experimentalFeatures: options.config.experimentalFeatures,
         },
       }),
 


### PR DESCRIPTION
## Summary

Previously https://github.com/elastic/kibana/pull/251199 had added the capability to parse Splunk v2 Dashboards. This PR adds a experimental feature flag dashboard v2 parsing to toggle that feature ON/OFF

```yaml
xpack.securitySolution.enableExperimental:
  - splunkV2DashboardsEnabled
```


## Desk Testing

Since this change impacts both v1 and v2 dashboards. It is important to test both of those versions to see if these changes does not negatively impact anything else

### When feature flag is disabled ( Default scenario )

1. Testing v2 dashboards

Testing [v2 dashboards](https://drive.google.com/file/d/1Hqbb-gnZlNxS1_FLMeyIz26uWdr5ja9V/view?usp=drive_link) should result in `Not Translated` Status with summary comments as below:

<img width="837" height="387" alt="image" src="https://github.com/user-attachments/assets/120bfd5a-b530-48da-a1d0-bc400fb3c465" />



2. Testing v1 dashboards

[v1 dashboards](https://drive.google.com/file/d/1Mjyef1NgdVBEVQpwD3qdapUJJiiPK7wN/view?usp=drive_link) should complete migration without any issues.


### When feature flag is enabled.

1. Testing v2 dashboards

Now both of the given [v2 dashboards](https://drive.google.com/file/d/1Hqbb-gnZlNxS1_FLMeyIz26uWdr5ja9V/view?usp=drive_link) should result in `Translated` / `partially translated`.

<img width="1427" height="515" alt="image" src="https://github.com/user-attachments/assets/3c2184ca-5e82-481b-b2d3-f5e1bfbae446" />


2. Testing v1 dashboards

[v1 dashboards](https://drive.google.com/file/d/1Mjyef1NgdVBEVQpwD3qdapUJJiiPK7wN/view?usp=drive_link) should complete migration without any issues .
