### PR TITLE
Add persistFiltersInLocalStorage option to rules list filter store

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/hooks/use_rules_list_filter_store.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/hooks/use_rules_list_filter_store.test.tsx
@@ -125,6 +125,48 @@ describe('useRulesListFilterStore', () => {
     expect(result.current.numberOfFiltersStore).toEqual(8);
   });
 
+  it('Should return props (not localStorage) when persistFiltersInLocalStorage is false and url is empty', () => {
+    jest.spyOn(useLocalStorage, 'default').mockImplementation(() => [
+      {
+        actionTypes: ['localStorage-actionType-filter'],
+        lastResponse: ['localStorage-lastResponse-filter'],
+        params: { localStorageRuleParams: 'localStorage-ruleParams-filter' },
+        search: 'localStorage-search-filter',
+        status: ['disabled'],
+        tags: ['localStorage-tag-filter'],
+        type: ['localStorage-ruleType-filter'],
+      },
+      () => null,
+      () => {},
+    ]);
+    const { result } = renderHook(() =>
+      useRulesListFilterStore({
+        lastResponseFilter: ['props-lastResponse-filter'],
+        lastRunOutcomeFilter: ['props-lastRunOutcome-filter'],
+        persistFiltersInLocalStorage: false,
+        rulesListKey: LOCAL_STORAGE_KEY,
+        ruleParamFilter: { propsRuleParams: 'props-ruleParams-filter' },
+        statusFilter: ['enabled'],
+        searchFilter: 'props-search-filter',
+        typeFilter: ['ruleType-filter'],
+      })
+    );
+    expect(result.current.filters).toEqual({
+      actionTypes: [],
+      kueryNode: undefined,
+      ruleExecutionStatuses: ['props-lastResponse-filter'],
+      ruleLastRunOutcomes: ['props-lastRunOutcome-filter'],
+      ruleParams: {
+        propsRuleParams: 'props-ruleParams-filter',
+      },
+      ruleStatuses: ['enabled'],
+      searchText: 'props-search-filter',
+      tags: [],
+      types: ['ruleType-filter'],
+    });
+    expect(result.current.numberOfFiltersStore).toEqual(6);
+  });
+
   it('Should return the url params as filter when url query param is empty', () => {
     jest.spyOn(useLocalStorage, 'default').mockImplementation(() => [
       {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/hooks/use_rules_list_filter_store.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/hooks/use_rules_list_filter_store.tsx
@@ -18,6 +18,7 @@ type FilterStoreProps = Pick<
   | 'lastResponseFilter'
   | 'lastRunOutcomeFilter'
   | 'rulesListKey'
+  | 'persistFiltersInLocalStorage'
   | 'ruleParamFilter'
   | 'statusFilter'
   | 'searchFilter'
@@ -53,6 +54,7 @@ export const useRulesListFilterStore = ({
   lastResponseFilter,
   lastRunOutcomeFilter,
   rulesListKey = RULES_LIST_FILTERS_KEY,
+  persistFiltersInLocalStorage = true,
   ruleParamFilter,
   statusFilter,
   searchFilter,
@@ -76,10 +78,11 @@ export const useRulesListFilterStore = ({
   );
   const hasFilterFromLocalStorage = useMemo(
     () =>
+      persistFiltersInLocalStorage &&
       rulesListFilterLocal
         ? !Object.values(rulesListFilterLocal).every((filters) => isEmpty(filters))
         : false,
-    [rulesListFilterLocal]
+    [persistFiltersInLocalStorage, rulesListFilterLocal]
   );
 
   const rulesListFilterUrl = useMemo(
@@ -97,7 +100,11 @@ export const useRulesListFilterStore = ({
 
   const filtersStore = useMemo(
     () =>
-      hasFilterFromUrl ? rulesListFilterUrl : hasFilterFromLocalStorage ? rulesListFilterLocal : {},
+      hasFilterFromUrl
+        ? rulesListFilterUrl
+        : hasFilterFromLocalStorage
+          ? rulesListFilterLocal
+          : {},
     [hasFilterFromLocalStorage, hasFilterFromUrl, rulesListFilterLocal, rulesListFilterUrl]
   );
   const [filters, setFilters] = useState<RulesListFilters>({
@@ -121,9 +128,11 @@ export const useRulesListFilterStore = ({
 
   const updateLocalFilters = useCallback(
     (updatedParams: RulesListFilters) => {
-      setRulesListFilterLocal(convertRulesListFiltersToFilterAttributes(updatedParams));
+      if (persistFiltersInLocalStorage) {
+        setRulesListFilterLocal(convertRulesListFiltersToFilterAttributes(updatedParams));
+      }
     },
-    [setRulesListFilterLocal]
+    [persistFiltersInLocalStorage, setRulesListFilterLocal]
   );
 
   const setFiltersStore = useCallback(

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
@@ -102,6 +102,12 @@ export interface RulesListProps {
   ruleDetailsRoute?: string;
   ruleParamFilter?: Record<string, string | number | object>;
   rulesListKey?: string;
+  /**
+   * When true (default), filter state (search, status, type, etc.) is persisted to and
+   * restored from localStorage so it survives page reloads and navigation. Set to false
+   * to keep filter state only in URL and props (no localStorage).
+   */
+  persistFiltersInLocalStorage?: boolean;
   searchFilter?: string;
   showActionFilter?: boolean;
   showCreateRuleButtonInPrompt?: boolean;
@@ -145,6 +151,7 @@ export const RulesList = ({
   ruleDetailsRoute,
   ruleParamFilter,
   rulesListKey,
+  persistFiltersInLocalStorage = true,
   searchFilter = '',
   showActionFilter = true,
   showCreateRuleButtonInPrompt = false,
@@ -237,6 +244,7 @@ export const RulesList = ({
       lastResponseFilter,
       lastRunOutcomeFilter,
       rulesListKey,
+      persistFiltersInLocalStorage,
       ruleParamFilter,
       statusFilter,
       searchFilter,


### PR DESCRIPTION
Fixes #252196 

This update introduces a new prop, `persistFiltersInLocalStorage`, to the `useRulesListFilterStore` and `RulesList` components. When set to true (default), filter state is saved to localStorage, allowing it to persist across page reloads. This preserves existing behavior with no unexpected changes.

When the new prop is set to false, filter state is only maintained in the URL and props. Additionally, tests have been added to verify the behavior when this option is toggled.

- Updated `useRulesListFilterStore` to handle localStorage persistence.
- Enhanced tests to cover scenarios with `persistFiltersInLocalStorage` set to false.
- Updated component interfaces to include the new prop.

