### PR TITLE
[index mgmt] Use esql instead of query dsl to get the index count

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_post_index_doc_count.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_post_index_doc_count.ts
@@ -9,11 +9,6 @@ import { schema } from '@kbn/config-schema';
 import type { RouteDependencies } from '../../../types';
 import { addInternalBasePath } from '..';
 
-interface Bucket {
-  key: string;
-  doc_count: number;
-}
-
 export function registerPostIndexDocCountRoute({
   router,
   lib: { handleEsError },
@@ -38,25 +33,20 @@ export function registerPostIndexDocCountRoute({
       const { indexNames } = request.body;
 
       try {
-        const result = await client.search<unknown, { by_index: { buckets: Bucket[] } }>({
-          index: indexNames,
-          size: 0,
-          aggs: {
-            by_index: {
-              terms: {
-                field: '_index',
-                size: indexNames.length,
-              },
-            },
-          },
+        // use ES since index list is too long for query dsl
+        const result = await client.esql.query({
+          query: `FROM ${indexNames.join(',')} METADATA _index | STATS count() BY _index`,
         });
 
-        const values = (result.aggregations?.by_index.buckets || []).reduce((col, bucket) => {
-          col[bucket.key] = bucket.doc_count;
+        const indexNameIndex = result.columns.findIndex((col) => col.name === '_index');
+        const countIndex = result.columns.findIndex((col) => col.name === 'count()');
+
+        const values = (result.values || []).reduce((col, vals) => {
+          col[vals[indexNameIndex] as string] = vals[countIndex] as number;
           return col;
         }, {} as Record<string, number>);
 
-        // add zeros back in since they won't be present in the agg results
+        // add zeros back in since they won't be present in the results
         indexNames.forEach((indexName) => {
           if (!(indexName in values)) {
             values[indexName] = 0;

--- a/x-pack/platform/test/api_integration/apis/management/index_management/index_doc_count.ts
+++ b/x-pack/platform/test/api_integration/apis/management/index_management/index_doc_count.ts
@@ -14,11 +14,19 @@ import { indicesHelpers } from './lib/indices.helpers';
 export default function ({ getService }: FtrProviderContext) {
   const es = getService('es');
   const supertest = getService('supertest');
+  const esDeleteAllIndices = getService('esDeleteAllIndices');
 
   const { createIndex, deleteAllIndices } = indicesHelpers(getService);
 
   describe('index doc count', () => {
     after(async () => await deleteAllIndices());
+
+    const createIndexNameWithLength = (prefix: string, length: number) => {
+      if (prefix.length > length) {
+        throw new Error(`prefix length (${prefix.length}) exceeds desired length (${length})`);
+      }
+      return `${prefix}${'a'.repeat(length - prefix.length)}`;
+    };
 
     it('returns counts per index and fills missing buckets with 0', async () => {
       const indexA = await createIndex('doc-count-a');
@@ -62,6 +70,42 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body[indices[0]]).to.be(1);
       expect(body[indices[11]]).to.be(1);
       expect(body[indices[5]]).to.be(0);
+    });
+
+    it('supports 255 character index names (20 indices)', async () => {
+      const indices: string[] = [];
+
+      try {
+        indices.push(
+          ...(await Promise.all(
+            Array.from({ length: 20 }, (_, i) => {
+              const suffix = i.toString().padStart(2, '0');
+              const indexName = createIndexNameWithLength(`doc-count-255-${suffix}-`, 255);
+              expect(indexName).to.have.length(255);
+              return createIndex(indexName);
+            })
+          ))
+        );
+
+        await es.bulk({
+          refresh: 'wait_for',
+          operations: indices.flatMap((index, i) => [{ index: { _index: index } }, { foo: i }]),
+        });
+
+        const { body } = await supertest
+          .post(`${INTERNAL_API_BASE_PATH}/index_doc_count`)
+          .set('kbn-xsrf', 'xxx')
+          .send({ indexNames: indices })
+          .expect(200);
+
+        expect(Object.keys(body).length).to.be(indices.length);
+        for (const index of indices) {
+          expect(body[index]).to.be(1);
+        }
+      } finally {
+        // Clean up immediately so this test doesn't leave behind a large number of long-named indices.
+        await esDeleteAllIndices(indices);
+      }
     });
 
     it('validates request body (indexNames must be non-empty)', async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/252409

In some cases the index management index list doc count will show error if the combined length of indices exceeds 4096 bytes. Indices can have names up to 255 chars so this problem could occur on a page size as small as 20.

The solution is to use ESQL instead of query dsl to get the index doc counts since the index list gets passed as part of the query body instead of as part of the url. 

### Release Notes

Fixes problem in 9.3.0 loading the doc count in index management when viewing larger page sizes with long index names.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->