### PR TITLE
Docs: saved objects create APIs migration versions

### DIFF
--- a/docs/extend/saved-objects.md
+++ b/docs/extend/saved-objects.md
@@ -20,6 +20,11 @@ By using Saved Objects your plugin can take advantage of the following features:
 * By declaring `references`, an object’s entire reference graph will be exported. This makes it easy for users to export e.g. a `dashboard` object and have all the `visualization` objects required to display the dashboard included in the export.
 * When the X-Pack security and spaces plugins are enabled these transparently provide RBAC access control and the ability to organize Saved Objects into spaces.
 
+:::::{note}
+When using the (deprecated) Saved Objects HTTP create APIs (`POST /api/saved_objects/{type}` and `POST /api/saved_objects/_bulk_create`), clients may include `typeMigrationVersion` and `coreMigrationVersion` (or legacy `migrationVersion`) in the request payload.
+When present, Kibana can migrate the saved object to the latest version **before** running Saved Objects type validation.
+:::::
+
 This document contains developer guidelines and best-practices for plugins wanting to use Saved Objects.
 
 ## Registering a Saved Object type [saved-objects-type-registration]

--- a/src/core/packages/saved-objects/docs/openapi/paths/api@saved_objects@_bulk_create.yaml
+++ b/src/core/packages/saved-objects/docs/openapi/paths/api@saved_objects@_bulk_create.yaml
@@ -25,6 +25,37 @@ post:
           type: array
           items:
             type: object
+            required:
+              - type
+              - attributes
+            properties:
+              type:
+                type: string
+                description: The saved object type.
+              id:
+                type: string
+                description: The saved object ID.
+              attributes:
+                $ref: '../components/schemas/attributes.yaml'
+              version:
+                type: string
+                description: The optimistic concurrency control version.
+              coreMigrationVersion:
+                type: string
+                description: The Kibana core migration version of the saved object.
+              typeMigrationVersion:
+                type: string
+                description: The migration version of the saved object type.
+              migrationVersion:
+                type: object
+                description: |
+                  Legacy per-type migration versions. Prefer `coreMigrationVersion` and `typeMigrationVersion`.
+                additionalProperties:
+                  type: string
+              references:
+                $ref: '../components/schemas/references.yaml'
+              initialNamespaces:
+                $ref: '../components/schemas/initial_namespaces.yaml'
   responses:
     '200':
       description: Indicates a successful call.

--- a/src/core/packages/saved-objects/docs/openapi/paths/api@saved_objects@{type}.yaml
+++ b/src/core/packages/saved-objects/docs/openapi/paths/api@saved_objects@{type}.yaml
@@ -29,6 +29,18 @@ post:
           properties:
             attributes:
               $ref: '../components/schemas/attributes.yaml'
+            coreMigrationVersion:
+              type: string
+              description: The Kibana core migration version of the saved object.
+            typeMigrationVersion:
+              type: string
+              description: The migration version of the saved object type.
+            migrationVersion:
+              type: object
+              description: |
+                Legacy per-type migration versions. Prefer `coreMigrationVersion` and `typeMigrationVersion`.
+              additionalProperties:
+                type: string
             initialNamespaces:
               $ref: '../components/schemas/initial_namespaces.yaml'
             references:

