### PR TITLE
[8.19] Improve session timeout redirect for serverless projects (#251630)

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/authentication/access_agreement/access_agreement_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/access_agreement/access_agreement_page.tsx
@@ -120,6 +120,7 @@ export function AccessAgreementPage({ http, fatalErrors, notifications }: Props)
         />
       }
     >
+      <EuiSpacer size="xl" />
       {content}
       <EuiSpacer size="xxl" />
     </AuthenticationStatePage>

--- a/x-pack/platform/plugins/shared/security/public/authentication/components/authentication_state_page/__snapshots__/authentication_state_page.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/components/authentication_state_page/__snapshots__/authentication_state_page.test.tsx.snap
@@ -29,9 +29,6 @@ exports[`AuthenticationStatePage renders 1`] = `
           foo
         </h1>
       </EuiTitle>
-      <EuiSpacer
-        size="xl"
-      />
     </div>
   </header>
   <div

--- a/x-pack/platform/plugins/shared/security/public/authentication/components/authentication_state_page/authentication_state_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/components/authentication_state_page/authentication_state_page.tsx
@@ -32,7 +32,6 @@ export const AuthenticationStatePage: FC<PropsWithChildren<Props>> = (props) => 
         <EuiTitle size="l" className="secAuthenticationStatePage__title">
           <h1>{props.title}</h1>
         </EuiTitle>
-        <EuiSpacer size="xl" />
       </div>
     </header>
     <div className="secAuthenticationStatePage__content eui-textCenter">{props.children}</div>

--- a/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/form_message.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/form_message.test.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { type FormMessage, formMessages, MessageType, renderMessage } from './form_message';
+
+describe('form_message', () => {
+  describe('renderMessage', () => {
+    it('should return null for MessageType.None', () => {
+      const message: FormMessage = {
+        type: MessageType.None,
+        content: 'Some content',
+      };
+      const result = renderMessage(message);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when content is undefined', () => {
+      const message: FormMessage = {
+        type: MessageType.Info,
+      };
+      const result = renderMessage(message);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when content is empty string', () => {
+      const message: FormMessage = {
+        type: MessageType.Info,
+        content: '',
+      };
+      const result = renderMessage(message);
+      expect(result).toBeNull();
+    });
+
+    it('should render Info message with primary color and correct attributes', () => {
+      const message: FormMessage = {
+        type: MessageType.Info,
+        content: 'Test info message',
+      };
+      render(<>{renderMessage(message)}</>);
+
+      const callOut = screen.getByTestId('loginInfoMessage');
+      expect(callOut).toBeInTheDocument();
+      expect(callOut).toHaveTextContent('Test info message');
+      expect(callOut).toHaveAttribute('role', 'status');
+    });
+
+    it('should render Danger message with danger color and correct attributes', () => {
+      const message: FormMessage = {
+        type: MessageType.Danger,
+        content: 'Test error message',
+      };
+      render(<>{renderMessage(message)}</>);
+
+      const callOut = screen.getByTestId('loginErrorMessage');
+      expect(callOut).toBeInTheDocument();
+      expect(callOut).toHaveTextContent('Test error message');
+      expect(callOut).toHaveAttribute('role', 'alert');
+    });
+
+    it('should include EuiSpacer for Info messages', () => {
+      const message: FormMessage = {
+        type: MessageType.Info,
+        content: 'Test message',
+      };
+      const { container } = render(<>{renderMessage(message)}</>);
+
+      // EuiSpacer should be rendered after the callout
+      expect(container.querySelector('.euiSpacer')).toBeInTheDocument();
+    });
+
+    it('should include EuiSpacer for Danger messages', () => {
+      const message: FormMessage = {
+        type: MessageType.Danger,
+        content: 'Test message',
+      };
+      const { container } = render(<>{renderMessage(message)}</>);
+
+      // EuiSpacer should be rendered after the callout
+      expect(container.querySelector('.euiSpacer')).toBeInTheDocument();
+    });
+
+    it('should render Info message with announceOnMount enabled', () => {
+      const message: FormMessage = {
+        type: MessageType.Info,
+        content: 'Test message',
+      };
+      render(<>{renderMessage(message)}</>);
+
+      const callOut = screen.getByTestId('loginInfoMessage');
+      // The announceOnMount prop is passed to the component
+      expect(callOut).toBeInTheDocument();
+    });
+
+    it('should render Danger message with announceOnMount enabled', () => {
+      const message: FormMessage = {
+        type: MessageType.Danger,
+        content: 'Test message',
+      };
+      render(<>{renderMessage(message)}</>);
+
+      const callOut = screen.getByTestId('loginErrorMessage');
+      // The announceOnMount prop is passed to the component
+      expect(callOut).toBeInTheDocument();
+    });
+  });
+
+  describe('formMessages', () => {
+    it('should have SESSION_EXPIRED message with Info type', () => {
+      expect(formMessages.SESSION_EXPIRED).toEqual({
+        type: MessageType.Info,
+        content: expect.any(String),
+      });
+      expect(formMessages.SESSION_EXPIRED.content).toBeTruthy();
+      expect(formMessages.SESSION_EXPIRED.content).toContain('session');
+    });
+
+    it('should have CONCURRENCY_LIMIT message with Info type', () => {
+      expect(formMessages.CONCURRENCY_LIMIT).toEqual({
+        type: MessageType.Info,
+        content: expect.any(String),
+      });
+      expect(formMessages.CONCURRENCY_LIMIT.content).toBeTruthy();
+      expect(formMessages.CONCURRENCY_LIMIT.content).toContain('logged in');
+    });
+
+    it('should have AUTHENTICATION_ERROR message with Info type', () => {
+      expect(formMessages.AUTHENTICATION_ERROR).toEqual({
+        type: MessageType.Info,
+        content: expect.any(String),
+      });
+      expect(formMessages.AUTHENTICATION_ERROR.content).toBeTruthy();
+      expect(formMessages.AUTHENTICATION_ERROR.content).toContain('authentication');
+    });
+
+    it('should have LOGGED_OUT message with Info type', () => {
+      expect(formMessages.LOGGED_OUT).toEqual({
+        type: MessageType.Info,
+        content: expect.any(String),
+      });
+      expect(formMessages.LOGGED_OUT.content).toBeTruthy();
+      expect(formMessages.LOGGED_OUT.content).toContain('logged out');
+    });
+
+    it('should have UNAUTHENTICATED message with Danger type', () => {
+      expect(formMessages.UNAUTHENTICATED).toEqual({
+        type: MessageType.Danger,
+        content: expect.any(String),
+      });
+      expect(formMessages.UNAUTHENTICATED.content).toBeTruthy();
+      expect(formMessages.UNAUTHENTICATED.content).toContain('logging in');
+    });
+
+    it('should have all LogoutReason types covered', () => {
+      const expectedReasons = [
+        'SESSION_EXPIRED',
+        'CONCURRENCY_LIMIT',
+        'AUTHENTICATION_ERROR',
+        'LOGGED_OUT',
+        'UNAUTHENTICATED',
+      ];
+
+      const actualReasons = Object.keys(formMessages);
+      expect(actualReasons.sort()).toEqual(expectedReasons.sort());
+    });
+
+    it('should only have UNAUTHENTICATED as Danger type', () => {
+      const dangerMessages = Object.entries(formMessages).filter(
+        ([_key, value]) => value.type === MessageType.Danger
+      );
+      expect(dangerMessages).toHaveLength(1);
+      expect(dangerMessages[0][0]).toBe('UNAUTHENTICATED');
+    });
+
+    it('should have all other messages as Info type', () => {
+      const infoMessages = Object.entries(formMessages).filter(
+        ([_key, value]) => value.type === MessageType.Info
+      );
+      expect(infoMessages).toHaveLength(4);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/form_message.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/form_message.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import React, { Fragment } from 'react';
+
+import { i18n } from '@kbn/i18n';
+
+import type { LogoutReason } from '../../../../common/types';
+
+export enum MessageType {
+  None,
+  Info,
+  Danger,
+}
+
+export interface FormMessage {
+  type: MessageType;
+  content?: string;
+}
+
+export const formMessages: Record<LogoutReason, FormMessage> = {
+  SESSION_EXPIRED: {
+    type: MessageType.Info,
+    content: i18n.translate('xpack.security.login.sessionExpiredDescription', {
+      defaultMessage: 'Your session has timed out. Please log in again.',
+    }),
+  },
+  CONCURRENCY_LIMIT: {
+    type: MessageType.Info,
+    content: i18n.translate('xpack.security.login.concurrencyLimitDescription', {
+      defaultMessage: 'You have logged in on another device. Please log in again.',
+    }),
+  },
+  AUTHENTICATION_ERROR: {
+    type: MessageType.Info,
+    content: i18n.translate('xpack.security.login.authenticationErrorDescription', {
+      defaultMessage: 'An unexpected authentication error occurred. Please log in again.',
+    }),
+  },
+  LOGGED_OUT: {
+    type: MessageType.Info,
+    content: i18n.translate('xpack.security.login.loggedOutDescription', {
+      defaultMessage: 'You have logged out of Elastic.',
+    }),
+  },
+  UNAUTHENTICATED: {
+    type: MessageType.Danger,
+    content: i18n.translate('xpack.security.unauthenticated.errorDescription', {
+      defaultMessage:
+        'Try logging in again, and if the problem persists, contact your system administrator.',
+    }),
+  },
+};
+
+export function renderMessage(message: FormMessage) {
+  if (message.type === MessageType.None || !message.content) {
+    return null;
+  }
+
+  if (message.type === MessageType.Danger) {
+    return (
+      <Fragment>
+        <EuiCallOut
+          announceOnMount
+          size="s"
+          color="danger"
+          data-test-subj="loginErrorMessage"
+          title={message.content}
+          role="alert"
+        />
+        <EuiSpacer size="l" />
+      </Fragment>
+    );
+  }
+
+  if (message.type === MessageType.Info) {
+    return (
+      <Fragment>
+        <EuiCallOut
+          announceOnMount
+          size="s"
+          color="primary"
+          data-test-subj="loginInfoMessage"
+          title={message.content}
+          role="status"
+        />
+        <EuiSpacer size="l" />
+      </Fragment>
+    );
+  }
+
+  return null;
+}

--- a/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/form_message.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/form_message.tsx
@@ -66,7 +66,6 @@ export function renderMessage(message: FormMessage) {
     return (
       <Fragment>
         <EuiCallOut
-          announceOnMount
           size="s"
           color="danger"
           data-test-subj="loginErrorMessage"
@@ -82,7 +81,6 @@ export function renderMessage(message: FormMessage) {
     return (
       <Fragment>
         <EuiCallOut
-          announceOnMount
           size="s"
           color="primary"
           data-test-subj="loginInfoMessage"

--- a/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/index.ts
+++ b/x-pack/platform/plugins/shared/security/public/authentication/components/form_message/index.ts
@@ -5,6 +5,4 @@
  * 2.0.
  */
 
-export type { LoginFormProps } from './login_form';
-export { LoginForm } from './login_form';
-export { DisabledLoginForm } from './disabled_login_form';
+export { MessageType, type FormMessage, formMessages, renderMessage } from './form_message';

--- a/x-pack/platform/plugins/shared/security/public/authentication/components/index.ts
+++ b/x-pack/platform/plugins/shared/security/public/authentication/components/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { AuthenticationStatePage } from './authentication_state_page';
+export { MessageType, type FormMessage, formMessages, renderMessage } from './form_message';

--- a/x-pack/platform/plugins/shared/security/public/authentication/logged_out/logged_out_page.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/logged_out/logged_out_page.test.tsx
@@ -7,6 +7,7 @@
 
 import { EuiButton } from '@elastic/eui';
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom-v5-compat';
 
 import { coreMock } from '@kbn/core/public/mocks';
 import { customBrandingServiceMock } from '@kbn/core-custom-branding-browser-mocks';
@@ -26,7 +27,9 @@ describe('LoggedOutPage', () => {
     const basePathMock = coreMock.createStart({ basePath: '/mock-base-path' }).http.basePath;
     const customBranding = customBrandingServiceMock.createStartContract();
     const wrapper = mountWithIntl(
-      <LoggedOutPage basePath={basePathMock} customBranding={customBranding} />
+      <BrowserRouter>
+        <LoggedOutPage basePath={basePathMock} customBranding={customBranding} />
+      </BrowserRouter>
     );
 
     expect(wrapper.find(EuiButton).prop('href')).toBe('/mock-base-path/');
@@ -40,7 +43,9 @@ describe('LoggedOutPage', () => {
     const customBranding = customBrandingServiceMock.createStartContract();
     const basePathMock = coreMock.createStart({ basePath: '/mock-base-path' }).http.basePath;
     const wrapper = mountWithIntl(
-      <LoggedOutPage basePath={basePathMock} customBranding={customBranding} />
+      <BrowserRouter>
+        <LoggedOutPage basePath={basePathMock} customBranding={customBranding} />
+      </BrowserRouter>
     );
 
     expect(wrapper.find(EuiButton).prop('href')).toBe('/mock-base-path/app/home#/?_g=()');

--- a/x-pack/platform/plugins/shared/security/public/authentication/logged_out/logged_out_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/logged_out/logged_out_page.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { EuiButton } from '@elastic/eui';
+import { EuiButton, EuiSpacer } from '@elastic/eui';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter, useSearchParams } from 'react-router-dom-v5-compat';
 import useObservable from 'react-use/lib/useObservable';
 
 import type { AppMountParameters, CustomBrandingStart, IBasePath } from '@kbn/core/public';
@@ -15,8 +16,9 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { parseNextURL } from '@kbn/std';
 
 import type { StartServices } from '../..';
-import { AuthenticationStatePage } from '../components';
-
+import { LOGOUT_REASON_QUERY_STRING_PARAMETER } from '../../../common/constants';
+import type { LogoutReason } from '../../../common/types';
+import { AuthenticationStatePage, formMessages, renderMessage } from '../components';
 interface Props {
   basePath: IBasePath;
   customBranding: CustomBrandingStart;
@@ -24,6 +26,11 @@ interface Props {
 
 export function LoggedOutPage({ basePath, customBranding }: Props) {
   const customBrandingValue = useObservable(customBranding.customBranding$);
+  const [searchParams] = useSearchParams();
+
+  const message =
+    formMessages[searchParams.get(LOGOUT_REASON_QUERY_STRING_PARAMETER) as LogoutReason];
+
   return (
     <AuthenticationStatePage
       title={
@@ -34,6 +41,8 @@ export function LoggedOutPage({ basePath, customBranding }: Props) {
       }
       logo={customBrandingValue?.logo}
     >
+      {message && renderMessage(message)}
+      <EuiSpacer size="l" />
       <EuiButton href={parseNextURL(window.location.href, basePath.serverBasePath)}>
         <FormattedMessage id="xpack.security.loggedOut.login" defaultMessage="Log in" />
       </EuiButton>
@@ -46,7 +55,14 @@ export function renderLoggedOutPage(
   { element }: Pick<AppMountParameters, 'element'>,
   props: Props
 ) {
-  ReactDOM.render(services.rendering.addContext(<LoggedOutPage {...props} />), element);
+  ReactDOM.render(
+    services.rendering.addContext(
+      <BrowserRouter>
+        <LoggedOutPage {...props} />
+      </BrowserRouter>
+    ),
+    element
+  );
 
   return () => ReactDOM.unmountComponentAtNode(element);
 }

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/index.ts
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/index.ts
@@ -6,4 +6,4 @@
  */
 
 export type { LoginFormProps } from './login_form';
-export { LoginForm, MessageType as LoginFormMessageType } from './login_form';
+export { LoginForm } from './login_form';

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/login_form.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/login_form.test.tsx
@@ -14,7 +14,8 @@ import ReactMarkdown from 'react-markdown';
 import { coreMock } from '@kbn/core/public/mocks';
 import { findTestSubject, mountWithIntl, nextTick, shallowWithIntl } from '@kbn/test-jest-helpers';
 
-import { LoginForm, MessageType, PageMode } from './login_form';
+import { LoginForm, PageMode } from './login_form';
+import { MessageType } from '../../../components';
 
 function expectPageMode(wrapper: ReactWrapper, mode: PageMode) {
   const assertions: Array<[string, boolean]> =

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/login_form.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/login_form.tsx
@@ -10,7 +10,6 @@ import './login_form.scss';
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiCallOut,
   EuiFieldPassword,
   EuiFieldText,
   EuiFlexGroup,
@@ -36,12 +35,14 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import { LoginValidator } from './validate_login';
 import type { LoginSelector, LoginSelectorProvider } from '../../../../../common/login_state';
+import type { FormMessage } from '../../../components';
+import { MessageType, renderMessage } from '../../../components';
 
 export interface LoginFormProps {
   http: HttpStart;
   notifications: NotificationsStart;
   selector: LoginSelector;
-  message?: { type: MessageType.Danger | MessageType.Info; content: string };
+  message?: FormMessage;
   loginAssistanceMessage: string;
   loginHelp?: string;
   authProviderHint?: string;
@@ -53,9 +54,7 @@ interface State {
     | { type: LoadingStateType.Selector; providerName: string };
   username: string;
   password: string;
-  message:
-    | { type: MessageType.None }
-    | { type: MessageType.Danger | MessageType.Info; content: string };
+  message: FormMessage;
   mode: PageMode;
   previousMode: PageMode;
 }
@@ -65,12 +64,6 @@ enum LoadingStateType {
   Form,
   Selector,
   AutoLogin,
-}
-
-export enum MessageType {
-  None,
-  Info,
-  Danger,
 }
 
 export enum PageMode {
@@ -127,7 +120,7 @@ export class LoginForm extends Component<LoginFormProps, State> {
     return (
       <Fragment>
         {this.renderLoginAssistanceMessage()}
-        {this.renderMessage()}
+        {renderMessage(this.state.message)}
         {this.renderContent()}
         {this.renderPageModeSwitchLink()}
       </Fragment>
@@ -147,41 +140,6 @@ export class LoginForm extends Component<LoginFormProps, State> {
         </EuiText>
       </div>
     );
-  };
-
-  private renderMessage = () => {
-    const { message } = this.state;
-    if (message.type === MessageType.Danger) {
-      return (
-        <Fragment>
-          <EuiCallOut
-            size="s"
-            color="danger"
-            data-test-subj="loginErrorMessage"
-            title={message.content}
-            role="alert"
-          />
-          <EuiSpacer size="l" />
-        </Fragment>
-      );
-    }
-
-    if (message.type === MessageType.Info) {
-      return (
-        <Fragment>
-          <EuiCallOut
-            size="s"
-            color="primary"
-            data-test-subj="loginInfoMessage"
-            title={message.content}
-            role="status"
-          />
-          <EuiSpacer size="l" />
-        </Fragment>
-      );
-    }
-
-    return null;
   };
 
   public renderContent() {

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.test.tsx
@@ -15,10 +15,11 @@ import { coreMock } from '@kbn/core/public/mocks';
 import { customBrandingServiceMock } from '@kbn/core-custom-branding-browser-mocks';
 import { nextTick } from '@kbn/test-jest-helpers';
 
-import { DisabledLoginForm, LoginForm, LoginFormMessageType } from './components';
+import { DisabledLoginForm, LoginForm } from './components';
 import { LoginPage } from './login_page';
 import { AUTH_PROVIDER_HINT_QUERY_STRING_PARAMETER } from '../../../common/constants';
 import type { LoginState } from '../../../common/login_state';
+import { MessageType } from '../components';
 
 const createLoginState = (options?: Partial<LoginState>) => {
   return {
@@ -374,7 +375,7 @@ describe('LoginPage', () => {
       const { authProviderHint, message } = wrapper.find(LoginForm).props();
       expect(authProviderHint).toBe('basic1');
       expect(message).toEqual({
-        type: LoginFormMessageType.Info,
+        type: MessageType.Info,
         content: 'Your session has timed out. Please log in again.',
       });
     });

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/login_page.tsx
@@ -35,7 +35,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { LoginFormProps } from './components';
-import { DisabledLoginForm, LoginForm, LoginFormMessageType } from './components';
+import { DisabledLoginForm, LoginForm } from './components';
 import type { StartServices } from '../..';
 import {
   AUTH_PROVIDER_HINT_QUERY_STRING_PARAMETER,
@@ -44,6 +44,7 @@ import {
 import type { LoginState } from '../../../common/login_state';
 import type { LogoutReason } from '../../../common/types';
 import type { ConfigType } from '../../config';
+import { MessageType } from '../components';
 
 interface Props {
   http: HttpStart;
@@ -61,31 +62,31 @@ interface State {
 
 const loginFormMessages: Record<LogoutReason, NonNullable<LoginFormProps['message']>> = {
   SESSION_EXPIRED: {
-    type: LoginFormMessageType.Info,
+    type: MessageType.Info,
     content: i18n.translate('xpack.security.login.sessionExpiredDescription', {
       defaultMessage: 'Your session has timed out. Please log in again.',
     }),
   },
   CONCURRENCY_LIMIT: {
-    type: LoginFormMessageType.Info,
+    type: MessageType.Info,
     content: i18n.translate('xpack.security.login.concurrencyLimitDescription', {
       defaultMessage: 'You have logged in on another device. Please log in again.',
     }),
   },
   AUTHENTICATION_ERROR: {
-    type: LoginFormMessageType.Info,
+    type: MessageType.Info,
     content: i18n.translate('xpack.security.login.authenticationErrorDescription', {
       defaultMessage: 'An unexpected authentication error occurred. Please log in again.',
     }),
   },
   LOGGED_OUT: {
-    type: LoginFormMessageType.Info,
+    type: MessageType.Info,
     content: i18n.translate('xpack.security.login.loggedOutDescription', {
       defaultMessage: 'You have logged out of Elastic.',
     }),
   },
   UNAUTHENTICATED: {
-    type: LoginFormMessageType.Danger,
+    type: MessageType.Danger,
     content: i18n.translate('xpack.security.unauthenticated.errorDescription', {
       defaultMessage:
         'Try logging in again, and if the problem persists, contact your system administrator.',

--- a/x-pack/platform/plugins/shared/security/public/authentication/overwritten_session/__snapshots__/overwritten_session_page.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/overwritten_session/__snapshots__/overwritten_session_page.test.tsx.snap
@@ -5,7 +5,8 @@ exports[`OverwrittenSessionPage renders as expected 1`] = `
   class="secAuthenticationStatePage "
 >
   <header
