### PR TITLE
Clarify testing commands in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,12 +23,19 @@
 
 ### Jest unit
 `yarn test:jest [--config=<pathToConfigFile>] [TestPathPattern]`
+- Config is auto-discovered from the test file path (walks up to nearest `jest.config.js`). Simplest usage:
+  `yarn test:jest src/core/packages/http/server-internal/src/http_server.test.ts`
+- Only one `--config` per run. To test multiple packages, run separate commands.
 
 ### Jest integration
 `yarn test:jest_integration [--config=<pathToConfigFile>] [TestPathPattern]`
+- Auto-discovers `jest.integration.config.js` (not `jest.config.js`). Same single-config constraint as above.
 
 ### Type check
 `yarn test:type_check [--project path/to/tsconfig.json]`
+- Without `--project` it checks **all** projects (very slow). Always scope to a single project:
+  `yarn test:type_check --project src/core/packages/http/server-internal/tsconfig.json`
+- Only one `--project` per run. To check multiple packages, run separate commands.
 
 ### Function Test Runner (FTR)
 `yarn test:ftr [--config <file1> [--config <file2> ...]]`


### PR DESCRIPTION
## Problem / Intent

AI agents [misuse](https://elastic.slack.com/archives/C0ABE1V4C12/p1770376936697159) the Jest and type check CLI commands -- constructing wrong config paths, passing multiple `--config` flags, or omitting `--project` and triggering a full-repo type check.

## Approach

Add targeted bullet points under each testing subsection in AGENTS.md that call out auto-discovery behavior, single-config constraints, and the performance cost of omitting `--project`.

Made with [Cursor](https://cursor.com)