### PR TITLE
[9.2] [Scout] Register Node require hook for `.peggy` files

### DIFF
--- a/src/platform/packages/shared/kbn-scout/moon.yml
+++ b/src/platform/packages/shared/kbn-scout/moon.yml
@@ -37,6 +37,7 @@ dependsOn:
   - '@kbn/streams-schema'
   - '@kbn/streamlang'
   - '@kbn/axe-config'
+  - '@kbn/peggy'
   - '@kbn/apm-synthtrace'
   - '@kbn/apm-synthtrace-client'
 tags:

--- a/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
@@ -7,6 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+// Needed for Scout tests dependent on .peggy grammar files (`@kbn/tinymath`)
+import './peggy_setup';
+
 // Config and utilities
 export { createPlaywrightConfig } from './config';
 export { createLazyPageObject } from './page_objects/utils';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/peggy_setup.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/peggy_setup.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Initialize Peggy require hook for .peggy grammar files.
+ * This is required for @kbn/tinymath and other packages that use Peggy grammars.
+ *
+ * Playwright needs to load it as @kbn/scout is dependent on @kbn/streamlang which uses Peggy (`@kbn/tinymath`).
+ * Without this, all Playwright tests would fail with: `"whitespace" SyntaxError: Unexpected string`
+ *
+ * This is similar to the Jest Peggy setup in src/platform/packages/shared/kbn-test/src/jest/transforms/peggy.js.
+ */
+import { requireHook } from '@kbn/peggy';
+requireHook();

--- a/src/platform/packages/shared/kbn-scout/tsconfig.json
+++ b/src/platform/packages/shared/kbn-scout/tsconfig.json
@@ -33,6 +33,7 @@
     "@kbn/streams-schema",
     "@kbn/streamlang",
     "@kbn/axe-config",
+    "@kbn/peggy",
     "@kbn/apm-synthtrace",
     "@kbn/apm-synthtrace-client"
   ]

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
@@ -14,10 +14,8 @@ import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '.
 // may include "observabilityGroup" panel group (and other panel groups)
 const DASHBOARD_PANEL_GROUP_ORDER = [
   'visualizationsGroup',
-  'controlsGroup',
   'annotation-and-navigationGroup',
   'mlGroup',
-  'legacyGroup',
 ];
 
 const DASHBOARD_PANEL_TYPE_COUNT = 18;

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
@@ -14,14 +14,12 @@ import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '.
 // includes "observabilityGroup" panel group
 const DASHBOARD_PANEL_GROUP_ORDER = [
   'visualizationsGroup',
-  'controlsGroup',
   'annotation-and-navigationGroup',
   'mlGroup',
   'observabilityGroup',
-  'legacyGroup',
 ];
 
-const DASHBOARD_PANEL_TYPE_COUNT = 24;
+const DASHBOARD_PANEL_TYPE_COUNT = 21;
 
 spaceTest.describe(
   'Dashboard panel listing (includes observability group)',

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
@@ -71,16 +71,19 @@ spaceTest.describe('Panel titles (dashboard)', { tag: tags.DEPLOYMENT_AGNOSTIC }
     });
   });
 
