### PR TITLE
[Search] Add connection details to platform index details page

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/constants/index.ts
@@ -67,3 +67,5 @@ export const PLUGIN = {
 
 export const MAX_DOCUMENTS_FOR_CONVERT_TO_LOOKUP_INDEX = 2000000000; // 2 billion documents
 export const MAX_SHARDS_FOR_CONVERT_TO_LOOKUP_INDEX = 1; // Single shard
+
+export const PLATFORM_INDEX_MGMT_V2 = 'platform:indexManagementV2';

--- a/x-pack/platform/plugins/shared/index_management/moon.yml
+++ b/x-pack/platform/plugins/shared/index_management/moon.yml
@@ -76,6 +76,7 @@ dependsOn:
   - '@kbn/deeplinks-management'
   - '@kbn/test-eui-helpers'
   - '@kbn/core-elasticsearch-server'
+  - '@kbn/cloud'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/index_management/public/application/lib/discover_link.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/lib/discover_link.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import { EuiButton, EuiButtonEmpty, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { PLATFORM_INDEX_MGMT_V2 } from '../../../common/constants';
 import { useAppContext } from '../app_context';
 
 export const DiscoverLink = ({
@@ -18,7 +19,8 @@ export const DiscoverLink = ({
   indexName: string;
   asButton?: boolean;
 }) => {
-  const { url } = useAppContext();
+  const { url, settings } = useAppContext();
+  const isNewDesignEnabled = settings?.client.get<boolean>(PLATFORM_INDEX_MGMT_V2, false);
   const discoverLocator = url?.locators.get('DISCOVER_APP_LOCATOR');
   if (!discoverLocator) {
     return null;
@@ -39,7 +41,14 @@ export const DiscoverLink = ({
     />
   );
   if (asButton) {
-    link = (
+    link = isNewDesignEnabled ? (
+      <EuiButtonEmpty onClick={onClick} iconType="discoverApp" data-test-subj="discoverButtonLink">
+        <FormattedMessage
+          id="xpack.idxMgmt.goToDiscover.discoverIndexButtonLabel"
+          defaultMessage="Discover index"
+        />
+      </EuiButtonEmpty>
+    ) : (
       <EuiButton fill onClick={onClick} iconType="discoverApp" data-test-subj="discoverButtonLink">
         <FormattedMessage
           id="xpack.idxMgmt.goToDiscover.discoverIndexButtonLabel"

--- a/x-pack/platform/plugins/shared/index_management/public/application/lib/discover_link.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/lib/discover_link.tsx
@@ -9,18 +9,18 @@ import React from 'react';
 import { EuiButton, EuiButtonEmpty, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { PLATFORM_INDEX_MGMT_V2 } from '../../../common/constants';
 import { useAppContext } from '../app_context';
 
 export const DiscoverLink = ({
   indexName,
   asButton = false,
+  fill = true,
 }: {
   indexName: string;
   asButton?: boolean;
+  fill?: boolean;
 }) => {
-  const { url, settings } = useAppContext();
-  const isNewDesignEnabled = settings?.client.get<boolean>(PLATFORM_INDEX_MGMT_V2, false);
+  const { url } = useAppContext();
   const discoverLocator = url?.locators.get('DISCOVER_APP_LOCATOR');
   if (!discoverLocator) {
     return null;
@@ -41,20 +41,20 @@ export const DiscoverLink = ({
     />
   );
   if (asButton) {
-    link = isNewDesignEnabled ? (
-      <EuiButtonEmpty onClick={onClick} iconType="discoverApp" data-test-subj="discoverButtonLink">
-        <FormattedMessage
-          id="xpack.idxMgmt.goToDiscover.discoverIndexButtonLabel"
-          defaultMessage="Discover index"
-        />
-      </EuiButtonEmpty>
-    ) : (
+    link = fill ? (
       <EuiButton fill onClick={onClick} iconType="discoverApp" data-test-subj="discoverButtonLink">
         <FormattedMessage
           id="xpack.idxMgmt.goToDiscover.discoverIndexButtonLabel"
           defaultMessage="Discover index"
         />
       </EuiButton>
+    ) : (
+      <EuiButtonEmpty onClick={onClick} iconType="discoverApp" data-test-subj="discoverButtonLink">
+        <FormattedMessage
+          id="xpack.idxMgmt.goToDiscover.discoverIndexButtonLabel"
+          defaultMessage="Discover index"
+        />
+      </EuiButtonEmpty>
     );
   }
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
@@ -14,16 +14,23 @@ import { SectionLoading } from '@kbn/es-ui-shared-plugin/public';
 
 import { resetIndexUrlParams } from './reset_index_url_params';
 import type { IndexDetailsTabId } from '../../../../../../common/constants';
-import { IndexDetailsSection, Section } from '../../../../../../common/constants';
+import {
+  IndexDetailsSection,
+  PLATFORM_INDEX_MGMT_V2,
+  Section,
+} from '../../../../../../common/constants';
 import type { Index } from '../../../../../../common';
 import type { Error } from '../../../../../shared_imports';
 import { loadIndex } from '../../../../services';
+import { useAppContext } from '../../../../app_context';
 import { DetailsPageError } from './details_page_error';
 import { DetailsPageContent } from './details_page_content';
+import { DetailsPageContentV2 } from './details_page_content_v2';
 
 export const DetailsPage: FunctionComponent<
   RouteComponentProps<{ indexName: string; indexDetailsSection: IndexDetailsSection }>
 > = ({ location: { search }, history }) => {
+  const { settings } = useAppContext();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
   const indexName = queryParams.get('indexName') ?? '';
   const tab: IndexDetailsTabId = queryParams.get('tab') ?? IndexDetailsSection.Overview;
@@ -31,6 +38,8 @@ export const DetailsPage: FunctionComponent<
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [index, setIndex] = useState<Index | null>();
+
+  const isNewDesignEnabled = settings?.client.get<boolean>(PLATFORM_INDEX_MGMT_V2, false);
 
   const navigateToIndicesList = useCallback(() => {
     const paramsString = resetIndexUrlParams(search);
@@ -99,6 +108,18 @@ export const DetailsPage: FunctionComponent<
       <DetailsPageError
         indexName={indexName}
         resendRequest={fetchIndexDetails}
+        navigateToIndicesList={navigateToIndicesList}
+      />
+    );
+  }
+  if (isNewDesignEnabled) {
+    return (
+      <DetailsPageContentV2
+        index={index}
+        tab={tab}
+        fetchIndexDetails={fetchIndexDetails}
+        history={history}
+        search={search}
         navigateToIndicesList={navigateToIndicesList}
       />
     );

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
@@ -39,7 +39,7 @@ export const DetailsPage: FunctionComponent<
   const [error, setError] = useState<Error | null>(null);
   const [index, setIndex] = useState<Index | null>();
 
-  const isNewDesignEnabled = settings?.client.get<boolean>(PLATFORM_INDEX_MGMT_V2, false);
+  const isNewDesignEnabled = settings.client.get<boolean>(PLATFORM_INDEX_MGMT_V2, false);
 
   const navigateToIndicesList = useCallback(() => {
     const paramsString = resetIndexUrlParams(search);

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import type { EuiPageHeaderProps } from '@elastic/eui';
+import { EuiButton, EuiPageHeader, EuiPageSection, EuiSpacer } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import type { RouteComponentProps } from 'react-router-dom';
+
+import { useIndexErrors } from '../../../../hooks/use_index_errors';
+import { resetIndexUrlParams } from './reset_index_url_params';
+import { renderBadges } from '../../../../lib/render_badges';
+import type { Index } from '../../../../../../common';
+import type { IndexDetailsTab, IndexDetailsTabId } from '../../../../../../common/constants';
+import { INDEX_OPEN, IndexDetailsSection } from '../../../../../../common/constants';
+import { getIndexDetailsLink } from '../../../../services/routing';
+import { useAppContext } from '../../../../app_context';
+import { DiscoverLink } from '../../../../lib/discover_link';
+import { ManageIndexButton } from './manage_index_button';
+import { DetailsPageOverview } from './details_page_overview';
+import { DetailsPageMappings } from './details_page_mappings';
+import { DetailsPageSettings } from './details_page_settings';
+import { DetailsPageStats } from './details_page_stats';
+import { DetailsPageTab } from './details_page_tab';
+import { IndexErrorCallout } from './index_error_callout';
+
+const defaultTabs: IndexDetailsTab[] = [
+  {
+    id: IndexDetailsSection.Overview,
+    name: i18n.translate('xpack.idxMgmt.indexDetails.overviewTitle', {
+      defaultMessage: 'Overview',
+    }),
+    renderTabContent: ({ index }) => <DetailsPageOverview indexDetails={index} />,
+    order: 10,
+  },
+  {
+    id: IndexDetailsSection.Mappings,
+    name: i18n.translate('xpack.idxMgmt.indexDetails.mappingsTitle', {
+      defaultMessage: 'Mappings',
+    }),
+    renderTabContent: ({ index }) => <DetailsPageMappings index={index} />,
+    order: 20,
+  },
+  {
+    id: IndexDetailsSection.Settings,
+    name: i18n.translate('xpack.idxMgmt.indexDetails.settingsTitle', {
+      defaultMessage: 'Settings',
+    }),
+    renderTabContent: ({ index }) => <DetailsPageSettings indexName={index.name} />,
+    order: 30,
+  },
+];
+
+const statsTab: IndexDetailsTab = {
+  id: IndexDetailsSection.Stats,
+  name: i18n.translate('xpack.idxMgmt.indexDetails.statsTitle', {
+    defaultMessage: 'Statistics',
+  }),
+  renderTabContent: ({ index }) => (
+    <DetailsPageStats indexName={index.name} isIndexOpen={index.status === INDEX_OPEN} />
+  ),
+  order: 40,
+};
+
+interface Props {
+  index: Index;
+  tab: IndexDetailsTabId;
+  history: RouteComponentProps['history'];
+  search: string;
+  fetchIndexDetails: () => Promise<void>;
+  navigateToIndicesList: () => void;
+}
+export const DetailsPageContentV2: FunctionComponent<Props> = ({
+  index,
+  tab,
+  history,
+  search,
+  fetchIndexDetails,
+  navigateToIndicesList,
+}) => {
+  const {
+    core: {
+      application: { capabilities },
+    },
+    config: { enableIndexStats },
+    plugins: { console: consolePlugin, ml },
+    services: { extensionsService },
+  } = useAppContext();
+  const hasMLPermissions = capabilities?.ml?.canGetTrainedModels ? true : false;
+
+  const indexErrors = useIndexErrors(index, ml, hasMLPermissions);
+
+  const tabs = useMemo(() => {
+    const sortedTabs = [...defaultTabs];
+    if (enableIndexStats) {
+      sortedTabs.push(statsTab);
+    }
+    extensionsService.indexDetailsTabs.forEach((dynamicTab) => {
+      if (!dynamicTab.shouldRenderTab || dynamicTab.shouldRenderTab({ index })) {
+        sortedTabs.push(dynamicTab);
+      }
+    });
+
+    sortedTabs.sort((tabA, tabB) => {
+      return tabA.order - tabB.order;
+    });
+    return sortedTabs;
+  }, [enableIndexStats, extensionsService.indexDetailsTabs, index]);
+
+  const onSectionChange = useCallback(
+    (newSection: IndexDetailsTabId) => {
+      return history.push(getIndexDetailsLink(index.name, resetIndexUrlParams(search), newSection));
+    },
+    [history, index.name, search]
+  );
+
+  const headerTabs = useMemo<EuiPageHeaderProps['tabs']>(() => {
+    return tabs.map((tabConfig) => ({
+      onClick: () => onSectionChange(tabConfig.id),
+      isSelected: tabConfig.id === tab,
+      key: tabConfig.id,
+      'data-test-subj': `indexDetailsTab-${tabConfig.id}`,
+      label: tabConfig.name,
+    }));
+  }, [tabs, tab, onSectionChange]);
+
+  const pageTitle = (
+    <>
+      {index.name}
+      {renderBadges(index, extensionsService)}
+    </>
+  );
+
+  return (
+    <>
+      <EuiPageSection paddingSize="none">
+        <EuiButton
+          data-test-subj="indexDetailsBackToIndicesButton"
+          color="text"
+          iconType="arrowLeft"
+          onClick={navigateToIndicesList}
+        >
+          <FormattedMessage
+            id="xpack.idxMgmt.indexDetails.backToIndicesButtonLabel"
+            defaultMessage="Back to indices"
+          />
+        </EuiButton>
+      </EuiPageSection>
+      <EuiSpacer size="l" />
+      <EuiPageHeader
+        data-test-subj="indexDetailsHeader"
+        pageTitle={pageTitle}
+        bottomBorder
+        rightSideItems={[
+          <DiscoverLink indexName={index.name} asButton={true} />,
+          <ManageIndexButton
+            index={index}
+            reloadIndexDetails={fetchIndexDetails}
+            navigateToIndicesList={navigateToIndicesList}
+          />,
+        ]}
+        rightSideGroupProps={{
+          wrap: false,
+        }}
+        responsive="reverse"
+        tabs={headerTabs}
+      >
+        {indexErrors.length > 0 ? <IndexErrorCallout errors={indexErrors} /> : null}
+      </EuiPageHeader>
+      <EuiSpacer size="l" />
+      <div
+        data-test-subj={`indexDetailsContent`}
+        css={css`
+          height: 100%;
+        `}
+      >
+        <DetailsPageTab tabs={tabs} tab={tab} index={index} />
+      </div>
+      {consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
@@ -92,7 +92,7 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
     },
     config: { enableIndexStats },
     plugins: { console: consolePlugin, ml },
-    services: { extensionsService },
+    services: { extensionsService, notificationService },
   } = useAppContext();
   const hasMLPermissions = capabilities?.ml?.canGetTrainedModels ? true : false;
 
@@ -153,11 +153,13 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
             navigateToIndicesList={navigateToIndicesList}
             fill={true}
           />,
-          <DiscoverLink indexName={index.name} asButton={true} />,
+          <DiscoverLink indexName={index.name} asButton={true} fill={false} />,
           <EuiButtonEmpty
             onClick={() =>
               openWiredConnectionDetails({
                 props: { options: { defaultTabId: 'apiKeys' } },
+              }).catch((error) => {
+                notificationService.showDangerToast(error.body.message);
               })
             }
             iconType="plugs"

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
@@ -8,11 +8,12 @@
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useMemo } from 'react';
 import type { EuiPageHeaderProps } from '@elastic/eui';
-import { EuiButton, EuiPageHeader, EuiPageSection, EuiSpacer } from '@elastic/eui';
+import { EuiButtonEmpty, EuiPageHeader, EuiSpacer } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import type { RouteComponentProps } from 'react-router-dom';
+import { openWiredConnectionDetails } from '@kbn/cloud/connection_details';
 
 import { useIndexErrors } from '../../../../hooks/use_index_errors';
 import { resetIndexUrlParams } from './reset_index_url_params';
@@ -140,37 +141,34 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
 
   return (
     <>
-      <EuiPageSection paddingSize="none">
-        <EuiButton
-          data-test-subj="indexDetailsBackToIndicesButton"
-          color="text"
-          iconType="arrowLeft"
-          onClick={navigateToIndicesList}
-        >
-          <FormattedMessage
-            id="xpack.idxMgmt.indexDetails.backToIndicesButtonLabel"
-            defaultMessage="Back to indices"
-          />
-        </EuiButton>
-      </EuiPageSection>
-      <EuiSpacer size="l" />
       <EuiPageHeader
         data-test-subj="indexDetailsHeader"
         pageTitle={pageTitle}
         bottomBorder
+        tabs={headerTabs}
         rightSideItems={[
-          <DiscoverLink indexName={index.name} asButton={true} />,
           <ManageIndexButton
             index={index}
             reloadIndexDetails={fetchIndexDetails}
             navigateToIndicesList={navigateToIndicesList}
+            fill={true}
           />,
+          <DiscoverLink indexName={index.name} asButton={true} />,
+          <EuiButtonEmpty
+            onClick={() =>
+              openWiredConnectionDetails({
+                props: { options: { defaultTabId: 'apiKeys' } },
+              })
+            }
+            iconType="plugs"
+            data-test-subj="openConnectionDetails"
+          >
+            <FormattedMessage
+              id="xpack.idxMgmt.indexDetails.connectionDetailsButtonLabel"
+              defaultMessage="Connection details"
+            />
+          </EuiButtonEmpty>,
         ]}
-        rightSideGroupProps={{
-          wrap: false,
-        }}
-        responsive="reverse"
-        tabs={headerTabs}
       >
         {indexErrors.length > 0 ? <IndexErrorCallout errors={indexErrors} /> : null}
       </EuiPageHeader>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/manage_index_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/manage_index_button.tsx
@@ -42,6 +42,7 @@ interface Props {
   index: Index;
   reloadIndexDetails: () => Promise<void>;
   navigateToIndicesList: () => void;
+  fill?: boolean;
 }
 
 /**
@@ -54,6 +55,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
   index,
   reloadIndexDetails,
   navigateToIndicesList,
+  fill = false,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -223,7 +225,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       indexNames={indexNames}
       indices={indices}
       indexStatusByName={indexStatusByName}
-      fill={false}
+      fill={fill}
       isLoading={isLoading}
       // index actions
       closeIndices={closeIndices}

--- a/x-pack/platform/plugins/shared/index_management/tsconfig.json
+++ b/x-pack/platform/plugins/shared/index_management/tsconfig.json
@@ -70,7 +70,8 @@
     "@kbn/scout",
     "@kbn/deeplinks-management",
     "@kbn/test-eui-helpers",
-    "@kbn/core-elasticsearch-server"
+    "@kbn/core-elasticsearch-server",
+    "@kbn/cloud"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This PR introduces connection details to the Platform Index Details page as part of a broader effort to unify the Search Index Details and Platform Index Details experiences, with the goal of eventually deprecating the Search Index Details page.

To support this transition, a new `DetailsPageContentV2` component has been created to serve as the primary location for ongoing updates prior to the full migration. The component is currently gated behind a UI setting and will remain hidden until we are ready to complete the switch.

The following changes have been made to the index details page in this PR and can be seen in [this commit](https://github.com/elastic/kibana/pull/252693/changes/68f61100dcad07ab153276edb8c58543eb29a587):

- A `Connection details` button has been added which opens the Connection Details flyout
- The `Manage index` now has a fill on it to make it consistent with the style of a primary option button
- The `Discover index` button is now an empty button
- The `Back to indices` has been removed

### Screenshot
<img width="700" height="829" alt="Screenshot 2026-02-17 at 16 50 34" src="https://github.com/user-attachments/assets/548879ea-4e2e-4f46-8988-3cf2ee7dc474" />

### Testing

To preview these changes you can either add the following to `kibana.dev.yml`:
```
uiSettings:
  overrides:
    platform:indexManagementV2: true
```
or run this command in the console:

```
POST kbn:/internal/kibana/settings/platform:indexManagementV2
    {"value": true}
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~



