### PR TITLE
[Entity Analytics] Update `host.ip` aggregation to remove painless script

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
@@ -450,11 +450,7 @@ export const formattedSearchStrategyResponse = {
               aggs: { timestamp: { max: { field: '@timestamp' } } },
             },
             host_ip: {
-              terms: {
-                script: { source: "doc['host.ip']", lang: 'painless' },
-                size: 10,
-                order: { timestamp: 'desc' },
-              },
+              terms: { field: 'host.ip', value_type: 'ip', size: 10, order: { timestamp: 'desc' } },
               aggs: { timestamp: { max: { field: '@timestamp' } } },
             },
             host_mac: {
@@ -623,10 +619,8 @@ export const expectedDsl = {
     },
     host_ip: {
       terms: {
-        script: {
-          source: "doc['host.ip']",
-          lang: 'painless',
-        },
+        field: 'host.ip',
+        value_type: 'ip',
         size: 10,
         order: {
           timestamp: 'desc',

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helper.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helper.test.ts
@@ -58,10 +58,8 @@ describe('#Host details search strategy helpers', () => {
         },
         host_ip: {
           terms: {
-            script: {
-              source: "doc['host.ip']",
-              lang: 'painless',
-            },
+            field: 'host.ip',
+            value_type: 'ip',
             size: 10,
             order: {
               timestamp: Direction.desc,

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/helpers.ts
@@ -65,15 +65,8 @@ const getTermsAggregationTypeFromField = (field: string): AggregationRequest => 
     return {
       host_ip: {
         terms: {
-          script: {
-            // We might be able to remove this when PR is fixed in Elasticsearch: https://github.com/elastic/elasticsearch/issues/72276
-            // Currently we cannot use "value_type" with an aggregation when we have a mapping conflict which is why this painless script exists
-            // See public ticket: https://github.com/elastic/kibana/pull/78912
-            // See private ticket: https://github.com/elastic/security-team/issues/333
-            // for more details on the use cases and causes of the conflicts and why this is here.
-            source: "doc['host.ip']",
-            lang: 'painless',
-          },
+          field: 'host.ip',
+          value_type: 'ip',
           size: 10,
           order: {
             timestamp: Direction.desc,

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/index.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/index.test.ts.snap
@@ -78,10 +78,8 @@ Object {
     },
     \\"host_ip\\": {
       \\"terms\\": {
-        \\"script\\": {
-          \\"source\\": \\"doc['host.ip']\\",
-          \\"lang\\": \\"painless\\"
-        },
+        \\"field\\": \\"host.ip\\",
+        \\"value_type\\": \\"ip\\",
         \\"size\\": 10,
         \\"order\\": {
           \\"timestamp\\": \\"desc\\"

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/query.observed_user_details.dsl.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/query.observed_user_details.dsl.test.ts.snap
@@ -12,14 +12,12 @@ Object {
         },
       },
       "terms": Object {
+        "field": "host.ip",
         "order": Object {
           "timestamp": "desc",
         },
-        "script": Object {
-          "lang": "painless",
-          "source": "doc['host.ip']",
-        },
         "size": 10,
+        "value_type": "ip",
       },
     },
     "host_os_family": Object {


### PR DESCRIPTION
## Summary

The original reason for introducing this painless script into the `host.ip` aggregation was because the normal aggregation would fail when aggregating over data where the `host.ip` field had a mixed mapping (mapped as `keyword` in one index and `ip` in another). With the introduction of the `value_type` specification in Elasticsearch, we can now choose which value type to use when there are conflicts. This PR removes the inefficient painless script in the `host.ip` aggregation for the standard terms agg with a `value_type` specification.

## To Verify

**Verify that the host and user flyouts show aggregated IP information**
1. Start ES and Kibana and load some entity data that includes `host.ip` info
2. Open the host and user flyouts from the Explore and verify that IP information is populated in the observed details

**To recreate the original problem:**

1. Start ES and Kibana and go to the Dev Console
2. Create 2 indices with `host.ip` and `timestamp` fields. Notice one index has `host.ip` mapped as a `keyword` and one has `host.ip` mapped as `ip`. Index some documents

<details>
<summary> Dev Console Commands </summary>

```
PUT hosts-keyword
{
  "mappings": {
    "properties": {
      "host.ip": {
        "type": "keyword"
      },
      "timestamp": {
        "type": "date"
      }
    }
  }
}

POST hosts-keyword/_bulk
{"index":{}}
{"host.ip":"192.168.1.1","timestamp":"2025-02-09T10:00:00Z"}
{"index":{}}
{"host.ip":"10.0.0.5","timestamp":"2025-02-09T10:01:00Z"}
{"index":{}}
{"host.ip":"172.16.0.100","timestamp":"2025-02-09T10:02:00Z"}
{"index":{}}
{"host.ip":"192.168.2.50","timestamp":"2025-02-09T10:03:00Z"}
{"index":{}}
{"host.ip":"10.0.1.20","timestamp":"2025-02-09T10:04:00Z"}
{"index":{}}
{"host.ip":"203.0.113.42","timestamp":"2025-02-09T10:05:00Z"}
{"index":{}}
{"host.ip":"198.51.100.10","timestamp":"2025-02-09T10:06:00Z"}
{"index":{}}
{"host.ip":"192.168.0.1","timestamp":"2025-02-09T10:07:00Z"}
{"index":{}}
{"host.ip":"10.10.10.10","timestamp":"2025-02-09T10:08:00Z"}
{"index":{}}
{"host.ip":"172.31.255.1","timestamp":"2025-02-09T10:09:00Z"}

PUT hosts-ip
{
  "mappings": {
    "properties": {
      "host.ip": {
        "type": "ip"
      },
      "timestamp": {
        "type": "date"
      }
    }
  }
}

POST hosts-ip/_bulk
{"index":{}}
{"host.ip":"192.168.1.1","timestamp":"2025-02-09T10:00:00Z"}
{"index":{}}
{"host.ip":"10.0.0.5","timestamp":"2025-02-09T10:01:00Z"}
{"index":{}}
{"host.ip":"172.16.0.100","timestamp":"2025-02-09T10:02:00Z"}
{"index":{}}
{"host.ip":"192.168.2.50","timestamp":"2025-02-09T10:03:00Z"}
{"index":{}}
{"host.ip":"10.0.1.20","timestamp":"2025-02-09T10:04:00Z"}
{"index":{}}
{"host.ip":"203.0.113.42","timestamp":"2025-02-09T10:05:00Z"}
{"index":{}}
{"host.ip":"198.51.100.10","timestamp":"2025-02-09T10:06:00Z"}
{"index":{}}
{"host.ip":"192.168.0.1","timestamp":"2025-02-09T10:07:00Z"}
{"index":{}}
{"host.ip":"10.10.10.10","timestamp":"2025-02-09T10:08:00Z"}
{"index":{}}
{"host.ip":"172.31.255.1","timestamp":"2025-02-09T10:09:00Z"}
```
</details>

3. Try a normal terms aggregation against these two indices. You should see the aggregation fail and an error in the Elasticsearch logs:

```
GET hosts-ip,hosts-keyword/_search
{
  "size": 0,
  "aggs": {
    "host_ip": {
      "terms": {
        "field":"host.ip",
        "size": 10,
        "order": {
          "timestamp": "desc"
        }
      },
      "aggs": {
        "timestamp": {
          "max": {
            "field": "timestamp"
          }
        }
      }
    }
  }
}
```

```
java.lang.IllegalArgumentException: Failed trying to format bytes as IP address.  Possibly caused by a mapping mismatch
```

4. Add `value_type` to the terms aggregation. You should see the aggregation response with a shard failure indicating an illegal argument exception, but the aggregation should be performed over the correctly `ip` mapped data

```
GET hosts-ip,hosts-keyword/_search
{
  "size": 0,
  "aggs":{
    "host_ip": {
      "terms": {
        "field":"host.ip",
        "value_type": "ip",
        "size": 10,
        "order": {
          "timestamp": "desc"
        }
      },
      "aggs": {
        "timestamp": {
          "max": {
            "field": "timestamp"
          }
        }
      }
    }
  }
}
```

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->