### PR TITLE
[9.3] Streams: gate Advanced enterprise panels behind enabled && available

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic_advanced_view.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic_advanced_view.test.tsx
@@ -36,7 +36,9 @@ jest.mock('./unmanaged_elasticsearch_assets', () => ({
 jest.mock('../../../hooks/use_streams_privileges');
 import { useStreamsPrivileges } from '../../../hooks/use_streams_privileges';
 
-const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<typeof useStreamsPrivileges>;
+const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<
+  typeof useStreamsPrivileges
+>;
 
 const mockRefreshDefinition = jest.fn();
 
@@ -58,7 +60,10 @@ describe('Classic advanced view gating', () => {
     } as any);
 
     renderWithI18n(
-      <ClassicStreamDetailManagement definition={definition} refreshDefinition={mockRefreshDefinition} />
+      <ClassicStreamDetailManagement
+        definition={definition}
+        refreshDefinition={mockRefreshDefinition}
+      />
     );
 
     expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
@@ -76,7 +81,10 @@ describe('Classic advanced view gating', () => {
     } as any);
 
     renderWithI18n(
-      <ClassicStreamDetailManagement definition={definition} refreshDefinition={mockRefreshDefinition} />
+      <ClassicStreamDetailManagement
+        definition={definition}
+        refreshDefinition={mockRefreshDefinition}
+      />
     );
 
     expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
@@ -94,11 +102,13 @@ describe('Classic advanced view gating', () => {
     } as any);
 
     renderWithI18n(
-      <ClassicStreamDetailManagement definition={definition} refreshDefinition={mockRefreshDefinition} />
+      <ClassicStreamDetailManagement
+        definition={definition}
+        refreshDefinition={mockRefreshDefinition}
+      />
     );
 
     expect(screen.getByTestId('streamDescriptionPanel')).toBeInTheDocument();
     expect(screen.getByTestId('unmanagedAssetsPanel')).toBeInTheDocument();
   });
 });
