### PR TITLE
[SharedUX] Enforce feedback enablement check for header help menu

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/chrome_components.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/chrome_components.tsx
@@ -115,6 +115,7 @@ export const createChromeComponents = ({
       navControlsExtension$={navControls.extension$}
       customBranding$={customBranding$}
       appMenu$={state.appMenu.$}
+      isFeedbackEnabled$={state.feedback.isEnabled$}
     />
   );
 
@@ -132,6 +133,7 @@ export const createChromeComponents = ({
       navControlsLeft$={navControls.left$}
       navControlsCenter$={navControls.center$}
       navControlsRight$={navControls.right$}
+      isFeedbackEnabled$={state.feedback.isEnabled$}
       loadingCount$={loadingCount$}
       homeHref$={projectNavigation.homeHref$}
       docLinks={docLinks}

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header.test.tsx
@@ -47,6 +47,7 @@ function mockProps() {
     isLocked$: new BehaviorSubject(false),
     loadingCount$: new BehaviorSubject(0),
     appMenu$: new BehaviorSubject(undefined),
+    isFeedbackEnabled$: new BehaviorSubject(true),
   };
 }
 

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header.tsx
@@ -77,6 +77,7 @@ export interface HeaderProps {
   customBranding$: Observable<CustomBranding>;
   isServerless: boolean;
   appMenu$: Observable<AppMenuConfig | undefined>;
+  isFeedbackEnabled$: Observable<boolean>;
 }
 
 export function Header({
@@ -165,6 +166,7 @@ export function Header({
                     docLinks={docLinks}
                     kibanaVersion={kibanaVersion}
                     navigateToUrl={application.navigateToUrl}
+                    isFeedbackEnabled$={observables.isFeedbackEnabled$}
                   />,
                   <HeaderNavControls navControls$={observables.navControlsRight$} />,
                 ],

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_help_menu.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_help_menu.test.tsx
@@ -28,6 +28,7 @@ describe('HeaderHelpMenu', () => {
     | 'helpSupportUrl$'
     | 'kibanaDocLink'
     | 'isServerless'
+    | 'isFeedbackEnabled$'
   > = {
     navigateToUrl: application.navigateToUrl,
     kibanaVersion: 'version',
@@ -37,6 +38,7 @@ describe('HeaderHelpMenu', () => {
     helpSupportUrl$: new BehaviorSubject(''),
     kibanaDocLink: '',
     isServerless: false,
+    isFeedbackEnabled$: new BehaviorSubject(true),
   };
 
   test('it only renders the default content', () => {

--- a/src/core/packages/chrome/browser-internal/src/ui/project/header.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/header.test.tsx
@@ -36,6 +36,7 @@ describe('Header', () => {
     customBranding$: Rx.of({}),
     prependBasePath: (str) => `hello/world/${str}`,
     isServerless: false,
+    isFeedbackEnabled$: Rx.of(true),
   };
 
   it('renders', async () => {

--- a/src/core/packages/chrome/browser-internal/src/ui/project/header.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/header.tsx
@@ -113,6 +113,7 @@ export interface Props extends Pick<ComponentProps<typeof HeaderHelpMenu>, 'isSe
   navControlsLeft$: Observable<ChromeNavControl[]>;
   navControlsCenter$: Observable<ChromeNavControl[]>;
   navControlsRight$: Observable<ChromeNavControl[]>;
+  isFeedbackEnabled$: Observable<boolean>;
   prependBasePath: (url: string) => string;
 }
 
@@ -271,6 +272,7 @@ export const ProjectHeader = ({
                   globalHelpExtensionMenuLinks$={observables.globalHelpExtensionMenuLinks$}
                   helpExtension$={observables.helpExtension$}
                   helpSupportUrl$={observables.helpSupportUrl$}
+                  isFeedbackEnabled$={observables.isFeedbackEnabled$}
                   defaultContentLinks$={observables.helpMenuLinks$}
                   kibanaDocLink={docLinks.links.elasticStackGetStarted}
                   docLinks={docLinks}


### PR DESCRIPTION
## Summary

As part of [[Epic] Setting to disable feedback snippets, guided tours and announcements in Kibana](https://github.com/elastic/kibana/issues/234771) SharedUX has added two new `core.notifications` services for `feedback` and `tours`. Their `isEnabled()` API verifies if users should be shown that kind of elements by reading their preferences from global UI settings (`hideFeedback` and `hideAnnouncements`).

From now on, every feedback or tour component should call `isEnabled()` before rendering to honor user preferences. 

> [!IMPORTANT]
SharedUX will be opening PRs for existing occurrences per team. Each team should manually test their PR to verify toggling those settings results in the expected behavior. If your team owns more `feedback` or `tours` occurrences or are planning on doing so, this check needs to be added to honor user preferences.
>  

### Testing

**Feedback elements**
- This is a read-only setting, you need to override it via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`.
- Verify changing the setting value hides/render the element as expected.

**Tours/announcements elements**
- Toggle either the deprecated `hideAnnouncements` space setting or the global one on the Stack Management > Advanced Settings UI.
- Verify toggling the setting hides/render the element as expected.

Related PR: [[SharedUX] Add feedback and tours to core notifications](https://github.com/elastic/kibana/pull/248248)