### PR TITLE
Fix: Agent Builder index search support for special text fields match_only_text and pattern_text

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import type { ScopedModel } from '@kbn/agent-builder-server';
+import { relevanceSearch } from './relevance_search';
+import { resolveResource } from './utils/resources';
+import { performMatchSearch } from './steps';
+
+jest.mock('./utils/resources');
+jest.mock('./steps');
+
+const resolveResourceMock = resolveResource as jest.Mock;
+const performMatchSearchMock = performMatchSearch as jest.Mock;
+
+describe('relevanceSearch', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let model: ScopedModel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    logger = loggingSystemMock.createLogger();
+    model = {} as ScopedModel;
+    performMatchSearchMock.mockResolvedValue({ results: [] });
+  });
+
+  describe('field type selection', () => {
+    it('selects text fields', async () => {
+      resolveResourceMock.mockResolvedValue({
+        fields: [{ path: 'content', type: 'text', meta: {} }],
+      });
+
+      await relevanceSearch({
+        term: 'test',
+        target: 'my-index',
+        esClient,
+        model,
+        logger,
+      });
+
+      expect(performMatchSearchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: [{ path: 'content', type: 'text', meta: {} }],
+        })
+      );
+    });
+
+    it('selects semantic_text fields', async () => {
+      resolveResourceMock.mockResolvedValue({
+        fields: [{ path: 'embedding', type: 'semantic_text', meta: {} }],
+      });
+
+      await relevanceSearch({
+        term: 'test',
+        target: 'my-index',
+        esClient,
+        model,
+        logger,
+      });
+
+      expect(performMatchSearchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: [{ path: 'embedding', type: 'semantic_text', meta: {} }],
+        })
+      );
+    });
+
+    it('selects match_only_text fields', async () => {
+      resolveResourceMock.mockResolvedValue({
+        fields: [{ path: 'logs', type: 'match_only_text', meta: {} }],
+      });
+
+      await relevanceSearch({
+        term: 'test',
+        target: 'my-index',
+        esClient,
+        model,
+        logger,
+      });
+
+      expect(performMatchSearchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: [{ path: 'logs', type: 'match_only_text', meta: {} }],
+        })
+      );
+    });
+
+    it('selects pattern_text fields', async () => {
+      resolveResourceMock.mockResolvedValue({
+        fields: [{ path: 'pattern', type: 'pattern_text', meta: {} }],
+      });
+
+      await relevanceSearch({
+        term: 'test',
+        target: 'my-index',
+        esClient,
+        model,
+        logger,
+      });
+
+      expect(performMatchSearchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: [{ path: 'pattern', type: 'pattern_text', meta: {} }],
+        })
+      );
+    });
+
+    it('selects all supported text field types together', async () => {
+      const allTextFields = [
+        { path: 'content', type: 'text', meta: {} },
+        { path: 'embedding', type: 'semantic_text', meta: {} },
+        { path: 'logs', type: 'match_only_text', meta: {} },
+        { path: 'pattern', type: 'pattern_text', meta: {} },
+      ];
+
+      resolveResourceMock.mockResolvedValue({
+        fields: allTextFields,
+      });
+
+      await relevanceSearch({
+        term: 'test',
+        target: 'my-index',
+        esClient,
+        model,
+        logger,
+      });
+
+      expect(performMatchSearchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: allTextFields,
+        })
+      );
+    });
+
+    it('filters out non-text field types', async () => {
+      resolveResourceMock.mockResolvedValue({
+        fields: [
+          { path: 'content', type: 'text', meta: {} },
+          { path: 'count', type: 'integer', meta: {} },
+          { path: 'name', type: 'keyword', meta: {} },
+          { path: 'timestamp', type: 'date', meta: {} },
+          { path: 'embedding', type: 'semantic_text', meta: {} },
+        ],
+      });
+
+      await relevanceSearch({
+        term: 'test',
+        target: 'my-index',
+        esClient,
+        model,
+        logger,
+      });
+
+      expect(performMatchSearchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: [
+            { path: 'content', type: 'text', meta: {} },
+            { path: 'embedding', type: 'semantic_text', meta: {} },
+          ],
+        })
+      );
+    });
+
+    it('throws an error when no searchable text fields are found', async () => {
+      resolveResourceMock.mockResolvedValue({
+        fields: [
+          { path: 'count', type: 'integer', meta: {} },
+          { path: 'name', type: 'keyword', meta: {} },
+        ],
+      });
+
+      await expect(
+        relevanceSearch({
+          term: 'test',
+          target: 'my-index',
+          esClient,
+          model,
+          logger,
+        })
+      ).rejects.toThrow('No searchable text fields found, aborting search.');
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
@@ -38,9 +38,7 @@ export const relevanceSearch = async ({
 }): Promise<RelevanceSearchResponse> => {
   const { fields } = await resolveResource({ resourceName: target, esClient });
 
-  const selectedFields = fields.filter((field) =>
-    SEARCHABLE_TEXT_FIELD_TYPES.has(field.type)
-  );
+  const selectedFields = fields.filter((field) => SEARCHABLE_TEXT_FIELD_TYPES.has(field.type));
 
   if (selectedFields.length === 0) {
     throw new Error('No searchable text fields found, aborting search.');

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
@@ -14,6 +14,13 @@ import { resolveResource } from './utils/resources';
 
 export type RelevanceSearchResponse = PerformMatchSearchResponse;
 
+const SEARCHABLE_TEXT_FIELD_TYPES = new Set([
+  'match_only_text',
+  'pattern_text',
+  'semantic_text',
+  'text',
+]);
+
 export const relevanceSearch = async ({
   term,
   target,
@@ -31,12 +38,12 @@ export const relevanceSearch = async ({
 }): Promise<RelevanceSearchResponse> => {
   const { fields } = await resolveResource({ resourceName: target, esClient });
 
-  const selectedFields = fields.filter(
-    (field) => field.type === 'text' || field.type === 'semantic_text'
+  const selectedFields = fields.filter((field) =>
+    SEARCHABLE_TEXT_FIELD_TYPES.has(field.type)
   );
 
   if (selectedFields.length === 0) {
-    throw new Error('No text or semantic_text fields found, aborting search.');
+    throw new Error('No searchable text fields found, aborting search.');
   }
 
   return performMatchSearch({

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -34,10 +34,7 @@ export const performMatchSearch = async ({
   esClient: ElasticsearchClient;
   logger: Logger;
 }): Promise<PerformMatchSearchResponse> => {
-  const textFields = fields.filter((field) => field.type === 'text');
-  const semanticTextFields = fields.filter((field) => field.type === 'semantic_text');
-  const allSearchableFields = [...textFields, ...semanticTextFields];
-
+  
   // should replace `any` with `SearchRequest` type when the simplified retriever syntax is supported in @elastic/elasticsearch`
   const searchRequest: any = {
     index,
@@ -46,7 +43,7 @@ export const performMatchSearch = async ({
       rrf: {
         rank_window_size: size * 2,
         query: term,
-        fields: allSearchableFields.map((field) => field.path),
+        fields: fields.map((field) => field.path),
       },
     },
     highlight: {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -34,7 +34,6 @@ export const performMatchSearch = async ({
   esClient: ElasticsearchClient;
   logger: Logger;
 }): Promise<PerformMatchSearchResponse> => {
-  
   // should replace `any` with `SearchRequest` type when the simplified retriever syntax is supported in @elastic/elasticsearch`
   const searchRequest: any = {
     index,


### PR DESCRIPTION
Agent Builder's search tool was filtering for only text or semantic_text fields, leaving out other text fields like match_text and pattern_text. This fix will add those to the list of searchable fields. 