### PR TITLE
[ES|QL] Clean dependencies of the OSS code with regard Kibana

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
@@ -11,6 +11,7 @@ import type { LicenseType } from '@kbn/licensing-types';
 import type { PricingProduct } from '@kbn/core-pricing-common/src/types';
 import type { ESQLNumericLiteralType } from '../../types';
 import type { Location } from '../registry/types';
+import type { inlineCastsMapping } from './generated/inline_casts_mapping';
 
 /**
  * This is the list of all data types that are supported in ES|QL.
@@ -516,3 +517,5 @@ export function supportsArithmeticOperations(type: string): boolean {
 export const ESQL_STRING_TYPES = ['keyword', 'text'] as const;
 
 export const ESQL_NAMED_PARAMS_TYPE = 'function_named_parameters' as const;
+
+export type InlineCastingType = keyof typeof inlineCastsMapping;

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/expressions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/expressions.ts
@@ -19,6 +19,7 @@ import { lastItem } from '../../../ast/visitor/utils';
 import type {
   FunctionDefinition,
   FunctionParameterType,
+  InlineCastingType,
   PromQLFunctionParamType,
   Signature,
   SupportedDataType,
@@ -67,7 +68,7 @@ export function getExpressionType(
   }
 
   if (isInlineCast(root)) {
-    const castFunction = getFunctionForInlineCast(root.castType);
+    const castFunction = getFunctionForInlineCast(root.castType as InlineCastingType);
     if (!castFunction) {
       return 'unknown';
     }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/functions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/functions.ts
@@ -24,7 +24,7 @@ import { aggFunctionDefinitions } from '../generated/aggregation_functions';
 import { timeSeriesAggFunctionDefinitions } from '../generated/time_series_agg_functions';
 import { groupingFunctionDefinitions } from '../generated/grouping_functions';
 import { scalarFunctionDefinitions } from '../generated/scalar_functions';
-import type { inlineCastsMapping } from '../generated/inline_casts_mapping';
+import { inlineCastsMapping } from '../generated/inline_casts_mapping';
 import type { ESQLColumnData, ISuggestionItem } from '../../registry/types';
 import { withAutoSuggest } from './autocomplete/helpers';
 import { buildFunctionDocumentation } from './documentation';

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/functions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/functions.ts
@@ -17,18 +17,19 @@ import {
   type FunctionParameterType,
   FunctionDefinitionTypes,
   type SupportedDataType,
+  type InlineCastingType,
 } from '../types';
 import { operatorsDefinitions } from '../all_operators';
 import { aggFunctionDefinitions } from '../generated/aggregation_functions';
 import { timeSeriesAggFunctionDefinitions } from '../generated/time_series_agg_functions';
 import { groupingFunctionDefinitions } from '../generated/grouping_functions';
 import { scalarFunctionDefinitions } from '../generated/scalar_functions';
-import { inlineCastsMapping } from '../generated/inline_casts_mapping';
+import type { inlineCastsMapping } from '../generated/inline_casts_mapping';
 import type { ESQLColumnData, ISuggestionItem } from '../../registry/types';
 import { withAutoSuggest } from './autocomplete/helpers';
 import { buildFunctionDocumentation } from './documentation';
 import { getSafeInsertText, getControlSuggestion } from './autocomplete/helpers';
-import type { ESQLAstItem, ESQLFunction, InlineCastingType } from '../../../types';
+import type { ESQLAstItem, ESQLFunction } from '../../../types';
 import { removeFinalUnknownIdentiferArg, techPreviewLabel } from './shared';
 import { getTestFunctions } from './test_functions';
 import { getMatchingSignatures } from './expressions';

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/inline_cast.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/inline_cast.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { InlineCastingType } from '../../..';
 import type { WalkerAstNode } from '../../../../ast';
 import { isLiteral, walk } from '../../../../ast';
 import type { ESQLInlineCast, ESQLMessage } from '../../../../types';
@@ -46,7 +47,7 @@ export function validateInlineCasts(
  * value:intt -> Error
  */
 function checkUnknownCastingType(node: ESQLInlineCast) {
-  const castFunction = getFunctionForInlineCast(node.castType);
+  const castFunction = getFunctionForInlineCast(node.castType as InlineCastingType);
   if (!castFunction) {
     return errors.unknownCastingType(node.castType, node.location);
   }
@@ -60,7 +61,7 @@ function checkUnknownCastingType(node: ESQLInlineCast) {
  * true::date -> Error
  */
 function checkInvalidCastValue(node: ESQLInlineCast, context: ICommandContext) {
-  const castFunction = getFunctionForInlineCast(node.castType);
+  const castFunction = getFunctionForInlineCast(node.castType as InlineCastingType);
   if (!castFunction) {
     return;
   }

--- a/src/platform/packages/shared/kbn-esql-language/src/parser/core/cst_to_ast_converter.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/parser/core/cst_to_ast_converter.ts
@@ -2341,7 +2341,7 @@ export class CstToAstConverter {
     const value = this.fromPrimaryExpressionStrict(ctx.primaryExpression());
 
     return Builder.expression.inlineCast(
-      { castType: ctx.dataType().getText().toLowerCase() as ast.InlineCastingType, value },
+      { castType: ctx.dataType().getText().toLowerCase(), value },
       this.getParserFields(ctx)
     );
   }
@@ -2596,7 +2596,7 @@ export class CstToAstConverter {
     if (dataTypeCtx) {
       expression = Builder.expression.inlineCast(
         {
-          castType: dataTypeCtx.getText().toLowerCase() as ast.InlineCastingType,
+          castType: dataTypeCtx.getText().toLowerCase(),
           value: expression,
         },
         {

--- a/src/platform/packages/shared/kbn-esql-language/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/types.ts
@@ -6,8 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-
-import type { inlineCastsMapping } from './commands/definitions/generated/inline_casts_mapping';
 import type { PromQLAstQueryExpression } from './embedded_languages/promql/types';
 
 /**
@@ -352,12 +350,10 @@ export type BinaryExpressionMatchOperator = ':';
 export type BinaryExpressionIn = 'in' | 'not in';
 export type BinaryExpressionLogical = 'and' | 'or';
 
-export type InlineCastingType = keyof typeof inlineCastsMapping;
-
 export interface ESQLInlineCast<ValueType = ESQLAstItem> extends ESQLAstBaseItem {
   type: 'inlineCast';
   value: ValueType;
-  castType: InlineCastingType;
+  castType: string;
 }
 
 /**


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/250514
## Summary
This PR makes sure none of the code that will be exported to OSS depends on code outside of that group.

In this case, we were using code generated in the `definitions` folder to create a type used in the parser.