### PR TITLE
fix: remove `any` from data plugin public API exports

### DIFF
--- a/src/platform/plugins/shared/data/common/search/aggs/agg_params.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/agg_params.ts
@@ -13,18 +13,21 @@ import { OptionedParamType } from './param_types/optioned';
 import { StringParamType } from './param_types/string';
 import { JsonParamType } from './param_types/json';
 import { BaseParamType } from './param_types/base';
+import type { AggParamOutput } from './param_types/base';
 
 import type { AggConfig } from './agg_config';
 import type { IAggConfigs } from './agg_configs';
 
-const paramTypeMap = {
+type ParamTypeClass = new (config: Record<string, any>) => BaseParamType;
+
+const paramTypeMap: Record<string, ParamTypeClass> = {
   field: FieldParamType,
   optioned: OptionedParamType,
   string: StringParamType,
   json: JsonParamType,
   agg: AggParamType,
   _default: BaseParamType,
-} as Record<string, any>;
+};
 
 export type AggParam = BaseParamType;
 
@@ -40,7 +43,7 @@ export const initParams = <TAggParam extends AggParamType = AggParamType>(
   params.map((config: TAggParam) => {
     const Class = paramTypeMap[config.type] || paramTypeMap._default;
 
-    return new Class(config);
+    return new Class(config as unknown as Record<string, any>);
   }) as TAggParam[];
 
 /**
@@ -66,8 +69,8 @@ export const writeParams = <
   aggs?: IAggConfigs,
   locals?: Record<string, any>
 ) => {
-  const output: Record<string, any> = {
-    params: {} as Record<string, any>,
+  const output: AggParamOutput = {
+    params: {},
   };
   locals = locals || {};
 

--- a/src/platform/plugins/shared/data/common/search/aggs/agg_type.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/agg_type.ts
@@ -23,6 +23,10 @@ import type { IAggConfigs } from './agg_configs';
 import { BaseParamType } from './param_types/base';
 import type { AggParamType } from './param_types/agg';
 
+export interface AggTypeOrdered {
+  date?: boolean;
+}
+
 type PostFlightRequestFn<TAggConfig> = (
   resp: estypes.SearchResponse<any>,
   aggConfigs: IAggConfigs,
@@ -45,7 +49,7 @@ export interface AggTypeConfig<
   dslName?: string;
   expressionName: string;
   makeLabel?: ((aggConfig: TAggConfig) => string) | (() => string);
-  ordered?: any;
+  ordered?: AggTypeOrdered;
   hasNoDsl?: boolean;
   hasNoDslParams?: boolean;
   params?: Array<Partial<TParam>>;
@@ -54,7 +58,7 @@ export interface AggTypeConfig<
   getResponseAggs?: ((aggConfig: TAggConfig) => TAggConfig[]) | (() => TAggConfig[] | void);
   customLabels?: boolean;
   json?: boolean;
-  decorateAggConfig?: () => any;
+  decorateAggConfig?: () => PropertyDescriptorMap;
   postFlightRequest?: PostFlightRequestFn<TAggConfig>;
   hasPrecisionError?: (aggBucket: Record<string, unknown>) => boolean;
   getSerializedFormat?: (agg: TAggConfig) => SerializedFieldFormat;
@@ -130,7 +134,7 @@ export class AggType<
    * @property ordered
    * @type {object|undefined}
    */
-  ordered: any;
+  ordered: AggTypeOrdered | undefined;
   /**
    * Flag that prevents this aggregation from being included in the dsl. This is only
    * used by the count aggregation (currently) since it doesn't really exist and it's output
@@ -184,7 +188,7 @@ export class AggType<
    * A function that will be called each time an aggConfig of this type
    * is created, giving the agg type a chance to modify the agg config
    */
-  decorateAggConfig: () => any;
+  decorateAggConfig: () => PropertyDescriptorMap;
 
   hasPrecisionError?: (aggBucket: Record<string, unknown>) => boolean;
 
@@ -287,7 +291,7 @@ export class AggType<
           name: 'json',
           type: 'json',
           advanced: true,
-        });
+        } as Partial<TParam>);
       }
 
       // always append custom label
