### PR TITLE
[Agent Builder] Fix user resolution for task manager execution

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/users.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/users.ts
@@ -6,6 +6,8 @@
  */
 
 export interface UserIdAndName {
-  id: string;
+  /** profile UUID */
+  id?: string;
+  /** username */
   username: string;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
@@ -57,8 +57,13 @@ export const createClient = async ({
   toolsService: ToolsServiceStart;
   logger: Logger;
 }): Promise<AgentClient> => {
-  const user = getUserFromRequest(request, security);
-  const esClient = elasticsearch.client.asScoped(request).asInternalUser;
+  const scopedClient = elasticsearch.client.asScoped(request);
+  const user = await getUserFromRequest({
+    request,
+    security,
+    esClient: scopedClient.asCurrentUser,
+  });
+  const esClient = scopedClient.asInternalUser;
   const storage = createStorage({ logger, esClient });
 
   return new AgentClientImpl({ storage, user, request, space, toolsService });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -87,9 +87,7 @@ class ConversationClientImpl implements ConversationClient {
           filter: [createSpaceDslFilter(this.space)],
           must: [
             {
-              term: this.user.username
-                ? { user_name: this.user.username }
-                : { user_id: this.user.id },
+              term: { user_name: this.user.username },
             },
             ...(agentId ? [{ term: { agent_id: agentId } }] : []),
           ],
@@ -212,7 +210,8 @@ const hasAccess = ({
   conversation: Pick<Document, '_source'>;
   user: UserIdAndName;
 }) => {
-  return (
-    conversation._source!.user_id === user.id || conversation._source!.user_name === user.username
-  );
+  if (user.id && conversation._source!.user_id === user.id) {
+    return true;
+  }
+  return conversation._source!.user_name === user.username;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
@@ -34,7 +34,7 @@ const storageSettings = {
 } satisfies IndexStorageSettings;
 
 export interface ConversationProperties {
-  user_id: string;
+  user_id?: string;
   user_name: string;
   agent_id: string;
   space: string;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.ts
@@ -42,8 +42,13 @@ export class ConversationServiceImpl implements ConversationService {
   }
 
   async getScopedClient({ request }: { request: KibanaRequest }): Promise<ConversationClient> {
-    const user = getUserFromRequest(request, this.security);
-    const esClient = this.elasticsearch.client.asScoped(request).asInternalUser;
+    const scopedClient = this.elasticsearch.client.asScoped(request);
+    const user = await getUserFromRequest({
+      request,
+      security: this.security,
+      esClient: scopedClient.asCurrentUser,
+    });
+    const esClient = scopedClient.asInternalUser;
     const space = getCurrentSpaceId({ request, spaces: this.spaces });
 
     return createClient({ user, esClient, logger: this.logger, space });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  httpServerMock,
+  securityServiceMock,
+  elasticsearchServiceMock,
+} from '@kbn/core/server/mocks';
+import { getUserFromRequest } from './utils';
+
+describe('getUserFromRequest', () => {
+  let security: ReturnType<typeof securityServiceMock.createStart>;
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  beforeEach(() => {
+    security = securityServiceMock.createStart();
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+  });
+
+  it('returns user id and username from a real request when getCurrentUser succeeds', async () => {
+    const request = httpServerMock.createKibanaRequest();
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'testuser',
+      profile_uid: 'profile-123',
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({ id: 'profile-123', username: 'testuser' });
+    expect(security.authc.getCurrentUser).toHaveBeenCalledWith(request);
+    expect(esClient.security.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ES authenticate API when getCurrentUser returns null for a real request', async () => {
+    const request = httpServerMock.createKibanaRequest();
+
+    security.authc.getCurrentUser.mockReturnValue(null);
+    esClient.security.authenticate.mockResolvedValue({
+      username: 'api-key-user',
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({ username: 'api-key-user' });
+    expect(security.authc.getCurrentUser).toHaveBeenCalledWith(request);
+    expect(esClient.security.authenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips getCurrentUser and falls back to ES authenticate API for fake requests', async () => {
+    const request = httpServerMock.createFakeKibanaRequest({});
+
+    esClient.security.authenticate.mockResolvedValue({
+      username: 'task-manager-user',
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({ username: 'task-manager-user' });
+    expect(security.authc.getCurrentUser).not.toHaveBeenCalled();
+    expect(esClient.security.authenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not include id in the result when falling back to ES authenticate', async () => {
+    const request = httpServerMock.createFakeKibanaRequest({});
+
+    esClient.security.authenticate.mockResolvedValue({
+      username: 'some-user',
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).not.toHaveProperty('id');
+    expect(result.username).toBe('some-user');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
@@ -5,13 +5,38 @@
  * 2.0.
  */
 
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SecurityServiceStart } from '@kbn/core-security-server';
+import type { UserIdAndName } from '@kbn/agent-builder-common';
 
-export const getUserFromRequest = (request: KibanaRequest, security: SecurityServiceStart) => {
-  const authUser = security.authc.getCurrentUser(request);
-  const user = authUser
-    ? { id: authUser.profile_uid!, username: authUser.username }
-    : { id: 'anonymous', username: 'anonymous' };
-  return user;
+/**
+ * Resolves the current user from a request.
+ *
+ * For real HTTP requests, `security.authc.getCurrentUser` returns the authenticated user
+ * (including profile_uid and username).
+ *
+ * For fake requests (e.g. from Task Manager using an API key), `getCurrentUser` returns null.
+ * In that case, we fall back to the ES `_security/_authenticate` API, which works with API keys
+ * and returns the username of the API key owner.
+ */
+export const getUserFromRequest = async ({
+  request,
+  security,
+  esClient,
+}: {
+  request: KibanaRequest;
+  security: SecurityServiceStart;
+  esClient: ElasticsearchClient;
+}): Promise<UserIdAndName> => {
+  if (!request.isFakeRequest) {
+    const authUser = security.authc.getCurrentUser(request);
+    if (authUser) {
+      return { id: authUser.profile_uid!, username: authUser.username };
+    }
+  }
+
+  // Fallback for fake requests (e.g. Task Manager execution): call ES _security/_authenticate
+  const authResponse = await esClient.security.authenticate();
+  return { username: authResponse.username };
 };


### PR DESCRIPTION
## Summary

Extracted from https://github.com/elastic/kibana/pull/252615

Fix a bug which was causing conversations created with a fake request (e.g. execution via task manager - from workflows) to be assigned to the "anonymous" user. Those are now properly assigned to the user the fake request's apiKey belongs to.

