### PR TITLE
[8.19] Loosen `apiClient` ESLint rule on Security (#252212)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2362,10 +2362,8 @@ module.exports = {
         '@kbn/eslint/scout_no_describe_configure': 'error',
         '@kbn/eslint/scout_max_one_describe': 'error',
         '@kbn/eslint/scout_test_file_naming': 'error',
-        '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
-        '@kbn/eslint/scout_require_global_setup_hook_in_parallel_tests': 'error',
         '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
-        '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
+        '@kbn/eslint/scout_expect_import': 'error',
         '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },
@@ -2381,14 +2379,6 @@ module.exports = {
           'error',
           { alternativeFixtures: ['esClient'] },
         ],
-      },
-    },
-    {
-      // Ensure correct expect import path in solutions scout API tests
-      files: ['x-pack/solutions/**/plugins/**/test/scout/api/**/*.ts'],
-      rules: {
-        '@kbn/eslint/scout_expect_import': 'error',
-        '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2350,8 +2350,9 @@ module.exports = {
         ],
       },
     },
+    // Custom rules for scout tests
     {
-      // Custom rules for scout tests
+      // Platform & Solutions
       files: [
         'src/platform/plugins/**/test/{scout,scout_*}/**/*.ts',
         'x-pack/platform/**/plugins/**/test/{scout,scout_*}/**/*.ts',
@@ -2362,7 +2363,30 @@ module.exports = {
         '@kbn/eslint/scout_max_one_describe': 'error',
         '@kbn/eslint/scout_test_file_naming': 'error',
         '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
+        '@kbn/eslint/scout_require_global_setup_hook_in_parallel_tests': 'error',
         '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
+        '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
+        '@kbn/eslint/require_include_in_check_a11y': 'warn',
+      },
+    },
+    {
+      // Platform & Solutions API Tests
+      files: [
+        'src/platform/plugins/**/test/{scout,scout_*}/api/**/*.ts',
+        'x-pack/platform/**/plugins/**/test/{scout,scout_*}/api/**/*.ts',
+        'x-pack/solutions/**/plugins/**/test/{scout,scout_*}/api/**/*.ts',
+      ],
+      rules: {
+        '@kbn/eslint/scout_require_api_client_in_api_test': [
+          'error',
+          { alternativeFixtures: ['esClient'] },
+        ],
+      },
+    },
+    {
+      // Ensure correct expect import path in solutions scout API tests
+      files: ['x-pack/solutions/**/plugins/**/test/scout/api/**/*.ts'],
+      rules: {
         '@kbn/eslint/scout_expect_import': 'error',
         '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Loosen `apiClient` ESLint rule on Security (#252212)](https://github.com/elastic/kibana/pull/252212)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-11T05:42:20Z","message":"Loosen `apiClient` ESLint rule on Security (#252212)\n\n## Summary\n\nThe Security Solution team has test cases that intentionally use\n`esClient` directly without `apiClient`, so enforcing the\n`scout_require_api_client_in_api_test` rule on their scout tests\nproduces false positives. Instead of excluding Security Solution from\nthe rule entirely, this PR enhances the rule with a configurable\n`alternativeFixtures` schema option so it can accept additional fixtures\nper directory.\n\n## Changes\n\n- Added `alternativeFixtures` schema option to\n`scout_require_api_client_in_api_test`, allowing directories to\nconfigure additional accepted fixtures via `.eslintrc.js`\n- Generalized `functionUsesApiClient` to `functionUsesFixture`,\nparameterizing the fixture name so the same detection logic works for\nany fixture\n- Error messages are dynamic and list only the accepted fixtures for the\ngiven configuration\n- Added a Security Solution override in `.eslintrc.js` with\n`alternativeFixtures: ['esClient']` so their tests accept either\n`apiClient` or `esClient`\n- Added unit tests for the new `alternativeFixtures` option\n\n---------\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>","sha":"24d327be1100929b7c10c39a0a6cb1217355f09a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0"],"title":"Loosen `apiClient` ESLint rule on Security","number":252212,"url":"https://github.com/elastic/kibana/pull/252212","mergeCommit":{"message":"Loosen `apiClient` ESLint rule on Security (#252212)\n\n## Summary\n\nThe Security Solution team has test cases that intentionally use\n`esClient` directly without `apiClient`, so enforcing the\n`scout_require_api_client_in_api_test` rule on their scout tests\nproduces false positives. Instead of excluding Security Solution from\nthe rule entirely, this PR enhances the rule with a configurable\n`alternativeFixtures` schema option so it can accept additional fixtures\nper directory.\n\n## Changes\n\n- Added `alternativeFixtures` schema option to\n`scout_require_api_client_in_api_test`, allowing directories to\nconfigure additional accepted fixtures via `.eslintrc.js`\n- Generalized `functionUsesApiClient` to `functionUsesFixture`,\nparameterizing the fixture name so the same detection logic works for\nany fixture\n- Error messages are dynamic and list only the accepted fixtures for the\ngiven configuration\n- Added a Security Solution override in `.eslintrc.js` with\n`alternativeFixtures: ['esClient']` so their tests accept either\n`apiClient` or `esClient`\n- Added unit tests for the new `alternativeFixtures` option\n\n---------\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>","sha":"24d327be1100929b7c10c39a0a6cb1217355f09a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252212","number":252212,"mergeCommit":{"message":"Loosen `apiClient` ESLint rule on Security (#252212)\n\n## Summary\n\nThe Security Solution team has test cases that intentionally use\n`esClient` directly without `apiClient`, so enforcing the\n`scout_require_api_client_in_api_test` rule on their scout tests\nproduces false positives. Instead of excluding Security Solution from\nthe rule entirely, this PR enhances the rule with a configurable\n`alternativeFixtures` schema option so it can accept additional fixtures\nper directory.\n\n## Changes\n\n- Added `alternativeFixtures` schema option to\n`scout_require_api_client_in_api_test`, allowing directories to\nconfigure additional accepted fixtures via `.eslintrc.js`\n- Generalized `functionUsesApiClient` to `functionUsesFixture`,\nparameterizing the fixture name so the same detection logic works for\nany fixture\n- Error messages are dynamic and list only the accepted fixtures for the\ngiven configuration\n- Added a Security Solution override in `.eslintrc.js` with\n`alternativeFixtures: ['esClient']` so their tests accept either\n`apiClient` or `esClient`\n- Added unit tests for the new `alternativeFixtures` option\n\n---------\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>","sha":"24d327be1100929b7c10c39a0a6cb1217355f09a"}}]}] BACKPORT-->