### PR TITLE
[Monaco] Adds some missing imports

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/monaco_imports.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/monaco_imports.ts
@@ -38,6 +38,13 @@ import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController'; // Nee
 import 'monaco-editor/esm/vs/editor/standalone/browser/inspectTokens/inspectTokens.js'; // Needed for inspect tokens functionality
 import 'monaco-editor/esm/vs/editor/contrib/contextmenu/browser/contextmenu.js'; // Needed for enabling custom Monaco context menu
 
+// Register services required by contributions that may be loaded elsewhere (e.g. editor.all).
+// Without these, CodeLensContribution, InlayHintsController, and DropIntoEditorController
+// fail with "depends on UNKNOWN service" when StandaloneServices.initialize() already ran.
+import 'monaco-editor/esm/vs/editor/contrib/codelens/browser/codeLensCache.js';
+import 'monaco-editor/esm/vs/editor/contrib/inlayHints/browser/inlayHintsController.js';
+import 'monaco-editor/esm/vs/editor/common/services/treeViewsDndService.js';
+
 import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
 import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution.js'; // Needed for basic javascript support
 import 'monaco-editor/esm/vs/basic-languages/xml/xml.contribution.js'; // Needed for basic xml support


### PR DESCRIPTION
## Summary

Lately I was seeing console errors in Discover when moving from Classic to ES|QL and back.


![meow](https://github.com/user-attachments/assets/5a318426-6855-4d91-90f5-c3ad33d3388b)


I added some missing imports and I dont see the error anymore but the shared ux team needs to evaluate this solution
