### PR TITLE
[9.2] [APM] Migrate Infra home page tests to Scout - Part III - Alerts & Saved Views (#250072)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
@@ -93,7 +93,11 @@ export function ManageViewsFlyout<TSavedViewState extends SavedViewItem>({
           defaultMessage: 'Mark as default',
         })}
         key={item.id}
-        data-test-subj="infraRenderMakeDefaultActionButton"
+        data-test-subj={
+          item.attributes.isDefault
+            ? 'infraRenderMakeDefaultActionButton-filled'
+            : 'infraRenderMakeDefaultActionButton-empty'
+        }
         iconType={item.attributes.isDefault ? 'starFilled' : 'starEmpty'}
         size="s"
         onClick={() => {
@@ -161,6 +165,10 @@ export function ManageViewsFlyout<TSavedViewState extends SavedViewItem>({
             search={searchConfig}
             pagination={true}
             sorting={true}
+            tableCaption={i18n.translate('xpack.infra.openView.table.tableCaption', {
+              defaultMessage: 'Saved views',
+            })}
+            data-test-subj="savedViews-viewsTable"
           />
         </EuiFlyoutBody>
         <EuiModalFooter>
@@ -212,7 +220,7 @@ const DeleteConfimation = ({ isDisabled, onConfirm }: DeleteConfimationProps) =>
       aria-label={i18n.translate('xpack.infra.deleteConfimation.deleteButton.ariaLabel', {
         defaultMessage: 'Delete',
       })}
-      data-test-subj="infraDeleteConfimationButton"
+      data-test-subj="infraDeleteConfirmationButton"
       iconType="trash"
       color="danger"
       size="s"

--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/upsert_modal.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/upsert_modal.tsx
@@ -84,6 +84,7 @@ export const UpsertViewModal = ({
         <EuiSpacer size="xl" />
         <EuiSwitch
           id={'saved-view-save-time-checkbox'}
+          data-test-subj="savedViews-includeTimeCheckbox"
           label={
             <FormattedMessage
               defaultMessage="Store time with view"

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -112,6 +112,8 @@ export const DATE_WITHOUT_DATA = '04/01/2024 6:20:59 PM';
 export const EXTENDED_TIMEOUT = 45000; // 45 seconds
 
 export const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
+export const KUBERNETES_CARD_DISMISSED_STORAGE_KEY = 'infra.inventory.k8sCardDismissed';
+export const KUBERNETES_TOAST_STORAGE_KEY = 'kubernetesToastKey';
 
 export const BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES: Omit<
   CreateInventoryViewAttributes,

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
@@ -23,12 +23,14 @@ import { InventoryPage } from './page_objects/inventory';
 import { AssetDetailsPage } from './page_objects/asset_details/asset_details';
 import { getInventoryViewsApiService, type InventoryViewApiService } from './apis/inventory_views';
 import { NodeDetailsPage } from './page_objects/node_details/node_details';
+import { SavedViews } from './page_objects/saved_views';
 
 export interface ExtendedScoutTestFixtures extends ObltTestFixtures {
   pageObjects: ObltPageObjects & {
     inventoryPage: InventoryPage;
     assetDetailsPage: AssetDetailsPage;
     nodeDetailsPage: NodeDetailsPage;
+    savedViews: SavedViews;
   };
 }
 
@@ -44,11 +46,14 @@ export const test = base.extend<ExtendedScoutTestFixtures, ExtendedScoutWorkerFi
     { pageObjects, page, kbnUrl },
     use: (pageObjects: ExtendedScoutTestFixtures['pageObjects']) => Promise<void>
   ) => {
+    const savedViews = createLazyPageObject(SavedViews, page);
+
     const extendedPageObjects = {
       ...pageObjects,
-      inventoryPage: createLazyPageObject(InventoryPage, page, kbnUrl),
+      inventoryPage: createLazyPageObject(InventoryPage, page, kbnUrl, savedViews),
       assetDetailsPage: createLazyPageObject(AssetDetailsPage, page, kbnUrl),
       nodeDetailsPage: createLazyPageObject(NodeDetailsPage, page, kbnUrl),
+      savedViews,
     };
 
     await use(extendedPageObjects);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -6,7 +6,13 @@
  */
 
 import { type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
-import { EXTENDED_TIMEOUT, KUBERNETES_TOUR_STORAGE_KEY } from '../constants';
+import {
+  EXTENDED_TIMEOUT,
+  KUBERNETES_TOUR_STORAGE_KEY,
+  KUBERNETES_CARD_DISMISSED_STORAGE_KEY,
+  KUBERNETES_TOAST_STORAGE_KEY,
+} from '../constants';
+import type { SavedViews } from './saved_views';
 
 export class InventoryPage {
   public readonly feedbackLink: Locator;
@@ -18,6 +24,9 @@ export class InventoryPage {
   public readonly inventorySwitcherHostsButton: Locator;
   public readonly inventorySwitcherPodsButton: Locator;
   public readonly inventorySwitcherContainersButton: Locator;
+
+  public readonly metricSwitcherButton: Locator;
+  public readonly metricsContextMenu: Locator;
 
   public readonly k8sTourText: Locator;
   public readonly k8sTourDismissButton: Locator;
@@ -38,7 +47,26 @@ export class InventoryPage {
 
   public readonly k8sPodWaffleContextMenu: Locator;
 
-  constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
+  public readonly alertsHeaderButton: Locator;
+  public readonly alertsMenu: Locator;
+
+  public readonly inventoryAlertsMenuOption: Locator;
+  public readonly createInventoryRuleButton: Locator;
+
+  public readonly metricsAlertsMenuOption: Locator;
+  public readonly createMetricsThresholdRuleButton: Locator;
+
+  public readonly customThresholdAlertMenuOption: Locator;
+
+  public readonly alertsFlyout: Locator;
+  public readonly alertsFlyoutRuleDefinitionSection: Locator;
+  public readonly alertsFlyoutRuleTypeName: Locator;
+
+  constructor(
+    private readonly page: ScoutPage,
+    private readonly kbnUrl: KibanaUrl,
+    private readonly savedViews: SavedViews
+  ) {
     this.feedbackLink = this.page.getByTestId('infraInventoryFeedbackLink');
     this.k8sFeedbackLink = this.page.getByTestId('infra-kubernetes-feedback-link');
 
@@ -48,6 +76,9 @@ export class InventoryPage {
     this.inventorySwitcherHostsButton = this.page.getByTestId('goToHost');
     this.inventorySwitcherPodsButton = this.page.getByTestId('goToPods');
     this.inventorySwitcherContainersButton = this.page.getByTestId('goToContainer');
+
+    this.metricSwitcherButton = this.page.getByTestId('infraInventoryMetricDropdown');
+    this.metricsContextMenu = this.page.getByTestId('infraInventoryMetricsContextMenu');
 
     this.k8sTourText = this.page.getByTestId('infra-kubernetesTour-text');
     this.k8sTourDismissButton = this.page.getByTestId('infra-kubernetesTour-dismiss');
@@ -69,9 +100,32 @@ export class InventoryPage {
     this.k8sPodWaffleContextMenu = this.page
       .getByRole('dialog')
       .filter({ hasText: 'Kubernetes Pod details' });
+
+    this.alertsHeaderButton = this.page.getByTestId('infrastructure-alerts-and-rules');
+    this.alertsMenu = this.page.getByTestId('metrics-alert-menu');
+
+    this.inventoryAlertsMenuOption = this.alertsMenu.getByTestId('inventory-alerts-menu-option');
+    this.createInventoryRuleButton = this.alertsMenu.getByTestId('inventory-alerts-create-rule');
+
+    this.metricsAlertsMenuOption = this.alertsMenu.getByTestId(
+      'metrics-threshold-alerts-menu-option'
+    );
+    this.createMetricsThresholdRuleButton = this.alertsMenu.getByTestId(
+      'metrics-threshold-alerts-create-rule'
+    );
+
+    this.customThresholdAlertMenuOption = this.alertsMenu.getByTestId(
+      'custom-threshold-alerts-menu-option'
+    );
+
+    this.alertsFlyout = this.page.getByRole('dialog').filter({ hasText: 'Create rule' });
+    this.alertsFlyoutRuleDefinitionSection = this.alertsFlyout.getByTestId('ruleDefinition');
+    this.alertsFlyoutRuleTypeName = this.alertsFlyout.getByTestId(
+      'ruleDefinitionHeaderRuleTypeName'
+    );
   }
 
-  private async waitForNodesToLoad() {
+  public async waitForNodesToLoad() {
     await this.page
       .getByTestId('infraNodesOverviewLoadingPanel')
       .waitFor({ state: 'hidden', timeout: EXTENDED_TIMEOUT });
@@ -80,7 +134,7 @@ export class InventoryPage {
   private async waitForPageToLoad() {
     await this.page.getByTestId('infraMetricsPage').waitFor({ timeout: EXTENDED_TIMEOUT });
     await this.waitForNodesToLoad();
-    await this.page.getByTestId('savedViews-openPopover-loaded').waitFor();
+    await this.savedViews.waitForViewsToLoad();
   }
 
   public async goToPage(opts: { skipLoadWait?: boolean } = {}) {
@@ -158,6 +212,26 @@ export class InventoryPage {
     );
   }
 
+  public async addClearK8sCardDismissedInitScript() {
+    // Clear the K8s dashboard promotion card dismissed state to ensure cards are visible
+    await this.page.addInitScript(
+      ([k8sCardDismissedKey]) => {
+        window.localStorage.removeItem(k8sCardDismissedKey);
+      },
+      [KUBERNETES_CARD_DISMISSED_STORAGE_KEY]
+    );
+  }
+
+  public async addDismissK8sToastInitScript() {
+    // Dismiss k8s tour if it's present to avoid interference with other test assertions
+    await this.page.addInitScript(
+      ([k8sToastStorageKey]) => {
+        window.localStorage.setItem(k8sToastStorageKey, 'true');
+      },
+      [KUBERNETES_TOAST_STORAGE_KEY]
+    );
+  }
+
   public async goToTime(time: string) {
     await this.datePickerInput.fill(time);
     await this.datePickerInput.press('Escape');
@@ -219,5 +293,11 @@ export class InventoryPage {
       .getByRole('dialog')
       .filter({ hasText: 'Legend Options' })
       .waitFor({ state: 'hidden' });
+  }
+
+  public async selectMetric(metricName: string) {
+    await this.metricSwitcherButton.click();
+    await this.metricsContextMenu.getByRole('button', { name: metricName }).click();
+    await this.waitForNodesToLoad();
   }
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/saved_views.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/saved_views.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout-oblt';
+
+export class SavedViews {
+  public readonly selector: Locator;
+  public readonly manageViewsButton: Locator;
+  public readonly updateViewButton: Locator;
+  public readonly saveNewViewButton: Locator;
+
+  public readonly upsertModal: Locator;
+  public readonly viewNameInput: Locator;
+  public readonly includeTimeCheckbox: Locator;
+  public readonly cancelUpsertButton: Locator;
+  public readonly confirmUpsertButton: Locator;
+
+  public readonly manageViewsFlyout: Locator;
+  public readonly manageViewsFilterInput: Locator;
+  public readonly manageViewsTable: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.selector = this.page.getByTestId('savedViews-openPopover-loaded');
+    this.manageViewsButton = this.page.getByTestId('savedViews-manageViews');
+    this.updateViewButton = this.page.getByTestId('savedViews-updateView');
+    this.saveNewViewButton = this.page.getByTestId('savedViews-saveNewView');
+
+    this.upsertModal = this.page.getByTestId('savedViews-upsertModal');
+    this.viewNameInput = this.upsertModal.getByTestId('savedViewName');
+    this.includeTimeCheckbox = this.upsertModal.getByTestId('savedViews-includeTimeCheckbox');
+    this.cancelUpsertButton = this.upsertModal.getByTestId('infraSavedViewCreateModalCancelButton');
+    this.confirmUpsertButton = this.upsertModal.getByTestId('createSavedViewButton');
+
+    this.manageViewsFlyout = this.page.getByTestId('loadViewsFlyout');
+    this.manageViewsFilterInput = this.manageViewsFlyout.getByRole('searchbox');
+    this.manageViewsTable = this.manageViewsFlyout.getByTestId('savedViews-viewsTable');
+  }
+
+  public async waitForViewsToLoad() {
+    await this.selector.waitFor();
+  }
+
+  public async createView(viewName: string, opts: { saveTime?: boolean } = {}) {
+    await this.selector.click();
+    await this.saveNewViewButton.click();
+    await this.viewNameInput.fill(viewName);
+
+    if (opts.saveTime) {
+      await this.includeTimeCheckbox.click();
+    }
+
+    await this.confirmUpsertButton.click();
+    await this.upsertModal.waitFor({ state: 'hidden' });
+  }
+
+  public async saveCurrentView(newName?: string) {
+    await this.selector.click();
+    await this.updateViewButton.click();
+
+    if (newName) {
+      await this.viewNameInput.clear();
+      await this.viewNameInput.fill(newName);
+    }
+
+    await this.confirmUpsertButton.click();
+    await this.upsertModal.waitFor({ state: 'hidden' });
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+
+test.describe('Infrastructure Inventory - Alerts Flyout', { tag: ['@ess'] }, () => {
+  test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+    await browserAuth.loginAsPrivilegedUser();
+    await inventoryPage.addDismissK8sTourInitScript();
+    await inventoryPage.goToPage();
+  });
+
+  test(
+    'Should open inventory rule flyout',
+    { tag: ['@svlOblt'] },
+    async ({ pageObjects: { inventoryPage } }) => {
+      await test.step('open alerts menu', async () => {
+        await inventoryPage.alertsHeaderButton.click();
+        await expect(inventoryPage.alertsMenu).toBeVisible();
+      });
+
+      await test.step('open infrastructure rules submenu', async () => {
+        await inventoryPage.inventoryAlertsMenuOption.click();
+        await expect(inventoryPage.alertsMenu).toContainText('Infrastructure rules');
+      });
+
+      await test.step('open inventory rule flyout', async () => {
+        await inventoryPage.createInventoryRuleButton.click();
+        await expect(inventoryPage.alertsFlyout).toBeVisible();
+        await expect(inventoryPage.alertsFlyoutRuleDefinitionSection).toBeVisible();
+        await expect(inventoryPage.alertsFlyoutRuleTypeName).toHaveText('Inventory');
+      });
+    }
+  );
+
+  test('Should open metrics threshold rule flyout', async ({ pageObjects: { inventoryPage } }) => {
+    await test.step('open alerts menu', async () => {
+      await inventoryPage.alertsHeaderButton.click();
+      await expect(inventoryPage.alertsMenu).toBeVisible();
+    });
+
+    await test.step('open metrics rules submenu', async () => {
+      await inventoryPage.metricsAlertsMenuOption.click();
+      await expect(inventoryPage.alertsMenu).toContainText('Metrics rules');
+    });
+
+    await test.step('open metrics threshold rule flyout', async () => {
+      await inventoryPage.createMetricsThresholdRuleButton.click();
+      await expect(inventoryPage.alertsFlyout).toBeVisible();
+      await expect(inventoryPage.alertsFlyoutRuleDefinitionSection).toBeVisible();
+      await expect(inventoryPage.alertsFlyoutRuleTypeName).toHaveText('Metric threshold');
+    });
+  });
+
+  test(
+    'Should not have option to create custom threshold rule',
+    { tag: ['@svlOblt'] },
+    async ({ pageObjects: { inventoryPage } }) => {
+      await test.step('open alerts menu', async () => {
+        await inventoryPage.alertsHeaderButton.click();
+        await expect(inventoryPage.alertsMenu).toBeVisible();
+      });
+
+      await test.step('verify custom threshold alert menu option is not visible', async () => {
+        await expect(inventoryPage.customThresholdAlertMenuOption).toBeHidden();
+      });
+    }
+  );
+});

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/container_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/container_asset_details_flyout.spec.ts
@@ -54,7 +54,7 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices: { inventoryViews } }) => {
-      await inventoryViews.deleteOne(savedViewId);
+      await inventoryViews.deleteById(savedViewId);
     });
 
     test('Overview Tab', async ({ pageObjects: { assetDetailsPage } }) => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
@@ -49,7 +49,7 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices: { inventoryViews } }) => {
-      await inventoryViews.deleteOne(savedViewId);
+      await inventoryViews.deleteById(savedViewId);
     });
 
     test('Overview Tab', async ({ pageObjects: { assetDetailsPage } }) => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
@@ -1,0 +1,340 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+import {
+  DATE_WITH_DOCKER_DATA,
+  DATE_WITH_DOCKER_DATA_TIMESTAMP,
+  DATE_WITH_POD_DATA,
+} from '../../fixtures/constants';
+
+test.use({
+  timezoneId: 'GMT',
+});
+
+test.describe('Infrastructure Inventory - Saved Views', { tag: ['@ess', '@svlOblt'] }, () => {
+  let preloadedViewId = '';
+
+  test.beforeAll(async ({ apiServices: { inventoryViews } }) => {
+    const response = await inventoryViews.create({
+      name: 'Preloaded View',
+      nodeType: 'container',
+      metric: { type: 'memory' },
+      groupBy: [],
+      view: 'table',
+      customOptions: [],
+      customMetrics: [],
+      boundsOverride: {
+        max: 1,
+        min: 0,
+      },
+      autoBounds: true,
+      accountId: '',
+      region: '',
+      legend: {
+        palette: 'cool',
+        reverseColors: false,
+        steps: 10,
+      },
+      sort: {
+        by: 'name',
+        direction: 'desc',
+      },
+      timelineOpen: false,
+      autoReload: false,
+      filterQuery: {
+        expression: '',
+        kind: 'kuery',
+      },
+      preferredSchema: 'ecs',
+      time: DATE_WITH_DOCKER_DATA_TIMESTAMP,
+    });
+
+    preloadedViewId = response.id;
+  });
+
+  test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+    await browserAuth.loginAsPrivilegedUser();
+    await inventoryPage.addDismissK8sTourInitScript();
+    await inventoryPage.addDismissK8sToastInitScript();
+  });
+
+  test.afterEach(async ({ apiServices: { inventoryViews } }) => {
+    await inventoryViews.deleteByName([
+      'View without time',
+      'View with time',
+      'View to delete',
+      'View to update',
+      'View updated',
+    ]);
+    await inventoryViews.makeDefault('0'); // Reset to default view whose id is fixed to '0'
+  });
+
+  test.afterAll(async ({ apiServices: { inventoryViews } }) => {
+    await inventoryViews.deleteById(preloadedViewId);
+  });
+
+  test("Load the 'Default view' when no saved view is selected", async ({
+    pageObjects: { savedViews, inventoryPage },
+  }) => {
+    await test.step("load 'Default View' on page load", async () => {
+      await inventoryPage.goToPage();
+      await expect(savedViews.selector).toHaveText('Default view');
+    });
+
+    await test.step("verify 'Default View' cannot be updated", async () => {
+      await savedViews.selector.click();
+      await expect(savedViews.updateViewButton).toBeDisabled();
+    });
+
+    await test.step("verify 'Default View' is marked as default in manage views flyout", async () => {
+      await savedViews.manageViewsButton.click();
+      await savedViews.manageViewsFilterInput.pressSequentially('Default view');
+      await expect(savedViews.manageViewsTable.getByTestId('infraRenderNameButton')).toContainText(
+        'Default view'
+      );
+      await expect(
+        savedViews.manageViewsTable.getByTestId('infraRenderMakeDefaultActionButton-filled')
+      ).toBeVisible();
+    });
+  });
+
+  test('Apply an existing saved view when it is selected in the URL', async ({
+    pageObjects: { savedViews, inventoryPage },
+  }) => {
+    await inventoryPage.goToPageWithSavedView(preloadedViewId);
+    await expect(savedViews.selector).toHaveText('Preloaded View');
+    await expect(inventoryPage.datePickerInput).toHaveValue(DATE_WITH_DOCKER_DATA);
+    await expect(inventoryPage.tableViewButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(inventoryPage.nodesOverviewTable).toBeVisible();
+    await expect(inventoryPage.inventorySwitcherButton).toHaveText('Docker Containers');
+    await expect(inventoryPage.metricSwitcherButton).toHaveText('Memory usage');
+  });
+
+  test('Create a new saved view from the current inventory state without saving the time', async ({
+    page,
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await test.step('configure some inventory state', async () => {
+      await inventoryPage.goToPage();
+      await inventoryPage.goToTime(DATE_WITH_POD_DATA);
+      await inventoryPage.showPods();
+      await inventoryPage.selectMetric('Inbound traffic');
+      await inventoryPage.toggleTimeline();
+    });
+
+    await test.step('create a new saved view without saving the time', async () => {
+      await savedViews.createView('View without time', { saveTime: false });
+      await expect(savedViews.selector).toHaveText('View without time');
+
+      const url = new URL(page.url());
+      const inventoryViewId = url.searchParams.get('inventoryViewId')?.replace(/'/g, '');
+      expect(inventoryViewId).toBeDefined();
+      expect(inventoryViewId).not.toBe(0);
+
+      // The saved time doesn't match the one we set before creating the view as time wasn't saved
+      await expect(inventoryPage.datePickerInput).not.toHaveValue(DATE_WITH_POD_DATA);
+    });
+  });
+
+  test('Create a new saved view from the current inventory state saving the time', async ({
+    page,
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await test.step('configure some inventory state', async () => {
+      await inventoryPage.goToPage();
+      await inventoryPage.goToTime(DATE_WITH_DOCKER_DATA);
+      await inventoryPage.showContainers();
+      await inventoryPage.selectMetric('Outbound traffic');
+    });
+
+    await test.step('create a new saved view saving the time', async () => {
+      await savedViews.createView('View with time', { saveTime: true });
+      await expect(savedViews.selector).toHaveText('View with time');
+
+      const url = new URL(page.url());
+      const inventoryViewId = url.searchParams.get('inventoryViewId')?.replace(/'/g, '');
+      expect(inventoryViewId).toBeDefined();
+      expect(inventoryViewId).not.toBe(0);
+
+      // The saved time should match the one we set before creating the view
+      await expect(inventoryPage.datePickerInput).toHaveValue(DATE_WITH_DOCKER_DATA);
+      await expect(inventoryPage.waffleMap).toBeVisible();
+    });
+  });
+
+  test('Select and load an existing saved view from the manage views flyout', async ({
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await test.step('land on inventory page loading the default view', async () => {
+      await inventoryPage.goToPage();
+      await expect(savedViews.selector).toHaveText('Default view');
+    });
+
+    await test.step('open manage views flyout', async () => {
+      await savedViews.selector.click();
+      await savedViews.manageViewsButton.click();
+      await expect(savedViews.manageViewsFlyout).toBeVisible();
+    });
+
+    await test.step("filter views table and select 'Preloaded View'", async () => {
+      await savedViews.manageViewsFilterInput.pressSequentially('Preloaded View');
+      const viewLocator = savedViews.manageViewsTable.getByTestId('infraRenderNameButton');
+      await expect(viewLocator).toContainText('Preloaded View');
+      await viewLocator.click();
+      await savedViews.waitForViewsToLoad();
+      await inventoryPage.waitForNodesToLoad();
+    });
+
+    await test.step("verify 'Preloaded View' is applied", async () => {
+      await expect(savedViews.manageViewsFlyout).toBeHidden();
+      await expect(savedViews.selector).toHaveText('Preloaded View');
+      await expect(inventoryPage.datePickerInput).toHaveValue(DATE_WITH_DOCKER_DATA);
+      await expect(inventoryPage.tableViewButton).toHaveAttribute('aria-pressed', 'true');
+      await expect(inventoryPage.nodesOverviewTable).toBeVisible();
+      await expect(inventoryPage.inventorySwitcherButton).toHaveText('Docker Containers');
+      await expect(inventoryPage.metricSwitcherButton).toHaveText('Memory usage');
+    });
+  });
+
+  test('Can make a saved view the default view from the manage views flyout', async ({
+    pageObjects: { inventoryPage, savedViews, toasts },
+  }) => {
+    await test.step('land on inventory page loading the default view', async () => {
+      await inventoryPage.goToPage();
+      await expect(savedViews.selector).toHaveText('Default view');
+    });
+
+    await test.step('open manage views flyout', async () => {
+      await savedViews.selector.click();
+      await savedViews.manageViewsButton.click();
+      await expect(savedViews.manageViewsFlyout).toBeVisible();
+    });
+
+    await test.step("filter views table and make 'Preloaded View' the default view", async () => {
+      await savedViews.manageViewsFilterInput.pressSequentially('Preloaded View');
+      const makeDefaultButton = savedViews.manageViewsTable.getByTestId(
+        'infraRenderMakeDefaultActionButton-empty'
+      );
+      await expect(makeDefaultButton).toBeVisible();
+      await makeDefaultButton.click();
+      await toasts.waitFor();
+      expect(await toasts.getHeaderText()).toBe('Metrics settings successfully updated');
+      await expect(
+        savedViews.manageViewsTable.getByTestId('infraRenderMakeDefaultActionButton-filled')
+      ).toBeVisible();
+    });
+  });
+
+  test('Delete a saved view from the manage views flyout', async ({
+    apiServices: { inventoryViews },
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await inventoryViews.create({
+      name: 'View to delete',
+      nodeType: 'container',
+      metric: { type: 'memory' },
+      groupBy: [],
+      view: 'table',
+      customOptions: [],
+      customMetrics: [],
+      boundsOverride: {
+        max: 1,
+        min: 0,
+      },
+      autoBounds: true,
+      accountId: '',
+      region: '',
+      legend: {
+        palette: 'cool',
+        reverseColors: false,
+        steps: 10,
+      },
+      sort: {
+        by: 'name',
+        direction: 'desc',
+      },
+      timelineOpen: false,
+      autoReload: false,
+      filterQuery: {
+        expression: '',
+        kind: 'kuery',
+      },
+      preferredSchema: 'ecs',
+    });
+
+    await test.step('navigate page and open manage views flyout', async () => {
+      await inventoryPage.goToPage();
+      await savedViews.selector.click();
+      await savedViews.manageViewsButton.click();
+      await expect(savedViews.manageViewsFlyout).toBeVisible();
+    });
+
+    await test.step("filter views table and delete 'View to delete'", async () => {
+      await savedViews.manageViewsFilterInput.pressSequentially('View to delete');
+      const nameLocator = savedViews.manageViewsTable
+        .getByTestId('infraRenderNameButton')
+        .filter({ hasText: 'View to delete' });
+      await expect(nameLocator).toBeVisible();
+      await savedViews.manageViewsTable.getByTestId('infraDeleteConfirmationButton').click();
+      await savedViews.manageViewsTable.getByTestId('showConfirm').click();
+      await expect(nameLocator).toBeHidden();
+    });
+  });
+
+  test('Update a saved view from the manage views flyout', async ({
+    apiServices: { inventoryViews },
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    const response = await inventoryViews.create({
+      name: 'View to update',
+      nodeType: 'container',
+      metric: { type: 'memory' },
+      groupBy: [],
+      view: 'table',
+      customOptions: [],
+      customMetrics: [],
+      boundsOverride: {
+        max: 1,
+        min: 0,
+      },
+      autoBounds: true,
+      accountId: '',
+      region: '',
+      legend: {
+        palette: 'cool',
+        reverseColors: false,
+        steps: 10,
+      },
+      sort: {
+        by: 'name',
+        direction: 'desc',
+      },
+      timelineOpen: false,
+      autoReload: false,
+      filterQuery: {
+        expression: '',
+        kind: 'kuery',
+      },
+      preferredSchema: 'ecs',
+    });
+    const viewId = response.id;
+
+    await test.step('navigate page with preloaded view', async () => {
+      await inventoryPage.goToPageWithSavedView(viewId);
+      await expect(savedViews.selector).toHaveText('View to update');
+    });
+
+    await test.step('change inventory state and update view', async () => {
+      await inventoryPage.showHosts();
+      await savedViews.saveCurrentView('View updated');
+      await expect(savedViews.selector).toHaveText('View updated');
+      await expect(inventoryPage.inventorySwitcherButton).toHaveText('Hosts');
+    });
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[APM] Migrate Infra home page tests to Scout - Part III - Alerts & Saved Views (#250072)](https://github.com/elastic/kibana/pull/250072)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-28T13:30:55Z","message":"[APM] Migrate Infra home page tests to Scout - Part III - Alerts & Saved Views (#250072)\n\n## Summary\nPart of #246428\n\nThis PR is part III of the test migration effort to port infra home page\ntests from FTR to Scout. The original FTR file contains lots of tests\nthat I believe could be split into multiple separate suites following\nthe recommended approach of keeping 1 describe block per test file. The\nmigration will consist of these steps:\n\n- [x] Infra home page (this PR). Includes most of the standalone `it`\ntests inside the outter most describe block in the original FTR suite.\nIt tests the main home page contents, without opening any flyout pr\nnavigating away.\n- [x] **Asset details flyout**. Will cover the asset details flyout that\nopens up after clicking a node in the waffle map. Will in turn be split\ninto 2 separate files to cover the 2 distinct FTR describe blocks, one\nfor hosts and another for containers. This will also cover the \"Redirect\nto Node Details page\" block as the redirection occurs within the flyout.\n- [x] Alert flyouts. Will cover the equivalent describe block around\nalerts from the infra home page\n- [x] Saved views. Will cover the block around saved views functionality\n- [ ] React component test for waffle map. Will cover the outstanding\n`it` tests focused around waffle map functionality. As already specified\nin the FTR file, this are better suited as unit tests\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"740ae121d6caa98dced58869d1e567ce8f853854","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.3.0","ci:beta-faster-pr-build","v9.4.0","Team:obs-presentation"],"title":"[APM] Migrate Infra home page tests to Scout - Part III - Alerts & Saved Views","number":250072,"url":"https://github.com/elastic/kibana/pull/250072","mergeCommit":{"message":"[APM] Migrate Infra home page tests to Scout - Part III - Alerts & Saved Views (#250072)\n\n## Summary\nPart of #246428\n\nThis PR is part III of the test migration effort to port infra home page\ntests from FTR to Scout. The original FTR file contains lots of tests\nthat I believe could be split into multiple separate suites following\nthe recommended approach of keeping 1 describe block per test file. The\nmigration will consist of these steps:\n\n- [x] Infra home page (this PR). Includes most of the standalone `it`\ntests inside the outter most describe block in the original FTR suite.\nIt tests the main home page contents, without opening any flyout pr\nnavigating away.\n- [x] **Asset details flyout**. Will cover the asset details flyout that\nopens up after clicking a node in the waffle map. Will in turn be split\ninto 2 separate files to cover the 2 distinct FTR describe blocks, one\nfor hosts and another for containers. This will also cover the \"Redirect\nto Node Details page\" block as the redirection occurs within the flyout.\n- [x] Alert flyouts. Will cover the equivalent describe block around\nalerts from the infra home page\n- [x] Saved views. Will cover the block around saved views functionality\n- [ ] React component test for waffle map. Will cover the outstanding\n`it` tests focused around waffle map functionality. As already specified\nin the FTR file, this are better suited as unit tests\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"740ae121d6caa98dced58869d1e567ce8f853854"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250072","number":250072,"mergeCommit":{"message":"[APM] Migrate Infra home page tests to Scout - Part III - Alerts & Saved Views (#250072)\n\n## Summary\nPart of #246428\n\nThis PR is part III of the test migration effort to port infra home page\ntests from FTR to Scout. The original FTR file contains lots of tests\nthat I believe could be split into multiple separate suites following\nthe recommended approach of keeping 1 describe block per test file. The\nmigration will consist of these steps:\n\n- [x] Infra home page (this PR). Includes most of the standalone `it`\ntests inside the outter most describe block in the original FTR suite.\nIt tests the main home page contents, without opening any flyout pr\nnavigating away.\n- [x] **Asset details flyout**. Will cover the asset details flyout that\nopens up after clicking a node in the waffle map. Will in turn be split\ninto 2 separate files to cover the 2 distinct FTR describe blocks, one\nfor hosts and another for containers. This will also cover the \"Redirect\nto Node Details page\" block as the redirection occurs within the flyout.\n- [x] Alert flyouts. Will cover the equivalent describe block around\nalerts from the infra home page\n- [x] Saved views. Will cover the block around saved views functionality\n- [ ] React component test for waffle map. Will cover the outstanding\n`it` tests focused around waffle map functionality. As already specified\nin the FTR file, this are better suited as unit tests\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"740ae121d6caa98dced58869d1e567ce8f853854"}}]}] BACKPORT-->