### PR TITLE
[SharedUX] Enforce feedback enablement check for streams

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/feedback_button/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/feedback_button/index.tsx
@@ -21,7 +21,7 @@ export function FeedbackButton() {
     services: { version },
     core: { notifications },
   } = useKibana();
-  const isFeedbackEnabled = notifications?.feedback?.isEnabled() ?? true;
+  const isFeedbackEnabled = notifications.feedback.isEnabled();
   const deploymentType = isServerless
     ? 'Serverless'
     : cloud?.isCloudEnabled

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
@@ -111,6 +111,8 @@ export function Summary({ count }: { count: number }) {
     task?.status === TaskStatus.BeingCanceled ||
     isSchedulingTask;
 
+  const isFeedbackEnabled = notifications.feedback.isEnabled();
+
   if (insights && insights.length > 0) {
     return (
       <EuiFlexGroup direction="column">
@@ -118,9 +120,11 @@ export function Summary({ count }: { count: number }) {
           <EuiPanel hasBorder paddingSize="none">
             <EuiPanel color="subdued" hasShadow={false}>
               <EuiFlexGroup justifyContent="flexEnd">
-                <EuiFlexItem grow={false}>
-                  <FeedbackButtons />
-                </EuiFlexItem>
+                {isFeedbackEnabled && (
+                  <EuiFlexItem grow={false}>
+                    <FeedbackButtons />
+                  </EuiFlexItem>
+                )}
                 <EuiFlexItem grow={false}>
                   <EuiButton
                     fill={true}


### PR DESCRIPTION
Related obs-onboarding PR: https://github.com/elastic/kibana/pull/250738 already merged, found a couple other feedback instances for obs-onboarding in Streams.

## Summary

As part of [[Epic] Setting to disable feedback snippets, guided tours and announcements in Kibana](https://github.com/elastic/kibana/issues/234771) SharedUX has added two new `core.notifications` services for `feedback` and `tours`. Their `isEnabled()` API verifies if users should be shown that kind of elements by reading their preferences from global UI settings (`hideFeedback` and `hideAnnouncements`).

From now on, every feedback or tour component should call `isEnabled()` before rendering to honor user preferences. 

> [!IMPORTANT]
SharedUX will be opening PRs for existing occurrences per team. Each team should manually test their PR to verify toggling those settings results in the expected behavior. If your team owns more `feedback` or `tours` occurrences or are planning on doing so, this check needs to be added to honor user preferences.
>  

### Testing

**Feedback elements**
- This is a read-only setting, you need to override it via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`.
- Verify changing the setting value hides/render the element as expected.

**Tours/announcements elements**
- Toggle either the deprecated `hideAnnouncements` space setting or the global one on the Stack Management > Advanced Settings UI.
- Verify toggling the setting hides/render the element as expected.

Related PR: [[SharedUX] Add feedback and tours to core notifications](https://github.com/elastic/kibana/pull/248248)