### PR TITLE
[9.3] [OpenAPI generator] add `transformSchemaName` config options (#250857)

### DIFF
--- a/src/platform/packages/shared/kbn-openapi-generator/src/openapi_generator.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/openapi_generator.ts
@@ -36,6 +36,13 @@ export interface GeneratorConfig {
      */
     outFile: string;
   };
+  /**
+   * Schema name transformation strategy for generated TypeScript/zod types
+   * - 'pascalCase': Converts names to PascalCase
+   * - undefined: No transformation (preserves original names)
+   * @default undefined
+   */
+  schemaNameTransform?: 'pascalCase';
 }
 
 export const generate = async (config: GeneratorConfig) => {
@@ -62,7 +69,9 @@ export const generate = async (config: GeneratorConfig) => {
       return {
         sourcePath,
         generatedPath: getGeneratedFilePath(sourcePath),
-        generationContext: getGenerationContext(parsedSchema),
+        generationContext: getGenerationContext(parsedSchema, {
+          schemaNameTransform: config.schemaNameTransform,
+        }),
       };
     })
   );
@@ -105,6 +114,9 @@ export const generate = async (config: GeneratorConfig) => {
       info: {
         title,
         version: 'Bundle (no version)',
+      },
+      config: {
+        schemaNameTransform: config.schemaNameTransform,
       },
     });
 

--- a/src/platform/packages/shared/kbn-openapi-generator/src/parser/get_generation_context.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/parser/get_generation_context.ts
@@ -8,6 +8,7 @@
  */
 
 import type { OpenAPIV3 } from 'openapi-types';
+import type { GeneratorConfig } from '../openapi_generator';
 import { getApiOperationsList } from './lib/get_api_operations_list';
 import { getComponents } from './lib/get_components';
 import type { ImportsMap } from './lib/get_imports_map';
@@ -23,15 +24,20 @@ export interface GenerationContext {
   info: OpenAPIV3.InfoObject;
   imports: ImportsMap;
   circularRefs: Set<string>;
+  config: Pick<GeneratorConfig, 'schemaNameTransform'>;
 }
 
 export interface BundleGenerationContext {
   operations: NormalizedOperation[];
   sources: ParsedSource[];
   info: OpenAPIV3.InfoObject;
+  config: Pick<GeneratorConfig, 'schemaNameTransform'>;
 }
 
-export function getGenerationContext(document: OpenApiDocument): GenerationContext {
+export function getGenerationContext(
+  document: OpenApiDocument,
+  config: GenerationContext['config']
+): GenerationContext {
   const normalizedDocument = normalizeSchema(document);
 
   const components = getComponents(normalizedDocument);
@@ -46,5 +52,6 @@ export function getGenerationContext(document: OpenApiDocument): GenerationConte
     info,
     imports,
     circularRefs,
+    config,
   };
 }

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/register_helpers.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/register_helpers.ts
@@ -8,7 +8,11 @@
  */
 import type Handlebars from '@kbn/handlebars';
 import type { HelperOptions } from '@kbn/handlebars';
