### PR TITLE
Add maskProps.headerZindexLocation above to inspect component flyout

### DIFF
--- a/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/inspect_flyout.tsx
+++ b/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/inspect_flyout.tsx
@@ -33,6 +33,9 @@ export const flyoutOptions: OverlayFlyoutOpenOptions = {
   'data-test-subj': INSPECT_FLYOUT_ID,
   id: INSPECT_FLYOUT_ID,
   maxWidth: INSPECT_FLYOUT_MAX_WIDTH,
+  maskProps: {
+    headerZindexLocation: 'above',
+  },
 };
 
 export const InspectFlyout = ({ componentData, target, branch }: Props) => {


### PR DESCRIPTION
## Summary

This PR adds `maskProps.headerZindexLocation: "above"` to inspect component flyout, to make it appear above header.

