### PR TITLE
[Agent Builder] Fix create new tool page when switching types

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/esql/esql_params.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/esql/esql_params.tsx
@@ -164,7 +164,7 @@ export const EsqlParams = () => {
   });
 
   const hasArrayType = useMemo(() => {
-    return params.some((param) => param.type === EsqlToolFieldType.ARRAY);
+    return params?.some((param) => param.type === EsqlToolFieldType.ARRAY);
   }, [params]);
 
   const handleAppend = useCallback(

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/esql/esql_params.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/esql/esql_params.tsx
@@ -34,6 +34,7 @@ import { useEsqlParamsValidation } from '../../hooks/use_esql_params_validation'
 import { i18nMessages } from '../../i18n';
 import type { EsqlParamFormData } from '../../types/tool_form_types';
 import { EsqlParamSource, type EsqlToolFormData } from '../../types/tool_form_types';
+import { ESQL_DEFAULT_PARAMS } from '../../registry/tool_types/esql';
 import { EsqlParamRow } from './esql_param_row';
 
 interface EsqlParamActionsProps {
@@ -143,7 +144,10 @@ const EsqlParamsLayout = ({ actions, fields }: EsqlParamsLayoutProps) => {
 
 export const EsqlParams = () => {
   const { euiTheme } = useEuiTheme();
-  const { control } = useFormContext<EsqlToolFormData>();
+  const { control } = useFormContext<
+    // params is undefined for one render loop after type changes
+    Omit<EsqlToolFormData, 'params'> & { params?: EsqlParamFormData[] }
+  >();
   const {
     services: { docLinks },
   } = useKibana();
@@ -158,13 +162,14 @@ export const EsqlParams = () => {
     name: 'params',
   });
 
-  const params = useWatch({
-    control,
-    name: 'params',
-  });
+  const params =
+    useWatch({
+      control,
+      name: 'params',
+    }) ?? ESQL_DEFAULT_PARAMS;
 
   const hasArrayType = useMemo(() => {
-    return params?.some((param) => param.type === EsqlToolFieldType.ARRAY);
+    return params.some((param) => param.type === EsqlToolFieldType.ARRAY);
   }, [params]);
 
   const handleAppend = useCallback(

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/registry/tool_types/esql.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/registry/tool_types/esql.tsx
@@ -21,8 +21,10 @@ import { esqlFormValidationSchema } from '../../validation/esql_tool_form_valida
 import { zodResolver } from '../../../../../utils/zod_resolver';
 import { i18nMessages } from '../../i18n';
 import type { ToolTypeRegistryEntry } from '../common';
-import type { EsqlToolFormData } from '../../types/tool_form_types';
+import type { EsqlParamFormData, EsqlToolFormData } from '../../types/tool_form_types';
 import { commonToolFormDefaultValues } from '../common';
+
+export const ESQL_DEFAULT_PARAMS: EsqlParamFormData[] = [];
 
 export const esqlToolFormRegistryEntry: ToolTypeRegistryEntry<EsqlToolFormData> = {
   label: i18nMessages.configuration.form.type.esqlOption,
@@ -30,7 +32,7 @@ export const esqlToolFormRegistryEntry: ToolTypeRegistryEntry<EsqlToolFormData> 
   defaultValues: {
     ...commonToolFormDefaultValues,
     esql: '',
-    params: [],
+    params: ESQL_DEFAULT_PARAMS,
     type: ToolType.esql,
   },
   toolToFormData: (tool: ToolDefinitionWithSchema) => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
@@ -34,7 +34,7 @@ export interface BaseToolFormData {
 export interface EsqlToolFormData extends BaseToolFormData {
   type: ToolType.esql;
   esql: string;
-  params: EsqlParamFormData[] | undefined;
+  params: EsqlParamFormData[];
 }
 
 export interface BuiltinToolFormData extends BaseToolFormData {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/types/tool_form_types.ts
@@ -34,7 +34,7 @@ export interface BaseToolFormData {
 export interface EsqlToolFormData extends BaseToolFormData {
   type: ToolType.esql;
   esql: string;
-  params: EsqlParamFormData[];
+  params: EsqlParamFormData[] | undefined;
 }
 
 export interface BuiltinToolFormData extends BaseToolFormData {


### PR DESCRIPTION
## Summary

Fix create new tool page when switching types. This PR is a quick fix with no side effect.

<img width="1744" height="142" alt="image (3)" src="https://github.com/user-attachments/assets/da5941ef-24b8-4b3e-b744-96d32e5d41ec" />
<img width="1068" height="162" alt="Screenshot 2026-02-12 at 10 42 08" src="https://github.com/user-attachments/assets/a043f4b1-1a89-48d2-a979-cdcae943d14f" />


Te bug happen because param is undefined but it should never be undefined.
It gets undefined because of this code: 
<img width="566" height="267" alt="Screenshot 2026-02-12 at 14 39 44" src="https://github.com/user-attachments/assets/faa25674-c389-491f-89d4-67e7a7cc0f2d" />

https://github.com/machadoum/kibana/blob/8fe561de2db3b3afa4528306d7c2704703b63708/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/tool.tsx#L196C4-L207


It updated the tools default values but it does it on a followup react render call. Which means that for a simple react render call a tool type is executed with the default values of another tool type. That can cause several issues and we should fix the problem at the core.
This [draft PR](https://github.com/elastic/kibana/pull/252864) has a long term fix proposal, but that would require much time to get merged.







