### PR TITLE
Skip serverless search source alert tests for MKI

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/discover_ml_uptime/discover/search_source_alert.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover_ml_uptime/discover/search_source_alert.ts
@@ -385,9 +385,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   describe('Search source Alert', function () {
-    // Failing: https://github.com/elastic/kibana/issues/203045
-    // Failing: https://github.com/elastic/kibana/issues/207865
-    this.tags(['skipSvlOblt', 'skipSvlSearch']);
+    // Failing in Observability projects: https://github.com/elastic/kibana/issues/203045
+    // Failing in MKI Search projects: https://github.com/elastic/kibana/issues/207865
+    // Failing in MKI Security projects: https://github.com/elastic/kibana/issues/252028
+    this.tags(['skipSvlOblt', 'failsOnMKI']);
 
     before(async () => {
       await security.testUser.setRoles(['discover_alert']);


### PR DESCRIPTION
## Summary

This PR skips the serverless search source alert tests for MKI runs.
Details on the failure / flakiness in #252028.

Note that the suite was already skipped for serverless Observability and Search projects for local and MKI runs. From what I could see, the Search tests only failed on MKI, so I've updated the tagging to include them in local runs again and adjusted the comments to clarify that a bit.

With this PR, the test suite would run in the following scenarios:
- For local Search and Security project runs (in PRs and on-merge)

It will NOT run for
- Any MKI runs
- Local Observability projects (PRs, on-merge)