### PR TITLE
[9.2] chore(NA): adds on_merge_fanout (#252775)

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -58,6 +58,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: quick_checks
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -75,6 +76,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: checks
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -92,6 +94,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: linting
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -109,6 +112,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: linting_with_types
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -126,6 +130,7 @@ steps:
       preemptible: true
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
+    key: check_types
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -141,13 +146,12 @@ steps:
       machineType: n2-standard-4
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
+    key: check_oas_snapshot
     timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'
           limit: 3
-
-  - wait
 
   - command: .buildkite/scripts/steps/on_merge_api_docs.sh
     label: Check Public API Docs
@@ -197,7 +201,9 @@ steps:
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
+      JEST_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
+      FTR_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
     retry:
       automatic:
         - exit_status: '*'
@@ -209,260 +215,31 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-4
+      machineType: n2d-standard-8
       diskSizeGb: 105
     key: build_scout_tests
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     depends_on:
       - build
     env:
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:
       automatic:
         - exit_status: '*'
           limit: 1
 
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
-    label: 'Rule Management - Security Solution Cypress Tests'
+  - label: 'Upload on-merge fanout'
+    command: buildkite-agent pipeline upload .buildkite/pipelines/on_merge_fanout.yml
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 4
+      machineType: n2-standard-2
+    timeout_in_minutes: 10
     retry:
       automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
-    label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
-    label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
-    label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
-    label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
-    label: 'Detection Engine - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 5
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
-    label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 3
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
-    label: 'AI Assistant - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 1
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
-    label: 'Entity Analytics - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
-    label: 'Explore - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 3
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
-    label: 'Investigations - Security Solution Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 8
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
-    label: 'Osquery Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 60
-    parallelism: 8
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/defend_workflows.sh
-    label: 'Defend Workflows Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      enableNestedVirtualization: true
-      machineType: n2-standard-4
-      diskSizeGb: 105
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 75
-    parallelism: 20
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/profiling_cypress.sh
-    label: 'Profiling Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      diskSizeGb: 105
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 75
-    parallelism: 3
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/apm_cypress.sh
-    label: 'APM Cypress Tests'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-4
-      preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
-    timeout_in_minutes: 120
-    parallelism: 3
-    retry:
-      automatic:
-        - exit_status: '-1'
+        - exit_status: '*'
           limit: 1
 
   - command: '.buildkite/scripts/steps/functional/on_merge_unsupported_ftrs.sh'
@@ -473,6 +250,14 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
 
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
     label: 'Build Storybooks'
@@ -484,6 +269,14 @@ steps:
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     key: storybooks
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 80
     retry:
       automatic:
@@ -499,6 +292,14 @@ steps:
       machineType: n2-standard-2
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 60
     soft_fail: true
     retry:
@@ -516,6 +317,14 @@ steps:
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     artifact_paths: 'target/plugin_so_types_snapshot.json'
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 30
     retry:
       automatic:

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -1,0 +1,267 @@
+x-on-merge-gates: &on_merge_gates
+- build
+- quick_checks
+- checks
+- linting
+- linting_with_types
+- check_oas_snapshot
+- check_types
+
+steps:
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
+    label: 'Rule Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 4
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
+    label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
+    label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
+    label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
+    label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
+    label: 'Detection Engine - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 5
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
+    label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
+    label: 'AI Assistant - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
+    label: 'Entity Analytics - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
+    label: 'Explore - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
+    label: 'Investigations - Security Solution Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
+    label: 'Osquery Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/defend_workflows.sh
+    label: 'Defend Workflows Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      enableNestedVirtualization: true
+      machineType: n2-standard-4
+      diskSizeGb: 105
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 20
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/profiling_cypress.sh
+    label: 'Profiling Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      diskSizeGb: 105
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/apm_cypress.sh
+    label: 'APM Cypress Tests'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    timeout_in_minutes: 60
+    depends_on: *on_merge_gates
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1

--- a/.buildkite/pipelines/pull_request/apm_cypress.yml
+++ b/.buildkite/pipelines/pull_request/apm_cypress.yml
@@ -13,7 +13,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     parallelism: 3
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -32,7 +32,6 @@ steps:
 
   - command: .buildkite/scripts/steps/checks.sh
     label: 'Checks'
-    key: checks
     agents:
       machineType: c4d-standard-2
       diskType: hyperdisk-balanced
@@ -40,6 +39,7 @@ steps:
       spotZones: us-central1-c,us-central1-a
       diskSizeGb: 105
     timeout_in_minutes: 60
+    key: checks
     retry:
       automatic:
         - exit_status: '-1'
@@ -123,13 +123,13 @@ steps:
   - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
-      machineType: c3d-standard-8
+      machineType: n2d-standard-8
     key: build_scout_tests
     timeout_in_minutes: 20
     depends_on:
       - build
     env:
-      SCOUT_CONFIGS_DEPS: 'quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types,build_scout_tests'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:
       automatic:
@@ -159,11 +159,12 @@ steps:
     key: build_api_docs
     depends_on:
       - build
-      - check_types
+      - quick_checks
+      - checks
       - linting
       - linting_with_types
-      - quick_checks
       - check_oas_snapshot
+      - check_types
     timeout_in_minutes: 90
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -13,7 +13,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     parallelism: 11
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -13,7 +13,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -14,7 +14,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 75
+    timeout_in_minutes: 60
     soft_fail: true
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -15,7 +15,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 75
+    timeout_in_minutes: 60
     parallelism: 20
     retry:
       automatic:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [chore(NA): adds on_merge_fanout (#252775)](https://github.com/elastic/kibana/pull/252775)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2026-02-12T03:39:42Z","message":"chore(NA): adds on_merge_fanout (#252775)\n\nCloses https://github.com/elastic/kibana-operations/issues/416\n\nThis PR creates an `on_merge_fanout` pipeline to simplify the setup and\nread of the main on_merge pipeline itself. For now everything aside from\ncore jobs and dynamic pickup jobs for FTR and Scout goes into that file.\n\nI've made sure we are using an early upload to the fanout pipeline so\ntiming should be the same while anything inside the on_merge fanout\nstill aways on the same on_merge gates.\n\nFinally this also puts in sync the setup of on_merge after what we added\nat https://github.com/elastic/kibana/pull/252200\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9c57120bf579cac2fab52c218c1698c3b20be501","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v9.4.0"],"title":"chore(NA): adds on_merge_fanout","number":252775,"url":"https://github.com/elastic/kibana/pull/252775","mergeCommit":{"message":"chore(NA): adds on_merge_fanout (#252775)\n\nCloses https://github.com/elastic/kibana-operations/issues/416\n\nThis PR creates an `on_merge_fanout` pipeline to simplify the setup and\nread of the main on_merge pipeline itself. For now everything aside from\ncore jobs and dynamic pickup jobs for FTR and Scout goes into that file.\n\nI've made sure we are using an early upload to the fanout pipeline so\ntiming should be the same while anything inside the on_merge fanout\nstill aways on the same on_merge gates.\n\nFinally this also puts in sync the setup of on_merge after what we added\nat https://github.com/elastic/kibana/pull/252200\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9c57120bf579cac2fab52c218c1698c3b20be501"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252775","number":252775,"mergeCommit":{"message":"chore(NA): adds on_merge_fanout (#252775)\n\nCloses https://github.com/elastic/kibana-operations/issues/416\n\nThis PR creates an `on_merge_fanout` pipeline to simplify the setup and\nread of the main on_merge pipeline itself. For now everything aside from\ncore jobs and dynamic pickup jobs for FTR and Scout goes into that file.\n\nI've made sure we are using an early upload to the fanout pipeline so\ntiming should be the same while anything inside the on_merge fanout\nstill aways on the same on_merge gates.\n\nFinally this also puts in sync the setup of on_merge after what we added\nat https://github.com/elastic/kibana/pull/252200\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9c57120bf579cac2fab52c218c1698c3b20be501"}},{"url":"https://github.com/elastic/kibana/pull/252790","number":252790,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->