### PR TITLE
[Security Solution] fix flyout section localstorage not honoring all values

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/hooks/use_accordion_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/hooks/use_accordion_state.ts
@@ -38,11 +38,7 @@ export const toggleReducer = (state: ToggleReducerState, action: ToggleReducerAc
   const { storage, localStorageKey, title } = action;
 
   if (storage && localStorageKey && title) {
-    const localStorage = (storage.get(localStorageKey.toLowerCase()) ?? {}) as Record<
-      string,
-      boolean
-    >;
-
+    const localStorage = storage.get(localStorageKey);
     storage.set(localStorageKey, {
       ...localStorage,
       [title]: state !== OPEN,


### PR DESCRIPTION
## Summary

This previous [PR](https://github.com/elastic/kibana/pull/247614) made some changes to the code related to saving the expanded/collapsed state of our ExpandableSection component we use in our Secuity Solution flyouts. The changes actually partially broke the functionality: while a section's expanded/collapsed state is correctly saved every time the user makes the action in the UI, it also overrides all the expanded/collapsed states of the other sections.

Broken implementation

https://github.com/user-attachments/assets/f15d42a9-7660-4470-8a43-ce932362b1d0

Correct implementation

https://github.com/user-attachments/assets/87b92445-0dbb-4a26-8a17-536a812db875

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->