### PR TITLE
[Synthetics] Fix locations dropdown a11y: screen reader announces option names

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.test.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { FormLocation } from '../types';
+import { ConfigKey } from '../types';
+
+jest.mock('../../../hooks/use_monitor_name', () => ({
+  useMonitorName: () => ({ nameAlreadyExists: false, validName: '' }),
+}));
+
+jest.mock('../../../../../utils/kibana_service', () => ({
+  kibanaService: {
+    coreStart: {
+      docLinks: {
+        links: {
+          observability: {
+            syntheticsCommandReference: 'https://example.com',
+          },
+        },
+      },
+    },
+    isDev: false,
+    isServerless: false,
+  },
+}));
+
+describe('FIELD[ConfigKey.LOCATIONS] renderOption', () => {
+  // FIELD() must be required after mocks are in place
+  const { FIELD } = jest.requireActual('./field_config');
+  const fieldMap = FIELD();
+  const locationField = fieldMap[ConfigKey.LOCATIONS];
+
+  const mockLocations = [
+    { id: 'us_central', label: 'US Central', isServiceManaged: true, key: 'us_central' },
+    { id: 'us_east', label: 'US East', isServiceManaged: true, key: 'us_east' },
+    {
+      id: 'private_loc',
+      label: 'Private Location',
+      isServiceManaged: false,
+      key: 'private_loc',
+    },
+    {
+      id: 'invalid_loc',
+      label: 'Invalid Location',
+      isServiceManaged: true,
+      isInvalid: true,
+      key: 'invalid_loc',
+    },
+  ];
+
+  const getRenderOption = () => {
+    const props = locationField.props!({
+      field: {
+        value: {},
+        name: ConfigKey.LOCATIONS,
+        onChange: jest.fn(),
+        onBlur: jest.fn(),
+        ref: jest.fn(),
+      },
+      formState: { defaultValues: {} } as any,
+      setValue: jest.fn(),
+      trigger: jest.fn(),
+      reset: jest.fn(),
+      locations: mockLocations as any,
+      dependencies: [],
+      dependenciesFieldMeta: {} as any,
+    });
+    return props.renderOption as (option: FormLocation, searchValue: string) => React.ReactNode;
+  };
+
+  it('renders option label text that is accessible to screen readers', () => {
+    const renderOption = getRenderOption();
+    const option: FormLocation = {
+      id: 'us_central',
+      label: 'US Central',
+      isServiceManaged: true,
+    };
+
+    const { getByText } = render(<>{renderOption(option, '')}</>);
+    expect(getByText('US Central')).toBeInTheDocument();
+  });
+
+  it('does not wrap option content in an EuiToolTip', () => {
+    const renderOption = getRenderOption();
+    const option: FormLocation = {
+      id: 'invalid_loc',
+      label: 'Invalid Location',
+      isServiceManaged: true,
+      isInvalid: true,
+    };
+
+    const { container } = render(<>{renderOption(option, '')}</>);
+
+    // EuiToolTip renders a span with class 'euiToolTipAnchor' — verify it's absent
+    expect(container.querySelector('.euiToolTipAnchor')).not.toBeInTheDocument();
+  });
+
+  it('uses span elements instead of div to maintain valid HTML inside button options', () => {
+    const renderOption = getRenderOption();
+    const option: FormLocation = {
+      id: 'us_central',
+      label: 'US Central',
+      isServiceManaged: true,
+    };
+
+    const { container } = render(<>{renderOption(option, '')}</>);
+
+    // The top-level EuiFlexGroup should render as a <span> (component="span")
+    const flexGroup = container.firstElementChild;
+    expect(flexGroup?.tagName).toBe('SPAN');
+
+    // No div elements should be present inside the rendered option
+    // (EuiFlexGroup/EuiFlexItem with component="span" render as span, not div)
+    expect(container.querySelectorAll('div')).toHaveLength(0);
+  });
+
+  it('shows "Invalid" badge for invalid locations', () => {
+    const renderOption = getRenderOption();
+    const option: FormLocation = {
+      id: 'invalid_loc',
+      label: 'Invalid Location',
+      isServiceManaged: true,
+      isInvalid: true,
+    };
+
+    const { getByText } = render(<>{renderOption(option, '')}</>);
+    expect(getByText('Invalid')).toBeInTheDocument();
+  });
+
+  it('shows "Private" badge for non-service-managed locations', () => {
+    const renderOption = getRenderOption();
+    const option: FormLocation = {
+      id: 'private_loc',
+      label: 'Private Location',
+      isServiceManaged: false,
+    };
+
+    const { getByText } = render(<>{renderOption(option, '')}</>);
+    expect(getByText('Private')).toBeInTheDocument();
+  });
+
+  it('does not show "Private" badge for service-managed locations', () => {
+    const renderOption = getRenderOption();
+    const option: FormLocation = {
+      id: 'us_central',
+      label: 'US Central',
+      isServiceManaged: true,
+    };
+
+    const { queryByText } = render(<>{renderOption(option, '')}</>);
+    expect(queryByText('Private')).not.toBeInTheDocument();
+  });
+
+  it('highlights matching search text in the option label', () => {
+    const renderOption = getRenderOption();
+    const option: FormLocation = {
+      id: 'us_central',
+      label: 'US Central',
+      isServiceManaged: true,
+    };
+
+    const { container } = render(<>{renderOption(option, 'Central')}</>);
+
+    // EuiHighlight wraps matching text in a <mark> element
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark?.textContent).toBe('Central');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -30,7 +30,6 @@ import {
   EuiLink,
   EuiHighlight,
   EuiBadge,
-  EuiToolTip,
 } from '@elastic/eui';
 import { MaintenanceWindowsLink } from '../fields/maintenance_windows/create_maintenance_windows_btn';
 import type { MaintenanceWindowsFieldProps } from '../fields/maintenance_windows/maintenance_windows';
@@ -471,43 +470,29 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
         isDisabled: readOnly,
         renderOption: (option: FormLocation, searchValue: string) => {
           return (
-            <EuiToolTip
-              anchorProps={{
-                style: { width: '100%' },
-              }}
-              content={
-                option.isInvalid
-                  ? i18n.translate('xpack.synthetics.monitorConfig.locations.attachedPolicy', {
-                      defaultMessage:
-                        'The attached agent policy for this location has been deleted.',
-                    })
-                  : ''
-              }
-            >
-              <EuiFlexGroup gutterSize="s" alignItems="center">
-                <EuiFlexItem>
-                  <EuiHighlight search={searchValue}>{option.label}</EuiHighlight>
+            <EuiFlexGroup gutterSize="s" alignItems="center" component="span" responsive={false}>
+              <EuiFlexItem component="span">
+                <EuiHighlight search={searchValue}>{option.label}</EuiHighlight>
+              </EuiFlexItem>
+              {option.isInvalid && (
+                <EuiFlexItem grow={false} component="span">
+                  <EuiBadge color="danger">
+                    {i18n.translate('xpack.synthetics.monitorConfig.locations.invalid', {
+                      defaultMessage: 'Invalid',
+                    })}
+                  </EuiBadge>
                 </EuiFlexItem>
-                {option.isInvalid && (
-                  <EuiFlexItem grow={false}>
-                    <EuiBadge color="danger">
-                      {i18n.translate('xpack.synthetics.monitorConfig.locations.invalid', {
-                        defaultMessage: 'Invalid',
-                      })}
-                    </EuiBadge>
-                  </EuiFlexItem>
-                )}
-                {!option.isServiceManaged && (
-                  <EuiFlexItem grow={false}>
-                    <EuiBadge color="primary">
-                      {i18n.translate('xpack.synthetics.monitorConfig.locations.private', {
-                        defaultMessage: 'Private',
-                      })}
-                    </EuiBadge>
-                  </EuiFlexItem>
-                )}
-              </EuiFlexGroup>
-            </EuiToolTip>
+              )}
+              {!option.isServiceManaged && (
+                <EuiFlexItem grow={false} component="span">
+                  <EuiBadge color="primary">
+                    {i18n.translate('xpack.synthetics.monitorConfig.locations.private', {
+                      defaultMessage: 'Private',
+                    })}
+                  </EuiBadge>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
           );
         },
       };


### PR DESCRIPTION
## 🍒 Summary

Fixes the Locations combobox accessibility on the Synthetics monitor create/edit page. VoiceOver was announcing "text, 2 of 9" instead of the actual location name (e.g. "US Central") when navigating dropdown options.

Closes #212369

## 🛠️ Changes

- **Removed `EuiToolTip` wrapper** from `renderOption` in the `ConfigKey.LOCATIONS` field config. The tooltip's anchor span (`display: inline-block`) and the default `div`-based `EuiFlexGroup`/`EuiFlexItem` inside the `<button role="option">` produced invalid HTML (block elements inside inline elements), which broke VoiceOver's accessible name computation.
- **Added `component="span"`** to `EuiFlexGroup` and all `EuiFlexItem` components inside `renderOption`, ensuring only inline elements are rendered inside the option button — matching EUI's own internal pattern for `EuiFilterSelectItem`.
- **Added `responsive={false}`** to the `EuiFlexGroup` to prevent responsive layout changes within dropdown options.
- **Removed unused `EuiToolTip` import** from `@elastic/eui`.
- **Added unit tests** (`field_config.test.tsx`) verifying:
  - Option label text is rendered and accessible
  - No `EuiToolTip` anchor is present in the DOM
  - All elements use `<span>` (no `<div>`) for valid HTML inside `<button>`
  - "Invalid" and "Private" badges render correctly
  - Search text highlighting works

## 🎙️ Prompts

- Fix the a11y issue where VoiceOver does not announce location names in the Synthetics monitor Locations combobox dropdown (WCAG SC 4.1.2)

🤖 This pull request was assisted by Cursor
