### PR TITLE
[Entity Store] Require user privileges 

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
@@ -12,10 +12,10 @@
     "requiredPlugins": [
       "spaces",
       "taskManager",
-      "dataViews"
-    ],
+      "dataViews",
+      "security"
+  ],
     "optionalPlugins": [
-      "security",
       "encryptedSavedObjects"
     ]
   }

--- a/x-pack/solutions/security/plugins/entity_store/moon.yml
+++ b/x-pack/solutions/security/plugins/entity_store/moon.yml
@@ -38,6 +38,7 @@ dependsOn:
   - '@kbn/encrypted-saved-objects-plugin'
   - '@kbn/scout-security'
   - '@kbn/core-saved-objects-server'
+  - '@kbn/security-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
@@ -17,6 +17,10 @@ export const ENTITY_SCHEMA_VERSION_V2 = 'v2';
 
 export const ECS_MAPPINGS_COMPONENT_TEMPLATE = 'ecs@mappings';
 
+export const ENTITY_STORE_SOURCE_INDICES_PRIVILEGES = ['read', 'view_index_metadata'];
+export const ENTITY_STORE_TARGET_INDICES_PRIVILEGES = ['read', 'manage'];
+export const ENTITY_STORE_CLUSTER_PRIVILEGES = ['manage_index_templates'];
+
 type SchemaVersion = `v${number}`;
 type Dataset = typeof ENTITY_LATEST | typeof ENTITY_UPDATES;
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
@@ -131,7 +131,6 @@ export class LogsExtractionClient {
   }) {
     const { docsLimit } = engineDescriptor.logExtractionState;
     const indexPatterns = await this.getIndexPatterns(
-      engineDescriptor.type,
       engineDescriptor.logExtractionState.additionalIndexPattern
     );
     const latestIndex = getLatestEntitiesIndexName(this.namespace);
@@ -236,7 +235,7 @@ export class LogsExtractionClient {
     return { success: false, error };
   }
 
-  private async getIndexPatterns(type: EntityType, additionalIndexPatterns: string) {
+  public async getIndexPatterns(additionalIndexPatterns = '') {
     const updatesDataStream = getUpdatesEntitiesDataStreamName(this.namespace);
     const cleanAdditionalIndicesPatterns = additionalIndexPatterns
       .split(',')

--- a/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
@@ -70,8 +70,10 @@ export async function createRequestHandlerContext({
       namespace,
       isServerless,
       logsExtractionClient,
+      security: startPlugins.security,
     }),
     featureFlags: new FeatureFlags(core.uiSettings.client),
     logsExtractionClient,
+    security: startPlugins.security,
   };
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -47,6 +47,7 @@ export interface EntityStoreApiRequestHandlerContext {
   assetManager: AssetManager;
   featureFlags: FeatureFlags;
   logsExtractionClient: LogsExtractionClient;
+  security: SecurityPluginStart;
 }
 
 export type EntityStoreRequestHandlerContext = CustomRequestHandlerContext<{

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_privileges.spec.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchRoleDescriptor } from '@kbn/scout-security';
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+
+import {
+  ENTITY_STORE_CLUSTER_PRIVILEGES,
+  ENTITY_STORE_SOURCE_INDICES_PRIVILEGES,
+  ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
+} from '../../../../server/domain/constants';
+import { COMMON_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import { getLatestEntitiesIndexName } from '../../../../server/domain/assets/latest_index';
+import { getUpdatesEntitiesDataStreamName } from '../../../../server/domain/assets/updates_data_stream';
+
+apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_TAGS }, () => {
+  const TARGET_INDEX_LATEST = getLatestEntitiesIndexName('default');
+  const TARGET_INDEX_UPDATES = getUpdatesEntitiesDataStreamName('default');
+
+  const SAVED_OBJECT_PRIVILEGE = 'saved_object:entity-engine-descriptor-v2/create';
+
+  interface RoleOptions {
+    withTargetIndex?: boolean;
+    withSavedObjectCreate?: boolean;
+  }
+
+  const buildRoleDescriptor = ({
+    withTargetIndex = true,
+    withSavedObjectCreate = true,
+  }: RoleOptions = {}): ElasticsearchRoleDescriptor => {
+    const indices = [
+      { names: ['logs-*'], privileges: ENTITY_STORE_SOURCE_INDICES_PRIVILEGES },
+      { names: [TARGET_INDEX_UPDATES], privileges: ENTITY_STORE_SOURCE_INDICES_PRIVILEGES },
+    ];
+
+    if (withTargetIndex) {
+      indices.push({
+        names: [TARGET_INDEX_LATEST],
+        privileges: ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
+      });
+    }
+
+    return {
+      cluster: ENTITY_STORE_CLUSTER_PRIVILEGES,
+      indices,
+      applications: [
+        {
+          application: 'kibana-.kibana',
+          privileges: withSavedObjectCreate
+            ? ['feature_siem.all', SAVED_OBJECT_PRIVILEGE]
+            : ['feature_siem.all'],
+          resources: ['*'],
+        },
+      ],
+    };
+  };
+
+  const getRoleWithAllPrivileges = () => buildRoleDescriptor();
+  const getRoleWithoutTargetIndexPrivileges = () => buildRoleDescriptor({ withTargetIndex: false });
+  const getRoleWithoutSavedObjectCreate = () =>
+    buildRoleDescriptor({ withSavedObjectCreate: false });
+
+  let additionalIndicesToCleanup: string[] = [];
+
+  apiTest.beforeEach(async ({ kbnClient }) => {
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+  });
+
+  apiTest.afterEach(async ({ esClient, apiClient, samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    await Promise.allSettled([
+      apiClient.post(ENTITY_STORE_ROUTES.UNINSTALL, {
+        headers: { ...credentials.cookieHeader, ...COMMON_HEADERS },
+        body: {},
+      }),
+      ...additionalIndicesToCleanup.map((index) =>
+        esClient.indices.delete({ index, ignore_unavailable: true })
+      ),
+    ]);
+    additionalIndicesToCleanup = [];
+  });
+
+  apiTest(
+    'Should fail when user lacks permissions for source index patterns',
+    async ({ apiClient, esClient, requestAuth }) => {
+      const restrictedIndex = 'restricted-test-logs';
+      additionalIndicesToCleanup = [restrictedIndex];
+
+      await esClient.indices.create({ index: restrictedIndex });
+
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(getRoleWithAllPrivileges());
+
+      const response = await apiClient.post(ENTITY_STORE_ROUTES.INSTALL, {
+        headers: { ...COMMON_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: { logExtraction: { additionalIndexPattern: restrictedIndex } },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_elasticsearch_privileges: {
+          cluster: [],
+          index: [{ index: restrictedIndex, privileges: ENTITY_STORE_SOURCE_INDICES_PRIVILEGES }],
+        },
+      });
+    }
+  );
+
+  apiTest(
+    'Should fail when user lacks permissions for target index patterns',
+    async ({ apiClient, requestAuth }) => {
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(
+        getRoleWithoutTargetIndexPrivileges()
+      );
+
+      const response = await apiClient.post(ENTITY_STORE_ROUTES.INSTALL, {
+        headers: { ...COMMON_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: {},
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_elasticsearch_privileges: {
+          cluster: [],
+          index: [
+            {
+              index: TARGET_INDEX_LATEST,
+              privileges: expect.arrayContaining(ENTITY_STORE_TARGET_INDICES_PRIVILEGES),
+            },
+          ],
+        },
+      });
+    }
+  );
+
+  apiTest(
+    'Should fail when user lacks permissions for entity store saved object descriptor',
+    async ({ apiClient, requestAuth }) => {
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(
+        getRoleWithoutSavedObjectCreate()
+      );
+
+      const response = await apiClient.post(ENTITY_STORE_ROUTES.INSTALL, {
+        headers: { ...COMMON_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: {},
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_kibana_privileges: [SAVED_OBJECT_PRIVILEGE],
+      });
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/entity_store/tsconfig.json
+++ b/x-pack/solutions/security/plugins/entity_store/tsconfig.json
@@ -34,5 +34,6 @@
     "@kbn/encrypted-saved-objects-plugin",
     "@kbn/scout-security",
     "@kbn/core-saved-objects-server",
+    "@kbn/security-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

- adds a privilege check before installing the entity store 

- returns `403` if the user lacks required privileges


the required privileges are:
- source indices (+`additionalIndexPatterns`): `'read', 'view_index_metadata'`  
- target (`latest`): `'read', 'manage'`
- cluster: `manage_index_templates`

closes https://github.com/elastic/kibana/issues/251175

