### PR TITLE
perf: use refresh:true instead of wait_for for workflow CRUD APIs

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
@@ -792,7 +792,7 @@ steps:
             lastUpdatedBy: 'test-user',
             spaceId: 'default',
           }),
-          refresh: 'wait_for',
+          refresh: true,
           require_alias: true,
         })
       );
@@ -871,7 +871,7 @@ steps:
             lastUpdatedBy: 'test-user',
             spaceId: 'default',
           }),
-          refresh: 'wait_for',
+          refresh: true,
           require_alias: true,
         })
       );
@@ -1053,7 +1053,7 @@ steps:
             lastUpdatedBy: 'test-user',
             spaceId: 'default',
           }),
-          refresh: 'wait_for',
+          refresh: true,
           require_alias: true,
         })
       );
@@ -1120,7 +1120,7 @@ steps:
             spaceId: 'default',
             definition: undefined,
           }),
-          refresh: 'wait_for',
+          refresh: true,
           require_alias: true,
         })
       );
@@ -1169,7 +1169,7 @@ steps:
             spaceId: 'default',
             definition: undefined,
           }),
-          refresh: 'wait_for',
+          refresh: true,
           require_alias: true,
         })
       );
@@ -1215,7 +1215,7 @@ steps:
             spaceId: 'default',
             definition: undefined,
           }),
-          refresh: 'wait_for',
+          refresh: true,
           require_alias: true,
         })
       );

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
@@ -244,6 +244,7 @@ export class WorkflowsService {
     await this.workflowStorage.getClient().index({
       id,
       document: workflowData,
+      refresh: true,
     });
 
     // Schedule the workflow if it has triggers
@@ -409,6 +410,7 @@ export class WorkflowsService {
       await this.workflowStorage.getClient().index({
         id,
         document: finalData,
+        refresh: true,
       });
 
       // Update task scheduler if needed
@@ -514,6 +516,7 @@ export class WorkflowsService {
       try {
         const bulkResponse = await client.bulk({
           operations: bulkOperations,
+          refresh: true,
         });
 
         // Process bulk response to track successes and failures


### PR DESCRIPTION
## Summary

- Workflow create/update/bulk APIs were taking ~900ms per call due to `StorageIndexAdapter` defaulting to `refresh: 'wait_for'`, which passively waits up to 1s for the next ES refresh cycle
- Changed to `refresh: true` which forces an immediate refresh and returns instantly, cutting ~800ms from each operation
- Safe for the workflows index: <1,000 documents, human-initiated writes only, forced refresh on a tiny index takes microseconds

## References

Closes elastic/security-team#15729


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->