### PR TITLE
chore(NA): adds on_merge_fanout

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -236,14 +236,6 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-    depends_on:
-      - build
-      - quick_checks
-      - checks
-      - linting
-      - linting_with_types
-      - check_oas_snapshot
-      - check_types
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -58,6 +58,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: quick_checks
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -75,6 +76,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: checks
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -92,6 +94,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: linting
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -109,6 +112,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: linting_with_types
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -126,6 +130,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: check_types
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -141,13 +146,12 @@ steps:
       machineType: n2-standard-4
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
+    key: check_oas_snapshot
     timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'
           limit: 3
-
-  - wait
 
   - command: .buildkite/scripts/steps/on_merge_api_docs.sh
     label: Check Public API Docs
@@ -197,7 +201,9 @@ steps:
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
+      JEST_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
+      FTR_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
     retry:
       automatic:
         - exit_status: '*'
@@ -209,453 +215,39 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-4
+      machineType: n2d-standard-8
       diskSizeGb: 105
     key: build_scout_tests
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     depends_on:
       - build
     env:
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:
       automatic:
         - exit_status: '*'
           limit: 1
 
-  - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
-    label: 'Serverless Entity Analytics - Security Cypress Tests'
+  - label: 'Upload on-merge fanout'
+    command: buildkite-agent pipeline upload .buildkite/pipelines/on_merge_fanout.yml
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 3
+      machineType: n2-standard-2
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
+    timeout_in_minutes: 10
     retry:
       automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
-    label: 'Serverless Explore - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
-    label: 'Serverless Investigations - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 10
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
-    label: 'Serverless Rule Management - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 5
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
-    label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 1
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
-    label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 1
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
-    label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 1
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
-    label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 1
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
-    label: 'Rule Management - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 4
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
-    label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
-    label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
-    label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
-    label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
-    label: 'Serverless Detection Engine - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 5
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
-    label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 4
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
-    label: 'Detection Engine - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 5
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
-    label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 3
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
-    label: 'Serverless AI Assistant - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 1
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
-    label: 'AI Assistant - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 1
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
-    label: 'Entity Analytics - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
-    label: 'Explore - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 3
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
-    label: 'Investigations - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 8
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
-    label: 'Osquery Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 8
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    label: 'Osquery Cypress Tests on Serverless'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 8
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/defend_workflows.sh
-    label: 'Defend Workflows Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 105
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 75
-    parallelism: 20
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
-    label: 'Defend Workflows Cypress Tests on Serverless'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 105
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 75
-    parallelism: 14
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/apm_cypress.sh
-    label: 'APM Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 120
-    parallelism: 3
-    retry:
-      automatic:
-        - exit_status: '-1'
+        - exit_status: '*'
           limit: 1
 
   - command: '.buildkite/scripts/steps/functional/on_merge_unsupported_ftrs.sh'
@@ -666,6 +258,14 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
 
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
     label: 'Build Storybooks'
@@ -677,6 +277,14 @@ steps:
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     key: storybooks
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 80
     retry:
       automatic:
@@ -692,6 +300,14 @@ steps:
       machineType: n2-standard-2
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 60
     soft_fail: true
     retry:
@@ -709,6 +325,14 @@ steps:
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     artifact_paths: 'target/plugin_so_types_snapshot.json'
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 30
     retry:
       automatic:

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -1,435 +1,472 @@
-- command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
-  label: 'Serverless Entity Analytics - Security Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 3
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+x-on-merge-gates: &on_merge_gates
+- build
+- quick_checks
+- checks
+- linting
+- linting_with_types
+- check_oas_snapshot
+- check_types
 
-- command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
-  label: 'Serverless Explore - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 2
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+steps:
+  - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
+    label: 'Serverless Entity Analytics - Security Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
-  label: 'Serverless Investigations - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 10
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
+    label: 'Serverless Explore - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
-  label: 'Serverless Rule Management - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 5
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
+    label: 'Serverless Investigations - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 10
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
-  label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 1
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
+    label: 'Serverless Rule Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 5
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
-  label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 1
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
-  label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 1
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
-  label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 1
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
-  label: 'Rule Management - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 4
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
-  label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 2
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
+    label: 'Rule Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 4
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
-  label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 2
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
+    label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
-  label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 2
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
+    label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
-  label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 2
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
+    label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
-  label: 'Serverless Detection Engine - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 5
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
+    label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
-  label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 4
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
+    label: 'Serverless Detection Engine - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 5
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
-  label: 'Detection Engine - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 5
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
+    label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 4
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
-  label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 3
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
+    label: 'Detection Engine - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 5
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
-  label: 'Serverless AI Assistant - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 1
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
+    label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
-  label: 'AI Assistant - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 1
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
+    label: 'Serverless AI Assistant - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
-  label: 'Entity Analytics - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 2
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
+    label: 'AI Assistant - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_explore.sh
-  label: 'Explore - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 3
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
+    label: 'Entity Analytics - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
-  label: 'Investigations - Security Solution Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 8
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
+    label: 'Explore - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/osquery_cypress.sh
-  label: 'Osquery Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 8
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
+    label: 'Investigations - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-  label: 'Osquery Cypress Tests on Serverless'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 60
-  parallelism: 8
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
+    label: 'Osquery Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/defend_workflows.sh
-  label: 'Defend Workflows Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    enableNestedVirtualization: true
-    machineType: n2-standard-4
-    diskSizeGb: 105
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 75
-  parallelism: 20
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
+    label: 'Osquery Cypress Tests on Serverless'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
-  label: 'Defend Workflows Cypress Tests on Serverless'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    enableNestedVirtualization: true
-    machineType: n2-standard-4
-    diskSizeGb: 105
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 75
-  parallelism: 14
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/defend_workflows.sh
+    label: 'Defend Workflows Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      enableNestedVirtualization: true
+      machineType: n2-standard-4
+      diskSizeGb: 105
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 20
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
 
