### PR TITLE
[i18n] Add debug mode

### DIFF
--- a/packages/kbn-extract-plugin-translations/README.md
+++ b/packages/kbn-extract-plugin-translations/README.md
@@ -56,7 +56,7 @@ The extracted translation files can be consumed in your application using the `@
 ```typescript
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { I18nProvider } from '@kbn/i18n-react';
 
 // Import translation files (webpack will bundle them)
 const translations = {
@@ -82,10 +82,10 @@ export const MyPluginApp = ({ lang = 'en' }) => {
   });
 
   return (
-    <IntlProvider locale={lang} messages={selectedTranslations.messages}>
+    <I18nProvider>
       {/* Your plugin components here */}
       <YourPluginComponent />
-    </IntlProvider>
+    </I18nProvider>
   );
 };
 ```

--- a/src/core/packages/i18n/server-internal/src/i18n_config.ts
+++ b/src/core/packages/i18n/server-internal/src/i18n_config.ts
@@ -14,6 +14,7 @@ export const config = {
   path: 'i18n',
   schema: schema.object({
     locale: schema.string({ defaultValue: 'en' }),
+    debugMode: schema.boolean({ defaultValue: false }),
   }),
 };
 

--- a/src/core/packages/i18n/server-internal/src/i18n_service.ts
+++ b/src/core/packages/i18n/server-internal/src/i18n_service.ts
@@ -81,11 +81,16 @@ export class I18nService {
 
     const locale = i18nConfig.locale;
     this.log.debug(`Using locale: ${locale}`);
+    this.log.debug(`Using debug mode: ${i18nConfig.debugMode}`);
 
     const translationFiles = await getKibanaTranslationFiles(locale, pluginPaths);
 
     this.log.debug(`Using translation files: [${translationFiles.join(', ')}]`);
-    await initTranslations(locale, translationFiles);
+    await initTranslations({
+      locale,
+      translationFiles,
+      debug: i18nConfig.debugMode,
+    });
 
     const translationHash = getTranslationHash(i18n.getTranslation());
 

--- a/src/core/packages/i18n/server-internal/src/init_translations.ts
+++ b/src/core/packages/i18n/server-internal/src/init_translations.ts
@@ -9,9 +9,18 @@
 
 import { i18n, i18nLoader } from '@kbn/i18n';
 
-export const initTranslations = async (locale: string, translationFiles: string[]) => {
+interface InitTranslationsParams {
+  locale: string;
+  translationFiles: string[];
+  debug?: boolean;
+}
+export const initTranslations = async ({
+  locale,
+  translationFiles,
+  debug,
+}: InitTranslationsParams) => {
   i18nLoader.registerTranslationFiles(translationFiles);
   const translations = await i18nLoader.getTranslationsByLocale(locale);
   translations.locale = locale;
-  i18n.init(translations);
+  i18n.init(translations, { debug });
 };

--- a/src/core/packages/injected-metadata/common-internal/src/types.ts
+++ b/src/core/packages/injected-metadata/common-internal/src/types.ts
@@ -72,6 +72,7 @@ export interface InjectedMetadata {
   anonymousStatusPage: boolean;
   i18n: {
     translationsUrl: string;
+    debugMode: boolean;
   };
   theme: InjectedMetadataTheme;
   csp: {

--- a/src/core/packages/rendering/server-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.tsx
@@ -312,6 +312,7 @@ export class RenderingService {
         anonymousStatusPage: status?.isStatusPageAnonymous() ?? false,
         i18n: {
           translationsUrl,
+          debugMode: i18nLib.getDebugMode(),
         },
         theme: {
           darkMode,

--- a/src/core/packages/root/browser-internal/src/kbn_bootstrap.ts
+++ b/src/core/packages/root/browser-internal/src/kbn_bootstrap.ts
@@ -34,9 +34,11 @@ export async function __kbnBootstrap__() {
   await Promise.all([
     // eslint-disable-next-line no-console
     apmSystem.setup().catch(console.warn),
-    i18n.load(injectedMetadata.i18n.translationsUrl).catch((error) => {
-      i18nError = error;
-    }),
+    i18n
+      .load(injectedMetadata.i18n.translationsUrl, { debug: injectedMetadata.i18n.debugMode })
+      .catch((error) => {
+        i18nError = error;
+      }),
   ]);
 
   const isDomStorageDisabled = () => {

--- a/src/platform/packages/shared/kbn-i18n-react/index.tsx
+++ b/src/platform/packages/shared/kbn-i18n-react/index.tsx
@@ -13,20 +13,13 @@ import {
   FormattedTime,
   FormattedNumber,
   FormattedPlural,
-  FormattedMessage,
   FormattedRelativeTime,
 } from 'react-intl';
 
 export type { IntlShape, WrappedComponentProps };
-export {
-  FormattedDate,
-  FormattedTime,
-  FormattedNumber,
-  FormattedPlural,
-  FormattedMessage,
-  FormattedRelativeTime,
-};
+export { FormattedDate, FormattedTime, FormattedNumber, FormattedPlural, FormattedRelativeTime };
 
+export { FormattedMessage } from './src/formatted_message';
 export { FormattedRelative, __IntlProvider } from './src/compatiblity_layer';
 export type { FormattedRelativeProps, InjectedIntl } from './src/compatiblity_layer';
 export { I18nProvider } from './src/provider';

--- a/src/platform/packages/shared/kbn-i18n-react/src/formatted_message.tsx
+++ b/src/platform/packages/shared/kbn-i18n-react/src/formatted_message.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage as FormattedMessageOriginal } from 'react-intl';
+import type { Props } from 'react-intl/src/components/message';
+
+export const FormattedMessage = (props: Props) => {
+  const debugMode = i18n.getDebugMode();
+
+  return (
+    <FormattedMessageOriginal
+      {...props}
+      tagName={debugMode ? createTag(props.id) : undefined}
+      ignoreTag={debugMode ? false : true}
+    />
+  );
+};
+
+const createTag = (id?: string) => (props: React.HTMLAttributes<HTMLSpanElement>) => {
+  return <span data-i18n-id={id} {...props} />;
+};

--- a/src/platform/packages/shared/kbn-i18n/index.ts
+++ b/src/platform/packages/shared/kbn-i18n/index.ts
@@ -10,6 +10,7 @@
 import {
   formatList,
   getIsInitialized,
+  getDebugMode,
   getLocale,
   getTranslation,
   handleIntlError,
@@ -36,6 +37,7 @@ const i18n = {
   load,
   handleIntlError,
   getIsInitialized,
+  getDebugMode,
 };
 
 const i18nLoader = {

--- a/src/platform/packages/shared/kbn-i18n/src/core/i18n.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/i18n.ts
@@ -29,6 +29,8 @@ const defaultLocale = EN_LOCALE;
  */
 let intl: IntlShape<string>;
 let isInitialized = false;
+let debugMode = false;
+
 /**
  * ideally here we would be using a `throw new Error()` if i18n.translate is called before init();
  * to make sure i18n is initialized before any message is attempting to be translated.
@@ -48,6 +50,11 @@ intl = createIntl({
 export const getIsInitialized = () => {
   return isInitialized;
 };
+
+export const getDebugMode = () => {
+  return debugMode;
+};
+
 /**
  * Normalizes locale to make it consistent with IntlMessageFormat locales
  * @param locale
@@ -187,21 +194,26 @@ export function formatList(type: 'conjunction' | 'disjunction' | 'unit', value: 
 /**
  * Initializes the engine
  * @param newTranslation
+ * @param debug
  */
-export function init(newTranslation?: TranslationInput) {
+export function init(
+  newTranslation?: TranslationInput,
+  { debug = false }: { debug?: boolean } = {}
+) {
   if (typeof newTranslation?.locale !== 'string') {
     return;
   }
 
   activateTranslation(newTranslation);
   isInitialized = true;
+  debugMode = debug;
 }
 
 /**
  * Loads JSON with translations from the specified URL and initializes i18n engine with them.
  * @param translationsUrl URL pointing to the JSON bundle with translations.
  */
-export async function load(translationsUrl: string) {
+export async function load(translationsUrl: string, { debug = false }: { debug?: boolean } = {}) {
   // Once this package is integrated into core Kibana we should switch to an abstraction
   // around `fetch` provided by the platform, e.g. `kfetch`.
   const response = await fetch(translationsUrl, {
@@ -217,6 +229,5 @@ export async function load(translationsUrl: string) {
     return;
   }
 
-  init(newTranslation);
-  isInitialized = true;
+  init(newTranslation, { debug });
 }

--- a/src/platform/packages/shared/kbn-i18n/src/core/index.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/index.ts
@@ -17,6 +17,7 @@ export {
   translate,
   formatList,
   getIsInitialized,
+  getDebugMode,
 } from './i18n';
 export type { TranslateArguments } from './i18n';
 export { handleIntlError } from './error_handler';


### PR DESCRIPTION
## Summary

### i18n debug mode
Add a new config `i18n.debugMode` which enabled debugging i18n messages.

For now this will add a `data-i18n-id` attribute to the React FormattedMessage when enabled for easier debugging.
This is useful for:
1. Easier debugging, just inspect an element to find its id
2. Good for testing. You can test that a react text is i18n'ed without having to run the test suite multiple times
3. In the future i will expend on this to include all i18n messages not just `FormattedMessage` so we can use it for debugging, quality control, and fixing initialization timing problems

<img width="860" height="396" alt="image" src="https://github.com/user-attachments/assets/efe261d8-a5cc-4085-9db8-c54b58b8cc82" />


### Update Lens i18n tests
Lens currently runs their UI test suite 5 times once for each locale, the goal of these tests is to:
1. developers didnt remove the id by mistake and use a hardcoded string instead
2. translations do exist in the translation files

So now with the debug flag we can just run this test once in english and then check for the data attribute to ensure that the text is i18n'ed and then import the localization files to check that the translation exists in the files for each locale.


