### PR TITLE
[ES|QL] Move Rerank to GA

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
+++ b/src/platform/packages/private/kbn-language-documentation/scripts/resources/commands/processing_data.ts
@@ -856,7 +856,7 @@ FROM books METADATA _score
       ignoreTag: true,
     },
     openLinksInNewTab: true,
-    preview: true,
+    preview: false,
   },
   {
     name: 'sample',

--- a/src/platform/packages/private/kbn-language-documentation/src/sections/generated/processing_commands.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/generated/processing_commands.tsx
@@ -813,7 +813,7 @@ FROM employees
       label: i18n.translate('languageDocumentation.documentationESQL.rerank', {
         defaultMessage: 'RERANK',
       }),
-      preview: true,
+      preview: false,
       description: {
         markdownContent: i18n.translate('languageDocumentation.documentationESQL.rerank.markdown', {
           defaultMessage: `### RERANK

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/index.ts
@@ -37,7 +37,7 @@ export const rerankCommand: ICommand = {
       'FROM movies | RERANK "star wars" ON title WITH { "inference_id": "reranker" }',
       'FROM books | RERANK rerank_score = "hobbit" ON title, description WITH { "inference_id": "my_reranker" }',
     ],
-    preview: true,
+    preview: false,
     hidden: false,
   },
 };


### PR DESCRIPTION
## Summary

Moves the RERANK command to GA

<img width="682" height="534" alt="image" src="https://github.com/user-attachments/assets/05ab5925-2fbf-4db5-9b81-22518352856f" />
