### PR TITLE
Remove obsolete eslint-disable for scout_require_api_client_in_api_test

### DIFF
--- a/x-pack/platform/plugins/shared/security/test/scout/api/tests/builtin_roles_kibana_access.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout/api/tests/builtin_roles_kibana_access.spec.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @kbn/eslint/scout_require_api_client_in_api_test */
-
 import type {
   SecurityGetRoleResponse,
   SecurityGetRoleRole,


### PR DESCRIPTION
Fix jest failure on main caused by the now-unnecessary disable comment after the ESLint rule was loosened in 24d327be1100 (#252212).

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->