### PR TITLE
[CI] Export some metadata params to ingest

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -29,5 +29,8 @@ fi
 
 # Annotate ingestable meta-data (prefixed with 'ingest:')
 if [[ "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" != "" ]]; then # if we're in a PR build
-  buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-}" # GITHUB_PR_DRAFT is set by our pr build trigger bot
+  # GITHUB_PR_DRAFT is set by our pr build trigger bot
+  buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-}"
+  # GITHUB_PR_LABELS is set by our pr build trigger bot, and is a comma-separated list of labels on the PR
+  buildkite-agent meta-data set "ingest:pr_labels" "${GITHUB_PR_LABELS:-}"
 fi

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -26,3 +26,8 @@ if [[ "${KIBANA_BUILD_ID:-}" && "${KIBANA_REUSABLE_BUILD_JOB_URL:-}" ]]; then
   See job here: $KIBANA_REUSABLE_BUILD_JOB_URL
 EOF
 fi
+
+# Annotate ingestable meta-data (prefixed with 'ingest:')
+if [[ "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" != "" ]]; then # if we're in a PR build
+  buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-}" # GITHUB_PR_DRAFT is set by our pr build trigger bot
+fi


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana-buildkite-build-bot/pull/23 adds the ability to send metadata that's set with a label prefixed with `ingest:` (up to debate on the naming) should be sent to the ES cluster indexing buildkite build data. 

This PR sends 2 bits of data that we've been wanting to see in our buildkite stats: 
 - whether the PR is draft
 - what labels the PR has

Closes: https://github.com/elastic/buildkite-receiver/issues/81
Depends on: https://github.com/elastic/kibana-buildkite-build-bot/pull/23

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->