### PR TITLE
[ES|QL] Fix Promql  validation after pipe to avoid false unknown column

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/validation.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/validation.test.ts
@@ -914,5 +914,15 @@ describe('validation logic', () => {
       expect(errorsNoPolicies.some((e) => e.code === 'unknownIndex')).toBe(true);
       expect(errorsNoPolicies.some((e) => e.code === 'unknownPolicy')).toBe(false);
     });
+
+    it('should no flag Promql metrics/labels as unknown after a pipe', async () => {
+      const callbacks = getCallbackMocks();
+      const { errors } = await validateQuery(
+        'Promql step="5m" sum(doubleField) | KEEP step',
+        callbacks
+      );
+
+      expect(errors.some((e) => e.code === 'unknownColumn')).toBe(false);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/validation.ts
@@ -139,8 +139,13 @@ async function validateAst(
         ? subquery
         : { ...subquery, commands: subquery.commands.slice(0, -1) };
 
+    const queryForColumns =
+      currentCommand.name === 'promql'
+        ? queryString.slice(0, currentCommand.location.max + 1)
+        : queryString;
+
     const columns = shouldValidateCallback(callbacks, 'getColumnsFor')
-      ? await new QueryColumns(subqueryForColumns, queryString, callbacks, options).asMap()
+      ? await new QueryColumns(subqueryForColumns, queryForColumns, callbacks, options).asMap()
       : new Map();
 
     const references: ReferenceMaps = {


### PR DESCRIPTION
## Summary

When a Promql command is followed by a pipe, validation of the Promql command uses` post-pipe` columns instead of source columns.
Because `column_after `sees the pipe in the full query string, it returns only derived columns, so valid metric/label references (eg. bytes, event.dataset) inside the Promql query are incorrectly reported as `unknowncolumn`

`Validation.ts` passes the full query string to `QueryColumns `when validating a Promql command. 
With a trailing pipe, `column_after.ts` switched to the post-pipe path and returned column set.