### PR TITLE
[9.3] Update rest of API tests to use `expect` from `/api` (#250965)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2717,14 +2717,8 @@ module.exports = {
         '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
         '@kbn/eslint/scout_require_global_setup_hook_in_parallel_tests': 'error',
         '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
-        '@kbn/eslint/require_include_in_check_a11y': 'warn',
-      },
-    },
-    {
-      // Ensure correct expect import path in solutions scout API tests
-      files: ['x-pack/solutions/**/plugins/**/test/scout/api/**/*.ts'],
-      rules: {
         '@kbn/eslint/scout_expect_import': 'error',
+        '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },
     {

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.test.js
@@ -57,39 +57,72 @@ ruleTester.run('@kbn/eslint/scout_expect_import', rule, {
   ],
 
   invalid: [
-    // Solutions API: missing /api suffix → suggests @kbn/scout-oblt/api
+    // Multi-import: different source paths (missing suffix, wrong suffix, external package)
     {
       filename: OBLT_API_FILE,
-      code: `import { expect } from '@kbn/scout-oblt';`,
-      output: `import { expect } from '@kbn/scout-oblt/api';`,
+      code: `import { test, expect, page } from '@kbn/scout-oblt';`,
+      output: `import { test, page } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/api';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
-    // Solutions API: wrong /ui suffix → suggests @kbn/scout-oblt/api
-    {
-      filename: OBLT_API_FILE,
-      code: `import { expect } from '@kbn/scout-oblt/ui';`,
-      output: `import { expect } from '@kbn/scout-oblt/api';`,
-      errors: [{ messageId: 'wrongImportPath' }],
-    },
-    // Solutions UI: wrong /api suffix → suggests @kbn/scout-oblt/ui
     {
       filename: OBLT_UI_FILE,
-      code: `import { expect } from '@kbn/scout-oblt/api';`,
-      output: `import { expect } from '@kbn/scout-oblt/ui';`,
+      code: `import { expect, test } from '@kbn/scout-oblt/api';`,
+      output: `import { test } from '@kbn/scout-oblt/api';
+import { expect } from '@kbn/scout-oblt/ui';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
-    // Platform API: missing suffix → suggests @kbn/scout/api
+    {
+      filename: OBLT_API_FILE,
+      code: `import { test, expect } from '@playwright/test';`,
+      output: `import { test } from '@playwright/test';
+import { expect } from '@kbn/scout-oblt/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Platform: single import (multi-import behavior already covered above)
     {
       filename: PLATFORM_API_FILE,
       code: `import { expect } from '@kbn/scout';`,
       output: `import { expect } from '@kbn/scout/api';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
-    // Playwright import → suggests correct scout package
+    // Existing import: append, duplicate removal, multi-import merge
     {
       filename: OBLT_API_FILE,
-      code: `import { expect } from '@playwright/test';`,
-      output: `import { expect } from '@kbn/scout-oblt/api';`,
+      code: `import { test } from '@kbn/scout-oblt/api';
+import { expect } from '@playwright/test';`,
+      output: `import { test, expect } from '@kbn/scout-oblt/api';
+`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    {
+      filename: OBLT_UI_FILE,
+      code: `import { test, expect } from '@kbn/scout-oblt/ui';
+import { expect } from '@playwright/test';`,
+      output: `import { test, expect } from '@kbn/scout-oblt/ui';
+`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    {
+      filename: OBLT_API_FILE,
+      code: `import { test, page } from '@kbn/scout-oblt/api';
+import { page, expect } from '@playwright/test';`,
+      output: `import { test, page, expect } from '@kbn/scout-oblt/api';
+import { page } from '@playwright/test';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Alias: single and multi-import
+    {
+      filename: OBLT_API_FILE,
+      code: `import { expect as e } from '@playwright/test';`,
+      output: `import { expect as e } from '@kbn/scout-oblt/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    {
+      filename: OBLT_UI_FILE,
+      code: `import { test, expect as e } from '@playwright/test';`,
+      output: `import { test } from '@playwright/test';
+import { expect as e } from '@kbn/scout-oblt/ui';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
   ],

--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -11,15 +11,7 @@
 export * as cli from './src/cli';
 
 // Test framework
-export {
-  expect,
-  test,
-  spaceTest,
-  lighthouseTest,
-  apiTest,
-  globalSetupHook,
-  tags,
-} from './src/playwright';
+export { test, spaceTest, lighthouseTest, apiTest, globalSetupHook, tags } from './src/playwright';
 
 // Fixtures & configuration
 export {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/README.md
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/README.md
@@ -69,12 +69,19 @@ The following [Playwright matchers](https://playwright.dev/docs/api/class-generi
 - `toBe(expected)` - compares using `Object.is`, use for primitive literals
 - `toBeDefined()` - value is not `undefined`
 - `toBeUndefined()` - value is `undefined`
-- `toContain(expected)` - string contains substring, or Array/Set contains item
-- `toHaveLength(n)` - value has `.length` property equal to n
-- `toStrictEqual(expected)` - deep equality with type checking
+- `toBeNull()` - value is `null`
+- `toBeCloseTo(expected, numDigits?)` - compares floating point numbers for approximate equality
 - `toBeGreaterThan(n)` - value > n
 - `toBeLessThan(n)` - value < n
+- `toBeInstanceOf(expected)` - value is an instance of a class (uses `instanceof`)
+- `toContain(expected)` - string contains substring, or Array/Set contains item
+- `toHaveLength(n)` - value has `.length` property equal to n
+- `toMatch(expected)` - string value matches a regular expression or substring
 - `toMatchObject(expected)` - partial object matching
+- `toStrictEqual(expected)` - deep equality with type checking
+- `toThrow(expected?)` - function throws; supports string, regex, or error
+- `toThrowError(expected?)` - alias for `toThrow`
+- `rejects.toThrow(expected?)` - promise rejects with an error; supports string, regex, or error
 
 **Asymmetric matchers:**
 
@@ -99,6 +106,9 @@ expect(exists).toBe(true); // ✅ be explicit
 
 expect(response.apiKey).not.toBeDefined(); // ❌ not available
 expect(response.apiKey).toBeUndefined(); // ✅ preferred by playwright
+
+expect(value).not.toBeNull(); // ❌ not available
+expect(value).toBe(true); // ✅ be explicit
 ```
 
 **UI-specific matchers** like `toBeVisible`, `toBeEnabled`, `toHaveAttribute`, etc. are not available for API tests.

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
@@ -8,15 +8,15 @@
  */
 
 import { expect as baseExpect } from '@playwright/test';
-import type { GenericMatchers } from './types';
+import type { ExpectOptions, GenericMatchers } from './types';
 import { wrapMatcher } from './utils';
 
 /**
  * Create generic matchers delegating to Playwright/Jest expect
  */
-export function createGenericMatchers(actual: unknown): GenericMatchers {
+export function createGenericMatchers(actual: unknown, options?: ExpectOptions): GenericMatchers {
   // eslint-disable-next-line playwright/valid-expect
-  const base = baseExpect(actual);
+  const base = baseExpect(actual, options);
   return {
     toBe: wrapMatcher((expected: unknown) => base.toBe(expected)),
     toBeDefined: wrapMatcher(() => base.toBeDefined()),
@@ -29,6 +29,19 @@ export function createGenericMatchers(actual: unknown): GenericMatchers {
     toMatchObject: wrapMatcher((expected: Record<string, unknown> | unknown[]) =>
       base.toMatchObject(expected)
     ),
+    toMatch: wrapMatcher((expected: RegExp | string) => base.toMatch(expected)),
+    toBeNull: wrapMatcher(() => base.toBeNull()),
+    toBeCloseTo: wrapMatcher((expected: number, precision?: number) =>
+      base.toBeCloseTo(expected, precision)
+    ),
+    toBeInstanceOf: wrapMatcher((expected: new (...args: unknown[]) => unknown) =>
+      base.toBeInstanceOf(expected)
+    ),
+    toThrow: wrapMatcher((expected?: unknown) => base.toThrow(expected)),
+    toThrowError: wrapMatcher((expected?: unknown) => base.toThrowError(expected)),
+    rejects: {
+      toThrow: wrapMatcher((expected?: unknown) => base.rejects.toThrow(expected)),
+    },
     not: {
       toBe: wrapMatcher((expected: unknown) => base.not.toBe(expected)),
       toBeUndefined: wrapMatcher(() => base.not.toBeUndefined()),
@@ -40,6 +53,15 @@ export function createGenericMatchers(actual: unknown): GenericMatchers {
       toMatchObject: wrapMatcher((expected: Record<string, unknown> | unknown[]) =>
         base.not.toMatchObject(expected)
       ),
+      toMatch: wrapMatcher((expected: string | RegExp) => base.not.toMatch(expected)),
+      toBeCloseTo: wrapMatcher((expected: number, precision?: number) =>
+        base.not.toBeCloseTo(expected, precision)
+      ),
+      toBeInstanceOf: wrapMatcher((expected: new (...args: unknown[]) => unknown) =>
+        base.not.toBeInstanceOf(expected)
+      ),
+      toThrow: wrapMatcher((expected?: unknown) => base.not.toThrow(expected)),
+      toThrowError: wrapMatcher((expected?: unknown) => base.not.toThrowError(expected)),
     },
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/index.ts
@@ -7,10 +7,20 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Matchers } from './types';
+import type { ExpectOptions, ExpectOptionsOrMessage, Matchers } from './types';
 import { createGenericMatchers } from './generic_matchers';
 import { createResponseMatchers } from './response_matchers';
 import { asymmetricMatchers } from './asymmetric_matchers';
+
+/**
+ * Normalize options parameter to ExpectOptions object.
+ */
+function normalizeOptions(options?: ExpectOptionsOrMessage): ExpectOptions | undefined {
+  if (typeof options === 'string') {
+    return { message: options };
+  }
+  return options;
+}
 
 /**
  * Custom expect wrapper for API tests with generic and response matchers.
@@ -18,10 +28,12 @@ import { asymmetricMatchers } from './asymmetric_matchers';
  * @example
  * expect(response).toHaveStatusCode(200);
  * expect(response).toMatchObject({ body: { count: expect.toBeGreaterThan(0) } });
+ * expect(value, 'Custom error message').toBeDefined();
  */
-function expectFn(actual: unknown): Matchers {
-  const genericMatchers = createGenericMatchers(actual);
-  const responseMatchers = createResponseMatchers(actual);
+function expectFn(actual: unknown, options?: ExpectOptionsOrMessage): Matchers {
+  const normalizedOptions = normalizeOptions(options);
+  const genericMatchers = createGenericMatchers(actual, normalizedOptions);
+  const responseMatchers = createResponseMatchers(actual, normalizedOptions);
 
   return {
     ...genericMatchers,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
@@ -12,18 +12,22 @@ import { toHaveStatusCode } from './to_have_status_code';
 import { toHaveStatusText } from './to_have_status_text';
 import { wrapMatcher } from './utils';
 import type { ToHaveStatusCodeOptions } from './to_have_status_code';
-import type { ResponseMatchers } from './types';
+import type { ExpectOptions, ResponseMatchers } from './types';
 
 /**
  * Create response matchers for API response assertions.
  * Matchers validate that the object has required properties before asserting.
  */
-export function createResponseMatchers(obj: unknown): ResponseMatchers {
+export function createResponseMatchers(obj: unknown, options?: ExpectOptions): ResponseMatchers {
   return {
     toHaveStatusCode: wrapMatcher((code: number | ToHaveStatusCodeOptions) =>
-      toHaveStatusCode(obj, code)
+      toHaveStatusCode(obj, code, false, options?.message)
     ),
-    toHaveStatusText: wrapMatcher((text: string) => toHaveStatusText(obj, text)),
-    toHaveHeaders: wrapMatcher((headers: Record<string, string>) => toHaveHeaders(obj, headers)),
+    toHaveStatusText: wrapMatcher((text: string) =>
+      toHaveStatusText(obj, text, false, options?.message)
+    ),
+    toHaveHeaders: wrapMatcher((headers: Record<string, string>) =>
+      toHaveHeaders(obj, headers, false, options?.message)
+    ),
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.ts
@@ -22,7 +22,8 @@ import { createMatcherError } from './utils';
 export function toHaveHeaders(
   obj: unknown,
   expectedHeaders: Record<string, string>,
-  isNegated = false
+  isNegated = false,
+  message?: string
 ): void {
   if (typeof obj !== 'object' || obj === null || !('headers' in obj)) {
     throw createMatcherError({
@@ -30,6 +31,7 @@ export function toHaveHeaders(
       matcherName: 'toHaveHeaders',
       received: obj,
       isNegated,
+      message,
     });
   }
 
@@ -56,6 +58,7 @@ export function toHaveHeaders(
       matcherName: 'toHaveHeaders',
       received: JSON.stringify(actualHeaders),
       isNegated,
+      message,
     });
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.ts
@@ -27,7 +27,8 @@ export interface ToHaveStatusCodeOptions {
 export function toHaveStatusCode(
   obj: unknown,
   expected: number | ToHaveStatusCodeOptions,
-  isNegated = false
+  isNegated = false,
+  message?: string
 ): void {
   if (typeof obj !== 'object' || obj === null || (!('status' in obj) && !('statusCode' in obj))) {
     const expectedValue = typeof expected === 'number' ? expected : expected.oneOf;
@@ -38,6 +39,7 @@ export function toHaveStatusCode(
       matcherName: 'toHaveStatusCode',
       received: obj,
       isNegated,
+      message,
     });
   }
 
@@ -56,6 +58,7 @@ export function toHaveStatusCode(
       matcherName: 'toHaveStatusCode',
       received: actual,
       isNegated,
+      message,
     });
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.ts
@@ -17,7 +17,12 @@ import { createMatcherError } from './utils';
  * expect(response).toHaveStatusText('OK');
  * expect(response).not.toHaveStatusText('Not Found');
  */
-export function toHaveStatusText(obj: unknown, expected: string, isNegated = false): void {
+export function toHaveStatusText(
+  obj: unknown,
+  expected: string,
+  isNegated = false,
+  message?: string
+): void {
   if (
     typeof obj !== 'object' ||
     obj === null ||
@@ -30,6 +35,7 @@ export function toHaveStatusText(obj: unknown, expected: string, isNegated = fal
       matcherName: 'toHaveStatusText',
       received: obj,
       isNegated,
+      message,
     });
   }
 
@@ -46,6 +52,7 @@ export function toHaveStatusText(obj: unknown, expected: string, isNegated = fal
       matcherName: 'toHaveStatusText',
       received: actual,
       isNegated,
+      message,
     });
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/types.ts
@@ -11,6 +11,19 @@ import type { expect as baseExpect } from '@playwright/test';
 import type { ToHaveStatusCodeOptions } from './to_have_status_code';
 
 /**
+ * Options for the expect function.
+ */
+export interface ExpectOptions {
+  /** Custom message to display on assertion failure */
+  message?: string;
+}
+
+/**
+ * Second parameter for expect() - can be a string (shorthand for message) or options object.
+ */
+export type ExpectOptionsOrMessage = string | ExpectOptions;
+
+/**
  * Generic matchers that delegate to Playwright/Jest expect.
  * These work on any value type.
  */
@@ -33,8 +46,26 @@ export interface GenericMatchers {
   toBeLessThan(expected: number): void;
   /** Compares contents of the value with contents of `expected`, performing "deep equality" check. Allows extra properties to be present in the value */
   toMatchObject(expected: unknown): void;
+  /** Ensures that string value matches a regular expression or string */
+  toMatch(expected: string | RegExp): void;
+  /** Ensures that value is `null` */
+  toBeNull(): void;
+  /** Compares floating point numbers for approximate equality. Use this method instead of `toBe` when comparing floating point numbers */
+  toBeCloseTo(expected: number, numDigits?: number): void;
+  /** Ensures that value is an instance of a class. Uses `instanceof` operator */
+  toBeInstanceOf(expected: new (...args: unknown[]) => unknown): void;
+  /** Calls the function and ensures it throws an error. Optionally compares the error with `expected` (string, regex, error object, or error class) */
+  toThrow(expected?: unknown): void;
+  /** An alias for `toThrow` */
+  toThrowError(expected?: unknown): void;
 
-  not: Omit<GenericMatchers, 'not' | 'toBeDefined'>;
+  /** Async matchers for promises that are expected to reject */
+  rejects: {
+    /** Ensures that a rejected promise throws an error that optionally matches `expected` */
+    toThrow(expected?: unknown): Promise<void>;
+  };
+
+  not: Omit<GenericMatchers, 'not' | 'toBeDefined' | 'toBeNull' | 'rejects'>;
 }
 
 /**
@@ -56,7 +87,7 @@ export interface ResponseMatchers {
  */
 export type Matchers = GenericMatchers &
   ResponseMatchers & {
-    not: Omit<GenericMatchers, 'not' | 'toBeDefined'>;
+    not: Omit<GenericMatchers, 'not' | 'toBeDefined' | 'toBeNull' | 'rejects'>;
   };
 
 /**

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.ts
@@ -12,13 +12,14 @@ export interface MatcherErrorOptions {
   matcherName: string;
   received: unknown;
   isNegated?: boolean;
+  message?: string;
 }
 
 /**
  * Format error messages for API matchers like Playwright.
  */
 export function createMatcherError(options: MatcherErrorOptions): Error {
-  const { expected, matcherName, received, isNegated = false } = options;
+  const { expected, matcherName, received, isNegated = false, message } = options;
   const gray = '\x1b[90m';
   const red = '\x1b[31m';
   const green = '\x1b[32m';
@@ -30,11 +31,13 @@ export function createMatcherError(options: MatcherErrorOptions): Error {
     `${matcherName}` +
     `${gray}(${green}expected${gray})${reset}`;
 
-  return new Error(
+  const errorMessage =
     `${matcherCall}\n\n` +
-      `Expected: ${isNegated ? 'not ' : ''}${green}${expected}${reset}\n` +
-      `Received: ${red}${received}${reset}`
-  );
+    `Expected: ${isNegated ? 'not ' : ''}${green}${expected}${reset}\n` +
+    `Received: ${red}${received}${reset}`;
+
+  // Prepend custom message if provided (matching Playwright's format)
+  return new Error(message ? `${message}\n\n${errorMessage}` : errorMessage);
 }
 
 /**

--- a/src/platform/plugins/shared/console/test/scout/api/tests/spec_definitions.spec.ts
+++ b/src/platform/plugins/shared/console/test/scout/api/tests/spec_definitions.spec.ts
@@ -8,7 +8,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { apiTest, expect } from '@kbn/scout';
+import { apiTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS } from '../fixtures/constants';
 
 apiTest.describe(
@@ -28,7 +29,7 @@ apiTest.describe(
         responseType: 'json',
       });
       expect(statusCode).toBe(200);
-      expect(body).toHaveProperty('es');
+      expect(body.es).toBeDefined();
       const {
         es: { name, globals, endpoints },
       } = body;

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/tests/step_definitions_approval.spec.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/tests/step_definitions_approval.spec.ts
@@ -8,7 +8,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { apiTest, expect } from '@kbn/scout';
+import { apiTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { APPROVED_STEP_DEFINITIONS } from '../fixtures/approved_step_definitions';
 import { COMMON_HEADERS } from '../fixtures/constants';
 
@@ -34,7 +35,7 @@ apiTest.describe(
         });
 
         expect(response.statusCode).toBe(200);
-        expect(response.body).toHaveProperty('steps');
+        expect(response.body.steps).toBeDefined();
         expect(Array.isArray(response.body.steps)).toBe(true);
 
         expect(response.body.steps, {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/append.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { AppendProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/convert.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { ConvertProcessor, SetProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -33,7 +33,7 @@ apiTest.describe('Cross-compatibility - Convert Processor', { tag: ['@ess', '@sv
     await testBed.ingest('esql-convert-value', docs);
     const esqlResult = await esql.queryOnIndex('esql-convert-value', query);
 
-    expect(ingestResult[0]).toHaveProperty('attributes.size', '4096');
+    expect(ingestResult[0]?.attributes?.size).toBe('4096');
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(
       expect.objectContaining({ 'attributes.size': '4096' })
     );
@@ -63,11 +63,11 @@ apiTest.describe('Cross-compatibility - Convert Processor', { tag: ['@ess', '@sv
       await testBed.ingest('esql-convert-value-to-target', docs);
       const esqlResult = await esql.queryOnIndex('esql-convert-value-to-target', query);
 
-      expect(ingestResult[0]).toHaveProperty('attributes.size', 4096);
+      expect(ingestResult[0]?.attributes?.size).toBe(4096);
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
         expect.objectContaining({ 'attributes.size': 4096 })
       );
-      expect(ingestResult[0]).toHaveProperty('attributes.size_str', '4096');
+      expect(ingestResult[0]?.attributes?.size_str).toBe('4096');
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
         expect.objectContaining({ 'attributes.size_str': '4096' })
       );
@@ -104,11 +104,11 @@ apiTest.describe('Cross-compatibility - Convert Processor', { tag: ['@ess', '@sv
       await testBed.ingest('esql-convert-value-to-target-with-where', docs);
       const esqlResult = await esql.queryOnIndex('esql-convert-value-to-target-with-where', query);
 
-      expect(ingestResult[0]).toHaveProperty('attributes.size', 4096);
+      expect(ingestResult[0]?.attributes?.size).toBe(4096);
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
         expect.objectContaining({ 'attributes.size': 4096 })
       );
-      expect(ingestResult[0]).toHaveProperty('attributes.size_str', '4096');
+      expect(ingestResult[0]?.attributes?.size_str).toBe('4096');
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
         expect.objectContaining({ 'attributes.size_str': '4096' })
       );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/date.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DateProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/dissect.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DissectProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql, transpileIngestPipeline } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -68,7 +68,7 @@ apiTest.describe('Cross-compatibility - Dissect Processor', { tag: ['@ess', '@sv
       await testBed.ingest('esql-dissect-append', docs);
       const esqlResult = await esql.queryOnIndex('esql-dissect-append', query);
 
-      expect(ingestResult[0]).toHaveProperty('field1', 'value1,value2');
+      expect(ingestResult[0]?.field1).toBe('value1,value2');
       expect(esqlResult.documentsWithoutKeywords[0]).toStrictEqual(
         expect.objectContaining({ field1: 'value1,value2' })
       );
@@ -152,11 +152,8 @@ apiTest.describe('Cross-compatibility - Dissect Processor', { tag: ['@ess', '@sv
       await testBed.ingest('esql-dissect-source', [mappingDoc, ...docs]);
       const esqlResult = await esql.queryOnIndex('esql-dissect-source', query);
 
-      expect(ingestResult[0]).toHaveProperty('message', docs[0].message);
-      expect(esqlResult.documentsWithoutKeywordsOrdered[1]).toHaveProperty(
-        'message',
-        docs[0].message
-      );
+      expect(ingestResult[0]?.message).toBe(docs[0].message);
+      expect(esqlResult.documentsWithoutKeywordsOrdered[1]?.message).toBe(docs[0].message);
 
       const { order_id: _ingestOrderId, ...ingestDoc } = ingestResult[0];
       const { order_id: _esqlOrderId, ...esqlDoc } = esqlResult.documentsWithoutKeywordsOrdered[1];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/drop_document.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DropDocumentProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql, transpileIngestPipeline } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -58,13 +58,11 @@ apiTest.describe(
         const esqlResult = await esql.queryOnIndex('esql-e2e-test-drop-basic', query);
 
         expect(ingestResult).toHaveLength(2);
-        ingestResult.forEach((remainingDoc) =>
-          expect(remainingDoc).not.toHaveProperty('logType', 'info')
-        );
+        ingestResult.forEach((remainingDoc) => expect(remainingDoc?.logType).not.toBe('info'));
 
         expect(esqlResult.documents).toHaveLength(2);
         esqlResult.documents.forEach((remainingDoc) =>
-          expect(remainingDoc).not.toHaveProperty('logType', 'info')
+          expect(remainingDoc?.logType).not.toBe('info')
         );
       }
     );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { SetProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -49,8 +49,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[0]).toStrictEqual(
       expect.objectContaining({ attributes: { status: 'active', is_active: 'yes' } })
     );
-    expect(ingestResult[1].attributes).not.toHaveProperty('is_active');
-    expect(ingestResult[2].attributes).not.toHaveProperty('is_active');
+    expect(ingestResult[1].attributes?.is_active).toBeUndefined();
+    expect(ingestResult[2].attributes?.is_active).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({ 'attributes.status': 'active', 'attributes.is_active': 'yes' })
@@ -97,7 +97,7 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[0]).toStrictEqual(
       expect.objectContaining({ attributes: { status: 'active', not_deleted: 'kept' } })
     );
-    expect(ingestResult[1].attributes).not.toHaveProperty('not_deleted');
+    expect(ingestResult[1].attributes?.not_deleted).toBeUndefined();
     expect(ingestResult[2]).toStrictEqual(
       expect.objectContaining({ attributes: { status: 'inactive', not_deleted: 'kept' } })
     );
@@ -154,8 +154,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[1]).toStrictEqual(
       expect.objectContaining({ attributes: { priority: 8, high_priority: 'high' } })
     );
-    expect(ingestResult[2].attributes).not.toHaveProperty('high_priority');
-    expect(ingestResult[3].attributes).not.toHaveProperty('high_priority');
+    expect(ingestResult[2].attributes?.high_priority).toBeUndefined();
+    expect(ingestResult[3].attributes?.high_priority).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({ 'attributes.priority': 10, 'attributes.high_priority': 'high' })
@@ -210,7 +210,7 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
       expect(ingestResult[1]).toStrictEqual(
         expect.objectContaining({ attributes: { age: 18, adult: 'yes' } })
       );
-      expect(ingestResult[2].attributes).not.toHaveProperty('adult');
+      expect(ingestResult[2].attributes?.adult).toBeUndefined();
 
       expect(esqlResult.documentsOrdered[1]).toStrictEqual(
         expect.objectContaining({ 'attributes.age': 25, 'attributes.adult': 'yes' })
@@ -262,8 +262,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[1]).toStrictEqual(
       expect.objectContaining({ attributes: { quantity: 8, low_stock: 'low' } })
     );
-    expect(ingestResult[2].attributes).not.toHaveProperty('low_stock');
-    expect(ingestResult[3].attributes).not.toHaveProperty('low_stock');
+    expect(ingestResult[2].attributes?.low_stock).toBeUndefined();
+    expect(ingestResult[3].attributes?.low_stock).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({ 'attributes.quantity': 5, 'attributes.low_stock': 'low' })
@@ -316,7 +316,7 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[1]).toStrictEqual(
       expect.objectContaining({ attributes: { size: 1024, small_file: 'small' } })
     );
-    expect(ingestResult[2].attributes).not.toHaveProperty('small_file');
+    expect(ingestResult[2].attributes?.small_file).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({ 'attributes.size': 512, 'attributes.small_file': 'small' })
@@ -363,7 +363,7 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[0].attributes).toStrictEqual(
       expect.objectContaining({ user_email: 'test@example.com', has_email: 'yes' })
     );
-    expect(ingestResult[1].attributes).not.toHaveProperty('has_email');
+    expect(ingestResult[1].attributes?.has_email).toBeUndefined();
     expect(ingestResult[2].attributes).toStrictEqual(
       expect.objectContaining({ user_email: 'another@example.com', has_email: 'yes' })
     );
@@ -421,15 +421,15 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     await testBed.ingest('esql-range', [mappingDoc, ...docs]);
     const esqlResult = await esql.queryOnIndex('esql-range', query);
 
-    expect(ingestResult[0].attributes).not.toHaveProperty('in_range');
+    expect(ingestResult[0].attributes?.in_range).toBeUndefined();
     expect(ingestResult[1]).toStrictEqual(
       expect.objectContaining({ attributes: { temperature: 20, in_range: 'optimal' } })
     );
     expect(ingestResult[2]).toStrictEqual(
       expect.objectContaining({ attributes: { temperature: 25, in_range: 'optimal' } })
     );
-    expect(ingestResult[3].attributes).not.toHaveProperty('in_range');
-    expect(ingestResult[4].attributes).not.toHaveProperty('in_range');
+    expect(ingestResult[3].attributes?.in_range).toBeUndefined();
+    expect(ingestResult[4].attributes?.in_range).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({ 'attributes.temperature': 15, 'attributes.in_range': null })
@@ -493,8 +493,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
         matched: 'matched',
       })
     );
-    expect(ingestResult[2].attributes).not.toHaveProperty('matched');
-    expect(ingestResult[3].attributes).not.toHaveProperty('matched');
+    expect(ingestResult[2].attributes?.matched).toBeUndefined();
+    expect(ingestResult[3].attributes?.matched).toBeUndefined();
     // Case-insensitive matches
     expect(ingestResult[4].attributes).toStrictEqual(
       expect.objectContaining({ service_name: 'SYNTH-SERVICE-2', matched: 'matched' })
@@ -592,8 +592,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[1].attributes).toStrictEqual(
       expect.objectContaining({ message: 'Error: Timeout occurred', is_error: 'error' })
     );
-    expect(ingestResult[2].attributes).not.toHaveProperty('is_error');
-    expect(ingestResult[3].attributes).not.toHaveProperty('is_error');
+    expect(ingestResult[2].attributes?.is_error).toBeUndefined();
+    expect(ingestResult[3].attributes?.is_error).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({
@@ -659,8 +659,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[1].attributes).toStrictEqual(
       expect.objectContaining({ filename: 'error.log', is_log_file: 'log' })
     );
-    expect(ingestResult[2].attributes).not.toHaveProperty('is_log_file');
-    expect(ingestResult[3].attributes).not.toHaveProperty('is_log_file');
+    expect(ingestResult[2].attributes?.is_log_file).toBeUndefined();
+    expect(ingestResult[3].attributes?.is_log_file).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({
@@ -745,8 +745,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[0].attributes).toStrictEqual(
       expect.objectContaining({ service_name: 'prod-api', priority: 'high' })
     );
-    expect(ingestResult[1].attributes).not.toHaveProperty('priority');
-    expect(ingestResult[2].attributes).not.toHaveProperty('priority');
+    expect(ingestResult[1].attributes?.priority).toBeUndefined();
+    expect(ingestResult[2].attributes?.priority).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({
@@ -802,11 +802,11 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[0].attributes).toStrictEqual(
       expect.objectContaining({ log_level: 'INFO', not_debug: 'production' })
     );
-    expect(ingestResult[1].attributes).not.toHaveProperty('not_debug');
+    expect(ingestResult[1].attributes?.not_debug).toBeUndefined();
     expect(ingestResult[2].attributes).toStrictEqual(
       expect.objectContaining({ log_level: 'ERROR', not_debug: 'production' })
     );
-    expect(ingestResult[3].attributes).not.toHaveProperty('not_debug');
+    expect(ingestResult[3].attributes?.not_debug).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({
@@ -875,7 +875,7 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[2].attributes).toStrictEqual(
       expect.objectContaining({ message: 'Kernel panic', important: 'critical' })
     );
-    expect(ingestResult[3].attributes).not.toHaveProperty('important');
+    expect(ingestResult[3].attributes?.important).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({
@@ -941,8 +941,8 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
     expect(ingestResult[1].attributes).toStrictEqual(
       expect.objectContaining({ url_path: '/api/v1/products/123', is_api_path: 'api_v1' })
     );
-    expect(ingestResult[2].attributes).not.toHaveProperty('is_api_path');
-    expect(ingestResult[3].attributes).not.toHaveProperty('is_api_path');
+    expect(ingestResult[2].attributes?.is_api_path).toBeUndefined();
+    expect(ingestResult[3].attributes?.is_api_path).toBeUndefined();
 
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/grok.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GrokProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/math.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { MathProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,7 +34,7 @@ apiTest.describe('Cross-compatibility - Math Processor', { tag: ['@ess', '@svlOb
     await testBed.ingest('esql-math-multiply', docs);
     const esqlResult = await esql.queryOnIndex('esql-math-multiply', query);
 
-    expect(ingestResult[0]).toHaveProperty('total', 50);
+    expect(ingestResult[0]?.total).toBe(50);
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(expect.objectContaining({ total: 50 }));
   });
 
@@ -164,11 +164,11 @@ apiTest.describe('Cross-compatibility - Math Processor', { tag: ['@ess', '@svlOb
     await testBed.ingest('esql-math-neq', docs);
     const esqlResult = await esql.queryOnIndex('esql-math-neq', query);
 
-    expect(ingestResult[0]).toHaveProperty('not_equal', true);
+    expect(ingestResult[0]?.not_equal).toBe(true);
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(
       expect.objectContaining({ not_equal: true })
     );
-    expect(ingestResult[1]).toHaveProperty('not_equal', false);
+    expect(ingestResult[1]?.not_equal).toBe(false);
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({ not_equal: false })
     );
@@ -198,11 +198,11 @@ apiTest.describe('Cross-compatibility - Math Processor', { tag: ['@ess', '@svlOb
     await testBed.ingest('esql-math-gt', docs);
     const esqlResult = await esql.queryOnIndex('esql-math-gt', query);
 
-    expect(ingestResult[0]).toHaveProperty('a_greater', true);
+    expect(ingestResult[0]?.a_greater).toBe(true);
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(
       expect.objectContaining({ a_greater: true })
     );
-    expect(ingestResult[1]).toHaveProperty('a_greater', false);
+    expect(ingestResult[1]?.a_greater).toBe(false);
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(
       expect.objectContaining({ a_greater: false })
     );
@@ -232,9 +232,9 @@ apiTest.describe('Cross-compatibility - Math Processor', { tag: ['@ess', '@svlOb
     await testBed.ingest('esql-math-eq', docs);
     const esqlResult = await esql.queryOnIndex('esql-math-eq', query);
 
-    expect(ingestResult[0]).toHaveProperty('equal', true);
+    expect(ingestResult[0]?.equal).toBe(true);
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(expect.objectContaining({ equal: true }));
-    expect(ingestResult[1]).toHaveProperty('equal', false);
+    expect(ingestResult[1]?.equal).toBe(false);
     expect(esqlResult.documentsOrdered[1]).toStrictEqual(expect.objectContaining({ equal: false }));
   });
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/multi_step.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/multi_step.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   StreamlangDSL,
   SetProcessor,

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/operator_coercions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/operator_coercions.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { StreamlangDSL, SetProcessor } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/remove_by_prefix.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RemoveByPrefixProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -46,10 +46,10 @@ apiTest.describe(
         const esqlResult = await esql.queryOnIndex('esql-remove-by-prefix-nested', query);
 
         // Both remove the parent field and all nested fields
-        expect(ingestResult[0]).not.toHaveProperty('host');
-        expect(ingestResult[0]).not.toHaveProperty('host.name');
-        expect(ingestResult[0]).not.toHaveProperty('host.ip');
-        expect(ingestResult[0]).toHaveProperty('message', 'keep-this');
+        expect(ingestResult[0]?.host).toBeUndefined();
+        expect(ingestResult[0]?.['host.name']).toBeUndefined();
+        expect(ingestResult[0]?.['host.ip']).toBeUndefined();
+        expect(ingestResult[0]?.message).toBe('keep-this');
 
         // ES|QL also removes the parent field when all nested fields are removed
         expect(esqlResult.documents[0]).toStrictEqual(
@@ -91,13 +91,13 @@ apiTest.describe(
         const esqlResult = await esql.queryOnIndex('esql-remove-by-prefix-flattened', query);
 
         // Both should remove the nested fields
-        expect(ingestResult[0]).not.toHaveProperty('labels.env');
-        expect(ingestResult[0]).not.toHaveProperty('labels.team');
+        expect(ingestResult[0]?.['labels.env']).toBeUndefined();
+        expect(ingestResult[0]?.['labels.team']).toBeUndefined();
         expect(esqlResult.columnNames).not.toContain('labels.env');
         expect(esqlResult.columnNames).not.toContain('labels.team');
 
         // Both should keep the message
-        expect(ingestResult[0]).toHaveProperty('message', 'keep-this');
+        expect(ingestResult[0]?.message).toBe('keep-this');
         expect(esqlResult.documents[0]).toStrictEqual(
           expect.objectContaining({ message: 'keep-this' })
         );
@@ -170,9 +170,9 @@ apiTest.describe(
         const esqlResult = await esql.queryOnIndex('esql-remove-by-prefix-parent', query);
 
         // Both behave the same: remove the parent field and all nested fields
-        expect(ingestResult[0]).not.toHaveProperty('metadata');
-        expect(ingestResult[0]).not.toHaveProperty('metadata.timestamp');
-        expect(ingestResult[0]).not.toHaveProperty('metadata.host');
+        expect(ingestResult[0]?.metadata).toBeUndefined();
+        expect(ingestResult[0]?.['metadata.timestamp']).toBeUndefined();
+        expect(ingestResult[0]?.['metadata.host']).toBeUndefined();
 
         expect(esqlResult.columnNames).not.toContain('metadata');
         expect(esqlResult.columnNames).not.toContain('metadata.timestamp');

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/rename.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RenameProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/replace.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { ReplaceProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -37,7 +37,7 @@ apiTest.describe('Cross-compatibility - Replace Processor', { tag: ['@ess', '@sv
       const esqlResult = await esql.queryOnIndex('esql-replace', query);
 
       expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-      expect(ingestResult[0]).toHaveProperty('message', 'An warning occurred');
+      expect(ingestResult[0]?.message).toBe('An warning occurred');
     }
   );
 
@@ -67,8 +67,8 @@ apiTest.describe('Cross-compatibility - Replace Processor', { tag: ['@ess', '@sv
       const esqlResult = await esql.queryOnIndex('esql-replace-target', query);
 
       expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-      expect(ingestResult[0]).toHaveProperty('message', 'An error occurred'); // Original preserved
-      expect(ingestResult[0]).toHaveProperty('clean_message', 'An warning occurred'); // New field created
+      expect(ingestResult[0]?.message).toBe('An error occurred'); // Original preserved
+      expect(ingestResult[0]?.clean_message).toBe('An warning occurred'); // New field created
     }
   );
 
@@ -97,7 +97,7 @@ apiTest.describe('Cross-compatibility - Replace Processor', { tag: ['@ess', '@sv
       const esqlResult = await esql.queryOnIndex('esql-replace-regex', query);
 
       expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-      expect(ingestResult[0]).toHaveProperty('message', 'Error code [NUM] found');
+      expect(ingestResult[0]?.message).toBe('Error code [NUM] found');
     }
   );
 
@@ -126,7 +126,7 @@ apiTest.describe('Cross-compatibility - Replace Processor', { tag: ['@ess', '@sv
       const esqlResult = await esql.queryOnIndex('esql-replace-capture', query);
 
       expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-      expect(ingestResult[0]).toHaveProperty('message', 'Messages: 3 for user alice');
+      expect(ingestResult[0]?.message).toBe('Messages: 3 for user alice');
     }
   );
 
@@ -176,8 +176,8 @@ apiTest.describe('Cross-compatibility - Replace Processor', { tag: ['@ess', '@sv
 
       expect(ingestDoc1).toStrictEqual(esqlDoc1);
       expect(ingestDoc2).toStrictEqual(esqlDoc2);
-      expect(ingestDoc1).toHaveProperty('message', 'An warning occurred');
-      expect(ingestDoc2).toHaveProperty('message', 'An error occurred');
+      expect(ingestDoc1?.message).toBe('An warning occurred');
+      expect(ingestDoc2?.message).toBe('An error occurred');
     }
   );
 
@@ -247,8 +247,8 @@ apiTest.describe('Cross-compatibility - Replace Processor', { tag: ['@ess', '@sv
 
       // Both should overwrite the numeric target field with the string result
       expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-      expect(ingestResult[0]).toHaveProperty('message', 'An error occurred'); // Source preserved
-      expect(ingestResult[0]).toHaveProperty('status_code', 'An warning occurred'); // Target overwritten with string
+      expect(ingestResult[0]?.message).toBe('An error occurred'); // Source preserved
+      expect(ingestResult[0]?.status_code).toBe('An warning occurred'); // Target overwritten with string
     }
   );
 
@@ -328,13 +328,13 @@ apiTest.describe('Cross-compatibility - Replace Processor', { tag: ['@ess', '@sv
       const esqlResult = await esql.queryOnIndex('esql-replace-single', query);
 
       // Ingest Pipeline processes all array elements
-      expect(ingestResult[0]).toHaveProperty('message', [
+      expect(ingestResult[0]?.message).toStrictEqual([
         'An warning occurred 01',
         'An warning occurred 02',
       ]);
 
       // ES|QL sets the field to null since it cannot handle multi-value arrays for replace()
-      expect(esqlResult.documentsWithoutKeywords[0]).toHaveProperty('message', null);
+      expect(esqlResult.documentsWithoutKeywords[0]?.message).toBeNull();
     }
   );
 });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/set.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { SetProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -33,7 +33,7 @@ apiTest.describe('Cross-compatibility - Set Processor', { tag: ['@ess', '@svlObl
     await testBed.ingest('esql-set-value', docs);
     const esqlResult = await esql.queryOnIndex('esql-set-value', query);
 
-    expect(ingestResult[0]).toHaveProperty('attributes.status', 'active');
+    expect(ingestResult[0]?.attributes?.status).toBe('active');
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(
       expect.objectContaining({ 'attributes.status': 'active' })
     );
@@ -60,7 +60,7 @@ apiTest.describe('Cross-compatibility - Set Processor', { tag: ['@ess', '@svlObl
     await testBed.ingest('esql-set-copy', docs);
     const esqlResult = await esql.queryOnIndex('esql-set-copy', query);
 
-    expect(ingestResult[0]).toHaveProperty('attributes.status', 'should-be-copied');
+    expect(ingestResult[0]?.attributes?.status).toBe('should-be-copied');
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(
       expect.objectContaining({ 'attributes.status': 'should-be-copied' })
     );
@@ -88,7 +88,7 @@ apiTest.describe('Cross-compatibility - Set Processor', { tag: ['@ess', '@svlObl
     await testBed.ingest('esql-set-override', docs);
     const esqlResult = await esql.queryOnIndex('esql-set-override', query);
 
-    expect(ingestResult[0]).toHaveProperty('attributes.status', 'inactive');
+    expect(ingestResult[0]?.attributes?.status).toBe('inactive');
     expect(esqlResult.documentsOrdered[0]).toStrictEqual(
       expect.objectContaining({ 'attributes.status': 'inactive' })
     );
@@ -118,7 +118,7 @@ apiTest.describe('Cross-compatibility - Set Processor', { tag: ['@ess', '@svlObl
       await testBed.ingest('esql-set-no-override', docs);
       const esqlResult = await esql.queryOnIndex('esql-set-no-override', query);
 
-      expect(ingestResult[0]).toHaveProperty('attributes.status', 'active');
+      expect(ingestResult[0]?.attributes?.status).toBe('active');
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
         expect.objectContaining({ 'attributes.status': 'active' })
       );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/append.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { AppendProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/convert.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { ConvertProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/date.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DateProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/dissect.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DissectProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { expectDefined } from '../../../utils';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/drop_document.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DropDocumentProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -40,8 +40,8 @@ apiTest.describe(
 
       expect(esqlResult.documents).toHaveLength(1);
       const source = esqlResult.documents[0];
-      expect(source).toHaveProperty('environment', 'production');
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.environment).toBe('production');
+      expect(source?.message).toBe('keep-this');
     });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/grok.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GrokProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { expectDefined } from '../../../utils';
@@ -583,13 +583,12 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents).toHaveLength(1);
-      expect(esqlResult.documents[0]).toHaveProperty('timestamp', '11-06 13:43:41.377');
-      expect(esqlResult.documents[0]).toHaveProperty('pid', '1702');
-      expect(esqlResult.documents[0]).toHaveProperty('tid', '17633');
-      expect(esqlResult.documents[0]).toHaveProperty('level', 'W');
-      expect(esqlResult.documents[0]).toHaveProperty('tag', 'ActivityManager');
-      expect(esqlResult.documents[0]).toHaveProperty(
-        'log_message',
+      expect(esqlResult.documents[0]?.timestamp).toBe('11-06 13:43:41.377');
+      expect(esqlResult.documents[0]?.pid).toBe('1702');
+      expect(esqlResult.documents[0]?.tid).toBe('17633');
+      expect(esqlResult.documents[0]?.level).toBe('W');
+      expect(esqlResult.documents[0]?.tag).toBe('ActivityManager');
+      expect(esqlResult.documents[0]?.log_message).toBe(
         'getRunningAppProcesses: caller 10113 does not hold REAL_GET_TASKS; limiting output'
       );
     }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/manual_ingest_pipeline.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/manual_ingest_pipeline.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { StreamlangDSL } from '@kbn/streamlang';
 import type { ManualIngestPipelineProcessor } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
@@ -59,11 +59,11 @@ apiTest.describe(
         expect(result.documents.length).toBeGreaterThan(0);
 
         // The original fields should be preserved since manual_ingest_pipeline is not processed
-        expect(result.documents[0]).toHaveProperty('message', 'test message');
-        expect(result.documents[0]).toHaveProperty('existing_field', 'existing_value');
+        expect(result.documents[0]?.message).toBe('test message');
+        expect(result.documents[0]?.existing_field).toBe('existing_value');
 
         // The manual processor should NOT have been applied (no 'status' field)
-        expect(result.documents[0]).not.toHaveProperty('status');
+        expect(result.documents[0]?.status).toBeUndefined();
       }
     );
 
@@ -112,7 +112,7 @@ apiTest.describe(
 
         // Neither document should have the conditional field applied
         result.documents.forEach((doc) => {
-          expect(doc).not.toHaveProperty('conditional_field');
+          expect(doc?.conditional_field).toBeUndefined();
         });
       }
     );
@@ -173,12 +173,12 @@ apiTest.describe(
         const doc = result.documents[0];
 
         // Supported processors should work
-        expect(doc).toHaveProperty('supported_field', 'supported_value');
-        expect(doc).toHaveProperty('new_field', 'to_be_renamed');
-        expect(doc).not.toHaveProperty('old_field'); // Should be renamed
+        expect(doc?.supported_field).toBe('supported_value');
+        expect(doc?.new_field).toBe('to_be_renamed');
+        expect(doc?.old_field).toBeUndefined(); // Should be renamed
 
         // Manual processor should be ignored
-        expect(doc).not.toHaveProperty('unsupported_field');
+        expect(doc?.unsupported_field).toBeUndefined();
       }
     );
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/math.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { MathProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RemoveProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -30,7 +30,7 @@ apiTest.describe('Streamlang to ES|QL - Remove Processor', { tag: ['@ess', '@svl
     const esqlResult = await esql.queryOnIndex(indexName, query);
 
     expect(esqlResult.documents).toHaveLength(1);
-    expect(esqlResult.documents[0]).not.toHaveProperty('temp_field');
+    expect(esqlResult.documents[0]?.temp_field).toBeUndefined();
     expect(esqlResult.documents[0]).toStrictEqual(
       expect.objectContaining({ message: 'keep-this' })
     );
@@ -59,7 +59,7 @@ apiTest.describe('Streamlang to ES|QL - Remove Processor', { tag: ['@ess', '@svl
     // ES|QL filters out documents with missing field when ignore_missing: false
     expect(esqlResult.documents).toHaveLength(1);
     expect(esqlResult.documents[0]).toStrictEqual(expect.objectContaining({ message: 'doc1' }));
-    expect(esqlResult.documents[0]).not.toHaveProperty('temp_field');
+    expect(esqlResult.documents[0]?.temp_field).toBeUndefined();
   });
 
   apiTest('should handle ignore_missing: true with DROP', async ({ testBed, esql }) => {
@@ -87,8 +87,8 @@ apiTest.describe('Streamlang to ES|QL - Remove Processor', { tag: ['@ess', '@svl
     expect(esqlResult.documents).toHaveLength(2);
     const doc1 = esqlResult.documents.find((d: any) => d.message === 'doc1');
     const doc2 = esqlResult.documents.find((d: any) => d.message === 'doc2');
-    expect(doc1).not.toHaveProperty('temp_field');
-    expect(doc2).not.toHaveProperty('temp_field');
+    expect(doc1?.temp_field).toBeUndefined();
+    expect(doc2?.temp_field).toBeUndefined();
   });
 
   apiTest('should remove field conditionally with EVAL CASE', async ({ testBed, esql }) => {
@@ -121,12 +121,12 @@ apiTest.describe('Streamlang to ES|QL - Remove Processor', { tag: ['@ess', '@svl
     // First doc should have temp_data nulled (where condition matched)
     const doc1 = esqlResult.documents.find((d: any) => d.message === 'doc1');
     // Note: ESQL CASE sets to null, which is removed from the result
-    expect(doc1).toHaveProperty('temp_data', null);
+    expect(doc1?.temp_data).toBeNull();
     expect(doc1?.['event.kind']).toBe('test');
 
     // Second doc should keep temp_data (where condition not matched)
     const doc2 = esqlResult.documents.find((d: any) => d.message === 'doc2');
-    expect(doc2).toHaveProperty('temp_data', 'keep-me');
+    expect(doc2?.temp_data).toBe('keep-me');
     expect(doc2?.['event.kind']).toBe('production');
   });
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove_by_prefix.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RemoveByPrefixProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -36,7 +36,7 @@ apiTest.describe(
 
         expect(esqlResult.documents).toHaveLength(1);
         // The parent field itself is not removed, only nested fields would be
-        expect(esqlResult.documents[0]).toHaveProperty('temp_field');
+        expect(esqlResult.documents[0]?.temp_field).toBeDefined();
         expect(esqlResult.documents[0]).toStrictEqual(
           expect.objectContaining({ message: 'keep-this', temp_field: 'to-be-kept' })
         );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/rename.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RenameProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,7 +34,7 @@ apiTest.describe('Streamlang to ES|QL - Rename Processor', { tag: ['@ess', '@svl
     expect(esqlResult.documents[0]).toStrictEqual(
       expect.objectContaining({ 'host.renamed': 'test-host' })
     );
-    expect(esqlResult.documents[0]).not.toHaveProperty('host.original');
+    expect(esqlResult.documents[0]?.['host.original']).toBeUndefined();
   });
 
   apiTest(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/replace.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { ReplaceProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,7 +34,7 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
-      expect(esqlResult.documents[0]).toHaveProperty('message', 'An warning occurred');
+      expect(esqlResult.documents[0]?.message).toBe('An warning occurred');
     }
   );
 
@@ -62,8 +62,8 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
-      expect(esqlResult.documents[0]).toHaveProperty('message', 'An error occurred'); // Original preserved
-      expect(esqlResult.documents[0]).toHaveProperty('clean_message', 'An warning occurred'); // New field created
+      expect(esqlResult.documents[0]?.message).toBe('An error occurred'); // Original preserved
+      expect(esqlResult.documents[0]?.clean_message).toBe('An warning occurred'); // New field created
     }
   );
 
@@ -88,7 +88,7 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
     const esqlResult = await esql.queryOnIndex(indexName, query);
 
     expect(esqlResult.documents).toHaveLength(1);
-    expect(esqlResult.documents[0]).toHaveProperty('message', 'Error code [NUM] found');
+    expect(esqlResult.documents[0]?.message).toBe('Error code [NUM] found');
   });
 
   apiTest('should replace literal dot with escaped dot pattern', async ({ testBed, esql }) => {
@@ -112,7 +112,7 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
     const esqlResult = await esql.queryOnIndex(indexName, query);
 
     expect(esqlResult.documents).toHaveLength(1);
-    expect(esqlResult.documents[0]).toHaveProperty('message', 'Android-log');
+    expect(esqlResult.documents[0]?.message).toBe('Android-log');
   });
 
   apiTest('should replace using regex with capture groups', async ({ testBed, esql }) => {
@@ -136,7 +136,7 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
     const esqlResult = await esql.queryOnIndex(indexName, query);
 
     expect(esqlResult.documents).toHaveLength(1);
-    expect(esqlResult.documents[0]).toHaveProperty('message', 'Messages: 3 for user alice');
+    expect(esqlResult.documents[0]?.message).toBe('Messages: 3 for user alice');
   });
 
   apiTest(
@@ -166,7 +166,7 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
       // ES|QL filters out documents with missing field when ignore_missing: false
       expect(esqlResult.documents).toHaveLength(1);
       expect(esqlResult.documents[0]).toStrictEqual(expect.objectContaining({ status: 'doc1' }));
-      expect(esqlResult.documents[0]).toHaveProperty('message', 'An warning occurred');
+      expect(esqlResult.documents[0]?.message).toBe('An warning occurred');
     }
   );
 
@@ -197,8 +197,8 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
     expect(esqlResult.documents).toHaveLength(2);
     const doc1 = esqlResult.documents.find((d: any) => d.status === 'doc1');
     const doc2 = esqlResult.documents.find((d: any) => d.status === 'doc2');
-    expect(doc1).toHaveProperty('message', 'An warning occurred');
-    expect(doc2).toHaveProperty('message', null);
+    expect(doc1?.message).toBe('An warning occurred');
+    expect(doc2?.message).toBeNull();
   });
 
   apiTest('should replace field conditionally with EVAL CASE', async ({ testBed, esql }) => {
@@ -232,12 +232,12 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
 
     // First doc should have message replaced (where condition matched)
     const doc1 = esqlResult.documents.find((d: any) => d.status === 'doc1');
-    expect(doc1).toHaveProperty('message', 'An warning occurred');
+    expect(doc1?.message).toBe('An warning occurred');
     expect(doc1?.['event.kind']).toBe('test');
 
     // Second doc should keep original message (where condition not matched)
     const doc2 = esqlResult.documents.find((d: any) => d.status === 'doc2');
-    expect(doc2).toHaveProperty('message', 'An error occurred');
+    expect(doc2?.message).toBe('An error occurred');
     expect(doc2?.['event.kind']).toBe('production');
   });
 
@@ -285,14 +285,14 @@ apiTest.describe('Streamlang to ES|QL - Replace Processor', { tag: ['@ess', '@sv
 
       // First doc should have clean_message created (where condition matched)
       const doc1 = esqlResult.documents.find((d: any) => d.status === 'doc1');
-      expect(doc1).toHaveProperty('message', 'An error occurred'); // Original preserved
-      expect(doc1).toHaveProperty('clean_message', 'An warning occurred'); // New field created
+      expect(doc1?.message).toBe('An error occurred'); // Original preserved
+      expect(doc1?.clean_message).toBe('An warning occurred'); // New field created
       expect(doc1?.['event.kind']).toBe('test');
 
       // Second doc should have clean_message as empty string (where condition not matched)
       const doc2 = esqlResult.documents.find((d: any) => d.status === 'doc2');
-      expect(doc2).toHaveProperty('message', 'An error occurred');
-      expect(doc2).toHaveProperty('clean_message', '');
+      expect(doc2?.message).toBe('An error occurred');
+      expect(doc2?.clean_message).toBe('');
       expect(doc2?.['event.kind']).toBe('production');
     }
   );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/set.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { SetProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
 import { streamlangApiTest as apiTest } from '../..';

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/append.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { AppendProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,7 +34,7 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('tags', ['existing_tag', 'new_tag']);
+      expect(ingestedDocs[0]?.tags).toStrictEqual(['existing_tag', 'new_tag']);
     });
 
     apiTest('should append values to a non-existent field', async ({ testBed }) => {
@@ -57,7 +57,7 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('tags', ['new_tag']);
+      expect(ingestedDocs[0]?.tags).toStrictEqual(['new_tag']);
     });
 
     apiTest(
@@ -83,7 +83,7 @@ apiTest.describe(
 
         const ingestedDocs = await testBed.getDocs(indexName);
         expect(ingestedDocs).toHaveLength(1);
-        expect(ingestedDocs[0]).toHaveProperty('tags', ['existing_tag']);
+        expect(ingestedDocs[0]?.tags).toStrictEqual(['existing_tag']);
       }
     );
 
@@ -108,7 +108,7 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('tags', ['existing_tag', 'existing_tag']);
+      expect(ingestedDocs[0]?.tags).toStrictEqual(['existing_tag', 'existing_tag']);
     });
 
     // Template validation tests - should reject Mustache templates

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/convert.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { ConvertProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -33,7 +33,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]attributes.size', '4096');
+      expect(ingestedDocs[0]?.attributes?.size).toBe('4096');
     });
 
     // Template syntax validation tests - these should now REJECT Mustache templates
@@ -103,8 +103,8 @@ apiTest.describe(
         await testBed.ingest(indexName, docs, processors);
 
         const ingestedDocs = await testBed.getDocs(indexName);
-        expect(ingestedDocs).toHaveProperty('[0]attributes.size', 4096);
-        expect(ingestedDocs).toHaveProperty('[0]attributes.size_str', '4096');
+        expect(ingestedDocs[0]?.attributes?.size).toBe(4096);
+        expect(ingestedDocs[0]?.attributes?.size_str).toBe('4096');
       }
     );
 
@@ -134,8 +134,8 @@ apiTest.describe(
         await testBed.ingest(indexName, docs, processors);
 
         const ingestedDocs = await testBed.getDocs(indexName);
-        expect(ingestedDocs).toHaveProperty('[0]attributes.size', 4096);
-        expect(ingestedDocs).toHaveProperty('[0]attributes.size_str', '4096');
+        expect(ingestedDocs[0]?.attributes?.size).toBe(4096);
+        expect(ingestedDocs[0]?.attributes?.size_str).toBe('4096');
       }
     );
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/date.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DateProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,7 +34,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('@timestamp', '2025-01-01T12:34:56.789Z');
+      expect(ingestedDocs[0]?.['@timestamp']).toBe('2025-01-01T12:34:56.789Z');
     }
   );
 
@@ -63,7 +63,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('event.created', '2025-01-01');
+      expect(ingestedDocs[0]?.event?.created).toBe('2025-01-01');
     }
   );
 
@@ -91,7 +91,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('event.created_date', '2025-01-01T12:34:56.000Z');
+      expect(ingestedDocs[0]?.event?.created_date).toBe('2025-01-01T12:34:56.000Z');
     }
   );
 
@@ -121,8 +121,8 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
 
     const ingestedDocs = await testBed.getDocsOrdered(indexName);
     expect(ingestedDocs).toHaveLength(2);
-    expect(ingestedDocs[0]).toHaveProperty('event.created_date', '01 01 2025 12:34');
-    expect(ingestedDocs[1]).toHaveProperty('event.created_date', '01 01 2025 12:35');
+    expect(ingestedDocs[0]?.event?.created_date).toBe('01 01 2025 12:34');
+    expect(ingestedDocs[1]?.event?.created_date).toBe('01 01 2025 12:35');
   });
 
   apiTest(
@@ -150,7 +150,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('event.created_date', '2025-01-01');
+      expect(ingestedDocs[0]?.event?.created_date).toBe('2025-01-01');
     }
   );
 
@@ -235,7 +235,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
       const ingestedDocs = await testBed.getDocs(indexName);
 
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('event.created_date', '2025-09-10T00:00:00.000+02:00');
+      expect(ingestedDocs[0]?.event?.created_date).toBe('2025-09-10T00:00:00.000+02:00');
     }
   );
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/dissect.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DissectProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -40,11 +40,11 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('log.level', 'info');
-      expect(source).toHaveProperty('client.ip', '127.0.0.1');
-      expect(source).toHaveProperty('http.version', '1.1');
-      expect(source).toHaveProperty('http.response.status_code', '200');
-      expect(source).toHaveProperty('http.response.body.bytes', '123');
+      expect(source?.log?.level).toBe('info');
+      expect(source?.client?.ip).toBe('127.0.0.1');
+      expect(source?.http?.version).toBe('1.1');
+      expect(source?.http?.response?.status_code).toBe('200');
+      expect(source?.http?.response?.body?.bytes).toBe('123');
     });
 
     apiTest('should ignore missing field when ignore_missing is true', async ({ testBed }) => {
@@ -69,7 +69,7 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).not.toHaveProperty('client.ip');
+      expect(source?.client?.ip).toBeUndefined();
     });
 
     apiTest('should fail if field is missing and ignore_missing is false', async ({ testBed }) => {
@@ -115,7 +115,7 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('field1', 'value1,value2');
+      expect(source?.field1).toBe('value1,value2');
     });
 
     [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/drop_document.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { DropDocumentProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -40,8 +40,8 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('environment', 'production');
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.environment).toBe('production');
+      expect(source?.message).toBe('keep-this');
     });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/grok.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GrokProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -37,11 +37,11 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('client.ip', '55.3.244.1');
-      expect(source).toHaveProperty('http.request.method', 'GET');
-      expect(source).toHaveProperty('url.path', '/index.html');
-      expect(source).toHaveProperty('http.response.body.bytes', '15824');
-      expect(source).toHaveProperty('event.duration', '0.043');
+      expect(source?.client?.ip).toBe('55.3.244.1');
+      expect(source?.http?.request?.method).toBe('GET');
+      expect(source?.url?.path).toBe('/index.html');
+      expect(source?.http?.response?.body?.bytes).toBe('15824');
+      expect(source?.event?.duration).toBe('0.043');
     });
 
     apiTest('should ignore missing field when ignore_missing is true', async ({ testBed }) => {
@@ -66,7 +66,7 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).not.toHaveProperty('client.ip');
+      expect(source?.client?.ip).toBeUndefined();
     });
 
     apiTest('should fail if field is missing and ignore_missing is false', async ({ testBed }) => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/manual_ingest_pipeline.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/manual_ingest_pipeline.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { StreamlangDSL } from '@kbn/streamlang';
 import type { ManualIngestPipelineProcessor } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
@@ -49,9 +49,9 @@ apiTest.describe(
         const ingestedDocs = await testBed.getDocs(indexName);
         expect(ingestedDocs).toHaveLength(1);
         const source = ingestedDocs[0];
-        expect(source).toHaveProperty('status', 'processed');
-        expect(source).toHaveProperty('message', 'test message');
-        expect(source).toHaveProperty('existing_field', 'existing_value');
+        expect(source?.status).toBe('processed');
+        expect(source?.message).toBe('test message');
+        expect(source?.existing_field).toBe('existing_value');
       }
     );
 
@@ -95,10 +95,10 @@ apiTest.describe(
         const ingestedDocs = await testBed.getDocs(indexName);
         expect(ingestedDocs).toHaveLength(1);
         const source = ingestedDocs[0];
-        expect(source).toHaveProperty('processor_type', 'manual');
-        expect(source).toHaveProperty('renamed_field', 'test_value');
-        expect(source).not.toHaveProperty('original_name'); // Should be renamed
-        expect(source).toHaveProperty('message', 'test message');
+        expect(source?.processor_type).toBe('manual');
+        expect(source?.renamed_field).toBe('test_value');
+        expect(source?.original_name).toBeUndefined(); // Should be renamed
+        expect(source?.message).toBe('test message');
       }
     );
 
@@ -144,8 +144,8 @@ apiTest.describe(
         const processedDoc = ingestedDocs.find((doc) => doc.message === 'should be processed');
         const skippedDoc = ingestedDocs.find((doc) => doc.message === 'should NOT be processed');
 
-        expect(processedDoc).toHaveProperty('status', 'processed_with_condition');
-        expect(skippedDoc).not.toHaveProperty('status'); // Should not be processed
+        expect(processedDoc?.status).toBe('processed_with_condition');
+        expect(skippedDoc?.status).toBeUndefined(); // Should not be processed
       }
     );
 
@@ -181,8 +181,8 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('tagged_field', 'tagged_value');
-      expect(source).toHaveProperty('message', 'test message with tag');
+      expect(source?.tagged_field).toBe('tagged_value');
+      expect(source?.message).toBe('test message with tag');
     });
 
     apiTest(
@@ -224,11 +224,11 @@ apiTest.describe(
         const ingestedDocs = await testBed.getDocs(indexName);
         expect(ingestedDocs).toHaveLength(1);
         const source = ingestedDocs[0];
-        expect(source).toHaveProperty('client_ip', '192.168.1.1');
-        expect(source).toHaveProperty('method', 'GET');
-        expect(source).toHaveProperty('path', '/api/users');
-        expect(source).toHaveProperty('parsed_by', 'manual_grok');
-        expect(source).toHaveProperty('message', '192.168.1.1 GET /api/users');
+        expect(source?.client_ip).toBe('192.168.1.1');
+        expect(source?.method).toBe('GET');
+        expect(source?.path).toBe('/api/users');
+        expect(source?.parsed_by).toBe('manual_grok');
+        expect(source?.message).toBe('192.168.1.1 GET /api/users');
       }
     );
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/math.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { MathProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,7 +34,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]total', 50);
+      expect(ingestedDocs[0]?.total).toBe(50);
     });
 
     apiTest('should compute addition of fields', async ({ testBed }) => {
@@ -56,7 +56,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]sum', 40);
+      expect(ingestedDocs[0]?.sum).toBe(40);
     });
 
     apiTest('should compute subtraction of fields', async ({ testBed }) => {
@@ -78,7 +78,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]difference', 70);
+      expect(ingestedDocs[0]?.difference).toBe(70);
     });
 
     apiTest('should compute division of fields', async ({ testBed }) => {
@@ -100,7 +100,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]average', 25);
+      expect(ingestedDocs[0]?.average).toBe(25);
     });
 
     // === Nested Field Paths ===
@@ -175,8 +175,8 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocsOrdered(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]not_equal', true);
-      expect(ingestedDocs).toHaveProperty('[1]not_equal', false);
+      expect(ingestedDocs[0]?.not_equal).toBe(true);
+      expect(ingestedDocs[1]?.not_equal).toBe(false);
     });
 
     apiTest('should compute gt (greater than) comparison', async ({ testBed }) => {
@@ -201,8 +201,8 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocsOrdered(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]a_greater', true);
-      expect(ingestedDocs).toHaveProperty('[1]a_greater', false);
+      expect(ingestedDocs[0]?.a_greater).toBe(true);
+      expect(ingestedDocs[1]?.a_greater).toBe(false);
     });
 
     apiTest('should compute lt (less than) comparison', async ({ testBed }) => {
@@ -227,8 +227,8 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocsOrdered(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]a_less', true);
-      expect(ingestedDocs).toHaveProperty('[1]a_less', false);
+      expect(ingestedDocs[0]?.a_less).toBe(true);
+      expect(ingestedDocs[1]?.a_less).toBe(false);
     });
 
     apiTest('should compute eq (equality) comparison', async ({ testBed }) => {
@@ -253,8 +253,8 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocsOrdered(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]equal', true);
-      expect(ingestedDocs).toHaveProperty('[1]equal', false);
+      expect(ingestedDocs[0]?.equal).toBe(true);
+      expect(ingestedDocs[1]?.equal).toBe(false);
     });
 
     // === Where Condition ===
@@ -285,9 +285,9 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocsOrdered(indexName);
       // Active doc should have total calculated
-      expect(ingestedDocs).toHaveProperty('[0]total', 50);
+      expect(ingestedDocs[0]?.total).toBe(50);
       // Inactive doc should not have total field
-      expect((ingestedDocs as Array<Record<string, unknown>>)[1]).not.toHaveProperty('total');
+      expect(ingestedDocs[1]?.total).toBeUndefined();
     });
 
     // === Ignore Missing ===
@@ -317,9 +317,9 @@ apiTest.describe(
 
         const ingestedDocs = await testBed.getDocsOrdered(indexName);
         // First doc should have total calculated
-        expect(ingestedDocs).toHaveProperty('[0]total', 50);
+        expect(ingestedDocs[0]?.total).toBe(50);
         // Second doc should not have total field (skipped)
-        expect((ingestedDocs as Array<Record<string, unknown>>)[1]).not.toHaveProperty('total');
+        expect(ingestedDocs[1]?.total).toBeUndefined();
       }
     );
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RemoveProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,8 +34,8 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).not.toHaveProperty('temp_field');
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.temp_field).toBeUndefined();
+      expect(source?.message).toBe('keep-this');
     });
 
     apiTest('should ignore missing field when ignore_missing is true', async ({ testBed }) => {
@@ -59,7 +59,7 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('message', 'some_value');
+      expect(source?.message).toBe('some_value');
     });
 
     apiTest('should fail if field is missing and ignore_missing is false', async ({ testBed }) => {
@@ -112,13 +112,13 @@ apiTest.describe(
 
       // First doc should have temp_data removed (where condition matched)
       const doc1 = ingestedDocs.find((d: any) => d.message === 'doc1');
-      expect(doc1).not.toHaveProperty('temp_data');
-      expect(doc1).toHaveProperty('event.kind', 'test');
+      expect(doc1?.temp_data).toBeUndefined();
+      expect(doc1?.event?.kind).toBe('test');
 
       // Second doc should keep temp_data (where condition not matched)
       const doc2 = ingestedDocs.find((d: any) => d.message === 'doc2');
-      expect(doc2).toHaveProperty('temp_data.value', 'keep-me');
-      expect(doc2).toHaveProperty('event.kind', 'production');
+      expect(doc2?.temp_data?.value).toBe('keep-me');
+      expect(doc2?.event?.kind).toBe('production');
     });
 
     apiTest('default value of ignore_missing (false)', async ({ testBed }) => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove_by_prefix.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RemoveByPrefixProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -34,8 +34,8 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).not.toHaveProperty('temp_field');
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.temp_field).toBeUndefined();
+      expect(source?.message).toBe('keep-this');
     });
 
     apiTest('should remove a field and all nested fields (subobjects)', async ({ testBed }) => {
@@ -70,13 +70,13 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).not.toHaveProperty('host');
-      expect(source).not.toHaveProperty('host.name');
-      expect(source).not.toHaveProperty('host.ip');
-      expect(source).not.toHaveProperty('host.os');
-      expect(source).not.toHaveProperty('host.os.platform');
-      expect(source).not.toHaveProperty('host.os.version');
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.host).toBeUndefined();
+      expect(source?.['host.name']).toBeUndefined();
+      expect(source?.['host.ip']).toBeUndefined();
+      expect(source?.['host.os']).toBeUndefined();
+      expect(source?.['host.os.platform']).toBeUndefined();
+      expect(source?.['host.os.version']).toBeUndefined();
+      expect(source?.message).toBe('keep-this');
     });
 
     apiTest('should remove flattened fields with prefix', async ({ testBed }) => {
@@ -107,11 +107,11 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).not.toHaveProperty('labels');
-      expect(source).not.toHaveProperty('labels.env');
-      expect(source).not.toHaveProperty('labels.team');
-      expect(source).not.toHaveProperty('labels.version');
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.labels).toBeUndefined();
+      expect(source?.['labels.env']).toBeUndefined();
+      expect(source?.['labels.team']).toBeUndefined();
+      expect(source?.['labels.version']).toBeUndefined();
+      expect(source?.message).toBe('keep-this');
     });
 
     apiTest(
@@ -144,12 +144,12 @@ apiTest.describe(
         expect(ingestedDocs).toHaveLength(1);
         const source = ingestedDocs[0];
         // Parent field and all nested fields removed
-        expect(source).not.toHaveProperty('metadata.user');
-        expect(source).not.toHaveProperty('metadata.user.id');
-        expect(source).not.toHaveProperty('metadata.user.name');
+        expect(source?.['metadata.user']).toBeUndefined();
+        expect(source?.['metadata.user.id']).toBeUndefined();
+        expect(source?.['metadata.user.name']).toBeUndefined();
         // Other metadata fields kept (as dotted notation - accessed with bracket notation)
         expect(source['metadata.timestamp']).toBe('2025-01-01');
-        expect(source).toHaveProperty('message', 'keep-this');
+        expect(source?.message).toBe('keep-this');
       }
     );
 
@@ -185,13 +185,13 @@ apiTest.describe(
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
       // Parent field and all nested fields removed
-      expect(source).not.toHaveProperty('metadata.user');
-      expect(source).not.toHaveProperty('metadata.user.id');
-      expect(source).not.toHaveProperty('metadata.user.name');
+      expect(source?.['metadata.user']).toBeUndefined();
+      expect(source?.['metadata.user.id']).toBeUndefined();
+      expect(source?.['metadata.user.name']).toBeUndefined();
       // Other metadata fields kept (as nested object)
-      expect(source).toHaveProperty('metadata');
-      expect(source.metadata).toHaveProperty('timestamp', '2025-01-01');
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.metadata).toBeDefined();
+      expect(source.metadata?.timestamp).toBe('2025-01-01');
+      expect(source?.message).toBe('keep-this');
     });
 
     apiTest('should remove flattened fields within a nested subobject', async ({ testBed }) => {
@@ -226,13 +226,13 @@ apiTest.describe(
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
       // All foo.bar* fields removed from attributes
-      expect(source.attributes).not.toHaveProperty('foo.bar');
-      expect(source.attributes).not.toHaveProperty('foo.bar.xyz');
-      expect(source.attributes).not.toHaveProperty('foo.bar.xyz2');
-      expect(source.attributes).not.toHaveProperty('foo.bar.xyz2.234');
+      expect(source.attributes?.['foo.bar']).toBeUndefined();
+      expect(source.attributes?.['foo.bar.xyz']).toBeUndefined();
+      expect(source.attributes?.['foo.bar.xyz2']).toBeUndefined();
+      expect(source.attributes?.['foo.bar.xyz2.234']).toBeUndefined();
       // Other fields kept
       expect(source.attributes['foo.baz']).toBe(789);
-      expect(source).toHaveProperty('message', 'keep-this');
+      expect(source?.message).toBe('keep-this');
     });
 
     apiTest(
@@ -271,13 +271,13 @@ apiTest.describe(
         expect(ingestedDocs).toHaveLength(1);
         const source = ingestedDocs[0];
         // All foo.bar* fields removed from resource.attributes
-        expect(source.resource.attributes).not.toHaveProperty('foo.bar');
-        expect(source.resource.attributes).not.toHaveProperty('foo.bar.xyz');
-        expect(source.resource.attributes).not.toHaveProperty('foo.bar.xyz2');
-        expect(source.resource.attributes).not.toHaveProperty('foo.bar.xyz2.234');
+        expect(source.resource.attributes?.['foo.bar']).toBeUndefined();
+        expect(source.resource.attributes?.['foo.bar.xyz']).toBeUndefined();
+        expect(source.resource.attributes?.['foo.bar.xyz2']).toBeUndefined();
+        expect(source.resource.attributes?.['foo.bar.xyz2.234']).toBeUndefined();
         // Other fields kept
         expect(source.resource.attributes['foo.baz']).toBe(789);
-        expect(source).toHaveProperty('message', 'keep-this');
+        expect(source?.message).toBe('keep-this');
       }
     );
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/rename.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RenameProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -35,8 +35,8 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('host.renamed', 'test-host');
-      expect(source).not.toHaveProperty('host.original');
+      expect(source?.host?.renamed).toBe('test-host');
+      expect(source?.host?.original).toBeUndefined();
     });
 
     [
@@ -90,7 +90,7 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).not.toHaveProperty('host.renamed');
+      expect(source?.host?.renamed).toBeUndefined();
     });
 
     apiTest('should fail if field is missing and ignore_missing is false', async ({ testBed }) => {
@@ -137,7 +137,7 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('host.renamed', 'test-host');
+      expect(source?.host?.renamed).toBe('test-host');
     });
 
     apiTest('should fail if target field exists and override is false', async ({ testBed }) => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/replace.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { ReplaceProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -35,7 +35,7 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('message', 'An warning occurred');
+      expect(ingestedDocs[0]?.message).toBe('An warning occurred');
     });
 
     apiTest('should replace a literal string to target field', async ({ testBed }) => {
@@ -60,8 +60,8 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('message', 'An error occurred'); // Original preserved
-      expect(ingestedDocs[0]).toHaveProperty('clean_message', 'An warning occurred'); // New field created
+      expect(ingestedDocs[0]?.message).toBe('An error occurred'); // Original preserved
+      expect(ingestedDocs[0]?.clean_message).toBe('An warning occurred'); // New field created
     });
 
     apiTest('should replace using regex pattern', async ({ testBed }) => {
@@ -85,7 +85,7 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('message', 'Error code [NUM] found');
+      expect(ingestedDocs[0]?.message).toBe('Error code [NUM] found');
     });
 
     apiTest('should replace using regex with capture groups', async ({ testBed }) => {
@@ -109,7 +109,7 @@ apiTest.describe(
 
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
-      expect(ingestedDocs[0]).toHaveProperty('message', 'Messages: 3 for user alice');
+      expect(ingestedDocs[0]?.message).toBe('Messages: 3 for user alice');
     });
 
     apiTest(
@@ -160,8 +160,8 @@ apiTest.describe(
       const ingestedDocs = await testBed.getDocs(indexName);
       expect(ingestedDocs).toHaveLength(1);
       const source = ingestedDocs[0];
-      expect(source).toHaveProperty('message', 'some_value');
-      expect(source).not.toHaveProperty('nonexistent');
+      expect(source?.message).toBe('some_value');
+      expect(source?.nonexistent).toBeUndefined();
     });
 
     apiTest('should replace field conditionally with where condition', async ({ testBed }) => {
@@ -195,13 +195,13 @@ apiTest.describe(
 
       // First doc should have message replaced (where condition matched)
       const doc1 = ingestedDocs.find((d: any) => d.event?.kind === 'test');
-      expect(doc1).toHaveProperty('message', 'An warning occurred');
-      expect(doc1).toHaveProperty('event.kind', 'test');
+      expect(doc1?.message).toBe('An warning occurred');
+      expect(doc1?.event?.kind).toBe('test');
 
       // Second doc should keep original message (where condition not matched)
       const doc2 = ingestedDocs.find((d: any) => d.event?.kind === 'production');
-      expect(doc2).toHaveProperty('message', 'An error occurred');
-      expect(doc2).toHaveProperty('event.kind', 'production');
+      expect(doc2?.message).toBe('An error occurred');
+      expect(doc2?.event?.kind).toBe('production');
     });
 
     apiTest(
@@ -238,15 +238,15 @@ apiTest.describe(
 
         // First doc should have clean_message created (where condition matched)
         const doc1 = ingestedDocs.find((d: any) => d.event?.kind === 'test');
-        expect(doc1).toHaveProperty('message', 'An error occurred'); // Original preserved
-        expect(doc1).toHaveProperty('clean_message', 'An warning occurred'); // New field created
-        expect(doc1).toHaveProperty('event.kind', 'test');
+        expect(doc1?.message).toBe('An error occurred'); // Original preserved
+        expect(doc1?.clean_message).toBe('An warning occurred'); // New field created
+        expect(doc1?.event?.kind).toBe('test');
 
         // Second doc should not have clean_message (where condition not matched)
         const doc2 = ingestedDocs.find((d: any) => d.event?.kind === 'production');
-        expect(doc2).toHaveProperty('message', 'An error occurred');
-        expect(doc2).not.toHaveProperty('clean_message');
-        expect(doc2).toHaveProperty('event.kind', 'production');
+        expect(doc2?.message).toBe('An error occurred');
+        expect(doc2?.clean_message).toBeUndefined();
+        expect(doc2?.event?.kind).toBe('production');
       }
     );
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { SetProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
@@ -33,7 +33,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]attributes.status', 'active');
+      expect(ingestedDocs[0]?.attributes?.status).toBe('active');
     });
 
     // Template syntax validation tests - these should now REJECT Mustache templates
@@ -99,7 +99,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]attributes.status', 'should-be-copied');
+      expect(ingestedDocs[0]?.attributes?.status).toBe('should-be-copied');
     });
 
     apiTest('should not override an existing field when override is false', async ({ testBed }) => {
@@ -122,7 +122,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]attributes.status', 'active');
+      expect(ingestedDocs[0]?.attributes?.status).toBe('active');
     });
 
     apiTest('should override an existing field when override is true', async ({ testBed }) => {
@@ -145,7 +145,7 @@ apiTest.describe(
       await testBed.ingest(indexName, docs, processors);
 
       const ingestedDocs = await testBed.getDocs(indexName);
-      expect(ingestedDocs).toHaveProperty('[0]attributes.status', 'inactive');
+      expect(ingestedDocs[0]?.attributes?.status).toBe('inactive');
     });
 
     apiTest('should throw error if value and copy_from are missing', async () => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/utils/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/utils/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 
 /**
  * Expects that the provided value is defined while narrowing its type.

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { apiTest, expect } from '@kbn/scout';
+import { apiTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
 
 apiTest.describe(
@@ -29,7 +30,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });
@@ -46,7 +47,7 @@ apiTest.describe(
         body: TEST_INPUT.invalid_script,
       });
 
-      expect(response.statusCode).toBe(200);
+      expect(response).toHaveStatusCode(200);
       expect(response.body.error.reason).toBe('compile error');
     });
   }

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { apiTest, expect, tags } from '@kbn/scout';
+import { apiTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
 
 apiTest.describe(
@@ -28,7 +29,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });
@@ -50,7 +51,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });
@@ -92,7 +93,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_disabled.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_disabled.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { apiTest, expect } from '@kbn/scout';
+import { apiTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
 
 apiTest.describe(
@@ -26,7 +27,7 @@ apiTest.describe(
         responseType: 'json',
         body: TEST_INPUT.script,
       });
-      expect(response.statusCode).toBe(404);
+      expect(response).toHaveStatusCode(404);
       expect(response.body.message).toBe('Not Found');
     });
   }

--- a/x-pack/platform/plugins/private/transform/test/scout/api/helpers/transform_assertions.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/helpers/transform_assertions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RoleApiCredentials } from '@kbn/scout';
 import { TRANSFORM_STATE, type TransformId } from '../../../../common';
 import type { TransformApiServicesFixture } from '../fixtures';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_delete_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_delete_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   DeleteTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reauthorize_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reauthorize_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader, RoleApiCredentials } from '@kbn/scout';
 import type { ReauthorizeTransformsRequestSchema } from '../../../../common';
 import { generateTransformConfig, generateDestIndex } from '../helpers/transform_config';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reset_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reset_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   ResetTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_schedule_now_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_schedule_now_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   ScheduleNowTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_start_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_start_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   StartTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_stop_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_stop_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type { estypes } from '@elastic/elasticsearch';
 import type { StopTransformsRequestSchema, StopTransformsResponseSchema } from '../../../../common';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/delete_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/delete_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   DeleteTransformsRequestSchema,
   DeleteTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/reauthorize_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/reauthorize_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RoleApiCredentials } from '@kbn/scout';
 import type { ReauthorizeTransformsRequestSchema } from '../../../../common';
 import { generateTransformConfig, generateDestIndex } from '../helpers/transform_config';
@@ -171,7 +172,7 @@ apiTest.describe('/internal/transform/reauthorize_transforms', { tag: tags.ESS_O
       );
       expect(statusCode).toBe(200);
       expect(body[invalidTransformId].success).toBe(false);
-      expect(body[invalidTransformId]).toHaveProperty('error');
+      expect(body[invalidTransformId].error).toBeDefined();
     }
   );
 });

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/reset_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/reset_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   ResetTransformsRequestSchema,
   ResetTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/schedule_now_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/schedule_now_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   ScheduleNowTransformsRequestSchema,
   ScheduleNowTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/start_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/start_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   StartTransformsRequestSchema,
   StartTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/stop_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/stop_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { StopTransformsRequestSchema, StopTransformsResponseSchema } from '../../../../common';
 import { TRANSFORM_STATE } from '../../../../common/constants';
 import { generateTransformConfig } from '../helpers/transform_config';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GetTransformsResponseSchema } from '../../../../common';
 import { transformApiTest as apiTest } from '../fixtures';
 import { COMMON_HEADERS } from '../constants';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_create.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_create.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type { PutTransformsResponseSchema } from '../../../../common';
 import { generateTransformConfig, generateDestIndex } from '../helpers/transform_config';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_nodes.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_nodes.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GetTransformNodesResponseSchema } from '../../../../common';
 import { transformApiTest as apiTest } from '../fixtures';
 import { COMMON_HEADERS } from '../constants';
@@ -27,7 +28,7 @@ apiTest.describe('/internal/transform/transforms/_nodes', { tag: tags.ESS_ONLY }
 
       expect(statusCode).toBe(200);
 
-      expect(nodesResponse.count).toBeGreaterThanOrEqual(1);
+      expect(nodesResponse.count).toBeGreaterThan(0);
     }
   );
 
@@ -47,7 +48,7 @@ apiTest.describe('/internal/transform/transforms/_nodes', { tag: tags.ESS_ONLY }
 
       expect(statusCode).toBe(200);
 
-      expect(nodesResponse.count).toBeGreaterThanOrEqual(1);
+      expect(nodesResponse.count).toBeGreaterThan(0);
     }
   );
 

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_preview.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_preview.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   PostTransformsPreviewRequestSchema,
   PostTransformsPreviewResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_stats.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_stats.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GetTransformsStatsResponseSchema } from '../../../../common';
 import { TRANSFORM_STATE } from '../../../../common/constants';
 import { transformApiTest as apiTest } from '../fixtures';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_update.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_update.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   GetTransformsResponseSchema,
   PostTransformsUpdateResponseSchema,
@@ -64,7 +65,7 @@ apiTest.describe(
       );
       const originalBody = originalResponse.body as GetTransformsResponseSchema;
 
-      expect(originalResponse.statusCode).toBe(200);
+      expect(originalResponse).toHaveStatusCode(200);
 
       expect(originalBody.count).toBe(1);
       expect(originalBody.transforms).toHaveLength(1);
@@ -92,7 +93,7 @@ apiTest.describe(
       );
       const updatedTransform = updateResponse.body as PostTransformsUpdateResponseSchema;
 
-      expect(updateResponse.statusCode).toBe(200);
+      expect(updateResponse).toHaveStatusCode(200);
 
       const expectedConfig = getTransformUpdateConfig();
       expect(updatedTransform.id).toBe(TRANSFORM_ID);
@@ -113,7 +114,7 @@ apiTest.describe(
       });
       const verifyBody = verifyResponse.body as GetTransformsResponseSchema;
 
-      expect(verifyResponse.statusCode).toBe(200);
+      expect(verifyResponse).toHaveStatusCode(200);
 
       expect(verifyBody.count).toBe(1);
       expect(verifyBody.transforms).toHaveLength(1);

--- a/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/converters.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/conversation/client/converters.test.ts
@@ -10,7 +10,7 @@ import { isToolCallStep, ConversationRoundStepType, ToolResultType } from '@kbn/
 import { getToolResultId } from '@kbn/onechat-server/tools/utils';
 
 import { fromEs, toEs, type Document as ConversationDocument } from './converters';
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 
 jest.mock('@kbn/onechat-server/tools/utils');
 

--- a/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_multiple_spaces.spec.ts
+++ b/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_multiple_spaces.spec.ts
@@ -14,7 +14,8 @@
  */
 
 import type { KbnClient, RoleApiCredentials, ScoutLogger } from '@kbn/scout';
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 
 import {
   ATTRIBUTE_TITLE_KEY,
@@ -98,7 +99,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse1.statusCode).toBe(200);
+      expect(importResponse1).toHaveStatusCode(200);
       expect(importResponse1.body.success).toBe(true);
       expect(importResponse1.body.successCount).toBe(1);
 
@@ -124,7 +125,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse2.statusCode).toBe(200);
+      expect(importResponse2).toHaveStatusCode(200);
       expect(importResponse2.body.success).toBe(true);
       expect(importResponse2.body.successCount).toBe(1);
 
@@ -180,7 +181,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse1.statusCode).toBe(200);
+      expect(importResponse1).toHaveStatusCode(200);
       expect(importResponse1.body.success).toBe(true);
       expect(importResponse1.body.successCount).toBe(1);
 
@@ -207,7 +208,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse2.statusCode).toBe(200);
+      expect(importResponse2).toHaveStatusCode(200);
       expect(importResponse2.body.success).toBe(true);
       expect(importResponse2.body.successCount).toBe(1);
       expect(importResponse2.body.successResults[0].id).toBe(uniqueId);
@@ -224,7 +225,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
       });
 
       // Import should succeed and the object should exist in space 2 with the new ID
-      expect(importResponse2.statusCode).toBe(200);
+      expect(importResponse2).toHaveStatusCode(200);
       expect(importResponse2.body.success).toBe(true);
 
       // The originId should point to the original object's ID

--- a/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_single_space.spec.ts
+++ b/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_single_space.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 
 import {
   ATTRIBUTE_TITLE_KEY,
@@ -90,7 +91,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response1.statusCode).toBe(200);
+        expect(response1).toHaveStatusCode(200);
         expect(response1.body.success).toBe(true);
         expect(response1.body.successCount).toBe(1);
 
@@ -114,7 +115,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response2.statusCode).toBe(200);
+        expect(response2).toHaveStatusCode(200);
         expect(response2.body.success).toBe(false);
         expect(response2.body.errors).toHaveLength(1);
         expect(response2.body.errors[0].error.type).toBe('conflict');
@@ -146,7 +147,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response1.statusCode).toBe(200);
+        expect(response1).toHaveStatusCode(200);
         expect(response1.body.success).toBe(true);
         expect(response1.body.successCount).toBe(1);
 
@@ -171,7 +172,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response2.statusCode).toBe(200);
+        expect(response2).toHaveStatusCode(200);
         expect(response2.body.success).toBe(true);
 
         const getResponse = await kbnClient.savedObjects.get({
@@ -210,7 +211,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response1.statusCode).toBe(200);
+        expect(response1).toHaveStatusCode(200);
         expect(response1.body.success).toBe(true);
         expect(response1.body.successCount).toBe(1);
         expect(response1.body.successResults[0].id).toBe(uniqueId);
@@ -252,7 +253,7 @@ TEST_SPACES.forEach((space) => {
         }
       );
 
-      expect(response.statusCode).toBe(200);
+      expect(response).toHaveStatusCode(200);
       expect(response.body.success).toBe(false);
       expect(response.body.errors).toHaveLength(1);
       expect(response.body.errors[0].error.type).toBe('unsupported_type');

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -13,9 +13,9 @@ import {
   EuiComboBoxWrapper,
   EuiDataGridWrapper,
   EuiSuperSelectWrapper,
-  expect,
   KibanaCodeEditorWrapper,
 } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { FieldTypeOption } from '../../../../../public/components/data_management/schema_editor/constants';
 
 export class StreamsApp {

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -9,7 +9,7 @@
 export { test, apiTest, spaceTest } from './src/playwright';
 
 // re-exported test framework from @kbn/scout
-export { expect, lighthouseTest, tags } from '@kbn/scout';
+export { lighthouseTest, tags } from '@kbn/scout';
 
 // Custom global setup hook with profiling support
 export { globalSetupHook } from './src/playwright/global_hook';

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependencies_inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependencies_inventory.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 
 const DEPENDENCY_NAME = 'postgresql';

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_overview.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_overview.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 
 const SERVICE_NAME = 'opbeans-java';

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/service_dependencies.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/service_dependencies.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 
 const DEPENDENCY_NAME = 'postgresql';

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/node_details/node_details.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/node_details/node_details.ts
@@ -7,7 +7,8 @@
 
 import type { Moment } from 'moment';
 import rison from '@kbn/rison';
-import { type KibanaUrl, type Locator, type ScoutPage, expect } from '@kbn/scout-oblt';
+import { type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { EXTENDED_TIMEOUT } from '../../constants';
 
 interface QueryParams {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 
 test.describe('Infrastructure Inventory - Alerts Flyout', { tag: ['@ess'] }, () => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import {
   DATE_WITH_DOCKER_DATA,

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.host.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.host.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import moment from 'moment-timezone';
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import {
   DATE_WITH_K8S_HOSTS_DATA_FROM,

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.host_with_kubernetes.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.host_with_kubernetes.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import moment from 'moment';
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import {
   DATE_WITH_K8S_HOSTS_DATA_FROM,

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.host_without_metrics.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.host_without_metrics.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import { HOST7_NAME } from '../../fixtures/constants';
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/node_details/node_details.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import { K8S_HOST_NAME } from '../../fixtures/constants';
 

--- a/x-pack/solutions/search/packages/kbn-scout-search/index.ts
+++ b/x-pack/solutions/search/packages/kbn-scout-search/index.ts
@@ -9,7 +9,7 @@
 export { test, apiTest, spaceTest } from './src/playwright';
 
 // re-exported test framework from @kbn/scout
-export { expect, lighthouseTest, globalSetupHook, tags } from '@kbn/scout';
+export { lighthouseTest, globalSetupHook, tags } from '@kbn/scout';
 
 // re-exported fixtures & configuration from @kbn/scout
 export {

--- a/x-pack/solutions/security/packages/kbn-scout-security/index.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/index.ts
@@ -9,7 +9,7 @@
 export { test, spaceTest } from './src/playwright';
 
 // re-exported test framework from @kbn/scout
-export { expect, lighthouseTest, apiTest, globalSetupHook, tags } from '@kbn/scout';
+export { lighthouseTest, apiTest, globalSetupHook, tags } from '@kbn/scout';
 
 // re-exported fixtures & configuration from @kbn/scout
 export {

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/alerts_table.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/alerts_table.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ScoutPage, Locator } from '@kbn/scout';
-import { expect } from '@kbn/scout';
+import { expect } from '../../../../../ui';
 
 const PAGE_URL = 'security/alerts';
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Update rest of API tests to use `expect` from `/api` (#250965)](https://github.com/elastic/kibana/pull/250965)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-09T06:57:47Z","message":"Update rest of API tests to use `expect` from `/api` (#250965)\n\n## Summary\n\nUpdates rest of API tests to import `expect` from the dedicated `/api`\nsubpath and adds custom message support to API expect matchers.\n\n### Changes\n\n- Updated rest of API tests to import `expect` from `@kbn/scout/api` and\nuse response matchers wherever is possible\n- Added custom error message support to `expect()` (string or object\nformat)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bdcdbce7c9135bc305aec07b331cb2eb326c25c3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0","Team:obs-presentation"],"title":"Update rest of API tests to use `expect` from `/api`","number":250965,"url":"https://github.com/elastic/kibana/pull/250965","mergeCommit":{"message":"Update rest of API tests to use `expect` from `/api` (#250965)\n\n## Summary\n\nUpdates rest of API tests to import `expect` from the dedicated `/api`\nsubpath and adds custom message support to API expect matchers.\n\n### Changes\n\n- Updated rest of API tests to import `expect` from `@kbn/scout/api` and\nuse response matchers wherever is possible\n- Added custom error message support to `expect()` (string or object\nformat)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bdcdbce7c9135bc305aec07b331cb2eb326c25c3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250965","number":250965,"mergeCommit":{"message":"Update rest of API tests to use `expect` from `/api` (#250965)\n\n## Summary\n\nUpdates rest of API tests to import `expect` from the dedicated `/api`\nsubpath and adds custom message support to API expect matchers.\n\n### Changes\n\n- Updated rest of API tests to import `expect` from `@kbn/scout/api` and\nuse response matchers wherever is possible\n- Added custom error message support to `expect()` (string or object\nformat)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bdcdbce7c9135bc305aec07b331cb2eb326c25c3"}}]}] BACKPORT-->