-- command: .buildkite/scripts/steps/functional/apm_cypress.sh
-  label: 'APM Cypress Tests'
-  agents:
-    image: family/kibana-ubuntu-2404
-    imageProject: elastic-images-prod
-    provider: gcp
-    machineType: n2-standard-4
-    preemptible: true
-    spotZones: us-central1-f,us-central1-c,us-central1-a
-  timeout_in_minutes: 120
-  parallelism: 3
-  retry:
-    automatic:
-      - exit_status: '-1'
-        limit: 1
+  - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
+    label: 'Defend Workflows Cypress Tests on Serverless'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      enableNestedVirtualization: true
+      machineType: n2-standard-4
+      diskSizeGb: 105
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 14
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/apm_cypress.sh
+    label: 'APM Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -1,0 +1,435 @@
+- command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
+  label: 'Serverless Entity Analytics - Security Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 3
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
+  label: 'Serverless Explore - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 2
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
+  label: 'Serverless Investigations - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 10
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
+  label: 'Serverless Rule Management - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 5
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
+  label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 1
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
+  label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 1
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
+  label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 1
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
+  label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 1
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
+  label: 'Rule Management - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 4
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
+  label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 2
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
+  label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 2
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
+  label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 2
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
+  label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 2
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
+  label: 'Serverless Detection Engine - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 5
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
+  label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 4
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
+  label: 'Detection Engine - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 5
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
+  label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 3
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
+  label: 'Serverless AI Assistant - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 1
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
+  label: 'AI Assistant - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 1
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
+  label: 'Entity Analytics - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 2
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_explore.sh
+  label: 'Explore - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 3
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
+  label: 'Investigations - Security Solution Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 8
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/osquery_cypress.sh
+  label: 'Osquery Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 8
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
+  label: 'Osquery Cypress Tests on Serverless'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 60
+  parallelism: 8
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/defend_workflows.sh
+  label: 'Defend Workflows Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    enableNestedVirtualization: true
+    machineType: n2-standard-4
+    diskSizeGb: 105
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 75
+  parallelism: 20
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
+  label: 'Defend Workflows Cypress Tests on Serverless'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    enableNestedVirtualization: true
+    machineType: n2-standard-4
+    diskSizeGb: 105
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 75
+  parallelism: 14
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1
+
+- command: .buildkite/scripts/steps/functional/apm_cypress.sh
+  label: 'APM Cypress Tests'
+  agents:
+    image: family/kibana-ubuntu-2404
+    imageProject: elastic-images-prod
+    provider: gcp
+    machineType: n2-standard-4
+    preemptible: true
+    spotZones: us-central1-f,us-central1-c,us-central1-a
+  timeout_in_minutes: 120
+  parallelism: 3
+  retry:
+    automatic:
+      - exit_status: '-1'
+        limit: 1

--- a/.buildkite/pipelines/pull_request/apm_cypress.yml
+++ b/.buildkite/pipelines/pull_request/apm_cypress.yml
@@ -13,7 +13,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     parallelism: 3
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -32,7 +32,6 @@ steps:
 
   - command: .buildkite/scripts/steps/checks.sh
     label: 'Checks'
-    key: checks
     agents:
       machineType: c4d-standard-2
       diskType: hyperdisk-balanced
@@ -40,6 +39,7 @@ steps:
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
+    key: checks
     retry:
       automatic:
         - exit_status: '-1'
@@ -123,13 +123,13 @@ steps:
   - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
-      machineType: c3d-standard-8
+      machineType: n2d-standard-8
     key: build_scout_tests
     timeout_in_minutes: 20
     depends_on:
       - build
     env:
-      SCOUT_CONFIGS_DEPS: 'quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types,build_scout_tests'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:
       automatic:
@@ -159,11 +159,12 @@ steps:
     key: build_api_docs
     depends_on:
       - build
-      - check_types
+      - quick_checks
+      - checks
       - linting
       - linting_with_types
-      - quick_checks
       - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 90
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -13,7 +13,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     parallelism: 11
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -13,7 +13,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -14,7 +14,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 75
+    timeout_in_minutes: 60
     soft_fail: true
     parallelism: 1
     retry:
@@ -35,7 +35,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 75
+    timeout_in_minutes: 60
     soft_fail: true
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -15,7 +15,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 75
+    timeout_in_minutes: 60
     parallelism: 20
     retry:
       automatic:
@@ -38,7 +38,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 75
+    timeout_in_minutes: 60
     parallelism: 14
     retry:
       automatic:

--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
@@ -59,7 +59,7 @@ async function updateScoutConfigManifests(
       if (config.manifest.sha1 !== configDirSHA1) {
         log.info(
           `Manifest file is outdated for Scout test config at ${config.path} ` +
-          `(expected parent directory git object hash '${config.manifest.sha1}' but got '${configDirSHA1}')`
+            `(expected parent directory git object hash '${config.manifest.sha1}' but got '${configDirSHA1}')`
         );
       }
     } else {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-operations/issues/416

This PR creates an `on_merge_fanout` pipeline to simplify the setup and read of the main on_merge pipeline itself. For now everything aside from core jobs and dynamic pickup jobs for FTR and Scout goes into that file.

I've made sure we are using an early upload to the fanout pipeline so timing should be the same while anything inside the on_merge fanout still aways on the same on_merge gates.

Finally this also puts in sync the setup of on_merge after what we added at https://github.com/elastic/kibana/pull/252200

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->