### PR TITLE
[Security Solution] automatic troubleshooting skill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3022,6 +3022,7 @@ x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insight
 /x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/pages/osquery_automated_response_actions.tsx @elastic/security-defend-workflows
 /x-pack/solutions/security/packages/test-api-clients/supertest/endpoint_management.gen.ts @elastic/security-defend-workflows
 /x-pack/solutions/security/packages/test-api-clients/supertest/osquery.gen.ts @elastic/security-defend-workflows
+/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting @elastic/security-defend-workflows
 
 ## Security Solution sub teams - security-telemetry (Data Engineering)
 x-pack/solutions/security/plugins/security_solution/server/usage/ @elastic/security-data-analytics

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/type_definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/type_definition.ts
@@ -34,6 +34,7 @@ export type SkillsDirectoryStructure = Directory<{
         rules: FileDirectory;
       }>;
       entities: FileDirectory<{}>;
+      endpoint: FileDirectory<{}>;
     }>;
     search: FileDirectory<{}>;
   }>;

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/defend_insights/common_attributes.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/defend_insights/common_attributes.gen.ts
@@ -44,8 +44,8 @@ export const DefendInsightEvent = z.object({
 export type DefendInsightType = z.infer<typeof DefendInsightType>;
 export const DefendInsightType = z.enum([
   'incompatible_antivirus',
-  'noisy_process_tree',
   'policy_response_failure',
+  'custom',
 ]);
 export type DefendInsightTypeEnum = typeof DefendInsightType.enum;
 export const DefendInsightTypeEnum = DefendInsightType.enum;

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/defend_insights/common_attributes.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/defend_insights/common_attributes.schema.yaml
@@ -29,8 +29,8 @@ components:
       type: string
       enum:
         - incompatible_antivirus
-        - noisy_process_tree
         - policy_response_failure
+        - custom
 
     DefendInsight:
       type: object

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/raw_defend_insights.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/__mocks__/raw_defend_insights.ts
@@ -74,7 +74,7 @@ export const getParsedDefendInsightsMock = (timestamp: string): EsDefendInsightS
       model: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
     },
     endpoint_ids: ['b557bb12-8206-44b6-b2a5-dbcce5b1e65e'],
-    insight_type: DefendInsightType.Enum.noisy_process_tree,
+    insight_type: DefendInsightType.Enum.incompatible_antivirus,
     insights: [
       {
         group: 'linux_security',

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -225,6 +225,11 @@ export const allowedExperimentalValues = Object.freeze({
    * Enables Rule Health UI
    */
   ruleHealthUIEnabled: false,
+
+  /**
+   * Enables the Automatic Troubleshooting Agent Builder skill
+   */
+  automaticTroubleshootingSkill: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/data_sources.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/data_sources.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Available indices for automatic troubleshooting
+ */
+interface AvailableIndexMetadata {
+  pattern: string;
+  description: string;
+}
+
+export const AVAILABLE_INDICES: AvailableIndexMetadata[] = [
+  {
+    pattern: 'metrics-endpoint.metadata-*',
+    description: 'Raw Elastic Defend metadata documents',
+  },
+  {
+    pattern: 'metrics-endpoint.metadata_current_*',
+    description: 'Latest Elastic Defend metadata document for each endpoint',
+  },
+  {
+    pattern: '.fleet-agents*',
+    description: 'Fleet agent documents containing agent and policy information',
+  },
+  {
+    pattern: '.metrics-endpoint.metadata_united_*',
+    description:
+      'Unified Elastic Defend metadata + fleet agent documents. Contains documents sourced from "metrics-endpoint.metadata_current_*" and ".fleet-agents*" indices. Used as the source of truth for many Elastic Defend pages in Kibana including the endpoint list page.',
+  },
+  {
+    pattern: 'logs-elastic_agent.endpoint_security-*',
+    description: 'Elastic Defend integration logs',
+  },
+  {
+    pattern: 'metrics-endpoint.policy-*',
+    description:
+      'Elastic Defend policy responses containing warnings and errors for policy responses',
+  },
+  {
+    pattern: 'logs-endpoint.events.file-*',
+    description: 'Elastic Defend file event activity',
+  },
+  {
+    pattern: 'logs-endpoint.events.network-*',
+    description: 'Elastic Defend network event activity',
+  },
+  {
+    pattern: 'logs-endpoint.events.process-*',
+    description: 'Elastic Defend process event activity',
+  },
+  {
+    pattern: 'logs-endpoint.events.library-*',
+    description: 'Elastic Defend library event activity',
+  },
+  {
+    pattern: 'logs-endpoint.events.registry-*',
+    description: 'Elastic Defend registry event activity',
+  },
+  {
+    pattern: 'logs-endpoint.events.security-*',
+    description: 'Elastic Defend security event activity',
+  },
+  {
+    pattern: 'logs-endpoint.events.device-*',
+    description: 'Elastic Defend device event activity',
+  },
+  {
+    pattern: 'logs-endpoint.events.api-*',
+    description: 'Elastic Defend api event activity',
+  },
+  {
+    pattern: 'logs-endpoint.alerts-*',
+    description: 'Elastic Defend alerts',
+  },
+  {
+    pattern: 'metrics-endpoint.metrics-*',
+    description: 'Elastic Defend metrics',
+  },
+  {
+    pattern: '.logs-endpoint.actions-*',
+    description: 'Elastic Defend actions',
+  },
+  {
+    pattern: '.logs-endpoint.action.responses-*',
+    description: 'Elastic Defend action responses',
+  },
+];

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools } from '@kbn/agent-builder-common';
+
+import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import { createMockEndpointAppContext } from '../../../endpoint/mocks';
+import { createAutomaticTroubleshootingSkill } from '.';
+
+describe('createAutomaticTroubleshootingSkill', () => {
+  let mockEndpointAppContextService: EndpointAppContextService;
+
+  beforeEach(() => {
+    mockEndpointAppContextService = createMockEndpointAppContext().service;
+  });
+
+  describe('skill definition', () => {
+    it('returns a valid skill definition', () => {
+      const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
+
+      expect(skill).toBeDefined();
+      expect(skill.id).toBe('automatic_troubleshooting');
+      expect(skill.name).toBe('elastic_defend_configuration_troubleshooting');
+      expect(skill.basePath).toBe('skills/security/endpoint');
+      expect(skill.description).toContain(
+        'Troubleshoot Elastic Defend endpoint configuration issues'
+      );
+      expect(skill.content).toContain('Elastic Defend Configuration Troubleshooting');
+    });
+
+    it('includes available indices in referenced content', () => {
+      const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
+
+      expect(skill.referencedContent).toBeDefined();
+      expect(skill.referencedContent).toHaveLength(1);
+      expect(skill.referencedContent![0].name).toBe('available_indices');
+      expect(skill.referencedContent![0].relativePath).toBe('.');
+      expect(skill.referencedContent![0].content).toContain('metrics-endpoint.metadata');
+    });
+
+    it('includes system instructions in content', () => {
+      const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
+
+      expect(skill.content).toContain('Elastic Defend Configuration Troubleshooting');
+      expect(skill.content).toContain('When to use this skill');
+      expect(skill.content).toContain('Available Indices');
+      expect(skill.content).toContain('Troubleshooting Tools');
+      expect(skill.content).toContain('Troubleshooting Approach');
+      expect(skill.content).toContain('Constraints');
+    });
+  });
+
+  describe('getAllowedTools', () => {
+    it('returns the correct platform core tools', () => {
+      const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
+
+      const allowedTools = skill.getAllowedTools?.();
+
+      expect(allowedTools).toBeDefined();
+      expect(allowedTools).toHaveLength(3);
+      expect(allowedTools).toContain(platformCoreTools.search);
+      expect(allowedTools).toContain(platformCoreTools.getDocumentById);
+      expect(allowedTools).toContain(platformCoreTools.integrationKnowledge);
+    });
+  });
+
+  describe('getInlineTools', () => {
+    it('returns two inline tools', () => {
+      const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
+
+      const inlineTools = skill.getInlineTools?.();
+
+      expect(inlineTools).toBeDefined();
+      expect(inlineTools).toHaveLength(2);
+    });
+
+    it('includes get_package_configurations tool', async () => {
+      const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
+
+      const inlineTools = await skill.getInlineTools?.();
+
+      const getPackageConfigTool = inlineTools?.find((tool) =>
+        tool.id.includes('get_package_configurations')
+      );
+
+      expect(getPackageConfigTool).toBeDefined();
+      expect(getPackageConfigTool?.description).toContain('Fetches Elastic Defend package');
+    });
+
+    it('includes generate_insight tool', async () => {
+      const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
+
+      const inlineTools = await skill.getInlineTools?.();
+
+      const generateInsightTool = inlineTools?.find((tool) => tool.id.includes('generate_insight'));
+
+      expect(generateInsightTool).toBeDefined();
+      expect(generateInsightTool?.description).toContain('Generate and store structured');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SkillDefinition } from '@kbn/agent-builder-server/skills';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { platformCoreTools } from '@kbn/agent-builder-common';
+
+import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import { getPackageConfigurationsTool, generateInsightTool } from './tools';
+import { AVAILABLE_INDICES } from './data_sources';
+
+const ID = 'automatic_troubleshooting';
+const NAME = 'elastic_defend_configuration_troubleshooting';
+const BASE_PATH = 'skills/security/endpoint';
+function toolName(name: string) {
+  return `${ID}.${name}`;
+}
+export const GET_PACKAGE_CONFIGURATIONS_TOOL_ID = toolName('get_package_configurations');
+export const GENERATE_INSIGHT_TOOL_ID = toolName('generate_insight');
+
+export const createAutomaticTroubleshootingSkill = (
+  endpointAppContextService: EndpointAppContextService
+): SkillDefinition<typeof NAME, typeof BASE_PATH> => {
+  const systemInstructions = `# Elastic Defend Configuration Troubleshooting
+
+This skill provides guidance for diagnosing and resolving Elastic Defend configuration issues on endpoints.
+
+## When to use this skill
+
+Use this skill when:
+- When a user is having issues with Elastic Defend configuration on one or more endpoints.
+
+## Available Indices
+
+Reference './available_indices' for the list of indices available for troubleshooting queries. Only query indices listed there.
+
+## Troubleshooting Tools
+
+- **${platformCoreTools.integrationKnowledge}** - Retrieve Elastic Defend knowledge base context to inform the analysis
+- **${platformCoreTools.search}** - Query raw data from available indices for troubleshooting evidence
+- **${platformCoreTools.getDocumentById}** - Retrieve full document content by ID from query results
+- **${GET_PACKAGE_CONFIGURATIONS_TOOL_ID}** - Inspect Elastic Defend package configuration details
+- **${GENERATE_INSIGHT_TOOL_ID}** - Persist structured troubleshooting findings (mandatory final step)
+
+## Troubleshooting Approach
+
+1. **Gather context** - Use ${platformCoreTools.integrationKnowledge} to retrieve relevant Elastic Defend knowledge that informs the analysis approach.
+2. **Investigate data** - Use ${platformCoreTools.search} to query relevant indices for evidence of errors, warnings, misconfigurations, or incompatibilities. Use ${platformCoreTools.getDocumentById} to retrieve full documents when needed. Use ${GET_PACKAGE_CONFIGURATIONS_TOOL_ID} to inspect Elastic Defend package configuration if relevant.
+3. **Iterate** - Continue querying and gathering context until the root cause or relevant findings are understood.
+4. **Persist findings** - Call ${GENERATE_INSIGHT_TOOL_ID} with a clear problem description, actionable remediation steps, affected endpoint IDs, and relevant raw documents.
+
+## Constraints
+
+- Only query indices listed in './available_indices.md'
+- Always include document \`_id\` and \`_index\` fields in search queries
+- Keep query result sets small enough to fit within context limits
+- Base all conclusions on actual queried data, not assumptions
+- **Always call ${GENERATE_INSIGHT_TOOL_ID}** to persist findings — this is mandatory and must not be skipped`;
+
+  return defineSkillType({
+    id: ID,
+    name: NAME,
+    basePath: BASE_PATH,
+    description: 'Troubleshoot Elastic Defend endpoint configuration issues',
+    content: systemInstructions,
+    referencedContent: [
+      {
+        relativePath: '.',
+        name: 'available_indices',
+        content: JSON.stringify(AVAILABLE_INDICES, null, 2),
+      },
+    ],
+    getAllowedTools: () => [
+      platformCoreTools.search,
+      platformCoreTools.getDocumentById,
+      platformCoreTools.integrationKnowledge,
+    ],
+    getInlineTools: () => {
+      return [getPackageConfigurationsTool(endpointAppContextService), generateInsightTool()];
+    },
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/graph.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/graph.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScopedModel, ToolHandlerResult } from '@kbn/agent-builder-server';
+import type { DefendInsights } from '@kbn/elastic-assistant-common';
+import { StateGraph, Annotation } from '@langchain/langgraph';
+import { z } from '@kbn/zod';
+import { ToolResultType } from '@kbn/agent-builder-common/tools';
+import { DefendInsightType } from '@kbn/elastic-assistant-common';
+
+import { securityWorkflowInsightsService } from '../../../../../endpoint/services';
+import { getDefendInsightsOutputSchema } from './schemas';
+import { getPrompts } from './prompts';
+
+const CATEGORIZE_INSIGHT_TYPE_NODE_NAME = 'categorizeInsightType';
+const GENERATE_INSIGHT_NODE_NAME = 'generateInsights';
+const CREATE_WORKFLOW_INSIGHTS_NODE_NAME = 'createWorkflowInsights';
+
+const StateAnnotation = Annotation.Root({
+  insightType: Annotation<DefendInsightType>(),
+  insights: Annotation<DefendInsights>(),
+  error: Annotation<string>(),
+  results: Annotation<ToolHandlerResult[]>({
+    reducer: (a, b) => [...a, ...b],
+    default: () => [],
+  }),
+});
+
+export type StateType = typeof StateAnnotation.State;
+
+export const createGenerateInsightGraph = ({
+  model,
+  problemDescription,
+  remediation,
+  endpointIds,
+  data,
+}: {
+  model: ScopedModel;
+  problemDescription: string;
+  remediation: string;
+  endpointIds: string[];
+  data: unknown[];
+}) => {
+  async function categorizeInsightType(): Promise<{ insightType: DefendInsightType }> {
+    const output = await model.chatModel.withStructuredOutput(
+      z.object({ insightType: DefendInsightType.default(DefendInsightType.Enum.custom) })
+    ).invoke(`
+Categorize the following problem description into one of the following Defend Insight Types: ${DefendInsightType}. If no good match exists, use 'custom'.
+
+## Problem Description:
+${problemDescription}
+    `);
+    return { insightType: output.insightType || DefendInsightType.Enum.custom };
+  }
+
+  async function generateInsights({ insightType }: StateType): Promise<{
+    insights: DefendInsights;
+  }> {
+    const { insights } = await model.chatModel.withStructuredOutput(
+      getDefendInsightsOutputSchema({ type: insightType })
+    ).invoke(`
+${getPrompts(insightType).DEFAULT}
+
+## Problem Description:
+${problemDescription}
+
+## Remediation:
+${remediation}
+
+## Endpoint IDs:
+${endpointIds.join(', ')}
+
+## Data:
+${JSON.stringify(data, null, 2)}
+
+Provide a concise and actionable insight for each group of events that can help address the problem described.
+    `);
+
+    return {
+      insights: insights.filter((insight) => insight.events && insight.events.length),
+    };
+  }
+
+  async function createWorkflowInsights({ insights, insightType }: StateType) {
+    if (insights.length === 0) {
+      return {
+        results: [],
+      };
+    }
+
+    const workflowInsights = await securityWorkflowInsightsService.createFromDefendInsights(
+      insights,
+      endpointIds,
+      insightType,
+      model.connector.connectorId,
+      model.chatModel.name
+    );
+
+    const results: ToolHandlerResult[] = [
+      {
+        type: ToolResultType.other,
+        data: {
+          workflowInsights,
+        },
+      },
+    ];
+
+    return { results };
+  }
+
+  return new StateGraph(StateAnnotation)
+    .addNode(CATEGORIZE_INSIGHT_TYPE_NODE_NAME, categorizeInsightType)
+    .addNode(GENERATE_INSIGHT_NODE_NAME, generateInsights)
+    .addNode(CREATE_WORKFLOW_INSIGHTS_NODE_NAME, createWorkflowInsights)
+    .addEdge('__start__', CATEGORIZE_INSIGHT_TYPE_NODE_NAME)
+    .addEdge(CATEGORIZE_INSIGHT_TYPE_NODE_NAME, GENERATE_INSIGHT_NODE_NAME)
+    .addEdge(GENERATE_INSIGHT_NODE_NAME, CREATE_WORKFLOW_INSIGHTS_NODE_NAME)
+    .addEdge(CREATE_WORKFLOW_INSIGHTS_NODE_NAME, '__end__')
+    .compile();
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.test.ts
@@ -1,0 +1,429 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolHandlerContext } from '@kbn/agent-builder-server/tools';
+import type { ScopedModel } from '@kbn/agent-builder-server';
+import type { InferenceChatModel } from '@kbn/inference-langchain';
+import type { InferenceConnector, BoundInferenceClient } from '@kbn/inference-common';
+import { InferenceConnectorType } from '@kbn/inference-common';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools';
+
+import { GENERATE_INSIGHT_TOOL_ID } from '../..';
+import { createGenerateInsightGraph } from './graph';
+import { generateInsightTool } from '.';
+
+jest.mock('./graph');
+
+const mockCreateGenerateInsightGraph = createGenerateInsightGraph as jest.Mock;
+
+describe('automaticTroubleshootingGenerateInsightTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('tool definition', () => {
+    it('returns a valid builtin tool definition', () => {
+      const tool = generateInsightTool();
+
+      expect(tool).toBeDefined();
+      expect(tool.type).toBe(ToolType.builtin);
+      expect(tool.id).toBe(GENERATE_INSIGHT_TOOL_ID);
+      expect(tool.description).toContain(
+        'Generate and store structured Automatic Troubleshooting insights.'
+      );
+    });
+
+    it('has correct tool id format', () => {
+      expect(GENERATE_INSIGHT_TOOL_ID).toBe('automatic_troubleshooting.generate_insight');
+    });
+  });
+
+  describe('schema validation', () => {
+    const tool = generateInsightTool();
+
+    it('validates correct schema with all required fields', () => {
+      const validInput = {
+        problemDescription: 'test problem description',
+        remediation: 'solve the thing',
+        endpointIds: ['endpoint-1', 'endpoint-2'],
+        data: [{ field1: 'value1' }, { field2: 'value2' }],
+      };
+
+      const result = tool.schema.safeParse(validInput);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.problemDescription).toBe(validInput.problemDescription);
+        expect(result.data.endpointIds).toEqual(validInput.endpointIds);
+        expect(result.data.data).toEqual(validInput.data);
+      }
+    });
+
+    it('accepts data with catchall unknown fields', () => {
+      const validInput = {
+        problemDescription: 'Test problem',
+        remediation: 'solve the thing',
+        endpointIds: ['endpoint-1'],
+        data: [
+          { anyField: 'anyValue', nested: { deep: { object: true } } },
+          { different: 123, array: [1, 2, 3] },
+        ],
+      };
+
+      const result = tool.schema.safeParse(validInput);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing problemDescription', () => {
+      const invalidInput = {
+        endpointIds: ['endpoint-1'],
+        data: [{ test: 'data' }],
+      };
+
+      const result = tool.schema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('reject empty problemDescription', () => {
+      const validInput = {
+        problemDescription: '',
+        remediation: 'solve the thing',
+        endpointIds: ['endpoint-1'],
+        data: [{ test: 'data' }],
+      };
+      const result = tool.schema.safeParse(validInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing remediation', () => {
+      const invalidInput = {
+        problemDescription: 'test problem',
+        endpointIds: ['endpoint-1'],
+        data: [{ test: 'data' }],
+      };
+
+      const result = tool.schema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('reject empty remediation', () => {
+      const validInput = {
+        problemDescription: 'test problem',
+        remediation: '',
+        endpointIds: ['endpoint-1'],
+        data: [{ test: 'data' }],
+      };
+      const result = tool.schema.safeParse(validInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing endpointIds', () => {
+      const invalidInput = {
+        problemDescription: 'test problem',
+        remediation: 'solve the thing',
+        data: [{ test: 'data' }],
+      };
+
+      const result = tool.schema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty endpointIds array', () => {
+      const invalidInput = {
+        problemDescription: 'test problem',
+        remediation: 'solve the thing',
+        endpointIds: [],
+        data: [{ test: 'data' }],
+      };
+
+      const result = tool.schema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-array endpointIds', () => {
+      const invalidInput = {
+        problemDescription: 'test problem',
+        remediation: 'solve the thing',
+        endpointIds: 'not-an-array',
+        data: [{ test: 'data' }],
+      };
+
+      const result = tool.schema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing data', () => {
+      const invalidInput = {
+        problemDescription: 'Test problem',
+        remediation: 'solve the thing',
+        endpointIds: ['endpoint-1'],
+      };
+
+      const result = tool.schema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty data array', () => {
+      const validInput = {
+        problemDescription: 'Test problem',
+        remediation: 'solve the thing',
+        endpointIds: ['endpoint-1'],
+        data: [],
+      };
+
+      const result = tool.schema.safeParse(validInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-array data', () => {
+      const invalidInput = {
+        problemDescription: 'Test problem',
+        remediation: 'solve the thing',
+        endpointIds: ['endpoint-1'],
+        data: 'not-an-array',
+      };
+
+      const result = tool.schema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('handler', () => {
+    const tool = generateInsightTool();
+    let mockModelProvider: ToolHandlerContext['modelProvider'];
+    let mockModel: ScopedModel;
+    let mockGraph: { invoke: jest.Mock };
+
+    beforeEach(() => {
+      mockGraph = {
+        invoke: jest.fn(),
+      };
+
+      mockModel = {
+        chatModel: {} as InferenceChatModel,
+        connector: {
+          connectorId: 'test-connector-id',
+          type: InferenceConnectorType.OpenAI,
+          name: 'test-connector',
+          config: {},
+          capabilities: {},
+        } as InferenceConnector,
+        inferenceClient: {} as BoundInferenceClient,
+      } as ScopedModel;
+
+      mockModelProvider = {
+        getDefaultModel: jest.fn().mockResolvedValue(mockModel),
+      } as unknown as ToolHandlerContext['modelProvider'];
+
+      mockCreateGenerateInsightGraph.mockReturnValue(mockGraph);
+    });
+
+    it('successfully generates insights when data is provided', async () => {
+      const mockResults = [
+        {
+          type: ToolResultType.other,
+          data: { workflowInsights: ['insight-1', 'insight-2'] },
+        },
+      ];
+
+      mockGraph.invoke.mockResolvedValue({ results: mockResults });
+
+      const inputData = [{ event: { type: 'process' } }, { event: { type: 'network' } }];
+
+      const result = await tool.handler(
+        {
+          problemDescription: 'configuration issue detected',
+          remediation: 'fix the thing',
+          endpointIds: ['endpoint-1', 'endpoint-2'],
+          data: inputData,
+        },
+        { modelProvider: mockModelProvider } as ToolHandlerContext
+      );
+
+      expect(mockModelProvider.getDefaultModel).toHaveBeenCalledTimes(1);
+      expect(mockCreateGenerateInsightGraph).toHaveBeenCalledWith({
+        model: mockModel,
+        problemDescription: 'configuration issue detected',
+        remediation: 'fix the thing',
+        endpointIds: ['endpoint-1', 'endpoint-2'],
+        data: inputData,
+      });
+      expect(mockGraph.invoke).toHaveBeenCalledWith({});
+      expect(result).toEqual({ results: mockResults });
+    });
+
+    it('handles graph returning empty results', async () => {
+      mockGraph.invoke.mockResolvedValue({ results: [] });
+
+      const result = await tool.handler(
+        {
+          problemDescription: 'test problem',
+          remediation: 'fix the thing',
+          endpointIds: ['endpoint-1'],
+          data: [{ test: 'data' }],
+        },
+        { modelProvider: mockModelProvider } as ToolHandlerContext
+      );
+
+      expect(result).toEqual({ results: [] });
+    });
+
+    it('handles graph returning multiple results', async () => {
+      const mockResults = [
+        {
+          type: ToolResultType.other,
+          data: { workflowInsights: ['insight-1'] },
+        },
+        {
+          type: ToolResultType.other,
+          data: { workflowInsights: ['insight-2'] },
+        },
+        {
+          type: ToolResultType.other,
+          data: { workflowInsights: ['insight-3'] },
+        },
+      ];
+
+      mockGraph.invoke.mockResolvedValue({ results: mockResults });
+
+      const result = await tool.handler(
+        {
+          problemDescription: 'multiple issues',
+          remediation: 'fix the things',
+          endpointIds: ['endpoint-1', 'endpoint-2', 'endpoint-3'],
+          data: [{ issue: 1 }, { issue: 2 }, { issue: 3 }],
+        },
+        { modelProvider: mockModelProvider } as ToolHandlerContext
+      );
+
+      if ('results' in result) {
+        expect(result.results).toHaveLength(3);
+        expect(result).toEqual({ results: mockResults });
+      }
+    });
+
+    it('works with nested data structures', async () => {
+      const mockResults = [
+        {
+          type: ToolResultType.other,
+          data: { workflowInsights: ['insight-1'] },
+        },
+      ];
+
+      mockGraph.invoke.mockResolvedValue({ results: mockResults });
+
+      const data = [
+        {
+          event: {
+            type: 'process',
+            action: 'start',
+            process: {
+              name: 'test.exe',
+              args: ['--config', 'test.conf'],
+              parent: {
+                process: {
+                  name: 'parent.exe',
+                },
+              },
+            },
+          },
+          agent: {
+            id: 'agent-1',
+            version: '9.4.0',
+          },
+        },
+      ];
+
+      await tool.handler(
+        {
+          problemDescription: 'solve me',
+          remediation: 'fix the thing',
+          endpointIds: ['endpoint-1'],
+          data,
+        },
+        { modelProvider: mockModelProvider } as ToolHandlerContext
+      );
+
+      expect(mockCreateGenerateInsightGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data,
+        })
+      );
+    });
+
+    it('handles multiple endpoint ids', async () => {
+      const mockResults = [
+        {
+          type: ToolResultType.other,
+          data: { workflowInsights: ['insight-1'] },
+        },
+      ];
+
+      mockGraph.invoke.mockResolvedValue({ results: mockResults });
+
+      const endpointIds = ['endpoint-1', 'endpoint-2', 'endpoint-3', 'endpoint-4', 'endpoint-5'];
+
+      await tool.handler(
+        {
+          problemDescription: 'multi-endpoint issue',
+          remediation: 'fix the things',
+          endpointIds,
+          data: [{ test: 'data' }],
+        },
+        { modelProvider: mockModelProvider } as ToolHandlerContext
+      );
+
+      expect(mockCreateGenerateInsightGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpointIds,
+        })
+      );
+    });
+
+    it('properly invokes graph with empty object', async () => {
+      mockGraph.invoke.mockResolvedValue({ results: [] });
+
+      await tool.handler(
+        {
+          problemDescription: 'test',
+          remediation: 'fix the thing',
+          endpointIds: ['endpoint-1'],
+          data: [{ test: 'data' }],
+        },
+        { modelProvider: mockModelProvider } as ToolHandlerContext
+      );
+
+      expect(mockGraph.invoke).toHaveBeenCalledWith({});
+      expect(mockGraph.invoke).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('tool metadata', () => {
+    const tool = generateInsightTool();
+
+    it('has appropriate description for when to use the tool', () => {
+      expect(tool.description).toContain('When to use:');
+      expect(tool.description).toContain('When a conclusion has been reached');
+    });
+
+    it('describes that the tool must be called', () => {
+      expect(tool.description).toContain('This tool MUST ALWAYS be called.');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/index.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
+import { ToolResultType, ToolType } from '@kbn/agent-builder-common';
+import { z } from '@kbn/zod';
+
+import { GENERATE_INSIGHT_TOOL_ID } from '../..';
+import { createGenerateInsightGraph } from './graph';
+
+const generateInsightSchema = z.object({
+  problemDescription: z
+    .string()
+    .min(1)
+    .describe('A brief description of the original problem being diagnosed.'),
+  remediation: z.string().min(1).describe('A detailed guide for how to remediate the problem.'),
+  endpointIds: z.array(z.string()).min(1).describe('Related endpoint IDs'),
+  data: z
+    .array(z.object({}).catchall(z.unknown()))
+    .min(1)
+    .describe('Relevant raw unedited documents.'),
+});
+
+export const generateInsightTool = (): BuiltinSkillBoundedTool => {
+  return {
+    id: GENERATE_INSIGHT_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Generate and store structured Automatic Troubleshooting insights.
+
+This tool MUST ALWAYS be called.
+
+This tool creates structured insights for persisting the results of the troubleshooting session.
+
+**When to use:**
+- When a conclusion has been reached`,
+    schema: generateInsightSchema,
+    handler: async (
+      { problemDescription, remediation, endpointIds, data },
+      { modelProvider, logger }
+    ) => {
+      if (!data || data.length === 0) {
+        return {
+          results: [],
+        };
+      }
+
+      try {
+        const model = await modelProvider.getDefaultModel();
+        const graph = createGenerateInsightGraph({
+          model,
+          problemDescription,
+          remediation,
+          endpointIds,
+          data,
+        });
+        const outState = await graph.invoke({});
+
+        return { results: outState.results };
+      } catch (error) {
+        logger.error(`Error in ${GENERATE_INSIGHT_TOOL_ID} tool: ${error.message}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Error: ${error.message}`,
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/prompts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/prompts.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DefendInsightType } from '@kbn/elastic-assistant-common';
+
+export function getPrompts(insightType: DefendInsightType) {
+  switch (insightType) {
+    case DefendInsightType.Enum.policy_response_failure:
+      return PROMPTS.POLICY_RESPONSE_FAILURE;
+    case DefendInsightType.Enum.incompatible_antivirus:
+      return PROMPTS.INCOMPATIBLE_ANTIVIRUS;
+    case DefendInsightType.Enum.custom:
+      return PROMPTS.CUSTOM;
+  }
+}
+
+const COMMON_PROMPT =
+  'You are a leading expert on resolving Elastic Defend configuration issues. You have just completed an analysis and are organizing the results. Organize the below data precisely according to the following rules:';
+
+const DEFEND_INSIGHTS_INCOMPATIBLE_ANTIVIRUS_PROMPT = `
+${COMMON_PROMPT}
+- keep only ongoing antivirus (e.g. Windows Defender, AVG, Avast, Malwarebytes, clamav, chkrootkit) related processes
+- keep processes that reside within the antivirus' main and nested filepaths (e.g., C:\\ProgramData\\Microsoft\\Windows Defender\\..., C:\\Program Files\\AVG\\..., C:\\Program Files\\Avast Software\\..., /Applications/AVGAntivirus.app/...)
+- ignore events that are from non-antivirus operating system processes (e.g. C:\\Windows\\System32\\...)
+- ignore events that are single run processes (e.g. installers)
+- ignore events that are from temp directories
+- ignore events that are from Elastic Agent or Elastic Defend
+- group the processes by the antivirus program, keeping track of the agent.id and _id associated to each of the individual events as endpointId and eventId respectively
+- if there are no events, ignore the group field
+- never make any changes to the original file paths
+- new lines must always be escaped with double backslashes, i.e. \\\\n to ensure valid JSON
+- only return JSON output, as described above
+- do not add any additional text to describe your output
+`;
+
+const DEFEND_INSIGHTS_POLICY_RESPONSE_FAILURE_PROMPT = `
+${COMMON_PROMPT}
+- group the policy responses by the policy response action name, message, and os (actions.name:::actions.message:::host.os.name)
+- keep track of the agent.id and _id associated to each of the individual events as endpointId and eventId respectively
+- suggest a remediation action to take for each policy response warning or failure, using the remediationMessage field
+- include a remediation link in the remediationLink field only if one is provided in the context
+- if there are no events, ignore the group field
+- new lines must always be escaped with double backslashes, i.e. \\\\n to ensure valid JSON
+- only return JSON output, as described above
+- do not add any additional text to describe your output
+`;
+
+const DEFEND_INSIGHTS_CUSTOM_PROMPT = `
+${COMMON_PROMPT}
+- group relevant events under a descriptive and unique group identifier
+- provide a clear and concise insight that addresses the problem description
+- suggest actionable recommendations to resolve the issue
+- new lines must always be escaped with double backslashes, i.e. \\\\n to ensure valid JSON
+- only return JSON output, as described above
+- do not add any additional text to describe your output
+`;
+
+export const PROMPTS = {
+  INCOMPATIBLE_ANTIVIRUS: {
+    DEFAULT: DEFEND_INSIGHTS_INCOMPATIBLE_ANTIVIRUS_PROMPT,
+    GROUP: 'The program which is triggering the file process events',
+    EVENTS: 'The file process events that the insight is based on',
+    EVENTS_ID: 'The file process event ID',
+    EVENTS_ENDPOINT_ID: 'The endpoint ID',
+    EVENTS_VALUE: 'The process.executable value of the file process event',
+  },
+  POLICY_RESPONSE_FAILURE: {
+    DEFAULT: DEFEND_INSIGHTS_POLICY_RESPONSE_FAILURE_PROMPT,
+    GROUP: 'The policy response action name + message + os',
+    EVENTS: 'The events that the insight is based on',
+    EVENTS_ID: 'The policy response ID',
+    EVENTS_ENDPOINT_ID: 'The endpoint ID',
+    EVENTS_VALUE: 'The actions.message value of the policy response',
+    REMEDIATION: 'The suggested remediation action to take for the policy response failure',
+    REMEDIATION_MESSAGE:
+      'The suggested remediation message to take for the policy response failure',
+    REMEDIATION_LINK: 'A link to documented remediation steps for the policy response failure',
+  },
+  CUSTOM: {
+    DEFAULT: DEFEND_INSIGHTS_CUSTOM_PROMPT,
+    GROUP: 'A descriptive and unique group identifier for the events',
+    EVENTS: 'The events that the insight is based on',
+    EVENTS_ID: 'The event ID',
+    EVENTS_ENDPOINT_ID: 'The endpoint ID',
+    EVENTS_VALUE: 'The value or details of the event',
+    REMEDIATION: 'The suggested remediation action to take',
+    REMEDIATION_MESSAGE: 'The suggested remediation message to take',
+  },
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/schemas.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/schemas.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { DefendInsightType } from '@kbn/elastic-assistant-common';
+
+import { PROMPTS } from './prompts';
+
+export function getDefendInsightsOutputSchema({ type }: { type: DefendInsightType }) {
+  switch (type) {
+    case DefendInsightType.Enum.incompatible_antivirus:
+      const antivirusPrompts = PROMPTS.INCOMPATIBLE_ANTIVIRUS;
+      return z.object({
+        insights: z.array(
+          z.object({
+            group: z.string().describe(antivirusPrompts.GROUP),
+            events: z
+              .object({
+                id: z.string().describe(antivirusPrompts.EVENTS_ID),
+                endpointId: z.string().describe(antivirusPrompts.EVENTS_ENDPOINT_ID),
+                value: z.string().describe(antivirusPrompts.EVENTS_VALUE),
+              })
+              .array()
+              .describe(antivirusPrompts.EVENTS),
+          })
+        ),
+      });
+    case DefendInsightType.Enum.policy_response_failure:
+      const policyResponsePrompts = PROMPTS.POLICY_RESPONSE_FAILURE;
+      return z.object({
+        insights: z.array(
+          z.object({
+            group: z.string().describe(policyResponsePrompts.GROUP),
+            events: z
+              .object({
+                id: z.string().describe(policyResponsePrompts.EVENTS_ID),
+                endpointId: z.string().describe(policyResponsePrompts.EVENTS_ENDPOINT_ID),
+                value: z.string().describe(policyResponsePrompts.EVENTS_VALUE),
+              })
+              .array()
+              .describe(policyResponsePrompts.EVENTS),
+            remediation: z
+              .object({
+                message: z.string().describe(policyResponsePrompts.REMEDIATION_MESSAGE ?? ''),
+                link: z.string().describe(policyResponsePrompts.REMEDIATION_LINK ?? ''),
+              })
+              .describe(policyResponsePrompts.REMEDIATION ?? ''),
+          })
+        ),
+      });
+    default:
+      const customPrompts = PROMPTS.CUSTOM;
+      return z.object({
+        insights: z.array(
+          z.object({
+            group: z.string().describe(customPrompts.GROUP),
+            events: z
+              .object({
+                id: z.string().describe(customPrompts.EVENTS_ID),
+                endpointId: z.string().describe(customPrompts.EVENTS_ENDPOINT_ID),
+                value: z.string().describe(customPrompts.EVENTS_VALUE),
+              })
+              .array()
+              .describe(customPrompts.EVENTS),
+            remediation: z
+              .object({
+                message: z.string().describe(customPrompts.REMEDIATION_MESSAGE ?? ''),
+              })
+              .describe(customPrompts.REMEDIATION ?? ''),
+          })
+        ),
+      });
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/get_package_configurations/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/get_package_configurations/index.test.ts
@@ -1,0 +1,648 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  TransformGetTransformResponse,
+  TransformGetTransformStatsResponse,
+  IndicesGetSettingsResponse,
+  IngestGetPipelineResponse,
+  CatNodesResponse,
+} from '@elastic/elasticsearch/lib/api/types';
+import type { ToolHandlerContext } from '@kbn/agent-builder-server/tools';
+import type { PackageClient } from '@kbn/fleet-plugin/server';
+import type { ScopedClusterClientMock } from '@kbn/core/server/mocks';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+
+import type { EndpointAppContextService } from '../../../../../endpoint/endpoint_app_context_services';
+import { createMockEndpointAppContext } from '../../../../../endpoint/mocks';
+import { GET_PACKAGE_CONFIGURATIONS_TOOL_ID } from '../..';
+import { getPackageConfigurationsTool } from '.';
+
+describe('automaticTroubleshootingGetPackageConfigurationsTool', () => {
+  let mockEndpointAppContextService: EndpointAppContextService;
+  let mockPackageClient: PackageClient;
+  let mockEsClient: ScopedClusterClientMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockEndpointAppContextService = createMockEndpointAppContext().service;
+    mockPackageClient = mockEndpointAppContextService.getInternalFleetServices().packages;
+    mockEsClient = elasticsearchServiceMock.createScopedClusterClient();
+  });
+
+  describe('tool definition', () => {
+    it('returns a valid builtin tool definition', () => {
+      const tool = getPackageConfigurationsTool(mockEndpointAppContextService);
+
+      expect(tool).toBeDefined();
+      expect(tool.type).toBe(ToolType.builtin);
+      expect(tool.id).toBe(GET_PACKAGE_CONFIGURATIONS_TOOL_ID);
+      expect(tool.description).toContain('Fetches Elastic Defend package configurations');
+    });
+
+    it('has correct tool id format', () => {
+      expect(GET_PACKAGE_CONFIGURATIONS_TOOL_ID).toBe(
+        'automatic_troubleshooting.get_package_configurations'
+      );
+    });
+  });
+
+  describe('handler', () => {
+    let tool: ReturnType<typeof getPackageConfigurationsTool>;
+
+    beforeEach(() => {
+      tool = getPackageConfigurationsTool(mockEndpointAppContextService);
+    });
+
+    it('fetches all package configurations when installation exists', async () => {
+      const mockInstallation = {
+        name: 'endpoint',
+        version: '9.4.0',
+        install_version: '9.4.0',
+        install_status: 'installed',
+        install_started_at: '2024-01-01T00:00:00.000Z',
+        install_source: 'registry',
+        verification_status: 'verified',
+        installed_kibana: [],
+        installed_es: [],
+        package_assets: [],
+        es_index_patterns: {},
+      } as Awaited<ReturnType<typeof mockPackageClient.getInstallation>>;
+
+      const transformConfig = {
+        _meta: { managed: true },
+        source: { index: 'metrics-endpoint.metadata*' },
+        dest: { index: 'metrics-endpoint.metadata_current' },
+        frequency: '5m',
+        sync: { time: { field: '@timestamp', delay: '60s' } },
+      };
+
+      const mockAssetsMap = new Map<string, Buffer>();
+      mockAssetsMap.set(
+        'endpoint-9.4.0/elasticsearch/transform/metadata_current/default.json',
+        Buffer.from(JSON.stringify(transformConfig))
+      );
+
+      const mockPackageData = {
+        assetsMap: mockAssetsMap,
+        paths: ['elasticsearch/transform/metadata_current/default.json'],
+        packageInfo: {
+          name: 'endpoint',
+          version: '9.4.0',
+          title: 'Elastic Defend',
+          description: 'Endpoint security package',
+        },
+      } as Awaited<ReturnType<typeof mockPackageClient.getPackage>>;
+
+      (
+        mockPackageClient as jest.Mocked<typeof mockPackageClient>
+      ).getInstallation.mockResolvedValue(mockInstallation);
+      (mockPackageClient as jest.Mocked<typeof mockPackageClient>).getPackage.mockResolvedValue(
+        mockPackageData
+      );
+
+      const mockTransformResponse: TransformGetTransformResponse = {
+        count: 1,
+        transforms: [
+          {
+            id: 'metrics-endpoint.metadata_current-default',
+            source: { index: ['metrics-endpoint.metadata*'] },
+            dest: { index: 'metrics-endpoint.metadata_current' },
+            frequency: '5m',
+            sync: { time: { field: '@timestamp', delay: '60s' } },
+            settings: {},
+            version: '9.4.0',
+            create_time: 1234567890,
+          },
+        ],
+      };
+
+      const mockTransformStatsResponse: TransformGetTransformStatsResponse = {
+        count: 1,
+        transforms: [
+          {
+            id: 'metrics-endpoint.metadata_current-default',
+            state: 'started',
+            stats: {
+              pages_processed: 100,
+              documents_processed: 1000,
+              documents_indexed: 1000,
+              trigger_count: 50,
+              index_time_in_ms: 500,
+              index_total: 1000,
+              index_failures: 0,
+              search_time_in_ms: 300,
+              search_total: 100,
+              search_failures: 0,
+              processing_time_in_ms: 200,
+              processing_total: 1000,
+              exponential_avg_checkpoint_duration_ms: 100,
+              exponential_avg_documents_indexed: 20,
+              exponential_avg_documents_processed: 20,
+            },
+            checkpointing: {
+              last: {
+                checkpoint: 1,
+                timestamp_millis: 1234567890,
+              },
+              changes_last_detected_at: 1234567890,
+            },
+          },
+        ],
+      };
+
+      const mockIndexSettings: IndicesGetSettingsResponse = {
+        'metrics-endpoint.metadata-default': {
+          settings: {
+            index: {
+              number_of_shards: '1',
+              number_of_replicas: '1',
+              refresh_interval: '5s',
+            },
+          },
+        },
+      };
+
+      const mockIngestPipelines: IngestGetPipelineResponse = {
+        'metrics-endpoint.metadata@custom': {
+          processors: [
+            {
+              set: {
+                field: 'event.ingested',
+                value: '{{_ingest.timestamp}}',
+              },
+            },
+          ],
+        },
+      };
+
+      const mockNodeStats: CatNodesResponse = [
+        {
+          ip: '127.0.0.1',
+          'heap.percent': '50',
+          'ram.percent': '60',
+          cpu: '10',
+          load_1m: '0.5',
+          load_5m: '0.4',
+          load_15m: '0.3',
+          'node.role': 'h',
+          master: '*',
+          name: 'node-1',
+        },
+      ];
+
+      mockEsClient.asCurrentUser.transform.getTransform.mockResolvedValue(mockTransformResponse);
+      mockEsClient.asCurrentUser.transform.getTransformStats.mockResolvedValue(
+        mockTransformStatsResponse
+      );
+      mockEsClient.asCurrentUser.indices.getSettings.mockResolvedValue(mockIndexSettings);
+      mockEsClient.asCurrentUser.ingest.getPipeline.mockResolvedValue(mockIngestPipelines);
+      mockEsClient.asCurrentUser.cat.nodes.mockResolvedValue(mockNodeStats);
+      const result = await tool.handler({}, {
+        esClient: mockEsClient,
+      } as unknown as ToolHandlerContext);
+
+      expect(mockPackageClient.getInstallation).toHaveBeenCalledWith('endpoint');
+      expect(mockPackageClient.getPackage).toHaveBeenCalledWith('endpoint', '9.4.0');
+      expect(mockEsClient.asCurrentUser.transform.getTransform).toHaveBeenCalledWith({
+        transform_id: 'endpoint.metadata_*',
+      });
+      expect(mockEsClient.asCurrentUser.transform.getTransformStats).toHaveBeenCalledWith({
+        transform_id: 'endpoint.metadata_*',
+      });
+      expect(mockEsClient.asCurrentUser.indices.getSettings).toHaveBeenCalledWith({
+        index: 'metrics-endpoint.metadata*',
+      });
+      expect(mockEsClient.asCurrentUser.ingest.getPipeline).toHaveBeenCalledWith({
+        id: 'metrics-endpoint.metadata-*',
+      });
+      expect(mockEsClient.asCurrentUser.cat.nodes).toHaveBeenCalledWith({ v: true });
+
+      if ('results' in result) {
+        expect(result.results).toHaveLength(1);
+        expect(result.results[0].type).toBe(ToolResultType.other);
+        expect(result.results[0].data).toMatchObject({
+          defaultTransformSettings: [
+            {
+              path: 'endpoint-9.4.0/elasticsearch/transform/metadata_current/default.json',
+              config: transformConfig,
+            },
+          ],
+          currentTransformSettings: mockTransformResponse.transforms,
+          transformStats: mockTransformStatsResponse.transforms,
+          indexSettings: mockIndexSettings,
+          ingestPipelines: mockIngestPipelines,
+          nodeStats: mockNodeStats,
+        });
+        expect(result.results[0]).toHaveProperty('tool_result_id');
+        expect(typeof result.results[0].tool_result_id).toBe('string');
+      }
+    });
+
+    it('handles case when package is not installed', async () => {
+      (mockPackageClient.getInstallation as jest.Mock).mockResolvedValue(undefined);
+
+      const mockTransformResponse: TransformGetTransformResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockTransformStatsResponse: TransformGetTransformStatsResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockIndexSettings: IndicesGetSettingsResponse = {};
+      const mockIngestPipelines: IngestGetPipelineResponse = {};
+      const mockNodeStats: CatNodesResponse = [];
+
+      mockEsClient.asCurrentUser.transform.getTransform.mockResolvedValue(mockTransformResponse);
+      mockEsClient.asCurrentUser.transform.getTransformStats.mockResolvedValue(
+        mockTransformStatsResponse
+      );
+      mockEsClient.asCurrentUser.indices.getSettings.mockResolvedValue(mockIndexSettings);
+      mockEsClient.asCurrentUser.ingest.getPipeline.mockResolvedValue(mockIngestPipelines);
+      mockEsClient.asCurrentUser.cat.nodes.mockResolvedValue(mockNodeStats);
+      const result = await tool.handler({}, {
+        esClient: mockEsClient,
+      } as unknown as ToolHandlerContext);
+
+      expect(mockPackageClient.getInstallation).toHaveBeenCalledWith('endpoint');
+      expect(mockPackageClient.getPackage).not.toHaveBeenCalled();
+
+      if ('results' in result) {
+        expect(result.results).toHaveLength(1);
+        expect(result.results[0].data).toMatchObject({
+          defaultTransformSettings: [],
+          currentTransformSettings: [],
+          transformStats: [],
+          indexSettings: {},
+          ingestPipelines: {},
+          nodeStats: [],
+        });
+      }
+    });
+
+    it('handles case when package has no transform assets', async () => {
+      const mockInstallation = {
+        name: 'endpoint',
+        version: '9.4.0',
+        install_version: '9.4.0',
+        install_status: 'installed',
+        install_started_at: '2024-01-01T00:00:00.000Z',
+        install_source: 'registry',
+        verification_status: 'verified',
+        installed_kibana: [],
+        installed_es: [],
+        package_assets: [],
+        es_index_patterns: {},
+      } as Awaited<ReturnType<typeof mockPackageClient.getInstallation>>;
+
+      const mockAssetsMap = new Map<string, Buffer>();
+      mockAssetsMap.set('endpoint-9.4.0/kibana/dashboard/overview.json', Buffer.from('{}'));
+
+      const mockPackageData = {
+        assetsMap: mockAssetsMap,
+        paths: ['kibana/dashboard/overview.json'],
+        packageInfo: {
+          name: 'endpoint',
+          version: '9.4.0',
+          title: 'Elastic Defend',
+          description: 'Endpoint security package',
+        },
+      } as Awaited<ReturnType<typeof mockPackageClient.getPackage>>;
+
+      (mockPackageClient.getInstallation as jest.Mock).mockResolvedValue(mockInstallation);
+      (mockPackageClient.getPackage as jest.Mock).mockResolvedValue(mockPackageData);
+
+      const mockTransformResponse: TransformGetTransformResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockTransformStatsResponse: TransformGetTransformStatsResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockIndexSettings: IndicesGetSettingsResponse = {};
+      const mockIngestPipelines: IngestGetPipelineResponse = {};
+      const mockNodeStats: CatNodesResponse = [];
+
+      mockEsClient.asCurrentUser.transform.getTransform.mockResolvedValue(mockTransformResponse);
+      mockEsClient.asCurrentUser.transform.getTransformStats.mockResolvedValue(
+        mockTransformStatsResponse
+      );
+      mockEsClient.asCurrentUser.indices.getSettings.mockResolvedValue(mockIndexSettings);
+      mockEsClient.asCurrentUser.ingest.getPipeline.mockResolvedValue(mockIngestPipelines);
+      mockEsClient.asCurrentUser.cat.nodes.mockResolvedValue(mockNodeStats);
+
+      const result = await tool.handler({}, {
+        esClient: mockEsClient,
+      } as unknown as ToolHandlerContext);
+
+      if ('results' in result) {
+        expect(result.results[0].data).toMatchObject({
+          defaultTransformSettings: [],
+        });
+      }
+    });
+
+    it('handles multiple transform assets', async () => {
+      const mockInstallation = {
+        name: 'endpoint',
+        version: '9.4.0',
+        install_version: '9.4.0',
+        install_status: 'installed',
+        install_started_at: '2024-01-01T00:00:00.000Z',
+        install_source: 'registry',
+        verification_status: 'verified',
+        installed_kibana: [],
+        installed_es: [],
+        package_assets: [],
+        es_index_patterns: {},
+      } as Awaited<ReturnType<typeof mockPackageClient.getInstallation>>;
+
+      const transformConfig1 = { id: 'transform1', source: 'index1' };
+      const transformConfig2 = { id: 'transform2', source: 'index2' };
+
+      const mockAssetsMap = new Map<string, Buffer>();
+      mockAssetsMap.set(
+        'endpoint-9.4.0/elasticsearch/transform/metadata_current/default.json',
+        Buffer.from(JSON.stringify(transformConfig1))
+      );
+      mockAssetsMap.set(
+        'endpoint-9.4.0/elasticsearch/transform/metadata_united/default.json',
+        Buffer.from(JSON.stringify(transformConfig2))
+      );
+
+      const mockPackageData = {
+        assetsMap: mockAssetsMap,
+        paths: [
+          'elasticsearch/transform/metadata_current/default.json',
+          'elasticsearch/transform/metadata_united/default.json',
+        ],
+        packageInfo: {
+          name: 'endpoint',
+          version: '9.4.0',
+          title: 'Elastic Defend',
+          description: 'Endpoint security package',
+        },
+      } as Awaited<ReturnType<typeof mockPackageClient.getPackage>>;
+
+      (mockPackageClient.getInstallation as jest.Mock).mockResolvedValue(mockInstallation);
+      (mockPackageClient.getPackage as jest.Mock).mockResolvedValue(mockPackageData);
+
+      const mockTransformResponse: TransformGetTransformResponse = {
+        count: 2,
+        transforms: [
+          {
+            id: 'transform1',
+            source: { index: ['index1'] },
+            dest: { index: 'dest1' },
+            frequency: '5m',
+            sync: { time: { field: '@timestamp', delay: '60s' } },
+            settings: {},
+            version: '9.4.0',
+            create_time: 1234567890,
+          },
+          {
+            id: 'transform2',
+            source: { index: ['index2'] },
+            dest: { index: 'dest2' },
+            frequency: '5m',
+            sync: { time: { field: '@timestamp', delay: '60s' } },
+            settings: {},
+            version: '9.4.0',
+            create_time: 1234567890,
+          },
+        ],
+      };
+
+      const mockTransformStatsResponse: TransformGetTransformStatsResponse = {
+        count: 2,
+        transforms: [
+          {
+            id: 'transform1',
+            state: 'started',
+            stats: {
+              pages_processed: 100,
+              documents_processed: 1000,
+              documents_indexed: 1000,
+              trigger_count: 50,
+              index_time_in_ms: 500,
+              index_total: 1000,
+              index_failures: 0,
+              search_time_in_ms: 300,
+              search_total: 100,
+              search_failures: 0,
+              processing_time_in_ms: 200,
+              processing_total: 1000,
+              exponential_avg_checkpoint_duration_ms: 100,
+              exponential_avg_documents_indexed: 20,
+              exponential_avg_documents_processed: 20,
+            },
+            checkpointing: {
+              last: {
+                checkpoint: 1,
+                timestamp_millis: 1234567890,
+              },
+              changes_last_detected_at: 1234567890,
+            },
+          },
+          {
+            id: 'transform2',
+            state: 'stopped',
+            stats: {
+              pages_processed: 50,
+              documents_processed: 500,
+              documents_indexed: 500,
+              trigger_count: 25,
+              index_time_in_ms: 250,
+              index_total: 500,
+              index_failures: 0,
+              search_time_in_ms: 150,
+              search_total: 50,
+              search_failures: 0,
+              processing_time_in_ms: 100,
+              processing_total: 500,
+              exponential_avg_checkpoint_duration_ms: 50,
+              exponential_avg_documents_indexed: 10,
+              exponential_avg_documents_processed: 10,
+            },
+            checkpointing: {
+              last: {
+                checkpoint: 1,
+                timestamp_millis: 1234567890,
+              },
+              changes_last_detected_at: 1234567890,
+            },
+          },
+        ],
+      };
+
+      const mockIndexSettings: IndicesGetSettingsResponse = {};
+      const mockIngestPipelines: IngestGetPipelineResponse = {};
+      const mockNodeStats: CatNodesResponse = [];
+
+      mockEsClient.asCurrentUser.transform.getTransform.mockResolvedValue(mockTransformResponse);
+      mockEsClient.asCurrentUser.transform.getTransformStats.mockResolvedValue(
+        mockTransformStatsResponse
+      );
+      mockEsClient.asCurrentUser.indices.getSettings.mockResolvedValue(mockIndexSettings);
+      mockEsClient.asCurrentUser.ingest.getPipeline.mockResolvedValue(mockIngestPipelines);
+      mockEsClient.asCurrentUser.cat.nodes.mockResolvedValue(mockNodeStats);
+      const result = await tool.handler({}, {
+        esClient: mockEsClient,
+      } as unknown as ToolHandlerContext);
+
+      if ('results' in result) {
+        // @ts-expect-error
+        expect(result.results[0].data.defaultTransformSettings).toHaveLength(2);
+        // @ts-expect-error
+        expect(result.results[0].data.defaultTransformSettings).toEqual([
+          {
+            path: 'endpoint-9.4.0/elasticsearch/transform/metadata_current/default.json',
+            config: transformConfig1,
+          },
+          {
+            path: 'endpoint-9.4.0/elasticsearch/transform/metadata_united/default.json',
+            config: transformConfig2,
+          },
+        ]);
+      }
+    });
+
+    it('uses asCurrentUser for Elasticsearch client calls', async () => {
+      (mockPackageClient.getInstallation as jest.Mock).mockResolvedValue(undefined);
+
+      const mockTransformResponse: TransformGetTransformResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockTransformStatsResponse: TransformGetTransformStatsResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockIndexSettings: IndicesGetSettingsResponse = {};
+      const mockIngestPipelines: IngestGetPipelineResponse = {};
+      const mockNodeStats: CatNodesResponse = [];
+
+      mockEsClient.asCurrentUser.transform.getTransform.mockResolvedValue(mockTransformResponse);
+      mockEsClient.asCurrentUser.transform.getTransformStats.mockResolvedValue(
+        mockTransformStatsResponse
+      );
+      mockEsClient.asCurrentUser.indices.getSettings.mockResolvedValue(mockIndexSettings);
+      mockEsClient.asCurrentUser.ingest.getPipeline.mockResolvedValue(mockIngestPipelines);
+      mockEsClient.asCurrentUser.cat.nodes.mockResolvedValue(mockNodeStats);
+      const mockContext: ToolHandlerContext = {
+        esClient: mockEsClient,
+      } as unknown as ToolHandlerContext;
+
+      await tool.handler({}, mockContext);
+
+      expect(mockEsClient.asCurrentUser.transform.getTransform).toHaveBeenCalled();
+      expect(mockEsClient.asCurrentUser.transform.getTransformStats).toHaveBeenCalled();
+      expect(mockEsClient.asCurrentUser.indices.getSettings).toHaveBeenCalled();
+      expect(mockEsClient.asCurrentUser.ingest.getPipeline).toHaveBeenCalled();
+      expect(mockEsClient.asCurrentUser.cat.nodes).toHaveBeenCalled();
+    });
+
+    it('parses transform JSON configurations correctly', async () => {
+      const mockInstallation = {
+        name: 'endpoint',
+        version: '9.4.0',
+        install_version: '9.4.0',
+        install_status: 'installed',
+        install_started_at: '2024-01-01T00:00:00.000Z',
+        install_source: 'registry',
+        verification_status: 'verified',
+        installed_kibana: [],
+        installed_es: [],
+        package_assets: [],
+        es_index_patterns: {},
+      } as Awaited<ReturnType<typeof mockPackageClient.getInstallation>>;
+
+      const transformConfig = {
+        id: 'transform-id-1',
+        source: {
+          index: 'metrics-endpoint.metadata*',
+          query: {
+            bool: {
+              filter: [
+                { term: { 'agent.type': 'endpoint' } },
+                { range: { '@timestamp': { gte: 'now-1d' } } },
+              ],
+            },
+          },
+        },
+        dest: { index: 'metrics-endpoint.metadata_current' },
+        frequency: '5m',
+        sync: { time: { field: '@timestamp', delay: '60s' } },
+        settings: {
+          max_page_search_size: 500,
+        },
+      };
+
+      const mockAssetsMap = new Map<string, Buffer>();
+      mockAssetsMap.set(
+        'endpoint-9.4.0/elasticsearch/transform/metadata_current/default.json',
+        Buffer.from(JSON.stringify(transformConfig))
+      );
+
+      const mockPackageData = {
+        assetsMap: mockAssetsMap,
+        paths: ['elasticsearch/transform/metadata_current/default.json'],
+        packageInfo: {
+          name: 'endpoint',
+          version: '9.4.0',
+          title: 'Elastic Defend',
+          description: 'Endpoint security package',
+        },
+      } as Awaited<ReturnType<typeof mockPackageClient.getPackage>>;
+
+      (mockPackageClient.getInstallation as jest.Mock).mockResolvedValue(mockInstallation);
+      (mockPackageClient.getPackage as jest.Mock).mockResolvedValue(mockPackageData);
+
+      const mockTransformResponse: TransformGetTransformResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockTransformStatsResponse: TransformGetTransformStatsResponse = {
+        count: 0,
+        transforms: [],
+      };
+
+      const mockIndexSettings: IndicesGetSettingsResponse = {};
+      const mockIngestPipelines: IngestGetPipelineResponse = {};
+      const mockNodeStats: CatNodesResponse = [];
+
+      mockEsClient.asCurrentUser.transform.getTransform.mockResolvedValue(mockTransformResponse);
+      mockEsClient.asCurrentUser.transform.getTransformStats.mockResolvedValue(
+        mockTransformStatsResponse
+      );
+      mockEsClient.asCurrentUser.indices.getSettings.mockResolvedValue(mockIndexSettings);
+      mockEsClient.asCurrentUser.ingest.getPipeline.mockResolvedValue(mockIngestPipelines);
+      mockEsClient.asCurrentUser.cat.nodes.mockResolvedValue(mockNodeStats);
+      const result = await tool.handler({}, {
+        esClient: mockEsClient,
+      } as unknown as ToolHandlerContext);
+
+      if ('results' in result) {
+        // @ts-expect-error
+        expect(result.results[0].data.defaultTransformSettings).toHaveLength(1);
+        // @ts-expect-error
+        expect(result.results[0].data.defaultTransformSettings[0].config).toEqual(transformConfig);
+      }
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/get_package_configurations/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/get_package_configurations/index.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
+import { z } from '@kbn/zod';
+import { ToolResultType, ToolType, platformCoreTools } from '@kbn/agent-builder-common';
+import { FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
+import { getToolResultId } from '@kbn/agent-builder-server/tools';
+
+import type { EndpointAppContextService } from '../../../../../endpoint/endpoint_app_context_services';
+import {
+  METADATA_TRANSFORMS_PATTERN,
+  metadataIndexPattern,
+} from '../../../../../../common/endpoint/constants';
+import { GET_PACKAGE_CONFIGURATIONS_TOOL_ID } from '../..';
+
+const defendPackageConfigurations = z.object({});
+
+export const getPackageConfigurationsTool = (
+  endpointAppContextService: EndpointAppContextService
+): BuiltinSkillBoundedTool => {
+  return {
+    id: GET_PACKAGE_CONFIGURATIONS_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Fetches Elastic Defend package configurations.
+
+Before using this tool, ensure you first call the ${platformCoreTools.integrationKnowledge} tool to gather relevant context.
+
+This tool fetches Elastic Defend package configurations to assist in troubleshooting Elastic Defend configuration issues. Includes:
+- default transform settings
+- current transform settings
+- index settings
+- ingest pipelines
+- transform stats
+- node stats
+
+
+**When to use:**
+- When there is an issue with endpoints not displaying on the endpoint list
+- When there is an issue interacting with endpoints on the endpoint list
+- When there is potential misconfiguration in the Elastic Defend package assets`,
+    schema: defendPackageConfigurations,
+    handler: async (_, { esClient, logger }) => {
+      try {
+        const packageClient = endpointAppContextService.getInternalFleetServices().packages;
+        const installation = await packageClient.getInstallation(FLEET_ENDPOINT_PACKAGE);
+        let packageData: Awaited<ReturnType<typeof packageClient.getPackage>> | undefined;
+        if (installation) {
+          packageData = await packageClient.getPackage(
+            FLEET_ENDPOINT_PACKAGE,
+            installation.version
+          );
+        }
+        const defaultTransformSettings: Array<{ path: string; config: unknown }> = [];
+        if (packageData) {
+          packageData.assetsMap.forEach((buffer, path) => {
+            if (path.includes('elasticsearch/transform/') && buffer) {
+              const content = buffer.toString('utf-8');
+              const config: unknown = JSON.parse(content);
+              defaultTransformSettings.push({ path, config });
+            }
+          });
+        }
+
+        const internalEsClient = esClient.asCurrentUser;
+        const transformClient = internalEsClient.transform;
+        const getTransformsResponse = await transformClient.getTransform({
+          transform_id: METADATA_TRANSFORMS_PATTERN,
+        });
+        const getTransformStatsResponse = await transformClient.getTransformStats({
+          transform_id: METADATA_TRANSFORMS_PATTERN,
+        });
+        const indexSettings = await internalEsClient.indices.getSettings({
+          index: 'metrics-endpoint.metadata*',
+        });
+        const ingestPipelines = await internalEsClient.ingest.getPipeline({
+          id: metadataIndexPattern,
+        });
+        const nodeStats = await internalEsClient.cat.nodes({ v: true });
+
+        const data = {
+          defaultTransformSettings,
+          currentTransformSettings: getTransformsResponse.transforms,
+          transformStats: getTransformStatsResponse.transforms,
+          indexSettings,
+          ingestPipelines,
+          nodeStats,
+        };
+
+        return {
+          results: [
+            {
+              tool_result_id: getToolResultId(),
+              type: ToolResultType.other,
+              data,
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(`Error in ${GET_PACKAGE_CONFIGURATIONS_TOOL_ID} tool: ${error.message}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Error: ${error.message}`,
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/index.ts
@@ -5,6 +5,5 @@
  * 2.0.
  */
 
-export { alertAnalysisSampleSkill as alertAnalysisSkill } from './alert_analysis_skill';
-export { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
-export { registerSkills } from './register_skills';
+export { getPackageConfigurationsTool } from './get_package_configurations';
+export { generateInsightTool } from './generate_insight';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -6,10 +6,24 @@
  */
 
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import type { ExperimentalFeatures } from '../../../common/experimental_features';
+import type { EndpointAppContextService } from '../../endpoint/endpoint_app_context_services';
+import { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 
 /**
  * Registers all security agent builder skills with the agentBuilder plugin
  */
-export const registerSkills = async (agentBuilder: AgentBuilderPluginSetup): Promise<void> => {
+export const registerSkills = async (
+  agentBuilder: AgentBuilderPluginSetup,
+  experimentalFeatures: ExperimentalFeatures,
+  options: {
+    endpointAppContextService: EndpointAppContextService;
+  }
+): Promise<void> => {
   // await agentBuilder.skill.registerSkill(alertAnalysisSampleSkill);
+  if (experimentalFeatures.automaticTroubleshootingSkill) {
+    agentBuilder.skills.register(
+      createAutomaticTroubleshootingSkill(options.endpointAppContextService)
+    );
+  }
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
@@ -5,15 +5,12 @@
  * 2.0.
  */
 
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
 import moment from 'moment';
 
-import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
-import type { DefendInsightsPostRequestBody } from '@kbn/elastic-assistant-common';
-
-import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
-
+import type { EndpointMetadataService } from '../../metadata';
 import type { BuildWorkflowInsightParams } from '.';
-
 import {
   Category,
   SourceType,
@@ -21,7 +18,6 @@ import {
   ActionType,
 } from '../../../../../common/endpoint/types/workflow_insights';
 import { createMockEndpointAppContext } from '../../../mocks';
-import type { EndpointMetadataService } from '../../metadata';
 import { groupEndpointIdsByOS } from '../helpers';
 import { buildIncompatibleAntivirusWorkflowInsights } from './incompatible_antivirus';
 
@@ -55,19 +51,6 @@ describe('buildIncompatibleAntivirusWorkflowInsights', () => {
         ],
       },
     ],
-    request: {
-      body: {
-        insightType: 'incompatible_antivirus',
-        endpointIds: ['endpoint-1'],
-        apiConfig: {
-          connectorId: 'connector-id-1',
-          actionTypeId: 'action-type-id-1',
-          model: 'model-1',
-        },
-        anonymizationFields: [],
-        subAction: 'invokeAI',
-      },
-    } as unknown as KibanaRequest<unknown, unknown, DefendInsightsPostRequestBody>,
     endpointMetadataService,
     esClient: {
       search: jest.fn().mockResolvedValue({
@@ -76,6 +59,12 @@ describe('buildIncompatibleAntivirusWorkflowInsights', () => {
         },
       }),
     } as unknown as ElasticsearchClient,
+    options: {
+      insightType: 'incompatible_antivirus',
+      endpointIds: ['endpoint-1'],
+      connectorId: 'connector-id-1',
+      model: 'model-1',
+    },
   });
 
   const buildExpectedInsight = (os: string, signerField?: string, signerValue?: string) =>

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
@@ -30,8 +30,8 @@ export async function buildIncompatibleAntivirusWorkflowInsights(
   params: BuildWorkflowInsightParams
 ): Promise<SecurityWorkflowInsight[]> {
   const currentTime = moment();
-  const { defendInsights, request, endpointMetadataService, esClient } = params;
-  const { insightType, endpointIds, apiConfig } = request.body;
+  const { defendInsights, options, endpointMetadataService, esClient } = params;
+  const { insightType, endpointIds, connectorId, model } = options;
 
   const osEndpointIdsMap = await groupEndpointIdsByOS(endpointIds, endpointMetadataService);
 
@@ -88,7 +88,7 @@ export async function buildIncompatibleAntivirusWorkflowInsights(
           type: insightType,
           source: {
             type: SourceType.LlmConnector,
-            id: apiConfig.connectorId,
+            id: connectorId ?? '',
             // TODO use actual time range when we add support
             data_range_start: currentTime,
             data_range_end: currentTime.clone().add(24, 'hours'),
@@ -104,7 +104,7 @@ export async function buildIncompatibleAntivirusWorkflowInsights(
           value: `${filePath}${signatureValue ? ` ${signatureValue}` : ''}`,
           metadata: {
             notes: {
-              llm_model: apiConfig.model ?? '',
+              llm_model: model ?? '',
             },
             display_name: defendInsight.group,
           },

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/index.ts
@@ -5,32 +5,38 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
-import type { DefendInsight, DefendInsightsPostRequestBody } from '@kbn/elastic-assistant-common';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { DefendInsight } from '@kbn/elastic-assistant-common';
 import { DefendInsightType } from '@kbn/elastic-assistant-common';
 import { InvalidDefendInsightTypeError } from '@kbn/elastic-assistant-plugin/server/lib/defend_insights/errors';
 
 import type { SecurityWorkflowInsight } from '../../../../../common/endpoint/types/workflow_insights';
-
 import type { EndpointMetadataService } from '../../metadata';
 import { buildIncompatibleAntivirusWorkflowInsights } from './incompatible_antivirus';
-import { buildPolicyResponseFailureWorkflowInsights } from './policy_response_failure';
+import { buildCustomWorkflowInsights } from './custom';
 
 export interface BuildWorkflowInsightParams {
   defendInsights: DefendInsight[];
-  request: KibanaRequest<unknown, unknown, DefendInsightsPostRequestBody>;
   endpointMetadataService: EndpointMetadataService;
   esClient: ElasticsearchClient;
+  options: {
+    insightType: DefendInsightType;
+    endpointIds: string[];
+    connectorId?: string;
+    model?: string;
+  };
 }
 
 export function buildWorkflowInsights(
   params: BuildWorkflowInsightParams
 ): Promise<SecurityWorkflowInsight[]> {
-  switch (params.request.body.insightType) {
+  switch (params.options.insightType) {
     case DefendInsightType.Enum.incompatible_antivirus:
       return buildIncompatibleAntivirusWorkflowInsights(params);
     case DefendInsightType.Enum.policy_response_failure:
-      return buildPolicyResponseFailureWorkflowInsights(params);
+      return buildCustomWorkflowInsights(params);
+    case DefendInsightType.Enum.custom:
+      return buildCustomWorkflowInsights(params);
     default:
       throw new InvalidDefendInsightTypeError();
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.test.ts
@@ -251,12 +251,6 @@ describe('SecurityWorkflowInsightsService', () => {
       ];
 
       const workflowInsights: SecurityWorkflowInsight[] = [getDefaultInsight()];
-      const request = { body: { insightType: workflowInsights[0].type } } as KibanaRequest<
-        unknown,
-        unknown,
-        DefendInsightsPostRequestBody
-      >;
-
       const buildWorkflowInsightsMock = buildWorkflowInsights as jest.Mock;
       buildWorkflowInsightsMock.mockResolvedValueOnce(workflowInsights);
 
@@ -278,16 +272,24 @@ describe('SecurityWorkflowInsightsService', () => {
       });
       const result = await securityWorkflowInsightsService.createFromDefendInsights(
         defendInsights,
-        request
+        insight.events.map((e) => e.endpointId),
+        workflowInsights[0].type,
+        workflowInsights[0].source.id,
+        workflowInsights[0].source.type
       );
 
       // four since it calls fetch + update + fetch + create
       expect(isInitializedSpy).toHaveBeenCalledTimes(4);
       expect(buildWorkflowInsightsMock).toHaveBeenCalledWith({
         defendInsights,
-        request,
         endpointMetadataService: expect.any(Object),
         esClient,
+        options: {
+          insightType: workflowInsights[0].type,
+          endpointIds: insight.events.map((e) => e.endpointId),
+          connectorId: workflowInsights[0].source.id,
+          model: workflowInsights[0].source.type,
+        },
       });
       expect(result).toEqual(workflowInsights.map(() => esClientIndexResp));
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -249,7 +249,10 @@ export class Plugin implements ISecuritySolutionPlugin {
       return;
     }
 
-    registerTools(agentBuilder, core, logger, this.config.experimentalFeatures).catch((error) => {
+    const experimentalFeatures = this.config.experimentalFeatures;
+    const endpointAppContextService = this.endpointAppContextService;
+
+    registerTools(agentBuilder, core, logger, experimentalFeatures).catch((error) => {
       this.logger.error(`Error registering security tools: ${error}`);
     });
     registerAttachments(agentBuilder).catch((error) => {
@@ -258,7 +261,9 @@ export class Plugin implements ISecuritySolutionPlugin {
     registerAgents(agentBuilder, core, logger).catch((error) => {
       this.logger.error(`Error registering security agent: ${error}`);
     });
-    registerSkills(agentBuilder).catch((error) => {
+    registerSkills(agentBuilder, experimentalFeatures, {
+      endpointAppContextService,
+    }).catch((error) => {
       this.logger.error(`Error registering security skills: ${error}`);
     });
   }


### PR DESCRIPTION
## Summary

This commit adds the Automatic Troubleshooting Agent Builder skill. This skill is intended to replace the existing Automatic Troubleshooting (Defend Insights) feature that exists in the `elastic_assistant` plugin. Its purpose is to troubleshoot Elastic Defend configuration issues.

<img width="839" height="1169" alt="Screenshot 2026-02-12 at 9 48 40 PM" src="https://github.com/user-attachments/assets/61988fd0-9975-4944-8dc2-e4437eb00a39" />
<img width="850" height="1157" alt="Screenshot 2026-02-12 at 10 09 54 PM" src="https://github.com/user-attachments/assets/39dcac8d-c7f2-4cf1-a1c8-e815e2231bf2" />

This commit does not update the existing Automatic Troubleshooting UI to use this agent. This will be done in a separate PR.

This feature is gated behind the `automaticTroubleshootingSkill` FF (`agentBuilder:experimentalFeatures` flag is also needed to enable skills).


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios