### PR TITLE
[9.3] [Agent Builder] Default to Claude Sonnet 4.5 instead of 3.7 (#251931)

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/common/constants.ts
+++ b/x-pack/platform/plugins/shared/onechat/common/constants.ts
@@ -9,3 +9,5 @@ export const publicApiPath = `/api/agent_builder`;
 export const internalApiPath = `/internal/agent_builder`;
 
 export const ONECHAT_PLUGIN_ID = 'onechat';
+
+export const PREFERRED_DEFAULT_CONNECTOR_ID = 'Anthropic-Claude-Sonnet-4-5';

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/chat/use_default_connector.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/chat/use_default_connector.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import type { AIConnector } from '@kbn/elastic-assistant';
+import { PREFERRED_DEFAULT_CONNECTOR_ID } from '../../../../common/constants';
 
 interface UseDefaultConnectorParams {
   connectors: AIConnector[];
@@ -27,13 +28,19 @@ export function useDefaultConnector({
       return defaultConnectorId;
     }
 
-    // 2. If no default, try to find a preconfigured connector (Elastic-managed LLM)
+    // 2. If no default, prefer the preconfigured Claude Sonnet 4.5 connector when available
+    const preferredConnector = connectors.find((c) => c.id === PREFERRED_DEFAULT_CONNECTOR_ID);
+    if (preferredConnector) {
+      return preferredConnector.id;
+    }
+
+    // 3. Otherwise use the first preconfigured connector (Elastic-managed LLM)
     const preconfiguredConnector = connectors.find((c) => c.isPreconfigured);
     if (preconfiguredConnector) {
       return preconfiguredConnector.id;
     }
 
-    // 3. If no preconfigured connector, use the first custom connector
+    // 4. If no preconfigured connector, use the first custom connector
     return connectors[0]?.id;
   }, [connectors, defaultConnectorId]);
 }

--- a/x-pack/platform/plugins/shared/onechat/server/services/chat/utils/resolve_selected_connector_id.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/chat/utils/resolve_selected_connector_id.ts
@@ -15,11 +15,17 @@ import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
 } from '@kbn/management-settings-ids';
