### PR TITLE
[Chrome] Clean up unused APIs 

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -160,7 +160,6 @@ export function createChromeApi({
     hasHeaderBanner$: () => state.headerBanner.$.pipe(map((banner) => Boolean(banner))),
 
     // Chrome Style
-    getBodyClasses$: () => state.bodyClasses$,
     setChromeStyle: state.style.setChromeStyle,
     getChromeStyle$: () => state.style.chromeStyle$,
 

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
@@ -107,9 +107,10 @@ async function start({
   cspConfigMock = { warnLegacyBrowsers: true },
   startDeps = defaultStartDeps(),
 }: { options?: any; cspConfigMock?: any; startDeps?: ReturnType<typeof defaultStartDeps> } = {}) {
+  const mergedOptions = { ...defaultStartTestOptions({}), ...options };
   const service = new ChromeService({
-    ...options,
-    coreContext: options.coreContext ?? coreContextMock.create(),
+    ...mergedOptions,
+    coreContext: mergedOptions.coreContext ?? coreContextMock.create(),
   });
 
   if (cspConfigMock) {
@@ -130,6 +131,7 @@ beforeEach(() => {
   store.clear();
   registerAnalyticsContextProviderMock.mockReset();
   window.history.pushState(undefined, '', '#/home?a=b');
+  document.body.className = '';
 });
 
 afterAll(() => {
@@ -168,39 +170,26 @@ describe('start', () => {
   });
 
   it('adds the kibana versioned class to the document body', async () => {
-    const { chrome, service } = await start({
+    const { service } = await start({
       options: { browserSupportsCsp: false, kibanaVersion: '1.2.3' },
     });
-    const promise = firstValueFrom(chrome.getBodyClasses$().pipe(Rx.take(1), toArray()));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     service.stop();
-    await expect(promise).resolves.toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "kbnBody",
-          "kbnBody--noHeaderBanner",
-          "kbnBody--chromeHidden",
-          "kbnVersion-1-2-3",
-        ],
-      ]
-    `);
+
+    expect(document.body.classList.contains('kbnBody')).toBe(true);
+    expect(document.body.classList.contains('kbnBody--noHeaderBanner')).toBe(true);
+    expect(document.body.classList.contains('kbnBody--chromeHidden')).toBe(true);
+    expect(document.body.classList.contains('kbnVersion-1-2-3')).toBe(true);
   });
 
   it('strips off "snapshot" from the kibana version if present', async () => {
-    const { chrome, service } = await start({
+    const { service } = await start({
       options: { browserSupportsCsp: false, kibanaVersion: '8.0.0-SnAPshot' },
     });
-    const promise = firstValueFrom(chrome.getBodyClasses$().pipe(Rx.take(1), toArray()));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     service.stop();
-    await expect(promise).resolves.toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "kbnBody",
-          "kbnBody--noHeaderBanner",
-          "kbnBody--chromeHidden",
-          "kbnVersion-8-0-0",
-        ],
-      ]
-    `);
+
+    expect(document.body.classList.contains('kbnVersion-8-0-0')).toBe(true);
   });
 
   it('does not add legacy browser warning if browser supports CSP', async () => {

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
@@ -217,6 +217,7 @@ describe('start', () => {
       'coreStart',
       'getNotifications',
       'http',
+      'logger',
       'stop$',
       'uiSettings',
     ]);
@@ -227,6 +228,7 @@ describe('start', () => {
       uiSettings: expect.any(Object),
       getNotifications: expect.any(Function),
       stop$: expect.any(Object),
+      logger: expect.any(Object),
     });
   });
 

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
@@ -65,7 +65,6 @@ Object.defineProperty(window, 'localStorage', {
 function defaultStartDeps(availableApps?: App[], currentAppId?: string) {
   const notifications = notificationServiceMock.createStartContract();
   const deps = {
-    analytics: analyticsServiceMock.createAnalyticsServiceStart(),
     i18n: i18nServiceMock.createStartContract(),
     theme: themeServiceMock.createStartContract(),
     userProfile: userProfileServiceMock.createStart(),

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -141,6 +141,7 @@ export class ChromeService {
       stop$: this.stop$,
       http,
       uiSettings,
+      logger: this.logger,
     });
 
     // 3. Show CSP warning if needed

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -213,7 +213,6 @@ export class ChromeService {
       },
       loadingCount$,
       helpMenuLinks$,
-      forceAppSwitcherNavigation$: navLinks.getForceAppSwitcherNavigation$(),
       navLinks$,
       recentlyAccessed$,
       customBranding$: customBranding.customBranding$,

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -35,6 +35,7 @@ import { registerAnalyticsContextProvider } from './register_analytics_context_p
 import type { InternalChromeSetup, InternalChromeStart } from './types';
 import { createChromeState } from './state';
 import {
+  handleBodyClasses,
   handleEuiFullScreenChanges,
   handleSystemColorModeChange,
   showCspWarningIfNeeded,
@@ -111,7 +112,6 @@ export class ChromeService {
     // 1. Create all chrome state
     const state = createChromeState({
       application,
-      kibanaVersion: this.params.kibanaVersion,
       docLinks,
       feedbackDeps: {
         isEnabled$: defer(() =>
@@ -121,7 +121,15 @@ export class ChromeService {
       },
     });
 
-    // 2. Setup side effects (fullscreen changes, system color mode)
+    // 2. Setup side effects (body classes, fullscreen changes, system color mode)
+    handleBodyClasses({
+      kibanaVersion: this.params.kibanaVersion,
+      headerBanner$: state.headerBanner.$,
+      isVisible$: state.visibility.isVisible$,
+      chromeStyle$: state.style.chromeStyle.$,
+      actionMenu$: application.currentActionMenu$,
+      stop$: this.stop$,
+    });
     handleEuiFullScreenChanges({
       isVisible$: state.visibility.isVisible$,
       setIsVisible: state.visibility.setIsVisible,

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -11,7 +11,7 @@ import { defer, from, ReplaySubject } from 'rxjs';
 
 import type { CoreContext } from '@kbn/core-base-browser-internal';
 import type { InternalInjectedMetadataStart } from '@kbn/core-injected-metadata-browser-internal';
-import type { AnalyticsServiceSetup, AnalyticsServiceStart } from '@kbn/core-analytics-browser';
+import type { AnalyticsServiceSetup } from '@kbn/core-analytics-browser';
 import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import type { InternalHttpStart } from '@kbn/core-http-browser-internal';
 import type { NotificationsStart } from '@kbn/core-notifications-browser';
@@ -64,7 +64,6 @@ export interface StartDeps {
   theme: ThemeServiceStart;
   userProfile: UserProfileService;
   uiSettings: IUiSettingsClient;
-  analytics: AnalyticsServiceStart;
   featureFlags: FeatureFlagsStart;
 }
 
@@ -107,7 +106,6 @@ export class ChromeService {
     theme,
     userProfile,
     uiSettings,
-    analytics,
     featureFlags,
   }: StartDeps): Promise<InternalChromeStart> {
     // 1. Create all chrome state
@@ -213,7 +211,6 @@ export class ChromeService {
       customBranding$: customBranding.customBranding$,
       appMenuActions$: application.currentActionMenu$,
       prependBasePath: http.basePath.prepend,
-      reportEvent: analytics.reportEvent,
     });
 
     // 8. Return chrome API

--- a/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.test.ts
@@ -181,5 +181,4 @@ describe('NavLinksService', () => {
       expect(start.has('phony')).toBe(false);
     });
   });
-
 });

--- a/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.test.ts
@@ -182,17 +182,4 @@ describe('NavLinksService', () => {
     });
   });
 
-  describe('#enableForcedAppSwitcherNavigation()', () => {
-    it('flips #getForceAppSwitcherNavigation$()', async () => {
-      await expect(
-        lastValueFrom(start.getForceAppSwitcherNavigation$().pipe(take(1)))
-      ).resolves.toBe(false);
-
-      start.enableForcedAppSwitcherNavigation();
-
-      await expect(
-        lastValueFrom(start.getForceAppSwitcherNavigation$().pipe(take(1)))
-      ).resolves.toBe(true);
-    });
-  });
 });

--- a/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.ts
@@ -49,8 +49,6 @@ export class NavLinksService {
         navLinks$.next(navlinks);
       });
 
-    const forceAppSwitcherNavigation$ = new BehaviorSubject(false);
-
     return {
       getNavLinks$: () => {
         return navLinks$.pipe(map(sortNavLinks), takeUntil(this.stop$));
@@ -67,14 +65,6 @@ export class NavLinksService {
 
       has(id: string) {
         return navLinks$.value.has(id);
-      },
-
-      enableForcedAppSwitcherNavigation() {
-        forceAppSwitcherNavigation$.next(true);
-      },
-
-      getForceAppSwitcherNavigation$() {
-        return forceAppSwitcherNavigation$.asObservable();
       },
     };
   }

--- a/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/project_navigation/project_navigation_service.test.ts
@@ -51,8 +51,6 @@ const getNavLinksService = (ids: Readonly<string[]> = []) => {
     has: jest.fn(),
     get: jest.fn(),
     getAll: jest.fn().mockReturnValue(navLinks),
-    enableForcedAppSwitcherNavigation: jest.fn(),
-    getForceAppSwitcherNavigation$: jest.fn(),
   };
   return navLinksMock;
 };

--- a/src/core/packages/chrome/browser-internal/src/side_effects/handle_system_colormode_change.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/side_effects/handle_system_colormode_change.test.ts
@@ -32,6 +32,7 @@ jest.mock('@kbn/core-theme-browser-internal', () => {
 });
 
 describe('handleSystemColorModeChange', () => {
+  const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
   const originalMatchMedia = window.matchMedia;
 
   afterAll(() => {

--- a/src/core/packages/chrome/browser-internal/src/side_effects/handle_system_colormode_change.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/side_effects/handle_system_colormode_change.test.ts
@@ -33,7 +33,6 @@ jest.mock('@kbn/core-theme-browser-internal', () => {
 
 describe('handleSystemColorModeChange', () => {
   const originalMatchMedia = window.matchMedia;
-  const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
   afterAll(() => {
     window.matchMedia = originalMatchMedia;

--- a/src/core/packages/chrome/browser-internal/src/side_effects/handle_system_colormode_change.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/side_effects/handle_system_colormode_change.test.ts
@@ -13,6 +13,7 @@ import { themeServiceMock } from '@kbn/core-theme-browser-mocks';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { loggerMock } from '@kbn/logging-mocks';
 import { handleSystemColorModeChange } from './handle_system_colormode_change';
 import { ReplaySubject } from 'rxjs';
 import type { GetUserProfileResponse } from '@kbn/core-user-profile-browser';
@@ -32,6 +33,7 @@ jest.mock('@kbn/core-theme-browser-internal', () => {
 
 describe('handleSystemColorModeChange', () => {
   const originalMatchMedia = window.matchMedia;
+  const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
   afterAll(() => {
     window.matchMedia = originalMatchMedia;
@@ -47,6 +49,7 @@ describe('handleSystemColorModeChange', () => {
     const http = httpServiceMock.createStartContract();
     const uiSettings = uiSettingsServiceMock.createStartContract();
     const stop$ = new ReplaySubject<void>(1);
+    const logger = loggerMock.create();
 
     return {
       coreStart,
@@ -54,6 +57,7 @@ describe('handleSystemColorModeChange', () => {
       http,
       uiSettings,
       stop$,
+      logger,
     };
   };
 
@@ -96,30 +100,31 @@ describe('handleSystemColorModeChange', () => {
 
   describe('doHandle guard', () => {
     it('does not handle if the system color mode is not supported', () => {
+      const { logger } = getDeps();
       const { addEventListenerMock } = mockMatchMedia();
       expect(addEventListenerMock).not.toHaveBeenCalled();
       mockbrowsersSupportsSystemTheme.mockReturnValue(false);
 
-      handleSystemColorModeChange({} as any);
+      handleSystemColorModeChange({ logger } as any);
 
       expect(addEventListenerMock).not.toHaveBeenCalled();
     });
 
     it('does not handle on unauthenticated routes', () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const { addEventListenerMock } = mockMatchMedia();
       expect(addEventListenerMock).not.toHaveBeenCalled();
 
       mockbrowsersSupportsSystemTheme.mockReturnValue(true);
       http.anonymousPaths.isAnonymous.mockReturnValue(true);
 
-      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
 
       expect(addEventListenerMock).not.toHaveBeenCalled();
     });
 
     it('does not handle if user profile darkmode is not "system"', () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const { addEventListenerMock } = mockMatchMedia();
       expect(addEventListenerMock).not.toHaveBeenCalled();
 
@@ -133,13 +138,13 @@ describe('handleSystemColorModeChange', () => {
         },
       } as any);
 
-      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
 
       expect(addEventListenerMock).not.toHaveBeenCalled();
     });
 
     it('does not handle if user profile darkmode is "space_default" but the uiSettings darkmode is not "system"', () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const { addEventListenerMock } = mockMatchMedia();
       expect(addEventListenerMock).not.toHaveBeenCalled();
 
@@ -161,13 +166,13 @@ describe('handleSystemColorModeChange', () => {
         return 'foo';
       });
 
-      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
 
       expect(addEventListenerMock).not.toHaveBeenCalled();
     });
 
     it('does handle if user profile darkmode is "system"', async () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const { addEventListenerMock } = mockMatchMedia(false);
       expect(addEventListenerMock).not.toHaveBeenCalled();
 
@@ -175,13 +180,14 @@ describe('handleSystemColorModeChange', () => {
       http.anonymousPaths.isAnonymous.mockReturnValue(false);
       coreStart.userProfile.getCurrent.mockResolvedValue(mockUserProfileResponse('system'));
 
-      await handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
+      await flushPromises();
 
       expect(addEventListenerMock).toHaveBeenCalled();
     });
 
     it('does handle if user profile darkmode is "space_default" and uiSetting darkmode is "system"', async () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const { addEventListenerMock } = mockMatchMedia(false);
       expect(addEventListenerMock).not.toHaveBeenCalled();
 
@@ -190,15 +196,39 @@ describe('handleSystemColorModeChange', () => {
       coreStart.userProfile.getCurrent.mockResolvedValue(mockUserProfileResponse('space_default'));
       mockUiSettingsDarkMode(uiSettings, 'system');
 
-      await handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
+      await flushPromises();
 
       expect(addEventListenerMock).toHaveBeenCalled();
+    });
+
+    it('handles async errors internally', async () => {
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
+      const { addEventListenerMock } = mockMatchMedia();
+      mockbrowsersSupportsSystemTheme.mockReturnValue(true);
+      http.anonymousPaths.isAnonymous.mockReturnValue(false);
+      coreStart.userProfile.getCurrent.mockRejectedValue(new Error('boom'));
+
+      expect(() =>
+        handleSystemColorModeChange({
+          coreStart,
+          getNotifications,
+          http,
+          uiSettings,
+          stop$,
+          logger,
+        })
+      ).not.toThrow();
+
+      await flushPromises();
+      expect(addEventListenerMock).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(new Error('boom'));
     });
   });
 
   describe('onDarkModeChange()', () => {
     it('does show a toast when the system color mode changes', async () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const currentDarkMode = false; // The system is currently in light mode
       const addEventListenerMock = jest
         .fn()
@@ -220,12 +250,13 @@ describe('handleSystemColorModeChange', () => {
       http.anonymousPaths.isAnonymous.mockReturnValue(false);
       coreStart.userProfile.getCurrent.mockResolvedValue(mockUserProfileResponse('system'));
 
-      await handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
+      await flushPromises();
       expect(addEventListenerMock).toHaveBeenCalled();
     });
 
     it('does **not** show a toast when the system color mode changes to the current darkmode value', async () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const currentDarkMode = true; // The system is currently in dark mode
       const addEventListenerMock = jest
         .fn()
@@ -241,12 +272,13 @@ describe('handleSystemColorModeChange', () => {
       http.anonymousPaths.isAnonymous.mockReturnValue(false);
       coreStart.userProfile.getCurrent.mockResolvedValue(mockUserProfileResponse('system'));
 
-      await handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
+      await flushPromises();
       expect(addEventListenerMock).toHaveBeenCalled();
     });
 
     it('stops listening to changes on stop$ change', async () => {
-      const { coreStart, getNotifications, http, uiSettings, stop$ } = getDeps();
+      const { coreStart, getNotifications, http, uiSettings, stop$, logger } = getDeps();
       const currentDarkMode = false; // The system is currently in light mode
       const { addEventListenerMock, removeEventListenerMock } = mockMatchMedia(currentDarkMode);
 
@@ -254,7 +286,8 @@ describe('handleSystemColorModeChange', () => {
       http.anonymousPaths.isAnonymous.mockReturnValue(false);
       coreStart.userProfile.getCurrent.mockResolvedValue(mockUserProfileResponse('system'));
 
-      await handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$ });
+      handleSystemColorModeChange({ coreStart, getNotifications, http, uiSettings, stop$, logger });
+      await flushPromises();
       expect(addEventListenerMock).toHaveBeenCalled();
       expect(removeEventListenerMock).not.toHaveBeenCalled();
 

--- a/src/core/packages/chrome/browser-internal/src/side_effects/index.ts
+++ b/src/core/packages/chrome/browser-internal/src/side_effects/index.ts
@@ -16,3 +16,6 @@ export type { AppChangeHandlerDeps } from './app_change_handler';
 export { handleEuiDevProviderWarning } from './handle_eui_dev_provider_warning';
 export { handleEuiFullScreenChanges } from './handle_eui_fullscreen_changes';
 export { handleSystemColorModeChange } from './handle_system_colormode_change';
+
+export { handleBodyClasses } from './handle_body_classes';
+export type { BodyClassesSideEffectDeps } from './handle_body_classes';

--- a/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
@@ -33,7 +33,6 @@ import {
 import { createBreadcrumbsState } from './breadcrumbs_state';
 import { createVisibilityState, type VisibilityState } from './visibility_state';
 import { createChromeStyleState, type ChromeStyleState } from './chrome_style_state';
-import { createBodyClassesState } from './body_classes_state';
 import { createFeedbackState, type FeedbackState, type FeedbackStateDeps } from './feedback_state';
 
 const IS_SIDENAV_COLLAPSED_KEY = 'core.chrome.isSideNavCollapsed';
@@ -44,9 +43,6 @@ export interface ChromeState {
 
   /** Chrome style */
   style: ChromeStyleState;
-
-  /** Body CSS classes */
-  bodyClasses$: Observable<string[]>;
 
   /** Side navigation state */
   sideNav: {
@@ -81,7 +77,6 @@ export interface ChromeState {
 
 export interface ChromeStateDeps {
   application: InternalApplicationStart;
-  kibanaVersion: string;
   docLinks: DocLinksStart;
   feedbackDeps: Pick<FeedbackStateDeps, 'isEnabled$' | 'urlParams$'>;
 }
@@ -89,7 +84,6 @@ export interface ChromeStateDeps {
 /** Creates all chrome state in one place */
 export function createChromeState({
   application,
-  kibanaVersion,
   docLinks,
   feedbackDeps,
 }: ChromeStateDeps): ChromeState {
@@ -101,15 +95,6 @@ export function createChromeState({
 
   // Style
   const style = createChromeStyleState();
-
-  // Body classes
-  const bodyClasses$ = createBodyClassesState({
-    kibanaVersion,
-    headerBanner$: headerBanner.$,
-    isVisible$: visibility.isVisible$,
-    chromeStyle$: style.chromeStyle.$,
-    actionMenu$: application.currentActionMenu$,
-  });
 
   // Side Nav
   const sideNavCollapsed = createPersistedState(IS_SIDENAV_COLLAPSED_KEY, false);
@@ -144,7 +129,6 @@ export function createChromeState({
   return {
     visibility,
     style,
-    bodyClasses$,
     sideNav: {
       collapsed: sideNavCollapsed,
     },

--- a/src/core/packages/chrome/browser-internal/src/state/index.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/index.ts
@@ -21,8 +21,5 @@ export type { FeedbackState, FeedbackStateDeps } from './feedback_state';
 export { createVisibilityState } from './visibility_state';
 export type { VisibilityState, VisibilityStateDeps } from './visibility_state';
 
-export { createBodyClassesState } from './body_classes_state';
-export type { BodyClassesStateDeps } from './body_classes_state';
-
 export { createChromeState } from './chrome_state';
 export type { ChromeState, ChromeStateDeps } from './chrome_state';

--- a/src/core/packages/chrome/browser-internal/src/types.ts
+++ b/src/core/packages/chrome/browser-internal/src/types.ts
@@ -98,13 +98,6 @@ export interface InternalChromeStart extends ChromeStart {
   getSidebarComponent(): JSX.Element;
 
   /**
-   * Used only by the rendering service to retrieve the set of classNames
-   * that will be set on the body element.
-   * @internal
-   */
-  getBodyClasses$(): Observable<string[]>;
-
-  /**
    * Used only by the rendering service to render the global footer UI (devbar)
    * @internal
    */

--- a/src/core/packages/chrome/browser-internal/src/ui/chrome_components.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/chrome_components.tsx
@@ -61,7 +61,6 @@ export interface ChromeComponentsDeps {
   projectNavigation: ProjectNavigationObservables;
   loadingCount$: Observable<number>;
   helpMenuLinks$: Observable<ChromeHelpMenuLink[]>;
-  forceAppSwitcherNavigation$: Observable<boolean>;
   navLinks$: Observable<ChromeNavLink[]>;
   recentlyAccessed$: Observable<RecentlyAccessedHistoryItem[]>;
   customBranding$: CustomBrandingStart['customBranding$'];
@@ -77,7 +76,6 @@ export const createChromeComponents = ({
   state,
   loadingCount$,
   helpMenuLinks$,
-  forceAppSwitcherNavigation$,
   navLinks$,
   recentlyAccessed$,
   navControls,
@@ -98,7 +96,6 @@ export const createChromeComponents = ({
       customNavLink$={state.customNavLink.$}
       kibanaDocLink={config.kibanaDocLink}
       docLinks={docLinks}
-      forceAppSwitcherNavigation$={forceAppSwitcherNavigation$}
       globalHelpExtensionMenuLinks$={state.help.globalMenuLinks.$}
       helpExtension$={state.help.extension.$}
       helpSupportUrl$={state.help.supportUrl.$}

--- a/src/core/packages/chrome/browser-internal/src/ui/chrome_components.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/chrome_components.tsx
@@ -67,7 +67,6 @@ export interface ChromeComponentsDeps {
   customBranding$: CustomBrandingStart['customBranding$'];
   appMenuActions$: InternalApplicationStart['currentActionMenu$'];
   prependBasePath: InternalHttpStart['basePath']['prepend'];
-  reportEvent: (eventType: string, eventData: object) => void;
 }
 
 export const createChromeComponents = ({
@@ -86,7 +85,6 @@ export const createChromeComponents = ({
   appMenuActions$,
   projectNavigation,
   prependBasePath,
-  reportEvent,
 }: ChromeComponentsDeps) => {
   const getClassicHeader = () => (
     <Header
@@ -144,7 +142,6 @@ export const createChromeComponents = ({
     const navProps: NavigationProps = {
       basePath,
       application,
-      reportEvent,
       navigationTree$: projectNavigation.navigationTree$,
       activeNodes$: projectNavigation.activeNodes$,
       navLinks$,

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header.test.tsx
@@ -35,7 +35,6 @@ function mockProps() {
     navLinks$: new BehaviorSubject([]),
     customNavLink$: new BehaviorSubject(undefined),
     recentlyAccessed$: new BehaviorSubject([]),
-    forceAppSwitcherNavigation$: new BehaviorSubject(false),
     globalHelpExtensionMenuLinks$: new BehaviorSubject([]),
     helpExtension$: new BehaviorSubject(undefined),
     helpSupportUrl$: new BehaviorSubject(''),

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header.tsx
@@ -63,7 +63,6 @@ export interface HeaderProps {
   docLinks: DocLinksStart;
   navLinks$: Observable<ChromeNavLink[]>;
   recentlyAccessed$: Observable<ChromeRecentlyAccessedHistoryItem[]>;
-  forceAppSwitcherNavigation$: Observable<boolean>;
   globalHelpExtensionMenuLinks$: Observable<ChromeGlobalHelpExtensionMenuLink[]>;
   helpExtension$: Observable<ChromeHelpExtension | undefined>;
   helpSupportUrl$: Observable<string>;
@@ -127,8 +126,6 @@ export function Header({
                   />,
                   <HeaderLogo
                     href={homeHref}
-                    forceNavigation$={observables.forceAppSwitcherNavigation$}
-                    navLinks$={observables.navLinks$}
                     navigateToApp={application.navigateToApp}
                     loadingCount$={observables.loadingCount$}
                     customBranding$={customBranding$}

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_logo.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_logo.tsx
@@ -12,82 +12,33 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import type { Observable } from 'rxjs';
-import Url from 'url';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
 import type { HttpStart } from '@kbn/core-http-browser';
-import type { ChromeNavLink } from '@kbn/core-chrome-browser';
 import { useEuiTheme } from '@elastic/eui';
 import { ElasticMark } from './elastic_mark';
 import { LoadingIndicator } from '../loading_indicator';
 
-function findClosestAnchor(element: HTMLElement): HTMLAnchorElement | void {
-  let current = element;
-  while (current) {
-    if (current.tagName === 'A') {
-      return current as HTMLAnchorElement;
-    }
-
-    if (!current.parentElement || current.parentElement === document.body) {
-      return undefined;
-    }
-
-    current = current.parentElement;
-  }
-}
-
 function onClick(
   event: React.MouseEvent<HTMLAnchorElement>,
-  forceNavigation: boolean,
-  navLinks: ChromeNavLink[],
   navigateToApp: (appId: string) => void
 ) {
-  const anchor = findClosestAnchor((event as any).nativeEvent.target);
-  if (!anchor) {
-    return;
-  }
-
   if (event.isDefaultPrevented() || event.altKey || event.metaKey || event.ctrlKey) {
     return;
   }
-
-  if (forceNavigation) {
-    const toParsed = Url.parse(anchor.href);
-    const fromParsed = Url.parse(document.location.href);
-    const sameProto = toParsed.protocol === fromParsed.protocol;
-    const sameHost = toParsed.host === fromParsed.host;
-    const samePath = toParsed.path === fromParsed.path;
-
-    if (sameProto && sameHost && samePath) {
-      if (toParsed.hash) {
-        document.location.reload();
-      }
-
-      // event.preventDefault() keeps the browser from seeing the new url as an update
-      // and even setting window.location does not mimic that behavior, so instead
-      // we use stopPropagation() to prevent angular from seeing the click and
-      // starting a digest cycle/attempting to handle it in the router.
-      event.stopPropagation();
-    }
-  } else {
-    navigateToApp('home');
-    event.preventDefault();
-  }
+  navigateToApp('home');
+  event.preventDefault();
 }
 
 interface Props {
   href: string;
-  navLinks$: Observable<ChromeNavLink[]>;
-  forceNavigation$: Observable<boolean>;
   navigateToApp: (appId: string) => void;
   loadingCount$?: ReturnType<HttpStart['getLoadingCount$']>;
   customBranding$: Observable<CustomBranding>;
 }
 
-export function HeaderLogo({ href, navigateToApp, loadingCount$, ...observables }: Props) {
+export function HeaderLogo({ href, navigateToApp, loadingCount$, customBranding$ }: Props) {
   const { euiTheme } = useEuiTheme();
-  const forceNavigation = useObservable(observables.forceNavigation$, false);
-  const navLinks = useObservable(observables.navLinks$, []);
-  const customBranding = useObservable(observables.customBranding$, {});
+  const customBranding = useObservable(customBranding$, {});
   const { customizedLogo, logo } = customBranding;
 
   const styles = {
@@ -105,7 +56,7 @@ export function HeaderLogo({ href, navigateToApp, loadingCount$, ...observables 
 
   return (
     <a
-      onClick={(e) => onClick(e, forceNavigation, navLinks, navigateToApp)}
+      onClick={(e) => onClick(e, navigateToApp)}
       css={styles.logoCss}
       href={href}
       data-test-subj="logo"

--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav/navigation/navigation.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav/navigation/navigation.tsx
@@ -34,7 +34,6 @@ export interface ChromeNavigationProps {
   // kibana deps
   basePath: BasePath;
   application: Pick<ApplicationStart, 'navigateToUrl' | 'currentAppId$'>;
-  reportEvent: (eventType: string, eventData: object) => void;
 
   // nav state
   navigationTree$: Observable<NavigationTreeDefinitionUI>;

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -90,7 +90,6 @@ const createStartContractMock = () => {
     setCustomNavLink: jest.fn(),
     setHeaderBanner: jest.fn(),
     hasHeaderBanner$: jest.fn().mockReturnValue(new BehaviorSubject(false)),
-    getBodyClasses$: jest.fn().mockReturnValue(new BehaviorSubject([])),
     getChromeStyle$: jest.fn().mockReturnValue(new BehaviorSubject('classic')),
     setChromeStyle: jest.fn(),
     getActiveSolutionNavId$: jest.fn(),

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -41,8 +41,6 @@ const createStartContractMock = () => {
       has: jest.fn(),
       get: jest.fn(),
       getAll: jest.fn().mockReturnValue([]),
-      enableForcedAppSwitcherNavigation: jest.fn(),
-      getForceAppSwitcherNavigation$: jest.fn(),
     }),
     recentlyAccessed: lazyObject({
       add: jest.fn(),

--- a/src/core/packages/chrome/browser/src/nav_links.ts
+++ b/src/core/packages/chrome/browser/src/nav_links.ts
@@ -109,5 +109,4 @@ export interface ChromeNavLinks {
    * @param id
    */
   has(id: string): boolean;
-
 }

--- a/src/core/packages/chrome/browser/src/nav_links.ts
+++ b/src/core/packages/chrome/browser/src/nav_links.ts
@@ -110,22 +110,4 @@ export interface ChromeNavLinks {
    */
   has(id: string): boolean;
 
-  /**
-   * Enable forced navigation mode, which will trigger a page refresh
-   * when a nav link is clicked and only the hash is updated.
-   *
-   * @remarks
-   * This is only necessary when rendering the status page in place of another
-   * app, as links to that app will set the current URL and change the hash, but
-   * the routes for the correct are not loaded so nothing will happen.
-   * https://github.com/elastic/kibana/pull/29770
-   *
-   * Used only by status_page plugin
-   */
-  enableForcedAppSwitcherNavigation(): void;
-
-  /**
-   * An observable of the forced app switcher state.
-   */
-  getForceAppSwitcherNavigation$(): Observable<boolean>;
 }

--- a/src/core/packages/rendering/browser-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/browser-internal/src/rendering_service.tsx
@@ -86,7 +86,7 @@ export class RenderingService implements IRenderingService {
     renderCoreDeps: RenderingServiceRenderCoreDeps,
     targetDomElement: HTMLDivElement
   ) {
-    const { chrome, featureFlags } = renderCoreDeps;
+    const { featureFlags } = renderCoreDeps;
     const debugLayout = getLayoutDebugFlag(featureFlags);
 
     const startServices = this.contextDeps.getValue()!;

--- a/src/core/packages/rendering/browser-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/browser-internal/src/rendering_service.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import useObservable from 'react-use/lib/useObservable';
-import { BehaviorSubject, pairwise, startWith } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 import { EuiLoadingSpinner } from '@elastic/eui';
 import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
@@ -90,15 +90,6 @@ export class RenderingService implements IRenderingService {
     const debugLayout = getLayoutDebugFlag(featureFlags);
 
     const startServices = this.contextDeps.getValue()!;
-
-    const body = document.querySelector('body')!;
-    chrome
-      .getBodyClasses$()
-      .pipe(startWith<string[]>([]), pairwise())
-      .subscribe(([previousClasses, newClasses]) => {
-        body.classList.remove(...previousClasses);
-        body.classList.add(...newClasses);
-      });
 
     const layout: LayoutService = new GridLayout(renderCoreDeps, { debug: debugLayout });
 

--- a/src/core/packages/root/browser-internal/src/core_system.ts
+++ b/src/core/packages/root/browser-internal/src/core_system.ts
@@ -378,7 +378,6 @@ export class CoreSystem {
         theme,
         userProfile,
         uiSettings,
-        analytics,
         featureFlags,
       });
       const deprecations = this.deprecations.start({ http });


### PR DESCRIPTION
Part of https://github.com/elastic/kibana-team/issues/2651, 

Noticed some APIs that weren't used and some small fixes and consolidation:

- Drop the unused force app switcher navigation API and its observable
- Move body classes handling directly into the Chrome service to consolidate side effects
- Remove obsolete analytics plumbing
- Remove floating promit from handleColorModeChange