### PR TITLE
ci: fix spotZones for n4d-standard-32

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -73,7 +73,7 @@ steps:
       machineType: n4d-standard-2
       diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -90,7 +90,7 @@ steps:
       machineType: n4d-standard-16
       diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -107,7 +107,7 @@ steps:
       machineType: n4d-standard-32
       diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:


### PR DESCRIPTION
n4d-standard-32 is only available in us-central1*


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->