@@ -300,7 +304,7 @@ export class AggType<
           }),
           type: 'string',
           write: noop,
-        });
+        } as Partial<TParam>);
       }
 
       this.params = initParams(params);

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/bucket_agg_type.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/bucket_agg_type.ts
@@ -97,6 +97,11 @@ export class BucketAggType<TBucketAggConfig extends IAggConfig = IBucketAggConfi
   }
 }
 
-export function isBucketAggType(aggConfig: any): aggConfig is BucketAggType {
-  return aggConfig && aggConfig.type === bucketType;
+export function isBucketAggType(aggConfig: unknown): aggConfig is BucketAggType {
+  return (
+    typeof aggConfig === 'object' &&
+    aggConfig !== null &&
+    'type' in aggConfig &&
+    (aggConfig as BucketAggType).type === bucketType
+  );
 }

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/filter.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/filter.ts
@@ -91,7 +91,7 @@ export const getFilterBucketAgg = ({
             ? moment(calculateBounds(aggConfigs.timeRange).max)
             : undefined;
 
-          output.params =
+          output.params = (
             !timeWindow || !timeRangeAnchor || !aggConfig.getIndexPattern().timeFieldName
               ? query
               : {
@@ -116,7 +116,8 @@ export const getFilterBucketAgg = ({
                       query ? query : undefined,
                     ].filter(Boolean),
                   },
-                };
+                }
+          ) as Record<string, any>;
         },
         toExpressionAst: queryToAst,
       },

--- a/src/platform/plugins/shared/data/common/search/aggs/metrics/count.test.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/metrics/count.test.ts
@@ -19,7 +19,7 @@ function makeAgg(emptyAsNull: boolean = false, timeShift?: moment.Duration): IMe
     params: {
       emptyAsNull,
     },
-  } as IMetricAggConfig;
+  } as unknown as IMetricAggConfig;
 }
 
 function getBucket(value: number | undefined, timeShift?: moment.Duration) {

--- a/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
@@ -74,7 +74,7 @@ export const siblingPipelineAggHelper = {
         write: (agg: IMetricAggConfig, output: Record<string, any>) =>
           siblingPipelineAggWriter(agg, output),
       },
-    ] as Array<MetricAggParam<IMetricAggConfig>>;
+    ] as unknown as Array<MetricAggParam<IMetricAggConfig>>;
   },
 
   getSerializedFormat(agg: IMetricAggConfig) {

--- a/src/platform/plugins/shared/data/common/search/aggs/metrics/metric_agg_type.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/metrics/metric_agg_type.ts
@@ -115,6 +115,11 @@ export class MetricAggType<TMetricAggConfig extends AggConfig = IMetricAggConfig
   }
 }
 
