### PR TITLE
[One Workflow][Bug] Toggling workflow enabled state corrupts YAML conten

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
@@ -1013,272 +1013,6 @@ steps:
     });
   });
 
-  describe('bulkCreateWorkflows', () => {
-    const mockRequest = {
-      auth: {
-        credentials: {
-          username: 'test-user',
-        },
-      },
-    } as any;
-
-    it('should bulk create workflows successfully', async () => {
-      mockEsClient.bulk.mockResolvedValue({
-        errors: false,
-        items: [
-          { index: { _id: 'workflow-1', status: 201 } },
-          { index: { _id: 'workflow-2', status: 201 } },
-        ],
-        took: 10,
-      } as any);
-
-      const workflows = [
-        {
-          yaml: `
-name: workflow one
-triggers:
-  - type: manual
-steps:
-  - type: console
-    name: step-one
-    with:
-      message: "Hello"
-`,
-        },
-        {
-          yaml: `
-name: workflow two
-triggers:
-  - type: manual
-steps:
-  - type: console
-    name: step-two
-    with:
-      message: "World"
-`,
-        },
-      ];
-
-      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
-
-      expect(result.created).toHaveLength(2);
-      expect(result.failed).toHaveLength(0);
-      expect(result.created[0].name).toBe('workflow one');
-      expect(result.created[1].name).toBe('workflow two');
-      expect(mockEsClient.bulk).toHaveBeenCalledWith(
-        expect.objectContaining({
-          refresh: true,
-          require_alias: true,
-        })
-      );
-    });
-
-    it('should handle partial failures in bulk create', async () => {
-      mockEsClient.bulk.mockResolvedValue({
-        errors: true,
-        items: [
-          { index: { _id: 'workflow-1', status: 201 } },
-          {
-            index: {
-              _id: 'workflow-2',
-              status: 400,
-              error: { type: 'mapper_parsing_exception', reason: 'failed to parse' },
-            },
-          },
-        ],
-        took: 10,
-      } as any);
-
-      const workflows = [
-        {
-          yaml: `
-name: good workflow
-triggers:
-  - type: manual
-steps:
-  - type: console
-    name: step-one
-    with:
-      message: "Hello"
-`,
-        },
-        {
-          yaml: `
-name: bad workflow
-triggers:
-  - type: manual
-steps:
-  - type: console
-    name: step-two
-    with:
-      message: "World"
-`,
-        },
-      ];
-
-      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
-
-      expect(result.created).toHaveLength(1);
-      expect(result.failed).toHaveLength(1);
-      expect(result.created[0].name).toBe('good workflow');
-      expect(result.failed[0].index).toBe(1);
-      expect(result.failed[0].error).toContain('failed to parse');
-    });
-
-    it('should handle invalid yaml in bulk create without failing entire batch', async () => {
-      mockEsClient.bulk.mockResolvedValue({
-        errors: false,
-        items: [{ index: { _id: 'workflow-1', status: 201 } }],
-        took: 10,
-      } as any);
-
-      const workflows = [
-        {
-          yaml: `
-name: valid workflow
-triggers:
-  - type: manual
-steps:
-  - type: console
-    name: step-one
-    with:
-      message: "Hello"
-`,
-        },
-      ];
-
-      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
-
-      expect(result.created).toHaveLength(1);
-      expect(result.failed).toHaveLength(0);
-    });
-
-    it('should return empty results when given empty array', async () => {
-      const result = await service.bulkCreateWorkflows([], 'default', mockRequest);
-
-      expect(result.created).toHaveLength(0);
-      expect(result.failed).toHaveLength(0);
-      expect(mockEsClient.bulk).not.toHaveBeenCalled();
-    });
-
-    it('should reject malformed custom IDs and include them in failed', async () => {
-      mockEsClient.bulk.mockResolvedValue({
-        errors: false,
-        items: [{ index: { _id: 'workflow-1', status: 201 } }],
-        took: 10,
-      } as any);
-
-      const workflows = [
-        {
-          yaml: `
-name: valid workflow
-triggers:
-  - type: manual
-steps:
-  - type: console
-    name: step-one
-    with:
-      message: "Hello"
-`,
-        },
-        {
-          yaml: `
-name: bad id workflow
-triggers:
-  - type: manual
-steps:
-  - type: console
-    name: step-two
-    with:
-      message: "World"
-`,
-          id: 'not-a-valid-id',
-        },
-      ];
-
-      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
-
-      expect(result.created).toHaveLength(1);
-      expect(result.created[0].name).toBe('valid workflow');
-      expect(result.failed).toHaveLength(1);
-      expect(result.failed[0].index).toBe(1);
-      expect(result.failed[0].error).toContain('Invalid workflow ID format');
-    });
-
-    it('should schedule triggers for created workflows with scheduled triggers', async () => {
-      const mockTaskScheduler = {
-        scheduleWorkflowTask: jest.fn().mockResolvedValue(undefined),
-      };
-      service.setTaskScheduler(mockTaskScheduler as any);
-
-      mockEsClient.bulk.mockResolvedValue({
-        errors: false,
-        items: [{ index: { _id: 'workflow-1', status: 201 } }],
-        took: 10,
-      } as any);
-
-      const workflows = [
-        {
-          yaml: `
-name: scheduled workflow
-triggers:
-  - type: 'scheduled'
-    with:
-      every: '5m'
-steps:
-  - type: console
-    name: step-one
-    with:
-      message: "Hello"
-`,
-        },
-      ];
-
-      await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
-
-      expect(mockTaskScheduler.scheduleWorkflowTask).toHaveBeenCalled();
-    });
-
-    it('should log warning when trigger scheduling fails without affecting result', async () => {
-      const mockTaskScheduler = {
-        scheduleWorkflowTask: jest.fn().mockRejectedValue(new Error('scheduling failed')),
-      };
-      service.setTaskScheduler(mockTaskScheduler as any);
-
-      mockEsClient.bulk.mockResolvedValue({
-        errors: false,
-        items: [{ index: { _id: 'workflow-1', status: 201 } }],
-        took: 10,
-      } as any);
-
-      const workflows = [
-        {
-          yaml: `
-name: scheduled workflow
-triggers:
-  - type: 'scheduled'
-    with:
-      every: '5m'
-steps:
-  - type: console
-    name: step-one
-    with:
-      message: "Hello"
-`,
-        },
-      ];
-
-      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
-
-      // Workflow should still be in created despite scheduling failure
-      expect(result.created).toHaveLength(1);
-      expect(result.failed).toHaveLength(0);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to schedule trigger')
-      );
-    });
-  });
-
   describe('updateWorkflow', () => {
     it('should update workflow successfully', async () => {
       const mockRequest = {
@@ -1485,6 +1219,76 @@ steps:
           require_alias: true,
         })
       );
+    });
+
+    it('should preserve YAML comments, formatting, and template expressions when toggling enabled', async () => {
+      const mockRequest = {
+        auth: {
+          credentials: { username: 'test-user' },
+        },
+      } as any;
+
+      const yamlWithComments = `# Workflow configuration
+name: Test Workflow
+description: A test workflow
+
+# Whether the workflow is active
+enabled: false
+
+triggers:
+  - type: manual
+
+steps:
+  # Create a Jira ticket
+  - type: console
+    name: first-step
+    with:
+      message: "{{ inputs.comment }}"`;
+
+      const existingDoc = {
+        _id: 'test-workflow-id',
+        _source: {
+          ...mockWorkflowDocument._source,
+          enabled: false,
+          yaml: yamlWithComments,
+          definition: {
+            name: 'Test Workflow',
+            enabled: false,
+            triggers: [{ type: 'manual' }],
+            steps: [
+              {
+                type: 'console',
+                name: 'first-step',
+                with: { message: '{{ inputs.comment }}' },
+              },
+            ],
+          },
+        },
+      };
+
+      mockEsClient.search.mockResolvedValue({ hits: { hits: [existingDoc] } } as any);
+
+      // Toggle enabled without providing yaml (metadata-only update)
+      await service.updateWorkflow('test-workflow-id', { enabled: true }, 'default', mockRequest);
+
+      const indexCall = mockEsClient.index.mock.calls[0][0] as any;
+      const savedYaml = indexCall.document.yaml;
+
+      // enabled should be toggled
+      expect(savedYaml).toContain('enabled: true');
+      expect(savedYaml).not.toContain('enabled: false');
+
+      // Comments should be preserved
+      expect(savedYaml).toContain('# Workflow configuration');
+      expect(savedYaml).toContain('# Whether the workflow is active');
+      expect(savedYaml).toContain('# Create a Jira ticket');
+
+      // Template expressions should not be corrupted
+      expect(savedYaml).toContain('{{ inputs.comment }}');
+      expect(savedYaml).not.toContain('null');
+
+      // Blank lines should be preserved
+      expect((savedYaml.match(/\n\n/g) || []).length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
@@ -1013,6 +1013,272 @@ steps:
     });
   });
 
