### PR TITLE
[9.2] Eslint rule restrict imports from other solutions (#252680)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2484,6 +2484,7 @@ module.exports = {
         '@kbn/eslint/scout_max_one_describe': 'error',
         '@kbn/eslint/scout_test_file_naming': 'error',
         '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
+        '@kbn/eslint/scout_no_cross_boundary_imports': 'error',
         '@kbn/eslint/scout_expect_import': 'error',
         '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
@@ -2502,7 +2503,6 @@ module.exports = {
         ],
       },
     },
-
     {
       // Deployment-agnostic test files must use proper context and services
       files: [

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -29,6 +29,7 @@ module.exports = {
     scout_require_api_client_in_api_test: require('./rules/scout_require_api_client_in_api_test'),
     scout_no_es_archiver_in_parallel_tests: require('./rules/scout_no_es_archiver_in_parallel_tests'),
     scout_expect_import: require('./rules/scout_expect_import'),
+    scout_no_cross_boundary_imports: require('./rules/scout_no_cross_boundary_imports'),
     require_kbn_fs: require('./rules/require_kbn_fs'),
     require_include_in_check_a11y: require('./rules/require_include_in_check_a11y'),
   },

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+
+const SOLUTION_PACKAGES = {
+  observability: '@kbn/scout-oblt',
+  search: '@kbn/scout-search',
+  security: '@kbn/scout-security',
+};
+
+/**
+ * Determines which Scout package a test file should import from based on its path.
+ * Defaults to @kbn/scout unless the file is under a supported solution (security, observability, search).
+ * @param {string} filePath
+ * @returns {{ solution?: string, package: string } | null}
+ */
+const getAllowedPackage = (filePath) => {
+  // Solution plugin test files with a dedicated Scout package
+  const solutionMatch = filePath.match(
+    /x-pack\/solutions\/(\w+)\/plugins\/.*\/test\/(?:scout|scout_\w+)\//
+  );
+  if (solutionMatch) {
+    const solution = solutionMatch[1];
+    const pkg = SOLUTION_PACKAGES[solution];
+    return { solution, package: pkg || '@kbn/scout' };
+  }
+
+  // Platform plugin test files (src/platform and x-pack/platform)
+  if (
+    /(?:src\/platform|x-pack\/platform)\/(?:.*\/)?plugins\/.*\/test\/(?:scout|scout_\w+)\//.test(
+      filePath
+    )
+  ) {
+    return { package: '@kbn/scout' };
+  }
+
+  return null;
+};
+
+/**
+ * Extracts the base Scout package name from an import source.
+ * e.g. '@kbn/scout/ui' → '@kbn/scout', '@kbn/scout-security/api' → '@kbn/scout-security'
+ * @param {string} source
+ * @returns {string | null}
+ */
+const getScoutPackage = (source) => {
+  const match = source.match(/^(@kbn\/scout(?:-\w+)?)/);
+  return match ? match[1] : null;
+};
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ensure Scout test files import only from their designated Scout package. Solution tests must use their solution-specific package, platform tests must use @kbn/scout.',
+      category: 'Best Practices',
+    },
+    schema: [],
+    messages: {
+      platformTestImport:
+        "Tests without a solution-specific Scout package should import from '@kbn/scout'.",
+      solutionTestImport: "'{{solution}}' solution tests should import from '{{allowedPackage}}'.",
+    },
+  },
+
+  create(context) {
+    const filePath = context.getFilename();
+    const allowed = getAllowedPackage(filePath);
+
+    if (!allowed) {
+      return {};
+    }
+
+    const checkSource = (sourceNode) => {
+      const source = sourceNode.value;
+      const scoutPkg = getScoutPackage(source);
+
+      if (!scoutPkg || scoutPkg === allowed.package) {
+        return;
+      }
+
+      context.report({
+        node: sourceNode,
+        messageId: allowed.solution ? 'solutionTestImport' : 'platformTestImport',
+        data: {
+          solution: allowed.solution,
+          allowedPackage: allowed.package,
+        },
+      });
+    };
+
+    return {
+      ImportDeclaration(node) {
+        checkSource(node.source);
+      },
+      ExportNamedDeclaration(node) {
+        if (node.source) {
+          checkSource(node.source);
+        }
+      },
+      ExportAllDeclaration(node) {
+        if (node.source) {
+          checkSource(node.source);
+        }
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.test.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_cross_boundary_imports');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+  },
+});
+
+// Solution plugin test files
+const SECURITY_TEST = 'x-pack/solutions/security/plugins/my-plugin/test/scout/ui/some_test.ts';
+const OBLT_TEST = 'x-pack/solutions/observability/plugins/my-plugin/test/scout_api/some_test.ts';
+
+// Platform plugin test files
+const PLATFORM_XPACK_TEST = 'x-pack/platform/plugins/security/test/scout/ui/some_test.ts';
+const PLATFORM_SRC_TEST = 'src/platform/plugins/shared/discover/test/scout_ui/some_test.ts';
+
+// Unrelated file (not a Scout test)
+const UNRELATED = 'x-pack/solutions/security/plugins/my-plugin/server/index.ts';
+
+ruleTester.run('@kbn/eslint/scout_no_cross_boundary_imports', rule, {
+  valid: [
+    // Files outside Scout test directories are ignored
+    {
+      filename: UNRELATED,
+      code: `import { something } from '@kbn/scout';
+import { other } from '@kbn/scout-security';`,
+    },
+
+    // Non-Scout imports are always fine
+    {
+      filename: SECURITY_TEST,
+      code: `import { something } from 'lodash';`,
+    },
+
+    // Solution test importing from its own package (direct and subpath)
+    {
+      filename: SECURITY_TEST,
+      code: `import { test } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/ui';`,
+    },
+    {
+      filename: OBLT_TEST,
+      code: `import { expect } from '@kbn/scout-oblt/api';`,
+    },
+
+    // Platform test importing from @kbn/scout (direct and subpath)
+    {
+      filename: PLATFORM_XPACK_TEST,
+      code: `import { expect } from '@kbn/scout/ui';`,
+    },
+    {
+      filename: PLATFORM_SRC_TEST,
+      code: `import { test } from '@kbn/scout';`,
+    },
+  ],
+
+  invalid: [
+    // Solution test importing from platform @kbn/scout
+    {
+      filename: SECURITY_TEST,
+      code: `import { test } from '@kbn/scout';`,
+      errors: [{ messageId: 'solutionTestImport' }],
+    },
+
+    // Solution test importing from another solution's package
+    {
+      filename: SECURITY_TEST,
+      code: `import { something } from '@kbn/scout-oblt';`,
+      errors: [{ messageId: 'solutionTestImport' }],
+    },
+
+    // Solution test with multiple violations (platform + cross-solution)
+    {
+      filename: OBLT_TEST,
+      code: `import { expect } from '@kbn/scout/ui';
+import { something } from '@kbn/scout-security';`,
+      errors: [{ messageId: 'solutionTestImport' }, { messageId: 'solutionTestImport' }],
+    },
+
+    // Platform test (x-pack) importing from solution package
+    {
+      filename: PLATFORM_XPACK_TEST,
+      code: `import { test } from '@kbn/scout-security';`,
+      errors: [{ messageId: 'platformTestImport' }],
+    },
+
+    // Platform test (src/) importing from solution package
+    {
+      filename: PLATFORM_SRC_TEST,
+      code: `import { test } from '@kbn/scout-search';`,
+      errors: [{ messageId: 'platformTestImport' }],
+    },
+  ],
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Eslint rule restrict imports from other solutions (#252680)](https://github.com/elastic/kibana/pull/252680)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-11T18:43:26Z","message":"Eslint rule restrict imports from other solutions (#252680)\n\n## Summary\n\nAdds a new ESLint rule `scout_no_cross_boundary_imports` that ensures\nScout test files import from the correct Scout package:\n\n- Tests under a supported solution (`security`, `observability`,\n`search`) must import from their solution-specific package\n(`@kbn/scout-security`, `@kbn/scout-oblt`, `@kbn/scout-search`)\n- All other tests must import from `@kbn/scout`\n\n## Changes\n\n-\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.js`:\nRule implementation\n-\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.test.js`:\nUnit tests\n- `packages/kbn-eslint-plugin-eslint/index.js`: Register the rule\n- `.eslintrc.js`: Enable as `error` in the Scout test files override\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1043ba1043871f4dce4779e0a054907d77277463","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0"],"title":"Eslint rule restrict imports from other solutions","number":252680,"url":"https://github.com/elastic/kibana/pull/252680","mergeCommit":{"message":"Eslint rule restrict imports from other solutions (#252680)\n\n## Summary\n\nAdds a new ESLint rule `scout_no_cross_boundary_imports` that ensures\nScout test files import from the correct Scout package:\n\n- Tests under a supported solution (`security`, `observability`,\n`search`) must import from their solution-specific package\n(`@kbn/scout-security`, `@kbn/scout-oblt`, `@kbn/scout-search`)\n- All other tests must import from `@kbn/scout`\n\n## Changes\n\n-\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.js`:\nRule implementation\n-\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.test.js`:\nUnit tests\n- `packages/kbn-eslint-plugin-eslint/index.js`: Register the rule\n- `.eslintrc.js`: Enable as `error` in the Scout test files override\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1043ba1043871f4dce4779e0a054907d77277463"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252680","number":252680,"mergeCommit":{"message":"Eslint rule restrict imports from other solutions (#252680)\n\n## Summary\n\nAdds a new ESLint rule `scout_no_cross_boundary_imports` that ensures\nScout test files import from the correct Scout package:\n\n- Tests under a supported solution (`security`, `observability`,\n`search`) must import from their solution-specific package\n(`@kbn/scout-security`, `@kbn/scout-oblt`, `@kbn/scout-search`)\n- All other tests must import from `@kbn/scout`\n\n## Changes\n\n-\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.js`:\nRule implementation\n-\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.test.js`:\nUnit tests\n- `packages/kbn-eslint-plugin-eslint/index.js`: Register the rule\n- `.eslintrc.js`: Enable as `error` in the Scout test files override\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1043ba1043871f4dce4779e0a054907d77277463"}}]}] BACKPORT-->