### PR TITLE
[Dashboard] Adjust Horizontal Link panel height to 2 rows

### DIFF
--- a/src/platform/plugins/private/links/public/embeddable/get_panel_placement.ts
+++ b/src/platform/plugins/private/links/public/embeddable/get_panel_placement.ts
@@ -31,6 +31,6 @@ export async function getPanelPlacement(serializedState?: LinksEmbeddableState) 
   }
   const isHorizontal = layout === LINKS_HORIZONTAL_LAYOUT;
   const width = isHorizontal ? DASHBOARD_GRID_COLUMN_COUNT : 8;
-  const height = isHorizontal ? 4 : numLinks * 3 + 4;
+  const height = isHorizontal ? 2 : numLinks * 3 + 4;
   return { width, height, strategy: PanelPlacementStrategy.placeAtTop };
 }


### PR DESCRIPTION
Resolves #243680

Screenshot demonstrating the Horizontal Link panel after the height fix:

<img width="1306" height="611" alt="Screenshot 2026-02-11 at 13 56 30" src="https://github.com/user-attachments/assets/9a1ea590-2cce-4d8b-85cb-73c016ad7138" />