+  describe('bulkCreateWorkflows', () => {
+    const mockRequest = {
+      auth: {
+        credentials: {
+          username: 'test-user',
+        },
+      },
+    } as any;
+
+    it('should bulk create workflows successfully', async () => {
+      mockEsClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [
+          { index: { _id: 'workflow-1', status: 201 } },
+          { index: { _id: 'workflow-2', status: 201 } },
+        ],
+        took: 10,
+      } as any);
+
+      const workflows = [
+        {
+          yaml: `
+name: workflow one
+triggers:
+  - type: manual
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+        },
+        {
+          yaml: `
+name: workflow two
+triggers:
+  - type: manual
+steps:
+  - type: console
+    name: step-two
+    with:
+      message: "World"
+`,
+        },
+      ];
+
+      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
+
+      expect(result.created).toHaveLength(2);
+      expect(result.failed).toHaveLength(0);
+      expect(result.created[0].name).toBe('workflow one');
+      expect(result.created[1].name).toBe('workflow two');
+      expect(mockEsClient.bulk).toHaveBeenCalledWith(
+        expect.objectContaining({
+          refresh: true,
+          require_alias: true,
+        })
+      );
+    });
+
+    it('should handle partial failures in bulk create', async () => {
+      mockEsClient.bulk.mockResolvedValue({
+        errors: true,
+        items: [
+          { index: { _id: 'workflow-1', status: 201 } },
+          {
+            index: {
+              _id: 'workflow-2',
+              status: 400,
+              error: { type: 'mapper_parsing_exception', reason: 'failed to parse' },
+            },
+          },
+        ],
+        took: 10,
+      } as any);
+
+      const workflows = [
+        {
+          yaml: `
+name: good workflow
+triggers:
+  - type: manual
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+        },
+        {
+          yaml: `
+name: bad workflow
+triggers:
+  - type: manual
+steps:
+  - type: console
+    name: step-two
+    with:
+      message: "World"
+`,
+        },
+      ];
+
+      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
+
+      expect(result.created).toHaveLength(1);
+      expect(result.failed).toHaveLength(1);
+      expect(result.created[0].name).toBe('good workflow');
+      expect(result.failed[0].index).toBe(1);
+      expect(result.failed[0].error).toContain('failed to parse');
+    });
+
+    it('should handle invalid yaml in bulk create without failing entire batch', async () => {
+      mockEsClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ index: { _id: 'workflow-1', status: 201 } }],
+        took: 10,
+      } as any);
+
+      const workflows = [
+        {
+          yaml: `
+name: valid workflow
+triggers:
+  - type: manual
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+        },
+      ];
+
+      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
+
+      expect(result.created).toHaveLength(1);
+      expect(result.failed).toHaveLength(0);
+    });
+
+    it('should return empty results when given empty array', async () => {
+      const result = await service.bulkCreateWorkflows([], 'default', mockRequest);
+
+      expect(result.created).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+      expect(mockEsClient.bulk).not.toHaveBeenCalled();
+    });
+
+    it('should reject malformed custom IDs and include them in failed', async () => {
+      mockEsClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ index: { _id: 'workflow-1', status: 201 } }],
+        took: 10,
+      } as any);
+
+      const workflows = [
+        {
+          yaml: `
+name: valid workflow
+triggers:
+  - type: manual
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+        },
+        {
+          yaml: `
+name: bad id workflow
+triggers:
+  - type: manual
+steps:
+  - type: console
+    name: step-two
+    with:
+      message: "World"
+`,
+          id: 'not-a-valid-id',
+        },
+      ];
+
+      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
+
+      expect(result.created).toHaveLength(1);
+      expect(result.created[0].name).toBe('valid workflow');
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0].index).toBe(1);
+      expect(result.failed[0].error).toContain('Invalid workflow ID format');
+    });
+
+    it('should schedule triggers for created workflows with scheduled triggers', async () => {
+      const mockTaskScheduler = {
+        scheduleWorkflowTask: jest.fn().mockResolvedValue(undefined),
+      };
+      service.setTaskScheduler(mockTaskScheduler as any);
+
+      mockEsClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ index: { _id: 'workflow-1', status: 201 } }],
+        took: 10,
+      } as any);
+
+      const workflows = [
+        {
+          yaml: `
+name: scheduled workflow
+triggers:
+  - type: 'scheduled'
+    with:
+      every: '5m'
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+        },
+      ];
+
+      await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
+
+      expect(mockTaskScheduler.scheduleWorkflowTask).toHaveBeenCalled();
+    });
+
+    it('should log warning when trigger scheduling fails without affecting result', async () => {
+      const mockTaskScheduler = {
+        scheduleWorkflowTask: jest.fn().mockRejectedValue(new Error('scheduling failed')),
+      };
+      service.setTaskScheduler(mockTaskScheduler as any);
+
+      mockEsClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [{ index: { _id: 'workflow-1', status: 201 } }],
+        took: 10,
+      } as any);
+
+      const workflows = [
+        {
+          yaml: `
+name: scheduled workflow
+triggers:
+  - type: 'scheduled'
+    with:
+      every: '5m'
+steps:
+  - type: console
+    name: step-one
+    with:
+      message: "Hello"
+`,
+        },
+      ];
+
+      const result = await service.bulkCreateWorkflows(workflows, 'default', mockRequest);
+
+      // Workflow should still be in created despite scheduling failure
+      expect(result.created).toHaveLength(1);
+      expect(result.failed).toHaveLength(0);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to schedule trigger')
+      );
+    });
+  });
+
   describe('updateWorkflow', () => {
     it('should update workflow successfully', async () => {
       const mockRequest = {

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
@@ -69,11 +69,7 @@ import {
 } from '../../common/lib/errors';
 
 import { validateStepNameUniqueness } from '../../common/lib/validate_step_names';
-import {
-  parseWorkflowYamlToJSON,
-  parseYamlToJSONWithoutValidation,
-  stringifyWorkflowDefinition,
-} from '../../common/lib/yaml';
+import { parseWorkflowYamlToJSON, updateWorkflowYamlFields } from '../../common/lib/yaml';
 import { getWorkflowZodSchema } from '../../common/schema';
 import { getAuthenticatedUser } from '../lib/get_user';
 import { hasScheduledTriggers } from '../lib/schedule_utils';
@@ -531,23 +527,17 @@ export class WorkflowsService {
         }
 
         if (yamlUpdated && existingDocument._source?.yaml) {
-          const originalYamlParse = parseYamlToJSONWithoutValidation(existingDocument._source.yaml);
-          const baseDefinition = originalYamlParse.success
-            ? originalYamlParse.json
-            : existingDocument._source?.definition;
-
-          if (baseDefinition) {
-            const fieldUpdates = {
-              ...(workflow.name !== undefined && { name: workflow.name }),
-              ...(workflow.enabled !== undefined && { enabled: updatedData.enabled }),
-              ...(workflow.description !== undefined && { description: workflow.description }),
-              ...(workflow.tags !== undefined && { tags: workflow.tags }),
-            };
-            updatedData.yaml = stringifyWorkflowDefinition({
-              ...baseDefinition,
-              ...fieldUpdates,
-            });
-          }
+          // Use in-place YAML field updates to preserve formatting, comments,
+          // and template expressions that would be corrupted by a parse-to-JSON then re-stringify cycle.
+          // `enabledValue` is passed separately because the server may override
+          // the requested value (e.g. force `false` when the workflow has no valid
+          // definition). Other fields (name, description, tags) are read directly
+          // from the `workflow` object inside `updateWorkflowYamlFields`.
+          updatedData.yaml = updateWorkflowYamlFields(
+            existingDocument._source.yaml,
+            workflow,
+            updatedData.enabled
+          );
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes a bug where toggling a workflow's `enabled` state (or updating name/description/tags) would corrupt the stored YAML. The server was performing a full YAML → JSON → YAML roundtrip just to update metadata fields, which:

- Dropped all YAML comments and blank lines
- Corrupted template expressions like `{{ inputs.comment }}` into `"{ inputs.comment }": null`

### Before

https://github.com/user-attachments/assets/1930b6cf-7a6d-4bf9-ac44-75904cab936c

### After

https://github.com/user-attachments/assets/bf4320e1-a974-4682-b798-10ed5d97385c


## Fix

Replaced the parse-modify-stringify approach in `workflows_management_service.ts` with `updateWorkflowYamlFields()`, which edits fields in-place on the YAML AST (using `parseDocument` with `keepSourceTokens: true`), preserving all comments, formatting, and template expressions.

## Test plan

- Added unit tests for `updateYamlField` and `updateWorkflowYamlFields` covering comment/blank line/template expression preservation
- Added CRUD-level test in `workflows_management_service.test.ts` verifying the full update flow preserves YAML integrity when toggling enabled

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->