### PR TITLE
[DOCS][Security Solution] Add documentation for `xpack.securitySolution.disableEndpointRuleAutoInstall`

### DIFF
--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -108,6 +108,9 @@ stack: ga 9.2
 `xpack.actions.email.recipient_allowlist`
 :    A list of allowed email recipient patterns (`to`, `cc`, or `bcc`) that can be used with email connectors. If you attempt to send an email to a recipient that does not match the allowed patterns, the action will fail. The failure message indicates that the email is not allowed.
 
+`xpack.securitySolution.disableEndpointRuleAutoInstall` {applies_to}`stack: ga 9.2.4+`
+:   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Default is `false`.
+
 ### Version 9.1+ [ec_version_9_1]
 ```{applies_to}
 stack: ga 9.1

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -580,8 +580,8 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 :   Allow to configure the max file upload size for use with the Upload File Repsonse action available with the Defend Integration.  To learn more, check [Endpoint Response actions](docs-content://solutions/security/endpoint-response-actions.md).
     It is available in {{ecloud}} 8.9.0 and later versions.
 
-`xpack.securitySolution.disableEndpointRuleAutoInstall` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
-:   Set to `false` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4
+`xpack.securitySolution.disableEndpointRuleAutoInstall` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.2.4+`
+:   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4. Default is `false`.
 
 
 `xpack.snapshot_restore.ui.enabled`

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -579,7 +579,10 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 `xpack.securitySolution.maxUploadResponseActionFileBytes` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Allow to configure the max file upload size for use with the Upload File Repsonse action available with the Defend Integration.  To learn more, check [Endpoint Response actions](docs-content://solutions/security/endpoint-response-actions.md).
     It is available in {{ecloud}} 8.9.0 and later versions.
-% TBD: Available only in Elastic Cloud?
+
+`xpack.securitySolution.disableEndpointRuleAutoInstall` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+:   Set to `false` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4
+
 
 `xpack.snapshot_restore.ui.enabled`
 :   Set this value to false to disable the Snapshot and Restore UI. **Default: true**


### PR DESCRIPTION
## Summary

- Adds documentation for `xpack.securitySolution.disableEndpointRuleAutoInstall` server-side configuration settings. This setting has also been made available for customization on Cloud environments (via this [PR](https://github.com/elastic/cloud/pull/151414))


________
<img width="923" height="139" alt="image" src="https://github.com/user-attachments/assets/1802f8b5-1da9-4ff3-9f67-88203e7578ae" />

_____________



<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->