### PR TITLE
[OneWorkflow] Add datemath support to KQL evaluator

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/moon.extend.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.extend.yml
@@ -1,0 +1,2 @@
+dependsOn: 
+  - '@kbn/datemath'

--- a/src/platform/plugins/shared/workflows_execution_engine/moon.extend.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.extend.yml
@@ -1,2 +1,17 @@
-dependsOn: 
+dependsOn:
+  - '@kbn/core'
+  - '@kbn/config-schema'
+  - '@kbn/actions-plugin'
+  - '@kbn/workflows'
+  - '@kbn/task-manager-plugin'
+  - '@kbn/es-query'
+  - '@kbn/core-elasticsearch-server'
+  - '@kbn/cloud-plugin'
   - '@kbn/datemath'
+  - '@kbn/utility-types'
+  - '@kbn/zod'
+  - '@kbn/core-data-streams-server'
+  - '@kbn/data-streams'
+  - '@kbn/es-mappings'
+  - '@kbn/workflows-extensions'
+  - '@kbn/licensing-plugin'

--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -24,6 +24,7 @@ dependsOn:
   - '@kbn/workflows'
   - '@kbn/task-manager-plugin'
   - '@kbn/es-query'
+  - '@kbn/datemath'
   - '@kbn/core-elasticsearch-server'
   - '@kbn/cloud-plugin'
   - '@kbn/utility-types'

--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -18,7 +18,7 @@ project:
   metadata:
     sourceRoot: src/platform/plugins/shared/workflows_execution_engine
 dependsOn:
-  - '@kbn/core'
+  - '@kbn/datemath'
   - '@kbn/config-schema'
   - '@kbn/actions-plugin'
   - '@kbn/workflows'

--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -18,15 +18,15 @@ project:
   metadata:
     sourceRoot: src/platform/plugins/shared/workflows_execution_engine
 dependsOn:
-  - '@kbn/datemath'
+  - '@kbn/core'
   - '@kbn/config-schema'
   - '@kbn/actions-plugin'
   - '@kbn/workflows'
   - '@kbn/task-manager-plugin'
   - '@kbn/es-query'
-  - '@kbn/datemath'
   - '@kbn/core-elasticsearch-server'
   - '@kbn/cloud-plugin'
+  - '@kbn/datemath'
   - '@kbn/utility-types'
   - '@kbn/zod'
   - '@kbn/core-data-streams-server'

--- a/src/platform/plugins/shared/workflows_execution_engine/server/utils/eval_kql/eval_kql.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/utils/eval_kql/eval_kql.ts
@@ -10,6 +10,7 @@
 // TODO: Remove eslint exceptions comments and fix the issues
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import dateMath from '@kbn/datemath';
 import type { KueryNode } from '@kbn/es-query';
 import { fromKueryExpression } from '@kbn/es-query';
 import type {
@@ -133,8 +134,16 @@ function convertLiteralToValue(
   expectedType: 'string' | 'number' | 'boolean'
 ): any {
   switch (expectedType) {
-    case 'string':
-      return String(node.value);
+    case 'string': {
+      const strValue = String(node.value);
+      const parsed = dateMath.parse(strValue);
+      if (parsed?.isValid()) {
+        // it's a date math expression, return the resolved ISO string
+        return parsed.toISOString();
+      }
+
+      return strValue;
+    }
     case 'number':
       return parseFloat(node.value as string);
     case 'boolean':

--- a/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
@@ -19,6 +19,7 @@
     "@kbn/workflows",
     "@kbn/task-manager-plugin",
     "@kbn/es-query",
+    "@kbn/datemath",
     "@kbn/core-elasticsearch-server",
     "@kbn/cloud-plugin",
     "@kbn/utility-types",


### PR DESCRIPTION
## Summary

- Adds datemath expression support (e.g. `now`, `now-1d`, `now-7d/d`, `2025-01-01T00:00:00.000Z||+1d`) to the KQL evaluator used by the workflows execution engine
- When a KQL literal value is a valid datemath expression, it is resolved to an ISO date string before comparison, enabling time-relative filtering in workflow conditions
- Adds comprehensive unit tests covering datemath in "is" expressions, range expressions, rounding, anchor syntax, and fallback behavior for non-datemath strings

## Screenshot

<img width="1488" height="472" alt="Screenshot 2026-02-12 at 12 12 31" src="https://github.com/user-attachments/assets/b71fe08c-169c-46f3-880b-045cf403fd2b" />

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->