-  spaceTest('blank title clears unsaved changes', async ({ page, pageObjects }) => {
+  spaceTest('blank title clears unsaved changes', async ({ page, pageObjects }, testInfo) => {
     await spaceTest.step('add markdown panel by value', async () => {
       await pageObjects.dashboard.addMarkdownPanel(PANEL_TITLES_MARKDOWN_CONTENT);
     });
 
-    await spaceTest.step('set blank title and save', async () => {
+    await spaceTest.step('save dashboard', async () => {
+      await pageObjects.dashboard.saveDashboard(`Panel titles - ${testInfo.title}`);
+    });
+
+    await spaceTest.step('set blank title', async () => {
       await pageObjects.dashboard.openCustomizePanel();
       await pageObjects.dashboard.setCustomPanelTitle('');
       await pageObjects.dashboard.saveCustomizePanel();
-      await pageObjects.dashboard.clearUnsavedChanges();
     });
 
     await spaceTest.step('verify title is empty and badge is gone', async () => {
@@ -89,24 +92,33 @@ spaceTest.describe('Panel titles (dashboard)', { tag: tags.DEPLOYMENT_AGNOSTIC }
     });
   });
 
-  spaceTest('custom title causes unsaved changes and saving clears it', async ({ pageObjects }) => {
-    await spaceTest.step('add markdown panel by value', async () => {
-      await pageObjects.dashboard.addMarkdownPanel(PANEL_TITLES_MARKDOWN_CONTENT);
-    });
+  spaceTest(
+    'custom title causes unsaved changes and saving clears it',
+    async ({ page, pageObjects }, testInfo) => {
+      await spaceTest.step('add markdown panel by value', async () => {
+        await pageObjects.dashboard.addMarkdownPanel(PANEL_TITLES_MARKDOWN_CONTENT);
+      });
 
-    await spaceTest.step('set custom title and save', async () => {
-      await pageObjects.dashboard.openCustomizePanel();
-      await pageObjects.dashboard.setCustomPanelTitle(PANEL_TITLES_CUSTOM_TITLE);
-      await pageObjects.dashboard.saveCustomizePanel();
-    });
+      await spaceTest.step('save dashboard', async () => {
+        await pageObjects.dashboard.saveDashboard(`Panel titles - ${testInfo.title}`);
+      });
 
-    await spaceTest.step('verify title and clear unsaved changes', async () => {
-      await expect(pageObjects.dashboard.getPanelTitlesLocator()).toHaveText(
-        PANEL_TITLES_CUSTOM_TITLE
-      );
-      await pageObjects.dashboard.clearUnsavedChanges();
-    });
-  });
+      await spaceTest.step('set custom title and save', async () => {
+        await pageObjects.dashboard.openCustomizePanel();
+        await pageObjects.dashboard.setCustomPanelTitle(PANEL_TITLES_CUSTOM_TITLE);
+        await pageObjects.dashboard.saveCustomizePanel();
+        await expect(page.testSubj.locator('dashboardUnsavedChangesBadge')).toBeVisible();
+      });
+
+      await spaceTest.step('verify title and clear unsaved changes', async () => {
+        await expect(pageObjects.dashboard.getPanelTitlesLocator()).toHaveText(
+          PANEL_TITLES_CUSTOM_TITLE
+        );
+        await pageObjects.dashboard.clearUnsavedChanges();
+        await expect(page.testSubj.locator('dashboardUnsavedChangesBadge')).toHaveCount(0);
+      });
+    }
+  );
 
   spaceTest('reset title is hidden on a by value panel', async ({ pageObjects }) => {
     await spaceTest.step('add markdown panel by value', async () => {


### PR DESCRIPTION
This PR backports a small set of changes introduced by https://github.com/elastic/kibana/pull/246050 to the 9.2 branch (and to 8.19 after merging this PR).

### Context
Some Scout Playwright test configs indirectly import packages that load **Peggy grammar files** at runtime (e.g., `@kbn/es-query`). When Playwright is invoked via the Scout CLI (`node scripts/scout.js ...`) or via `node scripts/playwright`, **Kibana preloads its Node environment** (`@kbn/setup-node-env`), which registers the transforms/hooks needed to load non-JS files like `*.peggy`. 

However, when running Playwright directly (e.g., `npx playwright test --config ... --list`), the Kibana bootstrap is skipped / bypassed. In that case, Node.js ends up trying to interpret `*.peggy` files as JavaScript adn fails, which breaks Playwright config loading and test discovery for some tes configs.

### Background

This caused the Scout Test Run Builder CI step (`node scripts/scout.js update-test-config-manifests` more specifically) to incorrectly report the number tests for `src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts`). This PR fixes that by ensuring a `.peggy` require hook is installed automatically when `@kbn/scout` is imported/used, so Scout configs can be loaded reliably regardless of how Playwright is invoked.