-    class="secAuthenticationStatePage__header"
+    class="css-1w0q1qu-AuthenticationStatePage"
+    data-test-subj="secAuthenticationStatePageHeader"
   >
     <div
       class="secAuthenticationStatePage__content eui-textCenter"
@@ -14,7 +15,8 @@ exports[`OverwrittenSessionPage renders as expected 1`] = `
         class="euiSpacer euiSpacer--xxl emotion-euiSpacer-xxl"
       />
       <span
-        class="secAuthenticationStatePage__logo"
+        class="css-1rux1qp-AuthenticationStatePage"
+        data-test-subj="secAuthenticationStatePageLogo"
       >
         <span
           data-euiicon-type="logoElastic"
@@ -25,14 +27,14 @@ exports[`OverwrittenSessionPage renders as expected 1`] = `
       >
         You previously logged in as a different user.
       </h1>
-      <div
-        class="euiSpacer euiSpacer--xl emotion-euiSpacer-xl"
-      />
     </div>
   </header>
   <div
     class="secAuthenticationStatePage__content eui-textCenter"
   >
+    <div
+      class="euiSpacer euiSpacer--xl emotion-euiSpacer-xl"
+    />
     <a
       class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
       href="/mock-base-path/"

--- a/x-pack/platform/plugins/shared/security/public/authentication/overwritten_session/__snapshots__/overwritten_session_page.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/overwritten_session/__snapshots__/overwritten_session_page.test.tsx.snap
@@ -5,8 +5,7 @@ exports[`OverwrittenSessionPage renders as expected 1`] = `
   class="secAuthenticationStatePage "
 >
   <header
-    class="css-1w0q1qu-AuthenticationStatePage"
-    data-test-subj="secAuthenticationStatePageHeader"
+    class="secAuthenticationStatePage__header"
   >
     <div
       class="secAuthenticationStatePage__content eui-textCenter"
@@ -15,8 +14,7 @@ exports[`OverwrittenSessionPage renders as expected 1`] = `
         class="euiSpacer euiSpacer--xxl emotion-euiSpacer-xxl"
       />
       <span
