### PR TITLE
[9.2] [Synthetics] Sync global parameters task - exclude monitors that do not use modified global params (#248996)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/add_param.ts
@@ -57,6 +57,8 @@ export const addSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
         savedObjectsData
       );
 
+      const modifiedParamKeys = savedObjectsData.map((obj) => obj.attributes.key);
+
       await asyncGlobalParamsPropagation({
         server,
         paramsSpacesToSync: Array.from(
@@ -67,6 +69,7 @@ export const addSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
             )
           )
         ),
+        modifiedParamKeys,
       });
 
       if (savedObjectsData.length > 1) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -75,7 +75,7 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       };
 
       // value from data since we aren't using encrypted client
-      const { value } = existingParam.attributes;
+      const { value, key: existingKey } = existingParam.attributes;
       const {
         id: responseId,
         attributes: { key, tags, description },
@@ -86,9 +86,13 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
         newParam
       )) as SavedObject<SyntheticsParams>;
 
+      // Include both old and new key if the key was renamed
+      const modifiedParamKeys = existingKey !== key ? [existingKey, key] : [key];
+
       await asyncGlobalParamsPropagation({
         server,
         paramsSpacesToSync: existingParam.namespaces || [spaceId],
+        modifiedParamKeys,
       });
 
       return { id: responseId, key, tags, description, namespaces, value };

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -12,6 +12,14 @@ import type { ConfigKey, MonitorFields } from '../../../common/runtime_types';
 import type { ParsedVars } from './lightweight_param_formatter';
 import { replaceVarsWithParams } from './lightweight_param_formatter';
 import variableParser from './variable_parser';
