### PR TITLE
ci: Use k8s provider for lightweight PR pipeline steps

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -4,7 +4,8 @@ steps:
     timeout_in_minutes: 10
     id: pre_build
     agents:
-      machineType: n2-standard-2
+      provider: k8s
+      image: family/kibana-ubuntu-2404
 
   - wait
 
@@ -123,7 +124,8 @@ steps:
   - command: .buildkite/scripts/steps/ci_stats_ready.sh
     label: Mark CI Stats as ready
     agents:
-      machineType: n2-standard-2
+      provider: k8s
+      image: family/kibana-ubuntu-2404
     timeout_in_minutes: 10
     depends_on:
       - build

--- a/.buildkite/pipelines/pull_request/base_merged_phases.yml
+++ b/.buildkite/pipelines/pull_request/base_merged_phases.yml
@@ -126,8 +126,8 @@ steps:
   - command: .buildkite/scripts/steps/ci_stats_ready.sh
     label: Mark CI Stats as ready
     agents:
-      machineType: n2-standard-2
-      diskSizeGb: 115
+      provider: k8s
+      image: family/kibana-ubuntu-2404
     timeout_in_minutes: 10
     env:
       KIBANA_CI_PIPELINE_TYPE: 'faster_pr_build'


### PR DESCRIPTION
Switch Pre-Build and Mark CI Stats as ready steps to the k8s provider to cut down on time waiting for a GCP VM to provision. These steps only make API calls and don't need full VM resources.