-        class="css-1rux1qp-AuthenticationStatePage"
-        data-test-subj="secAuthenticationStatePageLogo"
+        class="secAuthenticationStatePage__logo"
       >
         <span
           data-euiicon-type="logoElastic"

--- a/x-pack/platform/plugins/shared/security/public/authentication/overwritten_session/overwritten_session_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/authentication/overwritten_session/overwritten_session_page.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButton } from '@elastic/eui';
+import { EuiButton, EuiSpacer } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -41,6 +41,7 @@ export function OverwrittenSessionPage({ authc, basePath }: Props) {
         />
       }
     >
+      <EuiSpacer size="xl" />
       <EuiButton href={parseNextURL(window.location.href, basePath.serverBasePath)}>
         <FormattedMessage
           id="xpack.security.overwrittenSession.continueAsUserText"

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
@@ -39,6 +39,7 @@ import {
 import { licenseMock } from '../../common/licensing/index.mock';
 import { mockAuthenticatedUser } from '../../common/model/authenticated_user.mock';
 import { userProfileMock } from '../../common/model/user_profile.mock';
+import { LogoutReason } from '../../common/types';
 import { auditLoggerMock, auditServiceMock } from '../audit/mocks';
 import { ConfigSchema, createConfig } from '../config';
 import { securityFeatureUsageServiceMock } from '../feature_usage/index.mock';
@@ -255,31 +256,53 @@ describe('Authenticator', () => {
         );
       });
 
