### PR TITLE
Return artifacts in public alerting rules GET and find endpoints

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/find/find_rules_route.ts
@@ -89,7 +89,7 @@ export const findRulesRoute = (
         });
 
         const responseBody: FindRulesResponseV1<RuleParamsV1>['body'] =
-          transformFindRulesResponseV1<RuleParamsV1>(findResult, options.fields, false);
+          transformFindRulesResponseV1<RuleParamsV1>(findResult, options.fields, true);
 
         return res.ok({
           body: responseBody,

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/get/get_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/get/get_rule_route.ts
@@ -75,9 +75,8 @@ const buildGetRuleRoute = ({
           excludeFromPublicApi,
           includeSnoozeData: true,
         })) as Rule<RuleParamsV1>;
-        const includeArtifacts = excludeFromPublicApi !== undefined ? !excludeFromPublicApi : false;
         const response: GetRuleResponseV1<RuleParamsV1> = {
-          body: transformGetResponseV1<RuleParamsV1>(rule, includeArtifacts),
+          body: transformGetResponseV1<RuleParamsV1>(rule, true),
         };
         return res.ok(response);
       })

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/get.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/get.ts
@@ -383,27 +383,25 @@ const getTestUtils = (
     it('should return the artifacts correctly', async () => {
       const { user, space } = SuperuserAtSpace1;
 
+      const expectedArtifacts = {
+        dashboards: [
+          {
+            id: 'dashboard-1',
+          },
+          {
+            id: 'dashboard-2',
+          },
+        ],
+        investigation_guide: { blob: '# Summary' },
+      };
+
       const { body: createdAlert } = await supertest
         .post(`${getUrlPrefix(space.id)}/api/alerting/rule`)
         .set('kbn-xsrf', 'foo')
         .send(
           getTestRuleData({
             enabled: true,
-            ...(describeType === 'internal'
-              ? {
-                  artifacts: {
-                    dashboards: [
-                      {
-                        id: 'dashboard-1',
-                      },
-                      {
-                        id: 'dashboard-2',
-                      },
-                    ],
-                    investigation_guide: { blob: '# Summary' },
-                  },
-                }
-              : {}),
+            artifacts: expectedArtifacts,
           })
         )
         .expect(200);
@@ -418,21 +416,7 @@ const getTestUtils = (
         )
         .auth(user.username, user.password);
 
-      if (describeType === 'public') {
-        expect(response.body.artifacts).to.be(undefined);
-      } else if (describeType === 'internal') {
-        expect(response.body.artifacts).to.eql({
-          dashboards: [
-            {
-              id: 'dashboard-1',
-            },
-            {
-              id: 'dashboard-2',
-            },
-          ],
-          investigation_guide: { blob: '# Summary' },
-        });
-      }
+      expect(response.body.artifacts).to.eql(expectedArtifacts);
     });
   });
 };

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/find.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/find.ts
@@ -400,7 +400,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
     });
 
     describe('artifacts', () => {
-      it('does not return artifacts when present', async () => {
+      it('returns artifacts when present', async () => {
         const expectedArtifacts = {
           artifacts: {
             investigation_guide: { blob: 'Sample investigation guide' },
@@ -425,7 +425,7 @@ export default function createFindTests({ getService }: FtrProviderContext) {
 
         const foundAlert = response.body.data.find((obj: any) => obj.id === id);
         expect(foundAlert).not.to.be(undefined);
-        expect(foundAlert.artifacts).to.be(undefined);
+        expect(foundAlert.artifacts).to.eql(expectedArtifacts.artifacts);
       });
     });
   });


### PR DESCRIPTION
- Public GET /api/alerting/rule/{id} now includes artifacts (dashboards, investigation_guide) in the response, matching create/update behavior.
- Public GET /api/alerting/rules/_find now includes artifacts on each rule.
- Update integration tests to expect artifacts on public GET and find.
