### PR TITLE
[contextual-security-apps] Thread refreshed PIT id through CSP queries

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/common/types/benchmarks/v1.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/common/types/benchmarks/v1.ts
@@ -14,7 +14,7 @@ export type AgentPolicyStatus = Pick<AgentPolicy, 'id' | 'name'> & { agents: num
 
 export const benchmarkScoreSchema = schema.object({
   postureScore: schema.number({ defaultValue: 0, min: 0 }),
-  resourcesEvaluated: schema.number({ defaultValue: 0, min: 0 }),
+  resourcesEvaluated: schema.maybe(schema.number({ defaultValue: 0, min: 0 })),
   totalFailed: schema.number({ defaultValue: 0, min: 0 }),
   totalFindings: schema.number({ defaultValue: 0, min: 0 }),
   totalPassed: schema.number({ defaultValue: 0, min: 0 }),

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmarks/v2.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmarks/v2.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { getBenchmarksData } from './v2';
+
+jest.mock('../benchmark_rules/get_states/v1', () => ({
+  getMutedRulesFilterQuery: jest.fn().mockResolvedValue([]),
+}));
+
+describe('getBenchmarksData PIT refresh', () => {
+  it('rolls forward pit_id between searches and uses latest for close', async () => {
+    const soClient = savedObjectsClientMock.create();
+    const encryptedSoClient = savedObjectsClientMock.create();
+
+    soClient.find.mockResolvedValue({
+      aggregations: {
+        benchmark_id: {
+          buckets: [
+            {
+              key: 'cis_k8s',
+              doc_count: 1,
+              name: {
+                buckets: [
+                  {
+                    key: 'CIS Kubernetes',
+                    doc_count: 1,
+                    version: {
+                      buckets: [
+                        { key: 'v1.0.0', doc_count: 1 },
+                        { key: 'v2.0.0', doc_count: 1 },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const esClient = {
+      openPointInTime: jest.fn().mockResolvedValue({ id: 'pit-0' }),
+      search: jest
+        .fn()
+        .mockResolvedValueOnce({
+          pit_id: 'pit-1',
+          aggregations: {
+            failed_findings: { doc_count: 1 },
+            passed_findings: { doc_count: 2 },
+            resources_evaluated: { value: 3 },
+          },
+        })
+        .mockResolvedValueOnce({
+          pit_id: 'pit-2',
+          aggregations: { aggs_by_asset_identifier: { buckets: [] } },
+        })
+        .mockResolvedValueOnce({
+          pit_id: 'pit-3',
+          aggregations: {
+            failed_findings: { doc_count: 2 },
+            passed_findings: { doc_count: 3 },
+            resources_evaluated: { value: 4 },
+          },
+        })
+        .mockResolvedValueOnce({
+          pit_id: 'pit-4',
+          aggregations: { aggs_by_asset_identifier: { buckets: [] } },
+        }),
+      closePointInTime: jest.fn().mockResolvedValue({ succeeded: true, num_freed: 1 }),
+    };
+
+    const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() };
+
+    await getBenchmarksData(soClient, encryptedSoClient, esClient as any, logger as any);
+
+    expect(esClient.search.mock.calls[0][0].pit.id).toBe('pit-0');
+    expect(esClient.search.mock.calls[1][0].pit.id).toBe('pit-1');
+    expect(esClient.search.mock.calls[2][0].pit.id).toBe('pit-2');
+    expect(esClient.search.mock.calls[3][0].pit.id).toBe('pit-3');
+    expect(esClient.closePointInTime).toHaveBeenCalledWith({ id: 'pit-4' });
+  });
+});

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { httpServerMock, httpServiceMock } from '@kbn/core/server/mocks';
+import type { RequestHandlerContext } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { defineGetComplianceDashboardRoute } from './compliance_dashboard';
+
+jest.mock('./get_trends', () => ({
+  getTrends: jest.fn().mockResolvedValue({ trends: [], namespaces: [] }),
+}));
+
+jest.mock('../benchmark_rules/get_states/v1', () => ({
+  getMutedRulesFilterQuery: jest.fn().mockResolvedValue([]),
+}));
+
+describe('compliance dashboard route PIT refresh', () => {
+  const setup = () => {
+    const httpService = httpServiceMock.createSetupContract();
+    const router = httpService.createRouter();
+
+    defineGetComplianceDashboardRoute(router as any);
+
+    const addVersionCalls = router.versioned.get.mock.results[0].value.addVersion.mock.calls;
+    const [v1RouteDefinition, v1RouteHandler] = addVersionCalls[0];
+    const [v2RouteDefinition, v2RouteHandler] = addVersionCalls[1];
+
+    return {
+      v1RouteDefinition,
+      v1RouteHandler,
+      v2RouteDefinition,
+      v2RouteHandler,
+    };
+  };
+
+  it('v1 should roll forward pit_id between searches and for close', async () => {
+    const { v1RouteHandler } = setup();
+
+    const esClient = {
+      openPointInTime: jest.fn().mockResolvedValue({ id: 'pit-0' }),
+      search: jest
+        .fn()
+        .mockResolvedValueOnce({
+          pit_id: 'pit-1',
+          aggregations: {
+            failed_findings: { doc_count: 1 },
+            passed_findings: { doc_count: 2 },
+            resources_evaluated: { value: 3 },
+          },
+        })
+        .mockResolvedValueOnce({
+          pit_id: 'pit-2',
+          aggregations: { aggs_by_resource_type: { buckets: [] } },
+        })
+        .mockResolvedValueOnce({
+          pit_id: 'pit-3',
+          aggregations: { aggs_by_asset_identifier: { buckets: [] } },
+        }),
+      closePointInTime: jest.fn().mockResolvedValue({ succeeded: true, num_freed: 1 }),
+    };
+
+    const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() };
+
+    const mockRouteContext = {
+      csp: Promise.resolve({
+        logger,
+        esClient: { asCurrentUser: esClient },
+        encryptedSavedObjects: {},
+      }),
+    } as unknown as RequestHandlerContext;
+
+    const request = httpServerMock.createKibanaRequest({
+      method: 'get',
+      params: { policy_template: 'cspm' },
+    });
+
+    await v1RouteHandler(mockRouteContext, request as any, kibanaResponseFactory);
+
+    expect(esClient.search.mock.calls[0][0].pit.id).toBe('pit-0');
+    expect(esClient.search.mock.calls[1][0].pit.id).toBe('pit-1');
+    expect(esClient.search.mock.calls[2][0].pit.id).toBe('pit-2');
+    expect(esClient.closePointInTime).toHaveBeenCalledWith({ id: 'pit-3' });
+  });
+
+  it('v2 should roll forward pit_id between searches and for close', async () => {
+    const { v2RouteHandler } = setup();
+
+    const esClient = {
+      openPointInTime: jest.fn().mockResolvedValue({ id: 'pit-0' }),
+      search: jest
+        .fn()
+        .mockResolvedValueOnce({
+          pit_id: 'pit-1',
+          aggregations: {
+            failed_findings: { doc_count: 1 },
+            passed_findings: { doc_count: 2 },
+            resources_evaluated: { value: 3 },
+          },
+        })
+        .mockResolvedValueOnce({
+          pit_id: 'pit-2',
+          aggregations: { aggs_by_resource_type: { buckets: [] } },
+        })
+        .mockResolvedValueOnce({
+          pit_id: 'pit-3',
+          aggregations: {
+            aggs_by_benchmark: {
+              buckets: [{ key: 'cis', doc_count: 0, aggs_by_benchmark_version: { buckets: [] } }],
+            },
+          },
+        }),
+      closePointInTime: jest.fn().mockResolvedValue({ succeeded: true, num_freed: 1 }),
+    };
+
+    const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() };
+
+    const mockRouteContext = {
+      csp: Promise.resolve({
+        logger,
+        esClient: { asCurrentUser: esClient },
+        encryptedSavedObjects: {},
+      }),
+    } as unknown as RequestHandlerContext;
+
+    const request = httpServerMock.createKibanaRequest({
+      method: 'get',
+      params: { policy_template: 'cspm' },
+      query: {},
+    });
+
+    await v2RouteHandler(mockRouteContext, request as any, kibanaResponseFactory);
+
+    expect(esClient.search.mock.calls[0][0].pit.id).toBe('pit-0');
+    expect(esClient.search.mock.calls[1][0].pit.id).toBe('pit-1');
+    expect(esClient.search.mock.calls[2][0].pit.id).toBe('pit-2');
+    expect(esClient.closePointInTime).toHaveBeenCalledWith({ id: 'pit-3' });
+  });
+});


### PR DESCRIPTION
## Summary
- Thread refreshed `pit_id` through Cloud Security Posture PIT-based queries and close with the most recent id.

## Test plan
- `yarn test:jest x-pack/solutions/security/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.test.ts`
- `yarn test:jest x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmarks/v2.test.ts`

Refs: ralph issue-236; elastic/kibana#252458

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->