### PR TITLE
make --dist toggle --no-cache on dist builds for shared webpack builds

### DIFF
--- a/packages/kbn-plugin-helpers/src/tasks/build_webpack_packages.ts
+++ b/packages/kbn-plugin-helpers/src/tasks/build_webpack_packages.ts
@@ -21,7 +21,10 @@ export async function buildWebpackPackages({ log, quiet, dist }: TaskContext) {
 
   const args = ['kbn', 'build-shared'];
   if (quiet) args.push('--quiet');
-  if (dist) args.push('--dist');
+  if (dist) {
+    args.push('--dist');
+    args.push('--no-cache');
+  }
 
   await execa('yarn', args, { cwd: REPO_ROOT, stdio });
 }


### PR DESCRIPTION
## Summary
There seem to be some sporadic errors in older branches with the jest integration tests testing the plugin builds. This change aims to fix those errors.

