### PR TITLE
[Data Plugin] Remove `any` from public API exports (#99519)

### DIFF
--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
@@ -165,7 +165,7 @@ describe('CsvGenerator', () => {
         case 'index':
           return dataView;
       }
-    });
+    }) as typeof searchSourceMock.getField;
 
     mockLogger = loggingSystemMock.createLogger();
   });

--- a/src/platform/plugins/private/vis_default_editor/public/components/agg_params_map.ts
+++ b/src/platform/plugins/private/vis_default_editor/public/components/agg_params_map.ts
@@ -7,9 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { AggGroupNames, BUCKET_TYPES, METRIC_TYPES, search } from '@kbn/data-plugin/public';
+import type { ComponentType } from 'react';
+import {
+  AggGroupNames,
+  BUCKET_TYPES,
+  METRIC_TYPES,
+  search,
+  type OptionedValueProp,
+} from '@kbn/data-plugin/public';
 import * as controls from './controls';
+import type { AggregateValueProp } from './controls/top_aggregate';
 import { wrapWithInlineComp } from './controls/utils';
+import type { AggParamEditorProps } from './agg_param_props';
 
 const { siblingPipelineType, parentPipelineType } = search.aggs;
 
@@ -50,7 +59,9 @@ const buckets = {
     exclude: controls.IncludeExcludeParamEditor,
     orderBy: controls.OrderByParamEditor,
     orderAgg: controls.OrderAggParamEditor,
-    order: wrapWithInlineComp(controls.OrderParamEditor),
+    order: wrapWithInlineComp(
+      controls.OrderParamEditor as unknown as ComponentType<AggParamEditorProps<OptionedValueProp>>
+    ),
     size: wrapWithInlineComp(controls.SizeParamEditor),
     otherBucket: controls.OtherBucketParamEditor,
     missingBucket: controls.MissingBucketParamEditor,
@@ -60,7 +71,11 @@ const buckets = {
 const metrics = {
   [METRIC_TYPES.TOP_HITS]: {
     field: controls.TopFieldParamEditor,
-    aggregate: wrapWithInlineComp(controls.TopAggregateParamEditor),
+    aggregate: wrapWithInlineComp(
+      controls.TopAggregateParamEditor as unknown as ComponentType<
+        AggParamEditorProps<AggregateValueProp>
+      >
+    ),
     size: wrapWithInlineComp(controls.TopSizeParamEditor),
     sortField: controls.TopSortFieldParamEditor,
     sortOrder: controls.OrderParamEditor,

--- a/src/platform/plugins/private/vis_default_editor/public/components/controls/time_interval.test.tsx
+++ b/src/platform/plugins/private/vis_default_editor/public/components/controls/time_interval.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { TimeIntervalParamEditor } from './time_interval';
 import { aggParamCommonPropsMock } from './test_utils';
+import type { AggParamOption } from '@kbn/data-plugin/public';
 import type { AggParamEditorProps } from '../agg_param_props';
 
 jest.mock('@kbn/data-plugin/public', () => ({
@@ -87,11 +88,11 @@ describe('TimeIntervalParamEditor', () => {
     });
 
     test('should filter out "auto" interval value if it is disabled in options and mark as invalid', () => {
-      props.aggParam.options[0].enabled = jest.fn().mockReturnValue(false);
+      (props.aggParam.options[0] as AggParamOption).enabled = jest.fn().mockReturnValue(false);
       props.value = 'auto';
       const comp = shallow(<TimeIntervalParamEditor {...props} />);
 
-      expect(props.aggParam.options[0].enabled).toHaveBeenCalledWith(props.agg);
+      expect((props.aggParam.options[0] as AggParamOption).enabled).toHaveBeenCalledWith(props.agg);
       expect(comp.prop('isInvalid')).toBeTruthy();
       expect(comp.children().prop('selectedOptions')).toEqual([]);
       expect(comp.children().prop('options')).toEqual([

--- a/src/platform/plugins/private/vis_default_editor/public/components/controls/time_interval.tsx
+++ b/src/platform/plugins/private/vis_default_editor/public/components/controls/time_interval.tsx
@@ -103,12 +103,15 @@ function TimeIntervalParamEditor({
   const timeBase: string = get(editorConfig, 'interval.timeBase') as string;
   const options = timeBase
     ? []
-    : (aggParam.options || []).reduce((filtered: ComboBoxOption[], option: AggParamOption) => {
-        if (option.enabled ? option.enabled(agg) : true) {
-          filtered.push({ label: option.display, key: option.val });
-        }
-        return filtered;
-      }, []);
+    : ((aggParam.options || []) as AggParamOption[]).reduce(
+        (filtered: ComboBoxOption[], option: AggParamOption) => {
+          if (option.enabled ? option.enabled(agg) : true) {
+            filtered.push({ label: option.display, key: option.val });
+          }
+          return filtered;
+        },
+        []
+      );
 
   let selectedOptions: ComboBoxOption[] = [];
   let definedOption: ComboBoxOption | undefined;

--- a/src/platform/plugins/private/vis_default_editor/public/components/controls/top_aggregate.tsx
+++ b/src/platform/plugins/private/vis_default_editor/public/components/controls/top_aggregate.tsx
@@ -81,7 +81,7 @@ export function TopAggregateParamEditor({
     }
 
     if (value) {
-      if (aggParam.options.find((opt) => opt.value === value.value)) {
+      if ((aggParam.options as AggregateValueProp[]).find((opt) => opt.value === value.value)) {
         return;
       }
 
@@ -89,7 +89,11 @@ export function TopAggregateParamEditor({
     }
 
     if (filteredOptions.length === 1) {
-      setValue(aggParam.options.find((opt) => opt.value === filteredOptions[0].value));
+      setValue(
+        (aggParam.options as AggregateValueProp[]).find(
+          (opt) => opt.value === filteredOptions[0].value
+        )
+      );
     }
   }, [aggParam.options, fieldType, filteredOptions, setValue, value]);
 
@@ -97,7 +101,9 @@ export function TopAggregateParamEditor({
     if (event.target.value === emptyValue.value) {
       setValue();
     } else {
-      setValue(aggParam.options.find((opt) => opt.value === event.target.value));
+      setValue(
+        (aggParam.options as AggregateValueProp[]).find((opt) => opt.value === event.target.value)
+      );
     }
   };
 

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
@@ -66,7 +66,7 @@ export class SearchAPI {
 
     return combineLatest(
       searchRequests.map((request) => {
-        const { name: requestId, ...restRequest } = request;
+        const { name: requestId, ...restRequest } = request as Record<string, any>;
 
         const requestParams = getSearchParamsFromRequest(restRequest, {
           getConfig: this.dependencies.uiSettings.get.bind(this.dependencies.uiSettings),

--- a/src/platform/plugins/shared/data/common/search/aggs/agg_params.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/agg_params.ts
@@ -13,6 +13,7 @@ import { OptionedParamType } from './param_types/optioned';
 import { StringParamType } from './param_types/string';
 import { JsonParamType } from './param_types/json';
 import { BaseParamType } from './param_types/base';
+import type { AggParamOutput } from './param_types/base';
 
 import type { AggConfig } from './agg_config';
 import type { IAggConfigs } from './agg_configs';
@@ -66,8 +67,8 @@ export const writeParams = <
   aggs?: IAggConfigs,
   locals?: Record<string, any>
 ) => {
-  const output: Record<string, any> = {
-    params: {} as Record<string, any>,
+  const output: AggParamOutput = {
+    params: {} as Record<string, unknown>,
   };
   locals = locals || {};
 

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/date_histogram.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/date_histogram.ts
@@ -27,6 +27,7 @@ import { TimeBuckets } from './lib/time_buckets';
 
 import { writeParams } from '../agg_params';
 import { isMetricAggType } from '../metrics/metric_agg_type';
+import type { AggParamOutput } from '../param_types/base';
 import type { BaseAggParams } from '../types';
 import { dateHistogramInterval } from '../utils';
 import { inferTimeZone } from '../utils';
@@ -87,7 +88,7 @@ export const getDateHistogramBucketAgg = ({
       date: true,
     },
     makeLabel(agg) {
-      let output: Record<string, any> = {};
+      let output: AggParamOutput = { params: {} };
 
       if (this.params) {
         output = writeParams(this.params, agg);
@@ -99,7 +100,9 @@ export const getDateHistogramBucketAgg = ({
         defaultMessage: '{fieldName} per {intervalDescription}',
         values: {
           fieldName: field,
-          intervalDescription: output.metricScaleText || output.bucketInterval.description,
+          intervalDescription:
+            output.metricScaleText ||
+            (output.bucketInterval as { description: string }).description,
         },
       });
     },
@@ -178,7 +181,7 @@ export const getDateHistogramBucketAgg = ({
         name: 'timeRange',
         default: null,
         write: noop,
-        toExpressionAst: timerangeToAst,
+        toExpressionAst: (value: unknown) => timerangeToAst(value as TimeRange),
       },
       {
         name: 'useNormalizedEsInterval',
@@ -363,7 +366,7 @@ export const getDateHistogramBucketAgg = ({
             );
           }
         },
-        toExpressionAst: extendedBoundsToAst,
+        toExpressionAst: (value: unknown) => extendedBoundsToAst(value as ExtendedBounds),
       },
     ],
   });

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/date_range.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/date_range.ts
@@ -69,7 +69,7 @@ export const getDateRangeBucketAgg = ({ aggExecutionContext, getConfig }: AggTyp
             to: 'now',
           },
         ],
-        toExpressionAst: (ranges) => ranges?.map(dateRangeToAst),
+        toExpressionAst: (value: unknown) => (value as DateRange[])?.map(dateRangeToAst),
       },
       {
         name: 'time_zone',

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/filter.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/filter.ts
@@ -48,7 +48,7 @@ export const getFilterBucketAgg = ({
     params: [
       {
         name: 'geo_bounding_box',
-        toExpressionAst: geoBoundingBoxToAst,
+        toExpressionAst: (value: unknown) => geoBoundingBoxToAst(value as GeoBoundingBox),
       },
       {
         name: 'timeShift',
@@ -91,7 +91,7 @@ export const getFilterBucketAgg = ({
             ? moment(calculateBounds(aggConfigs.timeRange).max)
             : undefined;
 
-          output.params =
+          output.params = (
             !timeWindow || !timeRangeAnchor || !aggConfig.getIndexPattern().timeFieldName
               ? query
               : {
@@ -116,9 +116,10 @@ export const getFilterBucketAgg = ({
                       query ? query : undefined,
                     ].filter(Boolean),
                   },
-                };
+                }
+          ) as Record<string, unknown>;
         },
-        toExpressionAst: queryToAst,
+        toExpressionAst: (value: unknown) => queryToAst(value as Query),
       },
     ],
   });

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/filters.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/filters.ts
@@ -96,7 +96,8 @@ export const getFiltersBucketAgg = ({ getConfig }: FiltersBucketAggDependencies)
           const params = output.params || (output.params = {});
           params.filters = outFilters;
         },
-        toExpressionAst: (filters: AggParamsFilters['filters']) => filters?.map(queryFilterToAst),
+        toExpressionAst: (value: unknown) =>
+          (value as AggParamsFilters['filters'])?.map(queryFilterToAst),
       },
     ],
   });

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/histogram.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/histogram.ts
@@ -222,7 +222,7 @@ export const getHistogramBucketAgg = ({
           }
         },
         shouldShow: (aggConfig: IBucketAggConfig) => aggConfig.params.has_extended_bounds,
-        toExpressionAst: extendedBoundsToAst,
+        toExpressionAst: (value: unknown) => extendedBoundsToAst(value as ExtendedBounds),
       },
     ],
   });

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/ip_prefix.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/ip_prefix.ts
@@ -69,7 +69,7 @@ export const getIpPrefixBucketAgg = () =>
           output.params.prefix_length = aggConfig.params.ipPrefix.prefixLength;
           output.params.is_ipv6 = aggConfig.params.ipPrefix.isIpv6;
         },
-        toExpressionAst: ipPrefixToAst,
+        toExpressionAst: (value: unknown) => ipPrefixToAst(value as IpPrefix),
       },
     ],
   });

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/ip_range.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/ip_range.ts
@@ -95,10 +95,13 @@ export const getIpRangeBucketAgg = () =>
 
           output.params.ranges = ranges;
         },
-        toExpressionAst: (ranges: AggParamsIpRange['ranges']) => [
-          ...map(ranges?.[IP_RANGE_TYPES.FROM_TO], ipRangeToAst),
-          ...map(ranges?.[IP_RANGE_TYPES.MASK], cidrToAst),
-        ],
+        toExpressionAst: (value: unknown) => {
+          const ranges = value as AggParamsIpRange['ranges'];
+          return [
+            ...map(ranges?.[IP_RANGE_TYPES.FROM_TO], ipRangeToAst),
+            ...map(ranges?.[IP_RANGE_TYPES.MASK], cidrToAst),
+          ];
+        },
       },
     ],
   });

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/migrate_include_exclude_format.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/migrate_include_exclude_format.ts
@@ -10,6 +10,7 @@
 import { isString, isObject } from 'lodash';
 import type { IBucketAggConfig, BucketAggType, BucketAggParam } from './bucket_agg_type';
 import type { IAggConfig } from '../agg_config';
+import type { AggParamOutput } from '../param_types/base';
 
 export const isType = (...types: string[]) => {
   return (agg: IAggConfig): boolean => {
@@ -32,7 +33,7 @@ export const migrateIncludeExcludeFormat = {
   write(
     this: BucketAggType<IBucketAggConfig>,
     aggConfig: IBucketAggConfig,
-    output: Record<string, any>
+    output: AggParamOutput
   ) {
     const value = aggConfig.getParam(this.name);
 

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/range.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/range.ts
@@ -101,7 +101,7 @@ export const getRangeBucketAgg = ({ getFieldFormatsStart }: RangeBucketAggDepend
 
           output.params.keyed = true;
         },
-        toExpressionAst: (ranges) => ranges?.map(numericalRangeToAst),
+        toExpressionAst: (value: unknown) => (value as NumericalRange[])?.map(numericalRangeToAst),
       },
     ],
   });

--- a/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/parent_pipeline_agg_writer.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/parent_pipeline_agg_writer.ts
@@ -8,11 +8,12 @@
  */
 
 import type { IAggConfigs } from '../../agg_configs';
+import type { AggParamOutput } from '../../param_types/base';
 import type { IMetricAggConfig } from '../metric_agg_type';
 
 export const parentPipelineAggWriter = (
   agg: IMetricAggConfig,
-  output: Record<string, any>,
+  output: AggParamOutput,
   aggConfigs?: IAggConfigs
 ): void => {
   const customMetric = agg.getParam('customMetric');

--- a/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
@@ -10,6 +10,7 @@
 import { i18n } from '@kbn/i18n';
 import { siblingPipelineAggWriter } from './sibling_pipeline_agg_writer';
 import { forwardModifyAggConfigOnSearchRequestStart } from './nested_agg_helpers';
+import type { AggParamOutput } from '../../param_types/base';
 import type { IMetricAggConfig, MetricAggParam } from '../metric_agg_type';
 
 const metricAggFilter: string[] = [
@@ -71,7 +72,7 @@ export const siblingPipelineAggHelper = {
         },
         modifyAggConfigOnSearchRequestStart:
           forwardModifyAggConfigOnSearchRequestStart('customMetric'),
-        write: (agg: IMetricAggConfig, output: Record<string, any>) =>
+        write: (agg: IMetricAggConfig, output: AggParamOutput) =>
           siblingPipelineAggWriter(agg, output),
       },
     ] as Array<MetricAggParam<IMetricAggConfig>>;

--- a/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_writer.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_writer.ts
@@ -8,10 +8,11 @@
  */
 
 import { siblingPipelineType } from '../../../..';
+import type { AggParamOutput } from '../../param_types/base';
 import type { IMetricAggConfig } from '../metric_agg_type';
 import { METRIC_TYPES } from '../metric_agg_types';
 
-export const siblingPipelineAggWriter = (agg: IMetricAggConfig, output: Record<string, any>) => {
+export const siblingPipelineAggWriter = (agg: IMetricAggConfig, output: AggParamOutput) => {
   const metricAgg = agg.getParam('customMetric');
   const bucketAgg = agg.getParam('customBucket');
   if (!metricAgg) return;

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/agg.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/agg.ts
@@ -10,6 +10,7 @@
 import type { IAggConfig, AggConfigSerialized } from '../agg_config';
 import { AggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 
 export class AggParamType<
   TAggConfig extends IAggConfig = IAggConfig
@@ -17,35 +18,36 @@ export class AggParamType<
   makeAgg: (agg: TAggConfig, state?: AggConfigSerialized) => TAggConfig;
   allowedAggs: string[] = [];
 
-  constructor(config: Record<string, any>) {
+  constructor(config: Record<string, unknown>) {
     super(config);
 
     if (config.allowedAggs) {
-      this.allowedAggs = config.allowedAggs;
+      this.allowedAggs = config.allowedAggs as string[];
     }
 
     if (!config.write) {
-      this.write = (aggConfig: TAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: TAggConfig, output: AggParamOutput) => {
         if (aggConfig.params[this.name] && aggConfig.params[this.name].length) {
           output.params[this.name] = aggConfig.params[this.name];
         }
       };
     }
     if (!config.serialize) {
-      this.serialize = (agg: TAggConfig) => {
-        return agg.serialize();
+      this.serialize = (value: unknown) => {
+        return (value as TAggConfig).serialize();
       };
     }
     if (!config.deserialize) {
-      this.deserialize = (state: AggConfigSerialized, agg?: TAggConfig): TAggConfig => {
+      this.deserialize = (state: unknown, agg?: TAggConfig): TAggConfig => {
         if (!agg) {
           throw new Error('aggConfig was not provided to AggParamType deserialize function');
         }
-        return this.makeAgg(agg, state);
+        return this.makeAgg(agg, state as AggConfigSerialized);
       };
     }
     if (!config.toExpressionAst) {
-      this.toExpressionAst = (agg: TAggConfig) => {
+      this.toExpressionAst = (value: unknown) => {
+        const agg = value as TAggConfig;
         if (!agg || !agg.toExpressionAst) {
           throw new Error('aggConfig was not provided to AggParamType toExpressionAst function');
         }
@@ -53,7 +55,7 @@ export class AggParamType<
       };
     }
 
-    this.makeAgg = config.makeAgg;
+    this.makeAgg = config.makeAgg as typeof this.makeAgg;
     this.getValueType = () => AggConfig;
   }
 }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/base.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/base.ts
@@ -13,24 +13,36 @@ import type { ISearchSource } from '../../../../public';
 import type { IAggConfigs } from '../agg_configs';
 import type { IAggConfig } from '../agg_config';
 
+export interface AggParamOutput {
+  params: Record<string, unknown>;
+  subAggs?: IAggConfig[];
+  parentAggs?: IAggConfig[];
+  bucketInterval?: unknown;
+  metricScale?: number;
+  metricScaleText?: string;
+  [key: string]: unknown;
+}
+
 export class BaseParamType<TAggConfig extends IAggConfig = IAggConfig> {
   name: string;
   type: string;
   displayName: string;
   required: boolean;
   advanced: boolean;
-  default: any;
+  default: unknown;
   write: (
     aggConfig: TAggConfig,
-    output: Record<string, any>,
+    output: AggParamOutput,
     aggConfigs?: IAggConfigs,
-    locals?: Record<string, any>
+    locals?: Record<string, unknown>
   ) => void;
-  serialize: (value: any, aggConfig?: TAggConfig) => any;
-  deserialize: (value: any, aggConfig?: TAggConfig) => any;
-  toExpressionAst?: (value: any) => ExpressionAstExpression[] | ExpressionAstExpression | undefined;
-  options: any[];
-  getValueType: (aggConfig: IAggConfig) => any;
+  serialize: (value: unknown, aggConfig?: TAggConfig) => unknown;
+  deserialize: (value: unknown, aggConfig?: TAggConfig) => unknown;
+  toExpressionAst?: (
+    value: unknown
+  ) => ExpressionAstExpression[] | ExpressionAstExpression | undefined;
+  options: unknown[];
+  getValueType: (aggConfig: IAggConfig) => unknown;
   onChange?(agg: TAggConfig): void;
   shouldShow?(agg: TAggConfig): boolean;
 
@@ -49,30 +61,31 @@ export class BaseParamType<TAggConfig extends IAggConfig = IAggConfig> {
     options?: ISearchOptions
   ) => void;
 
-  constructor(config: Record<string, any>) {
-    this.name = config.name;
-    this.type = config.type;
-    this.displayName = config.displayName || this.name;
+  constructor(config: Record<string, unknown>) {
+    this.name = config.name as string;
+    this.type = config.type as string;
+    this.displayName = (config.displayName as string) || this.name;
     this.required = config.required === true;
-    this.advanced = config.advanced || false;
-    this.onChange = config.onChange;
-    this.shouldShow = config.shouldShow;
+    this.advanced = (config.advanced as boolean) || false;
+    this.onChange = config.onChange as typeof this.onChange;
+    this.shouldShow = config.shouldShow as typeof this.shouldShow;
     this.default = config.default;
 
-    const defaultWrite = (aggConfig: TAggConfig, output: Record<string, any>) => {
+    const defaultWrite = (aggConfig: TAggConfig, output: AggParamOutput) => {
       if (aggConfig.params[this.name]) {
         output.params[this.name] = aggConfig.params[this.name] || this.default;
       }
     };
 
-    this.write = config.write || defaultWrite;
-    this.serialize = config.serialize;
-    this.deserialize = config.deserialize;
-    this.toExpressionAst = config.toExpressionAst;
-    this.options = config.options;
+    this.write = (config.write as typeof this.write) || defaultWrite;
+    this.serialize = config.serialize as typeof this.serialize;
+    this.deserialize = config.deserialize as typeof this.deserialize;
+    this.toExpressionAst = config.toExpressionAst as typeof this.toExpressionAst;
+    this.options = config.options as unknown[];
     this.modifyAggConfigOnSearchRequestStart =
-      config.modifyAggConfigOnSearchRequestStart || function () {};
+      (config.modifyAggConfigOnSearchRequestStart as typeof this.modifyAggConfigOnSearchRequestStart) ||
+      function () {};
 
-    this.getValueType = config.getValueType;
+    this.getValueType = config.getValueType as typeof this.getValueType;
   }
 }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/field.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/field.ts
@@ -12,6 +12,7 @@ import { SavedFieldTypeInvalidForAgg } from '@kbn/kibana-utils-plugin/common';
 import { isNestedField, DataViewField } from '@kbn/data-views-plugin/common';
 import type { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 import { propFilter } from '../utils';
 import { KBN_FIELD_TYPES } from '../../../kbn_field_types/types';
 
@@ -36,17 +37,17 @@ export class FieldParamType extends BaseParamType {
    */
   filterField?: FilterFieldFn;
 
-  constructor(config: Record<string, any>) {
+  constructor(config: Record<string, unknown>) {
     super(config);
 
-    this.filterFieldTypes = config.filterFieldTypes || '*';
+    this.filterFieldTypes = (config.filterFieldTypes as FieldTypes) || '*';
     this.onlyAggregatable = config.onlyAggregatable !== false;
     this.scriptable = config.scriptable !== false;
-    this.filterField = config.filterField;
+    this.filterField = config.filterField as FilterFieldFn | undefined;
 
     // TODO - are there any custom write methods that do a missing check?
     if (!config.write) {
-      this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: IAggConfig, output: AggParamOutput) => {
         const field = aggConfig.getField();
 
         if (!field) {
@@ -94,11 +95,12 @@ export class FieldParamType extends BaseParamType {
       };
     }
 
-    this.serialize = (field: DataViewField) => {
-      return field.name;
+    this.serialize = (value: unknown) => {
+      return (value as DataViewField).name;
     };
 
-    this.deserialize = (fieldName: string, aggConfig?: IAggConfig) => {
+    this.deserialize = (value: unknown, aggConfig?: IAggConfig) => {
+      const fieldName = value as string;
       if (!aggConfig) {
         throw new Error('aggConfig was not provided to FieldParamType deserialize function');
       }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/json.test.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/json.test.ts
@@ -8,13 +8,14 @@
  */
 
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 import { JsonParamType } from './json';
 import type { IAggConfig } from '../agg_config';
 
 describe('JSON', function () {
   const paramName = 'json_test';
   let aggConfig: IAggConfig;
-  let output: Record<string, any>;
+  let output: AggParamOutput;
 
   const initAggParam = (config: Record<string, any> = {}) =>
     new JsonParamType({

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/optioned.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/optioned.ts
@@ -9,6 +9,7 @@
 
 import type { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 
 export interface OptionedValueProp {
   value: string;
@@ -20,24 +21,24 @@ export interface OptionedValueProp {
 export class OptionedParamType extends BaseParamType {
   options: OptionedValueProp[];
 
-  constructor(config: Record<string, any>) {
+  constructor(config: Record<string, unknown>) {
     super(config);
 
     if (!config.write) {
-      this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: IAggConfig, output: AggParamOutput) => {
         output.params[this.name] = aggConfig.params[this.name].value;
       };
     }
     if (!config.serialize) {
-      this.serialize = (selected: OptionedValueProp) => {
-        return selected.value;
+      this.serialize = (value: unknown) => {
+        return (value as OptionedValueProp).value;
       };
     }
     if (!config.deserialize) {
-      this.deserialize = (value: any) => {
+      this.deserialize = (value: unknown) => {
         return this.options.find((option: OptionedValueProp) => option.value === value);
       };
     }
-    this.options = config.options || [];
+    this.options = (config.options as OptionedValueProp[]) || [];
   }
 }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/string.test.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/string.test.ts
@@ -8,13 +8,14 @@
  */
 
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 import { StringParamType } from './string';
 import type { IAggConfig } from '../agg_config';
 
 describe('String', function () {
   let paramName = 'json_test';
   let aggConfig: IAggConfig;
-  let output: Record<string, any>;
+  let output: AggParamOutput;
 
   const initAggParam = (config: Record<string, any> = {}) =>
     new StringParamType({

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/string.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/string.ts
@@ -9,13 +9,14 @@
 
 import type { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 
 export class StringParamType extends BaseParamType {
-  constructor(config: Record<string, any>) {
+  constructor(config: Record<string, unknown>) {
     super(config);
 
     if (!config.write) {
-      this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: IAggConfig, output: AggParamOutput) => {
         if (aggConfig.params[this.name] && aggConfig.params[this.name].length) {
           output.params[this.name] = aggConfig.params[this.name];
         }

--- a/src/platform/plugins/shared/data/common/search/expressions/utils/function_wrapper.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/utils/function_wrapper.ts
@@ -21,7 +21,7 @@ export const functionWrapper = (spec: AnyExpressionFunctionDefinition) => {
   const defaultArgs = mapValues(spec.args, (argSpec) => argSpec.default);
   return (
     context: object | null,
-    args: Record<string, any> = {},
+    args: Record<string, unknown> = {},
     handlers: ExecutionContext = {} as ExecutionContext
   ) => spec.fn(context, { ...defaultArgs, ...args }, handlers);
 };

--- a/src/platform/plugins/shared/data/common/search/search_source/create_search_source.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/create_search_source.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { estypes } from '@elastic/elasticsearch';
 import type { DataViewsContract, DataViewLazy } from '@kbn/data-views-plugin/common';
 import { DataView } from '@kbn/data-views-plugin/common';
 import type { FieldFormatsStartCommon } from '@kbn/field-formats-plugin/common';
@@ -42,9 +43,10 @@ export const createSearchSource = (
     searchSourceFields: SerializedSearchSourceFields = {},
     useDataViewLazy = false
   ) => {
-    const { index, parent, ...restOfFields } = searchSourceFields;
+    const { index, parent, highlight, ...restOfFields } = searchSourceFields;
     const fields: SearchSourceFields = {
       ...restOfFields,
+      ...(highlight ? { highlight: highlight as unknown as estypes.SearchHighlight } : {}),
     };
 
     // hydrating index pattern

--- a/src/platform/plugins/shared/data/common/search/search_source/fetch/get_search_params.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/fetch/get_search_params.ts
@@ -17,7 +17,7 @@ const defaultSessionId = `${Date.now()}`;
 export function getEsPreference(
   getConfigFn: GetConfigFn,
   sessionId = defaultSessionId
-): SearchRequest['preference'] {
+): string | undefined {
   const setPreference = getConfigFn<string>(UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE);
   if (setPreference === 'sessionId') return sessionId;
   const customPreference = getConfigFn<string>(UI_SETTINGS.COURIER_CUSTOM_REQUEST_PREFERENCE);
@@ -35,7 +35,11 @@ export function getSearchParamsFromRequest(
   const searchParams = { preference: getEsPreference(getConfig) };
   const dataView = typeof searchRequest.index !== 'string' ? searchRequest.index : undefined;
   const index = dataView?.title ?? `${searchRequest.index}`;
-  const trackTotalHits = searchRequest.track_total_hits ?? searchRequest.body.track_total_hits;
+  const req = searchRequest as {
+    track_total_hits?: boolean;
+    body?: { track_total_hits?: boolean };
+  };
+  const trackTotalHits = req.track_total_hits ?? req.body?.track_total_hits;
 
   // @ts-expect-error elasticsearch@9.0.0 `query` types don't match (it seems like it's been wrong here for a while)
   return {

--- a/src/platform/plugins/shared/data/common/search/search_source/fetch/types.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/fetch/types.ts
@@ -21,7 +21,7 @@ import type { GetConfigFn } from '../../../types';
  * where `ISearchRequestParams` is used externally instead.
  * FIXME: replace with estypes.SearchRequest?
  */
-export type SearchRequest<T extends Record<string, any> = Record<string, any>> = {
+export type SearchRequest<T extends Record<string, unknown> = Record<string, unknown>> = {
   index?: DataView | string;
   query?: Array<Query | AggregateQuery>;
   filters?: Filter[] | (() => Filter[]);

--- a/src/platform/plugins/shared/data/common/search/search_source/inspect/inspector_stats.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/inspect/inspector_stats.ts
@@ -119,14 +119,15 @@ export function getResponseInspectorStats(
     };
   }
 
-  if (lastRequest && (lastRequest.ms === 0 || lastRequest.ms)) {
+  const lastRequestMs = (lastRequest as { ms?: number })?.ms;
+  if (lastRequest && (lastRequestMs === 0 || lastRequestMs)) {
     stats.requestTime = {
       label: i18n.translate('data.search.searchSource.requestTimeLabel', {
         defaultMessage: 'Request time',
       }),
       value: i18n.translate('data.search.searchSource.requestTimeValue', {
         defaultMessage: '{requestTime}ms',
-        values: { requestTime: lastRequest.ms },
+        values: { requestTime: lastRequestMs },
       }),
       description: i18n.translate('data.search.searchSource.requestTimeDescription', {
         defaultMessage:

--- a/src/platform/plugins/shared/data/common/search/search_source/search_source.test.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/search_source.test.ts
@@ -282,7 +282,7 @@ describe('SearchSource', () => {
       );
 
       searchSource.setField('aggs', ac);
-      const request = searchSource.getSearchRequestBody();
+      const request = searchSource.getSearchRequestBody() as Record<string, any>;
       expect(request.aggs).toStrictEqual({ '1': { avg: { field: 'field1' } } });
     });
 
@@ -298,7 +298,7 @@ describe('SearchSource', () => {
           }),
         } as unknown as DataView);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.stored_fields).toEqual(['*']);
         expect(request.script_fields).toEqual({ world: {} });
         expect(request.fields).toEqual(['@timestamp']);
@@ -318,7 +318,7 @@ describe('SearchSource', () => {
         searchSource.setField('fields', ['@timestamp']);
         searchSource.setField('fieldsFromSource', ['foo']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request).not.toHaveProperty('docvalue_fields');
       });
 
@@ -335,7 +335,7 @@ describe('SearchSource', () => {
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('docvalue_fields', ['world']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request).toHaveProperty('docvalue_fields');
         expect(request.docvalue_fields).toEqual(['world']);
       });
@@ -355,9 +355,9 @@ describe('SearchSource', () => {
         searchSource.setField('fields', ['c']);
         searchSource.setField('fieldsFromSource', ['a', 'b', 'd']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request).toHaveProperty('docvalue_fields');
-        expect(request._source.includes).toEqual(['c', 'a', 'b', 'd']);
+        expect((request._source as { includes: string[] }).includes).toEqual(['c', 'a', 'b', 'd']);
         expect(request.docvalue_fields).toEqual([{ field: 'b', format: 'date_time' }]);
         expect(request.fields).toEqual(['c', { field: 'a', format: 'date_time' }]);
       });
@@ -379,7 +379,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', [{ field: 'hello', format: 'strict_date_time' }]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request).toHaveProperty('fields');
         expect(request.fields).toEqual([{ field: 'hello', format: 'strict_date_time' }]);
       });
@@ -396,7 +396,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['hello']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request).toHaveProperty('fields');
         expect(request.fields).toEqual([{ field: 'hello', format: 'date_time' }]);
       });
@@ -418,7 +418,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', [{ field: 'hello', a: 'a', c: 'c' }]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request).toHaveProperty('fields');
         expect(request.fields).toEqual([
           { field: 'hello', format: 'date_time', a: 'a', b: 'test', c: 'c' },
@@ -438,7 +438,7 @@ describe('SearchSource', () => {
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('script_fields', { world: {} });
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request).toHaveProperty('script_fields');
         expect(request.script_fields).toEqual({
           hello: {},
@@ -458,7 +458,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['hello', 'a', { field: 'c' }]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.script_fields).toEqual({ hello: {} });
         expect(request.stored_fields).toEqual(['a', 'c']);
       });
@@ -479,7 +479,7 @@ describe('SearchSource', () => {
           { foo: 'c' } as unknown as SearchFieldValue,
         ]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.script_fields).toEqual({ hello: {} });
         expect(request.stored_fields).toEqual(['a']);
       });
@@ -496,29 +496,29 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fieldsFromSource', ['hello', 'a']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.script_fields).toEqual({ hello: {} });
         expect(request.stored_fields).toEqual(['a']);
       });
 
       test('defaults to * for stored fields when no fields are provided', async () => {
-        const requestA = searchSource.getSearchRequestBody();
+        const requestA = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(requestA.stored_fields).toEqual(['*']);
 
         searchSource.setField('fields', ['*']);
-        const requestB = searchSource.getSearchRequestBody();
+        const requestB = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(requestB.stored_fields).toEqual(['*']);
       });
 
       test('defaults to * for stored fields when no fields are provided with fieldsFromSource', async () => {
         searchSource.setField('fieldsFromSource', ['*']);
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.stored_fields).toEqual(['*']);
       });
 
       test('_source is not set when using the fields API', async () => {
         searchSource.setField('fields', ['*']);
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual(['*']);
         expect(request._source).toEqual(false);
       });
@@ -528,7 +528,7 @@ describe('SearchSource', () => {
           query: 'agent.keyword : "Mozilla" ',
           language: 'kuery',
         });
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.query).toMatchSnapshot();
       });
 
@@ -538,7 +538,7 @@ describe('SearchSource', () => {
           language: 'kuery',
         });
         searchSource.setField('sort', [{ _score: SortDirection.asc }]);
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.query).toMatchSnapshot();
       });
     });
@@ -557,7 +557,7 @@ describe('SearchSource', () => {
         // @ts-expect-error Typings for excludes filters need to be fixed.
         searchSource.setField('source', { excludes: ['exclude-*'] });
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual(['@timestamp']);
       });
 
@@ -572,7 +572,7 @@ describe('SearchSource', () => {
           }),
         } as unknown as DataView);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual(['@timestamp']);
       });
 
@@ -588,7 +588,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['hello']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.script_fields).toEqual({ hello: {} });
       });
 
@@ -610,7 +610,7 @@ describe('SearchSource', () => {
           'somethingfoo',
           'xxfxxoxxo',
         ]);
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual(['hello', 'fooo', 'somethingfoo', 'xxfxxoxxo']);
       });
 
@@ -626,7 +626,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['*']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual([{ field: 'field1' }, { field: 'field2' }]);
       });
 
@@ -642,7 +642,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', [{ field: '*', include_unmapped: true }]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual([{ field: 'field1' }, { field: 'field2' }]);
       });
 
@@ -658,7 +658,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', [{ field: '*', include_unmapped: true }]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual([{ field: 'field1' }, { field: 'field2' }]);
 
         searchSource.setField('fields', ['foo-bar', 'foo--bar', 'field1', 'field2']);
@@ -681,7 +681,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['timestamp', '*']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.script_fields).toEqual({ hello: {}, world: {} });
       });
 
@@ -698,7 +698,7 @@ describe('SearchSource', () => {
         searchSourceDependencies.scriptedFieldsEnabled = false;
         searchSource.setField('fields', ['timestamp', '*']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.script_fields).toEqual({});
       });
     });
@@ -722,7 +722,7 @@ describe('SearchSource', () => {
           'bar-b',
         ]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request._source).toEqual({
           includes: ['@timestamp', 'bar-b'],
         });
@@ -741,7 +741,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['hello', '@timestamp', 'foo-a', 'bar']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual(['hello', '@timestamp', 'bar', 'date']);
         expect(request.script_fields).toEqual({ hello: {} });
         expect(request.stored_fields).toEqual(['@timestamp', 'bar']);
@@ -766,7 +766,7 @@ describe('SearchSource', () => {
           'runtime_field',
         ]);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request._source).toEqual({
           includes: ['@timestamp', 'bar'],
         });
@@ -789,7 +789,7 @@ describe('SearchSource', () => {
         searchSource.setField('fields', ['hello', '@timestamp', 'foo-a', 'bar']);
         searchSource.setField('fieldsFromSource', ['foo-b', 'date', 'baz']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request._source).toEqual({
           includes: ['@timestamp', 'bar', 'date', 'baz'],
         });
@@ -816,7 +816,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['*']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.fields).toEqual([
           '*',
           { field: '@timestamp', format: 'strict_date_optional_time_nanos' },
@@ -845,7 +845,7 @@ describe('SearchSource', () => {
         } as unknown as DataView);
         searchSource.setField('fields', ['*']);
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(Object.hasOwn(request, 'docvalue_fields')).toBe(false);
         expect(request.fields).toEqual([
           { field: 'foo-bar' },
@@ -877,7 +877,7 @@ describe('SearchSource', () => {
         });
         searchSource.setField('timezone', 'America/Los_Angeles');
 
-        const request = searchSource.getSearchRequestBody();
+        const request = searchSource.getSearchRequestBody() as Record<string, any>;
         expect(request.query).toEqual({
           bool: {
             filter: [
@@ -913,14 +913,14 @@ describe('SearchSource', () => {
             expect(searchSource.getField('source')).toBe(undefined);
             searchSource.setField('index', indexPattern);
             expect(searchSource.getField('index')).toBe(indexPattern);
-            const request = searchSource.getSearchRequestBody();
+            const request = searchSource.getSearchRequestBody() as Record<string, any>;
             expect(request._source).toBe(mockSource);
           });
 
           test('removes created searchSource filter on removal', async () => {
             searchSource.setField('index', indexPattern);
             searchSource.setField('index', undefined);
-            const request = searchSource.getSearchRequestBody();
+            const request = searchSource.getSearchRequestBody() as Record<string, any>;
             expect(request._source).toBe(undefined);
           });
         });
@@ -930,7 +930,7 @@ describe('SearchSource', () => {
             searchSource.setField('index', indexPattern);
             searchSource.setField('index', indexPattern2);
             expect(searchSource.getField('index')).toBe(indexPattern2);
-            const request = searchSource.getSearchRequestBody();
+            const request = searchSource.getSearchRequestBody() as Record<string, any>;
             expect(request._source).toBe(mockSource2);
           });
 
@@ -938,7 +938,7 @@ describe('SearchSource', () => {
             searchSource.setField('index', indexPattern);
             searchSource.setField('index', indexPattern2);
             searchSource.setField('index', undefined);
-            const request = searchSource.getSearchRequestBody();
+            const request = searchSource.getSearchRequestBody() as Record<string, any>;
             expect(request._source).toBe(undefined);
           });
         });
@@ -1094,7 +1094,7 @@ describe('SearchSource', () => {
           runtimeFields: {},
         }),
       } as unknown as DataView);
-      const request = searchSource.getSearchRequestBody();
+      const request = searchSource.getSearchRequestBody() as Record<string, any>;
       expect(request.stored_fields).toEqual(['geometry', 'prop1']);
       expect(request.docvalue_fields).toEqual(['prop1']);
       expect(request._source).toEqual(['geometry']);
@@ -1178,7 +1178,7 @@ describe('SearchSource', () => {
     test('should not include project_routing in ES request body (it is passed as an option)', () => {
       searchSource.setField('index', indexPattern);
       searchSource.setField('projectRouting', '_alias:_origin');
-      const request = searchSource.getSearchRequestBody();
+      const request = searchSource.getSearchRequestBody() as Record<string, any>;
       // projectRouting is now passed as an option, not in the request body
       expect(request.project_routing).toBeUndefined();
     });

--- a/src/platform/plugins/shared/data/common/search/search_source/types.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/types.ts
@@ -91,7 +91,7 @@ export interface SearchSourceFields {
    * {@link EsQuerySortValue}
    */
   sort?: EsQuerySortValue | EsQuerySortValue[];
-  highlight?: any;
+  highlight?: estypes.SearchHighlight;
   highlightAll?: boolean;
   trackTotalHits?: boolean | number;
   /**

--- a/src/platform/plugins/shared/data/common/search/tabify/tabify.test.ts
+++ b/src/platform/plugins/shared/data/common/search/tabify/tabify.test.ts
@@ -133,7 +133,7 @@ describe('tabifyAggResponse Integration', () => {
           { type: 'count', params: { scaleMetricValues: true } } as any,
         ]);
 
-        const writeMock = jest.fn(() => ({}));
+        const writeMock = jest.fn(() => ({ params: {} }));
         aggConfigs.getRequestAggs()[0].write = writeMock;
 
         tabifyAggResponse(aggConfigs, enrichResponseWithSampling(metricOnly), {

--- a/src/platform/plugins/shared/data/common/search/tabify/tabify.ts
+++ b/src/platform/plugins/shared/data/common/search/tabify/tabify.ts
@@ -35,7 +35,9 @@ function collectBucket(
     const agg = column.aggConfig;
     if (agg.getParam('scaleMetricValues')) {
       const aggInfo = agg.write(aggs);
-      aggScale *= aggInfo.metricScale || 1;
+      const metricScaleRaw = aggInfo.metricScale;
+      aggScale *=
+        typeof metricScaleRaw === 'number' && !Number.isNaN(metricScaleRaw) ? metricScaleRaw : 1;
     }
 
     switch (agg.type.type) {

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -274,6 +274,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       onResponse: (request, response, options) => {
         if (!options.disableWarningToasts) {
           const { rawResponse } = response;
+          const req = request as { id: string; body: estypes.SearchRequest };
 
           const requestName = options.inspector?.title
             ? options.inspector.title
@@ -285,16 +286,16 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
             : new RequestAdapter();
           if (!options.inspector?.adapter) {
             const requestResponder = requestAdapter.start(requestName, {
-              id: request.id,
+              id: req.id,
             });
-            requestResponder.json(request.body);
+            requestResponder.json(req.body);
             requestResponder.ok({ json: response });
           }
 
           handleWarnings({
-            request: request.body as estypes.SearchRequest,
+            request: req.body as estypes.SearchRequest,
             requestAdapter,
-            requestId: request.id,
+            requestId: req.id,
             requestName,
             response: rawResponse,
             services: warningsServices,

--- a/src/platform/plugins/shared/discover/public/__mocks__/discover_state.mock.ts
+++ b/src/platform/plugins/shared/discover/public/__mocks__/discover_state.mock.ts
@@ -36,6 +36,7 @@ import { createTabsStorageManager } from '../application/main/state_management/t
 import type { DiscoverSession, DiscoverSessionTab } from '@kbn/saved-search-plugin/common';
 import { DiscoverSearchSessionManager } from '../application/main/state_management/discover_search_session';
 import type { DataView, DataViewListItem } from '@kbn/data-views-plugin/common';
+import type { SearchSourceFields } from '@kbn/data-plugin/common';
 import { createSearchSourceMock } from '@kbn/data-plugin/public/mocks';
 import { omit } from 'lodash';
 import { getCurrentUrlState } from '../application/main/state_management/utils/cleanup_url_state';
@@ -151,7 +152,9 @@ export function getDiscoverInternalStateMock({
       );
     }
 
-    return Promise.resolve(createSearchSourceMock({ ...omit(fields, 'parent'), index: dataView }));
+    return Promise.resolve(
+      createSearchSourceMock({ ...omit(fields, 'parent'), index: dataView } as SearchSourceFields)
+    );
   });
 
   jest.spyOn(services.savedSearch, 'saveDiscoverSession').mockImplementation((discoverSession) =>

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/utils/saved_search_utils.ts
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/utils/saved_search_utils.ts
@@ -73,8 +73,8 @@ export function getEsQueryFromSavedSearch({
       cloneDeep(savedSearchSource.getSearchRequestBody()?.query) ?? getDefaultDSLQuery();
     const timeField = savedSearchSource.getField('index')?.timeFieldName;
 
-    if (Array.isArray(savedQuery.bool.filter) && timeField !== undefined) {
-      savedQuery.bool.filter = savedQuery.bool.filter.filter(
+    if (Array.isArray(savedQuery.bool?.filter) && timeField !== undefined) {
+      savedQuery.bool!.filter = savedQuery.bool!.filter.filter(
         (c: QueryDslQueryContainer) =>
           !(Object.hasOwn(c, 'range') && Object.hasOwn(c.range ?? {}, timeField))
       );

--- a/x-pack/platform/plugins/shared/aiops/public/application/utils/search_utils.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/application/utils/search_utils.ts
@@ -65,8 +65,8 @@ export function getEsQueryFromSavedSearch({
       cloneDeep(savedSearch.searchSource.getSearchRequestBody()?.query) ?? getDefaultDSLQuery();
     const timeField = savedSearch.searchSource.getField('index')?.timeFieldName;
 
-    if (Array.isArray(savedQuery.bool.filter) && timeField !== undefined) {
-      savedQuery.bool.filter = savedQuery.bool.filter.filter(
+    if (Array.isArray(savedQuery.bool?.filter) && timeField !== undefined) {
+      savedQuery.bool!.filter = savedQuery.bool!.filter.filter(
         (c: QueryDslQueryContainer) =>
           !(Object.hasOwn(c, 'range') && Object.hasOwn(c.range ?? {}, timeField))
       );

--- a/x-pack/platform/plugins/shared/aiops/public/hooks/use_search.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/hooks/use_search.ts
@@ -7,11 +7,13 @@
 
 import { useMemo } from 'react';
 
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { getEsQueryConfig, isQuery } from '@kbn/data-plugin/public';
 
 import { buildEsQuery } from '@kbn/es-query';
+import { getDefaultDSLQuery } from '@kbn/ml-query-utils';
 import { getEsQueryFromSavedSearch } from '../application/utils/search_utils';
 import {
   isDefaultSearchQuery,
@@ -75,13 +77,15 @@ export const useSearch = (
       }
 
       return {
-        ...(isDefaultSearchQuery(searchQuery) ? {} : { searchQuery }),
+        searchQuery: (isDefaultSearchQuery(searchQuery)
+          ? getDefaultDSLQuery()
+          : searchQuery) as QueryDslQueryContainer,
         searchString: aiopsListState?.searchString,
         searchQueryLanguage: aiopsListState?.searchQueryLanguage,
       };
     } else {
       return {
-        searchQuery: searchData.searchQuery,
+        searchQuery: searchData.searchQuery as QueryDslQueryContainer,
         searchString: searchData.searchString,
         searchQueryLanguage: searchData.queryLanguage,
       };


### PR DESCRIPTION
Agentic refactoring draft, executed locally with Claude Code, Model Opus 4.6 using the following prompt:

```

Refactor the data plugin src/platform/plugins/shared/data to no longer use TypeScript any in the global exports. 
Aim to change as little code as possible for good readability. 
Aim to apply best practices in terms of TypeScript types. 
Iterate in small steps and use the following commands to confirm nothing breaks:  
 - yarn test:type_check src/platform/plugins/shared/data to check that the types are correct
 - yarn test:jest src/platform/plugins/shared/data to check that no tests fail  
Initially make a plan before starting to execute

```

Refined with copy pasting of review comments of copilot and CI error

Asked Claude after the task to provide a better prompt for it 


```

Prompt: Remove any from data plugin public API exports

  Remove all any types from the public API exports of src/platform/plugins/shared/data (issue #99519). The public API surfaces are public/index.ts,
  server/index.ts, and common/index.ts.

  Changes by area

  1. SearchSourceFields.highlight (types.ts)

  Change highlight?: any to highlight?: estypes.SearchHighlight in common/search/search_source/types.ts. The estypes import already exists.

  2. SearchRequest generic (fetch/types.ts)

  Change Record<string, any> to Record<string, unknown> in both the constraint and default on line 24.

  3. functionWrapper (expressions/utils/function_wrapper.ts)

  Change args: Record<string, any> to args: Record<string, unknown>.

  4. BaseParamType + subclasses (param_types/)

  In base.ts, replace all any with unknown in the class declaration (default, serialize, deserialize, toExpressionAst, options, write output,
  constructor config, getValueType).

  Critical: Extract a named interface for the write output parameter:
  export interface AggParamOutput {
    params: Record<string, unknown>;
    subAggs?: IAggConfig[];
    parentAggs?: IAggConfig[];
    bucketInterval?: unknown;
    metricScale?: number;
    metricScaleText?: string;
    [key: string]: unknown;
  }
  This avoids as unknown[] casts in agg writers since subAggs/parentAggs are now typed as IAggConfig[].

  Update all subclass files (agg.ts, field.ts, optioned.ts, json.ts, string.ts) to match — change Record<string, any> to Record<string, unknown> in
  constructor params and write method output params. In json.ts internal functions, replace any with unknown and use existing lodash type guards.

  5. search_source.ts — the most complex file

  Add MutableSearchRequest interface (replaces the old Record<string, any> internal type):
  interface MutableSearchRequest extends SearchRequest {
    body: Record<string, unknown>;
    filters?: Filter[] | (() => Filter[]);
    nonHighlightingFilters?: Filter[];
    query?: (Query | AggregateQuery)[];
    fieldsFromSource?: SearchFieldValue[];
    index?: DataView | string;
    type?: string;
    highlightAll?: boolean;
    pit?: estypes.SearchPointInTimeReference;
    timezone?: string;
    [key: string]: unknown;
  }

  Type the body variable in flatten() with known ES body properties:
  const body = { ...bodyParams, ...searchRequest.body } as {
    fields?: SearchFieldValue[];
    _source?: estypes.MappingSourceField | boolean;
    script_fields?: Record<string, estypes.ScriptField>;
    docvalue_fields?: Array<{ field: string; format: string }>;
    size?: number;
    sort?: unknown;
    [key: string]: unknown;
  };

  Narrow _source before accessing .excludes:
  const _sourceObj = typeof _source === 'object' ? _source : undefined;

  Type getSearchRequestBody() return to include query (prevents 25+ cascading errors in aiops/data_visualizer):
  getSearchRequestBody(): Record<string, unknown> & { query?: estypes.QueryDslQueryContainer } {
    return this.flatten().body as Record<string, unknown> & { query?: estypes.QueryDslQueryContainer };
  }

  Other casts needed in search_source.ts:
  - searchRequest.index as unknown as DataView (line ~388, for options.indexPattern)
  - this.getSearchRequestBody() as object (for inspector .json())
  - val as SearchFieldValue | SearchFieldValue[] (in fieldsFromSource concat)
  - body.docvalue_fields ?? [] (fallback for undefined)
  - body?.size as number (in toExpressionAst)
  - (_sourceObj ?? {}) as estypes.MappingSourceField (for getRemainingFields)

  In mergeProp: Ensure val(this) is preserved (pass this to functional field values):
  val = typeof val === 'function'
    ? (val as (searchSource: SearchSource) => SearchSourceFields[K])(this)
    : val;

  6. Other internal files (replace Record<string, any> casts with typed shapes)

  - search_service.ts: request as { id: string; body: estypes.SearchRequest }
  - get_search_params.ts: searchRequest as { track_total_hits?: boolean; body?: { track_total_hits?: boolean } }
  - inspector_stats.ts: (lastRequest as { ms?: number })?.ms
  - tabify.ts: Replace (aggInfo.metricScale as number) || 1 with typeof narrowing

  7. Downstream cascading fixes (outside data plugin)

  - search_source.test.ts: Cast all getSearchRequestBody() calls as Record<string, any> (test file, ~39 occurrences). One special case:
  (request._source as { includes: string[] }).includes
  - vis_default_editor/ (4 files): Cast aggParam.options to specific types (AggParamOption[], AggregateValueProp[]) and component types with as unknown
   as ComponentType<...>
  - discover_state.mock.ts: Cast spread as SearchSourceFields
  - generate_csv.test.ts: Cast mock with as typeof searchSourceMock.getField
  - aiops/search_utils.ts: savedQuery.bool?.filter (optional chaining)
  - aiops/use_search.ts: Cast searchQuery returns as QueryDslQueryContainer, import getDefaultDSLQuery for fallback
  - data_visualizer/saved_search_utils.ts: Same .bool?.filter fix as aiops

  Verification

  After all changes, run these type checks (all must pass with 0 errors):
  yarn test:type_check --project src/platform/plugins/shared/data/tsconfig.json
  yarn test:type_check --project src/platform/plugins/private/vis_default_editor/tsconfig.json
  yarn test:type_check --project src/platform/plugins/shared/discover/tsconfig.json
  yarn test:type_check --project src/platform/packages/private/kbn-generate-csv/tsconfig.json

```

And then asked it to provide a generic refactoring prompt

```
Prompt: Remove any from a Kibana plugin's public API exports

  Remove all any types from the public API exports of [plugin path]. The public API surfaces are defined by the plugin's index.ts files and
  extraPublicDirs in kibana.jsonc.

  Process

  Phase 1: Map the blast radius before changing anything

  1. Identify every any in the public API by grepping the exported types, interfaces, classes, and function signatures.
  2. For each any, trace its consumers — both internal (within the plugin) and external (other plugins that import it). Use grep on the type/interface
  name across the repo.
  3. Group the any occurrences by dependency chain: which changes are isolated vs which will cascade. Prioritize isolated changes first.
  4. Before writing any code, list all files that will need changes — including downstream consumers in other plugins. This avoids discovering
  cascading errors one at a time.

  Phase 2: Choose replacement types strategically

  - Use unknown as the default replacement for any at type boundaries.
  - Use specific ES types (estypes.*) when the value flows to/from Elasticsearch.
  - For class hierarchies: change the base class first, then update all subclasses in the same step. Never change them separately.
  - For method return types that are consumed widely: add an explicit return type annotation with the most useful shape (include commonly-accessed
  properties as named fields plus [key: string]: unknown for flexibility). This prevents cascading unknown property-access errors in every consumer.
  - For interfaces used as "bags of properties" (like write-method output params): define a named interface with well-known optional fields instead of
  Record<string, unknown>. This avoids scattered as casts at every usage site.

  Phase 3: Apply changes in dependency order

  1. Leaf types first — types that nothing else depends on (e.g., a highlight field type).
  2. Shared interfaces next — types used across multiple files within the plugin (e.g., param output interfaces, request types).
  3. Class hierarchies together — base class + all subclasses in one step.
  4. Public method return types — especially methods consumed by other plugins. Always add explicit return type annotations with named properties for
  commonly-accessed fields.
  5. Downstream consumer fixes last — other plugins, test files, mock files.

  Phase 4: Handle test files pragmatically

  - In test files, casting to Record<string, any> or specific test types is acceptable — tests don't need the same type safety as production code.
  - For mock files, cast at the boundary where the mock meets the changed type.

  Phase 5: Verify comprehensively

  - Run type checks on the plugin itself AND all plugins that depend on it. Use tsconfig.json project references to identify dependents.
  - Run the full project type check (tsconfig.refs.json) if possible, as per-project checks can miss cross-project errors.
  - Lint all changed files with --fix.

```






## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