+import { hasNoParams } from './param_utils';
+
+export {
+  hasNoParams,
+  extractParamReferences,
+  valueContainsParams,
+  monitorUsesGlobalParams,
+} from './param_utils';
 
 export type FormatterFn = (
   fields: Partial<MonitorFields>,
@@ -68,12 +76,6 @@ const allParamsAreMissing = (parsedVars: ParsedVars, params: Record<string, stri
     .filter((parsedVar) => parsedVar.type === 'var')
     .map((v) => (typeof v.content === 'string' ? v.content : v.content.name));
   return varKeys.every((v) => !params[v]);
-};
-
-const SHELL_PARAMS_REGEX = /\$\{[a-zA-Z_][a-zA-Z0-9\._\-?:]*\}/g;
-
-export const hasNoParams = (strVal: string) => {
-  return strVal.match(SHELL_PARAMS_REGEX) === null;
 };
 
 export const secondsToCronFormatter: FormatterFn = (fields, key) => {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/param_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/param_utils.test.ts
@@ -1,0 +1,338 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  extractParamReferences,
+  monitorUsesGlobalParams,
+  valueContainsParams,
+} from './param_utils';
+import { ConfigKey } from '../../../common/constants/monitor_management';
+import type { SyntheticsMonitor } from '../../../common/runtime_types';
+import {
+  CodeEditorMode,
+  MonitorTypeEnum,
+  ScheduleUnit,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+
+describe('extractParamReferences', () => {
+  it('extracts single param reference', () => {
+    expect(extractParamReferences('${apiKey}')).toEqual(['apiKey']);
+  });
+
+  it('extracts multiple param references', () => {
+    const result = extractParamReferences('${baseUrl}/api/${version}');
+    expect(result).toEqual(['baseUrl', 'version']);
+  });
+
+  it('returns empty array when no params', () => {
+    expect(extractParamReferences('no params here')).toEqual([]);
+  });
+
+  it('handles params with default values', () => {
+    expect(extractParamReferences('${apiKey:defaultKey}')).toEqual(['apiKey']);
+  });
+
+  it('handles params with optional syntax', () => {
+    expect(extractParamReferences('${apiKey?}')).toEqual(['apiKey']);
+  });
+
+  it('returns unique param names', () => {
+    const result = extractParamReferences('${baseUrl}/api/${baseUrl}/other');
+    expect(result).toEqual(['baseUrl']);
+  });
+
+  it('handles dots in param names', () => {
+    expect(extractParamReferences('${host.name}')).toEqual(['host.name']);
+  });
+
+  it('handles dashes in param names', () => {
+    expect(extractParamReferences('${api-key}')).toEqual(['api-key']);
+  });
+
+  it('handles underscores in param names', () => {
+    expect(extractParamReferences('${api_key}')).toEqual(['api_key']);
+  });
+
+  it('handles complex string with multiple params', () => {
+    const result = extractParamReferences(
+      'https://${user}:${password}@${host}:${port}/path?key=${apiKey}'
+    );
+    expect(result.sort()).toEqual(['apiKey', 'host', 'password', 'port', 'user'].sort());
+  });
+});
+
+describe('valueContainsParams', () => {
+  it('returns true for string with params', () => {
+    expect(valueContainsParams('${apiKey}')).toBe(true);
+  });
+
+  it('returns false for string without params', () => {
+    expect(valueContainsParams('no params')).toBe(false);
+  });
+
+  it('returns true for object with params in values', () => {
+    expect(valueContainsParams({ url: '${baseUrl}/api' })).toBe(true);
+  });
+
+  it('returns false for object without params', () => {
+    expect(valueContainsParams({ url: 'https://example.com' })).toBe(false);
+  });
+
+  it('returns true for array with params', () => {
+    expect(valueContainsParams(['${item1}', 'static'])).toBe(true);
+  });
+
+  it('returns false for array without params', () => {
+    expect(valueContainsParams(['item1', 'item2'])).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(valueContainsParams(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(valueContainsParams(undefined)).toBe(false);
+  });
+
+  it('returns false for boolean', () => {
+    expect(valueContainsParams(true)).toBe(false);
+  });
+
+  it('returns false for number', () => {
+    expect(valueContainsParams(123)).toBe(false);
+  });
+});
+
+describe('monitorUsesGlobalParams', () => {
+  const baseMonitor: Partial<SyntheticsMonitor> = {
+    [ConfigKey.NAME]: 'Test Monitor',
+    [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+    [ConfigKey.ENABLED]: true,
+    [ConfigKey.SCHEDULE]: { unit: ScheduleUnit.MINUTES, number: '5' },
+    [ConfigKey.LOCATIONS]: [],
+    [ConfigKey.NAMESPACE]: 'default',
+  };
+
+  it('returns true when monitor URL contains global params', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: '${baseUrl}/api/health',
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  it('returns true when monitor has params in request headers', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+      [ConfigKey.REQUEST_HEADERS_CHECK]: { Authorization: 'Bearer ${apiToken}' },
+    } as unknown as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  it('returns true when monitor has params in request body', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+      [ConfigKey.REQUEST_BODY_CHECK]: {
+        value: '{"key": "${secretKey}"}',
+        type: CodeEditorMode.JSON,
+      },
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  it('returns true when monitor has params in username', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+      [ConfigKey.USERNAME]: '${username}',
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  it('returns true when monitor has params in password', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+      [ConfigKey.PASSWORD]: '${password}',
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  it('returns true when monitor has params in proxy URL', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+      [ConfigKey.PROXY_URL]: '${proxyHost}:8080',
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  it('returns false when monitor has no global params', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com/api/health',
+      [ConfigKey.REQUEST_HEADERS_CHECK]: { 'Content-Type': 'application/json' },
+    } as unknown as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(false);
+  });
+
+  it('returns false for minimal monitor without params', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(false);
+  });
+
+  it('ignores params in PARAMS_KEYS_TO_SKIP fields', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+      // PARAMS is in PARAMS_KEYS_TO_SKIP, so it should be ignored
+      [ConfigKey.PARAMS]: '{"localParam": "${shouldBeIgnored}"}',
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(false);
+  });
+
+  it('returns true when monitor has params in hosts field (TCP/ICMP)', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.TCP,
+      [ConfigKey.HOSTS]: '${tcpHost}:443',
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  it('returns true when monitor has params in response body check', () => {
+    const monitor = {
+      ...baseMonitor,
+      [ConfigKey.URLS]: 'https://example.com',
+      [ConfigKey.RESPONSE_BODY_CHECK_POSITIVE]: ['${expectedResponse}'],
+    } as SyntheticsMonitor;
+
+    expect(monitorUsesGlobalParams(monitor)).toBe(true);
+  });
+
+  describe('browser monitors', () => {
+    const baseBrowserMonitor: Partial<SyntheticsMonitor> = {
+      [ConfigKey.NAME]: 'Browser Monitor',
+      [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.BROWSER,
+      [ConfigKey.ENABLED]: true,
+      [ConfigKey.SCHEDULE]: { unit: ScheduleUnit.MINUTES, number: '10' },
+      [ConfigKey.LOCATIONS]: [],
+      [ConfigKey.NAMESPACE]: 'default',
+    };
+
+    it('always returns true for browser monitors (params accessed via JavaScript)', () => {
+      const monitor = {
+        ...baseBrowserMonitor,
+        [ConfigKey.SOURCE_INLINE]:
+          'step("test", async () => { await page.goto("https://example.com"); });',
+      } as SyntheticsMonitor;
+
+      // Browser monitors always return true because they access params via params.paramName
+      // in JavaScript, which we cannot reliably detect
+      expect(monitorUsesGlobalParams(monitor)).toBe(true);
+    });
+
+    it('returns true for browser monitor even without explicit param usage', () => {
+      const monitor = {
+        ...baseBrowserMonitor,
+      } as SyntheticsMonitor;
+
+      expect(monitorUsesGlobalParams(monitor)).toBe(true);
+    });
+
+    it('returns true for browser monitor with script using params', () => {
+      const monitor = {
+        ...baseBrowserMonitor,
+        [ConfigKey.SOURCE_INLINE]:
+          'step("test", async () => { await page.goto(params.baseUrl); });',
+      } as SyntheticsMonitor;
+
+      expect(monitorUsesGlobalParams(monitor)).toBe(true);
+    });
+
+    it('returns true for browser monitor even with modifiedParamKeys specified', () => {
+      const monitor = {
+        ...baseBrowserMonitor,
+      } as SyntheticsMonitor;
+
+      // Browser monitors always return true regardless of modifiedParamKeys
+      expect(monitorUsesGlobalParams(monitor, ['someKey'])).toBe(true);
+    });
+  });
+
+  describe('with modifiedParamKeys (granular filtering)', () => {
+    it('returns true when monitor uses one of the modified params', () => {
+      const monitor = {
+        ...baseMonitor,
+        [ConfigKey.URLS]: '${baseUrl}/api/health',
+      } as SyntheticsMonitor;
+
+      expect(monitorUsesGlobalParams(monitor, ['baseUrl', 'otherParam'])).toBe(true);
+    });
+
+    it('returns false when monitor does not use any of the modified params', () => {
+      const monitor = {
+        ...baseMonitor,
+        [ConfigKey.URLS]: '${baseUrl}/api/health',
+      } as SyntheticsMonitor;
+
+      expect(monitorUsesGlobalParams(monitor, ['differentParam', 'anotherParam'])).toBe(false);
+    });
+
+    it('returns false when monitor has no params and modifiedParamKeys is specified', () => {
+      const monitor = {
+        ...baseMonitor,
+        [ConfigKey.URLS]: 'https://example.com',
+      } as SyntheticsMonitor;
+
+      expect(monitorUsesGlobalParams(monitor, ['anyParam'])).toBe(false);
+    });
+
+    it('returns true when monitor uses multiple params and one matches', () => {
+      const monitor = {
+        ...baseMonitor,
+        [ConfigKey.URLS]: '${baseUrl}/api',
+        [ConfigKey.USERNAME]: '${username}',
+      } as SyntheticsMonitor;
+
+      expect(monitorUsesGlobalParams(monitor, ['username'])).toBe(true);
+    });
+
+    it('handles empty modifiedParamKeys array (falls back to any params check)', () => {
+      const monitor = {
+        ...baseMonitor,
+        [ConfigKey.URLS]: '${baseUrl}/api',
+      } as SyntheticsMonitor;
+
+      // Empty array should behave like no modifiedParamKeys specified
+      expect(monitorUsesGlobalParams(monitor, [])).toBe(true);
+    });
+
+    it('handles undefined modifiedParamKeys (falls back to any params check)', () => {
+      const monitor = {
+        ...baseMonitor,
+        [ConfigKey.URLS]: '${baseUrl}/api',
+      } as SyntheticsMonitor;
+
+      expect(monitorUsesGlobalParams(monitor, undefined)).toBe(true);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/param_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/param_utils.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  type ConfigKey,
+  type SyntheticsMonitor,
+  MonitorTypeEnum,
+} from '../../../common/runtime_types';
+import { PARAMS_KEYS_TO_SKIP } from './common';
+
+export const SHELL_PARAMS_REGEX = /\$\{[a-zA-Z_][a-zA-Z0-9\._\-?:]*\}/g;
+
+export const hasNoParams = (strVal: string) => {
+  return strVal.match(SHELL_PARAMS_REGEX) === null;
+};
+
+/**
+ * Extracts all parameter names referenced in a string using ${paramName} syntax.
+ * Handles optional default values (${paramName:default}) and nested syntax.
+ *
+ * @param strVal - The string to extract parameter references from
+ * @returns Array of unique parameter names found in the string
+ */
+export const extractParamReferences = (strVal: string): string[] => {
+  const matches = strVal.match(SHELL_PARAMS_REGEX);
+  if (!matches) {
+    return [];
+  }
+
+  const paramNames = new Set<string>();
+  for (const match of matches) {
+    // Remove ${ and } and extract just the param name (before any : for defaults)
+    const content = match.slice(2, -1);
+    // Handle ${paramName:default} syntax - extract just the param name
+    const paramName = content.split(':')[0].split('?')[0];
+    if (paramName) {
+      paramNames.add(paramName);
+    }
+  }
+
+  return Array.from(paramNames);
+};
+
+/**
+ * Checks if a value (string, object, or array) contains any global parameter references.
+ *
+ * @param value - The value to check for parameter references
+ * @returns true if the value contains at least one parameter reference
+ */
+export const valueContainsParams = (value: unknown): boolean => {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return !hasNoParams(value);
+  }
+
+  if (typeof value === 'object') {
+    const strValue = JSON.stringify(value);
+    return !hasNoParams(strValue);
+  }
+
+  return false;
+};
+
+/**
+ * Checks if a monitor configuration uses global parameters.
+ *
+ * For lightweight monitors (HTTP, TCP, ICMP): checks for ${paramName} syntax in fields.
+ * For browser monitors: always returns true since they access params via JavaScript
+ * (params.paramName) which we cannot reliably detect by scanning the script content.
+ *
+ * @param monitor - The monitor configuration to check
+ * @param modifiedParamKeys - Optional array of specific param keys to check for.
+ *                            If provided, only checks if the monitor uses any of these specific params.
+ *                            If not provided, checks if the monitor uses any global params.
+ * @returns true if the monitor uses at least one global parameter reference
+ */
+export const monitorUsesGlobalParams = (
+  monitor: SyntheticsMonitor,
+  modifiedParamKeys?: string[]
+): boolean => {
+  if (monitor.type === MonitorTypeEnum.BROWSER) {
+    return true;
+  }
+
+  const modifiedSet =
+    modifiedParamKeys && modifiedParamKeys.length > 0 ? new Set(modifiedParamKeys) : undefined;
+  const keysToCheck = Object.keys(monitor) as Array<keyof SyntheticsMonitor>;
+
+  for (const key of keysToCheck) {
+    if (PARAMS_KEYS_TO_SKIP.includes(key as ConfigKey)) {
+      continue;
+    }
+
+    const value = monitor[key];
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    const strValue = typeof value === 'string' ? value : JSON.stringify(value);
+    const params = extractParamReferences(strValue);
+
+    if (params.length === 0) {
+      continue;
+    }
+
+    if (!modifiedSet) {
+      return true;
+    }
+
+    if (params.some((p) => modifiedSet.has(p))) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
@@ -10,7 +10,7 @@
 import { omit, uniqBy } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { isValidNamespace } from '@kbn/fleet-plugin/common';
-import { hasNoParams } from '../../formatters/formatting_utils';
+import { hasNoParams } from '../../formatters/param_utils';
 import { formatLocation } from '../../../../common/utils/location_formatter';
 import type {
   BrowserFields,

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
@@ -23,6 +23,7 @@ const TASK_TYPE = 'Synthetics:Sync-Global-Params-Private-Locations';
 
 interface TaskState extends Record<string, unknown> {
   paramsSpaceToSync: string;
+  modifiedParamKeys?: string[];
 }
 
 export type CustomTaskInstance = Omit<ConcreteTaskInstance, 'state'> & {
@@ -73,6 +74,7 @@ export class SyncGlobalParamsPrivateLocationsTask {
     } = this.serverSetup;
 
     const paramsSpaceToSync = taskInstance.state.paramsSpaceToSync;
+    const modifiedParamKeys = taskInstance.state.modifiedParamKeys;
     if (paramsSpaceToSync) {
       try {
         this.debugLog(`current task state is ${JSON.stringify(taskInstance.state)}`);
@@ -85,6 +87,7 @@ export class SyncGlobalParamsPrivateLocationsTask {
             soClient,
             encryptedSavedObjects,
             spaceIdToSync: paramsSpaceToSync,
+            modifiedParamKeys,
           });
           this.debugLog(`Sync of global params succeeded for space  ${paramsSpaceToSync}`);
         }
@@ -94,6 +97,7 @@ export class SyncGlobalParamsPrivateLocationsTask {
           error,
           state: {
             paramsSpaceToSync,
+            modifiedParamKeys,
           },
         };
       }
@@ -108,9 +112,11 @@ export class SyncGlobalParamsPrivateLocationsTask {
 export const asyncGlobalParamsPropagation = async ({
   server,
   paramsSpacesToSync,
+  modifiedParamKeys,
 }: {
   server: SyntheticsServerSetup;
   paramsSpacesToSync: string[];
+  modifiedParamKeys?: string[];
 }) => {
   const {
     pluginsStart: { taskManager },
@@ -126,7 +132,7 @@ export const asyncGlobalParamsPropagation = async ({
         params: {},
         taskType: TASK_TYPE,
         runAt: new Date(Date.now() + 3 * 1000),
-        state: { paramsSpaceToSync: spaceId },
+        state: { paramsSpaceToSync: spaceId, modifiedParamKeys },
       });
     })
   );

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
@@ -31,6 +31,7 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./inspect_monitor'));
     loadTestFile(require.resolve('./suggestions.ts'));
     loadTestFile(require.resolve('./sync_global_params'));
+    loadTestFile(require.resolve('./sync_global_params_for_filtered_monitors'));
     loadTestFile(require.resolve('./synthetics_enablement'));
     loadTestFile(require.resolve('./test_now_monitor'));
     loadTestFile(require.resolve('./edit_private_location'));

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sync_global_params_for_filtered_monitors.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sync_global_params_for_filtered_monitors.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RoleCredentials } from '@kbn/ftr-common-functional-services';
+import type { HTTPFields, PrivateLocation } from '@kbn/synthetics-plugin/common/runtime_types';
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import expect from '@kbn/expect';
+import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
+import { syntheticsParamType } from '@kbn/synthetics-plugin/common/types/saved_objects';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import { getFixtureJson } from './helpers/get_fixture_json';
+import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  describe('SyncGlobalParamsForFilteredMonitors', function () {
+    this.tags('skipCloud');
+
+    const supertest = getService('supertestWithoutAuth');
+    const kibanaServer = getService('kibanaServer');
+    const samlAuth = getService('samlAuth');
+    const retry = getService('retry');
+
+    const testPrivateLocations = new PrivateLocationTestService(getService);
+    const monitorTestService = new SyntheticsMonitorTestService(getService);
+
+    let editorUser: RoleCredentials;
+    let privateLocation: PrivateLocation;
+    let testFleetPolicyID: string;
+    let _httpMonitorJson: HTTPFields;
+
+    let paramAId: string;
+
+    const MONITOR_WITH_PARAM_A = 'test-monitor-with-paramA';
+    const MONITOR_WITH_PARAM_B = 'test-monitor-with-paramB';
+    const MONITOR_WITH_BOTH_PARAMS = 'test-monitor-with-both-params';
+    const MONITOR_WITHOUT_PARAMS = 'test-monitor-without-params';
+
+    const findPolicyByMonitorName = (
+      policies: PackagePolicy[],
+      monitorName: string
+    ): PackagePolicy | undefined => {
+      return policies.find((p) => p.name.startsWith(monitorName));
+    };
+
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+      await testPrivateLocations.installSyntheticsPackage();
+      editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
+      await kibanaServer.savedObjects.clean({ types: [syntheticsParamType] });
+
+      _httpMonitorJson = getFixtureJson('http_monitor');
+
+      const testPolicyName = 'Fleet test server policy' + Date.now();
+      const fleetResponse = await testPrivateLocations.addFleetPolicy(testPolicyName);
+      testFleetPolicyID = fleetResponse.body.item.id;
+
+      const locations = await testPrivateLocations.setTestLocations([testFleetPolicyID]);
+      privateLocation = locations[0];
+    });
+
+    after(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+      await kibanaServer.savedObjects.clean({ types: [syntheticsParamType] });
+    });
+
+    it('creates global params paramA and paramB', async () => {
+      const paramAResponse = await supertest
+        .post(SYNTHETICS_API_URLS.PARAMS)
+        .set(editorUser.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send({ key: 'paramA', value: 'valueA' })
+        .expect(200);
+
+      paramAId = paramAResponse.body.id;
+
+      await supertest
+        .post(SYNTHETICS_API_URLS.PARAMS)
+        .set(editorUser.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send({ key: 'paramB', value: 'valueB' })
+        .expect(200);
+    });
+
+    it('creates four HTTP monitors with different param references on a private location', async () => {
+      const pvtLoc = {
+        id: testFleetPolicyID,
+        agentPolicyId: testFleetPolicyID,
+        label: privateLocation.label,
+        isServiceManaged: false,
+        geo: { lat: 0, lon: 0 },
+      };
+
+      await monitorTestService.createMonitor(
+        {
+          ..._httpMonitorJson,
+          name: MONITOR_WITH_PARAM_A,
+          urls: 'https://example.com/${paramA}/health',
+          locations: [pvtLoc],
+        },
+        editorUser
+      );
+
+      await monitorTestService.createMonitor(
+        {
+          ..._httpMonitorJson,
+          name: MONITOR_WITH_PARAM_B,
+          urls: 'https://example.com/${paramB}/health',
+          locations: [pvtLoc],
+        },
+        editorUser
+      );
+
+      await monitorTestService.createMonitor(
+        {
+          ..._httpMonitorJson,
+          name: MONITOR_WITH_BOTH_PARAMS,
+          urls: 'https://example.com/${paramA}/${paramB}',
+          locations: [pvtLoc],
+        },
+        editorUser
+      );
+
+      await monitorTestService.createMonitor(
+        {
+          ..._httpMonitorJson,
+          name: MONITOR_WITHOUT_PARAMS,
+          urls: 'https://example.com/static/health',
+          locations: [pvtLoc],
+        },
+        editorUser
+      );
+
+      await retry.tryForTime(30 * 1000, async () => {
+        const policies = await testPrivateLocations.getPackagePolicies();
+        expect(policies.length).to.eql(4);
+      });
+    });
+
+    it('only updates package policies for monitors that reference the modified param', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+
+      const policiesBefore = await testPrivateLocations.getPackagePolicies();
+      expect(policiesBefore.length).to.eql(4);
+
+      const revisionsBefore: Record<string, number> = {};
+      for (const p of policiesBefore) {
+        revisionsBefore[p.name] = p.revision;
+      }
+
+      expect(findPolicyByMonitorName(policiesBefore, MONITOR_WITH_PARAM_A)).to.be.ok();
+      expect(findPolicyByMonitorName(policiesBefore, MONITOR_WITH_PARAM_B)).to.be.ok();
+      expect(findPolicyByMonitorName(policiesBefore, MONITOR_WITH_BOTH_PARAMS)).to.be.ok();
+      expect(findPolicyByMonitorName(policiesBefore, MONITOR_WITHOUT_PARAMS)).to.be.ok();
+
+      await supertest
+        .put(SYNTHETICS_API_URLS.PARAMS + '/' + paramAId)
+        .set(editorUser.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send({ key: 'paramA', value: 'updatedValueA' })
+        .expect(200);
+
+      await retry.tryForTime(60 * 1000, async () => {
+        const policiesAfter = await testPrivateLocations.getPackagePolicies();
+
+        const policyParamA = findPolicyByMonitorName(policiesAfter, MONITOR_WITH_PARAM_A)!;
+        const policyBoth = findPolicyByMonitorName(policiesAfter, MONITOR_WITH_BOTH_PARAMS)!;
+
+        expect(policyParamA.revision).to.be.greaterThan(revisionsBefore[policyParamA.name]);
+        expect(policyBoth.revision).to.be.greaterThan(revisionsBefore[policyBoth.name]);
+      });
+
+      const policiesFinal = await testPrivateLocations.getPackagePolicies();
+
+      const policyParamB = findPolicyByMonitorName(policiesFinal, MONITOR_WITH_PARAM_B)!;
+      const policyNoParams = findPolicyByMonitorName(policiesFinal, MONITOR_WITHOUT_PARAMS)!;
+
+      expect(policyParamB.revision).to.eql(revisionsBefore[policyParamB.name]);
+      expect(policyNoParams.revision).to.eql(revisionsBefore[policyNoParams.name]);
+    });
+
+    it('confirms the updated param value is resolved in the affected package policy', async () => {
+      const policies = await testPrivateLocations.getPackagePolicies();
+      const policyParamA = findPolicyByMonitorName(policies, MONITOR_WITH_PARAM_A)!;
+
+      const httpInput = policyParamA.inputs.find((i) => i.type === 'synthetics/http');
+      const httpStream = httpInput?.streams?.[0];
+      const compiledStream = httpStream?.compiled_stream as Record<string, unknown> | undefined;
+
+      expect(compiledStream).to.be.ok();
+      expect(compiledStream!.urls).to.eql('https://example.com/updatedValueA/health');
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Synthetics] Sync global parameters task - exclude monitors that do not use modified global params (#248996)](https://github.com/elastic/kibana/pull/248996)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bena Kansara","email":"69037875+benakansara@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-10T18:14:16Z","message":"[Synthetics] Sync global parameters task - exclude monitors that do not use modified global params (#248996)\n\nResolves https://github.com/elastic/kibana/issues/241434\n\n- Adds filtering logic to exclude monitors that don't use modified\nglobal parameters during global params sync\n\n## Testing\n\n- Go to Synthetics → Settings → Global Parameters\n- Add param: testUrl = https://www.elastic.co/\n- Create 2 monitors on Private Location\n  - Monitor A: URL = ${testUrl}/health\n  - Monitor B: URL = https://www.elastic.co/\n- Update the global parameter\n  - Edit testUrl value\n- Verify in logs\n- Should see: Filtered out 1 monitors that do not use global parameters\n\n### Enable debug logs\n\n```\nlogging.loggers:\n - name: plugins.synthetics\n   level: debug\n   appenders: [console]\n```","sha":"25edf54dbffdbd381ac11d4a8934eb0408c5c185","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:actionable-obs","v9.4.0","author:actionable-obs","Team:obs-ux-management"],"title":"[Synthetics] Sync global parameters task - exclude monitors that do not use modified global params","number":248996,"url":"https://github.com/elastic/kibana/pull/248996","mergeCommit":{"message":"[Synthetics] Sync global parameters task - exclude monitors that do not use modified global params (#248996)\n\nResolves https://github.com/elastic/kibana/issues/241434\n\n- Adds filtering logic to exclude monitors that don't use modified\nglobal parameters during global params sync\n\n## Testing\n\n- Go to Synthetics → Settings → Global Parameters\n- Add param: testUrl = https://www.elastic.co/\n- Create 2 monitors on Private Location\n  - Monitor A: URL = ${testUrl}/health\n  - Monitor B: URL = https://www.elastic.co/\n- Update the global parameter\n  - Edit testUrl value\n- Verify in logs\n- Should see: Filtered out 1 monitors that do not use global parameters\n\n### Enable debug logs\n\n```\nlogging.loggers:\n - name: plugins.synthetics\n   level: debug\n   appenders: [console]\n```","sha":"25edf54dbffdbd381ac11d4a8934eb0408c5c185"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248996","number":248996,"mergeCommit":{"message":"[Synthetics] Sync global parameters task - exclude monitors that do not use modified global params (#248996)\n\nResolves https://github.com/elastic/kibana/issues/241434\n\n- Adds filtering logic to exclude monitors that don't use modified\nglobal parameters during global params sync\n\n## Testing\n\n- Go to Synthetics → Settings → Global Parameters\n- Add param: testUrl = https://www.elastic.co/\n- Create 2 monitors on Private Location\n  - Monitor A: URL = ${testUrl}/health\n  - Monitor B: URL = https://www.elastic.co/\n- Update the global parameter\n  - Edit testUrl value\n- Verify in logs\n- Should see: Filtered out 1 monitors that do not use global parameters\n\n### Enable debug logs\n\n```\nlogging.loggers:\n - name: plugins.synthetics\n   level: debug\n   appenders: [console]\n```","sha":"25edf54dbffdbd381ac11d4a8934eb0408c5c185"}},{"url":"https://github.com/elastic/kibana/pull/252595","number":252595,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->