-      it('points to a custom URL if `customLogoutURL` is specified', () => {
-        const authenticationProviderMock =
-          jest.requireMock(`./providers/saml`).SAMLAuthenticationProvider;
-        authenticationProviderMock.mockClear();
-        new Authenticator(
-          getMockOptions({
-            selector: { enabled: false },
-            providers: { saml: { saml1: { order: 0, realm: 'realm' } } },
-            customLogoutURL: 'https://some-logout-origin/logout',
-          })
-        );
-        const getLoggedOutURL = authenticationProviderMock.mock.calls[0][0].urls.loggedOut;
-
-        expect(getLoggedOutURL(httpServerMock.createKibanaRequest())).toBe(
-          'https://some-logout-origin/logout'
-        );
-
-        // We don't forward any Kibana specific query string parameters to the external logout URL.
-        expect(
-          getLoggedOutURL(
-            httpServerMock.createKibanaRequest({
-              query: { next: '/app/ml/encode me', msg: 'SESSION_EXPIRED' },
+      describe('custom URL', () => {
+        it('points to a custom URL if `customLogoutURL` is specified and logout reason is not SESSION_EXPIRED', () => {
+          const authenticationProviderMock =
+            jest.requireMock(`./providers/saml`).SAMLAuthenticationProvider;
+          authenticationProviderMock.mockClear();
+          new Authenticator(
+            getMockOptions({
+              selector: { enabled: false },
+              providers: { saml: { saml1: { order: 0, realm: 'realm' } } },
+              customLogoutURL: 'https://some-logout-origin/logout',
             })
-          )
-        ).toBe('https://some-logout-origin/logout');
+          );
+          const getLoggedOutURL = authenticationProviderMock.mock.calls[0][0].urls.loggedOut;
+
+          expect(getLoggedOutURL(httpServerMock.createKibanaRequest())).toBe(
+            'https://some-logout-origin/logout'
+          );
+
+          // We don't forward any Kibana specific query string parameters to the external logout URL.
+          expect(
+            getLoggedOutURL(
+              httpServerMock.createKibanaRequest({
+                query: { next: '/app/ml/encode me', msg: LogoutReason.LOGGED_OUT },
+              })
+            )
+          ).toBe('https://some-logout-origin/logout');
+        });
+
+        it('does not point to a custom URL if `customLogoutURL` is specified and logout reason is SESSION_EXPIRED', () => {
+          const authenticationProviderMock =
+            jest.requireMock(`./providers/saml`).SAMLAuthenticationProvider;
+          authenticationProviderMock.mockClear();
+          new Authenticator(
+            getMockOptions({
+              selector: { enabled: false },
+              providers: { saml: { saml1: { order: 0, realm: 'realm' } } },
+              customLogoutURL: 'https://some-logout-origin/logout',
+            })
+          );
+          const getLoggedOutURL = authenticationProviderMock.mock.calls[0][0].urls.loggedOut;
+
+          expect(
+            getLoggedOutURL(
+              httpServerMock.createKibanaRequest({ query: { msg: LogoutReason.SESSION_EXPIRED } })
+            )
+          ).toBe('/mock-server-basepath/security/logged_out?msg=SESSION_EXPIRED');
+        });
       });
     });
 

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
@@ -40,6 +40,7 @@ import {
   SESSION_ERROR_REASON_HEADER,
 } from '../../common/constants';
 import { shouldProviderUseLoginForm } from '../../common/model';
+import { LogoutReason } from '../../common/types';
 import { accessAgreementAcknowledgedEvent, userLoginEvent, userLogoutEvent } from '../audit';
 import type { ConfigType } from '../config';
 import { getErrorStatusCode } from '../errors';
@@ -1033,7 +1034,11 @@ export class Authenticator {
    * provider in the chain (default) is assumed.
    */
   private getLoggedOutURL(request: KibanaRequest, providerType?: string) {
-    if (this.options.customLogoutURL) {
+    const sessionExpired =
+      request.url.searchParams.get(LOGOUT_REASON_QUERY_STRING_PARAMETER) ===
+      LogoutReason.SESSION_EXPIRED;
+
+    if (this.options.customLogoutURL && !sessionExpired) {
       return this.options.customLogoutURL;
     }
 
@@ -1042,7 +1047,7 @@ export class Authenticator {
     const searchParams = new URLSearchParams();
     for (const [key, defaultValue] of [
       [NEXT_URL_QUERY_STRING_PARAMETER, null],
-      [LOGOUT_REASON_QUERY_STRING_PARAMETER, 'LOGGED_OUT'],
+      [LOGOUT_REASON_QUERY_STRING_PARAMETER, LogoutReason.LOGGED_OUT],
     ] as Array<[string, string | null]>) {
       const value = request.url.searchParams.get(key) || defaultValue;
       if (value) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Improve session timeout redirect for serverless projects (#251630)](https://github.com/elastic/kibana/pull/251630)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-02-10T09:45:58Z","message":"Improve session timeout redirect for serverless projects (#251630)\n\nCloses https://github.com/elastic/kibana/issues/238674\n\n## Summary\n\nUpdate authenticator to redirect to custom \"logged out\" URL if the\nsession has not expired. Custom logged out URLs are used in serverless\nto redirect the user to the organization's projects list page. When a\nsession expires, it is preferable to redirect back to a screen where the\nuser can log back into the project they were working on.\n\nAdditionally, this PR updates the \"logged out\" page...\n- Adds a message section under the title, mirroring the login form\n- Matches the logo style from the login page (removes shadow border)\n- Adjusts spacing - moved spacers from reusable components to achieve\nconsistency\n- Moved implementation of form messages from login components to\nauthentication components\n\nNote: considering the UI changes, I am backporting this PR to decrease\ndivergence of open branches.\n\n### Logged out screen\nBefore\n<img width=\"504\" height=\"318\" alt=\"Screenshot 2026-02-05 at 10 37 05\"\nsrc=\"https://github.com/user-attachments/assets/53b34ba0-3def-48d9-93ad-3d9c6ca41b8e\"\n/>\n\nAfter\n<img width=\"523\" height=\"336\" alt=\"Screenshot 2026-02-05 at 11 15 58\"\nsrc=\"https://github.com/user-attachments/assets/024799c1-36cd-4efe-91a2-1cbd52f4e10e\"\n/>\n\n### Login form \nUnchanged\n<img width=\"547\" height=\"465\" alt=\"Screenshot 2026-02-05 at 10 34 39\"\nsrc=\"https://github.com/user-attachments/assets/ea81d90e-ddf5-41eb-99f2-2fa7d811ae77\"\n/>\n\n### Testing\nTo test locally in serverless mode...\n\n1. Set a relatively short session lifespan in `serverless.yml`\n\n> xpack.security.session.lifespan: \"20s\"\n\n3. Comment out the following code in\n`x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts`,\nstarting at ln 331. This will prevent the mock SAML provider from\noverriding the redirect on logout.\n```\n        if (redirect != null) {\n           this.logger.debug('Redirecting user to Identity Provider to complete logout.');\n           return DeauthenticationResult.redirectTo(redirect);\n        }\n```\n5. Start ES & KB in serverless mode (e.g. `yarn es serverless\n--projectType=security`, `yarn start --serverless=security`)\n6. Log in as any type of user\n7. Let you session expire and verify that you are redirected to a local\nlogout screen with a button to log back in\n8. Verify the session expired message is displayed\n9. Change the `msg` parameter in the URL to any of the following and\nverify the displayed message: CONCURRENCY_LIMIT, AUTHENTICATION_ERROR,\nLOGGED_OUT, UNAUTHENTICATED\n10. Log in as any type of user\n11. Log out before your session expires and verify that you are\nredirected to the cloud organization projects screen (you will have to\nauthenticate to cloud if you have not already)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2661815747ad66dc9d53a70a12a57adb3c5bf85e","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","ci:project-deploy-elasticsearch","v9.4.0"],"title":"Improve session timeout redirect for serverless projects","number":251630,"url":"https://github.com/elastic/kibana/pull/251630","mergeCommit":{"message":"Improve session timeout redirect for serverless projects (#251630)\n\nCloses https://github.com/elastic/kibana/issues/238674\n\n## Summary\n\nUpdate authenticator to redirect to custom \"logged out\" URL if the\nsession has not expired. Custom logged out URLs are used in serverless\nto redirect the user to the organization's projects list page. When a\nsession expires, it is preferable to redirect back to a screen where the\nuser can log back into the project they were working on.\n\nAdditionally, this PR updates the \"logged out\" page...\n- Adds a message section under the title, mirroring the login form\n- Matches the logo style from the login page (removes shadow border)\n- Adjusts spacing - moved spacers from reusable components to achieve\nconsistency\n- Moved implementation of form messages from login components to\nauthentication components\n\nNote: considering the UI changes, I am backporting this PR to decrease\ndivergence of open branches.\n\n### Logged out screen\nBefore\n<img width=\"504\" height=\"318\" alt=\"Screenshot 2026-02-05 at 10 37 05\"\nsrc=\"https://github.com/user-attachments/assets/53b34ba0-3def-48d9-93ad-3d9c6ca41b8e\"\n/>\n\nAfter\n<img width=\"523\" height=\"336\" alt=\"Screenshot 2026-02-05 at 11 15 58\"\nsrc=\"https://github.com/user-attachments/assets/024799c1-36cd-4efe-91a2-1cbd52f4e10e\"\n/>\n\n### Login form \nUnchanged\n<img width=\"547\" height=\"465\" alt=\"Screenshot 2026-02-05 at 10 34 39\"\nsrc=\"https://github.com/user-attachments/assets/ea81d90e-ddf5-41eb-99f2-2fa7d811ae77\"\n/>\n\n### Testing\nTo test locally in serverless mode...\n\n1. Set a relatively short session lifespan in `serverless.yml`\n\n> xpack.security.session.lifespan: \"20s\"\n\n3. Comment out the following code in\n`x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts`,\nstarting at ln 331. This will prevent the mock SAML provider from\noverriding the redirect on logout.\n```\n        if (redirect != null) {\n           this.logger.debug('Redirecting user to Identity Provider to complete logout.');\n           return DeauthenticationResult.redirectTo(redirect);\n        }\n```\n5. Start ES & KB in serverless mode (e.g. `yarn es serverless\n--projectType=security`, `yarn start --serverless=security`)\n6. Log in as any type of user\n7. Let you session expire and verify that you are redirected to a local\nlogout screen with a button to log back in\n8. Verify the session expired message is displayed\n9. Change the `msg` parameter in the URL to any of the following and\nverify the displayed message: CONCURRENCY_LIMIT, AUTHENTICATION_ERROR,\nLOGGED_OUT, UNAUTHENTICATED\n10. Log in as any type of user\n11. Log out before your session expires and verify that you are\nredirected to the cloud organization projects screen (you will have to\nauthenticate to cloud if you have not already)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2661815747ad66dc9d53a70a12a57adb3c5bf85e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251630","number":251630,"mergeCommit":{"message":"Improve session timeout redirect for serverless projects (#251630)\n\nCloses https://github.com/elastic/kibana/issues/238674\n\n## Summary\n\nUpdate authenticator to redirect to custom \"logged out\" URL if the\nsession has not expired. Custom logged out URLs are used in serverless\nto redirect the user to the organization's projects list page. When a\nsession expires, it is preferable to redirect back to a screen where the\nuser can log back into the project they were working on.\n\nAdditionally, this PR updates the \"logged out\" page...\n- Adds a message section under the title, mirroring the login form\n- Matches the logo style from the login page (removes shadow border)\n- Adjusts spacing - moved spacers from reusable components to achieve\nconsistency\n- Moved implementation of form messages from login components to\nauthentication components\n\nNote: considering the UI changes, I am backporting this PR to decrease\ndivergence of open branches.\n\n### Logged out screen\nBefore\n<img width=\"504\" height=\"318\" alt=\"Screenshot 2026-02-05 at 10 37 05\"\nsrc=\"https://github.com/user-attachments/assets/53b34ba0-3def-48d9-93ad-3d9c6ca41b8e\"\n/>\n\nAfter\n<img width=\"523\" height=\"336\" alt=\"Screenshot 2026-02-05 at 11 15 58\"\nsrc=\"https://github.com/user-attachments/assets/024799c1-36cd-4efe-91a2-1cbd52f4e10e\"\n/>\n\n### Login form \nUnchanged\n<img width=\"547\" height=\"465\" alt=\"Screenshot 2026-02-05 at 10 34 39\"\nsrc=\"https://github.com/user-attachments/assets/ea81d90e-ddf5-41eb-99f2-2fa7d811ae77\"\n/>\n\n### Testing\nTo test locally in serverless mode...\n\n1. Set a relatively short session lifespan in `serverless.yml`\n\n> xpack.security.session.lifespan: \"20s\"\n\n3. Comment out the following code in\n`x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts`,\nstarting at ln 331. This will prevent the mock SAML provider from\noverriding the redirect on logout.\n```\n        if (redirect != null) {\n           this.logger.debug('Redirecting user to Identity Provider to complete logout.');\n           return DeauthenticationResult.redirectTo(redirect);\n        }\n```\n5. Start ES & KB in serverless mode (e.g. `yarn es serverless\n--projectType=security`, `yarn start --serverless=security`)\n6. Log in as any type of user\n7. Let you session expire and verify that you are redirected to a local\nlogout screen with a button to log back in\n8. Verify the session expired message is displayed\n9. Change the `msg` parameter in the URL to any of the following and\nverify the displayed message: CONCURRENCY_LIMIT, AUTHENTICATION_ERROR,\nLOGGED_OUT, UNAUTHENTICATED\n10. Log in as any type of user\n11. Log out before your session expires and verify that you are\nredirected to the cloud organization projects screen (you will have to\nauthenticate to cloud if you have not already)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2661815747ad66dc9d53a70a12a57adb3c5bf85e"}},{"url":"https://github.com/elastic/kibana/pull/252470","number":252470,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->