-

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic_advanced_view.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/classic_advanced_view.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { ClassicStreamDetailManagement } from './classic';
+import { createMockClassicStreamDefinition } from '../shared/mocks';
+
+jest.mock('../../../hooks/use_streams_app_params', () => ({
+  useStreamsAppParams: () => ({
+    path: { key: 'logs.classic-test', tab: 'advanced' },
+  }),
+}));
+
+jest.mock('../../../hooks/use_ai_features', () => ({
+  useAIFeatures: () => ({}),
+}));
+
+jest.mock('./wrapper', () => ({
+  Wrapper: ({ tabs, tab }: any) => <div>{tabs[tab]?.content}</div>,
+}));
+
+jest.mock('../../stream_detail_features/stream_description', () => ({
+  StreamDescription: () => <div data-test-subj="streamDescriptionPanel" />,
+}));
+
+jest.mock('./unmanaged_elasticsearch_assets', () => ({
+  UnmanagedElasticsearchAssets: () => <div data-test-subj="unmanagedAssetsPanel" />,
+}));
+
+jest.mock('../../../hooks/use_streams_privileges');
+import { useStreamsPrivileges } from '../../../hooks/use_streams_privileges';
+
+const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<typeof useStreamsPrivileges>;
+
+const mockRefreshDefinition = jest.fn();
+
+describe('Classic advanced view gating', () => {
+  const definition = createMockClassicStreamDefinition();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides StreamDescription in Advanced tab when enabled=true and available=false', () => {
+    mockUseStreamsPrivileges.mockReturnValue({
+      isLoading: false,
+      features: {
+        attachments: { enabled: false },
+        groupStreams: { enabled: false },
+        significantEvents: { enabled: true, available: false },
+      },
+    } as any);
+
+    renderWithI18n(
+      <ClassicStreamDetailManagement definition={definition} refreshDefinition={mockRefreshDefinition} />
+    );
+
+    expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('unmanagedAssetsPanel')).toBeInTheDocument();
+  });
+
+  it('hides StreamDescription in Advanced tab when enabled=true and available=undefined', () => {
+    mockUseStreamsPrivileges.mockReturnValue({
+      isLoading: false,
+      features: {
+        attachments: { enabled: false },
+        groupStreams: { enabled: false },
+        significantEvents: { enabled: true },
+      },
+    } as any);
+
+    renderWithI18n(
+      <ClassicStreamDetailManagement definition={definition} refreshDefinition={mockRefreshDefinition} />
+    );
+
+    expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('unmanagedAssetsPanel')).toBeInTheDocument();
+  });
+
+  it('shows StreamDescription in Advanced tab when enabled=true and available=true', () => {
+    mockUseStreamsPrivileges.mockReturnValue({
+      isLoading: false,
+      features: {
+        attachments: { enabled: false },
+        groupStreams: { enabled: false },
+        significantEvents: { enabled: true, available: true },
+      },
+    } as any);
+
+    renderWithI18n(
+      <ClassicStreamDetailManagement definition={definition} refreshDefinition={mockRefreshDefinition} />
+    );
+
+    expect(screen.getByTestId('streamDescriptionPanel')).toBeInTheDocument();
+    expect(screen.getByTestId('unmanagedAssetsPanel')).toBeInTheDocument();
+  });
+});
+

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/unmanaged_elasticsearch_assets.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/unmanaged_elasticsearch_assets.tsx
@@ -133,7 +133,7 @@ export function UnmanagedElasticsearchAssets({
     <>
       <EuiFlexGroup direction="column" gutterSize="l">
         <EuiFlexItem>
-          {significantEvents?.enabled && (
+          {significantEvents?.enabled && significantEvents?.available && (
             <StreamFeatureConfiguration definition={definition.stream} aiFeatures={aiFeatures} />
           )}
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/use_streams_detail_management_tabs.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/use_streams_detail_management_tabs.tsx
@@ -24,7 +24,7 @@ export function useStreamsDetailManagementTabs({
     isLoading,
   } = useStreamsPrivileges();
 
-  const isSignificantEventsEnabled = !!significantEvents?.enabled;
+  const isSignificantEventsEnabled = Boolean(significantEvents?.enabled && significantEvents?.available);
 
   return {
     isLoading,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/use_streams_detail_management_tabs.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/use_streams_detail_management_tabs.tsx
@@ -24,7 +24,9 @@ export function useStreamsDetailManagementTabs({
     isLoading,
   } = useStreamsPrivileges();
 
-  const isSignificantEventsEnabled = Boolean(significantEvents?.enabled && significantEvents?.available);
+  const isSignificantEventsEnabled = Boolean(
+    significantEvents?.enabled && significantEvents?.available
+  );
 
   return {
     isLoading,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { WiredAdvancedView } from './wired_advanced_view';
+import { createMockWiredStreamDefinition } from '../shared/mocks';
+
+jest.mock('@kbn/ebt-tools', () => ({
+  usePerformanceContext: () => ({ onPageReady: jest.fn() }),
+}));
+
+jest.mock('../../../hooks/use_ai_features', () => ({
+  useAIFeatures: () => ({}),
+}));
+
+jest.mock('../../../hooks/use_streams_privileges');
+import { useStreamsPrivileges } from '../../../hooks/use_streams_privileges';
+
+jest.mock('../../stream_detail_features/stream_description', () => ({
+  StreamDescription: () => <div data-test-subj="streamDescriptionPanel" />,
+}));
+
+jest.mock('../../stream_detail_features/stream_feature_configuration', () => ({
+  StreamFeatureConfiguration: () => <div data-test-subj="streamFeatureConfigurationPanel" />,
+}));
+
+jest.mock('./advanced_view/index_configuration', () => ({
+  IndexConfiguration: ({ children }: { children?: React.ReactNode }) => (
+    <div data-test-subj="indexConfigurationPanel">{children}</div>
+  ),
+}));
+
+jest.mock('./advanced_view/import_export', () => ({
+  ImportExportPanel: () => <div data-test-subj="importExportPanel" />,
+}));
+
+jest.mock('./advanced_view/delete_stream', () => ({
+  DeleteStreamPanel: () => <div data-test-subj="deleteStreamPanel" />,
+}));
+
+const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<typeof useStreamsPrivileges>;
+
+const mockRefreshDefinition = jest.fn();
+
+describe('WiredAdvancedView', () => {
+  const definition = createMockWiredStreamDefinition();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides significant events enterprise panels when enabled=true and available=false', () => {
+    mockUseStreamsPrivileges.mockReturnValue({
+      features: {
+        contentPacks: { enabled: false },
+        significantEvents: { enabled: true, available: false },
+      },
+    } as any);
+
+    renderWithI18n(<WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />);
+
+    expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('streamFeatureConfigurationPanel')).not.toBeInTheDocument();
+  });
+
+  it('hides significant events enterprise panels when enabled=true and available=undefined', () => {
+    mockUseStreamsPrivileges.mockReturnValue({
+      features: {
+        contentPacks: { enabled: false },
+        significantEvents: { enabled: true },
+      },
+    } as any);
+
+    renderWithI18n(<WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />);
+
+    expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('streamFeatureConfigurationPanel')).not.toBeInTheDocument();
+  });
+
+  it('shows significant events enterprise panels when enabled=true and available=true', () => {
+    mockUseStreamsPrivileges.mockReturnValue({
+      features: {
+        contentPacks: { enabled: false },
+        significantEvents: { enabled: true, available: true },
+      },
+    } as any);
+
+    renderWithI18n(<WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />);
+
+    expect(screen.getByTestId('streamDescriptionPanel')).toBeInTheDocument();
+    expect(screen.getByTestId('streamFeatureConfigurationPanel')).toBeInTheDocument();
+  });
+});
+

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.test.tsx
@@ -44,7 +44,9 @@ jest.mock('./advanced_view/delete_stream', () => ({
   DeleteStreamPanel: () => <div data-test-subj="deleteStreamPanel" />,
 }));
 
-const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<typeof useStreamsPrivileges>;
+const mockUseStreamsPrivileges = useStreamsPrivileges as jest.MockedFunction<
+  typeof useStreamsPrivileges
+>;
 
 const mockRefreshDefinition = jest.fn();
 
@@ -63,7 +65,9 @@ describe('WiredAdvancedView', () => {
       },
     } as any);
 
-    renderWithI18n(<WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />);
+    renderWithI18n(
+      <WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />
+    );
 
     expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
     expect(screen.queryByTestId('streamFeatureConfigurationPanel')).not.toBeInTheDocument();
@@ -77,7 +81,9 @@ describe('WiredAdvancedView', () => {
       },
     } as any);
 
-    renderWithI18n(<WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />);
+    renderWithI18n(
+      <WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />
+    );
 
     expect(screen.queryByTestId('streamDescriptionPanel')).not.toBeInTheDocument();
     expect(screen.queryByTestId('streamFeatureConfigurationPanel')).not.toBeInTheDocument();
@@ -91,10 +97,11 @@ describe('WiredAdvancedView', () => {
       },
     } as any);
 
-    renderWithI18n(<WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />);
+    renderWithI18n(
+      <WiredAdvancedView definition={definition} refreshDefinition={mockRefreshDefinition} />
+    );
 
     expect(screen.getByTestId('streamDescriptionPanel')).toBeInTheDocument();
     expect(screen.getByTestId('streamFeatureConfigurationPanel')).toBeInTheDocument();
   });
 });