-import { snakeCase, camelCase, upperCase } from 'lodash';
+import { snakeCase, camelCase, upperCase, startCase } from 'lodash';
+
+function pascalCase(str: string): string {
+  return startCase(camelCase(str)).replace(/ /g, '');
+}
 
 export function registerHelpers(handlebarsInstance: typeof Handlebars) {
   handlebarsInstance.registerHelper('concat', (...args) => {
@@ -18,6 +22,16 @@ export function registerHelpers(handlebarsInstance: typeof Handlebars) {
   handlebarsInstance.registerHelper('snakeCase', snakeCase);
   handlebarsInstance.registerHelper('camelCase', camelCase);
   handlebarsInstance.registerHelper('upperCase', upperCase);
+  handlebarsInstance.registerHelper(
+    'transformSchemaName',
+    (name: string, options: HelperOptions) => {
+      const config = options.data?.root?.config;
+      if (config?.schemaNameTransform === 'pascalCase') {
+        return pascalCase(name);
+      }
+      return name;
+    }
+  );
   handlebarsInstance.registerHelper('toJSON', (value: unknown) => {
     return JSON.stringify(value);
   });

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/ts_input_type.handlebars
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/ts_input_type.handlebars
@@ -3,7 +3,7 @@
 {{~/if~}}
 
 {{~#if $ref~}}
-  {{referenceName}}
+  {{transformSchemaName referenceName}}
   {{~#if (isCircularRef $ref)}}Input{{/if~}}
   {{~#if nullable}} | null {{/if~}}
 {{~/if~}}
@@ -11,21 +11,21 @@
 {{~#if allOf~}}
   {{~#each allOf~}}
     {{~> ts_input_type ~}}
-    {{~#unless @last~}}&{{~/unless~}} 
+    {{~#unless @last~}}&{{~/unless~}}
   {{~/each~}}
 {{~/if~}}
 
 {{~#if anyOf~}}
   {{~#each anyOf~}}
     {{~> ts_input_type ~}}
-    {{~#unless @last~}}|{{~/unless~}} 
+    {{~#unless @last~}}|{{~/unless~}}
   {{~/each~}}
 {{~/if~}}
 
 {{~#if oneOf~}}
   {{~#each oneOf~}}
     {{~> ts_input_type ~}}
-    {{~#unless @last~}}|{{~/unless~}} 
+    {{~#unless @last~}}|{{~/unless~}}
   {{~/each~}}
 {{~/if~}}
 
@@ -55,8 +55,8 @@ unknown
   {
     {{#each properties}}
       {{#if description}}
-      /** 
-      * {{{description}}} 
+      /**
+      * {{{description}}}
       */
       {{/if}}
       '{{@key}}'{{~#unless (includes ../required @key)}}?{{/unless~}}: {{> ts_input_type }};
@@ -77,7 +77,7 @@ unknown
   {{~#if enum~}}
     {{~#each enum~}}
       '{{.}}'
-      {{~#unless @last~}}|{{~/unless~}} 
+      {{~#unless @last~}}|{{~/unless~}}
     {{~/each~}}
   {{~else~}}
   string

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/ts_type.handlebars
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/ts_type.handlebars
@@ -3,28 +3,28 @@
 {{~/if~}}
 
 {{~#if $ref~}}
-  {{referenceName}}
+  {{transformSchemaName referenceName}}
   {{~#if nullable}} | null {{/if~}}
 {{~/if~}}
 
 {{~#if allOf~}}
   {{~#each allOf~}}
     {{~> ts_type ~}}
-    {{~#unless @last~}}&{{~/unless~}} 
+    {{~#unless @last~}}&{{~/unless~}}
   {{~/each~}}
 {{~/if~}}
 
 {{~#if anyOf~}}
   {{~#each anyOf~}}
     {{~> ts_type ~}}
-    {{~#unless @last~}}|{{~/unless~}} 
+    {{~#unless @last~}}|{{~/unless~}}
   {{~/each~}}
 {{~/if~}}
 
 {{~#if oneOf~}}
   {{~#each oneOf~}}
     {{~> ts_type ~}}
-    {{~#unless @last~}}|{{~/unless~}} 
+    {{~#unless @last~}}|{{~/unless~}}
   {{~/each~}}
 {{~/if~}}
 
@@ -54,8 +54,8 @@ unknown
   {
     {{#each properties}}
       {{#if description}}
-      /** 
-      * {{{description}}} 
+      /**
+      * {{{description}}}
       */
       {{/if}}
       '{{@key}}'{{~#unless (or (includes ../required @key) (defined default))}}?{{/unless~}}: {{> ts_type }};
@@ -76,7 +76,7 @@ unknown
   {{~#if enum~}}
     {{~#each enum~}}
       '{{.}}'
-      {{~#unless @last~}}|{{~/unless~}} 
+      {{~#unless @last~}}|{{~/unless~}}
     {{~/each~}}
   {{~else~}}
   string

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
@@ -27,26 +27,26 @@ import {
   */
 {{/if}}
 {{#if (isCircularSchema @key)}}
-export type {{@key}} = {{> ts_type}};
-export type {{@key}}Input = {{> ts_input_type }};
-export const {{@key}}: z.ZodType<{{@key}}, ZodTypeDef, {{@key}}Input> = {{> zod_schema_item }};
+export type {{transformSchemaName @key}} = {{> ts_type}};
+export type {{transformSchemaName @key}}Input = {{> ts_input_type }};
+export const {{transformSchemaName @key}}: z.ZodType<{{transformSchemaName @key}}, ZodTypeDef, {{transformSchemaName @key}}Input> = {{> zod_schema_item }};
 {{else}}
 {{#if (shouldCastExplicitly this)}}
-{{!-- We need this temporary type to infer from it below, but in the end we want to export as a casted {{@key}} type --}}
+{{!-- We need this temporary type to infer from it below, but in the end we want to export as a casted {{transformSchemaName @key}} type --}}
 {{!-- error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed. --}}
-export const {{@key}}Internal = {{> zod_schema_item}};
+export const {{transformSchemaName @key}}Internal = {{> zod_schema_item}};
 
-export type {{@key}} = z.infer<typeof {{@key}}Internal>;
-export const {{@key}} = {{@key}}Internal as z.ZodType<{{@key}}>;
+export type {{transformSchemaName @key}} = z.infer<typeof {{transformSchemaName @key}}Internal>;
+export const {{transformSchemaName @key}} = {{transformSchemaName @key}}Internal as z.ZodType<{{transformSchemaName @key}}>;
 {{else}}
-export type {{@key}} = z.infer<typeof {{@key}}>;
-export const {{@key}} = {{> zod_schema_item}};
+export type {{transformSchemaName @key}} = z.infer<typeof {{transformSchemaName @key}}>;
+export const {{transformSchemaName @key}} = {{> zod_schema_item}};
 {{/if }}
 {{/if}}
 {{#if enum}}
 {{#unless (isSingle enum)}}
-export type {{@key}}Enum = typeof {{@key}}.enum;
-export const {{@key}}Enum = {{@key}}.enum;
+export type {{transformSchemaName @key}}Enum = typeof {{transformSchemaName @key}}.enum;
+export const {{transformSchemaName @key}}Enum = {{transformSchemaName @key}}.enum;
 {{/unless}}
 {{/if}}
 

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/zod_query_item.handlebars
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/zod_query_item.handlebars
@@ -1,5 +1,5 @@
 {{~#if $ref~}}
-  {{referenceName}}
+  {{transformSchemaName referenceName}}
   {{~#if nullable}}.nullable(){{/if~}}
   {{~#if (eq requiredBool false)}}.optional(){{/if~}}
   {{~#if (defined default)}}.default({{{toJSON default}}}){{/if~}}
@@ -9,8 +9,8 @@
   z.object({
     {{#each properties}}
       {{#if description}}
-      /** 
-      * {{{description}}} 
+      /**
+      * {{{description}}}
       */
       {{/if}}
       {{@key}}: {{> zod_query_item requiredBool=(includes ../required @key)}},

--- a/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
@@ -7,9 +7,9 @@
 
 {{~#if $ref~}}
   {{~#if (isCircularRef $ref)~}}
-    z.lazy(() => {{referenceName}})
+    z.lazy(() => {{transformSchemaName referenceName}})
   {{~else~}}
-    {{referenceName}}
+      {{transformSchemaName referenceName}}
   {{~/if~}}
   {{~#if nullable}}.nullable(){{/if~}}
   {{~#if (eq requiredBool false)}}.optional(){{/if~}}
@@ -32,7 +32,7 @@
   {{#if discriminator}}
     z.discriminatedUnion('{{discriminator.propertyName}}', [
   {{else}}
-    z.union([ 
+    z.union([
   {{/if}}
   {{~#each anyOf~}}
     {{~> zod_schema_item ~}},
@@ -46,7 +46,7 @@
   {{#if discriminator}}
     z.discriminatedUnion('{{discriminator.propertyName}}', [
   {{else}}
-    z.union([ 
+    z.union([
   {{/if}}
   {{~#each oneOf~}}
     {{~> zod_schema_item ~}},
@@ -86,8 +86,8 @@ z.unknown()
   z.object({
     {{#each properties}}
       {{#if description}}
-      /** 
-      * {{{description}}} 
+      /**
+      * {{{description}}}
       */
       {{/if}}
       '{{@key}}':{{~> zod_schema_item requiredBool=(includes ../required @key)~}},

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/common_attributes.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/common_attributes.gen.ts
@@ -290,11 +290,11 @@ export const FindAttackDiscoveryAlertsParams = z.object({
 
 export type AttackDiscoveryGenerationConfig = z.infer<typeof AttackDiscoveryGenerationConfig>;
 export const AttackDiscoveryGenerationConfig = z.object({
-  /** 
+  /**
       * The (space specific) index pattern that contains the alerts to use as
 context for the attack discovery.
 Example: .alerts-security.alerts-default
- 
+
       */
   alertsIndexPattern: z.string(),
   /**
@@ -307,7 +307,7 @@ Example: .alerts-security.alerts-default
   apiConfig: ApiConfig,
   connectorName: z.string().optional(),
   end: z.string().optional(),
-  /** 
+  /**
       * An Elasticsearch-style query DSL object used to filter alerts. For example:
 ```json {
   "filter": {
@@ -331,7 +331,7 @@ Example: .alerts-security.alerts-default
       "must_not": []
     }
   }
-} ``` 
+} ```
       */
   filter: z.object({}).catchall(z.unknown()).optional(),
   langSmithProject: z.string().optional(),

--- a/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/api/find_endpoint_list_item/find_endpoint_list_item.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/api/find_endpoint_list_item/find_endpoint_list_item.gen.ts
@@ -24,10 +24,10 @@ export const FindEndpointListItemsFilter = NonEmptyString;
 
 export type FindEndpointListItemsRequestQuery = z.infer<typeof FindEndpointListItemsRequestQuery>;
 export const FindEndpointListItemsRequestQuery = z.object({
-  /** 
+  /**
       * Filters the returned results according to the value of the specified field,
 using the `<field name>:<field value>` syntax.
- 
+
       */
   filter: FindEndpointListItemsFilter.optional(),
   /**

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/find_exception_list_items/find_exception_list_items.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/find_exception_list_items/find_exception_list_items.gen.ts
@@ -33,16 +33,16 @@ export const FindExceptionListItemsRequestQuery = z.object({
    * The `list_id`s of the items to fetch.
    */
   list_id: ArrayFromString(ExceptionListHumanId),
-  /** 
+  /**
       * Filters the returned results according to the value of the specified field,
 using the `<field name>:<field value>` syntax.
- 
+
       */
   filter: ArrayFromString(FindExceptionListItemsFilter).optional().default([]),
-  /** 
+  /**
       * Determines whether the returned containers are Kibana associated with a Kibana space
 or available in all spaces (`agnostic` or `single`)
- 
+
       */
   namespace_type: ArrayFromString(ExceptionNamespaceType).optional().default(['single']),
   search: z.string().optional(),

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/find_exception_lists/find_exception_lists.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/find_exception_lists/find_exception_lists.gen.ts
@@ -24,20 +24,20 @@ export const FindExceptionListsFilter = z.string();
 
 export type FindExceptionListsRequestQuery = z.infer<typeof FindExceptionListsRequestQuery>;
 export const FindExceptionListsRequestQuery = z.object({
-  /** 
+  /**
       * Filters the returned results according to the value of the specified field.
 
 Uses the `so type.field name:field` value syntax, where `so type` can be:
 
 - `exception-list`: Specify a space-aware exception list.
 - `exception-list-agnostic`: Specify an exception list that is shared across spaces.
- 
+
       */
   filter: FindExceptionListsFilter.optional(),
-  /** 
+  /**
       * Determines whether the returned containers are Kibana associated with a Kibana space
 or available in all spaces (`agnostic` or `single`)
- 
+
       */
   namespace_type: ArrayFromString(ExceptionNamespaceType).optional().default(['single']),
   /**

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/import_exceptions/import_exceptions.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/api/import_exceptions/import_exceptions.gen.ts
@@ -39,17 +39,17 @@ export const ExceptionListsImportBulkErrorArray = z.array(ExceptionListsImportBu
 
 export type ImportExceptionListRequestQuery = z.infer<typeof ImportExceptionListRequestQuery>;
 export const ImportExceptionListRequestQuery = z.object({
-  /** 
+  /**
       * Determines whether existing exception lists with the same `list_id` are overwritten.
 If any exception items have the same `item_id`, those are also overwritten.
- 
+
       */
   overwrite: BooleanFromString.optional().default(false),
-  /** 
+  /**
       * Determines whether the list being imported will have a new `list_id` generated.
 Additional `item_id`'s are generated for each exception item. Both the exception
 list and its items are overwritten.
- 
+
       */
   as_new_list: BooleanFromString.optional().default(false),
 });

--- a/x-pack/solutions/security/packages/kbn-securitysolution-lists-common/api/find_list_items/find_list_items.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-lists-common/api/find_list_items/find_list_items.gen.ts
@@ -49,10 +49,10 @@ export const FindListItemsRequestQuery = z.object({
    */
   sort_order: z.enum(['desc', 'asc']).optional(),
   cursor: FindListItemsCursor.optional(),
-  /** 
+  /**
       * Filters the returned results according to the value of the specified field,
 using the <field name>:<field value> syntax.
- 
+
       */
   filter: FindListItemsFilter.optional(),
 });

--- a/x-pack/solutions/security/packages/kbn-securitysolution-lists-common/api/find_lists/find_lists.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-lists-common/api/find_lists/find_lists.gen.ts
@@ -47,10 +47,10 @@ export const FindListsRequestQuery = z.object({
    * Returns the lists that come after the last lists returned in the previous call (use the `cursor` value returned in the previous call). This parameter uses the `tie_breaker_id` field to ensure all lists are sorted and returned correctly.
    */
   cursor: FindListsCursor.optional(),
-  /** 
+  /**
       * Filters the returned results according to the value of the specified field,
 using the <field name>:<field value> syntax.
- 
+
       */
   filter: FindListsFilter.optional(),
 });

--- a/x-pack/solutions/security/packages/kbn-securitysolution-lists-common/api/import_list_items/import_list_items.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-lists-common/api/import_list_items/import_list_items.gen.ts
@@ -21,35 +21,35 @@ import { List } from '../model/list_schemas.gen';
 
 export type ImportListItemsRequestQuery = z.infer<typeof ImportListItemsRequestQuery>;
 export const ImportListItemsRequestQuery = z.object({
-  /** 
+  /**
       * List's id.
 
 Required when importing to an existing list.
- 
+
       */
   list_id: ListId.optional(),
-  /** 
+  /**
       * Type of the importing list.
 
 Required when importing a new list whose list `id` is not specified.
- 
+
       */
   type: ListType.optional(),
-  /** 
+  /**
       * Determines how uploaded list item values are parsed. By default, list items are parsed using these named regex groups:
 
 - `(?<value>.+)` - Single value item types, such as ip, long, date, keyword, and text.
 - `(?<gte>.+)-(?<lte>.+)|(?<value>.+)` - Range value item types, such as `date_range`, `ip_range`, `double_range`, `float_range`, `integer_range`, and `long_range`.
- 
+
       */
   serializer: z.string().optional(),
-  /** 
+  /**
       * Determines how retrieved list item values are presented. By default list items are presented using these Handelbar expressions:
 
 - `{{{value}}}` - Single value item types, such as `ip`, `long`, `date`, `keyword`, and `text`.
 - `{{{gte}}}-{{{lte}}}` - Range value item types, such as `ip_range`, `double_range`, `float_range`, `integer_range`, and `long_range`.
 - `{{{gte}}},{{{lte}}}` - Date range values.
- 
+
       */
   deserializer: z.string().optional(),
   /**

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.gen.ts
@@ -322,9 +322,9 @@ export const ThreatTechnique = z.object({
    * Technique reference
    */
   reference: z.string(),
-  /** 
+  /**
       * Array containing more specific information on the attack technique.
- 
+
       */
   subtechnique: z.array(ThreatSubtechnique).optional(),
 });
@@ -649,7 +649,7 @@ export const RuleActionId = z.string();
 
 export type RuleAction = z.infer<typeof RuleAction>;
 export const RuleAction = z.object({
-  /** 
+  /**
       * The action type used for sending notifications, can be:
 
   - `.slack`
@@ -669,7 +669,7 @@ export const RuleAction = z.object({
   - `.torq`
   - `.tines`
   - `.d3security`
- 
+
       */
   action_type_id: z.string(),
   group: RuleActionGroup.optional(),

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_schemas.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_schemas.gen.ts
@@ -143,11 +143,11 @@ export const BaseDefaultableFields = z.object({
   threat: ThreatArray.optional(),
   setup: SetupGuide.optional(),
   related_integrations: RelatedIntegrationArray.optional(),
-  /** 
+  /**
       * Elasticsearch fields and their types that need to be present for the rule to function.
 > info
 > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
- 
+
       */
   required_fields: z.array(RequiredFieldInput).optional(),
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -118,10 +118,10 @@ export const BulkActionBase = z.object({
    * Query to filter rules.
    */
   query: z.string().optional(),
-  /** 
+  /**
       * Array of rule `id`s to which a bulk action will be applied. Do not use rule's `rule_id` here.
 Only valid when query property is undefined.
- 
+
       */
   ids: z.array(z.string()).min(1).optional(),
   /**
@@ -319,11 +319,11 @@ export const BulkActionEditPayloadSchedule = z.object({
      * Interval in which the rule runs. For example, `"1h"` means the rule runs every hour.
      */
     interval: z.string().regex(/^[1-9]\d*[smh]$/),
-    /** 
+    /**
       * Lookback time for the rules.
 
 Additional look-back time that the rule analyzes. For example, "10m" means the rule analyzes the last 10 minutes of data in addition to the frequency interval.
- 
+
       */
     lookback: z.string().regex(/^[1-9]\d*[smh]$/),
   }),
@@ -458,7 +458,7 @@ export const BulkEditRules = BulkActionBase.merge(
 
 export type PerformRulesBulkActionRequestQuery = z.infer<typeof PerformRulesBulkActionRequestQuery>;
 export const PerformRulesBulkActionRequestQuery = z.object({
-  /** 
+  /**
       * Enables dry run mode for the request call.
 
 Enable dry run mode to verify that bulk actions can be applied to specified rules. Certain rules, such as prebuilt Elastic rules on a Basic subscription, can’t be edited and will return errors in the request response. Error details will contain an explanation, the rule name and/or ID, and additional troubleshooting information.
@@ -466,7 +466,7 @@ Enable dry run mode to verify that bulk actions can be applied to specified rule
 To enable dry run mode on a request, add the query parameter `dry_run=true` to the end of the request URL. Rules specified in the request will be temporarily updated. These updates won’t be written to Elasticsearch.
 > info
 > Dry run mode is not supported for the `export` bulk action. A 400 error will be returned in the request response.
- 
+
       */
   dry_run: BooleanFromString.optional(),
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
@@ -25,11 +25,11 @@ export const ExportRulesRequestQuery = z.object({
    * Determines whether a summary of the exported rules is returned.
    */
   exclude_export_details: BooleanFromString.optional().default(false),
-  /** 
+  /**
       * File name for saving the exported rules.
 > info
 > When using cURL to export rules to a file, use the -O and -J options to save the rules to the file name specified in the URL.
- 
+
       */
   file_name: z.string().optional().default('export.ndjson'),
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/find_rules/find_rules_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/find_rules/find_rules_route.gen.ts
@@ -45,7 +45,7 @@ export const FindRulesSortFieldEnum = FindRulesSortField.enum;
 export type FindRulesRequestQuery = z.infer<typeof FindRulesRequestQuery>;
 export const FindRulesRequestQuery = z.object({
   fields: ArrayFromString(z.string()).optional(),
-  /** 
+  /**
       * Search query
 
 Filters the returned results according to the value of the specified field, using the alert.attributes.<field name>:<field value> syntax, where <field name> can be:
@@ -57,7 +57,7 @@ Filters the returned results according to the value of the specified field, usin
 - updatedBy
 > info
 > Even though the JSON rule object uses created_by and updated_by fields, you must use createdBy and updatedBy fields in the filter.
- 
+
       */
   filter: z.string().optional(),
   /**

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/file_download/file_download.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/file_download/file_download.gen.ts
@@ -19,12 +19,12 @@ import { z } from '@kbn/zod';
 export type EndpointFileDownloadRequestParams = z.infer<typeof EndpointFileDownloadRequestParams>;
 export const EndpointFileDownloadRequestParams = z.object({
   action_id: z.string(),
-  /** 
+  /**
       * The file identifier is constructed in one of two ways:
 - For Elastic Defend agents (`agentType` of `endpoint`): combine the `action_id` and `agent_id` values using a dot (`.`) separator:
 `{file_id}` = `{action_id}.{agent_id}`
 - For all other agent types: the `file_id` is the `agent_id` for which the response action was sent to.
- 
+
       */
   file_id: z.string(),
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/file_info/file_info.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/file_info/file_info.gen.ts
@@ -19,12 +19,12 @@ import { z } from '@kbn/zod';
 export type EndpointFileInfoRequestParams = z.infer<typeof EndpointFileInfoRequestParams>;
 export const EndpointFileInfoRequestParams = z.object({
   action_id: z.string(),
-  /** 
+  /**
       * The file identifier is constructed in one of two ways:
 - For Elastic Defend agents (`agentType` of `endpoint`): combine the `action_id` and `agent_id` values using a dot (`.`) separator:
 `{file_id}` = `{action_id}.{agent_id}`
 - For all other agent types: the `file_id` is the `agent_id` for which the response action was sent to.
- 
+
       */
   file_id: z.string(),
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/run_script.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/run_script.gen.ts
@@ -102,9 +102,9 @@ export const MDERunScriptParameters = z.object({
 export type RunScriptRouteRequestBody = z.infer<typeof RunScriptRouteRequestBody>;
 export const RunScriptRouteRequestBody = BaseActionSchema.merge(
   z.object({
-    /** 
+    /**
       * One of the following set of parameters must be provided
- 
+
       */
     parameters: z.union([
       RawScriptParameters,

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
@@ -301,10 +301,10 @@ export const ResponseActionDetails = z.object({
       })
     )
     .optional(),
-  /** 
+  /**
       * The outputs of the response action for each agent ID that it was sent to. Content different depending on the
 response action command and will only be present for agents that have responded to the response action
- 
+
       */
   outputs: z
     .object({})

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/monitoring_entity_source/monitoring_entity_source.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/monitoring_entity_source/monitoring_entity_source.gen.ts
@@ -25,9 +25,9 @@ export const MonitoringEntitySourceTypeEnum = MonitoringEntitySourceType.enum;
 export type Matcher = z.infer<typeof Matcher>;
 export const Matcher = z.object({
   fields: z.array(z.string()),
-  /** 
+  /**
       * Matcher values. Must be either an array of strings (e.g. group or role names) or an array of booleans (e.g. integration-derived flags like privileged_group_member). Mixed types are intentionally not supported for simplicity and predictability.
- 
+
       */
   values: z.union([z.array(z.string()), z.array(z.boolean())]),
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[OpenAPI generator] add `transformSchemaName` config options (#250857)](https://github.com/elastic/kibana/pull/250857)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan Monschke","email":"jan.monschke@elastic.co"},"sourceCommit":{"committedDate":"2026-02-04T15:44:35Z","message":"[OpenAPI generator] add `transformSchemaName` config options (#250857)\n\n## Summary\n\nIf a yaml definition defines the type names in lowercase, like in the\ncases codebase, the generator would generate lowercase type/schema\nnames. This is against our eslint rules.\n\n```yaml\nin: query\nname: assignees\ndescription: >\n  Filters the returned cases by assignees.\n  Valid values are `none` or unique identifiers for the user profiles.\n  These identifiers can be found by using the suggest user profile API.\n```\n\nwould generate:\n\n```ts\nexport type assignees = z.infer<typeof assignees>; // <-- ESLint error\nexport const assignees = z.array(...)\n```\n\nThis PR adds a transformSchemaName option that allows to transform the\nschema names to `PascalCase`.\n\nThat allows us to generate the correct schema names without having to\ntouch the API documentation yaml files.\n\nThis is the code that is generated with `transformSchemaName` set to\n`pascalCase`.\n\n```ts\nexport type Assignees = z.infer<typeof Assignees>;\nexport const Assignees = z.array(...)\n```\n\nFor now `transformSchemaName` only supports `pascalCase` but it can be\nextended in the future.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>","sha":"cb8b5564dcd413630f3a21db9626e5d1d1bc585a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","Team:Cases","v9.4.0"],"title":"[OpenAPI generator] add `transformSchemaName` config options","number":250857,"url":"https://github.com/elastic/kibana/pull/250857","mergeCommit":{"message":"[OpenAPI generator] add `transformSchemaName` config options (#250857)\n\n## Summary\n\nIf a yaml definition defines the type names in lowercase, like in the\ncases codebase, the generator would generate lowercase type/schema\nnames. This is against our eslint rules.\n\n```yaml\nin: query\nname: assignees\ndescription: >\n  Filters the returned cases by assignees.\n  Valid values are `none` or unique identifiers for the user profiles.\n  These identifiers can be found by using the suggest user profile API.\n```\n\nwould generate:\n\n```ts\nexport type assignees = z.infer<typeof assignees>; // <-- ESLint error\nexport const assignees = z.array(...)\n```\n\nThis PR adds a transformSchemaName option that allows to transform the\nschema names to `PascalCase`.\n\nThat allows us to generate the correct schema names without having to\ntouch the API documentation yaml files.\n\nThis is the code that is generated with `transformSchemaName` set to\n`pascalCase`.\n\n```ts\nexport type Assignees = z.infer<typeof Assignees>;\nexport const Assignees = z.array(...)\n```\n\nFor now `transformSchemaName` only supports `pascalCase` but it can be\nextended in the future.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>","sha":"cb8b5564dcd413630f3a21db9626e5d1d1bc585a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250857","number":250857,"mergeCommit":{"message":"[OpenAPI generator] add `transformSchemaName` config options (#250857)\n\n## Summary\n\nIf a yaml definition defines the type names in lowercase, like in the\ncases codebase, the generator would generate lowercase type/schema\nnames. This is against our eslint rules.\n\n```yaml\nin: query\nname: assignees\ndescription: >\n  Filters the returned cases by assignees.\n  Valid values are `none` or unique identifiers for the user profiles.\n  These identifiers can be found by using the suggest user profile API.\n```\n\nwould generate:\n\n```ts\nexport type assignees = z.infer<typeof assignees>; // <-- ESLint error\nexport const assignees = z.array(...)\n```\n\nThis PR adds a transformSchemaName option that allows to transform the\nschema names to `PascalCase`.\n\nThat allows us to generate the correct schema names without having to\ntouch the API documentation yaml files.\n\nThis is the code that is generated with `transformSchemaName` set to\n`pascalCase`.\n\n```ts\nexport type Assignees = z.infer<typeof Assignees>;\nexport const Assignees = z.array(...)\n```\n\nFor now `transformSchemaName` only supports `pascalCase` but it can be\nextended in the future.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>","sha":"cb8b5564dcd413630f3a21db9626e5d1d1bc585a"}}]}] BACKPORT-->