### PR TITLE
[Automatic Migrations] Exclude failed rules from non-failed status filters

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.test.ts
@@ -16,17 +16,17 @@ describe('convertFilterOptions', () => {
 
   it('filters by `translated` status', () => {
     const filters = convertFilterOptions({ status: StatusFilterBase.TRANSLATED });
-    expect(filters).toEqual({ installed: false, fullyTranslated: true });
+    expect(filters).toEqual({ installed: false, fullyTranslated: true, failed: false });
   });
 
   it('filters by `partially translated` status', () => {
     const filters = convertFilterOptions({ status: StatusFilterBase.PARTIALLY_TRANSLATED });
-    expect(filters).toEqual({ installed: false, partiallyTranslated: true });
+    expect(filters).toEqual({ installed: false, partiallyTranslated: true, failed: false });
   });
 
   it('filters by `untranslatable` status', () => {
     const filters = convertFilterOptions({ status: StatusFilterBase.UNTRANSLATABLE });
-    expect(filters).toEqual({ untranslatable: true });
+    expect(filters).toEqual({ untranslatable: true, failed: false });
   });
 
   it('filters by `failed` status', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/utils/filters.ts
@@ -12,9 +12,13 @@ import type { DashboardMigrationFilters } from '../../../../../../common/siem_mi
 const STATUS_FILTERS: Record<StatusFilterBase, DashboardMigrationFilters> = {
   [StatusFilterBase.FAILED]: { failed: true },
   [StatusFilterBase.INSTALLED]: { installed: true },
-  [StatusFilterBase.TRANSLATED]: { installed: false, fullyTranslated: true },
-  [StatusFilterBase.PARTIALLY_TRANSLATED]: { installed: false, partiallyTranslated: true },
-  [StatusFilterBase.UNTRANSLATABLE]: { untranslatable: true },
+  [StatusFilterBase.TRANSLATED]: { installed: false, fullyTranslated: true, failed: false },
+  [StatusFilterBase.PARTIALLY_TRANSLATED]: {
+    installed: false,
+    partiallyTranslated: true,
+    failed: false,
+  },
+  [StatusFilterBase.UNTRANSLATABLE]: { untranslatable: true, failed: false },
 };
 
 export const convertFilterOptions = (filterOptions?: FilterOptionsBase) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/utils/filters.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/utils/filters.test.ts
@@ -17,17 +17,17 @@ describe('convertFilterOptions', () => {
 
   it('filters by `translated` status', () => {
     const filters = convertFilterOptions({ status: StatusFilterBase.TRANSLATED });
-    expect(filters).toEqual({ installed: false, fullyTranslated: true });
+    expect(filters).toEqual({ installed: false, fullyTranslated: true, failed: false });
   });
 
   it('filters by `partially translated` status', () => {
     const filters = convertFilterOptions({ status: StatusFilterBase.PARTIALLY_TRANSLATED });
-    expect(filters).toEqual({ partiallyTranslated: true });
+    expect(filters).toEqual({ partiallyTranslated: true, failed: false });
   });
 
   it('filters by `untranslatable` status', () => {
     const filters = convertFilterOptions({ status: StatusFilterBase.UNTRANSLATABLE });
-    expect(filters).toEqual({ untranslatable: true });
+    expect(filters).toEqual({ untranslatable: true, failed: false });
   });
 
   it('filters by `failed` status', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/utils/filters.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/utils/filters.ts
@@ -18,9 +18,9 @@ const AUTHOR_FILTERS: Record<AuthorFilter, RuleMigrationFilters> = {
 const STATUS_FILTERS: Record<RulesStatusFilter, RuleMigrationFilters> = {
   [StatusFilterBase.FAILED]: { failed: true },
   [StatusFilterBase.INSTALLED]: { installed: true },
-  [StatusFilterBase.TRANSLATED]: { installed: false, fullyTranslated: true },
-  [StatusFilterBase.PARTIALLY_TRANSLATED]: { partiallyTranslated: true },
-  [StatusFilterBase.UNTRANSLATABLE]: { untranslatable: true },
+  [StatusFilterBase.TRANSLATED]: { installed: false, fullyTranslated: true, failed: false },
+  [StatusFilterBase.PARTIALLY_TRANSLATED]: { partiallyTranslated: true, failed: false },
+  [StatusFilterBase.UNTRANSLATABLE]: { untranslatable: true, failed: false },
   [RulesSpecificStatusFilter.INDEX_PATTERN_MISSING]: { missingIndex: true },
 };
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where rules that failed translation showed up under "Partially Translated" when filtered. 

Adds `failed: false` to TRANSLATED, PARTIALLY_TRANSLATED, and UNTRANSLATABLE filters to ensure failed rules only appear under the FAILED filter.

See https://github.com/elastic/kibana/issues/247676


https://github.com/user-attachments/assets/4bbae084-e583-4235-ad5f-770ccf98f916

## Steps to reproduce

1. Upload a json containing splunk rules in the Automatic Migration flow: http://localhost:5601/app/security/get_started/siem_migrations#migrate_rules
eg:
```json
{
  "preview": false,
  "result": {
    "id": "https://127.0.0.1:8089/servicesNS/nobody/SA-AccessProtection/saved/searches/Access%20-%20Account%20Deleted%20-%20Rule",
    "title": "Access - Account Deleted - Rule",
    "search": "| from datamodel:\"Change\".\"Account_Management\" | where 'tag'=\"delete\" | stats max(\"_time\") as \"lastTime\",latest(\"_raw\") as \"orig_raw\",values(\"result\") as \"signature\",values(\"src\") as \"src\",values(\"dest\") as \"dest\",count by \"src_user\",\"user\" | where 'count'>0",
    "description": "Detects user and computer account deletion",
    "action.correlationsearch.annotations": "{\"mitre_attack\": [\"T1531\"]}"
  }
}
{
  "preview": false,
  "result": {
    "id": "https://127.0.0.1:8089/servicesNS/nobody/SA-AccessProtection/saved/searches/Access%20-%20Brute%20Force%20Access%20Behavior%20Detected%20-%20Rule",
    "title": "Access - Brute Force Access Behavior Detected - Rule",
    "search": "| from datamodel:\"Authentication\".\"Authentication\" | stats values(tag) as tag,values(app) as app,count(eval('action'==\"failure\")) as failure,count(eval('action'==\"success\")) as success by src | search success>0 | `mltk_apply_upper(\"app:failures_by_src_count_1h\", \"high\", \"failure\")`",
    "description": "Detects excessive number of failed login attempts along with a successful attempt (this could indicate a successful brute force attack)",
    "action.correlationsearch.annotations": "{\"mitre_attack\": [\"T1110\", \"T1201\"]}"
  }
}
```

2. Translate the rules - they should translate successfully
3. Go to the Dev Tools -> Console and update the migrated rules
- One of them to "Partially translated" and failed, and the other one just "Partially translated"

```
// set translation result
POST .kibana-siem-rule-migrations-rules-default/_update/<translated rule id eg 0v3IQZwBhzHG9M3Nk16B>
{
    "doc": {
        "translation_result": "full"
    }
}

// set status
POST .kibana-siem-rule-migrations-rules-default/_update/<translated rule id eg 0v3IQZwBhzHG9M3Nk16B>
{
    "doc": {
        "status": "failed"
    }
}
```

4. Go to the Security / Migrations / Translated rules page and find your translated rules and try filtering between "Partially translated" and "Failed" (and other filter combinations as well)

This should give you the same state as in the attached video, doing the steps before the fix would list both the failed and partially translated rules at the same time when filtering on "Partially translated"

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


*PR developed with Cursor CLI GPT Codex 5.2 Hight Fast*


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->