### PR TITLE
[9.3] [Lens] Fix KQL character escaping when query is generated from Top values column (breakdown). (#250925)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.test.ts
@@ -2481,6 +2481,59 @@ describe('IndexPattern Data Source', () => {
           disabled: { kuery: [], lucene: [] },
         });
       });
+      it('should escape special characters in term values for valid KQL syntax', () => {
+        publicAPI = FormBasedDatasource.getPublicAPI({
+          state: {
+            ...baseState,
+            layers: {
+              first: {
+                indexPatternId: '1',
+                columnOrder: ['col1'],
+                columns: {
+                  col1: {
+                    label: 'Terms',
+                    dataType: 'string',
+                    isBucketed: true,
+                    operationType: 'terms',
+                    sourceField: 'path.keyword',
+                    params: {
+                      orderBy: { type: 'alphabetical' },
+                      orderDirection: 'asc',
+                      size: 10,
+                    },
+                  } as TermsIndexPatternColumn,
+                },
+              },
+            },
+          },
+          layerId: 'first',
+          indexPatterns,
+        });
+        const data = {
+          first: {
+            type: 'datatable' as const,
+            columns: [{ id: 'col1', name: 'path.keyword', meta: { type: 'string' as const } }],
+            rows: [
+              { col1: 'C:\\' },
+              { col1: 'path with "quotes"' },
+              { col1: 'backslash\\and"quote' },
+            ],
+          },
+        };
+        expect(publicAPI.getFilters(data)).toEqual({
+          enabled: {
+            kuery: [
+              [
+                { language: 'kuery', query: 'path.keyword: "C:\\\\"' },
+                { language: 'kuery', query: 'path.keyword: "path with \\"quotes\\""' },
+                { language: 'kuery', query: 'path.keyword: "backslash\\\\and\\"quote"' },
+              ],
+            ],
+            lucene: [],
+          },
+          disabled: { kuery: [], lucene: [] },
+        });
+      });
       it('should ignore top values fields if other/missing option is enabled', () => {
         publicAPI = FormBasedDatasource.getPublicAPI({
           state: {

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/utils.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/utils.tsx
@@ -11,11 +11,11 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { DocLinksStart, ThemeServiceStart } from '@kbn/core/public';
 import { hasUnsupportedDownsampledAggregationFailure } from '@kbn/search-response-warnings';
 import type { DatatableUtilitiesService } from '@kbn/data-plugin/common';
-import type { TimeRange } from '@kbn/es-query';
+import { escapeQuotes, type TimeRange } from '@kbn/es-query';
 import { EuiLink, EuiSpacer } from '@elastic/eui';
 
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
-import { groupBy, escape, uniq, uniqBy } from 'lodash';
+import { groupBy, uniq, uniqBy } from 'lodash';
 import type { Query } from '@kbn/data-plugin/common';
 
 import {
@@ -747,13 +747,10 @@ function extractQueriesFromTerms(
       }
       if (typeof value !== 'string' && Array.isArray(value.keys)) {
         return value.keys
-          .map(
-            (term: string, index: number) =>
-              `${fields[index]}: ${`"${term === '' ? escape(term) : term}"`}`
-          )
+          .map((term: string, index: number) => `${fields[index]}: "${escapeQuotes(term)}"`)
           .join(' AND ');
       }
-      return `${column.sourceField}: ${`"${value === '' ? escape(value) : value}"`}`;
+      return `${column.sourceField}: "${escapeQuotes(String(value))}"`;
     })
     .filter(Boolean) as string[];
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Lens] Fix KQL character escaping when query is generated from Top values column (breakdown). (#250925)](https://github.com/elastic/kibana/pull/250925)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2026-02-05T08:13:44Z","message":"[Lens] Fix KQL character escaping when query is generated from Top values column (breakdown). (#250925)\n\n**Problem:** The \"Explore in Discover\" action fails with a\n`KQLSyntaxError` when using Top Values breakdown with values containing\nbackslashes or quotes (e.g., Windows paths like `C:\\`).\n\n**Root cause:** The `extractQueriesFromTerms()` function was using\n`lodash.escape()` (HTML escaping) instead of `escapeQuotes()` from\n`@kbn/es-query` (KQL escaping). Additionally, the escaping logic was\ninverted—it only escaped empty strings instead of non-empty values.\n\n**The fix:** Always escape term values using `escapeQuotes()` which\nproperly escapes `\\` and `\"` characters for KQL quoted values.\n\n## How to test/reproduce\n\n1. Create a test index with a special character value:\n```\nPOST bulk\n{ \"index\": { \"index\": \"my_windows_index\" } }\n{ \"@timestamp\": \"2025-07-31T01:00:00.000Z\", \"group\": \"A\", \"value\": \"C:\\\\\" }\n```\n2. In Lens, create a Bar chart:\n   - Data view: `my_windows_index` (create the data view if needed)\n- Vertical axis: Count of records (Drag the **Records** field from left\nsidebar)\n   - Breakdown: Top 5 values of `value.keyword`\n\n3. Click on the Breakdown dimension → Advanced → disable **Group\nremaining values as \"Other\"**\n\n4. Save the visualization and click \"Explore in Discover\"\n\n\n**Before fix:** `KQLSyntaxError: Expected \"(\", \"{\", value, whitespace\nbut \"\"\" found.`\n\n**After fix:** Discover opens with valid KQL query `value.keyword:\n\"C:\\\\\"` and shows the document.\n\n---\n**Tip**: To reproduce and observe, besides the breakdown, an additional\nfilter on the vertical axis can be added, e.g.\n<img width=\"400\" height=\"984\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6027675a-84c7-4531-809e-39e86bf8fca0\"\n/>\n\n### Before\nWhen a filter with value `C:\\\\` is also present on the vertical axis.\nNote that the filter converted from the vertical axis is escaped\ncorrectly (`C:\\\\`) whereas the one converted from breakdown isn't\n(`C:\\`).\n<img width=\"2540\" height=\"1667\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f7be32d2-61cb-4a85-ac4a-0df37315d070\"\n/>\n\n### After\n<img width=\"1267\" height=\"803\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f1e1299b-b3b1-4341-b3fb-7e7a57af6d52\"\n/>","sha":"fde2c581f60e9b17019e6ff8802943adc14d3ad9","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Visualizations","ci:cloud-deploy","backport:version","v9.3.0","v9.4.0"],"title":"[Lens] Fix KQL character escaping when query is generated from Top values column (breakdown).","number":250925,"url":"https://github.com/elastic/kibana/pull/250925","mergeCommit":{"message":"[Lens] Fix KQL character escaping when query is generated from Top values column (breakdown). (#250925)\n\n**Problem:** The \"Explore in Discover\" action fails with a\n`KQLSyntaxError` when using Top Values breakdown with values containing\nbackslashes or quotes (e.g., Windows paths like `C:\\`).\n\n**Root cause:** The `extractQueriesFromTerms()` function was using\n`lodash.escape()` (HTML escaping) instead of `escapeQuotes()` from\n`@kbn/es-query` (KQL escaping). Additionally, the escaping logic was\ninverted—it only escaped empty strings instead of non-empty values.\n\n**The fix:** Always escape term values using `escapeQuotes()` which\nproperly escapes `\\` and `\"` characters for KQL quoted values.\n\n## How to test/reproduce\n\n1. Create a test index with a special character value:\n```\nPOST bulk\n{ \"index\": { \"index\": \"my_windows_index\" } }\n{ \"@timestamp\": \"2025-07-31T01:00:00.000Z\", \"group\": \"A\", \"value\": \"C:\\\\\" }\n```\n2. In Lens, create a Bar chart:\n   - Data view: `my_windows_index` (create the data view if needed)\n- Vertical axis: Count of records (Drag the **Records** field from left\nsidebar)\n   - Breakdown: Top 5 values of `value.keyword`\n\n3. Click on the Breakdown dimension → Advanced → disable **Group\nremaining values as \"Other\"**\n\n4. Save the visualization and click \"Explore in Discover\"\n\n\n**Before fix:** `KQLSyntaxError: Expected \"(\", \"{\", value, whitespace\nbut \"\"\" found.`\n\n**After fix:** Discover opens with valid KQL query `value.keyword:\n\"C:\\\\\"` and shows the document.\n\n---\n**Tip**: To reproduce and observe, besides the breakdown, an additional\nfilter on the vertical axis can be added, e.g.\n<img width=\"400\" height=\"984\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6027675a-84c7-4531-809e-39e86bf8fca0\"\n/>\n\n### Before\nWhen a filter with value `C:\\\\` is also present on the vertical axis.\nNote that the filter converted from the vertical axis is escaped\ncorrectly (`C:\\\\`) whereas the one converted from breakdown isn't\n(`C:\\`).\n<img width=\"2540\" height=\"1667\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f7be32d2-61cb-4a85-ac4a-0df37315d070\"\n/>\n\n### After\n<img width=\"1267\" height=\"803\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f1e1299b-b3b1-4341-b3fb-7e7a57af6d52\"\n/>","sha":"fde2c581f60e9b17019e6ff8802943adc14d3ad9"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250925","number":250925,"mergeCommit":{"message":"[Lens] Fix KQL character escaping when query is generated from Top values column (breakdown). (#250925)\n\n**Problem:** The \"Explore in Discover\" action fails with a\n`KQLSyntaxError` when using Top Values breakdown with values containing\nbackslashes or quotes (e.g., Windows paths like `C:\\`).\n\n**Root cause:** The `extractQueriesFromTerms()` function was using\n`lodash.escape()` (HTML escaping) instead of `escapeQuotes()` from\n`@kbn/es-query` (KQL escaping). Additionally, the escaping logic was\ninverted—it only escaped empty strings instead of non-empty values.\n\n**The fix:** Always escape term values using `escapeQuotes()` which\nproperly escapes `\\` and `\"` characters for KQL quoted values.\n\n## How to test/reproduce\n\n1. Create a test index with a special character value:\n```\nPOST bulk\n{ \"index\": { \"index\": \"my_windows_index\" } }\n{ \"@timestamp\": \"2025-07-31T01:00:00.000Z\", \"group\": \"A\", \"value\": \"C:\\\\\" }\n```\n2. In Lens, create a Bar chart:\n   - Data view: `my_windows_index` (create the data view if needed)\n- Vertical axis: Count of records (Drag the **Records** field from left\nsidebar)\n   - Breakdown: Top 5 values of `value.keyword`\n\n3. Click on the Breakdown dimension → Advanced → disable **Group\nremaining values as \"Other\"**\n\n4. Save the visualization and click \"Explore in Discover\"\n\n\n**Before fix:** `KQLSyntaxError: Expected \"(\", \"{\", value, whitespace\nbut \"\"\" found.`\n\n**After fix:** Discover opens with valid KQL query `value.keyword:\n\"C:\\\\\"` and shows the document.\n\n---\n**Tip**: To reproduce and observe, besides the breakdown, an additional\nfilter on the vertical axis can be added, e.g.\n<img width=\"400\" height=\"984\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6027675a-84c7-4531-809e-39e86bf8fca0\"\n/>\n\n### Before\nWhen a filter with value `C:\\\\` is also present on the vertical axis.\nNote that the filter converted from the vertical axis is escaped\ncorrectly (`C:\\\\`) whereas the one converted from breakdown isn't\n(`C:\\`).\n<img width=\"2540\" height=\"1667\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f7be32d2-61cb-4a85-ac4a-0df37315d070\"\n/>\n\n### After\n<img width=\"1267\" height=\"803\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f1e1299b-b3b1-4341-b3fb-7e7a57af6d52\"\n/>","sha":"fde2c581f60e9b17019e6ff8802943adc14d3ad9"}}]}] BACKPORT-->