### PR TITLE
CPS Enabled for explicit tiers

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -3,6 +3,10 @@
 # Make sure the plugins belonging to this project type are loaded
 plugins.allowlistPluginGroups: ['platform', 'search']
 
+# Cross Project Search
+cps.enabled: true
+cps.cpsEnabled: false
+
 xpack.search.enabled: false
 xpack.osquery.enabled: false
 

--- a/config/serverless.oblt.complete.yml
+++ b/config/serverless.oblt.complete.yml
@@ -3,6 +3,10 @@
 ## Cloud settings
 xpack.cloud.serverless.product_tier: complete
 
+# Cross Project Search
+cps.enabled: true
+cps.cpsEnabled: false
+
 ## Enabled plugins
 xpack.infra.enabled: true
 xpack.slo.enabled: true

--- a/config/serverless.security.complete.yml
+++ b/config/serverless.security.complete.yml
@@ -3,6 +3,10 @@
 ## Cloud settings
 xpack.cloud.serverless.product_tier: complete
 
+# Cross Project Search
+cps.enabled: true
+cps.cpsEnabled: false
+
 xpack.features.overrides:
   ### Workflows Management should be moved from Analytics category to the Security one.
   workflowsManagement.category: "security"

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -296,7 +296,3 @@ xpack.genAiSettings:
   showAiBreadcrumb: false
   showSpacesIntegration: false
   showAiAssistantsVisibilitySetting: false
-
-# Cross Project Search
-cps.enabled: true
-cps.cpsEnabled: false


### PR DESCRIPTION
## Summary

CPS should only be enabled for o11y/Security complete tiers and for Elasticsearch projects. It should be disabled in other tiers.