--- a/src/core/server/integration_tests/saved_objects/routes/bulk_create.test.ts
+++ b/src/core/server/integration_tests/saved_objects/routes/bulk_create.test.ts
@@ -120,6 +120,8 @@ describe('POST /api/saved_objects/_bulk_create', () => {
         attributes: {
           title: 'foo',
         },
+        coreMigrationVersion: '8.13.0',
+        typeMigrationVersion: '1.2.3',
         references: [],
       },
       {
@@ -128,6 +130,8 @@ describe('POST /api/saved_objects/_bulk_create', () => {
         attributes: {
           title: 'bar',
         },
+        coreMigrationVersion: '8.13.0',
+        typeMigrationVersion: '1.2.3',
         references: [],
       },
     ];

--- a/src/core/server/integration_tests/saved_objects/routes/create.test.ts
+++ b/src/core/server/integration_tests/saved_objects/routes/create.test.ts
@@ -133,6 +133,40 @@ describe('POST /api/saved_objects/{type}', () => {
         overwrite: false,
         id: undefined,
         migrationVersion: undefined,
+        coreMigrationVersion: undefined,
+        typeMigrationVersion: undefined,
+        references: undefined,
+        initialNamespaces: undefined,
+        migrationVersionCompatibility: 'compatible',
+      }
+    );
+  });
+
+  it('accepts coreMigrationVersion and typeMigrationVersion', async () => {
+    await supertest(server.listener)
+      .post('/api/saved_objects/index-pattern')
+      .set('x-elastic-internal-origin', 'kibana')
+      .send({
+        attributes: {
+          title: 'Testing',
+        },
+        coreMigrationVersion: '8.13.0',
+        typeMigrationVersion: '1.2.3',
+      })
+      .expect(200);
+
+    expect(savedObjectsClient.create).toHaveBeenCalledTimes(1);
+    expect(savedObjectsClient.create).toHaveBeenCalledWith(
+      'index-pattern',
+      { title: 'Testing' },
+      {
+        overwrite: false,
+        id: undefined,
+        migrationVersion: undefined,
+        coreMigrationVersion: '8.13.0',
+        typeMigrationVersion: '1.2.3',
+        references: undefined,
+        initialNamespaces: undefined,
         migrationVersionCompatibility: 'compatible',
       }
     );
@@ -155,7 +189,16 @@ describe('POST /api/saved_objects/{type}', () => {
     expect(args).toEqual([
       'index-pattern',
       { title: 'Testing' },
-      { overwrite: false, id: 'logstash-*', migrationVersionCompatibility: 'compatible' },
+      {
+        overwrite: false,
+        id: 'logstash-*',
+        migrationVersion: undefined,
+        coreMigrationVersion: undefined,
+        typeMigrationVersion: undefined,
+        references: undefined,
+        initialNamespaces: undefined,
+        migrationVersionCompatibility: 'compatible',
+      },
     ]);
   });
 

--- a/src/platform/test/api_integration/apis/saved_objects/bulk_create.ts
+++ b/src/platform/test/api_integration/apis/saved_objects/bulk_create.ts
@@ -127,7 +127,9 @@ export default function ({ getService }: FtrProviderContext) {
         .then((resp) => {
           expect(resp.body.saved_objects).to.have.length(1);
           expect(resp.body.saved_objects[0].error).to.not.be.ok();
-          expect(resp.body.saved_objects[0].coreMigrationVersion).to.eql(created.coreMigrationVersion);
+          expect(resp.body.saved_objects[0].coreMigrationVersion).to.eql(
+            created.coreMigrationVersion
+          );
           expect(resp.body.saved_objects[0].typeMigrationVersion).to.be.ok();
         });
     });

--- a/src/platform/test/api_integration/apis/saved_objects/create.ts
+++ b/src/platform/test/api_integration/apis/saved_objects/create.ts
@@ -86,5 +86,34 @@ export default function ({ getService }: FtrProviderContext) {
           expect(resp.body.coreMigrationVersion).to.eql('8.8.0');
         });
     });
+
+    it('should accept coreMigrationVersion and typeMigrationVersion in the request (create)', async () => {
+      const { body: created } = await supertest
+        .post(`/api/saved_objects/visualization`)
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .send({
+          attributes: {
+            title: 'My favorite vis (used to read migration versions)',
+          },
+        })
+        .expect(200)
+        .then((resp) => resp);
+
+      await supertest
+        .post(`/api/saved_objects/visualization`)
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .send({
+          attributes: {
+            title: 'My favorite vis (with migration versions)',
+          },
+          coreMigrationVersion: created.coreMigrationVersion,
+          typeMigrationVersion: created.typeMigrationVersion,
+        })
+        .expect(200)
+        .then((resp) => {
+          expect(resp.body.coreMigrationVersion).to.eql(created.coreMigrationVersion);
+          expect(resp.body.typeMigrationVersion).to.be.ok();
+        });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Document optional `coreMigrationVersion` / `typeMigrationVersion` (and legacy `migrationVersion`) in the deprecated Saved Objects create APIs.
- Add API integration coverage to ensure requests including these fields are accepted.

Fixes: elastic/kibana#237323

## Test plan
- `yarn test:ftr --config src/platform/test/api_integration/config.js --grep \"should accept coreMigrationVersion and typeMigrationVersion\"`

Made with [Cursor](https://cursor.com)