+import { PREFERRED_DEFAULT_CONNECTOR_ID } from '../../../../common/constants';
 
 // TODO: Import from gen-ai-settings-plugin (package) once available
 const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
 
 const selectDefaultConnector = ({ connectors }: { connectors: InferenceConnector[] }) => {
+  const preferredConnector = connectors.find(
+    (connector) => connector.connectorId === PREFERRED_DEFAULT_CONNECTOR_ID
+  );
+  if (preferredConnector) return preferredConnector;
+
   const inferenceConnector = connectors.find(
     (connector) => connector.type === InferenceConnectorType.Inference
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Agent Builder] Default to Claude Sonnet 4.5 instead of 3.7 (#251931)](https://github.com/elastic/kibana/pull/251931)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexandra Shatova","email":"alexandra.shatova@elastic.co"},"sourceCommit":{"committedDate":"2026-02-06T12:05:49Z","message":"[Agent Builder] Default to Claude Sonnet 4.5 instead of 3.7 (#251931)\n\n## Summary\n\nThis PR updates the default connector selection logic for Agent Builder.\nWe are implementing a short-term fix to prioritise Claude Sonnet 4.5 as\nthe default fallback model.\n\n\n## Changes\n- Frontend: Updated `useDefaultConnector` hook to prioritise\n`PREFERRED_DEFAULT_CONNECTOR_ID`.\n- Backend: Updated `resolveSelectedConnectorId` and\n`selectDefaultConnector` to align with the same prioritisation logic.\n- Common: Added `PREFERRED_DEFAULT_CONNECTOR_ID` to shared constants.\n\n## Manual Testing\n\n- Confirmed Agent Builder automatically picks Sonnet 4.5 when no global\ndefault is set.\n- `Inspected /api/agent_builder/converse/async` and verified the backend\nresolves the correct `connector_id`\n- Confirmed the system correctly falls back to the next available model\nif Sonnet 4.5 is missing.\n\n## Automated Tests\nUpdated resolveSelectedConnectorId tests to verify the new\nprioritisation logic.\n\n\n<img width=\"1184\" height=\"385\" alt=\"Screenshot 2026-02-05 at 16 10 21\"\nsrc=\"https://github.com/user-attachments/assets/9f9c6067-b57c-48be-a239-e4fc06e9e7fd\"\n/>\n<img width=\"480\" height=\"234\" alt=\"Screenshot 2026-02-05 at 16 10 17\"\nsrc=\"https://github.com/user-attachments/assets/55e6d294-0247-407c-a0ae-aed4574dcf7c\"\n/>\n<img width=\"964\" height=\"518\" alt=\"Screenshot 2026-02-05 at 13 28 20\"\nsrc=\"https://github.com/user-attachments/assets/8b0215d6-0145-4279-8fe8-ba2c28079626\"\n/>","sha":"30f5eb0f8a26e86d7c23412009dfd7c15cfe49ad","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0","feature:agent-builder"],"title":"[Agent Builder] Default to Claude Sonnet 4.5 instead of 3.7","number":251931,"url":"https://github.com/elastic/kibana/pull/251931","mergeCommit":{"message":"[Agent Builder] Default to Claude Sonnet 4.5 instead of 3.7 (#251931)\n\n## Summary\n\nThis PR updates the default connector selection logic for Agent Builder.\nWe are implementing a short-term fix to prioritise Claude Sonnet 4.5 as\nthe default fallback model.\n\n\n## Changes\n- Frontend: Updated `useDefaultConnector` hook to prioritise\n`PREFERRED_DEFAULT_CONNECTOR_ID`.\n- Backend: Updated `resolveSelectedConnectorId` and\n`selectDefaultConnector` to align with the same prioritisation logic.\n- Common: Added `PREFERRED_DEFAULT_CONNECTOR_ID` to shared constants.\n\n## Manual Testing\n\n- Confirmed Agent Builder automatically picks Sonnet 4.5 when no global\ndefault is set.\n- `Inspected /api/agent_builder/converse/async` and verified the backend\nresolves the correct `connector_id`\n- Confirmed the system correctly falls back to the next available model\nif Sonnet 4.5 is missing.\n\n## Automated Tests\nUpdated resolveSelectedConnectorId tests to verify the new\nprioritisation logic.\n\n\n<img width=\"1184\" height=\"385\" alt=\"Screenshot 2026-02-05 at 16 10 21\"\nsrc=\"https://github.com/user-attachments/assets/9f9c6067-b57c-48be-a239-e4fc06e9e7fd\"\n/>\n<img width=\"480\" height=\"234\" alt=\"Screenshot 2026-02-05 at 16 10 17\"\nsrc=\"https://github.com/user-attachments/assets/55e6d294-0247-407c-a0ae-aed4574dcf7c\"\n/>\n<img width=\"964\" height=\"518\" alt=\"Screenshot 2026-02-05 at 13 28 20\"\nsrc=\"https://github.com/user-attachments/assets/8b0215d6-0145-4279-8fe8-ba2c28079626\"\n/>","sha":"30f5eb0f8a26e86d7c23412009dfd7c15cfe49ad"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251931","number":251931,"mergeCommit":{"message":"[Agent Builder] Default to Claude Sonnet 4.5 instead of 3.7 (#251931)\n\n## Summary\n\nThis PR updates the default connector selection logic for Agent Builder.\nWe are implementing a short-term fix to prioritise Claude Sonnet 4.5 as\nthe default fallback model.\n\n\n## Changes\n- Frontend: Updated `useDefaultConnector` hook to prioritise\n`PREFERRED_DEFAULT_CONNECTOR_ID`.\n- Backend: Updated `resolveSelectedConnectorId` and\n`selectDefaultConnector` to align with the same prioritisation logic.\n- Common: Added `PREFERRED_DEFAULT_CONNECTOR_ID` to shared constants.\n\n## Manual Testing\n\n- Confirmed Agent Builder automatically picks Sonnet 4.5 when no global\ndefault is set.\n- `Inspected /api/agent_builder/converse/async` and verified the backend\nresolves the correct `connector_id`\n- Confirmed the system correctly falls back to the next available model\nif Sonnet 4.5 is missing.\n\n## Automated Tests\nUpdated resolveSelectedConnectorId tests to verify the new\nprioritisation logic.\n\n\n<img width=\"1184\" height=\"385\" alt=\"Screenshot 2026-02-05 at 16 10 21\"\nsrc=\"https://github.com/user-attachments/assets/9f9c6067-b57c-48be-a239-e4fc06e9e7fd\"\n/>\n<img width=\"480\" height=\"234\" alt=\"Screenshot 2026-02-05 at 16 10 17\"\nsrc=\"https://github.com/user-attachments/assets/55e6d294-0247-407c-a0ae-aed4574dcf7c\"\n/>\n<img width=\"964\" height=\"518\" alt=\"Screenshot 2026-02-05 at 13 28 20\"\nsrc=\"https://github.com/user-attachments/assets/8b0215d6-0145-4279-8fe8-ba2c28079626\"\n/>","sha":"30f5eb0f8a26e86d7c23412009dfd7c15cfe49ad"}}]}] BACKPORT-->