### PR TITLE
Check response message in Content packs API integration tests

### DIFF
--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/helpers/requests.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/helpers/requests.ts
@@ -350,8 +350,7 @@ export async function importContent(
     include: ContentPackIncludedObjects;
     content: Readable;
     filename: string;
-  },
-  expectStatusCode: number = 200
+  }
 ) {
   return await apiClient
     .sendFile('POST /api/streams/{name}/content/import 2023-10-31', {
@@ -364,6 +363,5 @@ export async function importContent(
       },
       file: { key: 'content', filename: body.filename },
     })
-    .expect(expectStatusCode)
-    .then((response) => response.body);
+    .then((response) => ({ ...response.body, statusCode: response.status }));
 }


### PR DESCRIPTION
## Summary
This PR adds an additional check to Content packs API integration tests to ensure that successful responses don't contain a `message` field. This changes makes test failures more descriptive and allows to get more context in case of test flakiness.

Before:
<img width="1093" height="185" alt="image" src="https://github.com/user-attachments/assets/59a50076-ddfd-4643-8ed3-6a33720629ac" />

After:
<img width="1065" height="145" alt="image" src="https://github.com/user-attachments/assets/94036bce-3953-4c0f-aea6-b641f7da0c2d" />
