### PR TITLE
Fix streams status API test to allow extra keys

### DIFF
--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/basic.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/basic.ts
@@ -117,11 +117,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
               method: 'GET',
               path: '/_streams/status',
             });
-            expect(response).to.eql({
-              logs: {
-                enabled: true,
-              },
-            });
+            // Elasticsearch may return additional status keys (e.g. `logs.ecs`, `logs.otel`).
+            expect(response).to.have.property('logs');
+            expect(response.logs).to.have.property('enabled', true);
           });
         }
 

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/basic.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/basic.ts
@@ -113,7 +113,11 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           });
 
           it('Elasticsearch streams is enabled too', async () => {
-            const response = await esClient.transport.request({
+            type StreamsStatusResponse = {
+              logs: { enabled: boolean } & Record<string, unknown>;
+            } & Record<string, unknown>;
+
+            const response = await esClient.transport.request<StreamsStatusResponse>({
               method: 'GET',
               path: '/_streams/status',
             });


### PR DESCRIPTION
## 🍒 Summary

Closes https://github.com/elastic/kibana/issues/252197

Fix a Streams API integration test that started failing after Elasticsearch began returning additional keys from `GET /_streams/status`.

## 🛠️ Changes

- Update the `/_streams/status` assertion to only require `logs.enabled: true`, allowing additional keys like `logs.ecs` / `logs.otel`.
- Type the `esClient.transport.request` response via `transport.request<StreamsStatusResponse>(...)` so asserting on `response.logs.enabled` compiles (avoids TS18046).

## ✅ Test plan

- `yarn test:type_check --project x-pack/platform/test/tsconfig.json`