### PR TITLE
[8.19] Change cookie config for intermediate session (#249100)

### DIFF
--- a/src/core/packages/http/server-internal/src/cookie_session_storage.test.ts
+++ b/src/core/packages/http/server-internal/src/cookie_session_storage.test.ts
@@ -1,0 +1,508 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Request } from '@hapi/hapi';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { mockRouter } from '@kbn/core-http-router-server-mocks';
+import type { SessionStorageCookieOptions } from '@kbn/core-http-server';
+import { ensureRawRequest } from '@kbn/core-http-router-server-internal';
+import { createCookieSessionStorageFactory } from './cookie_session_storage';
+
+describe('createCookieSessionStorageFactory', () => {
+  let mockServer: {
+    register: jest.Mock;
+    auth: {
+      strategy: jest.Mock;
+      test: jest.Mock;
+    };
+  };
+  let mockLogger: ReturnType<typeof loggingSystemMock.create>;
+
+  const defaultCookieOptions: SessionStorageCookieOptions<any> = {
+    name: 'test-cookie',
+    encryptionKey: 'a'.repeat(32),
+    validate: jest.fn(() => ({ isValid: true })),
+    isSecure: false,
+  };
+
+  beforeEach(() => {
+    mockServer = {
+      register: jest.fn(),
+      auth: {
+        strategy: jest.fn(),
+        test: jest.fn(),
+      },
+    } as any;
+
+    mockLogger = loggingSystemMock.create();
+  });
+
+  describe('factory creation', () => {
+    it('should register hapi cookie plugin', async () => {
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        defaultCookieOptions,
+        false
+      );
+
+      expect(mockServer.register).toHaveBeenCalledTimes(1);
+      expect(mockServer.register).toHaveBeenCalledWith({ plugin: expect.any(Object) });
+    });
+
+    it('should configure auth strategy with correct options', async () => {
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        defaultCookieOptions,
+        false
+      );
+
+      expect(mockServer.auth.strategy).toHaveBeenCalledTimes(1);
+      expect(mockServer.auth.strategy).toHaveBeenCalledWith(
+        'security-cookie',
+        'cookie',
+        expect.objectContaining({
+          cookie: expect.objectContaining({
+            name: 'test-cookie',
+            password: 'a'.repeat(32),
+            isSecure: false,
+            path: '/',
+            clearInvalid: false,
+            isHttpOnly: true,
+            isSameSite: false,
+            isPartitioned: false,
+          }),
+          validate: expect.any(Function),
+        })
+      );
+    });
+
+    it('should configure auth strategy with custom basePath', async () => {
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        defaultCookieOptions,
+        false,
+        '/custom-base'
+      );
+
+      expect(mockServer.auth.strategy).toHaveBeenCalledWith(
+        'security-cookie',
+        'cookie',
+        expect.objectContaining({
+          cookie: expect.objectContaining({
+            path: '/custom-base',
+          }),
+        })
+      );
+    });
+
+    it('should configure auth strategy with sameSite option', async () => {
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        {
+          ...defaultCookieOptions,
+          sameSite: 'Strict',
+        },
+        false
+      );
+
+      expect(mockServer.auth.strategy).toHaveBeenCalledWith(
+        'security-cookie',
+        'cookie',
+        expect.objectContaining({
+          cookie: expect.objectContaining({
+            isSameSite: 'Strict',
+          }),
+        })
+      );
+    });
+
+    it('should enable partitioned cookies when sameSite=None, secure, and embedding enabled', async () => {
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        {
+          ...defaultCookieOptions,
+          sameSite: 'None',
+          isSecure: true,
+        },
+        false // disableEmbedding = false means embedding is enabled
+      );
+
+      expect(mockServer.auth.strategy).toHaveBeenCalledWith(
+        'security-cookie',
+        'cookie',
+        expect.objectContaining({
+          cookie: expect.objectContaining({
+            isPartitioned: true,
+          }),
+        })
+      );
+    });
+
+    it('should not enable partitioned cookies when embedding is disabled', async () => {
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        {
+          ...defaultCookieOptions,
+          sameSite: 'None',
+          isSecure: true,
+        },
+        true // disableEmbedding = true
+      );
+
+      expect(mockServer.auth.strategy).toHaveBeenCalledWith(
+        'security-cookie',
+        'cookie',
+        expect.objectContaining({
+          cookie: expect.objectContaining({
+            isPartitioned: false,
+          }),
+        })
+      );
+    });
+
+    it('should throw error when sameSite=None without secure connection', async () => {
+      await expect(
+        createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          {
+            ...defaultCookieOptions,
+            sameSite: 'None',
+            isSecure: false,
+          },
+          false
+        )
+      ).rejects.toThrow('"SameSite: None" requires Secure connection');
+    });
+  });
+
+  describe('validate callback', () => {
+    it('should call user validate function and return result', async () => {
+      const validateFn = jest.fn(() => ({ isValid: true }));
+
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        {
+          ...defaultCookieOptions,
+          validate: validateFn,
+        },
+        false
+      );
+
+      const strategyConfig = mockServer.auth.strategy.mock.calls[0][2] as any;
+      const mockRequest = {} as Request;
+      const session = { value: 'test' };
+
+      const result = await strategyConfig.validate(mockRequest, session);
+
+      expect(validateFn).toHaveBeenCalledWith(session);
+      expect(result).toEqual({ isValid: true });
+    });
+
+    it('should clear invalid cookie when validation fails', async () => {
+      const validateFn = jest.fn(() => ({ isValid: false, path: '/custom' }));
+      const mockRequest = {
+        cookieAuth: {
+          h: {
+            unstate: jest.fn(),
+          },
+        },
+      } as any;
+
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        {
+          ...defaultCookieOptions,
+          validate: validateFn,
+        },
+        false
+      );
+
+      const strategyConfig = mockServer.auth.strategy.mock.calls[0][2] as any;
+      const session = { value: 'test' };
+
+      await strategyConfig.validate(mockRequest, session);
+
+      expect(mockRequest.cookieAuth.h.unstate).toHaveBeenCalledWith('test-cookie', {
+        path: '/custom',
+      });
+      expect(loggingSystemMock.collect(mockLogger).debug).toEqual([
+        ['Clearing invalid session cookie'],
+      ]);
+    });
+
+    it('should use basePath when clearing invalid cookie without path in validation result', async () => {
+      const validateFn = jest.fn(() => ({ isValid: false }));
+      const mockRequest = {
+        cookieAuth: {
+          h: {
+            unstate: jest.fn(),
+          },
+        },
+      } as any;
+
+      await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        {
+          ...defaultCookieOptions,
+          validate: validateFn,
+        },
+        false,
+        '/my-base'
+      );
+
+      const strategyConfig = mockServer.auth.strategy.mock.calls[0][2] as any;
+      const session = { value: 'test' };
+
+      await strategyConfig.validate(mockRequest, session);
+
+      expect(mockRequest.cookieAuth.h.unstate).toHaveBeenCalledWith('test-cookie', {
+        path: '/my-base',
+      });
+    });
+  });
+
+  describe('asScoped', () => {
+    it('should return a scoped session storage', async () => {
+      const factory = await createCookieSessionStorageFactory(
+        mockLogger.get(),
+        mockServer as any,
+        defaultCookieOptions,
+        false
+      );
+
+      const mockRequest = mockRouter.createKibanaRequest();
+      const scopedStorage = factory.asScoped(mockRequest);
+
+      expect(scopedStorage).toHaveProperty('get');
+      expect(scopedStorage).toHaveProperty('set');
+      expect(scopedStorage).toHaveProperty('clear');
+    });
+  });
+
+  describe('ScopedCookieSessionStorage', () => {
+    describe('get()', () => {
+      it('should return session value when auth test succeeds', async () => {
+        const sessionData = { userId: '123' };
+        mockServer.auth.test = jest.fn().mockResolvedValue({
+          credentials: sessionData,
+        });
+
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const session = await factory.asScoped(mockRequest).get();
+
+        expect(session).toEqual(sessionData);
+        expect(mockServer.auth.test).toHaveBeenCalledWith(
+          'security-cookie',
+          ensureRawRequest(mockRequest)
+        );
+      });
+
+      it('should return first session when credentials is array with one element', async () => {
+        const sessionData = { userId: '123' };
+        mockServer.auth.test = jest.fn().mockResolvedValue({
+          credentials: [sessionData],
+        });
+
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const session = await factory.asScoped(mockRequest).get();
+
+        expect(session).toEqual(sessionData);
+      });
+
+      it('should return first session when multiple equal sessions are found', async () => {
+        const sessionData = { userId: '123' };
+        mockServer.auth.test = jest.fn().mockResolvedValue({
+          credentials: [sessionData, sessionData],
+        });
+
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const session = await factory.asScoped(mockRequest).get();
+
+        expect(session).toEqual(sessionData);
+        expect(loggingSystemMock.collect(mockLogger).warn).toEqual([
+          ['Found multiple auth sessions. Found:[2] sessions. Checking equality...'],
+        ]);
+        expect(loggingSystemMock.collect(mockLogger).error).toEqual([
+          ['Found multiple auth sessions. Found:[2] equal sessions'],
+        ]);
+      });
+
+      it('should return null when multiple unequal sessions are found', async () => {
+        const session1 = { userId: '123' };
+        const session2 = { userId: '456' };
+        mockServer.auth.test = jest.fn().mockResolvedValue({
+          credentials: [session1, session2],
+        });
+
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const session = await factory.asScoped(mockRequest).get();
+
+        expect(session).toBeNull();
+        expect(loggingSystemMock.collect(mockLogger).warn).toEqual([
+          ['Found multiple auth sessions. Found:[2] sessions. Checking equality...'],
+        ]);
+        expect(loggingSystemMock.collect(mockLogger).error).toEqual([
+          ['Found multiple auth sessions. Found:[2] unequal sessions'],
+        ]);
+      });
+
+      it('should return null when auth test throws error', async () => {
+        mockServer.auth.test = jest.fn().mockRejectedValue(new Error('Auth failed'));
+
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const session = await factory.asScoped(mockRequest).get();
+
+        expect(session).toBeNull();
+        expect(loggingSystemMock.collect(mockLogger).debug).toEqual([['Error: Auth failed']]);
+      });
+    });
+
+    describe('set()', () => {
+      it('should set session using default cookie auth', async () => {
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const rawRequest = ensureRawRequest(mockRequest);
+        const mockSet = jest.fn();
+        (rawRequest as any).cookieAuth = { set: mockSet };
+
+        const sessionData = { userId: '123' };
+        factory.asScoped(mockRequest).set(sessionData);
+
+        expect(mockSet).toHaveBeenCalledWith(sessionData);
+      });
+
+      it('should set session with custom cookie options', async () => {
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const rawRequest = ensureRawRequest(mockRequest);
+        const mockState = jest.fn();
+        (rawRequest as any).cookieAuth = {
+          h: { state: mockState },
+          set: jest.fn(),
+        };
+
+        const sessionData = { userId: '123' };
+        const options = { isSecure: true, sameSite: 'Strict' as const };
+        factory.asScoped(mockRequest).set(sessionData, options);
+
+        expect(mockState).toHaveBeenCalledWith('test-cookie', sessionData, {
+          isSecure: true,
+          isSameSite: 'Strict',
+        });
+      });
+
+      it('should use default cookie options when only partial options provided', async () => {
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          {
+            ...defaultCookieOptions,
+            isSecure: true,
+            sameSite: 'Lax',
+          },
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const rawRequest = ensureRawRequest(mockRequest);
+        const mockState = jest.fn();
+        (rawRequest as any).cookieAuth = {
+          h: { state: mockState },
+          set: jest.fn(),
+        };
+
+        const sessionData = { userId: '123' };
+        const options = { isSecure: false }; // Only override isSecure
+        factory.asScoped(mockRequest).set(sessionData, options);
+
+        expect(mockState).toHaveBeenCalledWith('test-cookie', sessionData, {
+          isSecure: false,
+          isSameSite: 'Lax', // Should use default from cookieOptions
+        });
+      });
+    });
+
+    describe('clear()', () => {
+      it('should clear session using cookie auth', async () => {
+        const factory = await createCookieSessionStorageFactory(
+          mockLogger.get(),
+          mockServer as any,
+          defaultCookieOptions,
+          false
+        );
+
+        const mockRequest = mockRouter.createKibanaRequest();
+        const rawRequest = ensureRawRequest(mockRequest);
+        const mockClear = jest.fn();
+        (rawRequest as any).cookieAuth = { clear: mockClear };
+
+        factory.asScoped(mockRequest).clear();
+
+        expect(mockClear).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/core/packages/http/server-internal/src/cookie_session_storage.ts
+++ b/src/core/packages/http/server-internal/src/cookie_session_storage.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Request, ResponseToolkit, Server } from '@hapi/hapi';
+import type { Request, ResponseToolkit, Server, ServerStateCookieOptions } from '@hapi/hapi';
 import hapiAuthCookie from '@hapi/cookie';
 
 import type { Logger } from '@kbn/logging';

--- a/src/core/packages/http/server-internal/src/cookie_session_storage.ts
+++ b/src/core/packages/http/server-internal/src/cookie_session_storage.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Request, Server, ServerStateCookieOptions } from '@hapi/hapi';
+import type { Request, ResponseToolkit, Server } from '@hapi/hapi';
 import hapiAuthCookie from '@hapi/cookie';
 
 import type { Logger } from '@kbn/logging';
@@ -16,6 +16,7 @@ import type {
   SessionStorageFactory,
   SessionStorage,
   SessionStorageCookieOptions,
+  SessionStorageSetOptions,
 } from '@kbn/core-http-server';
 
 import { isDeepStrictEqual } from 'util';
@@ -26,8 +27,13 @@ class ScopedCookieSessionStorage<T extends object> implements SessionStorage<T> 
   constructor(
     private readonly log: Logger,
     private readonly server: Server,
-    private readonly request: Request
+    private readonly request: Request,
+    private readonly cookieOptions: SessionStorageCookieOptions<T>
   ) {}
+
+  private getResponseToolkit(): ResponseToolkit {
+    return (this.request.cookieAuth as unknown as { h: ResponseToolkit }).h;
+  }
 
   public async get(): Promise<T | null> {
     try {
@@ -74,8 +80,21 @@ class ScopedCookieSessionStorage<T extends object> implements SessionStorage<T> 
     }
   }
 
-  public set(sessionValue: T) {
-    return this.request.cookieAuth.set(sessionValue);
+  public set(sessionValue: T, options?: SessionStorageSetOptions) {
+    if (!options) {
+      // Use default cookie auth
+      return this.request.cookieAuth.set(sessionValue);
+    }
+
+    // Use custom cookie options
+    const h = this.getResponseToolkit();
+    const isSecure = options?.isSecure ?? this.cookieOptions.isSecure;
+    const sameSite = options?.sameSite ?? this.cookieOptions.sameSite;
+
+    h.state(this.cookieOptions.name, sessionValue, {
+      isSecure,
+      isSameSite: sameSite,
+    });
   }
 
   public clear() {
@@ -93,8 +112,11 @@ function validateOptions(options: SessionStorageCookieOptions<any>) {
  * Creates SessionStorage factory, which abstract the way of
  * session storage implementation and scoping to the incoming requests.
  *
+ * @param log - logger instance
  * @param server - hapi server to create SessionStorage for
  * @param cookieOptions - cookies configuration
+ * @param disableEmbedding - whether embedding is disabled
+ * @param basePath - optional base path for the Kibana server
  */
 export async function createCookieSessionStorageFactory<T extends object>(
   log: Logger,
@@ -154,7 +176,12 @@ export async function createCookieSessionStorageFactory<T extends object>(
 
   return {
     asScoped(request: KibanaRequest) {
-      return new ScopedCookieSessionStorage<T>(log, server, ensureRawRequest(request));
+      return new ScopedCookieSessionStorage<T>(
+        log,
+        server,
+        ensureRawRequest(request),
+        cookieOptions
+      );
     },
   };
 }

--- a/src/core/packages/http/server/index.ts
+++ b/src/core/packages/http/server/index.ts
@@ -151,6 +151,7 @@ export type {
   SessionStorageFactory,
   SessionCookieValidationResult,
   SessionStorageCookieOptions,
+  SessionStorageSetOptions,
 } from './src/session_storage';
 
 export type { GetAuthState, IsAuthenticated } from './src/auth_state';

--- a/src/core/packages/http/server/src/session_storage.ts
+++ b/src/core/packages/http/server/src/session_storage.ts
@@ -10,6 +10,21 @@
 import type { KibanaRequest } from './router';
 
 /**
+ * Optional overrides for cookie attributes when setting or clearing session cookies.
+ * @public
+ */
+export interface SessionStorageSetOptions {
+  /**
+   * Optional override for the isSecure cookie attribute.
+   */
+  isSecure?: boolean;
+  /**
+   * Optional override for the sameSite cookie attribute.
+   */
+  sameSite?: 'Strict' | 'Lax' | 'None';
+}
+
+/**
  * Provides an interface to store and retrieve data across requests.
  * @public
  */
@@ -22,8 +37,9 @@ export interface SessionStorage<T> {
   /**
    * Puts current session value into the session storage.
    * @param sessionValue - value to put
+   * @param options - optional overrides for cookie attributes
    */
-  set(sessionValue: T): void;
+  set(sessionValue: T, options?: SessionStorageSetOptions): void;
 
   /**
    * Clears current session.

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -224,6 +224,7 @@ export type {
   IStaticAssets,
   SessionStorage,
   SessionStorageCookieOptions,
+  SessionStorageSetOptions,
   SessionCookieValidationResult,
   SessionStorageFactory,
   GetAuthState,

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_result.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_result.test.ts
@@ -221,6 +221,7 @@ describe('AuthenticationResult', () => {
       expect(authenticationResult.redirectURL).toBe(redirectURL);
       expect(authenticationResult.user).toBeUndefined();
       expect(authenticationResult.state).toBeUndefined();
+      expect(authenticationResult.stateCookieOptions).toBeUndefined();
       expect(authenticationResult.authHeaders).toBeUndefined();
       expect(authenticationResult.authResponseHeaders).toBeUndefined();
       expect(authenticationResult.userProfileGrant).toBeUndefined();
@@ -239,6 +240,7 @@ describe('AuthenticationResult', () => {
 
       expect(authenticationResult.redirectURL).toBe(redirectURL);
       expect(authenticationResult.state).toBe(state);
+      expect(authenticationResult.stateCookieOptions).toBeUndefined();
       expect(authenticationResult.authHeaders).toBeUndefined();
       expect(authenticationResult.authResponseHeaders).toBeUndefined();
       expect(authenticationResult.userProfileGrant).toBeUndefined();
@@ -259,6 +261,7 @@ describe('AuthenticationResult', () => {
 
       expect(authenticationResult.redirectURL).toBe(redirectURL);
       expect(authenticationResult.state).toBe(state);
+      expect(authenticationResult.stateCookieOptions).toBeUndefined();
       expect(authenticationResult.authHeaders).toBeUndefined();
       expect(authenticationResult.authResponseHeaders).toBeUndefined();
       expect(authenticationResult.userProfileGrant).toBeUndefined();
@@ -290,10 +293,35 @@ describe('AuthenticationResult', () => {
 
       expect(authenticationResult.redirectURL).toBe(redirectURL);
       expect(authenticationResult.state).toBe(state);
+      expect(authenticationResult.stateCookieOptions).toBeUndefined();
       expect(authenticationResult.authHeaders).toBeUndefined();
       expect(authenticationResult.authResponseHeaders).toBe(authResponseHeaders);
       expect(authenticationResult.user).toBe(user);
       expect(authenticationResult.userProfileGrant).toBe(userProfileGrant);
+      expect(authenticationResult.error).toBeUndefined();
+    });
+
+    it('correctly produces `redirected` authentication result with stateCookieOptions.', () => {
+      const redirectURL = '/redirect/url';
+      const state = { some: 'state' };
+      const stateCookieOptions = { isSecure: true, sameSite: 'Lax' as 'Lax' };
+      const authenticationResult = AuthenticationResult.redirectTo(redirectURL, {
+        state,
+        stateCookieOptions,
+      });
+
+      expect(authenticationResult.redirected()).toBe(true);
+      expect(authenticationResult.succeeded()).toBe(false);
+      expect(authenticationResult.failed()).toBe(false);
+      expect(authenticationResult.notHandled()).toBe(false);
+
+      expect(authenticationResult.redirectURL).toBe(redirectURL);
+      expect(authenticationResult.state).toBe(state);
+      expect(authenticationResult.stateCookieOptions).toBe(stateCookieOptions);
+      expect(authenticationResult.authHeaders).toBeUndefined();
+      expect(authenticationResult.authResponseHeaders).toBeUndefined();
+      expect(authenticationResult.userProfileGrant).toBeUndefined();
+      expect(authenticationResult.user).toBeUndefined();
       expect(authenticationResult.error).toBeUndefined();
     });
   });

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_result.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_result.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { AuthHeaders } from '@kbn/core/server';
+import type { AuthHeaders, SessionStorageSetOptions } from '@kbn/core/server';
 
 import type { AuthenticatedUser } from '../../common';
 import type { UserProfileGrant } from '../user_profile';
@@ -47,6 +47,7 @@ interface AuthenticationOptions {
   challenges?: string[];
   redirectURL?: string;
   state?: unknown;
+  stateCookieOptions?: SessionStorageSetOptions;
   user?: AuthenticatedUser;
   authHeaders?: AuthHeaders;
   authResponseHeaders?: AuthHeaders;
@@ -62,6 +63,7 @@ export interface SucceededAuthenticationResultOptions {
 
 export interface RedirectedAuthenticationResultOptions {
   state?: unknown;
+  stateCookieOptions?: SessionStorageSetOptions;
   user?: AuthenticatedUser;
   authResponseHeaders?: AuthHeaders;
   userProfileGrant?: UserProfileGrant;
@@ -143,6 +145,7 @@ export class AuthenticationResult {
    * @param [authResponseHeaders] Optional dictionary of the HTTP headers with authentication
    * information that should be specified in the response we send to the client request.
    * @param [state] Optional state to be stored and reused for the next request.
+   * @param [stateCookieOptions] Optional overrides for cookie attributes when setting state cookie.
    */
   public static redirectTo(
     redirectURL: string,
@@ -151,6 +154,7 @@ export class AuthenticationResult {
       userProfileGrant,
       authResponseHeaders,
       state,
+      stateCookieOptions,
     }: RedirectedAuthenticationResultOptions = {}
   ) {
     if (!redirectURL) {
@@ -163,6 +167,7 @@ export class AuthenticationResult {
       userProfileGrant,
       authResponseHeaders,
       state,
+      stateCookieOptions,
     });
   }
 
@@ -206,6 +211,13 @@ export class AuthenticationResult {
    */
   public get state() {
     return this.options.state;
+  }
+
+  /**
+   * Optional overrides for cookie attributes when setting state cookie (only available for `redirected` result).
+   */
+  public get stateCookieOptions() {
+    return this.options.stateCookieOptions;
   }
 
   /**

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
@@ -529,11 +529,16 @@ describe('Authenticator', () => {
       ).resolves.toEqual(AuthenticationResult.succeeded(user, { state: { authorization } }));
 
       expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
-      expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-        username: user.username,
-        provider: mockSessVal.provider,
-        state: { authorization },
-      });
+      expect(mockOptions.session.create).toHaveBeenCalledWith(
+        request,
+        {
+          username: user.username,
+          userProfileId: undefined,
+          provider: mockSessVal.provider,
+          state: { authorization },
+        },
+        undefined
+      );
       expectAuditEvents({ action: 'user_login', outcome: 'success' });
       expect(mockOptions.userProfileService.activate).not.toHaveBeenCalled();
     });
@@ -559,12 +564,16 @@ describe('Authenticator', () => {
       );
 
       expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
-      expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-        username: user.username,
-        userProfileId: 'some-profile-uid',
-        provider: mockSessVal.provider,
-        state: { authorization },
-      });
+      expect(mockOptions.session.create).toHaveBeenCalledWith(
+        request,
+        {
+          username: user.username,
+          userProfileId: 'some-profile-uid',
+          provider: mockSessVal.provider,
+          state: { authorization },
+        },
+        undefined
+      );
       expectAuditEvents({ action: 'user_login', outcome: 'success' });
       expect(mockOptions.userProfileService.activate).toHaveBeenCalledTimes(1);
       expect(mockOptions.userProfileService.activate).toHaveBeenCalledWith(userProfileGrant);
@@ -591,12 +600,16 @@ describe('Authenticator', () => {
       );
 
       expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
-      expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-        userProfileId: 'some-profile-uid',
-        username: user.username,
-        provider: mockSessVal.provider,
-        state: { authorization },
-      });
+      expect(mockOptions.session.create).toHaveBeenCalledWith(
+        request,
+        {
+          userProfileId: 'some-profile-uid',
+          username: user.username,
+          provider: mockSessVal.provider,
+          state: { authorization },
+        },
+        undefined
+      );
       expectAuditEvents({ action: 'user_login', outcome: 'success' });
       expect(mockOptions.userProfileService.activate).toHaveBeenCalledTimes(1);
       expect(mockOptions.userProfileService.activate).toHaveBeenCalledWith(userProfileGrant);
@@ -671,11 +684,16 @@ describe('Authenticator', () => {
         );
 
         expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
-        expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-          username: user.username,
-          provider: { type: 'saml', name: 'saml2' },
-          state: { token: 'access-token' },
-        });
+        expect(mockOptions.session.create).toHaveBeenCalledWith(
+          request,
+          {
+            username: user.username,
+            userProfileId: undefined,
+            provider: { type: 'saml', name: 'saml2' },
+            state: { token: 'access-token' },
+          },
+          undefined
+        );
 
         expect(mockBasicAuthenticationProvider.login).not.toHaveBeenCalled();
         expect(mockSAMLAuthenticationProvider1.login).not.toHaveBeenCalled();
@@ -719,16 +737,26 @@ describe('Authenticator', () => {
         }
 
         expect(mockOptions.session.create).toHaveBeenCalledTimes(2);
-        expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-          username: user.username,
-          provider: { type: 'saml', name: 'saml1' },
-          state: { result: '200' },
-        });
-        expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-          username: undefined,
-          provider: { type: 'saml', name: 'saml1' },
-          state: { result: '302' },
-        });
+        expect(mockOptions.session.create).toHaveBeenCalledWith(
+          request,
+          {
+            username: user.username,
+            userProfileId: undefined,
+            provider: { type: 'saml', name: 'saml1' },
+            state: { result: '200' },
+          },
+          undefined
+        );
+        expect(mockOptions.session.create).toHaveBeenCalledWith(
+          request,
+          {
+            username: undefined,
+            userProfileId: undefined,
+            provider: { type: 'saml', name: 'saml1' },
+            state: { result: '302' },
+          },
+          undefined
+        );
 
         expect(mockBasicAuthenticationProvider.login).not.toHaveBeenCalled();
         expect(mockSAMLAuthenticationProvider2.login).not.toHaveBeenCalled();
@@ -737,6 +765,42 @@ describe('Authenticator', () => {
           { action: 'user_login', outcome: 'failure' },
           { action: 'user_login', outcome: 'success' }
         );
+      });
+
+      it('passes stateCookieOptions to session.create when provider returns custom cookie options', async () => {
+        const request = httpServerMock.createKibanaRequest();
+        const customCookieOptions = { sameSite: 'None' as const, isSecure: true };
+
+        mockSAMLAuthenticationProvider1.login.mockResolvedValue(
+          AuthenticationResult.redirectTo('/some/url', {
+            state: { result: '302' },
+            stateCookieOptions: customCookieOptions,
+          })
+        );
+
+        await expect(
+          authenticator.login(request, { provider: { type: 'saml' }, value: {} })
+        ).resolves.toEqual(
+          AuthenticationResult.redirectTo('/some/url', {
+            state: { result: '302' },
+            stateCookieOptions: customCookieOptions,
+          })
+        );
+
+        expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
+        expect(mockOptions.session.create).toHaveBeenCalledWith(
+          request,
+          {
+            username: undefined,
+            userProfileId: undefined,
+            provider: { type: 'saml', name: 'saml1' },
+            state: { result: '302' },
+          },
+          customCookieOptions
+        );
+
+        expect(mockSAMLAuthenticationProvider1.login).toHaveBeenCalledTimes(1);
+        expect(auditLogger.log).not.toHaveBeenCalled();
       });
 
       it('provides session only if provider name matches', async () => {
@@ -1562,11 +1626,15 @@ describe('Authenticator', () => {
       );
 
       expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
-      expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-        username: user.username,
-        provider: mockSessVal.provider,
-        state: { authorization },
-      });
+      expect(mockOptions.session.create).toHaveBeenCalledWith(
+        request,
+        {
+          username: user.username,
+          provider: mockSessVal.provider,
+          state: { authorization },
+        },
+        undefined
+      );
       expectAuditEvents({ action: 'user_login', outcome: 'success' });
       expect(mockOptions.userProfileService.activate).not.toHaveBeenCalled();
     });
@@ -1587,11 +1655,15 @@ describe('Authenticator', () => {
       );
 
       expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
-      expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-        username: user.username,
-        provider: mockSessVal.provider,
-        state: { authorization },
-      });
+      expect(mockOptions.session.create).toHaveBeenCalledWith(
+        request,
+        {
+          username: user.username,
+          provider: mockSessVal.provider,
+          state: { authorization },
+        },
+        undefined
+      );
       expectAuditEvents({ action: 'user_login', outcome: 'success' });
       expect(mockOptions.userProfileService.activate).not.toHaveBeenCalled();
     });
@@ -1617,12 +1689,16 @@ describe('Authenticator', () => {
       );
 
       expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
-      expect(mockOptions.session.create).toHaveBeenCalledWith(request, {
-        username: user.username,
-        userProfileId: 'some-profile-uid',
-        provider: mockSessVal.provider,
-        state: { authorization },
-      });
+      expect(mockOptions.session.create).toHaveBeenCalledWith(
+        request,
+        {
+          username: user.username,
+          userProfileId: 'some-profile-uid',
+          provider: mockSessVal.provider,
+          state: { authorization },
+        },
+        undefined
+      );
       expectAuditEvents({ action: 'user_login', outcome: 'success' });
       expect(mockOptions.userProfileService.activate).toHaveBeenCalledTimes(1);
       expect(mockOptions.userProfileService.activate).toHaveBeenCalledWith(userProfileGrant);

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
@@ -854,8 +854,6 @@ export class Authenticator {
 
     let newSessionValue: Readonly<SessionValue> | null;
     if (!existingSessionValue) {
-      const startTime = performance.now();
-
       newSessionValue = await this.session.create(
         request,
         {

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
@@ -854,12 +854,18 @@ export class Authenticator {
 
     let newSessionValue: Readonly<SessionValue> | null;
     if (!existingSessionValue) {
-      newSessionValue = await this.session.create(request, {
-        username: authenticationResult.user?.username,
-        userProfileId,
-        provider,
-        state: authenticationResult.shouldUpdateState() ? authenticationResult.state : null,
-      });
+      const startTime = performance.now();
+
+      newSessionValue = await this.session.create(
+        request,
+        {
+          username: authenticationResult.user?.username,
+          userProfileId,
+          provider,
+          state: authenticationResult.shouldUpdateState() ? authenticationResult.state : null,
+        },
+        authenticationResult.stateCookieOptions
+      );
 
       // Log successful `user_login` event if a new authenticated session was created or an existing session was overwritten and
       // the username or authentication provider changed. When username or authentication provider changes the session

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.test.ts
@@ -441,6 +441,7 @@ describe('SAMLAuthenticationProvider', () => {
                 requestIdMap: requestIdMapResult,
                 realm: 'test-realm',
               },
+              stateCookieOptions: { sameSite: 'None', isSecure: true },
             }
           )
         );
@@ -944,6 +945,7 @@ describe('SAMLAuthenticationProvider', () => {
                 },
                 realm: 'test-realm',
               },
+              stateCookieOptions: { sameSite: 'None', isSecure: true },
             }
           )
         );
@@ -987,6 +989,7 @@ describe('SAMLAuthenticationProvider', () => {
                 },
                 realm: 'test-realm',
               },
+              stateCookieOptions: { sameSite: 'None', isSecure: true },
             }
           )
         );
@@ -1036,6 +1039,7 @@ describe('SAMLAuthenticationProvider', () => {
                 },
                 realm: 'test-realm',
               },
+              stateCookieOptions: { sameSite: 'None', isSecure: true },
             }
           )
         );
@@ -1161,6 +1165,7 @@ describe('SAMLAuthenticationProvider', () => {
                 },
               },
             },
+            stateCookieOptions: { sameSite: 'None', isSecure: true },
           }
         )
       );

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
@@ -675,6 +675,7 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider {
           requestIdMap: this.updateRequestIdMap(requestId, redirectURL, state?.requestIdMap),
           realm,
         },
+        stateCookieOptions: { sameSite: 'None', isSecure: true },
       });
     } catch (err) {
       this.logger.debug(() => `Failed to initiate SAML handshake: ${getDetailedErrorMessage(err)}`);

--- a/x-pack/platform/plugins/shared/security/server/session_management/session_cookie.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/session_management/session_cookie.test.ts
@@ -133,10 +133,31 @@ describe('Session cookie', () => {
 
       expect(mockSessionStorageFactory.asScoped).toHaveBeenCalledWith(request);
       expect(mockSessionStorage.set).toHaveBeenCalledTimes(1);
-      expect(mockSessionStorage.set).toHaveBeenCalledWith({
-        ...sessionValue,
-        path: '/mock-base-path',
-      });
+      expect(mockSessionStorage.set).toHaveBeenCalledWith(
+        {
+          ...sessionValue,
+          path: '/mock-base-path',
+        },
+        undefined
+      );
+    });
+
+    it('properly sets value with both isSecure and sameSite options', async () => {
+      const sessionValue = sessionCookieMock.createValue();
+      const options = { isSecure: false, sameSite: 'None' as 'None' };
+
+      const request = httpServerMock.createKibanaRequest();
+      await sessionCookie.set(request, sessionValue, options);
+
+      expect(mockSessionStorageFactory.asScoped).toHaveBeenCalledWith(request);
+      expect(mockSessionStorage.set).toHaveBeenCalledTimes(1);
+      expect(mockSessionStorage.set).toHaveBeenCalledWith(
+        {
+          ...sessionValue,
+          path: '/mock-base-path',
+        },
+        options
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/security/server/session_management/session_cookie.ts
+++ b/x-pack/platform/plugins/shared/security/server/session_management/session_cookie.ts
@@ -10,6 +10,7 @@ import type {
   KibanaRequest,
   Logger,
   SessionStorageFactory,
+  SessionStorageSetOptions,
 } from '@kbn/core/server';
 
 import type { ConfigType } from '../config';
@@ -125,11 +126,16 @@ export class SessionCookie {
    * Sets session value for the specified request.
    * @param request Request instance to set session value for.
    * @param sessionValue Session value parameters.
+   * @param options Optional overrides for cookie attributes (isSecure, sameSite).
    */
-  async set(request: KibanaRequest, sessionValue: Readonly<Omit<SessionCookieValue, 'path'>>) {
+  async set(
+    request: KibanaRequest,
+    sessionValue: Readonly<Omit<SessionCookieValue, 'path'>>,
+    options?: SessionStorageSetOptions
+  ) {
     (await this.cookieSessionValueStorage)
       .asScoped(request)
-      .set({ ...sessionValue, path: this.serverBasePath });
+      .set({ ...sessionValue, path: this.serverBasePath }, options);
   }
 
   /**

--- a/x-pack/platform/test/security_api_integration/tests/saml/saml_login.ts
+++ b/x-pack/platform/test/security_api_integration/tests/saml/saml_login.ts
@@ -31,6 +31,7 @@ export default function ({ getService }: FtrProviderContext) {
   const retry = getService('retry');
 
   const kibanaServerConfig = config.get('servers.kibana');
+  const isSSlEnabled = !!kibanaServerConfig.certificateAuthorities || false;
 
   function createSAMLResponse(options = {}) {
     return getSAMLResponse({
@@ -45,6 +46,16 @@ export default function ({ getService }: FtrProviderContext) {
       destination: `${kibanaServerConfig.protocol}://localhost:${kibanaServerConfig.port}/logout`,
       ...options,
     });
+  }
+
+  function checkStandardSessionCookiePropsDefault(sessionCookie: Cookie) {
+    expect(sessionCookie.sameSite).to.be(undefined);
+    expect(sessionCookie.secure).to.be(isSSlEnabled);
+  }
+
+  function checkIntermediateSessionCookiePropsDefault(sessionCookie: Cookie) {
+    expect(sessionCookie.sameSite).to.be('none');
+    expect(sessionCookie.secure).to.be(true);
   }
 
   async function checkSessionCookie(sessionCookie: Cookie, username = 'a@b.c') {
@@ -141,6 +152,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(handshakeCookie.value).to.not.be.empty();
         expect(handshakeCookie.path).to.be('/');
         expect(handshakeCookie.httpOnly).to.be(true);
+        checkIntermediateSessionCookiePropsDefault(handshakeCookie);
 
         const redirectURL = url.parse(
           handshakeResponse.headers.location,
@@ -215,7 +227,10 @@ export default function ({ getService }: FtrProviderContext) {
         const cookies = samlAuthenticationResponse.headers['set-cookie'];
         expect(cookies).to.have.length(1);
 
-        await checkSessionCookie(parseCookie(cookies[0])!);
+        const authenticatedCookie = parseCookie(cookies[0])!;
+
+        await checkSessionCookie(authenticatedCookie);
+        checkStandardSessionCookiePropsDefault(authenticatedCookie);
       });
 
       it('should succeed in case of IdP initiated login', async () => {
@@ -231,7 +246,10 @@ export default function ({ getService }: FtrProviderContext) {
         const cookies = samlAuthenticationResponse.headers['set-cookie'];
         expect(cookies).to.have.length(1);
 
-        await checkSessionCookie(parseCookie(cookies[0])!);
+        const authenticatedCookie = parseCookie(cookies[0])!;
+
+        await checkSessionCookie(authenticatedCookie);
+        checkStandardSessionCookiePropsDefault(authenticatedCookie);
       });
 
       it('should fail if SAML response is not valid', async () => {
@@ -273,6 +291,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(sessionCookieOne.value).to.not.be.empty();
         expect(sessionCookieOne.value).to.not.equal(sessionCookie.value);
+        checkStandardSessionCookiePropsDefault(sessionCookieOne);
 
         const apiResponseTwo = await supertest
           .get('/internal/security/me')
@@ -285,6 +304,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(sessionCookieTwo.value).to.not.be.empty();
         expect(sessionCookieTwo.value).to.not.equal(sessionCookieOne.value);
+        checkStandardSessionCookiePropsDefault(sessionCookieTwo);
       });
 
       it('should not extend cookie for system API calls', async () => {
@@ -354,6 +374,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(logoutCookie.path).to.be('/');
         expect(logoutCookie.httpOnly).to.be(true);
         expect(logoutCookie.maxAge).to.be(0);
+        checkStandardSessionCookiePropsDefault(logoutCookie);
 
         const redirectURL = url.parse(logoutResponse.headers.location, true /* parseQueryString */);
         expect(redirectURL.href!.startsWith(`https://elastic.co/slo/saml`)).to.be(true);
@@ -405,6 +426,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(logoutCookie.path).to.be('/');
         expect(logoutCookie.httpOnly).to.be(true);
         expect(logoutCookie.maxAge).to.be(0);
+        checkStandardSessionCookiePropsDefault(logoutCookie);
 
         const redirectURL = url.parse(logoutResponse.headers.location, true /* parseQueryString */);
         expect(redirectURL.href!.startsWith(`https://elastic.co/slo/saml`)).to.be(true);
@@ -497,6 +519,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         const firstNewCookie = parseCookie(firstResponseCookies[0])!;
         expectNewSessionCookie(firstNewCookie);
+        checkStandardSessionCookiePropsDefault(firstNewCookie);
 
         // Request with old cookie should reuse the same refresh token if within 60 seconds.
         // Returned cookie will contain the same new access and refresh token pairs as the first request
@@ -511,6 +534,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         const secondNewCookie = parseCookie(secondResponseCookies[0])!;
         expectNewSessionCookie(secondNewCookie);
+        checkStandardSessionCookiePropsDefault(secondNewCookie);
 
         expect(firstNewCookie.value).not.to.eql(secondNewCookie.value);
 
@@ -569,6 +593,7 @@ export default function ({ getService }: FtrProviderContext) {
             const newSessionCookie = parseCookie(newSessionCookies[0])!;
             expectNewSessionCookie(newSessionCookie);
             await checkSessionCookie(newSessionCookie);
+            checkStandardSessionCookiePropsDefault(newSessionCookie);
 
             // The second new cookie with fresh pair of access and refresh tokens should work.
             await supertest
@@ -647,6 +672,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(handshakeCookie.path).to.be('/');
         expect(handshakeCookie.httpOnly).to.be(true);
         expect(handshakeCookie.maxAge).to.be(0);
+        checkStandardSessionCookiePropsDefault(handshakeCookie);
 
         expect(handshakeResponse.headers.location).to.be(
           '/internal/security/capture-url?next=%2Fabc%2Fxyz%2Fhandshake%3Fone%3Dtwo%2Bthree%26auth_provider_hint%3Dsaml'
@@ -668,6 +694,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(handshakeCookie.value).to.not.be.empty();
         expect(handshakeCookie.path).to.be('/');
         expect(handshakeCookie.httpOnly).to.be(true);
+        checkIntermediateSessionCookiePropsDefault(handshakeCookie);
 
         const redirectURL = url.parse(
           handshakeResponse.headers.location,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Change cookie config for intermediate session (#249100)](https://github.com/elastic/kibana/pull/249100)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-03T20:49:24Z","message":"Change cookie config for intermediate session (#249100)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/240293\n\nAs stated in the issue, there is a protection in modern browsers where a\ncookie set not explicitly set with `SameSite=None` will not be sent,\nthis poses a problem for users who wait to long to complete their login\nduring the SAML flow.\n\nThe PR changes the options on the intermediate session's cookie to be\nexplicitly `SameSite=None; Secure;` for SAML logins.\n\n## Details\n\n### HAR Screenshots\n\nFrom Main:\n\nLogin:\n<img width=\"594\" height=\"789\" alt=\"Screenshot 2026-01-21 at 3 30 20 PM\"\nsrc=\"https://github.com/user-attachments/assets/bf8f9c41-78f5-4d99-a511-92deba75e434\"\n/>\n\n...wait at Keycloak login for a few mins...\n\n<img width=\"601\" height=\"675\" alt=\"Screenshot 2026-01-21 at 3 33 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/91c904f2-8e94-4d97-9aa2-3cb7da535fa6\"\n/>\n\n... callback fails since we waited too long....click login again, since\nKeycloak has a success session, it works (just to prove it wasn't a bad\nauthc attempt, but the issue we are trying to solve\n\n<img width=\"877\" height=\"742\" alt=\"Screenshot 2026-01-21 at 3 34 54 PM\"\nsrc=\"https://github.com/user-attachments/assets/10b4d152-d518-447f-a973-e92b6f5729c6\"\n/>\n\n\n\nFrom this branch:\n\nLogin:\n<img width=\"578\" height=\"752\" alt=\"Screenshot 2026-01-21 at 3 21 46 PM\"\nsrc=\"https://github.com/user-attachments/assets/99217c2d-232e-4d9f-b0cb-97c3a3753155\"\n/>\n\n...wait at Keycloak login for a few mins...\n\nCallback:\n<img width=\"579\" height=\"832\" alt=\"Screenshot 2026-01-21 at 3 26 01 PM\"\nsrc=\"https://github.com/user-attachments/assets/901b2bbd-be08-4221-b373-33bb1388f250\"\n/>\n\n## Testing\n\nThis will be interesting. I had to use my tunnel and keycloak to have a\n\"different site\" with a login screen I could wait at.\n\nWhoever ends up reviewing this, sync with me and we can get a setup for\nyou to experiment with","sha":"e691f0438c48a88535f53d4a3769a622a6b8dfc5","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport missing","backport:all-open","ci:project-deploy-observability","v9.4.0"],"title":"Change cookie config for intermediate session","number":249100,"url":"https://github.com/elastic/kibana/pull/249100","mergeCommit":{"message":"Change cookie config for intermediate session (#249100)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/240293\n\nAs stated in the issue, there is a protection in modern browsers where a\ncookie set not explicitly set with `SameSite=None` will not be sent,\nthis poses a problem for users who wait to long to complete their login\nduring the SAML flow.\n\nThe PR changes the options on the intermediate session's cookie to be\nexplicitly `SameSite=None; Secure;` for SAML logins.\n\n## Details\n\n### HAR Screenshots\n\nFrom Main:\n\nLogin:\n<img width=\"594\" height=\"789\" alt=\"Screenshot 2026-01-21 at 3 30 20 PM\"\nsrc=\"https://github.com/user-attachments/assets/bf8f9c41-78f5-4d99-a511-92deba75e434\"\n/>\n\n...wait at Keycloak login for a few mins...\n\n<img width=\"601\" height=\"675\" alt=\"Screenshot 2026-01-21 at 3 33 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/91c904f2-8e94-4d97-9aa2-3cb7da535fa6\"\n/>\n\n... callback fails since we waited too long....click login again, since\nKeycloak has a success session, it works (just to prove it wasn't a bad\nauthc attempt, but the issue we are trying to solve\n\n<img width=\"877\" height=\"742\" alt=\"Screenshot 2026-01-21 at 3 34 54 PM\"\nsrc=\"https://github.com/user-attachments/assets/10b4d152-d518-447f-a973-e92b6f5729c6\"\n/>\n\n\n\nFrom this branch:\n\nLogin:\n<img width=\"578\" height=\"752\" alt=\"Screenshot 2026-01-21 at 3 21 46 PM\"\nsrc=\"https://github.com/user-attachments/assets/99217c2d-232e-4d9f-b0cb-97c3a3753155\"\n/>\n\n...wait at Keycloak login for a few mins...\n\nCallback:\n<img width=\"579\" height=\"832\" alt=\"Screenshot 2026-01-21 at 3 26 01 PM\"\nsrc=\"https://github.com/user-attachments/assets/901b2bbd-be08-4221-b373-33bb1388f250\"\n/>\n\n## Testing\n\nThis will be interesting. I had to use my tunnel and keycloak to have a\n\"different site\" with a login screen I could wait at.\n\nWhoever ends up reviewing this, sync with me and we can get a setup for\nyou to experiment with","sha":"e691f0438c48a88535f53d4a3769a622a6b8dfc5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249100","number":249100,"mergeCommit":{"message":"Change cookie config for intermediate session (#249100)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/240293\n\nAs stated in the issue, there is a protection in modern browsers where a\ncookie set not explicitly set with `SameSite=None` will not be sent,\nthis poses a problem for users who wait to long to complete their login\nduring the SAML flow.\n\nThe PR changes the options on the intermediate session's cookie to be\nexplicitly `SameSite=None; Secure;` for SAML logins.\n\n## Details\n\n### HAR Screenshots\n\nFrom Main:\n\nLogin:\n<img width=\"594\" height=\"789\" alt=\"Screenshot 2026-01-21 at 3 30 20 PM\"\nsrc=\"https://github.com/user-attachments/assets/bf8f9c41-78f5-4d99-a511-92deba75e434\"\n/>\n\n...wait at Keycloak login for a few mins...\n\n<img width=\"601\" height=\"675\" alt=\"Screenshot 2026-01-21 at 3 33 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/91c904f2-8e94-4d97-9aa2-3cb7da535fa6\"\n/>\n\n... callback fails since we waited too long....click login again, since\nKeycloak has a success session, it works (just to prove it wasn't a bad\nauthc attempt, but the issue we are trying to solve\n\n<img width=\"877\" height=\"742\" alt=\"Screenshot 2026-01-21 at 3 34 54 PM\"\nsrc=\"https://github.com/user-attachments/assets/10b4d152-d518-447f-a973-e92b6f5729c6\"\n/>\n\n\n\nFrom this branch:\n\nLogin:\n<img width=\"578\" height=\"752\" alt=\"Screenshot 2026-01-21 at 3 21 46 PM\"\nsrc=\"https://github.com/user-attachments/assets/99217c2d-232e-4d9f-b0cb-97c3a3753155\"\n/>\n\n...wait at Keycloak login for a few mins...\n\nCallback:\n<img width=\"579\" height=\"832\" alt=\"Screenshot 2026-01-21 at 3 26 01 PM\"\nsrc=\"https://github.com/user-attachments/assets/901b2bbd-be08-4221-b373-33bb1388f250\"\n/>\n\n## Testing\n\nThis will be interesting. I had to use my tunnel and keycloak to have a\n\"different site\" with a login screen I could wait at.\n\nWhoever ends up reviewing this, sync with me and we can get a setup for\nyou to experiment with","sha":"e691f0438c48a88535f53d4a3769a622a6b8dfc5"}},{"url":"https://github.com/elastic/kibana/pull/251557","number":251557,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->