### PR TITLE
[Security Solution] modifying user and host flyouts to fetch observed data only when expanding the section

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/components/observed_data_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/components/observed_data_section.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiAccordion, EuiTitle, useEuiFontSize, useEuiTheme } from '@elastic/eui';
+
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { hostToCriteria } from '../../../../common/components/ml/criteria/host_to_criteria';
+import { useGlobalTime } from '../../../../common/containers/use_global_time';
+import { useInstalledSecurityJobNameById } from '../../../../common/components/ml/hooks/use_installed_security_jobs';
+import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
+import { ONE_WEEK_IN_HOURS } from '../../shared/constants';
+import { ObservedEntity } from '../../shared/components/observed_entity';
+import { useObservedHost } from '../hooks/use_observed_host';
+import { useObservedHostFields } from '../hooks/use_observed_host_fields';
+import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
+import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
+import type { HostItem } from '../../../../../common/search_strategy';
+import { useAnomaliesTableData } from '../../../../common/components/ml/anomaly/use_anomalies_table_data';
+
+const CLOSED = 'closed' as const;
+const OPEN = 'open' as const;
+
+export const ObservedDataSection = memo(
+  ({
+    setLastSeenDate,
+    hostName,
+    contextID,
+    scopeId,
+    queryId,
+  }: {
+    setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>;
+    hostName: string;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+  }) => {
+    const { euiTheme } = useEuiTheme();
+
+    const [expandedState, setExpandedState] = useState<typeof CLOSED | typeof OPEN>(CLOSED);
+    const renderContent = expandedState === OPEN;
+    const onToggle = useCallback(
+      (isOpen: boolean) => setExpandedState(isOpen ? OPEN : CLOSED),
+      [setExpandedState]
+    );
+
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [extraAction, setExtraAction] = useState<ReactElement | null | undefined>(null);
+
+    const buttonContent = (
+      <EuiTitle size="xs">
+        <h3>
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.entityDetails.observedDataTitle"
+            defaultMessage="Observed data"
+          />
+        </h3>
+      </EuiTitle>
+    );
+
+    return (
+      <InspectButtonContainer>
+        <EuiAccordion
+          onToggle={onToggle}
+          initialIsOpen={false}
+          isLoading={isLoading}
+          id="observedEntity-accordion"
+          data-test-subj="observedEntity-accordion"
+          buttonProps={{
+            'data-test-subj': 'observedEntity-accordion-button',
+            css: css`
+              color: ${euiTheme.colors.primary};
+            `,
+          }}
+          buttonContent={buttonContent}
+          extraAction={extraAction}
+          css={css`
+            .euiAccordion__optionalAction {
+              margin-left: auto;
+            }
+          `}
+        >
+          {renderContent && (
+            <ObservedDataSectionContent
+              setLastSeenDate={setLastSeenDate}
+              hostName={hostName}
+              contextID={contextID}
+              scopeId={scopeId}
+              queryId={queryId}
+              setIsLoading={setIsLoading}
+              setExtraAction={setExtraAction}
+            />
+          )}
+        </EuiAccordion>
+      </InspectButtonContainer>
+    );
+  }
+);
+ObservedDataSection.displayName = 'ObservedDataSection';
+
+const ObservedDataSectionContent = memo(
+  ({
+    setLastSeenDate,
+    hostName,
+    contextID,
+    scopeId,
+    queryId,
+    setIsLoading,
+    setExtraAction,
+  }: {
+    setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>;
+    hostName: string;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+    setIsLoading: Dispatch<SetStateAction<boolean>>;
+    setExtraAction: Dispatch<SetStateAction<ReactElement | null | undefined>>;
+  }) => {
+    const { to, from, isInitializing } = useGlobalTime();
+
+    const observedHost = useObservedHost(hostName, scopeId, setLastSeenDate);
+
+    const { jobNameById } = useInstalledSecurityJobNameById();
+    const jobIds = useMemo(() => Object.keys(jobNameById), [jobNameById]);
+    const [isLoadingAnomaliesData, anomaliesData] = useAnomaliesTableData({
+      criteriaFields: hostToCriteria(observedHost.details),
+      startDate: from,
+      endDate: to,
+      skip: isInitializing,
+      jobIds,
+      aggregationInterval: 'auto',
+    });
+
+    setIsLoading(isLoadingAnomaliesData);
+
+    const observedHostWithAnomalies: ObservedEntityData<HostItem> = {
+      ...observedHost,
+      anomalies: {
+        isLoading: isLoadingAnomaliesData,
+        anomalies: anomaliesData,
+        jobNameById,
+      },
+    };
+    const observedFields = useObservedHostFields(observedHostWithAnomalies);
+
+    const { euiTheme } = useEuiTheme();
+    const xsFontSize = useEuiFontSize('xxs').fontSize;
+
+    setExtraAction(
+      <>
+        <span
+          css={css`
+            margin-right: ${euiTheme.size.s};
+          `}
+        >
+          <InspectButton
+            queryId={queryId}
+            title={
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.entityDetails.observedDataInspectTitle"
+                defaultMessage="Observed data"
+              />
+            }
+          />
+        </span>
+        {observedHost.lastSeen.date && (
+          <span
+            css={css`
+              font-size: ${xsFontSize};
+            `}
+          >
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.entityDetails.observedEntityUpdatedTime"
+              defaultMessage="Updated {time}"
+              values={{
+                time: (
+                  <FormattedRelativePreferenceDate
+                    value={observedHost.lastSeen.date}
+                    dateFormat="MMM D, YYYY"
+                    relativeThresholdInHrs={ONE_WEEK_IN_HOURS}
+                  />
+                ),
+              }}
+            />
+          </span>
+        )}
+      </>
+    );
+
+    return (
+      <ObservedEntity
+        observedData={observedHostWithAnomalies}
+        contextID={contextID}
+        scopeId={scopeId}
+        observedFields={observedFields}
+      />
+    );
+  }
+);
+ObservedDataSectionContent.displayName = 'ObservedDataSectionContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
+import type { Dispatch, SetStateAction } from 'react';
 import React from 'react';
 import { EuiHorizontalRule } from '@elastic/eui';
