### PR TITLE
Remove dashboard JSON export feature flag

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -253,6 +253,9 @@ export const topNavStrings = {
     scheduleExportLabel: i18n.translate('dashboard.topNave.scheduleExportButtonAriaLabel', {
       defaultMessage: 'Schedule export',
     }),
+    jsonLabel: i18n.translate('dashboard.topNave.exportJsonButtonAriaLabel', {
+      defaultMessage: 'JSON',
+    }),
   },
   share: {
     label: i18n.translate('dashboard.topNave.shareButtonAriaLabel', {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/dashboard_export_provider.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/dashboard_export_provider.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiCodeBlock, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
+import { downloadFileAs } from '../../../../share/public';
+import type { ExportShare, RegisterShareIntegrationArgs } from '../../../../share/public/types';
+import type { DashboardReadResponseBody } from '../../../server';
+import type { DashboardApi } from '../../dashboard_api/types';
+import { dashboardClient } from '../../dashboard_client';
+
+const EMPTY_DASHBOARD_ID = '';
+
+export interface DashboardExportSharingData {
+  title: string;
+  dashboardApi: DashboardApi;
+}
+
+export const dashboardExportProvider = (): RegisterShareIntegrationArgs<ExportShare> => ({
+  id: 'dashboardJsonExport',
+  groupId: 'export',
+  getShareIntegrationConfig: async ({ sharingData }) => {
+    const { title, dashboardApi } = sharingData as DashboardExportSharingData;
+    const exportLabel = i18n.translate('dashboard.shareIntegration.exportDashboardJsonTitle', {
+      defaultMessage: 'JSON',
+    });
+
+    const getDashboardContent = async (): Promise<DashboardReadResponseBody> => {
+      const content = dashboardApi.getSerializedState();
+      const dashboardId = dashboardApi.savedObjectId$.getValue();
+      const mergedData = dashboardId
+        ? {
+            ...(await dashboardClient.get(dashboardId)).data,
+            ...content.attributes,
+          }
+        : content.attributes;
+
+      return {
+        id: dashboardId ?? EMPTY_DASHBOARD_ID,
+        data: mergedData,
+        meta: {
+          outcome: 'exactMatch',
+        },
+      };
+    };
+
+    const getDashboardContentJson = async () => {
+      const dashboardContent = await getDashboardContent();
+      return `${JSON.stringify(dashboardContent, null, 2)}\n`;
+    };
+
+    const DashboardJsonCodeBlock = () => {
+      const [savedObjectId, viewMode, hasUnsavedChanges] = useBatchedPublishingSubjects(
+        dashboardApi.savedObjectId$,
+        dashboardApi.viewMode$,
+        dashboardApi.hasUnsavedChanges$
+      );
+      const [contentState, setContentState] = React.useState<{
+        loading: boolean;
+        content: string | null;
+        error: Error | null;
+      }>({
+        loading: true,
+        content: null,
+        error: null,
+      });
+
+      React.useEffect(() => {
+        let isMounted = true;
+        setContentState({ loading: true, content: null, error: null });
+        getDashboardContentJson()
+          .then((value) => {
+            if (isMounted) {
+              setContentState({ loading: false, content: value, error: null });
+            }
+          })
+          .catch((error) => {
+            if (isMounted) {
+              setContentState({
+                loading: false,
+                content: null,
+                error: error instanceof Error ? error : new Error(String(error)),
+              });
+            }
+          });
+
+        return () => {
+          isMounted = false;
+        };
+      }, [hasUnsavedChanges, savedObjectId, viewMode]);
+
+      if (contentState.loading) {
+        return (
+          <EuiEmptyPrompt
+            data-test-subj="dashboardJsonExportLoading"
+            icon={<EuiLoadingSpinner size="l" />}
+          />
+        );
+      }
+
+      if (contentState.error) {
+        return (
+          <EuiCallOut
+            title={i18n.translate('dashboard.shareIntegration.exportDashboardJsonErrorTitle', {
+              defaultMessage: 'Unable to load dashboard JSON',
+            })}
+            color="danger"
+            iconType="alert"
+          >
+            {contentState.error.message}
+          </EuiCallOut>
+        );
+      }
+
+      if (!contentState.content) {
+        return null;
+      }
+
+      return (
+        <EuiCodeBlock language="json" isCopyable overflowHeight="100%" isVirtualized>
+          {contentState.content}
+        </EuiCodeBlock>
+      );
+    };
+
+    return {
+      label: exportLabel,
+      icon: 'document',
+      exportType: 'dashboardJson',
+      requiresSavedState: false,
+      generateAssetComponent: <DashboardJsonCodeBlock />,
+      generateAssetExport: async () => {
+        const dashboardContent = await getDashboardContentJson();
+        await downloadFileAs(`${title}.json`, {
+          content: dashboardContent,
+          type: 'application/json',
+        });
+      },
+    };
+  },
+});

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/dashboard_export_provider.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/dashboard_export_provider.tsx
@@ -11,11 +11,11 @@ import React from 'react';
 import { EuiCallOut, EuiCodeBlock, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
-import { downloadFileAs } from '../../../../share/public';
-import type { ExportShare, RegisterShareIntegrationArgs } from '../../../../share/public/types';
-import type { DashboardReadResponseBody } from '../../../server';
-import type { DashboardApi } from '../../dashboard_api/types';
-import { dashboardClient } from '../../dashboard_client';
+import { downloadFileAs } from '@kbn/share-plugin/public';
+import type { ExportShare, RegisterShareIntegrationArgs } from '@kbn/share-plugin/public/types';
+import type { DashboardReadResponseBody } from '../../../../server';
+import type { DashboardApi } from '../../../dashboard_api/types';
+import { dashboardClient } from '../../../dashboard_client';
 
 const EMPTY_DASHBOARD_ID = '';
 
@@ -28,7 +28,7 @@ export const dashboardExportProvider = (): RegisterShareIntegrationArgs<ExportSh
   id: 'dashboardJsonExport',
   groupId: 'export',
   getShareIntegrationConfig: async ({ sharingData }) => {
-    const { title, dashboardApi } = sharingData as DashboardExportSharingData;
+    const { title, dashboardApi } = sharingData as unknown as DashboardExportSharingData;
     const exportLabel = i18n.translate('dashboard.shareIntegration.exportDashboardJsonTitle', {
       defaultMessage: 'JSON',
     });

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/share_options_utils.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/share_options_utils.ts
@@ -16,6 +16,7 @@ import { getStateFromKbnUrl, setStateToKbnUrl, unhashUrl } from '@kbn/kibana-uti
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { topNavStrings } from '../../_dashboard_app_strings';
 import type { DashboardLocatorParams } from '../../../../common';
+import type { DashboardApi } from '../../../dashboard_api/types';
 import { getDashboardBackupService } from '../../../services/dashboard_backup_service';
 import { dataService, shareService } from '../../../services/kibana_services';
 import { getDashboardCapabilities } from '../../../utils/get_dashboard_capabilities';
@@ -109,9 +110,14 @@ export function getExportObjectTypeMeta() {
 /**
  * Builds sharingData for export operations.
  */
-export function buildExportSharingData(title: string, locatorParams: DashboardLocatorParams) {
+export function buildExportSharingData(
+  title: string,
+  locatorParams: DashboardLocatorParams,
+  dashboardApi: DashboardApi
+) {
   return {
     title,
+    dashboardApi,
     locatorParams: {
       id: DASHBOARD_APP_LOCATOR,
       params: locatorParams,
@@ -154,6 +160,13 @@ export const mapExportIntegrationToMetaData = (intgrationId: string) => {
         iconType: 'calendar',
         order: 3,
         separator: 'above' as const,
+      };
+    case 'dashboardJsonExport':
+      return {
+        label: topNavStrings.export.jsonLabel,
+        testId: 'exportMenuItem-JSON',
+        iconType: 'document',
+        order: 4,
       };
     default:
       return {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.test.tsx
@@ -14,6 +14,7 @@ import { shareService } from '../../../services/kibana_services';
 import { showPublicUrlSwitch, ShowShareModal } from './show_share_modal';
 import type { AccessControlClient } from '@kbn/content-management-access-control-public';
 import type { SavedObjectAccessControl } from '@kbn/core/server';
+import type { DashboardApi } from '../../../dashboard_api/types';
 
 describe('showPublicUrlSwitch', () => {
   test('returns false if "dashboard_v2" app is not available', () => {
@@ -78,6 +79,12 @@ describe('ShowShareModal', () => {
     isManaged: false,
     getCurrentUser: jest.fn().mockResolvedValue({} as { uid: string }),
     getActiveSpace: jest.fn().mockResolvedValue({ name: 'default' }),
+    dashboardApi: {
+      savedObjectId$: { getValue: jest.fn() },
+      viewMode$: { getValue: jest.fn() },
+      hasUnsavedChanges$: { getValue: jest.fn() },
+      getSerializedState: jest.fn(),
+    } as unknown as DashboardApi,
   };
 
   it('locatorParams is missing all unsaved state when none is given', () => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -11,7 +11,6 @@ import type { ReactElement } from 'react';
 import React, { useState } from 'react';
 import { EuiCheckbox, EuiFlexGrid, EuiFlexItem, EuiFormFieldset } from '@elastic/eui';
 import type { Capabilities } from '@kbn/core/public';
-import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { i18n } from '@kbn/i18n';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 
@@ -27,7 +26,8 @@ import { shareService, coreServices, spacesService } from '../../../services/kib
 import { getDashboardCapabilities } from '../../../utils/get_dashboard_capabilities';
 import { shareModalStrings } from '../../_dashboard_app_strings';
 import { dashboardUrlParams } from '../../dashboard_router';
-import { buildDashboardShareOptions } from './share_options_utils';
+import type { DashboardApi } from '../../../dashboard_api/types';
+import { buildDashboardShareOptions, buildExportSharingData } from './share_options_utils';
 
 const showFilterBarId = 'showFilterBar';
 
@@ -42,6 +42,7 @@ export interface ShowShareModalProps {
   accessControlClient: AccessControlClient;
   saveDashboard: () => Promise<void>;
   changeAccessMode: (accessMode: SavedObjectAccessControl['accessMode']) => Promise<void>;
+  dashboardApi: DashboardApi;
 }
 
 export const showPublicUrlSwitch = (anonymousUserCapabilities: Capabilities) => {
@@ -63,6 +64,7 @@ export function ShowShareModal({
   accessControlClient,
   saveDashboard,
   changeAccessMode,
+  dashboardApi,
 }: ShowShareModalProps) {
   if (!shareService) return;
 
@@ -199,11 +201,7 @@ export function ShowShareModal({
       },
     },
     sharingData: {
-      title,
-      locatorParams: {
-        id: DASHBOARD_APP_LOCATOR,
-        params: locatorParams,
-      },
+      ...buildExportSharingData(title, locatorParams, dashboardApi),
       accessModeContainer: showAccessContainer ? (
         <AccessModeContainer
           accessControl={accessControl}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -20,6 +20,7 @@ import {
   type AccessControlClient,
 } from '@kbn/content-management-access-control-public';
 
+import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { DASHBOARD_SAVED_OBJECT_TYPE } from '@kbn/deeplinks-analytics/constants';
 import type { DashboardLocatorParams } from '../../../../common';
 import { shareService, coreServices, spacesService } from '../../../services/kibana_services';

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/use_dashboard_export_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/use_dashboard_export_items.tsx
@@ -29,6 +29,7 @@ interface Props {
 }
 
 export const useDashboardExportItems = ({
+  dashboardApi,
   objectId,
   isDirty,
   dashboardTitle,
@@ -50,7 +51,7 @@ export const useDashboardExportItems = ({
       allowShortUrl,
       shareableUrl,
       objectTypeMeta: getExportObjectTypeMeta(),
-      sharingData: buildExportSharingData(title, locatorParams),
+      sharingData: buildExportSharingData(title, locatorParams, dashboardApi),
       shareableUrlLocatorParams: buildShareableUrlLocatorParams(locatorParams),
     };
 
@@ -91,5 +92,5 @@ export const useDashboardExportItems = ({
       }));
 
     return [...exportItems, ...derivativeItems];
-  }, [intl, objectId, isDirty, dashboardTitle]);
+  }, [dashboardApi, intl, objectId, isDirty, dashboardTitle]);
 };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -182,6 +182,7 @@ export const useDashboardMenuItems = ({
       accessControlClient,
       saveDashboard: saveFromShareModal,
       changeAccessMode: dashboardApi.changeAccessMode,
+      dashboardApi,
     });
   }, [
     dashboardTitle,
@@ -195,6 +196,7 @@ export const useDashboardMenuItems = ({
     dashboardApi.createdBy,
     accessControlClient,
     dashboardApi.isManaged,
+    dashboardApi,
   ]);
 
   const getEditTooltip = useCallback(() => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -192,10 +192,7 @@ export const useDashboardMenuItems = ({
     canManageAccessControl,
     accessControl,
     saveFromShareModal,
-    dashboardApi.changeAccessMode,
-    dashboardApi.createdBy,
     accessControlClient,
-    dashboardApi.isManaged,
     dashboardApi,
   ]);
 

--- a/src/platform/plugins/shared/dashboard/public/plugin.tsx
+++ b/src/platform/plugins/shared/dashboard/public/plugin.tsx
@@ -178,7 +178,8 @@ export class DashboardPlugin
         })
       );
 
-      if (core.featureFlags.getBooleanValue('dashboardPlugin.dashboardJsonExport', false)) {
+      const initialFeatureFlags = core.featureFlags.getInitialFeatureFlags();
+      if (Boolean(initialFeatureFlags['dashboardPlugin.dashboardJsonExport'])) {
         share.registerShareIntegration('dashboard', dashboardExportProvider());
       }
     }

--- a/src/platform/plugins/shared/dashboard/public/plugin.tsx
+++ b/src/platform/plugins/shared/dashboard/public/plugin.tsx
@@ -72,6 +72,7 @@ import {
   SEARCH_SESSION_ID,
 } from '../common/page_bundle_constants';
 import { setKibanaServices, untilPluginStartServicesReady } from './services/kibana_services';
+import { dashboardExportProvider } from './dashboard_app/top_nav/share/dashboard_export_provider';
 import { setLogger } from './services/logger';
 import { registerActions } from './dashboard_actions/register_actions';
 import { setupUrlForwarding } from './dashboard_app/url/setup_url_forwarding';
@@ -176,6 +177,10 @@ export class DashboardPlugin
           },
         })
       );
+
+      if (core.featureFlags.getBooleanValue('dashboardPlugin.dashboardJsonExport', false)) {
+        share.registerShareIntegration('dashboard', dashboardExportProvider());
+      }
     }
 
     const {

--- a/src/platform/plugins/shared/dashboard/public/plugin.tsx
+++ b/src/platform/plugins/shared/dashboard/public/plugin.tsx
@@ -178,10 +178,7 @@ export class DashboardPlugin
         })
       );
 
-      const initialFeatureFlags = core.featureFlags.getInitialFeatureFlags();
-      if (Boolean(initialFeatureFlags['dashboardPlugin.dashboardJsonExport'])) {
-        share.registerShareIntegration('dashboard', dashboardExportProvider());
-      }
+      share.registerShareIntegration('dashboard', dashboardExportProvider());
     }
 
     const {

--- a/src/platform/test/functional/apps/dashboard/group4/config.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/config.ts
@@ -10,7 +10,7 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const commonConfig = await readConfigFile(require.resolve('../../../common/config.js'));
+  const commonConfig = await readConfigFile(require.resolve('../../../../common/config.js'));
   const functionalConfig = await readConfigFile(require.resolve('../../../config.base.js'));
 
   return {

--- a/src/platform/test/functional/apps/dashboard/group4/config.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/config.ts
@@ -10,18 +10,10 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const commonConfig = await readConfigFile(require.resolve('../../../../common/config.js'));
   const functionalConfig = await readConfigFile(require.resolve('../../../config.base.js'));
 
   return {
     ...functionalConfig.getAll(),
     testFiles: [require.resolve('.')],
-    kbnTestServer: {
-      ...commonConfig.get('kbnTestServer'),
-      serverArgs: [
-        ...commonConfig.get('kbnTestServer.serverArgs'),
-        '--coreApp.allowDynamicConfigOverrides=true',
-      ],
-    },
   };
 }

--- a/src/platform/test/functional/apps/dashboard/group4/config.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/config.ts
@@ -10,10 +10,18 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const commonConfig = await readConfigFile(require.resolve('../../../common/config.js'));
   const functionalConfig = await readConfigFile(require.resolve('../../../config.base.js'));
 
   return {
     ...functionalConfig.getAll(),
     testFiles: [require.resolve('.')],
+    kbnTestServer: {
+      ...commonConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...commonConfig.get('kbnTestServer.serverArgs'),
+        '--coreApp.allowDynamicConfigOverrides=true',
+      ],
+    },
   };
 }

--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_export_json.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_export_json.ts
@@ -12,8 +12,8 @@ import {
   ELASTIC_HTTP_VERSION_HEADER,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
 } from '@kbn/core-http-common';
-import type { DashboardReadResponseBody } from '../../../../../plugins/shared/dashboard/server';
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import type { DashboardReadResponseBody } from '@kbn/dashboard-plugin/server';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
 
 const FEATURE_FLAG_SETTING = 'dashboardPlugin.dashboardJsonExport';
 

--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_export_json.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_export_json.ts
@@ -8,38 +8,13 @@
  */
 
 import expect from '@kbn/expect';
-import {
-  ELASTIC_HTTP_VERSION_HEADER,
-  X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
-} from '@kbn/core-http-common';
 import type { DashboardReadResponseBody } from '@kbn/dashboard-plugin/server';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
-
-const FEATURE_FLAG_SETTING = 'dashboardPlugin.dashboardJsonExport';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const { dashboard, exports } = getPageObjects(['dashboard', 'exports']);
   const esArchiver = getService('esArchiver');
   const browser = getService('browser');
-  const kibanaServer = getService('kibanaServer');
-
-  const setExportDashboardJsonFeatureFlag = async (enabled: boolean) => {
-    await kibanaServer.request({
-      path: '/internal/core/_settings',
-      method: 'PUT',
-      headers: {
-        [ELASTIC_HTTP_VERSION_HEADER]: '1',
-        [X_ELASTIC_INTERNAL_ORIGIN_REQUEST]: 'ftr',
-      },
-      body: {
-        feature_flags: {
-          overrides: {
-            [FEATURE_FLAG_SETTING]: enabled,
-          },
-        },
-      },
-    });
-  };
 
   describe('dashboard export json', function () {
     before(async function () {
@@ -57,19 +32,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
       );
       await kibanaServer.savedObjects.cleanStandardList();
-      await setExportDashboardJsonFeatureFlag(false);
-    });
-
-    it('does not show the export JSON option when the feature flag is disabled (default)', async function () {
-      await dashboard.gotoDashboardLandingPage();
-      await dashboard.loadSavedDashboard('dashboard with everything');
-      await dashboard.waitForRenderComplete();
-      expect(await exports.exportButtonExists()).to.be(false);
     });
 
     it('exports existing dashboard as JSON', async function () {
-      await setExportDashboardJsonFeatureFlag(true);
-      await browser.refresh();
+      await dashboard.gotoDashboardLandingPage();
+      await dashboard.loadSavedDashboard('dashboard with everything');
       await dashboard.waitForRenderComplete();
 
       await exports.clickExportTopNavButton();

--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_export_json.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_export_json.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import expect from '@kbn/expect';
+import {
+  ELASTIC_HTTP_VERSION_HEADER,
+  X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
+} from '@kbn/core-http-common';
+import type { DashboardReadResponseBody } from '../../../../../plugins/shared/dashboard/server';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const FEATURE_FLAG_SETTING = 'dashboardPlugin.dashboardJsonExport';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const { dashboard, exports } = getPageObjects(['dashboard', 'exports']);
+  const esArchiver = getService('esArchiver');
+  const browser = getService('browser');
+  const kibanaServer = getService('kibanaServer');
+
+  const setExportDashboardJsonFeatureFlag = async (enabled: boolean) => {
+    await kibanaServer.request({
+      path: '/internal/core/_settings',
+      method: 'PUT',
+      headers: {
+        [ELASTIC_HTTP_VERSION_HEADER]: '1',
+        [X_ELASTIC_INTERNAL_ORIGIN_REQUEST]: 'ftr',
+      },
+      body: {
+        feature_flags: {
+          overrides: {
+            [FEATURE_FLAG_SETTING]: enabled,
+          },
+        },
+      },
+    });
+  };
+
+  describe('dashboard export json', function () {
+    before(async function () {
+      await esArchiver.loadIfNeeded(
+        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
+      );
+      await dashboard.initTests({
+        kibanaIndex:
+          'src/platform/test/functional/fixtures/kbn_archiver/dashboard/current/kibana.json',
+      });
+    });
+
+    after(async function () {
+      await esArchiver.unload(
+        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
+      );
+      await kibanaServer.savedObjects.cleanStandardList();
+      await setExportDashboardJsonFeatureFlag(false);
+    });
+
+    it('does not show the export JSON option when the feature flag is disabled (default)', async function () {
+      await dashboard.gotoDashboardLandingPage();
+      await dashboard.loadSavedDashboard('dashboard with everything');
+      await dashboard.waitForRenderComplete();
+      expect(await exports.exportButtonExists()).to.be(false);
+    });
+
+    it('exports existing dashboard as JSON', async function () {
+      await setExportDashboardJsonFeatureFlag(true);
+      await browser.refresh();
+      await dashboard.waitForRenderComplete();
+
+      await exports.clickExportTopNavButton();
+      await exports.isExportFlyoutOpen();
+
+      await exports.copyExportAssetText();
+      const dashboardAsJson = JSON.parse(
+        await browser.getClipboardValue()
+      ) as DashboardReadResponseBody;
+      const panels = await dashboard.getPanelTitles();
+      expect(panels.length).to.equal(dashboardAsJson.data.panels?.length ?? 0);
+
+      await exports.closeExportFlyout();
+    });
+
+    it('includes unsaved changes in the exported JSON', async function () {
+      await dashboard.switchToEditMode();
+      await dashboard.addVisualizations(['non timebased line chart - dog data']);
+      await dashboard.expectUnsavedChangesBadge();
+
+      await exports.clickExportTopNavButton();
+      await exports.isExportFlyoutOpen();
+
+      await exports.copyExportAssetText();
+      const dashboardAsJson = JSON.parse(
+        await browser.getClipboardValue()
+      ) as DashboardReadResponseBody;
+      const panels = await dashboard.getPanelTitles();
+      expect(panels.length).to.equal(dashboardAsJson.data.panels?.length ?? 0);
+
+      await exports.closeExportFlyout();
+    });
+  });
+}

--- a/src/platform/test/functional/apps/dashboard/group4/index.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/index.ts
@@ -37,5 +37,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./dashboard_time'));
     loadTestFile(require.resolve('./dashboard_listing'));
     loadTestFile(require.resolve('./dashboard_clone'));
+    loadTestFile(require.resolve('./dashboard_export_json'));
   });
 }


### PR DESCRIPTION
## Summary
- always register the dashboard JSON share integration
- remove dashboard export JSON feature flag plumbing from functional tests
- simplify dashboard export JSON FTR config

## Testing
- Not run (attempted: `node scripts/build_kibana_platform_plugins && yarn test:ftr --config src/platform/test/functional/apps/dashboard/group4/config.ts --grep "dashboard export json"`, stopped due to access_control 500s / missing data view)
