### PR TITLE
[8.19] fix(stack_connectors): add optional indicator to fields i openai connector (#251857)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.test.tsx
@@ -91,6 +91,7 @@ describe('ConnectorFields renders', () => {
     expect(getAllByTestId('config.projectId-input')[0]).toBeInTheDocument();
     expect(getAllByTestId('open-ai-api-doc')[0]).toBeInTheDocument();
     expect(getAllByTestId('open-ai-api-keys-doc')[0]).toBeInTheDocument();
+    expect(getAllByTestId('form-optional-field-label')).toHaveLength(2);
   });
 
   test('azure ai connector fields are rendered', async () => {
@@ -282,7 +283,7 @@ describe('ConnectorFields renders', () => {
       expect(queryByTestId('link-gen-ai-token-dashboard')).not.toBeInTheDocument();
     });
     it('Does not render if isEdit is true and dashboardUrl is null', async () => {
-      mockDashboard.mockImplementation((id: string) => ({
+      mockDashboard.mockImplementation(() => ({
         dashboardUrl: null,
       }));
       const { queryByTestId } = render(

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/connector.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { useMemo } from 'react';
-import {
+import type {
   ActionConnectorFieldsProps,
-  SimpleConnectorForm,
+  ConnectorFormSchema,
 } from '@kbn/triggers-actions-ui-plugin/public';
+import { SimpleConnectorForm } from '@kbn/triggers-actions-ui-plugin/public';
 import {
   FilePickerField,
   SelectField,
@@ -36,6 +37,7 @@ import * as i18nAuth from '../../common/auth/translations';
 import DashboardLink from './dashboard_link';
 import { OpenAiProviderType } from '../../../common/openai/constants';
 import * as i18n from './translations';
+import type { Config, Secrets } from './types';
 import {
   azureAiConfig,
   azureAiSecrets,
@@ -47,12 +49,19 @@ import {
 } from './constants';
 import { CRT_REQUIRED, KEY_REQUIRED } from '../../common/auth/translations';
 
+interface OpenAIConnectorFormData extends ConnectorFormSchema<Config, Secrets> {
+  __internal__?: {
+    hasHeaders?: boolean;
+    hasPKI?: boolean;
+  };
+}
+
 const { emptyField } = fieldValidators;
 
 const ConnectorFields: React.FC<ActionConnectorFieldsProps> = ({ readOnly, isEdit }) => {
   const { euiTheme } = useEuiTheme();
   const { getFieldDefaultValue } = useFormContext();
-  const [{ config, __internal__, id, name }] = useFormData({
+  const [{ config, __internal__, id, name }] = useFormData<OpenAIConnectorFormData>({
     watch: ['config.apiProvider', '__internal__.hasHeaders', '__internal__.hasPKI'],
   });
   const hasHeaders = __internal__ != null ? __internal__.hasHeaders : false;
@@ -67,7 +76,6 @@ const ConnectorFields: React.FC<ActionConnectorFieldsProps> = ({ readOnly, isEdi
       getFieldDefaultValue<OpenAiProviderType>('config.apiProvider') ?? OpenAiProviderType.OpenAi,
     [getFieldDefaultValue]
   );
-
   const verificationModeOptions = [
     { value: 'full', text: i18n.VERIFICATION_MODE_FULL },
     { value: 'certificate', text: i18n.VERIFICATION_MODE_CERTIFICATE },
@@ -307,7 +315,7 @@ const ConnectorFields: React.FC<ActionConnectorFieldsProps> = ({ readOnly, isEdi
           }}
         </UseArray>
       )}
-      {isEdit && (
+      {isEdit && id && name && (
         <DashboardLink
           connectorId={id}
           connectorName={name}

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/constants.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/constants.tsx
@@ -8,8 +8,9 @@
 import React from 'react';
 import { ConfigFieldSchema, SecretsFieldSchema } from '@kbn/triggers-actions-ui-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiLink, EuiText } from '@elastic/eui';
+import { EuiLink } from '@elastic/eui';
 import { DEFAULT_OPENAI_MODEL, OpenAiProviderType } from '../../../common/openai/constants';
+import { OptionalFieldLabel } from '../../common/optional_field_label';
 import * as i18n from './translations';
 import { Config } from './types';
 
@@ -94,24 +95,19 @@ export const openAiConfig: ConfigFieldSchema[] = [
     id: 'organizationId',
     label: i18n.ORG_ID_LABEL,
     isRequired: false,
+    labelAppend: OptionalFieldLabel,
     helpText: (
       <FormattedMessage
         defaultMessage="For users who belong to multiple organizations. Organization IDs can be found on your Organization settings page."
         id="xpack.stackConnectors.components.genAi.openAiOrgId"
       />
     ),
-    euiFieldProps: {
-      append: (
-        <EuiText size="xs" color="subdued">
-          {i18n.OPTIONAL_LABEL}
-        </EuiText>
-      ),
-    },
   },
   {
     id: 'projectId',
     label: i18n.PROJECT_ID_LABEL,
     isRequired: false,
+    labelAppend: OptionalFieldLabel,
     helpText: (
       <FormattedMessage
         defaultMessage="For users who are accessing their projects through their legacy user API key. Project IDs can be found on your General settings page by selecting the specific project."
@@ -124,11 +120,6 @@ export const openAiConfig: ConfigFieldSchema[] = [
       onFocus: (event: React.FocusEvent<HTMLInputElement>) => {
         event.target.setAttribute('autocomplete', 'new-password');
       },
-      append: (
-        <EuiText size="xs" color="subdued">
-          {i18n.OPTIONAL_LABEL}
-        </EuiText>
-      ),
     },
   },
 ];

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/simple_connector_form.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/simple_connector_form.tsx
@@ -19,6 +19,7 @@ import { i18n } from '@kbn/i18n';
 export interface CommonFieldSchema {
   id: string;
   label: string;
+  labelAppend?: ReactNode;
   helpText?: string | ReactNode;
   isRequired?: boolean;
   type?: keyof typeof FIELD_TYPES;
@@ -51,6 +52,7 @@ const { emptyField, urlField } = fieldValidators;
 
 const getFieldConfig = ({
   label,
+  labelAppend,
   isRequired = true,
   isUrlField = false,
   requireTld = true,
@@ -58,6 +60,7 @@ const getFieldConfig = ({
   type,
 }: {
   label: string;
+  labelAppend?: ReactNode;
   isRequired?: boolean;
   isUrlField?: boolean;
   requireTld?: boolean;
@@ -65,6 +68,7 @@ const getFieldConfig = ({
   type?: keyof typeof FIELD_TYPES;
 }) => ({
   label,
+  labelAppend,
   validations: [
     ...(isRequired
       ? [
@@ -118,6 +122,7 @@ const FormRow: React.FC<FormRowProps> = ({
   isPasswordField,
   isRequired = true,
   isUrlField,
+  labelAppend,
   helpText,
   defaultValue,
   euiFieldProps = {},
@@ -140,6 +145,7 @@ const FormRow: React.FC<FormRowProps> = ({
                 type,
                 isRequired,
                 requireTld,
+                labelAppend,
               })}
               helpText={helpText}
               componentProps={{
@@ -154,7 +160,7 @@ const FormRow: React.FC<FormRowProps> = ({
           ) : (
             <UseField
               path={id}
-              config={getFieldConfig({ label, type, isRequired })}
+              config={getFieldConfig({ label, type, isRequired, labelAppend })}
               helpText={helpText}
               component={PasswordField}
               componentProps={{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [fix(stack_connectors): add optional indicator to fields i openai connector (#251857)](https://github.com/elastic/kibana/pull/251857)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-02-09T12:39:30Z","message":"fix(stack_connectors): add optional indicator to fields i openai connector (#251857)\n\n## Summary\n\nThis PR updates the OpenAI connector to use @MichaelMarcialis suggested\npattern for how to handle optional input fields.\n\nSee:\nhttps://github.com/elastic/kibana/issues/195048#issuecomment-2393788073\n\nCloses https://github.com/elastic/kibana/issues/195048\n\n### Implementation\n\nThe OpenAI connector is updated to use `labelAppend` to indicate\noptional fields. Existing solution using `append` has been replaced by\n`labelAppend` to align with how optional input fields are handled in\nother places (which also aligns with the recommended pattern).\n\n\n<img width=\"1657\" height=\"1250\" alt=\"Screenshot 2026-02-05 at 14 35 30\"\nsrc=\"https://github.com/user-attachments/assets/ca445b8f-d143-46a6-bc90-066071d6c961\"\n/>\n<img width=\"1659\" height=\"1255\" alt=\"Screenshot 2026-02-05 at 14 35 45\"\nsrc=\"https://github.com/user-attachments/assets/82e232cc-847e-44a8-ab9c-e21d2e9f7d18\"\n/>\n<img width=\"1657\" height=\"1251\" alt=\"Screenshot 2026-02-05 at 14 36 02\"\nsrc=\"https://github.com/user-attachments/assets/f09f3d88-ba3d-4557-abaa-37662f7aef23\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*","sha":"dedbf82d02200dbc3fecd57aa792438e73be8f5b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","Team: SecuritySolution","backport:version","v9.4.0","v9.3.1","v9.2.6","v8.19.12"],"title":"fix(stack_connectors): add optional indicator to fields i openai connector","number":251857,"url":"https://github.com/elastic/kibana/pull/251857","mergeCommit":{"message":"fix(stack_connectors): add optional indicator to fields i openai connector (#251857)\n\n## Summary\n\nThis PR updates the OpenAI connector to use @MichaelMarcialis suggested\npattern for how to handle optional input fields.\n\nSee:\nhttps://github.com/elastic/kibana/issues/195048#issuecomment-2393788073\n\nCloses https://github.com/elastic/kibana/issues/195048\n\n### Implementation\n\nThe OpenAI connector is updated to use `labelAppend` to indicate\noptional fields. Existing solution using `append` has been replaced by\n`labelAppend` to align with how optional input fields are handled in\nother places (which also aligns with the recommended pattern).\n\n\n<img width=\"1657\" height=\"1250\" alt=\"Screenshot 2026-02-05 at 14 35 30\"\nsrc=\"https://github.com/user-attachments/assets/ca445b8f-d143-46a6-bc90-066071d6c961\"\n/>\n<img width=\"1659\" height=\"1255\" alt=\"Screenshot 2026-02-05 at 14 35 45\"\nsrc=\"https://github.com/user-attachments/assets/82e232cc-847e-44a8-ab9c-e21d2e9f7d18\"\n/>\n<img width=\"1657\" height=\"1251\" alt=\"Screenshot 2026-02-05 at 14 36 02\"\nsrc=\"https://github.com/user-attachments/assets/f09f3d88-ba3d-4557-abaa-37662f7aef23\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*","sha":"dedbf82d02200dbc3fecd57aa792438e73be8f5b"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251857","number":251857,"mergeCommit":{"message":"fix(stack_connectors): add optional indicator to fields i openai connector (#251857)\n\n## Summary\n\nThis PR updates the OpenAI connector to use @MichaelMarcialis suggested\npattern for how to handle optional input fields.\n\nSee:\nhttps://github.com/elastic/kibana/issues/195048#issuecomment-2393788073\n\nCloses https://github.com/elastic/kibana/issues/195048\n\n### Implementation\n\nThe OpenAI connector is updated to use `labelAppend` to indicate\noptional fields. Existing solution using `append` has been replaced by\n`labelAppend` to align with how optional input fields are handled in\nother places (which also aligns with the recommended pattern).\n\n\n<img width=\"1657\" height=\"1250\" alt=\"Screenshot 2026-02-05 at 14 35 30\"\nsrc=\"https://github.com/user-attachments/assets/ca445b8f-d143-46a6-bc90-066071d6c961\"\n/>\n<img width=\"1659\" height=\"1255\" alt=\"Screenshot 2026-02-05 at 14 35 45\"\nsrc=\"https://github.com/user-attachments/assets/82e232cc-847e-44a8-ab9c-e21d2e9f7d18\"\n/>\n<img width=\"1657\" height=\"1251\" alt=\"Screenshot 2026-02-05 at 14 36 02\"\nsrc=\"https://github.com/user-attachments/assets/f09f3d88-ba3d-4557-abaa-37662f7aef23\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*","sha":"dedbf82d02200dbc3fecd57aa792438e73be8f5b"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/252305","number":252305,"state":"OPEN"},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.12","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->