### PR TITLE
fix: prevent assertion masking in PIT test error paths

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -47,6 +47,7 @@ import {
   createBulkIndexOperationTuple,
   checkClusterRoutingAllocationEnabled,
 } from '@kbn/core-saved-objects-migration-server-internal';
+import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 
 interface EsServer {
   stop: () => Promise<void>;
@@ -1394,20 +1395,27 @@ export const runActionTestSuite = ({
         ],
       });
 
+      let response: SearchResponse;
       try {
-        const response = await client.search({ pit: { id: pitId } });
-        expect(response._shards?.failed).toBeGreaterThanOrEqual(1);
-        const failureReason =
-          response._shards?.failures?.[0]?.reason?.reason ??
-          response._shards?.failures?.[0]?.reason?.type ??
-          '';
-        expect(failureReason).toMatch(
-          /No search context found for id|search_context_missing_exception/
-        );
+        response = await client.search({ pit: { id: pitId } });
       } catch (err: unknown) {
+        // if the search call throws, we're likely on a non-serverless environment
+        // where the PIT simply became invalid
         const message = err instanceof Error ? err.message : String(err);
         expect(message).toContain('search_phase_execution_exception');
+        return;
       }
+
+      // at this point, we're likely on a serverless environment
+      // the call succeeded but it contains failures
+      expect(response._shards?.failed).toBeGreaterThanOrEqual(1);
+      const failureReason =
+        response._shards?.failures?.[0]?.reason?.reason ??
+        response._shards?.failures?.[0]?.reason?.type ??
+        '';
+      expect(failureReason).toMatch(
+        /No search context found for id|search_context_missing_exception/
+      );
     });
 
     it('rejects search with closed PIT when allow_partial_search_results is false', async () => {


### PR DESCRIPTION
Refactors the closePit test to avoid putting expect() statements inside
try/catch blocks. Previously, if an assertion failed in the try block,
it would throw an error that would be caught by the catch block,
potentially making the wrong assertion and giving misleading test results.

The fix:
- Captures the search result or error in variables first (no assertions)
- Uses early return pattern to handle the error case
- Makes assertions only after the try/catch completes

This ensures that assertion failures are properly reported and not
masked by the catch block.

Addresses feedback from: https://github.com/elastic/kibana/pull/251928/changes#r2773609383