+import { ObservedDataSection } from './components/observed_data_section';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { EntityHighlightsAccordion } from '../../../entity_analytics/components/entity_details_flyout/components/entity_highlights';
 import { FlyoutBody } from '../../shared/components/flyout_body';
@@ -15,15 +17,10 @@ import { AssetCriticalityAccordion } from '../../../entity_analytics/components/
 import { FlyoutRiskSummary } from '../../../entity_analytics/components/risk_summary_flyout/risk_summary';
 import type { RiskScoreState } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { EntityIdentifierFields, EntityType } from '../../../../common/entity_analytics/types';
-import type { HostItem } from '../../../../common/search_strategy';
-import { ObservedEntity } from '../shared/components/observed_entity';
 import { HOST_PANEL_OBSERVED_HOST_QUERY_ID, HOST_PANEL_RISK_SCORE_QUERY_ID } from '.';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
-import { useObservedHostFields } from './hooks/use_observed_host_fields';
 import type { EntityDetailsPath } from '../shared/components/left_panel/left_panel_header';
 
 interface HostPanelContentProps {
-  observedHost: ObservedEntityData<HostItem>;
   riskScoreState: RiskScoreState<EntityType.host>;
   contextID: string;
   scopeId: string;
@@ -32,11 +29,12 @@ interface HostPanelContentProps {
   onAssetCriticalityChange: () => void;
   recalculatingScore: boolean;
   isPreviewMode: boolean;
+  setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>;
 }
 
 export const HostPanelContent = ({
+  setLastSeenDate,
   hostName,
-  observedHost,
   riskScoreState,
   recalculatingScore,
   contextID,
@@ -45,8 +43,6 @@ export const HostPanelContent = ({
   onAssetCriticalityChange,
   isPreviewMode,
 }: HostPanelContentProps) => {
-  const observedFields = useObservedHostFields(observedHost);
-
   const isEntityDetailsHighlightsAIEnabled = useIsExperimentalFeatureEnabled(
     'entityDetailsHighlightsEnabled'
   );
@@ -79,11 +75,11 @@ export const HostPanelContent = ({
         isPreviewMode={isPreviewMode}
         openDetailsPanel={openDetailsPanel}
       />
-      <ObservedEntity
-        observedData={observedHost}
+      <ObservedDataSection
+        setLastSeenDate={setLastSeenDate}
+        hostName={hostName}
         contextID={contextID}
         scopeId={scopeId}
-        observedFields={observedFields}
         queryId={HOST_PANEL_OBSERVED_HOST_QUERY_ID}
       />
     </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.tsx
@@ -5,33 +5,33 @@
  * 2.0.
  */
 
-import { EuiSpacer, EuiBadge, EuiText, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useMemo } from 'react';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import type { HostItem } from '../../../../common/search_strategy';
 import { getHostDetailsUrl } from '../../../common/components/link_to';
 import { SecuritySolutionLinkAnchor } from '../../../common/components/links';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
 import { FlyoutHeader } from '../../shared/components/flyout_header';
 import { FlyoutTitle } from '../../shared/components/flyout_title';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
 
 interface HostPanelHeaderProps {
   hostName: string;
-  observedHost: ObservedEntityData<HostItem>;
+  lastSeenDate: string | null | undefined;
 }
 
 const linkTitleCSS = { width: 'fit-content' };
 
 const urlParamOverride = { timeline: { isOpen: false } };
 
-export const HostPanelHeader = ({ hostName, observedHost }: HostPanelHeaderProps) => {
+export const HostPanelHeader = ({
+  hostName,
+  lastSeenDate: observedUserLastSeenDate,
+}: HostPanelHeaderProps) => {
   const lastSeenDate = useMemo(
-    () => observedHost.lastSeen.date && new Date(observedHost.lastSeen.date),
-    [observedHost.lastSeen.date]
+    () => observedUserLastSeenDate && new Date(observedUserLastSeenDate),
+    [observedUserLastSeenDate]
   );
-
   return (
     <FlyoutHeader data-test-subj="host-panel-header">
       <EuiFlexGroup gutterSize="s" responsive={false} direction="column">
@@ -56,7 +56,7 @@ export const HostPanelHeader = ({ hostName, observedHost }: HostPanelHeaderProps
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
-              {observedHost.lastSeen.date && (
+              {lastSeenDate && (
                 <EuiBadge data-test-subj="host-panel-header-observed-badge" color="hollow">
                   <FormattedMessage
                     id="xpack.securitySolution.flyout.entityDetails.host.observedBadge"

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useMemo } from 'react';
+import { type Dispatch, type SetStateAction, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { inputsSelectors, sourcererSelectors } from '../../../../common/store';
@@ -23,7 +23,8 @@ import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_ex
 
 export const useObservedHost = (
   hostName: string,
-  scopeId: string
+  scopeId: string,
+  setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>
 ): Omit<ObservedEntityData<HostItem>, 'anomalies'> => {
   const timelineTime = useDeepEqualSelector((state) =>
     inputsSelectors.timelineTimeRangeSelector(state)
@@ -74,6 +75,8 @@ export const useObservedHost = (
     order: Direction.desc,
     filterQuery: NOT_EVENT_KIND_ASSET_FILTER,
   });
+
+  setLastSeenDate(firstSeen);
 
   return useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/observed_entity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/observed_entity/index.tsx
@@ -5,16 +5,12 @@
  * 2.0.
  */
 
-import { EuiAccordion, EuiSpacer, EuiTitle, useEuiFontSize, useEuiTheme } from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
 
 import React from 'react';
-import { css } from '@emotion/react';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { EntityTable } from '../entity_table';
-import { FormattedRelativePreferenceDate } from '../../../../../common/components/formatted_date';
-import { InspectButton, InspectButtonContainer } from '../../../../../common/components/inspect';
+import { InspectButtonContainer } from '../../../../../common/components/inspect';
 import type { EntityTableRows } from '../entity_table/types';
-import { ONE_WEEK_IN_HOURS } from '../../constants';
 import type { ObservedEntityData } from './types';
 
 export const ObservedEntity = <T,>({
@@ -22,96 +18,21 @@ export const ObservedEntity = <T,>({
   contextID,
   scopeId,
   observedFields,
-  queryId,
 }: {
   observedData: ObservedEntityData<T>;
   contextID: string;
   scopeId: string;
   observedFields: EntityTableRows<ObservedEntityData<T>>;
-  queryId: string;
 }) => {
-  const { euiTheme } = useEuiTheme();
-  const xsFontSize = useEuiFontSize('xxs').fontSize;
-
   return (
-    <>
-      <InspectButtonContainer>
-        <EuiAccordion
-          initialIsOpen={true}
-          isLoading={observedData.isLoading}
-          id="observedEntity-accordion"
-          data-test-subj="observedEntity-accordion"
-          buttonProps={{
-            'data-test-subj': 'observedEntity-accordion-button',
-            css: css`
-              color: ${euiTheme.colors.primary};
-            `,
-          }}
-          buttonContent={
-            <EuiTitle size="xs">
-              <h3>
-                <FormattedMessage
-                  id="xpack.securitySolution.flyout.entityDetails.observedDataTitle"
-                  defaultMessage="Observed data"
-                />
-              </h3>
-            </EuiTitle>
-          }
-          extraAction={
-            <>
-              <span
-                css={css`
-                  margin-right: ${euiTheme.size.s};
-                `}
-              >
-                <InspectButton
-                  queryId={queryId}
-                  title={
-                    <FormattedMessage
-                      id="xpack.securitySolution.flyout.entityDetails.observedDataInspectTitle"
-                      defaultMessage="Observed data"
-                    />
-                  }
-                />
-              </span>
-              {observedData.lastSeen.date && (
-                <span
-                  css={css`
-                    font-size: ${xsFontSize};
-                  `}
-                >
-                  <FormattedMessage
-                    id="xpack.securitySolution.flyout.entityDetails.observedEntityUpdatedTime"
-                    defaultMessage="Updated {time}"
-                    values={{
-                      time: (
-                        <FormattedRelativePreferenceDate
-                          value={observedData.lastSeen.date}
-                          dateFormat="MMM D, YYYY"
-                          relativeThresholdInHrs={ONE_WEEK_IN_HOURS}
-                        />
-                      ),
-                    }}
-                  />
-                </span>
-              )}
-            </>
-          }
-          css={css`
-            .euiAccordion__optionalAction {
-              margin-left: auto;
-            }
-          `}
-        >
-          <EuiSpacer size="m" />
-          <EntityTable
-            contextID={contextID}
-            scopeId={scopeId}
-            data={observedData}
-            entityFields={observedFields}
-          />
-        </EuiAccordion>
-      </InspectButtonContainer>
-    </>
+    <InspectButtonContainer>
+      <EuiSpacer size="m" />
+      <EntityTable
+        contextID={contextID}
+        scopeId={scopeId}
+        data={observedData}
+        entityFields={observedFields}
+      />
+    </InspectButtonContainer>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/index.tsx
@@ -19,7 +19,6 @@ import { LeftPanelContent } from '../shared/components/left_panel/left_panel_con
 
 interface UserParam {
   name: string;
-  email: string[];
 }
 
 export interface UserDetailsPanelProps extends Record<string, unknown> {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/observed_data_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/observed_data_section.tsx
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiAccordion, EuiTitle, useEuiFontSize, useEuiTheme } from '@elastic/eui';
+
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useInstalledSecurityJobNameById } from '../../../../common/components/ml/hooks/use_installed_security_jobs';
+import { ONE_WEEK_IN_HOURS } from '../../shared/constants';
+import { ObservedEntity } from '../../shared/components/observed_entity';
+import { useObservedUser } from '../hooks/use_observed_user';
+import { useObservedUserItems } from '../hooks/use_observed_user_items';
+import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
+import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
+import { useAnomaliesTableData } from '../../../../common/components/ml/anomaly/use_anomalies_table_data';
+import { useGlobalTime } from '../../../../common/containers/use_global_time';
+import { getCriteriaFromUsersType } from '../../../../common/components/ml/criteria/get_criteria_from_users_type';
+import { UsersType } from '../../../../explore/users/store/model';
+
+const CLOSED = 'closed' as const;
+const OPEN = 'open' as const;
+
+export const ObservedDataSection = memo(
+  ({
+    setLastSeenDate,
+    userName,
+    contextID,
+    scopeId,
+    queryId,
+  }: {
+    setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>;
+    userName: string;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+  }) => {
+    const { euiTheme } = useEuiTheme();
+
+    const [expandedState, setExpandedState] = useState<typeof CLOSED | typeof OPEN>(CLOSED);
+    const renderContent = expandedState === OPEN;
+    const onToggle = useCallback(
+      (isOpen: boolean) => setExpandedState(isOpen ? OPEN : CLOSED),
+      [setExpandedState]
+    );
+
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [extraAction, setExtraAction] = useState<ReactElement | null | undefined>(null);
+
+    const buttonContent = (
+      <EuiTitle size="xs">
+        <h3>
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.entityDetails.observedDataTitle"
+            defaultMessage="Observed data"
+          />
+        </h3>
+      </EuiTitle>
+    );
+
+    return (
+      <InspectButtonContainer>
+        <EuiAccordion
+          onToggle={onToggle}
+          initialIsOpen={false}
+          isLoading={isLoading}
+          id="observedEntity-accordion"
+          data-test-subj="observedEntity-accordion"
+          buttonProps={{
+            'data-test-subj': 'observedEntity-accordion-button',
+            css: css`
+              color: ${euiTheme.colors.primary};
+            `,
+          }}
+          buttonContent={buttonContent}
+          extraAction={extraAction}
+          css={css`
+            .euiAccordion__optionalAction {
+              margin-left: auto;
+            }
+          `}
+        >
+          {renderContent && (
+            <ObservedDataSectionContent
+              setLastSeenDate={setLastSeenDate}
+              userName={userName}
+              contextID={contextID}
+              scopeId={scopeId}
+              queryId={queryId}
+              setIsLoading={setIsLoading}
+              setExtraAction={setExtraAction}
+            />
+          )}
+        </EuiAccordion>
+      </InspectButtonContainer>
+    );
+  }
+);
+ObservedDataSection.displayName = 'ObservedDataSection';
+
+const ObservedDataSectionContent = memo(
+  ({
+    setLastSeenDate,
+    userName,
+    contextID,
+    scopeId,
+    queryId,
+    setIsLoading,
+    setExtraAction,
+  }: {
+    setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>;
+    userName: string;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+    setIsLoading: Dispatch<SetStateAction<boolean>>;
+    setExtraAction: Dispatch<SetStateAction<ReactElement | null | undefined>>;
+  }) => {
+    const { to, from, isInitializing } = useGlobalTime();
+
+    const observedUser = useObservedUser(userName, scopeId, setLastSeenDate);
+
+    const { jobNameById } = useInstalledSecurityJobNameById();
+    const jobIds = useMemo(() => Object.keys(jobNameById), [jobNameById]);
+    const [isLoadingAnomaliesData, anomaliesData] = useAnomaliesTableData({
+      criteriaFields: getCriteriaFromUsersType(UsersType.details, userName),
+      startDate: from,
+      endDate: to,
+      skip: isInitializing,
+      jobIds,
+      aggregationInterval: 'auto',
+    });
+
+    setIsLoading(isLoadingAnomaliesData);
+
+    const observedUserWithAnomalies = {
+      ...observedUser,
+      anomalies: {
+        isLoading: isLoadingAnomaliesData,
+        anomalies: anomaliesData,
+        jobNameById,
+      },
+    };
+    const observedFields = useObservedUserItems(observedUserWithAnomalies);
+
+    const { euiTheme } = useEuiTheme();
+    const xsFontSize = useEuiFontSize('xxs').fontSize;
+
+    setExtraAction(
+      <>
+        <span
+          css={css`
+            margin-right: ${euiTheme.size.s};
+          `}
+        >
+          <InspectButton
+            queryId={queryId}
+            title={
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.entityDetails.observedDataInspectTitle"
+                defaultMessage="Observed data"
+              />
+            }
+          />
+        </span>
+        {observedUser.lastSeen.date && (
+          <span
+            css={css`
+              font-size: ${xsFontSize};
+            `}
+          >
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.entityDetails.observedEntityUpdatedTime"
+              defaultMessage="Updated {time}"
+              values={{
+                time: (
+                  <FormattedRelativePreferenceDate
+                    value={observedUser.lastSeen.date}
+                    dateFormat="MMM D, YYYY"
+                    relativeThresholdInHrs={ONE_WEEK_IN_HOURS}
+                  />
+                ),
+              }}
+            />
+          </span>
+        )}
+      </>
+    );
+
+    return (
+      <ObservedEntity
+        observedData={observedUserWithAnomalies}
+        contextID={contextID}
+        scopeId={scopeId}
+        observedFields={observedFields}
+      />
+    );
+  }
+);
+ObservedDataSectionContent.displayName = 'ObservedDataSectionContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -6,10 +6,10 @@
  */
 
 import { EuiHorizontalRule } from '@elastic/eui';
-import React from 'react';
+import React, { type Dispatch, type SetStateAction } from 'react';
+import { ObservedDataSection } from './components/observed_data_section';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { EntityHighlightsAccordion } from '../../../entity_analytics/components/entity_details_flyout/components/entity_highlights';
-import type { UserItem } from '../../../../common/search_strategy';
 import { AssetCriticalityAccordion } from '../../../entity_analytics/components/asset_criticality/asset_criticality_selector';
 import { OBSERVED_USER_QUERY_ID } from '../../../explore/users/containers/users/observed_details';
 import { FlyoutRiskSummary } from '../../../entity_analytics/components/risk_summary_flyout/risk_summary';
@@ -17,15 +17,11 @@ import type { RiskScoreState } from '../../../entity_analytics/api/hooks/use_ris
 import { EntityIdentifierFields, EntityType } from '../../../../common/entity_analytics/types';
 import { USER_PANEL_RISK_SCORE_QUERY_ID } from '.';
 import { FlyoutBody } from '../../shared/components/flyout_body';
-import { ObservedEntity } from '../shared/components/observed_entity';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
-import { useObservedUserItems } from './hooks/use_observed_user_items';
 import type { EntityDetailsPath } from '../shared/components/left_panel/left_panel_header';
 import { EntityInsight } from '../../../cloud_security_posture/components/entity_insight';
 
 interface UserPanelContentProps {
   userName: string;
-  observedUser: ObservedEntityData<UserItem>;
   riskScoreState: RiskScoreState<EntityType.user>;
   recalculatingScore: boolean;
   contextID: string;
@@ -33,11 +29,12 @@ interface UserPanelContentProps {
   onAssetCriticalityChange: () => void;
   openDetailsPanel: (path: EntityDetailsPath) => void;
   isPreviewMode: boolean;
+  setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>;
 }
 
 export const UserPanelContent = ({
+  setLastSeenDate,
   userName,
-  observedUser,
   riskScoreState,
   recalculatingScore,
   contextID,
@@ -46,8 +43,6 @@ export const UserPanelContent = ({
   onAssetCriticalityChange,
   isPreviewMode,
 }: UserPanelContentProps) => {
-  const observedFields = useObservedUserItems(observedUser);
-
   const isEntityDetailsHighlightsAIEnabled = useIsExperimentalFeatureEnabled(
     'entityDetailsHighlightsEnabled'
   );
@@ -80,11 +75,11 @@ export const UserPanelContent = ({
         isPreviewMode={isPreviewMode}
         openDetailsPanel={openDetailsPanel}
       />
-      <ObservedEntity
-        observedData={observedUser}
+      <ObservedDataSection
+        setLastSeenDate={setLastSeenDate}
+        userName={userName}
         contextID={contextID}
         scopeId={scopeId}
-        observedFields={observedFields}
         queryId={OBSERVED_USER_QUERY_ID}
       />
       <EuiHorizontalRule margin="m" />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/header.tsx
@@ -11,18 +11,16 @@ import React, { useMemo } from 'react';
 import { max } from 'lodash/fp';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
 import type { ManagedUserData } from '../shared/hooks/use_managed_user';
-import type { UserItem } from '../../../../common/search_strategy';
 import { ManagedUserDatasetKey } from '../../../../common/search_strategy/security_solution/users/managed_details';
 import { getUsersDetailsUrl } from '../../../common/components/link_to/redirect_to_users';
 import { SecuritySolutionLinkAnchor } from '../../../common/components/links';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
 import { FlyoutHeader } from '../../shared/components/flyout_header';
 import { FlyoutTitle } from '../../shared/components/flyout_title';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
 
 interface UserPanelHeaderProps {
   userName: string;
-  observedUser: ObservedEntityData<UserItem>;
+  lastSeenDate: string | null | undefined;
   managedUser: ManagedUserData;
 }
 
@@ -30,7 +28,11 @@ const linkTitleCSS = { width: 'fit-content' };
 
 const urlParamOverride = { timeline: { isOpen: false } };
 
-export const UserPanelHeader = ({ userName, observedUser, managedUser }: UserPanelHeaderProps) => {
+export const UserPanelHeader = ({
+  userName,
+  lastSeenDate: observedUserLastSeenDate,
+  managedUser,
+}: UserPanelHeaderProps) => {
   const oktaTimestamp = managedUser.data?.[ManagedUserDatasetKey.OKTA]?.fields?.[
     '@timestamp'
   ][0] as string | undefined;
@@ -42,9 +44,9 @@ export const UserPanelHeader = ({ userName, observedUser, managedUser }: UserPan
   const lastSeenDate = useMemo(
     () =>
       max(
-        [observedUser.lastSeen.date, entraTimestamp, oktaTimestamp].map((el) => el && new Date(el))
+        [observedUserLastSeenDate, entraTimestamp, oktaTimestamp].map((el) => el && new Date(el))
       ),
-    [oktaTimestamp, entraTimestamp, observedUser.lastSeen]
+    [oktaTimestamp, entraTimestamp, observedUserLastSeenDate]
   );
 
   return (
@@ -71,7 +73,7 @@ export const UserPanelHeader = ({ userName, observedUser, managedUser }: UserPan
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
-              {observedUser.lastSeen.date && (
+              {observedUserLastSeenDate && (
                 <EuiBadge data-test-subj="user-panel-header-observed-badge" color="hollow">
                   <FormattedMessage
                     id="xpack.securitySolution.flyout.entityDetails.user.observedBadge"

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.ts
@@ -27,7 +27,6 @@ interface UseNavigateToUserDetailsParams {
 
 export const useNavigateToUserDetails = ({
   userName,
-  email,
   scopeId,
   contextID,
   isRiskScoreExist,
@@ -51,7 +50,6 @@ export const useNavigateToUserDetails = ({
           scopeId,
           user: {
             name: userName,
-            email,
           },
           path,
           hasMisconfigurationFindings,
@@ -80,7 +78,6 @@ export const useNavigateToUserDetails = ({
       isRiskScoreExist,
       scopeId,
       userName,
-      email,
       hasMisconfigurationFindings,
       hasNonClosedAlerts,
       isPreviewMode,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useMemo } from 'react';
+import { type Dispatch, type SetStateAction, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { inputsSelectors } from '../../../../common/store';
@@ -23,7 +23,8 @@ import { sourcererSelectors } from '../../../../sourcerer/store';
 
 export const useObservedUser = (
   userName: string,
-  scopeId: string
+  scopeId: string,
+  setLastSeenDate: Dispatch<SetStateAction<string | null | undefined>>
 ): Omit<ObservedEntityData<UserItem>, 'anomalies'> => {
   const timelineTime = useDeepEqualSelector((state) =>
     inputsSelectors.timelineTimeRangeSelector(state)
@@ -74,6 +75,8 @@ export const useObservedUser = (
     order: Direction.desc,
     filterQuery: NOT_EVENT_KIND_ASSET_FILTER,
   });
+
+  setLastSeenDate(firstSeen);
 
   return useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
 import { TableId } from '@kbn/securitysolution-data-table';
@@ -18,17 +18,12 @@ import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score
 import { ManagedUserDatasetKey } from '../../../../common/search_strategy/security_solution/users/managed_details';
 import { useManagedUser } from '../shared/hooks/use_managed_user';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
-import { UsersType } from '../../../explore/users/store/model';
-import { getCriteriaFromUsersType } from '../../../common/components/ml/criteria/get_criteria_from_users_type';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
-import { AnomalyTableProvider } from '../../../common/components/ml/anomaly/anomaly_table_provider';
 import { buildUserNamesFilter } from '../../../../common/search_strategy';
-import { FlyoutLoading } from '../../shared/components/flyout_loading';
 import { FlyoutNavigation } from '../../shared/components/flyout_navigation';
 import { UserPanelFooter } from './footer';
 import { UserPanelContent } from './content';
 import { UserPanelHeader } from './header';
-import { useObservedUser } from './hooks/use_observed_user';
 import { EntityDetailsLeftPanelTab } from '../shared/components/left_panel/left_panel_header';
 import { UserPreviewPanelFooter } from '../user_preview/footer';
 import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../../overview/components/detection_response/alerts_by_status/types';
@@ -78,10 +73,10 @@ export const UserPanel = ({
   });
 
   const { inspect, refetch, loading } = riskScoreState;
-  const { to, from, isInitializing, setQuery, deleteQuery } = useGlobalTime();
+  const { to, from, setQuery, deleteQuery } = useGlobalTime();
 
-  const observedUser = useObservedUser(userName, scopeId);
-  const email = observedUser.details.user?.email;
+  const [lastSeenDate, setLastSeenDate] = useState<string | null | undefined>(null);
+
   const managedUser = useManagedUser();
 
   const { data: userRisk } = riskScoreState;
@@ -121,7 +116,6 @@ export const UserPanel = ({
 
   const openDetailsPanel = useNavigateToUserDetails({
     userName,
-    email,
     scopeId,
     contextID,
     isRiskScoreExist,
@@ -145,60 +139,31 @@ export const UserPanel = ({
     !!managedUser.data?.[ManagedUserDatasetKey.OKTA] ||
     !!managedUser.data?.[ManagedUserDatasetKey.ENTRA];
 
-  if (observedUser.isLoading) {
-    return <FlyoutLoading />;
-  }
-
   return (
-    <AnomalyTableProvider
-      criteriaFields={getCriteriaFromUsersType(UsersType.details, userName)}
-      startDate={from}
-      endDate={to}
-      skip={isInitializing}
-    >
-      {({ isLoadingAnomaliesData, anomaliesData, jobNameById }) => {
-        const observedUserWithAnomalies = {
-          ...observedUser,
-          anomalies: {
-            isLoading: isLoadingAnomaliesData,
-            anomalies: anomaliesData,
-            jobNameById,
-          },
-        };
-        return (
-          <>
-            <FlyoutNavigation
-              flyoutIsExpandable={
-                hasUserDetailsData || hasMisconfigurationFindings || hasNonClosedAlerts
-              }
-              expandDetails={openPanelFirstTab}
-              isPreviewMode={isPreviewMode}
-              isRulePreview={scopeId === TableId.rulePreview}
-            />
-            <UserPanelHeader
-              userName={userName}
-              observedUser={observedUserWithAnomalies}
-              managedUser={managedUser}
-            />
-            <UserPanelContent
-              userName={userName}
-              observedUser={observedUserWithAnomalies}
-              riskScoreState={riskScoreState}
-              recalculatingScore={recalculatingScore}
-              onAssetCriticalityChange={calculateEntityRiskScore}
-              contextID={contextID}
-              scopeId={scopeId}
-              openDetailsPanel={openDetailsPanel}
-              isPreviewMode={isPreviewMode}
-            />
-            {!isPreviewMode && assetInventoryEnabled && <UserPanelFooter userName={userName} />}
-            {isPreviewMode && (
-              <UserPreviewPanelFooter userName={userName} contextID={contextID} scopeId={scopeId} />
-            )}
-          </>
-        );
-      }}
-    </AnomalyTableProvider>
+    <>
+      <FlyoutNavigation
+        flyoutIsExpandable={hasUserDetailsData || hasMisconfigurationFindings || hasNonClosedAlerts}
+        expandDetails={openPanelFirstTab}
+        isPreviewMode={isPreviewMode}
+        isRulePreview={scopeId === TableId.rulePreview}
+      />
+      <UserPanelHeader userName={userName} lastSeenDate={lastSeenDate} managedUser={managedUser} />
+      <UserPanelContent
+        setLastSeenDate={setLastSeenDate}
+        userName={userName}
+        riskScoreState={riskScoreState}
+        recalculatingScore={recalculatingScore}
+        onAssetCriticalityChange={calculateEntityRiskScore}
+        contextID={contextID}
+        scopeId={scopeId}
+        openDetailsPanel={openDetailsPanel}
+        isPreviewMode={isPreviewMode}
+      />
+      {!isPreviewMode && assetInventoryEnabled && <UserPanelFooter userName={userName} />}
+      {isPreviewMode && (
+        <UserPreviewPanelFooter userName={userName} contextID={contextID} scopeId={scopeId} />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

This PR makes changes to the user and host flyouts to load the observed user or host information only when expanding the Observed data section.

Current the flyout has a loading spinner while loading that information. When fetching older data this can take many minutes to load. The rest of the flyout does not need that information to render.

## TODO

- [ ] fix unit tests
- [ ] check integration tests
- [ ] thoroughly desk test the changes
- [ ] check with Product if they're ok with the small UI changes
- [ ] improve PR description (text + add screenshots)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.