### PR TITLE
[Discover][UnifiedSearch] Show more content in the collapsed query input KQL/Lucene

### DIFF
--- a/src/platform/plugins/shared/kql/public/components/query_string_input/query_string_input.styles.tsx
+++ b/src/platform/plugins/shared/kql/public/components/query_string_input/query_string_input.styles.tsx
@@ -61,6 +61,7 @@ const queryStringInputStyles = {
         '&:not(.kbnQueryBar__textarea--autoHeight)': {
           overflowY: 'hidden',
           overflowX: 'hidden',
+          wordBreak: 'break-all',
         },
 
         // When focused, let it scroll


### PR DESCRIPTION
## Summary

Since the items in the UnifiedSearch got more compressed, the height of the input does not let to see the current KQL/Lucene query well.

This PR changes how the query string is wrapped when the input is not in focus.

Before:
<img width="1248" height="364" alt="Screenshot 2026-02-06 at 14 12 07" src="https://github.com/user-attachments/assets/ecc456fa-8dc1-402c-bc36-9c2dc73668a5" />

After:
<img width="1252" height="382" alt="Screenshot 2026-02-06 at 14 12 52" src="https://github.com/user-attachments/assets/36fc6924-a495-4902-8547-6955c25fa1e0" />



### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->