### PR TITLE
[8.19] [Scout] Add convenience API key methods for common roles in `requestAuth` (#252095)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
@@ -24,3 +24,4 @@ export {
   isElasticsearchRole,
 } from './custom_role';
 export type { ElasticsearchRoleDescriptor, KibanaRole } from './custom_role';
+export { getPrivilegedRoleName } from './roles';

--- a/src/platform/packages/shared/kbn-scout/src/common/services/roles.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/roles.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ServerlessProjectType } from '@kbn/es';
+import type { Role } from '@kbn/test/src/auth/types';
+import { PROJECT_DEFAULT_ROLES } from '../constants';
+
+/**
+ * Resolves the privileged (non-admin, elevated) role name based on the deployment environment.
+ * Returns `'developer'` for serverless Elasticsearch projects, `'editor'` for all others.
+ */
+export function getPrivilegedRoleName(config: {
+  serverless: boolean;
+  projectType: ServerlessProjectType;
+}): Role {
+  if (!config.serverless) {
+    return 'editor';
+  }
+
+  const roleName = PROJECT_DEFAULT_ROLES.get(config.projectType);
+
+  if (!roleName) {
+    throw new Error(
+      `No default privileged role defined for serverless project type: '${config.projectType}'. ` +
+        `Expected one of: ${[...PROJECT_DEFAULT_ROLES.keys()].join(', ')}`
+    );
+  }
+
+  return roleName;
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/browser_auth/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/browser_auth/index.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { KibanaRole, PROJECT_DEFAULT_ROLES } from '../../../../../common';
+import type { KibanaRole } from '../../../../../common';
+import { getPrivilegedRoleName } from '../../../../../common';
 import { coreWorkerFixtures } from '../../worker';
 
 export type LoginFunction = (role: string) => Promise<void>;
@@ -77,12 +78,10 @@ export const browserAuthFixture = coreWorkerFixtures.extend<{ browserAuth: Brows
 
     const loginAsAdmin = () => loginAs('admin');
     const loginAsViewer = () => loginAs('viewer');
-    const loginAsPrivilegedUser = () => {
-      const roleName = config.serverless
-        ? PROJECT_DEFAULT_ROLES.get(config.projectType!)!
-        : 'editor';
-      return loginAs(roleName);
-    };
+    const loginAsPrivilegedUser = () =>
+      loginAs(
+        getPrivilegedRoleName({ serverless: config.serverless, projectType: config.projectType! })
+      );
 
     log.serviceLoaded('browserAuth');
     await use({

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/api_key.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/api_key.ts
@@ -11,7 +11,11 @@ import { coreWorkerFixtures } from './core_fixtures';
 import type { ApiClientFixture } from './api_client';
 import type { DefaultRolesFixture } from './default_roles';
 import type { ElasticsearchRoleDescriptor, KibanaRole } from '../../../../common';
-import { measurePerformanceAsync, isElasticsearchRole } from '../../../../common';
+import {
+  measurePerformanceAsync,
+  isElasticsearchRole,
+  getPrivilegedRoleName,
+} from '../../../../common';
 
 export interface ApiKey {
   id: string;
@@ -30,10 +34,36 @@ export interface RoleApiCredentials {
 }
 
 export interface RequestAuthFixture {
+  /**
+   * Creates an API key for a predefined role (e.g. 'admin', 'viewer', 'editor').
+   * Role privileges are resolved from the corresponding roles.yml file.
+   * @param role - The predefined role name.
+   */
   getApiKey: (role: string) => Promise<RoleApiCredentials>;
+  /**
+   * Creates an API key for a custom role defined inline via a Kibana or Elasticsearch
+   * role descriptor. The role is created on-the-fly and cleaned up after the worker completes.
+   * @param role - A Kibana or Elasticsearch role descriptor with specific permissions.
+   */
   getApiKeyForCustomRole: (
     role: KibanaRole | ElasticsearchRoleDescriptor
   ) => Promise<RoleApiCredentials>;
+  /**
+   * Shorthand for `getApiKey('admin')`.
+   * Creates an API key with administrative privileges.
+   */
+  getApiKeyForAdmin: () => Promise<RoleApiCredentials>;
+  /**
+   * Shorthand for `getApiKey('viewer')`.
+   * Creates an API key with viewer-only permissions.
+   */
+  getApiKeyForViewer: () => Promise<RoleApiCredentials>;
+  /**
+   * Creates an API key for a non-admin user with elevated privileges.
+   * Resolves the role based on the environment: `developer` for serverless
+   * Elasticsearch projects, `editor` for all other deployments and project types.
+   */
+  getApiKeyForPrivilegedUser: () => Promise<RoleApiCredentials>;
 }
 
 export const requestAuthFixture = coreWorkerFixtures.extend<
@@ -45,7 +75,7 @@ export const requestAuthFixture = coreWorkerFixtures.extend<
   }
 >({
   requestAuth: [
-    async ({ log, samlAuth, defaultRoles, apiClient }, use, workerInfo) => {
+    async ({ log, config, samlAuth, defaultRoles, apiClient }, use, workerInfo) => {
       const generatedApiKeys: ApiKey[] = [];
 
       const createApiKeyPayload = (
@@ -153,7 +183,22 @@ export const requestAuthFixture = coreWorkerFixtures.extend<
         return result;
       };
 
-      await use({ getApiKey, getApiKeyForCustomRole });
+      const getApiKeyForAdmin = () => getApiKey('admin');
+      const getApiKeyForViewer = () => getApiKey('viewer');
+
+      const getApiKeyForPrivilegedUser = async (): Promise<RoleApiCredentials> => {
+        return getApiKey(
+          getPrivilegedRoleName({ serverless: config.serverless, projectType: config.projectType! })
+        );
+      };
+
+      await use({
+        getApiKey,
+        getApiKeyForCustomRole,
+        getApiKeyForAdmin,
+        getApiKeyForViewer,
+        getApiKeyForPrivilegedUser,
+      });
 
       // Invalidate all API Keys after tests
       await measurePerformanceAsync(log, `Delete all API Keys`, async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Scout] Add convenience API key methods for common roles in `requestAuth` (#252095)](https://github.com/elastic/kibana/pull/252095)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2026-02-09T10:48:36Z","message":"[Scout] Add convenience API key methods for common roles in `requestAuth` (#252095)\n\nThis PR updates the `requestAuth` fixture to expose common methods for\nAPI-key based authentication: `getApiKeyForAdmin`, `getApiKeyForViewer`,\nand `getApiKeyForPrivilegedUser`.\n\nThis is in line with our UI tests `browserAuth` fixture offering:\n`browserAuth.loginAsAdmin()`, `browserAuth.loginAsViewer()`,\n`loginAsPrivilegedUser.loginAsPrivilegedUser`, and more.\n\n### Context\n\nCurrently, just the `getApiKey: (role: string)` is available for API-key\nbased authentication in API tests. This method was enough for most\nauthentication use cases, but presented some problems when the same test\nwas run in different environments that call the equivalent role\ndifferently: `developer` in Elasticsearch serverless projects, and\n`editor` in all other deployments (stateful, other serverless project\ntypes). This is why we now introduce `getApiKeyForPrivilegedUser`.","sha":"bc28355488e08f4a6edbad5b30f497167db1cf55","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0"],"title":"[Scout] Add convenience API key methods for common roles in `requestAuth`","number":252095,"url":"https://github.com/elastic/kibana/pull/252095","mergeCommit":{"message":"[Scout] Add convenience API key methods for common roles in `requestAuth` (#252095)\n\nThis PR updates the `requestAuth` fixture to expose common methods for\nAPI-key based authentication: `getApiKeyForAdmin`, `getApiKeyForViewer`,\nand `getApiKeyForPrivilegedUser`.\n\nThis is in line with our UI tests `browserAuth` fixture offering:\n`browserAuth.loginAsAdmin()`, `browserAuth.loginAsViewer()`,\n`loginAsPrivilegedUser.loginAsPrivilegedUser`, and more.\n\n### Context\n\nCurrently, just the `getApiKey: (role: string)` is available for API-key\nbased authentication in API tests. This method was enough for most\nauthentication use cases, but presented some problems when the same test\nwas run in different environments that call the equivalent role\ndifferently: `developer` in Elasticsearch serverless projects, and\n`editor` in all other deployments (stateful, other serverless project\ntypes). This is why we now introduce `getApiKeyForPrivilegedUser`.","sha":"bc28355488e08f4a6edbad5b30f497167db1cf55"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252095","number":252095,"mergeCommit":{"message":"[Scout] Add convenience API key methods for common roles in `requestAuth` (#252095)\n\nThis PR updates the `requestAuth` fixture to expose common methods for\nAPI-key based authentication: `getApiKeyForAdmin`, `getApiKeyForViewer`,\nand `getApiKeyForPrivilegedUser`.\n\nThis is in line with our UI tests `browserAuth` fixture offering:\n`browserAuth.loginAsAdmin()`, `browserAuth.loginAsViewer()`,\n`loginAsPrivilegedUser.loginAsPrivilegedUser`, and more.\n\n### Context\n\nCurrently, just the `getApiKey: (role: string)` is available for API-key\nbased authentication in API tests. This method was enough for most\nauthentication use cases, but presented some problems when the same test\nwas run in different environments that call the equivalent role\ndifferently: `developer` in Elasticsearch serverless projects, and\n`editor` in all other deployments (stateful, other serverless project\ntypes). This is why we now introduce `getApiKeyForPrivilegedUser`.","sha":"bc28355488e08f4a6edbad5b30f497167db1cf55"}},{"url":"https://github.com/elastic/kibana/pull/252274","number":252274,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/252275","number":252275,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->