-

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.tsx
@@ -31,12 +31,13 @@ export function WiredAdvancedView({
     features: { contentPacks, significantEvents },
   } = useStreamsPrivileges();
   const aiFeatures = useAIFeatures();
+  const isSignificantEventsEnabled = Boolean(significantEvents?.enabled && significantEvents?.available);
 
   const { onPageReady } = usePerformanceContext();
 
   // Telemetry for TTFMP (time to first meaningful paint)
   useEffect(() => {
-    if (definition && !contentPacks?.enabled && !significantEvents?.enabled) {
+    if (definition && !contentPacks?.enabled && !isSignificantEventsEnabled) {
       const streamType = getStreamTypeFromDefinition(definition.stream);
       onPageReady({
         meta: {
@@ -44,7 +45,7 @@ export function WiredAdvancedView({
         },
       });
     }
-  }, [definition, contentPacks?.enabled, significantEvents?.enabled, onPageReady]);
+  }, [definition, contentPacks?.enabled, isSignificantEventsEnabled, onPageReady]);
 
   return (
     <>
@@ -55,7 +56,7 @@ export function WiredAdvancedView({
         </>
       )}
 
-      {significantEvents?.enabled && (
+      {isSignificantEventsEnabled && (
         <>
           <StreamDescription
             definition={definition}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wired_advanced_view.tsx
@@ -31,7 +31,9 @@ export function WiredAdvancedView({
     features: { contentPacks, significantEvents },
   } = useStreamsPrivileges();
   const aiFeatures = useAIFeatures();
-  const isSignificantEventsEnabled = Boolean(significantEvents?.enabled && significantEvents?.available);
+  const isSignificantEventsEnabled = Boolean(
+    significantEvents?.enabled && significantEvents?.available
+  );
 
   const { onPageReady } = usePerformanceContext();
 

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
@@ -115,4 +115,3 @@ test.describe('Advanced tab with basic license', { tag: ['@ess'] }, () => {
     await expect(page.getByRole('heading', { name: 'Delete stream' })).toBeVisible();
   });
 });
-

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { test } from '../../../fixtures';
+import { generateLogsData } from '../../../fixtures/generators';
+
+const CLASSIC_STREAM = 'logs-classic-license-test';
+const WIRED_STREAM = 'logs';
+
+/**
+ * Tests that verify enterprise-only features are hidden on the Advanced tab
+ * when the user has a basic license.
+ *
+ * Related issue: https://github.com/elastic/kibana/issues/251524
+ * The StreamDescription and StreamFeatureConfiguration components should not
+ * render when the license doesn't support significant events features.
+ */
+test.describe('Advanced tab with basic license', { tag: ['@ess'] }, () => {
+  test.beforeAll(async ({ logsSynthtraceEsClient }) => {
+    // Generate logs to create a classic stream
+    await generateLogsData(logsSynthtraceEsClient)({ index: CLASSIC_STREAM });
+  });
+
+  test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+    await apiServices.streams.deleteStream(CLASSIC_STREAM);
+    await logsSynthtraceEsClient.clean();
+  });
+
+  test('should NOT show enterprise features on wired stream Advanced tab with basic license', async ({
+    browserAuth,
+    pageObjects,
+    page,
+  }) => {
+    // Mock the licensing API to return a basic license
+    await page.route('**/api/licensing/info', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          license: {
+            uid: 'basic-license-test',
+            type: 'basic',
+            mode: 'basic',
+            expiryDateInMillis: 4884310543000,
+            status: 'active',
+          },
+          signature: 'basic-license-signature',
+        }),
+      })
+    );
+
+    await browserAuth.loginAsAdmin();
+    await pageObjects.streams.gotoAdvancedTab(WIRED_STREAM);
+
+    // Verify the Advanced tab is visible
+    await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible();
+
+    // Verify enterprise-only components are NOT rendered
+    // StreamDescription panel should be hidden
+    await expect(page.getByText('Stream description')).toBeHidden();
+
+    // StreamFeatureConfiguration panel should be hidden
+    await expect(page.getByText('Feature identification')).toBeHidden();
+
+    // Verify basic components ARE still visible
+    // Index Configuration should be visible for wired streams
+    await expect(page.getByText('Index Configuration')).toBeVisible();
+  });
+
+  test('should NOT show enterprise features on classic stream Advanced tab with basic license', async ({
+    browserAuth,
+    pageObjects,
+    page,
+  }) => {
+    // Mock the licensing API to return a basic license
+    await page.route('**/api/licensing/info', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          license: {
+            uid: 'basic-license-test',
+            type: 'basic',
+            mode: 'basic',
+            expiryDateInMillis: 4884310543000,
+            status: 'active',
+          },
+          signature: 'basic-license-signature',
+        }),
+      })
+    );
+
+    await browserAuth.loginAsAdmin();
+    await pageObjects.streams.gotoAdvancedTab(CLASSIC_STREAM);
+
+    // Verify the Advanced tab is visible
+    await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible();
+    // Verify we're on the classic stream
+    await pageObjects.streams.verifyClassicBadge();
+
+    // Verify enterprise-only components are NOT rendered
+    // StreamDescription panel should be hidden
+    await expect(page.getByText('Stream description')).toBeHidden();
+
+    // StreamFeatureConfiguration panel should be hidden
+    await expect(page.getByText('Feature identification')).toBeHidden();
+
+    // Verify basic components ARE still visible
+    // Delete stream panel should be visible for classic streams
+    await expect(page.getByRole('heading', { name: 'Delete stream' })).toBeVisible();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Manual backport of elastic/kibana#251541 to `9.3`.
- Gate enterprise-only Advanced tab panels behind `significantEvents.enabled && significantEvents.available` in both wired and classic Advanced views.
- Add unit + Scout UI coverage for basic license hiding enterprise panels.

## Test plan
- [x] `node scripts/scout.js run-tests --stateful --testFiles x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts`

Refs: elastic/kibana#251541, https://github.com/elastic/kibana/pull/251541#issuecomment-3889691513

Made with [Cursor](https://cursor.com)