-export function isMetricAggType(aggConfig: any): aggConfig is MetricAggType {
-  return aggConfig && aggConfig.type === metricType;
+export function isMetricAggType(aggConfig: unknown): aggConfig is MetricAggType {
+  return (
+    typeof aggConfig === 'object' &&
+    aggConfig !== null &&
+    'type' in aggConfig &&
+    (aggConfig as MetricAggType).type === metricType
+  );
 }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/agg.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/agg.ts
@@ -10,6 +10,7 @@
 import type { IAggConfig, AggConfigSerialized } from '../agg_config';
 import { AggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 
 export class AggParamType<
   TAggConfig extends IAggConfig = IAggConfig
@@ -25,7 +26,7 @@ export class AggParamType<
     }
 
     if (!config.write) {
-      this.write = (aggConfig: TAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: TAggConfig, output: AggParamOutput) => {
         if (aggConfig.params[this.name] && aggConfig.params[this.name].length) {
           output.params[this.name] = aggConfig.params[this.name];
         }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/base.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/base.ts
@@ -13,16 +13,22 @@ import type { ISearchSource } from '../../../../public';
 import type { IAggConfigs } from '../agg_configs';
 import type { IAggConfig } from '../agg_config';
 
+/** Output object passed to agg param write methods */
+export interface AggParamOutput {
+  params: Record<string, any>;
+  [key: string]: any;
+}
+
 export class BaseParamType<TAggConfig extends IAggConfig = IAggConfig> {
   name: string;
   type: string;
   displayName: string;
   required: boolean;
   advanced: boolean;
-  default: any;
+  default: unknown;
   write: (
     aggConfig: TAggConfig,
-    output: Record<string, any>,
+    output: AggParamOutput,
     aggConfigs?: IAggConfigs,
     locals?: Record<string, any>
   ) => void;
@@ -59,7 +65,7 @@ export class BaseParamType<TAggConfig extends IAggConfig = IAggConfig> {
     this.shouldShow = config.shouldShow;
     this.default = config.default;
 
-    const defaultWrite = (aggConfig: TAggConfig, output: Record<string, any>) => {
+    const defaultWrite = (aggConfig: TAggConfig, output: AggParamOutput) => {
       if (aggConfig.params[this.name]) {
         output.params[this.name] = aggConfig.params[this.name] || this.default;
       }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/field.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/field.ts
@@ -12,6 +12,7 @@ import { SavedFieldTypeInvalidForAgg } from '@kbn/kibana-utils-plugin/common';
 import { isNestedField, DataViewField } from '@kbn/data-views-plugin/common';
 import type { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 import { propFilter } from '../utils';
 import { KBN_FIELD_TYPES } from '../../../kbn_field_types/types';
 
@@ -46,7 +47,7 @@ export class FieldParamType extends BaseParamType {
 
     // TODO - are there any custom write methods that do a missing check?
     if (!config.write) {
-      this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: IAggConfig, output: AggParamOutput) => {
         const field = aggConfig.getField();
 
         if (!field) {
@@ -64,7 +65,7 @@ export class FieldParamType extends BaseParamType {
         const validField =
           field.type === KBN_FIELD_TYPES.MISSING // missing fields are always valid
             ? field
-            : this.getAvailableFields(aggConfig).find((f: any) => f.name === field.name);
+            : this.getAvailableFields(aggConfig).find((f: DataViewField) => f.name === field.name);
 
         if (!validField) {
           throw new SavedFieldTypeInvalidForAgg(

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/json.test.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/json.test.ts
@@ -8,13 +8,14 @@
  */
 
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 import { JsonParamType } from './json';
 import type { IAggConfig } from '../agg_config';
 
 describe('JSON', function () {
   const paramName = 'json_test';
   let aggConfig: IAggConfig;
-  let output: Record<string, any>;
+  let output: AggParamOutput;
 
   const initAggParam = (config: Record<string, any> = {}) =>
     new JsonParamType({

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/json.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/json.ts
@@ -11,6 +11,7 @@ import _ from 'lodash';
 
 import type { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 
 function collapseLiteralStrings(xjson: string) {
   const tripleQuotes = '"""';
@@ -30,7 +31,7 @@ export class JsonParamType extends BaseParamType {
     this.name = config.name || 'json';
 
     if (!config.write) {
-      this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: IAggConfig, output: AggParamOutput) => {
         let paramJson;
         const param = aggConfig.params[this.name];
 
@@ -44,27 +45,31 @@ export class JsonParamType extends BaseParamType {
           return;
         }
 
-        function filteredCombine(srcA: any, srcB: any) {
-          function mergeObjs(a: any, b: any) {
+        function filteredCombine(srcA: unknown, srcB: unknown): unknown {
+          function mergeObjs(
+            a: Record<string, unknown>,
+            b: Record<string, unknown>
+          ): Record<string, unknown> {
             return _(a)
               .keys()
               .union(_.keys(b))
-              .transform(function (dest: any, key) {
+              .transform(function (dest: Record<string, unknown>, key) {
                 const val = compare(a[key], b[key]);
                 if (val !== undefined) dest[key] = val;
               }, {})
               .value();
           }
 
-          function mergeArrays(a: any, b: any): any {
+          function mergeArrays(a: unknown[], b: unknown[]): unknown[] {
             // attempt to merge each value
             return _.times(Math.max(a.length, b.length), function (i) {
               return compare(a[i], b[i]);
             });
           }
 
-          function compare(a: any, b: any) {
-            if (_.isPlainObject(a) && _.isPlainObject(b)) return mergeObjs(a, b);
+          function compare(a: unknown, b: unknown): unknown {
+            if (_.isPlainObject(a) && _.isPlainObject(b))
+              return mergeObjs(a as Record<string, unknown>, b as Record<string, unknown>);
             if (Array.isArray(a) && Array.isArray(b)) return mergeArrays(a, b);
             if (b === null) return undefined;
             if (b !== undefined) return b;
@@ -74,7 +79,7 @@ export class JsonParamType extends BaseParamType {
           return compare(srcA, srcB);
         }
 
-        output.params = filteredCombine(output.params, paramJson);
+        output.params = filteredCombine(output.params, paramJson) as Record<string, any>;
         return;
       };
     }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/optioned.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/optioned.ts
@@ -9,6 +9,7 @@
 
 import type { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 
 export interface OptionedValueProp {
   value: string;
@@ -24,7 +25,7 @@ export class OptionedParamType extends BaseParamType {
     super(config);
 
     if (!config.write) {
-      this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: IAggConfig, output: AggParamOutput) => {
         output.params[this.name] = aggConfig.params[this.name].value;
       };
     }

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/string.test.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/string.test.ts
@@ -8,13 +8,14 @@
  */
 
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 import { StringParamType } from './string';
 import type { IAggConfig } from '../agg_config';
 
 describe('String', function () {
   let paramName = 'json_test';
   let aggConfig: IAggConfig;
-  let output: Record<string, any>;
+  let output: AggParamOutput;
 
   const initAggParam = (config: Record<string, any> = {}) =>
     new StringParamType({

--- a/src/platform/plugins/shared/data/common/search/aggs/param_types/string.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/param_types/string.ts
@@ -9,13 +9,14 @@
 
 import type { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
+import type { AggParamOutput } from './base';
 
 export class StringParamType extends BaseParamType {
   constructor(config: Record<string, any>) {
     super(config);
 
     if (!config.write) {
-      this.write = (aggConfig: IAggConfig, output: Record<string, any>) => {
+      this.write = (aggConfig: IAggConfig, output: AggParamOutput) => {
         if (aggConfig.params[this.name] && aggConfig.params[this.name].length) {
           output.params[this.name] = aggConfig.params[this.name];
         }

--- a/src/platform/plugins/shared/data/common/search/expressions/eql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/eql.ts
@@ -50,7 +50,7 @@ interface EqlStartDependencies {
 export const getEqlFn = ({
   getStartDependencies,
 }: {
-  getStartDependencies: (getKibanaRequest: any) => Promise<EqlStartDependencies>;
+  getStartDependencies: (getKibanaRequest: unknown) => Promise<EqlStartDependencies>;
 }) => {
   const eql: EqlExpressionFunctionDefinition = {
     name,
@@ -103,7 +103,9 @@ export const getEqlFn = ({
 
       if (input) {
         const dataview = args.index ? await dataViews.create({ title: args.index }) : undefined;
-        const esQueryConfigs = getEsQueryConfig(uiSettingsClient as any);
+        const esQueryConfigs = getEsQueryConfig(
+          uiSettingsClient as Parameters<typeof getEsQueryConfig>[0]
+        );
         const query = buildEsQuery(
           dataview,
           input.query || [],

--- a/src/platform/plugins/shared/data/common/search/expressions/esdsl.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esdsl.ts
@@ -47,7 +47,7 @@ interface EsdslStartDependencies {
 export const getEsdslFn = ({
   getStartDependencies,
 }: {
-  getStartDependencies: (getKibanaRequest: any) => Promise<EsdslStartDependencies>;
+  getStartDependencies: (getKibanaRequest: unknown) => Promise<EsdslStartDependencies>;
 }) => {
   const esdsl: EsdslExpressionFunctionDefinition = {
     name,
@@ -87,7 +87,9 @@ export const getEsdslFn = ({
       const dsl = JSON.parse(args.dsl);
 
       if (input) {
-        const esQueryConfigs = getEsQueryConfig(uiSettingsClient as any);
+        const esQueryConfigs = getEsQueryConfig(
+          uiSettingsClient as Parameters<typeof getEsQueryConfig>[0]
+        );
         const query = buildEsQuery(
           undefined, //        args.index,
           input.query || [],

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -87,12 +87,16 @@ interface EsqlStartDependencies {
   uiSettings: UiSettingsCommon;
 }
 
-function extractTypeAndReason(attributes: any): { type?: string; reason?: string } {
-  if (['type', 'reason'].every((prop) => prop in attributes)) {
-    return attributes;
+function extractTypeAndReason(attributes: unknown): { type?: string; reason?: string } {
+  if (typeof attributes !== 'object' || attributes === null) {
+    return {};
   }
-  if ('error' in attributes) {
-    return extractTypeAndReason(attributes.error);
+  const attrs = attributes as Record<string, unknown>;
+  if (['type', 'reason'].every((prop) => prop in attrs)) {
+    return attrs as { type?: string; reason?: string };
+  }
+  if ('error' in attrs) {
+    return extractTypeAndReason(attrs.error);
   }
   return {};
 }

--- a/src/platform/plugins/shared/data/common/search/expressions/exists_filter.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/exists_filter.ts
@@ -53,7 +53,7 @@ export const existsFilterFunction: ExpressionFunctionExistsFilter = {
     return {
       type: 'kibana_filter',
       ...buildFilter(
-        {} as any as DataView,
+        {} as unknown as DataView,
         args.field.spec,
         FILTERS.EXISTS,
         args.negate || false,

--- a/src/platform/plugins/shared/data/common/search/expressions/geo_bounding_box.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/geo_bounding_box.ts
@@ -97,19 +97,21 @@ type GeoPointsArguments =
 
 type GeoBoundingBoxArguments = GeoBox | GeoPointsArguments | WellKnownText;
 
-function isGeoBox(value: any): value is GeoBox {
-  return value?.top != null && value?.left != null && value?.bottom != null && value?.right != null;
+function isGeoBox(value: unknown): value is GeoBox {
+  const v = value as Record<string, unknown> | null | undefined;
+  return v?.top != null && v?.left != null && v?.bottom != null && v?.right != null;
 }
 
-function isGeoPoints(value: any): value is GeoPointsArguments {
+function isGeoPoints(value: unknown): value is GeoPointsArguments {
+  const v = value as Record<string, unknown> | null | undefined;
   return (
-    (value?.topLeft != null && value?.bottomRight != null) ||
-    (value?.topRight != null && value?.bottomLeft != null)
+    (v?.topLeft != null && v?.bottomRight != null) || (v?.topRight != null && v?.bottomLeft != null)
   );
 }
 
-function isWellKnownText(value: any): value is WellKnownText {
-  return value?.wkt != null;
+function isWellKnownText(value: unknown): value is WellKnownText {
+  const v = value as Record<string, unknown> | null | undefined;
+  return v?.wkt != null;
 }
 
 export type ExpressionFunctionGeoBoundingBox = ExpressionFunctionDefinition<

--- a/src/platform/plugins/shared/data/common/search/expressions/phrase_filter.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/phrase_filter.ts
@@ -63,7 +63,7 @@ export const phraseFilterFunction: ExpressionFunctionPhraseFilter = {
       return {
         type: 'kibana_filter',
         ...buildFilter(
-          {} as any as DataView,
+          {} as unknown as DataView,
           args.field.spec,
           FILTERS.PHRASE,
           args.negate || false,

--- a/src/platform/plugins/shared/data/common/search/expressions/range_filter.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/range_filter.ts
@@ -62,7 +62,7 @@ export const rangeFilterFunction: ExpressionFunctionRangeFilter = {
     return {
       type: 'kibana_filter',
       ...buildFilter(
-        {} as any as DataView,
+        {} as unknown as DataView,
         args.field.spec,
         FILTERS.RANGE,
         args.negate || false,

--- a/src/platform/plugins/shared/data/common/search/expressions/utils/function_wrapper.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/utils/function_wrapper.ts
@@ -21,7 +21,7 @@ export const functionWrapper = (spec: AnyExpressionFunctionDefinition) => {
   const defaultArgs = mapValues(spec.args, (argSpec) => argSpec.default);
   return (
     context: object | null,
-    args: Record<string, any> = {},
+    args: Record<string, unknown> = {},
     handlers: ExecutionContext = {} as ExecutionContext
   ) => spec.fn(context, { ...defaultArgs, ...args }, handlers);
 };

--- a/src/platform/plugins/shared/data/common/search/tabify/buckets.test.ts
+++ b/src/platform/plugins/shared/data/common/search/tabify/buckets.test.ts
@@ -74,7 +74,7 @@ describe('Buckets wrapper', () => {
           ],
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
 
       const buckets = new TabifyBuckets(aggResp, agg);
 
@@ -107,7 +107,7 @@ describe('Buckets wrapper', () => {
           ],
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
 
       const buckets = new TabifyBuckets(aggResp, agg);
 
@@ -135,7 +135,7 @@ describe('Buckets wrapper', () => {
           ],
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
 
       const buckets = new TabifyBuckets(aggResp, agg);
 
@@ -193,7 +193,7 @@ describe('Buckets wrapper', () => {
           },
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
       const timeRange = {
         from: moment(150),
         to: moment(350),
@@ -253,7 +253,7 @@ describe('Buckets wrapper', () => {
           },
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
       const timeRange = {
         from: moment(150),
         to: moment(350),
@@ -273,7 +273,7 @@ describe('Buckets wrapper', () => {
           },
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
       const timeRange = {
         from: moment(100),
         to: moment(400),
@@ -293,7 +293,7 @@ describe('Buckets wrapper', () => {
           },
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
       const timeRange = {
         from: moment(150),
         to: moment(350),
@@ -313,7 +313,7 @@ describe('Buckets wrapper', () => {
           },
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
       const timeRange = {
         from: moment(100),
         to: moment(350),
@@ -333,7 +333,7 @@ describe('Buckets wrapper', () => {
           },
         },
         aggConfigs: {},
-      } as IAggConfig;
+      } as unknown as IAggConfig;
       const timeRange = {
         from: moment(100),
         to: moment(350),

--- a/src/platform/plugins/shared/data/common/search/tabify/tabify.test.ts
+++ b/src/platform/plugins/shared/data/common/search/tabify/tabify.test.ts
@@ -133,7 +133,7 @@ describe('tabifyAggResponse Integration', () => {
           { type: 'count', params: { scaleMetricValues: true } } as any,
         ]);
 
-        const writeMock = jest.fn(() => ({}));
+        const writeMock = jest.fn(() => ({ params: {} }));
         aggConfigs.getRequestAggs()[0].write = writeMock;
 
         tabifyAggResponse(aggConfigs, enrichResponseWithSampling(metricOnly), {

--- a/src/platform/plugins/shared/data/common/serialize_utils.ts
+++ b/src/platform/plugins/shared/data/common/serialize_utils.ts
@@ -39,7 +39,7 @@ export const SerializableType = {
 };
 
 export function deserializeField(field: SerializedValue) {
-  const type = field != null && (field as any)?.type;
+  const type = field != null && (field as Record<string, unknown>)?.type;
 
   switch (type) {
     case SerializableType.MultiFieldKey:

--- a/src/platform/plugins/shared/data/public/query/persisted_log/persisted_log.ts
+++ b/src/platform/plugins/shared/data/public/query/persisted_log/persisted_log.ts
@@ -12,7 +12,7 @@ import type { Observable } from 'rxjs';
 import { BehaviorSubject, defer, finalize, map } from 'rxjs';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 
-const defaultIsDuplicate = (oldItem: any, newItem: any) => {
+const defaultIsDuplicate = (oldItem: unknown, newItem: unknown) => {
   return isEqual(oldItem, newItem);
 };
 
@@ -82,7 +82,7 @@ export class PersistedLog<T = any> {
     }
   }
 
-  public add(val: any) {
+  public add(val: T) {
     if (val == null) {
       return this.items;
     }


### PR DESCRIPTION
Replace TypeScript `any` with stricter types across the data plugin's public API surface: expression functions, type guards, PersistedLog, search source types, and agg param types. Introduce AggParamOutput interface and AggTypeOrdered for better type specificity. Internal implementation `any` usages are preserved where removal would cause excessive cascading changes across 50+ files.

Closes #99519

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



