### PR TITLE
[9.2] chore(NA): changes machine types for blocking steps on CI (#252224)

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -36,9 +36,10 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-8
+      machineType: n4d-standard-16
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
     key: build
     timeout_in_minutes: 60
     retry:
@@ -52,10 +53,11 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-highcpu-8
+      machineType: n4d-standard-8
+      diskType: hyperdisk-balanced
       preemptible: true
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -68,7 +70,8 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-2
+      machineType: n4d-standard-2
+      diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
@@ -84,7 +87,8 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-16
+      machineType: n4d-standard-16
+      diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
@@ -100,7 +104,8 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-32
+      machineType: n4d-standard-32
+      diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
@@ -116,10 +121,10 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: c4-standard-4
+      machineType: n4d-standard-4
       diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -22,10 +22,11 @@ steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution
     agents:
-      machineType: n2-standard-8
+      machineType: c4d-standard-16
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
-      diskSizeGb: 150
+      spotZones: us-central1-c,us-central1-a
+      diskSizeGb: 200
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
     timeout_in_minutes: 90
@@ -37,9 +38,10 @@ steps:
   - command: .buildkite/scripts/steps/quick_checks.sh
     label: 'Quick Checks'
     agents:
-      machineType: n2-highcpu-8
+      machineType: c4d-standard-8
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     key: quick_checks
     timeout_in_minutes: 60
@@ -52,9 +54,10 @@ steps:
     label: 'Checks'
     key: checks
     agents:
-      machineType: n2-standard-2
+      machineType: c4d-standard-2
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -65,9 +68,10 @@ steps:
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
-      machineType: n2-standard-16
+      machineType: c4d-standard-16
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     key: linting
     timeout_in_minutes: 60
@@ -79,9 +83,10 @@ steps:
   - command: .buildkite/scripts/steps/lint_with_types.sh
     label: 'Linting (with types)'
     agents:
-      machineType: n2-standard-32
+      machineType: c4d-standard-32
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     key: linting_with_types
     timeout_in_minutes: 60
@@ -106,10 +111,10 @@ steps:
   - command: .buildkite/scripts/steps/typecheck/check_types.sh
     label: 'Check Types'
     agents:
-      machineType: c4-standard-4
+      machineType: c4d-standard-4
       diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: northamerica-northeast2-b,us-central1-c,us-central1-a
+      spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [chore(NA): changes machine types for blocking steps on CI (#252224)](https://github.com/elastic/kibana/pull/252224)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2026-02-10T06:10:26Z","message":"chore(NA): changes machine types for blocking steps on CI (#252224)\n\nThis PR changes blocking steps into using new `n4d` machines and\nhyperdisks improving performance by 50%.","sha":"c9a284b193fead3a86eac702e55dcae5eb485b9f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v9.3.0","v9.4.0","v8.19.12"],"title":"chore(NA): changes machine types for blocking steps on CI","number":252224,"url":"https://github.com/elastic/kibana/pull/252224","mergeCommit":{"message":"chore(NA): changes machine types for blocking steps on CI (#252224)\n\nThis PR changes blocking steps into using new `n4d` machines and\nhyperdisks improving performance by 50%.","sha":"c9a284b193fead3a86eac702e55dcae5eb485b9f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/252445","number":252445,"state":"MERGED","mergeCommit":{"sha":"7386347594f51a0ea5726f959f5759eceb099a61","message":"[9.3] chore(NA): changes machine types for blocking steps on CI (#252224) (#252445)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [chore(NA): changes machine types for blocking steps on CI\n(#252224)](https://github.com/elastic/kibana/pull/252224)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252224","number":252224,"mergeCommit":{"message":"chore(NA): changes machine types for blocking steps on CI (#252224)\n\nThis PR changes blocking steps into using new `n4d` machines and\nhyperdisks improving performance by 50%.","sha":"c9a284b193fead3a86eac702e55dcae5eb485b9f"}},{"branch":"8.19","label":"v8.19.12","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/252444","number":252444,"state":"MERGED","mergeCommit":{"sha":"0dd36d616ba286d528a39c79a06d339c28c731c7","message":"[8.19] chore(NA): changes machine types for blocking steps on CI (#252224) (#252444)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [chore(NA): changes machine types for blocking steps on CI\n(#252224)](https://github.com/elastic/kibana/pull/252224)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>"}}]}] BACKPORT-->