### PR TITLE
[8.19] Update rest of API tests to use `expect` from `/api` (#250965)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2363,14 +2363,8 @@ module.exports = {
         '@kbn/eslint/scout_test_file_naming': 'error',
         '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
         '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
-        '@kbn/eslint/require_include_in_check_a11y': 'warn',
-      },
-    },
-    {
-      // Ensure correct expect import path in solutions scout API tests
-      files: ['x-pack/solutions/**/plugins/**/test/scout/api/**/*.ts'],
-      rules: {
         '@kbn/eslint/scout_expect_import': 'error',
+        '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },
     {

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.test.js
@@ -57,39 +57,72 @@ ruleTester.run('@kbn/eslint/scout_expect_import', rule, {
   ],
 
   invalid: [
-    // Solutions API: missing /api suffix → suggests @kbn/scout-oblt/api
+    // Multi-import: different source paths (missing suffix, wrong suffix, external package)
     {
       filename: OBLT_API_FILE,
-      code: `import { expect } from '@kbn/scout-oblt';`,
-      output: `import { expect } from '@kbn/scout-oblt/api';`,
+      code: `import { test, expect, page } from '@kbn/scout-oblt';`,
+      output: `import { test, page } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/api';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
-    // Solutions API: wrong /ui suffix → suggests @kbn/scout-oblt/api
-    {
-      filename: OBLT_API_FILE,
-      code: `import { expect } from '@kbn/scout-oblt/ui';`,
-      output: `import { expect } from '@kbn/scout-oblt/api';`,
-      errors: [{ messageId: 'wrongImportPath' }],
-    },
-    // Solutions UI: wrong /api suffix → suggests @kbn/scout-oblt/ui
     {
       filename: OBLT_UI_FILE,
-      code: `import { expect } from '@kbn/scout-oblt/api';`,
-      output: `import { expect } from '@kbn/scout-oblt/ui';`,
+      code: `import { expect, test } from '@kbn/scout-oblt/api';`,
+      output: `import { test } from '@kbn/scout-oblt/api';
+import { expect } from '@kbn/scout-oblt/ui';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
-    // Platform API: missing suffix → suggests @kbn/scout/api
+    {
+      filename: OBLT_API_FILE,
+      code: `import { test, expect } from '@playwright/test';`,
+      output: `import { test } from '@playwright/test';
+import { expect } from '@kbn/scout-oblt/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Platform: single import (multi-import behavior already covered above)
     {
       filename: PLATFORM_API_FILE,
       code: `import { expect } from '@kbn/scout';`,
       output: `import { expect } from '@kbn/scout/api';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
-    // Playwright import → suggests correct scout package
+    // Existing import: append, duplicate removal, multi-import merge
     {
       filename: OBLT_API_FILE,
-      code: `import { expect } from '@playwright/test';`,
-      output: `import { expect } from '@kbn/scout-oblt/api';`,
+      code: `import { test } from '@kbn/scout-oblt/api';
+import { expect } from '@playwright/test';`,
+      output: `import { test, expect } from '@kbn/scout-oblt/api';
+`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    {
+      filename: OBLT_UI_FILE,
+      code: `import { test, expect } from '@kbn/scout-oblt/ui';
+import { expect } from '@playwright/test';`,
+      output: `import { test, expect } from '@kbn/scout-oblt/ui';
+`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    {
+      filename: OBLT_API_FILE,
+      code: `import { test, page } from '@kbn/scout-oblt/api';
+import { page, expect } from '@playwright/test';`,
+      output: `import { test, page, expect } from '@kbn/scout-oblt/api';
+import { page } from '@playwright/test';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Alias: single and multi-import
+    {
+      filename: OBLT_API_FILE,
+      code: `import { expect as e } from '@playwright/test';`,
+      output: `import { expect as e } from '@kbn/scout-oblt/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    {
+      filename: OBLT_UI_FILE,
+      code: `import { test, expect as e } from '@playwright/test';`,
+      output: `import { test } from '@playwright/test';
+import { expect as e } from '@kbn/scout-oblt/ui';`,
       errors: [{ messageId: 'wrongImportPath' }],
     },
   ],

--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -11,15 +11,7 @@
 export * as cli from './src/cli';
 
 // Test framework
-export {
-  expect,
-  test,
-  spaceTest,
-  lighthouseTest,
-  apiTest,
-  globalSetupHook,
-  tags,
-} from './src/playwright';
+export { test, spaceTest, lighthouseTest, apiTest, globalSetupHook, tags } from './src/playwright';
 
 // Fixtures & configuration
 export {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/README.md
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/README.md
@@ -69,12 +69,19 @@ The following [Playwright matchers](https://playwright.dev/docs/api/class-generi
 - `toBe(expected)` - compares using `Object.is`, use for primitive literals
 - `toBeDefined()` - value is not `undefined`
 - `toBeUndefined()` - value is `undefined`
-- `toContain(expected)` - string contains substring, or Array/Set contains item
-- `toHaveLength(n)` - value has `.length` property equal to n
-- `toStrictEqual(expected)` - deep equality with type checking
+- `toBeNull()` - value is `null`
+- `toBeCloseTo(expected, numDigits?)` - compares floating point numbers for approximate equality
 - `toBeGreaterThan(n)` - value > n
 - `toBeLessThan(n)` - value < n
+- `toBeInstanceOf(expected)` - value is an instance of a class (uses `instanceof`)
+- `toContain(expected)` - string contains substring, or Array/Set contains item
+- `toHaveLength(n)` - value has `.length` property equal to n
+- `toMatch(expected)` - string value matches a regular expression or substring
 - `toMatchObject(expected)` - partial object matching
+- `toStrictEqual(expected)` - deep equality with type checking
+- `toThrow(expected?)` - function throws; supports string, regex, or error
+- `toThrowError(expected?)` - alias for `toThrow`
+- `rejects.toThrow(expected?)` - promise rejects with an error; supports string, regex, or error
 
 **Asymmetric matchers:**
 
@@ -99,6 +106,9 @@ expect(exists).toBe(true); // ✅ be explicit
 
 expect(response.apiKey).not.toBeDefined(); // ❌ not available
 expect(response.apiKey).toBeUndefined(); // ✅ preferred by playwright
+
+expect(value).not.toBeNull(); // ❌ not available
+expect(value).toBe(true); // ✅ be explicit
 ```
 
 **UI-specific matchers** like `toBeVisible`, `toBeEnabled`, `toHaveAttribute`, etc. are not available for API tests.

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
@@ -8,14 +8,14 @@
  */
 
 import { expect as baseExpect } from '@playwright/test';
-import type { GenericMatchers } from './types';
+import type { ExpectOptions, GenericMatchers } from './types';
 import { wrapMatcher } from './utils';
 
 /**
  * Create generic matchers delegating to Playwright/Jest expect
  */
-export function createGenericMatchers(actual: unknown): GenericMatchers {
-  const base = baseExpect(actual);
+export function createGenericMatchers(actual: unknown, options?: ExpectOptions): GenericMatchers {
+  const base = baseExpect(actual, options);
   return {
     toBe: wrapMatcher((expected: unknown) => base.toBe(expected)),
     toBeDefined: wrapMatcher(() => base.toBeDefined()),
@@ -28,6 +28,19 @@ export function createGenericMatchers(actual: unknown): GenericMatchers {
     toMatchObject: wrapMatcher((expected: Record<string, unknown> | unknown[]) =>
       base.toMatchObject(expected)
     ),
+    toMatch: wrapMatcher((expected: RegExp | string) => base.toMatch(expected)),
+    toBeNull: wrapMatcher(() => base.toBeNull()),
+    toBeCloseTo: wrapMatcher((expected: number, precision?: number) =>
+      base.toBeCloseTo(expected, precision)
+    ),
+    toBeInstanceOf: wrapMatcher((expected: new (...args: unknown[]) => unknown) =>
+      base.toBeInstanceOf(expected)
+    ),
+    toThrow: wrapMatcher((expected?: unknown) => base.toThrow(expected)),
+    toThrowError: wrapMatcher((expected?: unknown) => base.toThrowError(expected)),
+    rejects: {
+      toThrow: wrapMatcher((expected?: unknown) => base.rejects.toThrow(expected)),
+    },
     not: {
       toBe: wrapMatcher((expected: unknown) => base.not.toBe(expected)),
       toBeUndefined: wrapMatcher(() => base.not.toBeUndefined()),
@@ -39,6 +52,15 @@ export function createGenericMatchers(actual: unknown): GenericMatchers {
       toMatchObject: wrapMatcher((expected: Record<string, unknown> | unknown[]) =>
         base.not.toMatchObject(expected)
       ),
+      toMatch: wrapMatcher((expected: string | RegExp) => base.not.toMatch(expected)),
+      toBeCloseTo: wrapMatcher((expected: number, precision?: number) =>
+        base.not.toBeCloseTo(expected, precision)
+      ),
+      toBeInstanceOf: wrapMatcher((expected: new (...args: unknown[]) => unknown) =>
+        base.not.toBeInstanceOf(expected)
+      ),
+      toThrow: wrapMatcher((expected?: unknown) => base.not.toThrow(expected)),
+      toThrowError: wrapMatcher((expected?: unknown) => base.not.toThrowError(expected)),
     },
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/index.ts
@@ -7,10 +7,20 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Matchers } from './types';
+import type { ExpectOptions, ExpectOptionsOrMessage, Matchers } from './types';
 import { createGenericMatchers } from './generic_matchers';
 import { createResponseMatchers } from './response_matchers';
 import { asymmetricMatchers } from './asymmetric_matchers';
+
+/**
+ * Normalize options parameter to ExpectOptions object.
+ */
+function normalizeOptions(options?: ExpectOptionsOrMessage): ExpectOptions | undefined {
+  if (typeof options === 'string') {
+    return { message: options };
+  }
+  return options;
+}
 
 /**
  * Custom expect wrapper for API tests with generic and response matchers.
@@ -18,10 +28,12 @@ import { asymmetricMatchers } from './asymmetric_matchers';
  * @example
  * expect(response).toHaveStatusCode(200);
  * expect(response).toMatchObject({ body: { count: expect.toBeGreaterThan(0) } });
+ * expect(value, 'Custom error message').toBeDefined();
  */
-function expectFn(actual: unknown): Matchers {
-  const genericMatchers = createGenericMatchers(actual);
-  const responseMatchers = createResponseMatchers(actual);
+function expectFn(actual: unknown, options?: ExpectOptionsOrMessage): Matchers {
+  const normalizedOptions = normalizeOptions(options);
+  const genericMatchers = createGenericMatchers(actual, normalizedOptions);
+  const responseMatchers = createResponseMatchers(actual, normalizedOptions);
 
   return {
     ...genericMatchers,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
@@ -12,18 +12,22 @@ import { toHaveStatusCode } from './to_have_status_code';
 import { toHaveStatusText } from './to_have_status_text';
 import { wrapMatcher } from './utils';
 import type { ToHaveStatusCodeOptions } from './to_have_status_code';
-import type { ResponseMatchers } from './types';
+import type { ExpectOptions, ResponseMatchers } from './types';
 
 /**
  * Create response matchers for API response assertions.
  * Matchers validate that the object has required properties before asserting.
  */
-export function createResponseMatchers(obj: unknown): ResponseMatchers {
+export function createResponseMatchers(obj: unknown, options?: ExpectOptions): ResponseMatchers {
   return {
     toHaveStatusCode: wrapMatcher((code: number | ToHaveStatusCodeOptions) =>
-      toHaveStatusCode(obj, code)
+      toHaveStatusCode(obj, code, false, options?.message)
     ),
-    toHaveStatusText: wrapMatcher((text: string) => toHaveStatusText(obj, text)),
-    toHaveHeaders: wrapMatcher((headers: Record<string, string>) => toHaveHeaders(obj, headers)),
+    toHaveStatusText: wrapMatcher((text: string) =>
+      toHaveStatusText(obj, text, false, options?.message)
+    ),
+    toHaveHeaders: wrapMatcher((headers: Record<string, string>) =>
+      toHaveHeaders(obj, headers, false, options?.message)
+    ),
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.ts
@@ -22,7 +22,8 @@ import { createMatcherError } from './utils';
 export function toHaveHeaders(
   obj: unknown,
   expectedHeaders: Record<string, string>,
-  isNegated = false
+  isNegated = false,
+  message?: string
 ): void {
   if (typeof obj !== 'object' || obj === null || !('headers' in obj)) {
     throw createMatcherError({
@@ -30,6 +31,7 @@ export function toHaveHeaders(
       matcherName: 'toHaveHeaders',
       received: obj,
       isNegated,
+      message,
     });
   }
 
@@ -56,6 +58,7 @@ export function toHaveHeaders(
       matcherName: 'toHaveHeaders',
       received: JSON.stringify(actualHeaders),
       isNegated,
+      message,
     });
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.ts
@@ -27,7 +27,8 @@ export interface ToHaveStatusCodeOptions {
 export function toHaveStatusCode(
   obj: unknown,
   expected: number | ToHaveStatusCodeOptions,
-  isNegated = false
+  isNegated = false,
+  message?: string
 ): void {
   if (typeof obj !== 'object' || obj === null || (!('status' in obj) && !('statusCode' in obj))) {
     const expectedValue = typeof expected === 'number' ? expected : expected.oneOf;
@@ -38,6 +39,7 @@ export function toHaveStatusCode(
       matcherName: 'toHaveStatusCode',
       received: obj,
       isNegated,
+      message,
     });
   }
 
@@ -56,6 +58,7 @@ export function toHaveStatusCode(
       matcherName: 'toHaveStatusCode',
       received: actual,
       isNegated,
+      message,
     });
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.ts
@@ -17,7 +17,12 @@ import { createMatcherError } from './utils';
  * expect(response).toHaveStatusText('OK');
  * expect(response).not.toHaveStatusText('Not Found');
  */
-export function toHaveStatusText(obj: unknown, expected: string, isNegated = false): void {
+export function toHaveStatusText(
+  obj: unknown,
+  expected: string,
+  isNegated = false,
+  message?: string
+): void {
   if (
     typeof obj !== 'object' ||
     obj === null ||
@@ -30,6 +35,7 @@ export function toHaveStatusText(obj: unknown, expected: string, isNegated = fal
       matcherName: 'toHaveStatusText',
       received: obj,
       isNegated,
+      message,
     });
   }
 
@@ -46,6 +52,7 @@ export function toHaveStatusText(obj: unknown, expected: string, isNegated = fal
       matcherName: 'toHaveStatusText',
       received: actual,
       isNegated,
+      message,
     });
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/types.ts
@@ -11,6 +11,19 @@ import type { expect as baseExpect } from '@playwright/test';
 import type { ToHaveStatusCodeOptions } from './to_have_status_code';
 
 /**
+ * Options for the expect function.
+ */
+export interface ExpectOptions {
+  /** Custom message to display on assertion failure */
+  message?: string;
+}
+
+/**
+ * Second parameter for expect() - can be a string (shorthand for message) or options object.
+ */
+export type ExpectOptionsOrMessage = string | ExpectOptions;
+
+/**
  * Generic matchers that delegate to Playwright/Jest expect.
  * These work on any value type.
  */
@@ -33,8 +46,26 @@ export interface GenericMatchers {
   toBeLessThan(expected: number): void;
   /** Compares contents of the value with contents of `expected`, performing "deep equality" check. Allows extra properties to be present in the value */
   toMatchObject(expected: unknown): void;
+  /** Ensures that string value matches a regular expression or string */
+  toMatch(expected: string | RegExp): void;
+  /** Ensures that value is `null` */
+  toBeNull(): void;
+  /** Compares floating point numbers for approximate equality. Use this method instead of `toBe` when comparing floating point numbers */
+  toBeCloseTo(expected: number, numDigits?: number): void;
+  /** Ensures that value is an instance of a class. Uses `instanceof` operator */
+  toBeInstanceOf(expected: new (...args: unknown[]) => unknown): void;
+  /** Calls the function and ensures it throws an error. Optionally compares the error with `expected` (string, regex, error object, or error class) */
+  toThrow(expected?: unknown): void;
+  /** An alias for `toThrow` */
+  toThrowError(expected?: unknown): void;
 
-  not: Omit<GenericMatchers, 'not' | 'toBeDefined'>;
+  /** Async matchers for promises that are expected to reject */
+  rejects: {
+    /** Ensures that a rejected promise throws an error that optionally matches `expected` */
+    toThrow(expected?: unknown): Promise<void>;
+  };
+
+  not: Omit<GenericMatchers, 'not' | 'toBeDefined' | 'toBeNull' | 'rejects'>;
 }
 
 /**
@@ -56,7 +87,7 @@ export interface ResponseMatchers {
  */
 export type Matchers = GenericMatchers &
   ResponseMatchers & {
-    not: Omit<GenericMatchers, 'not' | 'toBeDefined'>;
+    not: Omit<GenericMatchers, 'not' | 'toBeDefined' | 'toBeNull' | 'rejects'>;
   };
 
 /**

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.ts
@@ -12,13 +12,14 @@ export interface MatcherErrorOptions {
   matcherName: string;
   received: unknown;
   isNegated?: boolean;
+  message?: string;
 }
 
 /**
  * Format error messages for API matchers like Playwright.
  */
 export function createMatcherError(options: MatcherErrorOptions): Error {
-  const { expected, matcherName, received, isNegated = false } = options;
+  const { expected, matcherName, received, isNegated = false, message } = options;
   const gray = '\x1b[90m';
   const red = '\x1b[31m';
   const green = '\x1b[32m';
@@ -30,11 +31,13 @@ export function createMatcherError(options: MatcherErrorOptions): Error {
     `${matcherName}` +
     `${gray}(${green}expected${gray})${reset}`;
 
-  return new Error(
+  const errorMessage =
     `${matcherCall}\n\n` +
-      `Expected: ${isNegated ? 'not ' : ''}${green}${expected}${reset}\n` +
-      `Received: ${red}${received}${reset}`
-  );
+    `Expected: ${isNegated ? 'not ' : ''}${green}${expected}${reset}\n` +
+    `Received: ${red}${received}${reset}`;
+
+  // Prepend custom message if provided (matching Playwright's format)
+  return new Error(message ? `${message}\n\n${errorMessage}` : errorMessage);
 }
 
 /**

--- a/src/platform/plugins/shared/console/test/scout/api/tests/spec_definitions.spec.ts
+++ b/src/platform/plugins/shared/console/test/scout/api/tests/spec_definitions.spec.ts
@@ -8,7 +8,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { apiTest, expect } from '@kbn/scout';
+import { apiTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS } from '../fixtures/constants';
 
 apiTest.describe(
@@ -28,7 +29,7 @@ apiTest.describe(
         responseType: 'json',
       });
       expect(statusCode).toBe(200);
-      expect(body).toHaveProperty('es');
+      expect(body.es).toBeDefined();
       const {
         es: { name, globals, endpoints },
       } = body;

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/async_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/async_dashboard.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import {
   SAMPLE_DATA_SET_ID,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_lens_by_value.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_lens_by_value.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { PageObjects } from '@kbn/scout';
 import {
   LENS_BASIC_KIBANA_ARCHIVE,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_maps_by_value.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_maps_by_value.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { PageObjects, ScoutPage } from '@kbn/scout';
 import { LENS_BASIC_KIBANA_ARCHIVE } from '../constants';
 

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '../constants';
 
 // may include "observabilityGroup" panel group (and other panel groups)

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect } from '@kbn/scout';
+import { spaceTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '../constants';
 
 // includes "observabilityGroup" panel group

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_search_by_value.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_search_by_value.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '../constants';
 
 const DASHBOARD_SAVED_SEARCH_NAME = 'Rendering-Test:-saved-search';

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/controls_migration_smoke.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/controls_migration_smoke.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { ScoutPage } from '@kbn/scout';
 import {
   findImportedSavedObjectId,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/lens_migration_smoke.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/lens_migration_smoke.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import {
   ensureIndexPatternFromExport,
   findImportedSavedObjectId,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/tsvb_migration_smoke_7_12_1.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/tsvb_migration_smoke_7_12_1.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import {
   findImportedSavedObjectId,
   getDashboardPanels,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/tsvb_migration_smoke_7_13_3.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/tsvb_migration_smoke_7_13_3.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import {
   ensureIndexPatternFromExport,
   findImportedSavedObjectId,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/visualize_migration_smoke.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/migration_smoke_tests/visualize_migration_smoke.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import {
   ensureIndexPatternFromExport,
   findImportedSavedObjectId,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_time_range.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_time_range.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { PageObjects } from '@kbn/scout';
 import {
   LENS_BASIC_KIBANA_ARCHIVE,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { PageObjects } from '@kbn/scout';
 import {
   LENS_BASIC_DATA_VIEW,

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/sync_colors.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/sync_colors.spec.ts
@@ -8,7 +8,8 @@
  */
 
 import type { DebugState } from '@elastic/charts';
-import { spaceTest, expect, tags } from '@kbn/scout';
+import { spaceTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { PageObjects } from '@kbn/scout';
 import type { ScoutPage } from '@kbn/scout';
 import {

--- a/src/platform/plugins/shared/dashboard/test/scout/utils/migration_smoke_helpers.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/utils/migration_smoke_helpers.ts
@@ -9,7 +9,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import type { ScoutPage } from '@kbn/scout';
 import type { KbnClient } from '@kbn/test';
 

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { RoleApiCredentials, apiTest, expect } from '@kbn/scout';
+import { RoleApiCredentials, apiTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
 
 apiTest.describe(
@@ -28,7 +29,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });
@@ -45,7 +46,7 @@ apiTest.describe(
         body: TEST_INPUT.invalid_script,
       });
 
-      expect(response.statusCode).toBe(200);
+      expect(response).toHaveStatusCode(200);
       expect(response.body.error.reason).toBe('compile error');
     });
   }

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { apiTest, expect, tags } from '@kbn/scout';
+import { apiTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
 
 apiTest.describe(
@@ -28,7 +29,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });
@@ -50,7 +51,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });
@@ -92,7 +93,7 @@ apiTest.describe(
           responseType: 'json',
           body: TEST_INPUT.script,
         });
-        expect(response.statusCode).toBe(200);
+        expect(response).toHaveStatusCode(200);
         expect(response.body).toStrictEqual({
           result: 'true',
         });

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_disabled.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_disabled.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { RoleApiCredentials, apiTest, expect } from '@kbn/scout';
+import { RoleApiCredentials, apiTest } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
 
 apiTest.describe(
@@ -25,7 +26,7 @@ apiTest.describe(
         responseType: 'json',
         body: TEST_INPUT.script,
       });
-      expect(response.statusCode).toBe(404);
+      expect(response).toHaveStatusCode(404);
       expect(response.body.message).toBe('Not Found');
     });
   }

--- a/x-pack/platform/plugins/private/transform/test/scout/api/helpers/transform_assertions.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/helpers/transform_assertions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RoleApiCredentials } from '@kbn/scout';
 import { TRANSFORM_STATE, type TransformId } from '../../../../common';
 import type { TransformApiServicesFixture } from '../fixtures';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_delete_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_delete_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   DeleteTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reauthorize_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reauthorize_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader, RoleApiCredentials } from '@kbn/scout';
 import type { ReauthorizeTransformsRequestSchema } from '../../../../common';
 import { generateTransformConfig, generateDestIndex } from '../helpers/transform_config';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reset_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_reset_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   ResetTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_schedule_now_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_schedule_now_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   ScheduleNowTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_start_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_start_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type {
   StartTransformsRequestSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_stop_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/bulk_stop_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type { estypes } from '@elastic/elasticsearch';
 import type { StopTransformsRequestSchema, StopTransformsResponseSchema } from '../../../../common';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/delete_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/delete_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   DeleteTransformsRequestSchema,
   DeleteTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/reauthorize_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/reauthorize_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { RoleApiCredentials } from '@kbn/scout';
 import type { ReauthorizeTransformsRequestSchema } from '../../../../common';
 import { generateTransformConfig, generateDestIndex } from '../helpers/transform_config';
@@ -171,7 +172,7 @@ apiTest.describe('/internal/transform/reauthorize_transforms', { tag: tags.ESS_O
       );
       expect(statusCode).toBe(200);
       expect(body[invalidTransformId].success).toBe(false);
-      expect(body[invalidTransformId]).toHaveProperty('error');
+      expect(body[invalidTransformId].error).toBeDefined();
     }
   );
 });

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/reset_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/reset_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   ResetTransformsRequestSchema,
   ResetTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/schedule_now_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/schedule_now_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   ScheduleNowTransformsRequestSchema,
   ScheduleNowTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/start_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/start_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   StartTransformsRequestSchema,
   StartTransformsResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/stop_transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/stop_transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { StopTransformsRequestSchema, StopTransformsResponseSchema } from '../../../../common';
 import { TRANSFORM_STATE } from '../../../../common/constants';
 import { generateTransformConfig } from '../helpers/transform_config';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GetTransformsResponseSchema } from '../../../../common';
 import { transformApiTest as apiTest } from '../fixtures';
 import { COMMON_HEADERS } from '../constants';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_create.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_create.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { CookieHeader } from '@kbn/scout';
 import type { PutTransformsResponseSchema } from '../../../../common';
 import { generateTransformConfig, generateDestIndex } from '../helpers/transform_config';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_nodes.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_nodes.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GetTransformNodesResponseSchema } from '../../../../common';
 import { transformApiTest as apiTest } from '../fixtures';
 import { COMMON_HEADERS } from '../constants';
@@ -27,7 +28,7 @@ apiTest.describe('/internal/transform/transforms/_nodes', { tag: tags.ESS_ONLY }
 
       expect(statusCode).toBe(200);
 
-      expect(nodesResponse.count).toBeGreaterThanOrEqual(1);
+      expect(nodesResponse.count).toBeGreaterThan(0);
     }
   );
 
@@ -47,7 +48,7 @@ apiTest.describe('/internal/transform/transforms/_nodes', { tag: tags.ESS_ONLY }
 
       expect(statusCode).toBe(200);
 
-      expect(nodesResponse.count).toBeGreaterThanOrEqual(1);
+      expect(nodesResponse.count).toBeGreaterThan(0);
     }
   );
 

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_preview.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_preview.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   PostTransformsPreviewRequestSchema,
   PostTransformsPreviewResponseSchema,

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_stats.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_stats.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type { GetTransformsStatsResponseSchema } from '../../../../common';
 import { TRANSFORM_STATE } from '../../../../common/constants';
 import { transformApiTest as apiTest } from '../fixtures';

--- a/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_update.spec.ts
+++ b/x-pack/platform/plugins/private/transform/test/scout/api/tests/transforms_update.spec.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 import type {
   GetTransformsResponseSchema,
   PostTransformsUpdateResponseSchema,
@@ -64,7 +65,7 @@ apiTest.describe(
       );
       const originalBody = originalResponse.body as GetTransformsResponseSchema;
 
-      expect(originalResponse.statusCode).toBe(200);
+      expect(originalResponse).toHaveStatusCode(200);
 
       expect(originalBody.count).toBe(1);
       expect(originalBody.transforms).toHaveLength(1);
@@ -92,7 +93,7 @@ apiTest.describe(
       );
       const updatedTransform = updateResponse.body as PostTransformsUpdateResponseSchema;
 
-      expect(updateResponse.statusCode).toBe(200);
+      expect(updateResponse).toHaveStatusCode(200);
 
       const expectedConfig = getTransformUpdateConfig();
       expect(updatedTransform.id).toBe(TRANSFORM_ID);
@@ -113,7 +114,7 @@ apiTest.describe(
       });
       const verifyBody = verifyResponse.body as GetTransformsResponseSchema;
 
-      expect(verifyResponse.statusCode).toBe(200);
+      expect(verifyResponse).toHaveStatusCode(200);
 
       expect(verifyBody.count).toBe(1);
       expect(verifyBody.transforms).toHaveLength(1);

--- a/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_multiple_spaces.spec.ts
+++ b/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_multiple_spaces.spec.ts
@@ -14,7 +14,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 
 import {
   ATTRIBUTE_TITLE_KEY,
@@ -94,7 +95,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse1.statusCode).toBe(200);
+      expect(importResponse1).toHaveStatusCode(200);
       expect(importResponse1.body.success).toBe(true);
       expect(importResponse1.body.successCount).toBe(1);
 
@@ -120,7 +121,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse2.statusCode).toBe(200);
+      expect(importResponse2).toHaveStatusCode(200);
       expect(importResponse2.body.success).toBe(true);
       expect(importResponse2.body.successCount).toBe(1);
 
@@ -176,7 +177,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse1.statusCode).toBe(200);
+      expect(importResponse1).toHaveStatusCode(200);
       expect(importResponse1.body.success).toBe(true);
       expect(importResponse1.body.successCount).toBe(1);
 
@@ -203,7 +204,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
         }
       );
 
-      expect(importResponse2.statusCode).toBe(200);
+      expect(importResponse2).toHaveStatusCode(200);
       expect(importResponse2.body.success).toBe(true);
       expect(importResponse2.body.successCount).toBe(1);
       expect(importResponse2.body.successResults[0].id).toBe(uniqueId);
@@ -220,7 +221,7 @@ apiTest.describe(`_import API with multiple spaces`, { tag: tags.ESS_ONLY }, () 
       });
 
       // Import should succeed and the object should exist in space 2 with the new ID
-      expect(importResponse2.statusCode).toBe(200);
+      expect(importResponse2).toHaveStatusCode(200);
       expect(importResponse2.body.success).toBe(true);
 
       // The originId should point to the original object's ID

--- a/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_single_space.spec.ts
+++ b/x-pack/platform/plugins/shared/spaces/test/scout/api/tests/spaces_only/import_in_single_space.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
-import { expect, tags } from '@kbn/scout';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
 
 import {
   ATTRIBUTE_TITLE_KEY,
@@ -90,7 +91,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response1.statusCode).toBe(200);
+        expect(response1).toHaveStatusCode(200);
         expect(response1.body.success).toBe(true);
         expect(response1.body.successCount).toBe(1);
 
@@ -114,7 +115,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response2.statusCode).toBe(200);
+        expect(response2).toHaveStatusCode(200);
         expect(response2.body.success).toBe(false);
         expect(response2.body.errors).toHaveLength(1);
         expect(response2.body.errors[0].error.type).toBe('conflict');
@@ -146,7 +147,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response1.statusCode).toBe(200);
+        expect(response1).toHaveStatusCode(200);
         expect(response1.body.success).toBe(true);
         expect(response1.body.successCount).toBe(1);
 
@@ -171,7 +172,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response2.statusCode).toBe(200);
+        expect(response2).toHaveStatusCode(200);
         expect(response2.body.success).toBe(true);
 
         const getResponse = await kbnClient.savedObjects.get({
@@ -210,7 +211,7 @@ TEST_SPACES.forEach((space) => {
           }
         );
 
-        expect(response1.statusCode).toBe(200);
+        expect(response1).toHaveStatusCode(200);
         expect(response1.body.success).toBe(true);
         expect(response1.body.successCount).toBe(1);
         expect(response1.body.successResults[0].id).toBe(uniqueId);
@@ -252,7 +253,7 @@ TEST_SPACES.forEach((space) => {
         }
       );
 
-      expect(response.statusCode).toBe(200);
+      expect(response).toHaveStatusCode(200);
       expect(response.body.success).toBe(false);
       expect(response.body.errors).toHaveLength(1);
       expect(response.body.errors[0].error.type).toBe('unsupported_type');

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -4,7 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ScoutPage, expect } from '@kbn/scout';
+import { ScoutPage } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 
 export class StreamsApp {
   constructor(private readonly page: ScoutPage) {}

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/classic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/classic.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import { testData, test } from '../fixtures';
 
 const DATA_STREAM_NAME = 'my-data-stream';

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/wired.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/wired.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 import { testData, test } from '../fixtures';
 
 test.describe('Wired Streams', { tag: ['@ess', '@svlOblt'] }, () => {

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -9,7 +9,7 @@
 export { test, apiTest, spaceTest } from './src/playwright';
 
 // re-exported test framework from @kbn/scout
-export { expect, lighthouseTest, tags } from '@kbn/scout';
+export { lighthouseTest, tags } from '@kbn/scout';
 
 // Custom global setup hook with profiling support
 export { globalSetupHook } from './src/playwright/global_hooks/profiling_setup';

--- a/x-pack/solutions/search/packages/kbn-scout-search/index.ts
+++ b/x-pack/solutions/search/packages/kbn-scout-search/index.ts
@@ -9,7 +9,7 @@
 export { test, apiTest, spaceTest } from './src/playwright';
 
 // re-exported test framework from @kbn/scout
-export { expect, lighthouseTest, globalSetupHook, tags } from '@kbn/scout';
+export { lighthouseTest, globalSetupHook, tags } from '@kbn/scout';
 
 // re-exported fixtures & configuration from @kbn/scout
 export {

--- a/x-pack/solutions/security/packages/kbn-scout-security/index.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/index.ts
@@ -9,7 +9,7 @@
 export { test, spaceTest } from './src/playwright';
 
 // re-exported test framework from @kbn/scout
-export { expect, lighthouseTest, apiTest, globalSetupHook, tags } from '@kbn/scout';
+export { lighthouseTest, apiTest, globalSetupHook, tags } from '@kbn/scout';
 
 // re-exported fixtures & configuration from @kbn/scout
 export {

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/alerts_table.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/alerts_table.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { ScoutPage, Locator, expect } from '@kbn/scout';
+import { ScoutPage, Locator } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
 
 const PAGE_URL = 'security/alerts';
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update rest of API tests to use `expect` from `/api` (#250965)](https://github.com/elastic/kibana/pull/250965)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-09T06:57:47Z","message":"Update rest of API tests to use `expect` from `/api` (#250965)\n\n## Summary\n\nUpdates rest of API tests to import `expect` from the dedicated `/api`\nsubpath and adds custom message support to API expect matchers.\n\n### Changes\n\n- Updated rest of API tests to import `expect` from `@kbn/scout/api` and\nuse response matchers wherever is possible\n- Added custom error message support to `expect()` (string or object\nformat)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bdcdbce7c9135bc305aec07b331cb2eb326c25c3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0","Team:obs-presentation"],"title":"Update rest of API tests to use `expect` from `/api`","number":250965,"url":"https://github.com/elastic/kibana/pull/250965","mergeCommit":{"message":"Update rest of API tests to use `expect` from `/api` (#250965)\n\n## Summary\n\nUpdates rest of API tests to import `expect` from the dedicated `/api`\nsubpath and adds custom message support to API expect matchers.\n\n### Changes\n\n- Updated rest of API tests to import `expect` from `@kbn/scout/api` and\nuse response matchers wherever is possible\n- Added custom error message support to `expect()` (string or object\nformat)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bdcdbce7c9135bc305aec07b331cb2eb326c25c3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250965","number":250965,"mergeCommit":{"message":"Update rest of API tests to use `expect` from `/api` (#250965)\n\n## Summary\n\nUpdates rest of API tests to import `expect` from the dedicated `/api`\nsubpath and adds custom message support to API expect matchers.\n\n### Changes\n\n- Updated rest of API tests to import `expect` from `@kbn/scout/api` and\nuse response matchers wherever is possible\n- Added custom error message support to `expect()` (string or object\nformat)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bdcdbce7c9135bc305aec07b331cb2eb326c25c3"}}]}] BACKPORT-->