### PR TITLE
[Discover] [Group by] Support restoring UI state when switching tabs

### DIFF
--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
@@ -12,6 +12,7 @@ export type {
   GroupNode,
   LeafNode,
   DataCascadeProps,
+  DataCascadeImplRef,
   DataCascadeRowProps,
   DataCascadeRowCellProps,
   CascadeRowCellNestedVirtualizationAnchorProps,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
@@ -16,6 +16,7 @@ export type {
   DataCascadeRowProps,
   DataCascadeRowCellProps,
   CascadeRowCellNestedVirtualizationAnchorProps,
+  DataCascadeUISnapshot,
 } from './src/components';
 export * from './src/lib';
 export { NumberBadge } from './src/components/helpers';

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -64,6 +64,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
   enableRowSelection = false,
   enableStickyGroupHeader = true,
   allowMultipleRowToggle = false,
+  initialScrollOffset,
   cascadeRef,
 }: DataCascadeImplProps<G, L>) {
   const rowElement = Children.only(children);
@@ -147,6 +148,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     enableStickyGroupHeader,
     estimatedRowHeight: size === 's' ? 32 : size === 'm' ? 40 : 48,
     onStateChange: collectVirtualizerStateChanges,
+    initialOffset: initialScrollOffset,
   });
 
   const {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -26,6 +26,7 @@ import {
   calculateActiveStickyIndex,
   type VirtualizedCascadeListProps,
 } from '../../lib/core/virtualizer';
+import { useExposePublicApi } from '../../lib/core/api';
 import {
   useRegisterCascadeAccessibilityHelpers,
   useTreeGridContainerARIAAttributes,
@@ -63,6 +64,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
   enableRowSelection = false,
   enableStickyGroupHeader = true,
   allowMultipleRowToggle = false,
+  cascadeRef,
 }: DataCascadeImplProps<G, L>) {
   const rowElement = Children.only(children);
 
@@ -132,6 +134,11 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     rowCell: cascadeRowCell,
   });
 
+  const { collectVirtualizerStateChanges } = useExposePublicApi<G, L>(cascadeRef, {
+    rows,
+    enableStickyGroupHeader,
+  });
+
   // persist the virtualizer instance to ref, so that invocations of getVirtualizer will always return the latest instance
   virtualizerInstance.current = useCascadeVirtualizer<G>({
     rows,
@@ -139,6 +146,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     getScrollElement,
     enableStickyGroupHeader,
     estimatedRowHeight: size === 's' ? 32 : size === 'm' ? 40 : 48,
+    onStateChange: collectVirtualizerStateChanges,
   });
 
   const {
@@ -160,6 +168,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     enableStickyGroupHeader
   );
 
+  // register handlers for accessibility
   useRegisterCascadeAccessibilityHelpers<G>({
     tableRows: rows,
     tableWrapperElement: cascadeWrapperRef.current!,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -65,6 +65,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
   enableStickyGroupHeader = true,
   allowMultipleRowToggle = false,
   initialScrollOffset,
+  initialRect,
   cascadeRef,
 }: DataCascadeImplProps<G, L>) {
   const rowElement = Children.only(children);
@@ -149,6 +150,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     estimatedRowHeight: size === 's' ? 32 : size === 'm' ? 40 : 48,
     onStateChange: collectVirtualizerStateChanges,
     initialOffset: initialScrollOffset,
+    initialRect,
   });
 
   const {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.tsx
@@ -118,11 +118,6 @@ export function CascadeRowCellPrimitive<G extends GroupNode, L extends LeafNode>
   // Keep a reference to the virtualizer for cleanup and scroll-to operations
   const rootVirtualizer = useMemo(() => getVirtualizer(), [getVirtualizer]);
 
-  const virtualRow = useMemo(
-    () => rootVirtualizer.getVirtualItems().find((v) => v.index === row.index),
-    [rootVirtualizer, row]
-  );
-
   const getScrollElement = useCallback(() => rootVirtualizer.scrollElement, [rootVirtualizer]);
 
   /**
@@ -132,26 +127,6 @@ export function CascadeRowCellPrimitive<G extends GroupNode, L extends LeafNode>
   const preventSizeChangePropagation = useCallback(() => {
     return rootVirtualizer.preventRowSizeChangePropagation(row.index);
   }, [rootVirtualizer, row.index]);
-
-  useEffect(
-    () => () => {
-      // ensure that for a row that's been scrolled,
-      // if said row is technically still in view because it's cell is being rendered,
-      // when we are unmounting because the expand action from the cell's row was clicked,
-      // we want to ensure said row is the top most item in our list
-      if (
-        virtualRow?.index &&
-        !rootVirtualizer.isScrolling &&
-        getScrollOffset() > getScrollMargin()
-      ) {
-        rootVirtualizer.scrollToVirtualizedIndex(virtualRow.index, {
-          align: 'start',
-          behavior: 'auto',
-        });
-      }
-    },
-    [rootVirtualizer, virtualRow?.index, getScrollOffset, getScrollMargin]
-  );
 
   const memoizedChild = useMemo(() => {
     return React.createElement(children, {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -257,6 +257,10 @@ interface DataCascadeImplBaseProps<G extends GroupNode, L extends LeafNode>
    * Whether to allow multiple group rows to be expanded at the same time, default is false.
    */
   allowMultipleRowToggle?: boolean;
+  /**
+   * Initial vertical scroll position in pixels. When set, the list and scroll container start at this offset.
+   */
+  initialScrollOffset?: number;
   children: React.ReactElement<DataCascadeRowProps<G, L>>;
   cascadeRef: React.ForwardedRef<DataCascadeImplRef<G, L>>;
 }

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -13,6 +13,7 @@ import type { Table, CellContext, Row } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
 import type { GroupNode, LeafNode } from '../../store_provider';
 import type { CascadeVirtualizerProps, useCascadeVirtualizer } from '../../lib/core/virtualizer';
+import type { DataCascadeImplRef } from '../../lib/core/api';
 import type { SelectionDropdownProps } from './data_cascade_header/group_selection_combobox/selection_dropdown';
 
 /**
@@ -257,6 +258,7 @@ interface DataCascadeImplBaseProps<G extends GroupNode, L extends LeafNode>
    */
   allowMultipleRowToggle?: boolean;
   children: React.ReactElement<DataCascadeRowProps<G, L>>;
+  cascadeRef: React.ForwardedRef<DataCascadeImplRef<G, L>>;
 }
 
 export type DataCascadeImplProps<

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -261,6 +261,10 @@ interface DataCascadeImplBaseProps<G extends GroupNode, L extends LeafNode>
    * Initial vertical scroll position in pixels. When set, the list and scroll container start at this offset.
    */
   initialScrollOffset?: number;
+  /**
+   * Initial scroll rectangle dimensions. When set, the list and scroll container start at this size.
+   */
+  initialRect?: { width: number; height: number };
   children: React.ReactElement<DataCascadeRowProps<G, L>>;
   cascadeRef: React.ForwardedRef<DataCascadeImplRef<G, L>>;
 }

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -9,13 +9,7 @@
 
 import type React from 'react';
 import type { EuiThemeShape, EuiButtonIconProps, EuiButtonEmptyProps } from '@elastic/eui';
-import type {
-  ExpandedState,
-  RowSelectionState,
-  Table,
-  CellContext,
-  Row,
-} from '@tanstack/react-table';
+import type { Table, CellContext, Row } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
 import type { GroupNode, LeafNode } from '../../store_provider';
 import type { CascadeVirtualizerProps, useCascadeVirtualizer } from '../../lib/core/virtualizer';

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -9,7 +9,13 @@
 
 import type React from 'react';
 import type { EuiThemeShape, EuiButtonIconProps, EuiButtonEmptyProps } from '@elastic/eui';
-import type { Table, CellContext, Row } from '@tanstack/react-table';
+import type {
+  ExpandedState,
+  RowSelectionState,
+  Table,
+  CellContext,
+  Row,
+} from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
 import type { GroupNode, LeafNode } from '../../store_provider';
 import type { CascadeVirtualizerProps, useCascadeVirtualizer } from '../../lib/core/virtualizer';

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -42,6 +42,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     initialGroupColumn,
     customTableHeader,
     tableTitleSlot,
+    initialExpandedRowIds,
     ...restProps
   }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
   ref: ForwardedRef<DataCascadeImplRef<G, L>>
@@ -54,6 +55,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     <DataCascadeProvider<G, L>
       cascadeGroups={cascadeGroups}
       initialGroupColumn={initialGroupColumn}
+      initialExpandedRowIds={initialExpandedRowIds}
     >
       <DataCascadeImpl<G, L> {...cascadeImplProps} />
     </DataCascadeProvider>

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -7,26 +7,55 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type ComponentProps } from 'react';
+import React, { forwardRef, type ComponentProps, type ForwardedRef } from 'react';
 import { DataCascadeImpl, type DataCascadeImplProps } from './data_cascade_impl';
+import type { DataCascadeImplRef } from '../lib/core/api';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../store_provider';
 
-export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps };
+export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps, DataCascadeImplRef };
+
 export { DataCascadeRow, DataCascadeRowCell } from './data_cascade_impl';
+
 export type {
   DataCascadeRowProps,
   DataCascadeRowCellProps,
   CascadeRowCellNestedVirtualizationAnchorProps,
 } from './data_cascade_impl';
 
-export function DataCascade<G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>({
-  cascadeGroups,
-  initialGroupColumn,
-  ...props
-}: DataCascadeImplProps<G, L> & ComponentProps<typeof DataCascadeProvider>) {
+type DataCascadeProviderProps = ComponentProps<typeof DataCascadeProvider>;
+
+type DataCascadeComponent = <G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>(
+  props: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> &
+    DataCascadeProviderProps & { ref?: React.Ref<DataCascadeImplRef<G, L>> }
+) => React.ReactElement;
+
+/**
+ * Public data cascade component. Forwards the ref to DataCascadeImpl so consumers
+ * receive the imperative handle on the ref.
+ */
+export const DataCascade = forwardRef(function DataCascadeWithProvider<
+  G extends GroupNode,
+  L extends LeafNode
+>(
+  {
+    cascadeGroups,
+    initialGroupColumn,
+    customTableHeader,
+    tableTitleSlot,
+    ...restProps
+  }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
+  ref: ForwardedRef<DataCascadeImplRef<G, L>>
+) {
+  const cascadeImplProps: DataCascadeImplProps<G, L> = customTableHeader
+    ? { ...restProps, customTableHeader, cascadeRef: ref }
+    : { ...restProps, tableTitleSlot: tableTitleSlot!, cascadeRef: ref };
+
   return (
-    <DataCascadeProvider cascadeGroups={cascadeGroups} initialGroupColumn={initialGroupColumn}>
-      <DataCascadeImpl<G, L> {...props} />
+    <DataCascadeProvider<G, L>
+      cascadeGroups={cascadeGroups}
+      initialGroupColumn={initialGroupColumn}
+    >
+      <DataCascadeImpl<G, L> {...cascadeImplProps} />
     </DataCascadeProvider>
   );
-}
+}) as DataCascadeComponent;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -44,6 +44,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     tableTitleSlot,
     initialTableState,
     initialScrollOffset,
+    initialRect,
     ...restProps
   }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
   ref: ForwardedRef<DataCascadeImplRef<G, L>>
@@ -51,6 +52,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
   // create a stable reference for the component initializer props
   const initialTableStateRef = useRef(initialTableState);
   const initialScrollOffsetRef = useRef(initialScrollOffset);
+  const initialRectRef = useRef(initialRect);
 
   const cascadeImplProps = useMemo<DataCascadeImplProps<G, L>>(
     () =>
@@ -70,6 +72,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
         <DataCascadeImpl<G, L>
           {...cascadeImplProps}
           initialScrollOffset={initialScrollOffsetRef.current}
+          initialRect={initialRectRef.current}
         />
       </DataCascadeProvider>
     ),

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { forwardRef, type ComponentProps, type ForwardedRef } from 'react';
+import React, { forwardRef, useMemo, useRef, type ComponentProps, type ForwardedRef } from 'react';
 import { DataCascadeImpl, type DataCascadeImplProps } from './data_cascade_impl';
 import type { DataCascadeImplRef } from '../lib/core/api';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../store_provider';
@@ -42,22 +42,37 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     initialGroupColumn,
     customTableHeader,
     tableTitleSlot,
-    initialExpandedRowIds,
+    initialTableState,
+    initialScrollOffset,
     ...restProps
   }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
   ref: ForwardedRef<DataCascadeImplRef<G, L>>
 ) {
-  const cascadeImplProps: DataCascadeImplProps<G, L> = customTableHeader
-    ? { ...restProps, customTableHeader, cascadeRef: ref }
-    : { ...restProps, tableTitleSlot: tableTitleSlot!, cascadeRef: ref };
+  // create a stable reference for the component initializer props
+  const initialTableStateRef = useRef(initialTableState);
+  const initialScrollOffsetRef = useRef(initialScrollOffset);
 
-  return (
-    <DataCascadeProvider<G, L>
-      cascadeGroups={cascadeGroups}
-      initialGroupColumn={initialGroupColumn}
-      initialExpandedRowIds={initialExpandedRowIds}
-    >
-      <DataCascadeImpl<G, L> {...cascadeImplProps} />
-    </DataCascadeProvider>
+  const cascadeImplProps = useMemo<DataCascadeImplProps<G, L>>(
+    () =>
+      customTableHeader
+        ? { ...restProps, customTableHeader, cascadeRef: ref }
+        : { ...restProps, tableTitleSlot: tableTitleSlot!, cascadeRef: ref },
+    [customTableHeader, restProps, tableTitleSlot, ref]
+  );
+
+  return React.useMemo(
+    () => (
+      <DataCascadeProvider<G, L>
+        cascadeGroups={cascadeGroups}
+        initialGroupColumn={initialGroupColumn}
+        initialTableState={initialTableStateRef.current}
+      >
+        <DataCascadeImpl<G, L>
+          {...cascadeImplProps}
+          initialScrollOffset={initialScrollOffsetRef.current}
+        />
+      </DataCascadeProvider>
+    ),
+    [cascadeGroups, cascadeImplProps, initialGroupColumn]
   );
 }) as DataCascadeComponent;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -13,7 +13,7 @@ import type { DataCascadeImplRef } from '../lib/core/api';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../store_provider';
 
 export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps, DataCascadeImplRef };
-
+export type { DataCascadeUISnapshot } from '../lib/core/api';
 export { DataCascadeRow, DataCascadeRowCell } from './data_cascade_impl';
 
 export type {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useSyncExternalStore } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useExposePublicApi, type DataCascadeImplRef } from '.';
+import { DataCascadeProvider, type GroupNode, type LeafNode } from '../../../store_provider';
+import type { CascadeVirtualizerReturnValue } from '../virtualizer';
+
+describe('useExposePublicApi', () => {
+  it('should return the correct value', () => {
+    const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+      current: null,
+    };
+
+    const { result } = renderHook(
+      () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+      {
+        wrapper: ({ children }) => (
+          <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+        ),
+      }
+    );
+
+    expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+    // ref should be populated with public API method after mount
+    expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+  });
+
+  describe('getUISnapshotStore', () => {
+    it('should return a store snapshot with the correct initial state', () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const snapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      expect(snapshotStore!.getSnapshot()).toEqual({
+        scrollOffset: 0,
+        range: null,
+        isScrolling: false,
+        activeStickyIndex: null,
+        totalRowCount: 0,
+        totalSize: 0,
+        expanded: {},
+        rowSelection: {},
+      });
+    });
+
+    it('changes on the virtualizer instance should notify subscribers, and reflect changes in the store snapshot', () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const uiSnapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      const subscriptionSpy = jest.fn();
+
+      const unsubscribe = uiSnapshotStore!.subscribe(subscriptionSpy);
+
+      const virtualizerInstance = {
+        range: { startIndex: 0, endIndex: 10 },
+        scrollOffset: 100,
+        isScrolling: false,
+        // it's fine to cast to unknown
+        // because we only need a minimal implementation of the virtualizer instance for the test
+      } as unknown as CascadeVirtualizerReturnValue;
+
+      // simulate changes in the virtualizer instance
+      act(() => {
+        result.current.collectVirtualizerStateChanges(virtualizerInstance);
+      });
+
+      expect(subscriptionSpy).toHaveBeenCalled();
+
+      const updatedUISnapshot = uiSnapshotStore!.getSnapshot();
+
+      expect(updatedUISnapshot).toHaveProperty('scrollOffset', virtualizerInstance.scrollOffset);
+      expect(updatedUISnapshot).toHaveProperty('range', virtualizerInstance.range);
+      expect(updatedUISnapshot).toHaveProperty('isScrolling', virtualizerInstance.isScrolling);
+
+      // these properties did not change because we did not provide updates for them
+      expect(updatedUISnapshot).toHaveProperty('activeStickyIndex', null);
+      expect(updatedUISnapshot).toHaveProperty('totalRowCount', 0);
+      expect(updatedUISnapshot).toHaveProperty('totalSize', 0);
+      expect(updatedUISnapshot).toHaveProperty('expanded', {});
+      expect(updatedUISnapshot).toHaveProperty('rowSelection', {});
+
+      unsubscribe();
+    });
+
+    it('should be compatible with the useSyncExternalStore hook', () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const snapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      const { result: externalSyncResult } = renderHook(() =>
+        useSyncExternalStore(
+          snapshotStore!.subscribe,
+          snapshotStore!.getSnapshot,
+          snapshotStore!.getServerSnapshot
+        )
+      );
+
+      expect(externalSyncResult.current).toEqual({
+        scrollOffset: 0,
+        range: null,
+        isScrolling: false,
+        activeStickyIndex: null,
+        totalRowCount: 0,
+        totalSize: 0,
+        expanded: {},
+        rowSelection: {},
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
@@ -11,7 +11,7 @@ import React, { useSyncExternalStore } from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { useExposePublicApi, type DataCascadeImplRef } from '.';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../../../store_provider';
-import type { CascadeVirtualizerReturnValue } from '../virtualizer';
+import type { UseVirtualizerReturnType } from '../virtualizer';
 
 describe('useExposePublicApi', () => {
   it('should return the correct value', () => {
@@ -94,7 +94,7 @@ describe('useExposePublicApi', () => {
         isScrolling: false,
         // it's fine to cast to unknown
         // because we only need a minimal implementation of the virtualizer instance for the test
-      } as unknown as CascadeVirtualizerReturnValue;
+      } as unknown as UseVirtualizerReturnType;
 
       // simulate changes in the virtualizer instance
       act(() => {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Row } from '@tanstack/react-table';
+import { useCallback, useLayoutEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import {
+  useDataCascadeState,
+  type GroupNode,
+  type LeafNode,
+  type IStoreState,
+} from '../../../store_provider';
+import {
+  calculateActiveStickyIndex,
+  type CascadeVirtualizerReturnValue,
+  type UseVirtualizerReturnType,
+} from '../virtualizer';
+
+/**
+ * Snapshot of data cascade ui state for use with useSyncExternalStore.
+ * Includes virtualizer-derived state and specific table state.
+ */
+export interface DataCascadeUISnapshot<G extends GroupNode, L extends LeafNode>
+  extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
+  scrollOffset: number;
+  range: { startIndex: number; endIndex: number } | null;
+  isScrolling: boolean;
+  activeStickyIndex: number | null;
+  totalRowCount: number;
+  totalSize: number;
+}
+
+/**
+ * useSyncExternalStore-compatible store for data cascade ui state.
+ */
+export interface DataCascadeUISnapshotStore<G extends GroupNode, L extends LeafNode> {
+  subscribe(onStoreChange: () => void): () => void;
+  getSnapshot(): DataCascadeUISnapshot<G, L>;
+  getServerSnapshot(): DataCascadeUISnapshot<G, L>;
+}
+
+/**
+ * Options for useExposePublicApi. Supplies table/UI state needed to build the snapshot.
+ */
+export interface UseExposePublicApiOptions<G extends GroupNode> {
+  rows: Row<G>[];
+  enableStickyGroupHeader: boolean;
+}
+
+/**
+ * Return value of useExposePublicApi.
+ */
+export interface UseExposePublicApiReturnValue {
+  /** Updates the store snapshot from virtualizer instance changes */
+  collectVirtualizerStateChanges: (
+    instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined
+  ) => void;
+}
+
+const createDefaultUISnapshot = <G extends GroupNode, L extends LeafNode>(): DataCascadeUISnapshot<
+  G,
+  L
+> => ({
+  scrollOffset: 0,
+  range: null,
+  isScrolling: false,
+  activeStickyIndex: null,
+  totalRowCount: 0,
+  totalSize: 0,
+  expanded: {},
+  rowSelection: {},
+});
+
+/**
+ * Definition of the public API ref for the data cascade component.
+ */
+export interface DataCascadeImplRef<G extends GroupNode, L extends LeafNode> {
+  /**
+   * Returns helpers to access a minimal readonly state of the data cascade component.
+   * This can be used as-is or put together leveraging useSyncExternalStore to create a more reactive
+   * component state.
+   *
+   * @example
+   * ```ts
+   * export function useDataCascadeSnapshot(ref: React.RefObject<DataCascadeImplRef | null>): DataCascadeSnapshot {
+   *   return useSyncExternalStore(
+   *     (onStoreChange) => ref.current?.getUISnapshotStore()?.subscribe(onStoreChange) ?? (() => {}),
+   *     () => ref.current?.getUISnapshotStore()?.getSnapshot() ?? DEFAULT_SNAPSHOT,
+   *     () => ref.current?.getUISnapshotStore()?.getServerSnapshot() ?? DEFAULT_SNAPSHOT
+   *   );
+   * }
+   * ```
+   */
+  getUISnapshotStore: () => DataCascadeUISnapshotStore<G, L> | null;
+}
+
+/**
+ * Hook that owns the public API ref: aggregates state + virtualizer into a snapshot store,
+ * updates the store when inputs change, and exposes getStateStore via useImperativeHandle.
+ * Call from the cascade impl with the ref and options; the ref will be populated after mount.
+ */
+export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
+  ref: React.Ref<DataCascadeImplRef<G, L>>,
+  options: UseExposePublicApiOptions<G>
+): UseExposePublicApiReturnValue {
+  // Use a stable handle object and only update its method.
+  const handleRef = useRef<DataCascadeImplRef<G, L>>({
+    getUISnapshotStore: () => null,
+  });
+
+  const { rows } = options;
+  const state = useDataCascadeState<G, L>();
+
+  const expanded = useMemo<DataCascadeUISnapshot<G, L>['expanded']>(
+    () =>
+      typeof state.table.expanded === 'object' && state.table.expanded !== null
+        ? state.table.expanded
+        : {},
+    [state.table.expanded]
+  );
+
+  const rowSelection = useMemo<DataCascadeUISnapshot<G, L>['rowSelection']>(
+    () => state.table.rowSelection ?? {},
+    [state.table.rowSelection]
+  );
+
+  const optionsRef = useRef(options);
+  const latestStateRef = useRef({ expanded, rowSelection });
+  optionsRef.current = options;
+  latestStateRef.current = { expanded, rowSelection };
+
+  const storeRef = useRef<{
+    listeners: Set<() => void>;
+    snapshot: DataCascadeUISnapshot<G, L>;
+  }>({
+    listeners: new Set(),
+    snapshot: createDefaultUISnapshot(),
+  });
+
+  const subscribe = useCallback((onUISnapshotChange: () => void) => {
+    storeRef.current.listeners.add(onUISnapshotChange);
+    return () => {
+      storeRef.current.listeners.delete(onUISnapshotChange);
+    };
+  }, []);
+
+  const getSnapshot = useCallback((): DataCascadeUISnapshot<G, L> => storeRef.current.snapshot, []);
+  const getServerSnapshot = useCallback(
+    (): DataCascadeUISnapshot<G, L> => storeRef.current.snapshot,
+    []
+  );
+
+  /** Notifies all subscribed listeners that the store snapshot may have changed. */
+  const notifyListeners = useCallback(() => {
+    const opts = optionsRef.current;
+    const { expanded: exp, rowSelection: sel } = latestStateRef.current;
+    const snap = storeRef.current.snapshot;
+
+    snap.totalRowCount = opts.rows.length;
+    snap.expanded = exp;
+    snap.rowSelection = sel;
+
+    storeRef.current.listeners.forEach((listener) => listener());
+  }, []);
+
+  /** scans updates from virtualizer instance and updates the store snapshot. */
+  const collectVirtualizerStateChanges = useCallback(
+    (instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined) => {
+      const opts = optionsRef.current;
+      const snap = storeRef.current.snapshot;
+      // if the virtualizer instance is not null, update the store snapshot
+      if (instance != null) {
+        const range =
+          instance.range != null
+            ? { startIndex: instance.range.startIndex, endIndex: instance.range.endIndex }
+            : null;
+        const activeStickyIndex = calculateActiveStickyIndex(
+          opts.rows,
+          range?.startIndex ?? 0,
+          opts.enableStickyGroupHeader
+        );
+        snap.scrollOffset = instance.scrollOffset ?? 0;
+        snap.range = range;
+        snap.isScrolling = instance.isScrolling ?? false;
+        snap.activeStickyIndex = activeStickyIndex;
+        snap.totalSize = instance.getTotalSize ? instance.getTotalSize() : 0;
+
+        notifyListeners();
+      }
+    },
+    [notifyListeners]
+  );
+
+  useLayoutEffect(() => {
+    notifyListeners();
+  }, [notifyListeners, expanded, rowSelection, rows.length]);
+
+  const getStateStore = useCallback(
+    (): DataCascadeUISnapshotStore<G, L> => ({
+      subscribe,
+      getSnapshot,
+      getServerSnapshot,
+    }),
+    [subscribe, getSnapshot, getServerSnapshot]
+  );
+
+  handleRef.current = {
+    getUISnapshotStore: getStateStore,
+  };
+
+  // Magic happens here, the ref is populated after mount and consumers can use it to access the public API
+  useImperativeHandle(ref, () => handleRef.current, []);
+
+  return { collectVirtualizerStateChanges };
+}

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -25,8 +25,10 @@ import {
  * Snapshot of data cascade ui state for use with useSyncExternalStore.
  * Includes virtualizer-derived state and specific table state.
  */
-export interface DataCascadeUISnapshot<G extends GroupNode, L extends LeafNode>
-  extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
+export interface DataCascadeUISnapshot<
+  G extends GroupNode = GroupNode,
+  L extends LeafNode = LeafNode
+> extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
   scrollOffset: number;
   range: { startIndex: number; endIndex: number } | null;
   isScrolling: boolean;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Row } from '@tanstack/react-table';
+import { debounce } from 'lodash';
 import { useCallback, useLayoutEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import {
   useDataCascadeState,
@@ -158,17 +159,21 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
   );
 
   /** Notifies all subscribed listeners that the store snapshot may have changed. */
-  const notifyListeners = useCallback(() => {
-    const opts = optionsRef.current;
-    const { expanded: exp, rowSelection: sel } = latestStateRef.current;
-    const snap = storeRef.current.snapshot;
+  const notifyListeners = useMemo(
+    () =>
+      debounce(() => {
+        const opts = optionsRef.current;
+        const { expanded: exp, rowSelection: sel } = latestStateRef.current;
+        const snap = storeRef.current.snapshot;
 
-    snap.totalRowCount = opts.rows.length;
-    snap.expanded = exp;
-    snap.rowSelection = sel;
+        snap.totalRowCount = opts.rows.length;
+        snap.expanded = exp;
+        snap.rowSelection = sel;
 
-    storeRef.current.listeners.forEach((listener) => listener());
-  }, []);
+        storeRef.current.listeners.forEach((listener) => listener());
+      }, 100),
+    []
+  );
 
   /** scans updates from virtualizer instance and updates the store snapshot. */
   const collectVirtualizerStateChanges = useCallback(

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -16,11 +16,7 @@ import {
   type LeafNode,
   type IStoreState,
 } from '../../../store_provider';
-import {
-  calculateActiveStickyIndex,
-  type CascadeVirtualizerReturnValue,
-  type UseVirtualizerReturnType,
-} from '../virtualizer';
+import { calculateActiveStickyIndex, type UseVirtualizerReturnType } from '../virtualizer';
 
 /**
  * Snapshot of data cascade ui state for use with useSyncExternalStore.
@@ -30,6 +26,7 @@ export interface DataCascadeUISnapshot<
   G extends GroupNode = GroupNode,
   L extends LeafNode = LeafNode
 > extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
+  scrollRect: { width: number; height: number };
   scrollOffset: number;
   range: { startIndex: number; endIndex: number } | null;
   isScrolling: boolean;
@@ -60,9 +57,7 @@ export interface UseExposePublicApiOptions<G extends GroupNode> {
  */
 export interface UseExposePublicApiReturnValue {
   /** Updates the store snapshot from virtualizer instance changes */
-  collectVirtualizerStateChanges: (
-    instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined
-  ) => void;
+  collectVirtualizerStateChanges: (instance: UseVirtualizerReturnType | undefined) => void;
 }
 
 const createDefaultUISnapshot = <G extends GroupNode, L extends LeafNode>(): DataCascadeUISnapshot<
@@ -70,6 +65,7 @@ const createDefaultUISnapshot = <G extends GroupNode, L extends LeafNode>(): Dat
   L
 > => ({
   scrollOffset: 0,
+  scrollRect: { width: 0, height: 0 },
   range: null,
   isScrolling: false,
   activeStickyIndex: null,
@@ -177,7 +173,7 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
 
   /** scans updates from virtualizer instance and updates the store snapshot. */
   const collectVirtualizerStateChanges = useCallback(
-    (instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined) => {
+    (instance: UseVirtualizerReturnType | undefined) => {
       const opts = optionsRef.current;
       const snap = storeRef.current.snapshot;
       // if the virtualizer instance is not null, update the store snapshot
@@ -195,6 +191,7 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
         snap.range = range;
         snap.isScrolling = instance.isScrolling ?? false;
         snap.activeStickyIndex = activeStickyIndex;
+        snap.scrollRect = instance.scrollRect ?? { width: 0, height: 0 };
         snap.totalSize = instance.getTotalSize ? instance.getTotalSize() : 0;
 
         notifyListeners();

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/table/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/table/index.tsx
@@ -138,7 +138,8 @@ export const useCascadeTable = <G extends GroupNode, L extends LeafNode>({
         }
       }
 
-      return actions.setExpandedRows(newRootRow ? { [newRootRow]: true } : newExpandedRows);
+      const nextExpandedState = newRootRow ? { [newRootRow]: true } : newExpandedRows;
+      return actions.setExpandedRows(nextExpandedState);
     },
     getRowId: (rowData) => rowData.id,
     getSubRows: (row) => row.children as G[],

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -13,7 +13,7 @@ import { useVirtualizer, defaultRangeExtractor, type VirtualItem } from '@tansta
 import type { GroupNode } from '../../../store_provider';
 
 type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
-type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
+export type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
 
 export interface CascadeVirtualizerProps<G extends GroupNode>
   extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan'> {
@@ -24,6 +24,11 @@ export interface CascadeVirtualizerProps<G extends GroupNode>
    */
   enableStickyGroupHeader: boolean;
   estimatedRowHeight?: number;
+  /**
+   * Called whenever the virtualizer updates (scroll, range, size, etc.).
+   * Used to conduit values into external state (e.g. public API store).
+   */
+  onStateChange?: (instance: UseVirtualizerReturnType) => void;
 }
 
 export interface UseVirtualizedRowScrollStateStoreOptions {
@@ -168,6 +173,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   estimatedRowHeight = 0,
   rows,
   getScrollElement,
+  onStateChange,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
 
@@ -202,9 +208,11 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
         // but it not included in the type definition because it is marked as a private property,
         // see {@link https://github.com/TanStack/virtual/blob/v3.13.2/packages/virtual-core/src/index.ts#L360}
         virtualizedRowsSizeCacheRef.current = rowVirtualizerInstance.itemSizeCache;
+        // propagate virtualizer state changes
+        onStateChange?.(rowVirtualizerInstance);
       },
     }),
-    [estimatedRowHeight, getScrollElement, overscan, rangeExtractor, rows.length]
+    [estimatedRowHeight, getScrollElement, overscan, rangeExtractor, rows.length, onStateChange]
   );
 
   const virtualizerImpl = useVirtualizer(virtualizerOptions);

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -16,7 +16,10 @@ type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
 export type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
 
 export interface CascadeVirtualizerProps<G extends GroupNode>
-  extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan' | 'initialOffset'> {
+  extends Pick<
+    UseVirtualizerOptions,
+    'getScrollElement' | 'overscan' | 'initialOffset' | 'initialRect'
+  > {
   rows: Row<G>[];
   /**
    * setting a value of true causes the active group root row
@@ -175,6 +178,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   getScrollElement,
   onStateChange,
   initialOffset,
+  initialRect,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
 
@@ -205,6 +209,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       overscan,
       rangeExtractor,
       initialOffset,
+      initialRect,
       onChange: (rowVirtualizerInstance) => {
         // @ts-expect-error -- the itemsSizeCache property does exist,
         // but it not included in the type definition because it is marked as a private property,
@@ -218,6 +223,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       estimatedRowHeight,
       getScrollElement,
       initialOffset,
+      initialRect,
       overscan,
       rangeExtractor,
       rows.length,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -16,7 +16,7 @@ type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
 export type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
 
 export interface CascadeVirtualizerProps<G extends GroupNode>
-  extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan'> {
+  extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan' | 'initialOffset'> {
   rows: Row<G>[];
   /**
    * setting a value of true causes the active group root row
@@ -174,6 +174,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   rows,
   getScrollElement,
   onStateChange,
+  initialOffset,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
 
@@ -203,6 +204,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       getScrollElement,
       overscan,
       rangeExtractor,
+      initialOffset,
       onChange: (rowVirtualizerInstance) => {
         // @ts-expect-error -- the itemsSizeCache property does exist,
         // but it not included in the type definition because it is marked as a private property,
@@ -212,7 +214,15 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
         onStateChange?.(rowVirtualizerInstance);
       },
     }),
-    [estimatedRowHeight, getScrollElement, overscan, rangeExtractor, rows.length, onStateChange]
+    [
+      estimatedRowHeight,
+      getScrollElement,
+      initialOffset,
+      overscan,
+      rangeExtractor,
+      rows.length,
+      onStateChange,
+    ]
   );
 
   const virtualizerImpl = useVirtualizer(virtualizerOptions);

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/store_provider/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/store_provider/index.tsx
@@ -22,13 +22,12 @@ export type { GroupNode, LeafNode, IStoreState } from './reducers';
 
 interface IDataCascadeProviderProps {
   initialGroupColumn?: string[];
-  /**
-   * Row ids (from rowData.id) to expand on mount. For a nested row to be visible,
-   * include the full path from root to that row (e.g. ['root-id', 'child-id', 'leaf-id']).
-   * Order in the array does not matter.
-   */
-  initialExpandedRowIds?: string[];
   cascadeGroups: string[];
+  /**
+   * Properties to set the initial table state on mount.
+   * Only expanded and rowSelection properties are supported for now.
+   */
+  initialTableState?: Pick<Partial<TableState>, 'expanded' | 'rowSelection'>;
 }
 
 interface IStoreContext<G extends GroupNode, L extends LeafNode> {
@@ -75,7 +74,7 @@ export function useCascadeLeafNode<G extends GroupNode, L extends LeafNode>(cach
 export function DataCascadeProvider<G extends GroupNode, L extends LeafNode>({
   cascadeGroups,
   initialGroupColumn,
-  initialExpandedRowIds,
+  initialTableState,
   children,
 }: PropsWithChildren<IDataCascadeProviderProps>) {
   const StoreContext = createStoreContext<G, L>();
@@ -86,19 +85,9 @@ export function DataCascadeProvider<G extends GroupNode, L extends LeafNode>({
     return initialGroupColumn.filter((col) => cascadeGroups.includes(col));
   }, [initialGroupColumn, cascadeGroups]);
 
-  const initialTableState = useMemo<TableState>(() => {
-    if (initialExpandedRowIds?.length) {
-      return {
-        expanded: Object.fromEntries(initialExpandedRowIds.map((id) => [id, true])),
-      } as TableState;
-    }
-    return {} as TableState;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally empty: only use initialExpandedRowIds on mount
-  }, []);
-
   const { state, actions } = useCreateStore({
     initialState: {
-      table: initialTableState,
+      table: (initialTableState ?? {}) as TableState,
       groupNodes: [] as G[],
       leafNodes: new Map<string, L[]>(), // TODO: consider externalizing this so the consumer might provide their own external cache
       groupByColumns: cascadeGroups,

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -34,7 +34,11 @@ import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { FetchStatus } from '../../../types';
 import { checkHitCount, sendErrorTo } from '../../hooks/use_saved_search_messages';
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
-import { type DiscoverAppState, useAppStateSelector } from '../../state_management/redux';
+import {
+  type DiscoverAppState,
+  selectTabCombinedFilters,
+  useAppStateSelector,
+} from '../../state_management/redux';
 import type {
   DataDocumentsMsg,
   DiscoverLatestFetchDetails,
@@ -201,14 +205,7 @@ export const useDiscoverHistogram = (
   const histogramCustomization = useDiscoverCustomization('unified_histogram');
 
   const query = useAppStateSelector((state) => state.query);
-  const appFilters = useAppStateSelector((state) => state.filters);
-  const { filters: globalFilters } = useCurrentTabSelector((state) => state.globalState);
-
-  const filtersMemoized = useMemo(() => {
-    const allFilters = [...(globalFilters ?? []), ...(appFilters ?? [])];
-    return allFilters.length ? allFilters : EMPTY_FILTERS;
-  }, [appFilters, globalFilters]);
-
+  const filters = useCurrentTabSelector(selectTabCombinedFilters);
   const timeInterval = useAppStateSelector((state) => state.interval);
   const breakdownField = useAppStateSelector((state) => state.breakdownField);
   const esqlVariables = useCurrentTabSelector((tab) => tab.esqlVariables);
@@ -228,7 +225,7 @@ export const useDiscoverHistogram = (
       requestAdapter: inspectorAdapters.requests,
       dataView,
       query,
-      filters: isEsqlMode ? EMPTY_FILTERS : filtersMemoized,
+      filters,
       timeRange,
       relativeTimeRange,
       breakdownField,
@@ -245,7 +242,7 @@ export const useDiscoverHistogram = (
     currentTabControlState,
     dataView,
     esqlVariables,
-    filtersMemoized,
+    filters,
     inspectorAdapters.requests,
     isEsqlMode,
     timeRange,

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -26,7 +26,6 @@ import { distinctUntilChanged, filter, map, pairwise, startWith } from 'rxjs';
 import useLatest from 'react-use/lib/useLatest';
 import type { RequestAdapter } from '@kbn/inspector-plugin/common';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
-import type { Filter } from '@kbn/es-query';
 import { ESQL_TABLE_TYPE } from '@kbn/data-plugin/common';
 import { useProfileAccessor } from '../../../../context_awareness';
 import { useDiscoverCustomization } from '../../../../customizations';
@@ -56,7 +55,6 @@ import { useDataState } from '../../hooks/use_data_state';
 import { getDefinedControlGroupState } from '../../state_management/utils/get_defined_control_group_state';
 
 const EMPTY_ESQL_COLUMNS: DatatableColumn[] = [];
-const EMPTY_FILTERS: Filter[] = [];
 const TAB_ATTRIBUTE_TO_TRIGGER_CHART_FETCH: Array<keyof UnifiedHistogramFetchParamsExternal> = [
   'externalVisContext',
   'breakdownField',

--- a/src/platform/plugins/shared/discover/public/application/main/components/field_stats_table/field_stats_tab.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/field_stats_table/field_stats_tab.tsx
@@ -8,14 +8,17 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-import { useQuerySubscriber } from '@kbn/unified-field-list/src/hooks/use_query_subscriber';
 import { filter, map } from 'rxjs';
 import useObservable from 'react-use/lib/useObservable';
 import type { DataVisualizerTableState } from '@kbn/data-visualizer-plugin/common/types';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { FieldStatisticsTable } from './field_stats_table';
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
-import { useAppStateSelector } from '../../state_management/redux';
+import {
+  selectTabCombinedFilters,
+  useAppStateSelector,
+  useCurrentTabSelector,
+} from '../../state_management/redux';
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
 import { FetchStatus } from '../../../types';
 import type { FieldStatisticsTableProps } from './types';
@@ -31,9 +34,8 @@ type FieldStatisticsTabProps = Omit<FieldStatisticsTableProps, 'query' | 'filter
 
 export const FieldStatisticsTab: React.FC<FieldStatisticsTabProps> = React.memo((props) => {
   const services = useDiscoverServices();
-  const { query, filters } = useQuerySubscriber({
-    data: services.data,
-  });
+  const query = useAppStateSelector((state) => state.query);
+  const filters = useCurrentTabSelector(selectTabCombinedFilters);
   const isEsql = useIsEsqlMode();
   const hideAggregatedPreview = useAppStateSelector((state) => state.hideAggregatedPreview);
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { EuiPanel, EuiText, type EuiDataGridCustomBodyProps, useEuiTheme } from '@elastic/eui';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { throttle } from 'lodash';
 import {
   getRenderCustomToolbarWithElements,
   UnifiedDataTable,
@@ -23,6 +24,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { useDiscoverServices } from '../../../../../../hooks/use_discover_services';
 import { getCustomCascadeGridBodyStyle } from './cascade_leaf_component.styles';
 import type { ESQLDataGroupNode } from './types';
+import type { DataCascadeLeafUiState } from '../../../../state_management/redux/types';
 
 interface ESQLDataCascadeLeafCellProps
   extends Pick<
@@ -41,6 +43,8 @@ interface ESQLDataCascadeLeafCellProps
     > {
   cellData: DataTableRecord[];
   cellId: string;
+  leafUiState?: DataCascadeLeafUiState;
+  onLeafUiStateChange?: (nextState: DataCascadeLeafUiState) => void;
 }
 
 interface CustomCascadeGridBodyProps
@@ -52,6 +56,7 @@ interface CustomCascadeGridBodyProps
   data: DataTableRecord[];
   isFullScreenMode?: boolean;
   initialOffset: () => number;
+  onScrollOffsetChange?: (scrollOffset: number) => void;
 }
 
 const EMPTY_SORT: SortOrder[] = [];
@@ -72,6 +77,7 @@ export const CustomCascadeGridBodyMemoized = React.memo(function CustomCascadeGr
   getScrollElement,
   getScrollMargin,
   preventSizeChangePropagation,
+  onScrollOffsetChange,
   Cell,
   visibleColumns,
   visibleRowData,
@@ -115,6 +121,15 @@ export const CustomCascadeGridBodyMemoized = React.memo(function CustomCascadeGr
     }
   }, [getScrollElement, isFullScreenMode]);
 
+  const onVirtualizerChange = useCallback(
+    (instance: ReturnType<typeof useVirtualizer>) => {
+      if (isFullScreenMode) {
+        onScrollOffsetChange?.(instance.scrollOffset ?? 0);
+      }
+    },
+    [isFullScreenMode, onScrollOffsetChange]
+  );
+
   const virtualizer = useVirtualizer({
     count: visibleRows.length,
     estimateSize: () => 50,
@@ -122,6 +137,7 @@ export const CustomCascadeGridBodyMemoized = React.memo(function CustomCascadeGr
     initialOffset,
     scrollMargin: getScrollMargin(),
     getScrollElement: scrollElementGetter,
+    onChange: onVirtualizerChange,
   });
 
   /**
@@ -203,29 +219,38 @@ export const ESQLDataCascadeLeafCell = React.memo(
     getScrollOffset,
     preventSizeChangePropagation,
     onUpdateDataGridDensity,
+    leafUiState,
+    onLeafUiStateChange,
   }: ESQLDataCascadeLeafCellProps) => {
     const services = useDiscoverServices();
-    const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>();
-    const [cascadeDataGridDensityState, setCascadeDataGridDensityState] = useState<DataGridDensity>(
-      dataGridDensityState ?? DataGridDensity.COMPACT
-    );
+    const cascadeDataGridDensityState =
+      leafUiState?.density ?? dataGridDensityState ?? DataGridDensity.COMPACT;
 
     // TODO: Implement column selection logic,
     // probably requires a new selection component that will be used within the row
-    const [selectedColumns, setSelectedColumns] = useState<string[]>([]);
+    const selectedColumns = leafUiState?.selectedColumns ?? [];
 
-    useEffect(() => {
-      // propagate localized changes of the data grid density,
-      // so that other rows can use the same density value
-      onUpdateDataGridDensity?.(cascadeDataGridDensityState);
-    }, [cascadeDataGridDensityState, onUpdateDataGridDensity]);
+    const isCellInFullScreenMode = leafUiState?.isFullScreen ?? false;
 
-    const [isCellInFullScreenMode, setIsCellInFullScreenMode] = useState(false);
+    const expandedDoc = useMemo(() => {
+      if (!leafUiState?.expandedDocId) {
+        return undefined;
+      }
+
+      return cellData.find((doc) => doc.id === leafUiState.expandedDocId);
+    }, [cellData, leafUiState?.expandedDocId]);
+
+    const handleFullScreenChange = useCallback(
+      (nextIsFullScreen: boolean) => {
+        onLeafUiStateChange?.({ isFullScreen: nextIsFullScreen });
+      },
+      [onLeafUiStateChange]
+    );
 
     const setExpandedDocFn = useCallback(
       (...args: Parameters<NonNullable<UnifiedDataTableProps['setExpandedDoc']>>) =>
-        setExpandedDoc(args[0]),
-      [setExpandedDoc]
+        onLeafUiStateChange?.({ expandedDocId: args[0]?.id }),
+      [onLeafUiStateChange]
     );
 
     const renderCustomToolbarWithElements = useMemo(
@@ -245,6 +270,18 @@ export const ESQLDataCascadeLeafCell = React.memo(
         }),
       [cellData]
     );
+
+    const handleLeafScrollOffsetChange = useMemo(
+      () =>
+        throttle((scrollOffset: number) => {
+          onLeafUiStateChange?.({ scrollOffset });
+        }, 150),
+      [onLeafUiStateChange]
+    );
+
+    useEffect(() => {
+      return () => handleLeafScrollOffsetChange.cancel();
+    }, [handleLeafScrollOffsetChange]);
 
     const renderCustomCascadeGridBodyCallback = useCallback<
       NonNullable<UnifiedDataTableProps['renderCustomGridBody']>
@@ -271,8 +308,11 @@ export const ESQLDataCascadeLeafCell = React.memo(
           setCustomGridBodyProps={setCustomGridBodyProps}
           getScrollElement={getScrollElement}
           preventSizeChangePropagation={preventSizeChangePropagation}
-          initialOffset={getScrollOffset}
+          initialOffset={() =>
+            isCellInFullScreenMode ? leafUiState?.scrollOffset ?? 0 : getScrollOffset()
+          }
           isFullScreenMode={isCellInFullScreenMode}
+          onScrollOffsetChange={handleLeafScrollOffsetChange}
         />
       ),
       [
@@ -283,7 +323,24 @@ export const ESQLDataCascadeLeafCell = React.memo(
         getScrollMargin,
         getScrollOffset,
         isCellInFullScreenMode,
+        handleLeafScrollOffsetChange,
+        leafUiState?.scrollOffset,
       ]
+    );
+
+    const handleSetColumns = useCallback(
+      (nextColumns: string[]) => {
+        onLeafUiStateChange?.({ selectedColumns: nextColumns });
+      },
+      [onLeafUiStateChange]
+    );
+
+    const handleDensityChange = useCallback(
+      (nextDensity: DataGridDensity) => {
+        onUpdateDataGridDensity?.(nextDensity);
+        onLeafUiStateChange?.({ density: nextDensity });
+      },
+      [onLeafUiStateChange, onUpdateDataGridDensity]
     );
 
     return (
@@ -302,15 +359,15 @@ export const ESQLDataCascadeLeafCell = React.memo(
           rows={cellData}
           loadingState={DataLoadingState.loaded}
           columns={selectedColumns}
-          onSetColumns={setSelectedColumns}
+          onSetColumns={handleSetColumns}
           renderCustomToolbar={renderCustomToolbarWithElements}
           expandedDoc={expandedDoc}
           setExpandedDoc={setExpandedDocFn}
           dataGridDensityState={cascadeDataGridDensityState}
-          onUpdateDataGridDensity={setCascadeDataGridDensityState}
+          onUpdateDataGridDensity={handleDensityChange}
           renderDocumentView={renderDocumentView}
           renderCustomGridBody={renderCustomCascadeGridBodyCallback}
-          onFullScreenChange={setIsCellInFullScreenMode}
+          onFullScreenChange={handleFullScreenChange}
           externalCustomRenderers={externalCustomRenderers}
           paginationMode="infinite"
           sampleSizeState={cellData.length}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
@@ -26,7 +26,7 @@ import { getCustomCascadeGridBodyStyle } from './cascade_leaf_component.styles';
 import type { ESQLDataGroupNode } from './types';
 import type { DataCascadeLeafUiState } from '../../../../state_management/redux/types';
 
-interface ESQLDataCascadeLeafCellProps
+export interface ESQLDataCascadeLeafCellProps
   extends Pick<
       UnifiedDataTableProps,
       | 'dataGridDensityState'
@@ -148,13 +148,18 @@ export const CustomCascadeGridBodyMemoized = React.memo(function CustomCascadeGr
   useEffect(() => {
     let unregister: (() => void) | null = null;
 
-    if (virtualizer.scrollElement?.isSameNode(scrollElementGetter())) {
+    if (virtualizer.scrollElement?.isSameNode(getScrollElement())) {
       // Only register when using the parent's scroll element (not in fullscreen mode)
       unregister = preventSizeChangePropagation();
     }
 
     return () => unregister?.();
-  }, [preventSizeChangePropagation, scrollElementGetter, virtualizer.scrollElement]);
+  }, [
+    getScrollElement,
+    preventSizeChangePropagation,
+    scrollElementGetter,
+    virtualizer.scrollElement,
+  ]);
 
   const items = virtualizer.getVirtualItems();
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/index.ts
@@ -9,5 +9,8 @@
 
 export { useEsqlDataCascadeRowHeaderComponents } from './use_row_header_components';
 export { useEsqlDataCascadeHeaderComponent } from './use_table_header_components';
-export { ESQLDataCascadeLeafCell } from './cascade_leaf_component';
+export {
+  ESQLDataCascadeLeafCell,
+  type ESQLDataCascadeLeafCellProps,
+} from './cascade_leaf_component';
 export type { ESQLDataGroupNode } from './types';

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/use_table_header_components.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/use_table_header_components.tsx
@@ -103,7 +103,7 @@ function CascadeGroupingSelectionPopover({
             data-test-subj="discoverEnableCascadeLayoutSwitch"
           >
             <FormattedMessage
-              id="discover.cascade.header.layoutSwitchLabel"
+              id="discover.dataCascade.header.layoutSwitchLabel"
               defaultMessage="Group by"
             />
           </EuiDataGridToolbarControl>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -22,8 +22,6 @@ import { EsqlQuery } from '@kbn/esql-language';
 import { type ESQLStatsQueryMeta } from '@kbn/esql-utils';
 import { getStatsCommandToOperateOn } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers/utils';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { useDiscoverServices } from '../../../../../hooks/use_discover_services';
-import { useScopedServices } from '../../../../../components/scoped_services_provider/scoped_services_provider';
 import {
   useEsqlDataCascadeRowHeaderComponents,
   useEsqlDataCascadeHeaderComponent,
@@ -32,11 +30,7 @@ import {
 } from './blocks';
 import { cascadedDocumentsStyles } from './cascaded_documents.styles';
 import { useEsqlDataCascadeRowActionHelpers } from './blocks/use_row_header_components';
-import {
-  useDataCascadeRowExpansionHandlers,
-  useGroupedCascadeData,
-  useScopedESQLQueryFetchClient,
-} from './hooks';
+import { useDataCascadeRowExpansionHandlers, useGroupedCascadeData } from './hooks';
 import { useCascadedDocumentsContext } from './cascaded_documents_provider';
 
 export interface ESQLDataCascadeProps
@@ -61,15 +55,11 @@ const ESQLDataCascade = React.memo(
     const {
       availableCascadeGroups,
       selectedCascadeGroups,
-      esqlQuery,
       esqlVariables,
-      timeRange,
       viewModeToggle,
       cascadeGroupingChangeHandler,
       registerCascadeRequestsInspectorAdapter,
     } = useCascadedDocumentsContext();
-    const { scopedProfilesManager } = useScopedServices();
-    const { data, expressions } = useDiscoverServices();
 
     const cascadeRequestsInspectorAdapter = useRef<RequestAdapter>(new RequestAdapter());
 
@@ -84,23 +74,12 @@ const ESQLDataCascade = React.memo(
       esqlVariables,
     });
 
-    const fetchCascadeData = useScopedESQLQueryFetchClient({
-      query: esqlQuery,
-      dataView,
-      data,
-      esqlVariables,
-      expressions,
-      timeRange,
-      scopedProfilesManager,
-      inspectorAdapters: { requests: cascadeRequestsInspectorAdapter.current },
-    });
-
     const {
       onCascadeGroupNodeExpanded,
       onCascadeGroupNodeCollapsed,
       onCascadeLeafNodeExpanded,
       onCascadeLeafNodeCollapsed,
-    } = useDataCascadeRowExpansionHandlers({ cascadeFetchClient: fetchCascadeData });
+    } = useDataCascadeRowExpansionHandlers({ dataView });
 
     const customTableHeading = useEsqlDataCascadeHeaderComponent({
       viewModeToggle,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useCallback, Fragment, useRef, useEffect } from 'react';
+import React, { useMemo, useCallback, Fragment, useRef } from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import {
   DataCascade,
@@ -15,7 +15,6 @@ import {
   DataCascadeRowCell,
   type DataCascadeRowCellProps,
 } from '@kbn/shared-ux-document-data-cascade';
-import { RequestAdapter } from '@kbn/inspector-plugin/common';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
 import { getESQLStatsQueryMeta } from '@kbn/esql-utils';
 import { EsqlQuery } from '@kbn/esql-language';
@@ -58,14 +57,7 @@ const ESQLDataCascade = React.memo(
       esqlVariables,
       viewModeToggle,
       cascadeGroupingChangeHandler,
-      registerCascadeRequestsInspectorAdapter,
     } = useCascadedDocumentsContext();
-
-    const cascadeRequestsInspectorAdapter = useRef<RequestAdapter>(new RequestAdapter());
-
-    useEffect(() => {
-      registerCascadeRequestsInspectorAdapter(cascadeRequestsInspectorAdapter.current);
-    }, [registerCascadeRequestsInspectorAdapter]);
 
     const cascadeGroupData = useGroupedCascadeData({
       selectedCascadeGroups,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -72,9 +72,9 @@ const ESQLDataCascade = React.memo(
       cascadeGroupingChangeHandler,
     } = useCascadedDocumentsContext();
 
-    const cascadeStateSnapshotHandler = useCallback(
-      (ref: DataCascadeImplRef<ESQLDataGroupNode, DataTableRecord>) => {
-        const snapshotStore = ref?.getUISnapshotStore();
+    const cascadeInstanceRefHandler = useCallback(
+      (cascadeInstanceRef: DataCascadeImplRef<ESQLDataGroupNode, DataTableRecord>) => {
+        const snapshotStore = cascadeInstanceRef?.getUISnapshotStore();
 
         if (snapshotStore && !cascadeStateChangesSubscription.current) {
           cascadeStateChangesSubscription.current = snapshotStore.subscribe(
@@ -174,11 +174,12 @@ const ESQLDataCascade = React.memo(
       <DataCascade<ESQLDataGroupNode>
         size="s"
         overscan={25}
-        ref={cascadeStateSnapshotHandler}
+        ref={cascadeInstanceRefHandler}
         data={cascadeGroupData}
         cascadeGroups={availableCascadeGroups}
         initialGroupColumn={selectedCascadeGroups}
         initialScrollOffset={dataCascadeUiState?.scrollOffset}
+        initialExpandedRowIds={Object.keys(dataCascadeUiState?.expanded ?? {})}
         customTableHeader={customTableHeading}
       >
         <DataCascadeRow<ESQLDataGroupNode, DataTableRecord>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -7,13 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useCallback, Fragment, useRef } from 'react';
+import React, { useMemo, useCallback, Fragment, useRef, useEffect } from 'react';
 import { useEuiTheme } from '@elastic/eui';
+import { throttle } from 'lodash';
 import {
   DataCascade,
   DataCascadeRow,
   DataCascadeRowCell,
   type DataCascadeRowCellProps,
+  type DataCascadeImplRef,
 } from '@kbn/shared-ux-document-data-cascade';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
 import { getESQLStatsQueryMeta } from '@kbn/esql-utils';
@@ -31,6 +33,7 @@ import { cascadedDocumentsStyles } from './cascaded_documents.styles';
 import { useEsqlDataCascadeRowActionHelpers } from './blocks/use_row_header_components';
 import { useDataCascadeRowExpansionHandlers, useGroupedCascadeData } from './hooks';
 import { useCascadedDocumentsContext } from './cascaded_documents_provider';
+import type { DataCascadeLeafUiState } from '../../../state_management/redux';
 
 export interface ESQLDataCascadeProps
   extends Pick<
@@ -51,13 +54,54 @@ export interface ESQLDataCascadeProps
 
 const ESQLDataCascade = React.memo(
   ({ rows, columns, dataView, togglePopover, queryMeta, ...props }: ESQLDataCascadeProps) => {
+    const cascadeStateChangesSubscription = useRef<ReturnType<
+      NonNullable<
+        ReturnType<
+          NonNullable<DataCascadeImplRef<ESQLDataGroupNode, DataTableRecord>['getUISnapshotStore']>
+        >
+      >['subscribe']
+    > | null>(null);
+
     const {
       availableCascadeGroups,
       selectedCascadeGroups,
+      dataCascadeUiState,
+      setDataCascadeUiState,
       esqlVariables,
       viewModeToggle,
       cascadeGroupingChangeHandler,
     } = useCascadedDocumentsContext();
+
+    const cascadeStateSnapshotHandler = useCallback(
+      (ref: DataCascadeImplRef<ESQLDataGroupNode, DataTableRecord>) => {
+        const snapshotStore = ref?.getUISnapshotStore();
+
+        if (snapshotStore && !cascadeStateChangesSubscription.current) {
+          cascadeStateChangesSubscription.current = snapshotStore.subscribe(
+            throttle(() => {
+              const snapshot = snapshotStore.getSnapshot();
+              setDataCascadeUiState({
+                expanded: snapshot.expanded,
+                rowSelection: snapshot.rowSelection,
+                scrollOffset: snapshot.scrollOffset,
+              });
+            }, 150)
+          );
+        }
+      },
+      [setDataCascadeUiState]
+    );
+
+    useEffect(
+      () => () => {
+        // unsubscribe from the snapshot store when the component unmounts
+        if (cascadeStateChangesSubscription.current) {
+          cascadeStateChangesSubscription.current();
+          cascadeStateChangesSubscription.current = null;
+        }
+      },
+      []
+    );
 
     const cascadeGroupData = useGroupedCascadeData({
       selectedCascadeGroups,
@@ -84,6 +128,21 @@ const ESQLDataCascade = React.memo(
       togglePopover
     );
 
+    const updateLeafUiState = useCallback(
+      (cellId: string, nextState: DataCascadeLeafUiState) => {
+        const existingLeafState = dataCascadeUiState?.leafUiState?.[cellId] ?? {};
+        setDataCascadeUiState({
+          leafUiState: {
+            [cellId]: {
+              ...existingLeafState,
+              ...nextState,
+            },
+          },
+        });
+      },
+      [dataCascadeUiState?.leafUiState, setDataCascadeUiState]
+    );
+
     const cascadeLeafRowRenderer = useCallback<
       DataCascadeRowCellProps<ESQLDataGroupNode, DataTableRecord>['children']
     >(
@@ -100,22 +159,26 @@ const ESQLDataCascade = React.memo(
           dataView={dataView}
           cellData={cellData!}
           cellId={cellId}
+          leafUiState={dataCascadeUiState?.leafUiState?.[cellId]}
+          onLeafUiStateChange={(nextState) => updateLeafUiState(cellId, nextState)}
           getScrollElement={getScrollElement}
           getScrollOffset={getScrollOffset}
           getScrollMargin={getScrollMargin}
           preventSizeChangePropagation={preventSizeChangePropagation}
         />
       ),
-      [dataView, props]
+      [dataCascadeUiState?.leafUiState, dataView, props, updateLeafUiState]
     );
 
     return (
       <DataCascade<ESQLDataGroupNode>
         size="s"
         overscan={25}
+        ref={cascadeStateSnapshotHandler}
         data={cascadeGroupData}
         cascadeGroups={availableCascadeGroups}
         initialGroupColumn={selectedCascadeGroups}
+        initialScrollOffset={dataCascadeUiState?.scrollOffset}
         customTableHeader={customTableHeading}
       >
         <DataCascadeRow<ESQLDataGroupNode, DataTableRecord>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -32,7 +32,10 @@ import {
 import { cascadedDocumentsStyles } from './cascaded_documents.styles';
 import { useEsqlDataCascadeRowActionHelpers } from './blocks/use_row_header_components';
 import { useDataCascadeRowExpansionHandlers, useGroupedCascadeData } from './hooks';
-import { useCascadedDocumentsContext } from './cascaded_documents_provider';
+import {
+  useCascadedDocumentsContext,
+  useCascadedInitialUiStateRef,
+} from './cascaded_documents_provider';
 import type { DataCascadeLeafUiState } from '../../../state_management/redux';
 
 export interface ESQLDataCascadeProps
@@ -65,12 +68,13 @@ const ESQLDataCascade = React.memo(
     const {
       availableCascadeGroups,
       selectedCascadeGroups,
-      dataCascadeUiState,
       setDataCascadeUiState,
       esqlVariables,
       viewModeToggle,
       cascadeGroupingChangeHandler,
     } = useCascadedDocumentsContext();
+
+    const initialCascadeUiState = useCascadedInitialUiStateRef();
 
     const cascadeInstanceRefHandler = useCallback(
       (cascadeInstanceRef: DataCascadeImplRef<ESQLDataGroupNode, DataTableRecord>) => {
@@ -80,6 +84,7 @@ const ESQLDataCascade = React.memo(
           cascadeStateChangesSubscription.current = snapshotStore.subscribe(
             throttle(() => {
               const snapshot = snapshotStore.getSnapshot();
+
               setDataCascadeUiState({
                 expanded: snapshot.expanded,
                 rowSelection: snapshot.rowSelection,
@@ -130,7 +135,7 @@ const ESQLDataCascade = React.memo(
 
     const updateLeafUiState = useCallback(
       (cellId: string, nextState: DataCascadeLeafUiState) => {
-        const existingLeafState = dataCascadeUiState?.leafUiState?.[cellId] ?? {};
+        const existingLeafState = initialCascadeUiState.current?.leafUiState?.[cellId] ?? {};
         setDataCascadeUiState({
           leafUiState: {
             [cellId]: {
@@ -140,7 +145,14 @@ const ESQLDataCascade = React.memo(
           },
         });
       },
-      [dataCascadeUiState?.leafUiState, setDataCascadeUiState]
+      [initialCascadeUiState, setDataCascadeUiState]
+    );
+
+    const onLeafUiStateChange = useCallback(
+      (cellId: string, nextState: DataCascadeLeafUiState) => {
+        updateLeafUiState(cellId, nextState);
+      },
+      [updateLeafUiState]
     );
 
     const cascadeLeafRowRenderer = useCallback<
@@ -159,16 +171,23 @@ const ESQLDataCascade = React.memo(
           dataView={dataView}
           cellData={cellData!}
           cellId={cellId}
-          leafUiState={dataCascadeUiState?.leafUiState?.[cellId]}
-          onLeafUiStateChange={(nextState) => updateLeafUiState(cellId, nextState)}
+          leafUiState={initialCascadeUiState.current?.leafUiState?.[cellId]}
+          onLeafUiStateChange={onLeafUiStateChange.bind(null, cellId)}
           getScrollElement={getScrollElement}
           getScrollOffset={getScrollOffset}
           getScrollMargin={getScrollMargin}
           preventSizeChangePropagation={preventSizeChangePropagation}
         />
       ),
-      [dataCascadeUiState?.leafUiState, dataView, props, updateLeafUiState]
+      [dataView, initialCascadeUiState, props, onLeafUiStateChange]
     );
+
+    const initialTableState = useMemo(() => {
+      return {
+        expanded: initialCascadeUiState.current?.expanded,
+        rowSelection: initialCascadeUiState.current?.rowSelection,
+      };
+    }, [initialCascadeUiState]);
 
     return (
       <DataCascade<ESQLDataGroupNode>
@@ -178,8 +197,8 @@ const ESQLDataCascade = React.memo(
         data={cascadeGroupData}
         cascadeGroups={availableCascadeGroups}
         initialGroupColumn={selectedCascadeGroups}
-        initialScrollOffset={dataCascadeUiState?.scrollOffset}
-        initialExpandedRowIds={Object.keys(dataCascadeUiState?.expanded ?? {})}
+        initialScrollOffset={initialCascadeUiState.current?.scrollOffset}
+        initialTableState={initialTableState}
         customTableHeader={customTableHeading}
       >
         <DataCascadeRow<ESQLDataGroupNode, DataTableRecord>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -32,10 +32,7 @@ import {
 import { cascadedDocumentsStyles } from './cascaded_documents.styles';
 import { useEsqlDataCascadeRowActionHelpers } from './blocks/use_row_header_components';
 import { useDataCascadeRowExpansionHandlers, useGroupedCascadeData } from './hooks';
-import {
-  useCascadedDocumentsContext,
-  useCascadedInitialUiStateRef,
-} from './cascaded_documents_provider';
+import { useCascadedDocumentsContext } from './cascaded_documents_provider';
 import type { DataCascadeLeafUiState } from '../../../state_management/redux';
 
 export interface ESQLDataCascadeProps
@@ -68,13 +65,12 @@ const ESQLDataCascade = React.memo(
     const {
       availableCascadeGroups,
       selectedCascadeGroups,
+      dataCascadeUiState,
       setDataCascadeUiState,
       esqlVariables,
       viewModeToggle,
       cascadeGroupingChangeHandler,
     } = useCascadedDocumentsContext();
-
-    const initialCascadeUiState = useCascadedInitialUiStateRef();
 
     const cascadeInstanceRefHandler = useCallback(
       (cascadeInstanceRef: DataCascadeImplRef<ESQLDataGroupNode, DataTableRecord>) => {
@@ -89,6 +85,7 @@ const ESQLDataCascade = React.memo(
                 expanded: snapshot.expanded,
                 rowSelection: snapshot.rowSelection,
                 scrollOffset: snapshot.scrollOffset,
+                scrollRect: snapshot.scrollRect,
               });
             }, 150)
           );
@@ -135,7 +132,7 @@ const ESQLDataCascade = React.memo(
 
     const updateLeafUiState = useCallback(
       (cellId: string, nextState: DataCascadeLeafUiState) => {
-        const existingLeafState = initialCascadeUiState.current?.leafUiState?.[cellId] ?? {};
+        const existingLeafState = dataCascadeUiState?.leafUiState?.[cellId] ?? {};
         setDataCascadeUiState({
           leafUiState: {
             [cellId]: {
@@ -145,7 +142,7 @@ const ESQLDataCascade = React.memo(
           },
         });
       },
-      [initialCascadeUiState, setDataCascadeUiState]
+      [dataCascadeUiState, setDataCascadeUiState]
     );
 
     const onLeafUiStateChange = useCallback(
@@ -171,7 +168,7 @@ const ESQLDataCascade = React.memo(
           dataView={dataView}
           cellData={cellData!}
           cellId={cellId}
-          leafUiState={initialCascadeUiState.current?.leafUiState?.[cellId]}
+          leafUiState={dataCascadeUiState?.leafUiState?.[cellId]}
           onLeafUiStateChange={onLeafUiStateChange.bind(null, cellId)}
           getScrollElement={getScrollElement}
           getScrollOffset={getScrollOffset}
@@ -179,15 +176,15 @@ const ESQLDataCascade = React.memo(
           preventSizeChangePropagation={preventSizeChangePropagation}
         />
       ),
-      [dataView, initialCascadeUiState, props, onLeafUiStateChange]
+      [dataView, dataCascadeUiState, props, onLeafUiStateChange]
     );
 
     const initialTableState = useMemo(() => {
       return {
-        expanded: initialCascadeUiState.current?.expanded,
-        rowSelection: initialCascadeUiState.current?.rowSelection,
+        expanded: dataCascadeUiState?.expanded,
+        rowSelection: dataCascadeUiState?.rowSelection,
       };
-    }, [initialCascadeUiState]);
+    }, [dataCascadeUiState]);
 
     return (
       <DataCascade<ESQLDataGroupNode>
@@ -197,8 +194,9 @@ const ESQLDataCascade = React.memo(
         data={cascadeGroupData}
         cascadeGroups={availableCascadeGroups}
         initialGroupColumn={selectedCascadeGroups}
-        initialScrollOffset={initialCascadeUiState.current?.scrollOffset}
+        initialScrollOffset={dataCascadeUiState?.scrollOffset}
         initialTableState={initialTableState}
+        initialRect={dataCascadeUiState?.scrollRect}
         customTableHeader={customTableHeading}
       >
         <DataCascadeRow<ESQLDataGroupNode, DataTableRecord>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
@@ -18,9 +18,11 @@ import type {
   internalStateActions,
 } from '../../../state_management/redux';
 import type { UpdateESQLQueryFn } from '../../../../../context_awareness';
+import type { CascadedDocumentsFetcher } from '../../../data_fetching/cascaded_documents_fetcher';
 
 export interface CascadedDocumentsContext
   extends Pick<CascadedDocumentsState, 'availableCascadeGroups' | 'selectedCascadeGroups'> {
+  cascadedDocumentsFetcher: CascadedDocumentsFetcher;
   esqlQuery: AggregateQuery;
   esqlVariables: ESQLControlVariable[] | undefined;
   timeRange: TimeRange | undefined;

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
@@ -13,6 +13,7 @@ import type { ReactElement } from 'react';
 import { createContext, useContext } from 'react';
 import type {
   CascadedDocumentsState,
+  DataCascadeUiState,
   DiscoverAppState,
   internalStateActions,
 } from '../../../state_management/redux';
@@ -22,6 +23,8 @@ import type { CascadedDocumentsFetcher } from '../../../data_fetching/cascaded_d
 export interface CascadedDocumentsContext
   extends Pick<CascadedDocumentsState, 'availableCascadeGroups' | 'selectedCascadeGroups'> {
   cascadedDocumentsFetcher: CascadedDocumentsFetcher;
+  dataCascadeUiState: Partial<DataCascadeUiState> | undefined;
+  setDataCascadeUiState: (uiState: Partial<DataCascadeUiState>) => void;
   esqlQuery: AggregateQuery;
   esqlVariables: ESQLControlVariable[] | undefined;
   timeRange: TimeRange | undefined;

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
@@ -11,7 +11,6 @@ import { isOfAggregateQueryType, type AggregateQuery, type TimeRange } from '@kb
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { ReactElement } from 'react';
 import { createContext, useContext } from 'react';
-import type { RequestAdapter } from '@kbn/inspector-plugin/public';
 import type {
   CascadedDocumentsState,
   DiscoverAppState,
@@ -30,7 +29,6 @@ export interface CascadedDocumentsContext
   cascadeGroupingChangeHandler: (cascadeGrouping: string[]) => void;
   onUpdateESQLQuery: UpdateESQLQueryFn;
   openInNewTab: (...args: Parameters<typeof internalStateActions.openInNewTab>) => void;
-  registerCascadeRequestsInspectorAdapter: (requestAdapter: RequestAdapter) => void;
 }
 
 const cascadedDocumentsContext = createContext<CascadedDocumentsContext | undefined>(undefined);

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
@@ -10,7 +10,7 @@
 import { isOfAggregateQueryType, type AggregateQuery, type TimeRange } from '@kbn/es-query';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { ReactElement } from 'react';
-import { createContext, useContext, useRef } from 'react';
+import { createContext, useContext } from 'react';
 import type {
   CascadedDocumentsState,
   DataCascadeUiState,
@@ -63,16 +63,4 @@ export const useCascadedDocumentsContext = () => {
   }
 
   return context;
-};
-
-export const useCascadedInitialUiStateRef = () => {
-  const context = useCascadedDocumentsContext();
-
-  const initialUiStateRef = useRef(context.dataCascadeUiState);
-
-  if (initialUiStateRef.current === undefined && context.dataCascadeUiState !== undefined) {
-    initialUiStateRef.current = structuredClone(context.dataCascadeUiState);
-  }
-
-  return initialUiStateRef;
 };

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
@@ -10,7 +10,7 @@
 import { isOfAggregateQueryType, type AggregateQuery, type TimeRange } from '@kbn/es-query';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { ReactElement } from 'react';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useRef } from 'react';
 import type {
   CascadedDocumentsState,
   DataCascadeUiState,
@@ -63,4 +63,16 @@ export const useCascadedDocumentsContext = () => {
   }
 
   return context;
+};
+
+export const useCascadedInitialUiStateRef = () => {
+  const context = useCascadedDocumentsContext();
+
+  const initialUiStateRef = useRef(context.dataCascadeUiState);
+
+  if (initialUiStateRef.current === undefined && context.dataCascadeUiState !== undefined) {
+    initialUiStateRef.current = structuredClone(context.dataCascadeUiState);
+  }
+
+  return initialUiStateRef;
 };

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
@@ -7,566 +7,566 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// import { renderHook, act } from '@testing-library/react';
-// import { RequestAdapter } from '@kbn/inspector-plugin/common';
-// import type { DataTableRecord } from '@kbn/discover-utils';
-// import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
-// import { dataViewWithTimefieldMock } from '../../../../../../__mocks__/data_view_with_timefield';
-// import { discoverServiceMock } from '../../../../../../__mocks__/services';
-// import {
-//   useGroupedCascadeData,
-//   useScopedESQLQueryFetchClient,
-//   useDataCascadeRowExpansionHandlers,
-// } from './data_fetching';
-// import { fetchEsql } from '../../../../data_fetching/fetch_esql';
-// import { constructCascadeQuery } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
-// import { apm } from '@elastic/apm-rum';
-// import type { ESQLStatsQueryMeta } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
-// import type { ESQLDataGroupNode } from '../blocks';
-// import type { RecordsFetchResponse } from '../../../../../types';
-
-// jest.mock('../../../../data_fetching/fetch_esql', () => ({
-//   fetchEsql: jest.fn(),
-// }));
-
-// jest.mock('@kbn/esql-utils/src/utils/cascaded_documents_helpers', () => ({
-//   ...jest.requireActual('@kbn/esql-utils/src/utils/cascaded_documents_helpers'),
-//   constructCascadeQuery: jest.fn(),
-// }));
-
-// jest.mock('@elastic/apm-rum', () => ({
-//   apm: {
-//     captureError: jest.fn(),
-//   },
-// }));
-
-// const mockFetchEsql = fetchEsql as jest.MockedFunction<typeof fetchEsql>;
-// const mockConstructCascadeQuery = constructCascadeQuery as jest.MockedFunction<
-//   typeof constructCascadeQuery
-// >;
-// const mockApmCaptureError = apm.captureError as jest.MockedFunction<typeof apm.captureError>;
-
-// describe('data_fetching related hooks', () => {
-//   beforeEach(() => {
-//     jest.clearAllMocks();
-//   });
-
-//   describe('useGroupedCascadeData', () => {
-//     const createMockRows = (data: Array<Record<string, unknown>>): DataTableRecord[] =>
-//       data.map((item, idx) => ({
-//         id: String(idx),
-//         raw: item,
-//         flattened: item,
-//       }));
-
-//     const defaultQueryMeta: ESQLStatsQueryMeta = {
-//       groupByFields: [{ field: 'category', type: 'column' }],
-//       appliedFunctions: [{ identifier: 'count', aggregation: 'count' }],
-//     };
-
-//     const defaultSelectedCascadeGroups = ['category'];
-
-//     it('should return empty array when rows are undefined', () => {
-//       const { result } = renderHook(() =>
-//         useGroupedCascadeData({
-//           selectedCascadeGroups: defaultSelectedCascadeGroups,
-//           rows: undefined,
-//           queryMeta: defaultQueryMeta,
-//           esqlVariables: undefined,
-//         })
-//       );
-
-//       expect(result.current).toEqual([]);
-//     });
-
-//     it('should return empty array when rows are empty', () => {
-//       const { result } = renderHook(() =>
-//         useGroupedCascadeData({
-//           selectedCascadeGroups: defaultSelectedCascadeGroups,
-//           rows: [],
-//           queryMeta: defaultQueryMeta,
-//           esqlVariables: undefined,
-//         })
-//       );
-
-//       expect(result.current).toEqual([]);
-//     });
-
-//     it('should group rows by selected cascade groups', () => {
-//       const mockRows = createMockRows([
-//         { category: 'A', count: 10 },
-//         { category: 'A', count: 5 },
-//         { category: 'B', count: 20 },
-//       ]);
-
-//       const { result } = renderHook(() =>
-//         useGroupedCascadeData({
-//           selectedCascadeGroups: defaultSelectedCascadeGroups,
-//           rows: mockRows,
-//           queryMeta: defaultQueryMeta,
-//           esqlVariables: undefined,
-//         })
-//       );
-
-//       expect(result.current).toHaveLength(2);
-//       expect(result.current[0].groupValue).toBe('A');
-//       expect(result.current[0].aggregatedValues.count).toBe(15); // 10 + 5 aggregated
-//       expect(result.current[1].groupValue).toBe('B');
-//       expect(result.current[1].aggregatedValues.count).toBe(20);
-//     });
-
-//     it('should skip undefined and null values in grouping', () => {
-//       const mockRows = createMockRows([
-//         { category: 'A', count: 10 },
-//         { category: undefined, count: 5 },
-//         { category: null, count: 15 },
-//         { category: 'B', count: 20 },
-//       ]);
-
-//       const { result } = renderHook(() =>
-//         useGroupedCascadeData({
-//           selectedCascadeGroups: defaultSelectedCascadeGroups,
-//           rows: mockRows,
-//           queryMeta: defaultQueryMeta,
-//           esqlVariables: undefined,
-//         })
-//       );
-
-//       expect(result.current).toHaveLength(2);
-//       expect(result.current.find((r) => r.groupValue === 'A')).toBeDefined();
-//       expect(result.current.find((r) => r.groupValue === 'B')).toBeDefined();
-//     });
-
-//     it('should aggregate multiple applied functions', () => {
-//       const mockRows = createMockRows([
-//         { category: 'A', count: 10, sum: 100 },
-//         { category: 'A', count: 5, sum: 50 },
-//       ]);
-
-//       const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
-//         groupByFields: [{ field: 'category', type: 'column' }],
-//         appliedFunctions: [
-//           { identifier: 'count', aggregation: 'count' },
-//           { identifier: 'sum', aggregation: 'sum' },
-//         ],
-//       };
-
-//       const { result } = renderHook(() =>
-//         useGroupedCascadeData({
-//           selectedCascadeGroups: defaultSelectedCascadeGroups,
-//           rows: mockRows,
-//           queryMeta: queryMetaWithMultipleFunctions,
-//           esqlVariables: undefined,
-//         })
-//       );
-
-//       expect(result.current).toHaveLength(1);
-//       expect(result.current[0].aggregatedValues.count).toBe(15);
-//       expect(result.current[0].aggregatedValues.sum).toBe(150);
-//     });
-
-//     it('should aggregate multiple applied functions with array values', () => {
-//       const mockRows = createMockRows([
-//         { category: 'A', count: 10, ext: ['css', 'js'] },
-//         { category: 'A', count: 5, ext: ['deb', 'rpm'] },
-//       ]);
-
-//       const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
-//         groupByFields: [{ field: 'category', type: 'column' }],
-//         appliedFunctions: [
-//           { identifier: 'count', aggregation: 'count' },
-//           { identifier: 'ext', aggregation: 'ext' },
-//         ],
-//       };
-
-//       const { result } = renderHook(() =>
-//         useGroupedCascadeData({
-//           selectedCascadeGroups: defaultSelectedCascadeGroups,
-//           rows: mockRows,
-//           queryMeta: queryMetaWithMultipleFunctions,
-//           esqlVariables: undefined,
-//         })
-//       );
-
-//       expect(result.current).toHaveLength(1);
-//       expect(result.current[0].aggregatedValues.count).toBe(15);
-//       expect(result.current[0].aggregatedValues.ext).toEqual(['css', 'js', 'deb', 'rpm']);
-//     });
-
-//     it('should resolve esql variable for group key', () => {
-//       const mockRows = createMockRows([
-//         { actualField: 'X', count: 10 },
-//         { actualField: 'X', count: 5 },
-//         { actualField: 'Y', count: 20 },
-//       ]);
-
-//       const esqlVariables: ESQLControlVariable[] = [
-//         { key: 'myVar', value: 'actualField', type: ESQLVariableType.FIELDS },
-//       ];
-
-//       const { result } = renderHook(() =>
-//         useGroupedCascadeData({
-//           selectedCascadeGroups: ['??myVar'],
-//           rows: mockRows,
-//           queryMeta: defaultQueryMeta,
-//           esqlVariables,
-//         })
-//       );
-
-//       expect(result.current).toHaveLength(2);
-//       expect(result.current[0].groupValue).toBe('X');
-//       expect(result.current[1].groupValue).toBe('Y');
-//     });
-//   });
-
-//   describe('useScopedESQLQueryFetchClient', () => {
-//     const scopedProfilesManager = discoverServiceMock.profilesManager.createScopedProfilesManager({
-//       scopedEbtManager: discoverServiceMock.ebtManager.createScopedEBTManager(),
-//     });
-
-//     const defaultProps = {
-//       query: { esql: 'FROM logs | STATS count() BY category' },
-//       dataView: dataViewWithTimefieldMock,
-//       data: discoverServiceMock.data,
-//       expressions: discoverServiceMock.expressions,
-//       esqlVariables: undefined,
-//       filters: undefined,
-//       timeRange: undefined,
-//       scopedProfilesManager,
-//       inspectorAdapters: { requests: new RequestAdapter() },
-//     };
-
-//     const createMockFetchResponse = (records: DataTableRecord[] = []): RecordsFetchResponse => ({
-//       records,
-//       esqlQueryColumns: [],
-//       esqlHeaderWarning: undefined,
-//       interceptedWarnings: [],
-//     });
-
-//     beforeEach(() => {
-//       mockFetchEsql.mockResolvedValue(createMockFetchResponse());
-//       mockConstructCascadeQuery.mockReturnValue({ esql: 'FROM logs | WHERE category == "A"' });
-//     });
-
-//     it('should return a fetch function with cancel method', () => {
-//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-//       expect(result.current).toBeInstanceOf(Function);
-//       expect(result.current.cancel).toBeInstanceOf(Function);
-//     });
-
-//     it('should fetch data by invoking constructCascadeQuery and fetchEsql', async () => {
-//       const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
-//       mockFetchEsql.mockResolvedValue(createMockFetchResponse(mockRecords));
-
-//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-//       let records: DataTableRecord[] = [];
-
-//       await act(async () => {
-//         records = await result.current({
-//           nodeType: 'leaf',
-//           nodePath: ['category'],
-//           nodePathMap: { category: 'A' },
-//         });
-//       });
-
-//       expect(mockConstructCascadeQuery).toHaveBeenCalledWith({
-//         query: defaultProps.query,
-//         esqlVariables: undefined,
-//         dataView: dataViewWithTimefieldMock,
-//         nodeType: 'leaf',
-//         nodePath: ['category'],
-//         nodePathMap: { category: 'A' },
-//       });
-//       expect(mockFetchEsql).toHaveBeenCalled();
-//       expect(records).toEqual(mockRecords);
-//     });
-
-//     it('should return empty array and capture error when constructCascadeQuery returns undefined', async () => {
-//       mockConstructCascadeQuery.mockReturnValue(undefined);
-
-//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-//       let records: DataTableRecord[] = [];
-//       await act(async () => {
-//         records = await result.current({
-//           nodeType: 'leaf',
-//           nodePath: ['category'],
-//           nodePathMap: { category: 'A' },
-//         });
-//       });
-
-//       expect(records).toEqual([]);
-//       expect(mockApmCaptureError).toHaveBeenCalledWith(
-//         new Error('Failed to construct cascade query')
-//       );
-//       expect(mockFetchEsql).not.toHaveBeenCalled();
-//     });
-
-//     it('should abort previous requests when making a new request', async () => {
-//       const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
-
-//       let resolveFirst: (value: RecordsFetchResponse) => void;
-//       const firstPromise = new Promise<RecordsFetchResponse>((resolve) => {
-//         resolveFirst = resolve;
-//       });
-
-//       mockFetchEsql
-//         .mockImplementationOnce(() => firstPromise)
-//         .mockResolvedValueOnce(createMockFetchResponse(mockRecords));
-
-//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-//       // Start first request (don't await)
-//       result.current({
-//         nodeType: 'leaf',
-//         nodePath: ['category'],
-//         nodePathMap: { category: 'A' },
-//       });
-
-//       // Start second request immediately (should abort first)
-//       const secondRequest = result.current({
-//         nodeType: 'leaf',
-//         nodePath: ['category'],
-//         nodePathMap: { category: 'B' },
-//       });
-
-//       // Resolve first request after abort
-//       resolveFirst!(createMockFetchResponse());
-
-//       const secondRecords = await secondRequest;
-//       expect(secondRecords).toEqual(mockRecords);
-//     });
-
-//     it('should handle abort errors gracefully', async () => {
-//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-//       let records: DataTableRecord[] = [];
-
-//       const pendingRequest = result.current({
-//         nodeType: 'leaf',
-//         nodePath: ['category'],
-//         nodePathMap: { category: 'A' },
-//       });
-
-//       act(() => {
-//         result.current.cancel();
-//       });
-
-//       await act(async () => {
-//         records = await pendingRequest;
-//       });
-
-//       expect(records).toEqual([]);
-//     });
-
-//     it('should rethrow non-abort errors', async () => {
-//       const networkError = new Error('Network failure');
-//       mockFetchEsql.mockRejectedValue(networkError);
-
-//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-//       await expect(
-//         result.current({
-//           nodeType: 'leaf',
-//           nodePath: ['category'],
-//           nodePathMap: { category: 'A' },
-//         })
-//       ).rejects.toThrow('Network failure');
-//     });
-
-//     it('should cancel pending requests on unmount', async () => {
-//       const { result, unmount } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-//       // Start a request
-//       const pendingRequestPromise = result.current({
-//         nodeType: 'leaf',
-//         nodePath: ['category'],
-//         nodePathMap: { category: 'A' },
-//       });
-
-//       // Unmount the hook
-//       unmount();
-
-//       // The abort controller should have been called
-//       // Request should complete gracefully
-//       await expect(pendingRequestPromise).resolves.toBeDefined();
-//     });
-//   });
-
-//   describe('useDataCascadeRowExpansionHandlers', () => {
-//     const createMockCascadeFetchClient = () => {
-//       const mockFetch = jest.fn().mockResolvedValue([]) as jest.Mock & { cancel: jest.Mock };
-//       mockFetch.cancel = jest.fn();
-//       return mockFetch as unknown as ReturnType<typeof useScopedESQLQueryFetchClient>;
-//     };
-
-//     const createMockRowData = (): ESQLDataGroupNode => ({
-//       id: '1',
-//       groupColumn: 'category',
-//       groupValue: 'A',
-//       aggregatedValues: {},
-//     });
-
-//     it('should return all four expansion handlers', () => {
-//       const mockCascadeFetchClient = createMockCascadeFetchClient();
-
-//       const { result } = renderHook(() =>
-//         useDataCascadeRowExpansionHandlers({
-//           cascadeFetchClient: mockCascadeFetchClient,
-//         })
-//       );
-
-//       expect(result.current.onCascadeGroupNodeExpanded).toBeInstanceOf(Function);
-//       expect(result.current.onCascadeGroupNodeCollapsed).toBeInstanceOf(Function);
-//       expect(result.current.onCascadeLeafNodeExpanded).toBeInstanceOf(Function);
-//       expect(result.current.onCascadeLeafNodeCollapsed).toBeInstanceOf(Function);
-//     });
-
-//     describe('onCascadeGroupNodeExpanded', () => {
-//       it('should call cascadeFetchClient with nodeType "group"', async () => {
-//         const mockCascadeFetchClient = createMockCascadeFetchClient();
-//         const mockRow = createMockRowData();
-
-//         const { result } = renderHook(() =>
-//           useDataCascadeRowExpansionHandlers({
-//             cascadeFetchClient: mockCascadeFetchClient,
-//           })
-//         );
-
-//         await act(async () => {
-//           await result.current.onCascadeGroupNodeExpanded({
-//             row: mockRow,
-//             nodePath: ['category', 'subcategory'],
-//             nodePathMap: { category: 'A', subcategory: 'X' },
-//           });
-//         });
-
-//         expect(mockCascadeFetchClient).toHaveBeenCalledWith({
-//           nodePath: ['category', 'subcategory'],
-//           nodePathMap: { category: 'A', subcategory: 'X' },
-//           nodeType: 'group',
-//         });
-//       });
-//     });
-
-//     describe('onCascadeGroupNodeCollapsed', () => {
-//       it('should call cascadeFetchClient.cancel', () => {
-//         const mockCascadeFetchClient = createMockCascadeFetchClient();
-//         const mockRow = createMockRowData();
-
-//         const { result } = renderHook(() =>
-//           useDataCascadeRowExpansionHandlers({
-//             cascadeFetchClient: mockCascadeFetchClient,
-//           })
-//         );
-
-//         result.current.onCascadeGroupNodeCollapsed!({
-//           row: mockRow,
-//           nodePath: ['category'],
-//           nodePathMap: { category: 'A' },
-//         });
-
-//         expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
-//       });
-//     });
-
-//     describe('onCascadeLeafNodeExpanded', () => {
-//       it('should call cascadeFetchClient with nodeType "leaf"', async () => {
-//         const mockCascadeFetchClient = createMockCascadeFetchClient();
-//         const mockRow = createMockRowData();
-
-//         const { result } = renderHook(() =>
-//           useDataCascadeRowExpansionHandlers({
-//             cascadeFetchClient: mockCascadeFetchClient,
-//           })
-//         );
-
-//         await act(async () => {
-//           await result.current.onCascadeLeafNodeExpanded({
-//             row: mockRow,
-//             nodePath: ['category'],
-//             nodePathMap: { category: 'A' },
-//           });
-//         });
-
-//         expect(mockCascadeFetchClient).toHaveBeenCalledWith({
-//           nodePath: ['category'],
-//           nodePathMap: { category: 'A' },
-//           nodeType: 'leaf',
-//         });
-//       });
-//     });
-
-//     describe('onCascadeLeafNodeCollapsed', () => {
-//       it('should call cascadeFetchClient.cancel', () => {
-//         const mockCascadeFetchClient = createMockCascadeFetchClient();
-//         const mockRow = createMockRowData();
-
-//         const { result } = renderHook(() =>
-//           useDataCascadeRowExpansionHandlers({
-//             cascadeFetchClient: mockCascadeFetchClient,
-//           })
-//         );
-
-//         result.current.onCascadeLeafNodeCollapsed!({
-//           row: mockRow,
-//           nodePath: ['category'],
-//           nodePathMap: { category: 'A' },
-//         });
-
-//         expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
-//       });
-//     });
-
-//     it('should memoize handlers and return same references on rerender', () => {
-//       const mockCascadeFetchClient = createMockCascadeFetchClient();
-
-//       const { result, rerender } = renderHook(() =>
-//         useDataCascadeRowExpansionHandlers({
-//           cascadeFetchClient: mockCascadeFetchClient,
-//         })
-//       );
-
-//       const firstResult = result.current;
-
-//       rerender();
-
-//       expect(result.current.onCascadeGroupNodeExpanded).toBe(
-//         firstResult.onCascadeGroupNodeExpanded
-//       );
-//       expect(result.current.onCascadeGroupNodeCollapsed).toBe(
-//         firstResult.onCascadeGroupNodeCollapsed
-//       );
-//       expect(result.current.onCascadeLeafNodeExpanded).toBe(firstResult.onCascadeLeafNodeExpanded);
-//       expect(result.current.onCascadeLeafNodeCollapsed).toBe(
-//         firstResult.onCascadeLeafNodeCollapsed
-//       );
-//     });
-
-//     it('should update handlers when cascadeFetchClient changes', () => {
-//       const mockCascadeFetchClient1 = createMockCascadeFetchClient();
-//       const mockCascadeFetchClient2 = createMockCascadeFetchClient();
-
-//       const { result, rerender } = renderHook(
-//         ({ cascadeFetchClient }) =>
-//           useDataCascadeRowExpansionHandlers({
-//             cascadeFetchClient,
-//           }),
-//         {
-//           initialProps: { cascadeFetchClient: mockCascadeFetchClient1 },
-//         }
-//       );
-
-//       const firstResult = result.current;
-
-//       rerender({ cascadeFetchClient: mockCascadeFetchClient2 });
-
-//       // Handlers should be new references after dependency change
-//       expect(result.current.onCascadeGroupNodeExpanded).not.toBe(
-//         firstResult.onCascadeGroupNodeExpanded
-//       );
-//     });
-//   });
-// });
+import { renderHook, act } from '@testing-library/react';
+import { RequestAdapter } from '@kbn/inspector-plugin/common';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
+import { dataViewWithTimefieldMock } from '../../../../../../__mocks__/data_view_with_timefield';
+import { discoverServiceMock } from '../../../../../../__mocks__/services';
+import {
+  useGroupedCascadeData,
+  useScopedESQLQueryFetchClient,
+  useDataCascadeRowExpansionHandlers,
+} from './data_fetching';
+import { fetchEsql } from '../../../../data_fetching/fetch_esql';
+import { constructCascadeQuery } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
+import { apm } from '@elastic/apm-rum';
+import type { ESQLStatsQueryMeta } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
+import type { ESQLDataGroupNode } from '../blocks';
+import type { RecordsFetchResponse } from '../../../../../types';
+
+jest.mock('../../../../data_fetching/fetch_esql', () => ({
+  fetchEsql: jest.fn(),
+}));
+
+jest.mock('@kbn/esql-utils/src/utils/cascaded_documents_helpers', () => ({
+  ...jest.requireActual('@kbn/esql-utils/src/utils/cascaded_documents_helpers'),
+  constructCascadeQuery: jest.fn(),
+}));
+
+jest.mock('@elastic/apm-rum', () => ({
+  apm: {
+    captureError: jest.fn(),
+  },
+}));
+
+const mockFetchEsql = fetchEsql as jest.MockedFunction<typeof fetchEsql>;
+const mockConstructCascadeQuery = constructCascadeQuery as jest.MockedFunction<
+  typeof constructCascadeQuery
+>;
+const mockApmCaptureError = apm.captureError as jest.MockedFunction<typeof apm.captureError>;
+
+describe('data_fetching related hooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useGroupedCascadeData', () => {
+    const createMockRows = (data: Array<Record<string, unknown>>): DataTableRecord[] =>
+      data.map((item, idx) => ({
+        id: String(idx),
+        raw: item,
+        flattened: item,
+      }));
+
+    const defaultQueryMeta: ESQLStatsQueryMeta = {
+      groupByFields: [{ field: 'category', type: 'column' }],
+      appliedFunctions: [{ identifier: 'count', aggregation: 'count' }],
+    };
+
+    const defaultSelectedCascadeGroups = ['category'];
+
+    it('should return empty array when rows are undefined', () => {
+      const { result } = renderHook(() =>
+        useGroupedCascadeData({
+          selectedCascadeGroups: defaultSelectedCascadeGroups,
+          rows: undefined,
+          queryMeta: defaultQueryMeta,
+          esqlVariables: undefined,
+        })
+      );
+
+      expect(result.current).toEqual([]);
+    });
+
+    it('should return empty array when rows are empty', () => {
+      const { result } = renderHook(() =>
+        useGroupedCascadeData({
+          selectedCascadeGroups: defaultSelectedCascadeGroups,
+          rows: [],
+          queryMeta: defaultQueryMeta,
+          esqlVariables: undefined,
+        })
+      );
+
+      expect(result.current).toEqual([]);
+    });
+
+    it('should group rows by selected cascade groups', () => {
+      const mockRows = createMockRows([
+        { category: 'A', count: 10 },
+        { category: 'A', count: 5 },
+        { category: 'B', count: 20 },
+      ]);
+
+      const { result } = renderHook(() =>
+        useGroupedCascadeData({
+          selectedCascadeGroups: defaultSelectedCascadeGroups,
+          rows: mockRows,
+          queryMeta: defaultQueryMeta,
+          esqlVariables: undefined,
+        })
+      );
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current[0].groupValue).toBe('A');
+      expect(result.current[0].aggregatedValues.count).toBe(15); // 10 + 5 aggregated
+      expect(result.current[1].groupValue).toBe('B');
+      expect(result.current[1].aggregatedValues.count).toBe(20);
+    });
+
+    it('should skip undefined and null values in grouping', () => {
+      const mockRows = createMockRows([
+        { category: 'A', count: 10 },
+        { category: undefined, count: 5 },
+        { category: null, count: 15 },
+        { category: 'B', count: 20 },
+      ]);
+
+      const { result } = renderHook(() =>
+        useGroupedCascadeData({
+          selectedCascadeGroups: defaultSelectedCascadeGroups,
+          rows: mockRows,
+          queryMeta: defaultQueryMeta,
+          esqlVariables: undefined,
+        })
+      );
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current.find((r) => r.groupValue === 'A')).toBeDefined();
+      expect(result.current.find((r) => r.groupValue === 'B')).toBeDefined();
+    });
+
+    it('should aggregate multiple applied functions', () => {
+      const mockRows = createMockRows([
+        { category: 'A', count: 10, sum: 100 },
+        { category: 'A', count: 5, sum: 50 },
+      ]);
+
+      const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
+        groupByFields: [{ field: 'category', type: 'column' }],
+        appliedFunctions: [
+          { identifier: 'count', aggregation: 'count' },
+          { identifier: 'sum', aggregation: 'sum' },
+        ],
+      };
+
+      const { result } = renderHook(() =>
+        useGroupedCascadeData({
+          selectedCascadeGroups: defaultSelectedCascadeGroups,
+          rows: mockRows,
+          queryMeta: queryMetaWithMultipleFunctions,
+          esqlVariables: undefined,
+        })
+      );
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].aggregatedValues.count).toBe(15);
+      expect(result.current[0].aggregatedValues.sum).toBe(150);
+    });
+
+    it('should aggregate multiple applied functions with array values', () => {
+      const mockRows = createMockRows([
+        { category: 'A', count: 10, ext: ['css', 'js'] },
+        { category: 'A', count: 5, ext: ['deb', 'rpm'] },
+      ]);
+
+      const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
+        groupByFields: [{ field: 'category', type: 'column' }],
+        appliedFunctions: [
+          { identifier: 'count', aggregation: 'count' },
+          { identifier: 'ext', aggregation: 'ext' },
+        ],
+      };
+
+      const { result } = renderHook(() =>
+        useGroupedCascadeData({
+          selectedCascadeGroups: defaultSelectedCascadeGroups,
+          rows: mockRows,
+          queryMeta: queryMetaWithMultipleFunctions,
+          esqlVariables: undefined,
+        })
+      );
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].aggregatedValues.count).toBe(15);
+      expect(result.current[0].aggregatedValues.ext).toEqual(['css', 'js', 'deb', 'rpm']);
+    });
+
+    it('should resolve esql variable for group key', () => {
+      const mockRows = createMockRows([
+        { actualField: 'X', count: 10 },
+        { actualField: 'X', count: 5 },
+        { actualField: 'Y', count: 20 },
+      ]);
+
+      const esqlVariables: ESQLControlVariable[] = [
+        { key: 'myVar', value: 'actualField', type: ESQLVariableType.FIELDS },
+      ];
+
+      const { result } = renderHook(() =>
+        useGroupedCascadeData({
+          selectedCascadeGroups: ['??myVar'],
+          rows: mockRows,
+          queryMeta: defaultQueryMeta,
+          esqlVariables,
+        })
+      );
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current[0].groupValue).toBe('X');
+      expect(result.current[1].groupValue).toBe('Y');
+    });
+  });
+
+  describe('useScopedESQLQueryFetchClient', () => {
+    const scopedProfilesManager = discoverServiceMock.profilesManager.createScopedProfilesManager({
+      scopedEbtManager: discoverServiceMock.ebtManager.createScopedEBTManager(),
+    });
+
+    const defaultProps = {
+      query: { esql: 'FROM logs | STATS count() BY category' },
+      dataView: dataViewWithTimefieldMock,
+      data: discoverServiceMock.data,
+      expressions: discoverServiceMock.expressions,
+      esqlVariables: undefined,
+      filters: undefined,
+      timeRange: undefined,
+      scopedProfilesManager,
+      inspectorAdapters: { requests: new RequestAdapter() },
+    };
+
+    const createMockFetchResponse = (records: DataTableRecord[] = []): RecordsFetchResponse => ({
+      records,
+      esqlQueryColumns: [],
+      esqlHeaderWarning: undefined,
+      interceptedWarnings: [],
+    });
+
+    beforeEach(() => {
+      mockFetchEsql.mockResolvedValue(createMockFetchResponse());
+      mockConstructCascadeQuery.mockReturnValue({ esql: 'FROM logs | WHERE category == "A"' });
+    });
+
+    it('should return a fetch function with cancel method', () => {
+      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+      expect(result.current).toBeInstanceOf(Function);
+      expect(result.current.cancel).toBeInstanceOf(Function);
+    });
+
+    it('should fetch data by invoking constructCascadeQuery and fetchEsql', async () => {
+      const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
+      mockFetchEsql.mockResolvedValue(createMockFetchResponse(mockRecords));
+
+      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+      let records: DataTableRecord[] = [];
+
+      await act(async () => {
+        records = await result.current({
+          nodeType: 'leaf',
+          nodePath: ['category'],
+          nodePathMap: { category: 'A' },
+        });
+      });
+
+      expect(mockConstructCascadeQuery).toHaveBeenCalledWith({
+        query: defaultProps.query,
+        esqlVariables: undefined,
+        dataView: dataViewWithTimefieldMock,
+        nodeType: 'leaf',
+        nodePath: ['category'],
+        nodePathMap: { category: 'A' },
+      });
+      expect(mockFetchEsql).toHaveBeenCalled();
+      expect(records).toEqual(mockRecords);
+    });
+
+    it('should return empty array and capture error when constructCascadeQuery returns undefined', async () => {
+      mockConstructCascadeQuery.mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+      let records: DataTableRecord[] = [];
+      await act(async () => {
+        records = await result.current({
+          nodeType: 'leaf',
+          nodePath: ['category'],
+          nodePathMap: { category: 'A' },
+        });
+      });
+
+      expect(records).toEqual([]);
+      expect(mockApmCaptureError).toHaveBeenCalledWith(
+        new Error('Failed to construct cascade query')
+      );
+      expect(mockFetchEsql).not.toHaveBeenCalled();
+    });
+
+    it('should abort previous requests when making a new request', async () => {
+      const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
+
+      let resolveFirst: (value: RecordsFetchResponse) => void;
+      const firstPromise = new Promise<RecordsFetchResponse>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      mockFetchEsql
+        .mockImplementationOnce(() => firstPromise)
+        .mockResolvedValueOnce(createMockFetchResponse(mockRecords));
+
+      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+      // Start first request (don't await)
+      result.current({
+        nodeType: 'leaf',
+        nodePath: ['category'],
+        nodePathMap: { category: 'A' },
+      });
+
+      // Start second request immediately (should abort first)
+      const secondRequest = result.current({
+        nodeType: 'leaf',
+        nodePath: ['category'],
+        nodePathMap: { category: 'B' },
+      });
+
+      // Resolve first request after abort
+      resolveFirst!(createMockFetchResponse());
+
+      const secondRecords = await secondRequest;
+      expect(secondRecords).toEqual(mockRecords);
+    });
+
+    it('should handle abort errors gracefully', async () => {
+      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+      let records: DataTableRecord[] = [];
+
+      const pendingRequest = result.current({
+        nodeType: 'leaf',
+        nodePath: ['category'],
+        nodePathMap: { category: 'A' },
+      });
+
+      act(() => {
+        result.current.cancel();
+      });
+
+      await act(async () => {
+        records = await pendingRequest;
+      });
+
+      expect(records).toEqual([]);
+    });
+
+    it('should rethrow non-abort errors', async () => {
+      const networkError = new Error('Network failure');
+      mockFetchEsql.mockRejectedValue(networkError);
+
+      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+      await expect(
+        result.current({
+          nodeType: 'leaf',
+          nodePath: ['category'],
+          nodePathMap: { category: 'A' },
+        })
+      ).rejects.toThrow('Network failure');
+    });
+
+    it('should cancel pending requests on unmount', async () => {
+      const { result, unmount } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+      // Start a request
+      const pendingRequestPromise = result.current({
+        nodeType: 'leaf',
+        nodePath: ['category'],
+        nodePathMap: { category: 'A' },
+      });
+
+      // Unmount the hook
+      unmount();
+
+      // The abort controller should have been called
+      // Request should complete gracefully
+      await expect(pendingRequestPromise).resolves.toBeDefined();
+    });
+  });
+
+  describe('useDataCascadeRowExpansionHandlers', () => {
+    const createMockCascadeFetchClient = () => {
+      const mockFetch = jest.fn().mockResolvedValue([]) as jest.Mock & { cancel: jest.Mock };
+      mockFetch.cancel = jest.fn();
+      return mockFetch as unknown as ReturnType<typeof useScopedESQLQueryFetchClient>;
+    };
+
+    const createMockRowData = (): ESQLDataGroupNode => ({
+      id: '1',
+      groupColumn: 'category',
+      groupValue: 'A',
+      aggregatedValues: {},
+    });
+
+    it('should return all four expansion handlers', () => {
+      const mockCascadeFetchClient = createMockCascadeFetchClient();
+
+      const { result } = renderHook(() =>
+        useDataCascadeRowExpansionHandlers({
+          cascadeFetchClient: mockCascadeFetchClient,
+        })
+      );
+
+      expect(result.current.onCascadeGroupNodeExpanded).toBeInstanceOf(Function);
+      expect(result.current.onCascadeGroupNodeCollapsed).toBeInstanceOf(Function);
+      expect(result.current.onCascadeLeafNodeExpanded).toBeInstanceOf(Function);
+      expect(result.current.onCascadeLeafNodeCollapsed).toBeInstanceOf(Function);
+    });
+
+    describe('onCascadeGroupNodeExpanded', () => {
+      it('should call cascadeFetchClient with nodeType "group"', async () => {
+        const mockCascadeFetchClient = createMockCascadeFetchClient();
+        const mockRow = createMockRowData();
+
+        const { result } = renderHook(() =>
+          useDataCascadeRowExpansionHandlers({
+            cascadeFetchClient: mockCascadeFetchClient,
+          })
+        );
+
+        await act(async () => {
+          await result.current.onCascadeGroupNodeExpanded({
+            row: mockRow,
+            nodePath: ['category', 'subcategory'],
+            nodePathMap: { category: 'A', subcategory: 'X' },
+          });
+        });
+
+        expect(mockCascadeFetchClient).toHaveBeenCalledWith({
+          nodePath: ['category', 'subcategory'],
+          nodePathMap: { category: 'A', subcategory: 'X' },
+          nodeType: 'group',
+        });
+      });
+    });
+
+    describe('onCascadeGroupNodeCollapsed', () => {
+      it('should call cascadeFetchClient.cancel', () => {
+        const mockCascadeFetchClient = createMockCascadeFetchClient();
+        const mockRow = createMockRowData();
+
+        const { result } = renderHook(() =>
+          useDataCascadeRowExpansionHandlers({
+            cascadeFetchClient: mockCascadeFetchClient,
+          })
+        );
+
+        result.current.onCascadeGroupNodeCollapsed!({
+          row: mockRow,
+          nodePath: ['category'],
+          nodePathMap: { category: 'A' },
+        });
+
+        expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
+      });
+    });
+
+    describe('onCascadeLeafNodeExpanded', () => {
+      it('should call cascadeFetchClient with nodeType "leaf"', async () => {
+        const mockCascadeFetchClient = createMockCascadeFetchClient();
+        const mockRow = createMockRowData();
+
+        const { result } = renderHook(() =>
+          useDataCascadeRowExpansionHandlers({
+            cascadeFetchClient: mockCascadeFetchClient,
+          })
+        );
+
+        await act(async () => {
+          await result.current.onCascadeLeafNodeExpanded({
+            row: mockRow,
+            nodePath: ['category'],
+            nodePathMap: { category: 'A' },
+          });
+        });
+
+        expect(mockCascadeFetchClient).toHaveBeenCalledWith({
+          nodePath: ['category'],
+          nodePathMap: { category: 'A' },
+          nodeType: 'leaf',
+        });
+      });
+    });
+
+    describe('onCascadeLeafNodeCollapsed', () => {
+      it('should call cascadeFetchClient.cancel', () => {
+        const mockCascadeFetchClient = createMockCascadeFetchClient();
+        const mockRow = createMockRowData();
+
+        const { result } = renderHook(() =>
+          useDataCascadeRowExpansionHandlers({
+            cascadeFetchClient: mockCascadeFetchClient,
+          })
+        );
+
+        result.current.onCascadeLeafNodeCollapsed!({
+          row: mockRow,
+          nodePath: ['category'],
+          nodePathMap: { category: 'A' },
+        });
+
+        expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
+      });
+    });
+
+    it('should memoize handlers and return same references on rerender', () => {
+      const mockCascadeFetchClient = createMockCascadeFetchClient();
+
+      const { result, rerender } = renderHook(() =>
+        useDataCascadeRowExpansionHandlers({
+          cascadeFetchClient: mockCascadeFetchClient,
+        })
+      );
+
+      const firstResult = result.current;
+
+      rerender();
+
+      expect(result.current.onCascadeGroupNodeExpanded).toBe(
+        firstResult.onCascadeGroupNodeExpanded
+      );
+      expect(result.current.onCascadeGroupNodeCollapsed).toBe(
+        firstResult.onCascadeGroupNodeCollapsed
+      );
+      expect(result.current.onCascadeLeafNodeExpanded).toBe(firstResult.onCascadeLeafNodeExpanded);
+      expect(result.current.onCascadeLeafNodeCollapsed).toBe(
+        firstResult.onCascadeLeafNodeCollapsed
+      );
+    });
+
+    it('should update handlers when cascadeFetchClient changes', () => {
+      const mockCascadeFetchClient1 = createMockCascadeFetchClient();
+      const mockCascadeFetchClient2 = createMockCascadeFetchClient();
+
+      const { result, rerender } = renderHook(
+        ({ cascadeFetchClient }) =>
+          useDataCascadeRowExpansionHandlers({
+            cascadeFetchClient,
+          }),
+        {
+          initialProps: { cascadeFetchClient: mockCascadeFetchClient1 },
+        }
+      );
+
+      const firstResult = result.current;
+
+      rerender({ cascadeFetchClient: mockCascadeFetchClient2 });
+
+      // Handlers should be new references after dependency change
+      expect(result.current.onCascadeGroupNodeExpanded).not.toBe(
+        firstResult.onCascadeGroupNodeExpanded
+      );
+    });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
@@ -8,43 +8,17 @@
  */
 
 import { renderHook, act } from '@testing-library/react';
-import { RequestAdapter } from '@kbn/inspector-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
+import type { AggregateQuery } from '@kbn/es-query';
 import { dataViewWithTimefieldMock } from '../../../../../../__mocks__/data_view_with_timefield';
-import { discoverServiceMock } from '../../../../../../__mocks__/services';
-import {
-  useGroupedCascadeData,
-  useScopedESQLQueryFetchClient,
-  useDataCascadeRowExpansionHandlers,
-} from './data_fetching';
-import { fetchEsql } from '../../../../data_fetching/fetch_esql';
-import { constructCascadeQuery } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
-import { apm } from '@elastic/apm-rum';
+import { useGroupedCascadeData, useDataCascadeRowExpansionHandlers } from './data_fetching';
 import type { ESQLStatsQueryMeta } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
 import type { ESQLDataGroupNode } from '../blocks';
-import type { RecordsFetchResponse } from '../../../../../types';
-
-jest.mock('../../../../data_fetching/fetch_esql', () => ({
-  fetchEsql: jest.fn(),
-}));
-
-jest.mock('@kbn/esql-utils/src/utils/cascaded_documents_helpers', () => ({
-  ...jest.requireActual('@kbn/esql-utils/src/utils/cascaded_documents_helpers'),
-  constructCascadeQuery: jest.fn(),
-}));
-
-jest.mock('@elastic/apm-rum', () => ({
-  apm: {
-    captureError: jest.fn(),
-  },
-}));
-
-const mockFetchEsql = fetchEsql as jest.MockedFunction<typeof fetchEsql>;
-const mockConstructCascadeQuery = constructCascadeQuery as jest.MockedFunction<
-  typeof constructCascadeQuery
->;
-const mockApmCaptureError = apm.captureError as jest.MockedFunction<typeof apm.captureError>;
+import { CascadedDocumentsProvider } from '../cascaded_documents_provider';
+import type { CascadedDocumentsContext } from '../cascaded_documents_provider';
+import { createElement, type ReactNode } from 'react';
+import type { CascadedDocumentsFetcher } from '../../../../data_fetching/cascaded_documents_fetcher';
 
 describe('data_fetching related hooks', () => {
   beforeEach(() => {
@@ -219,187 +193,35 @@ describe('data_fetching related hooks', () => {
     });
   });
 
-  describe('useScopedESQLQueryFetchClient', () => {
-    const scopedProfilesManager = discoverServiceMock.profilesManager.createScopedProfilesManager({
-      scopedEbtManager: discoverServiceMock.ebtManager.createScopedEBTManager(),
-    });
-
-    const defaultProps = {
-      query: { esql: 'FROM logs | STATS count() BY category' },
-      dataView: dataViewWithTimefieldMock,
-      data: discoverServiceMock.data,
-      expressions: discoverServiceMock.expressions,
-      esqlVariables: undefined,
-      filters: undefined,
-      timeRange: undefined,
-      scopedProfilesManager,
-      inspectorAdapters: { requests: new RequestAdapter() },
-    };
-
-    const createMockFetchResponse = (records: DataTableRecord[] = []): RecordsFetchResponse => ({
-      records,
-      esqlQueryColumns: [],
-      esqlHeaderWarning: undefined,
-      interceptedWarnings: [],
-    });
-
-    beforeEach(() => {
-      mockFetchEsql.mockResolvedValue(createMockFetchResponse());
-      mockConstructCascadeQuery.mockReturnValue({ esql: 'FROM logs | WHERE category == "A"' });
-    });
-
-    it('should return a fetch function with cancel method', () => {
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      expect(result.current).toBeInstanceOf(Function);
-      expect(result.current.cancel).toBeInstanceOf(Function);
-    });
-
-    it('should fetch data by invoking constructCascadeQuery and fetchEsql', async () => {
-      const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
-      mockFetchEsql.mockResolvedValue(createMockFetchResponse(mockRecords));
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      let records: DataTableRecord[] = [];
-
-      await act(async () => {
-        records = await result.current({
-          nodeType: 'leaf',
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        });
-      });
-
-      expect(mockConstructCascadeQuery).toHaveBeenCalledWith({
-        query: defaultProps.query,
-        esqlVariables: undefined,
-        dataView: dataViewWithTimefieldMock,
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-      expect(mockFetchEsql).toHaveBeenCalled();
-      expect(records).toEqual(mockRecords);
-    });
-
-    it('should return empty array and capture error when constructCascadeQuery returns undefined', async () => {
-      mockConstructCascadeQuery.mockReturnValue(undefined);
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      let records: DataTableRecord[] = [];
-      await act(async () => {
-        records = await result.current({
-          nodeType: 'leaf',
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        });
-      });
-
-      expect(records).toEqual([]);
-      expect(mockApmCaptureError).toHaveBeenCalledWith(
-        new Error('Failed to construct cascade query')
-      );
-      expect(mockFetchEsql).not.toHaveBeenCalled();
-    });
-
-    it('should abort previous requests when making a new request', async () => {
-      const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
-
-      let resolveFirst: (value: RecordsFetchResponse) => void;
-      const firstPromise = new Promise<RecordsFetchResponse>((resolve) => {
-        resolveFirst = resolve;
-      });
-
-      mockFetchEsql
-        .mockImplementationOnce(() => firstPromise)
-        .mockResolvedValueOnce(createMockFetchResponse(mockRecords));
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      // Start first request (don't await)
-      result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-
-      // Start second request immediately (should abort first)
-      const secondRequest = result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'B' },
-      });
-
-      // Resolve first request after abort
-      resolveFirst!(createMockFetchResponse());
-
-      const secondRecords = await secondRequest;
-      expect(secondRecords).toEqual(mockRecords);
-    });
-
-    it('should handle abort errors gracefully', async () => {
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      let records: DataTableRecord[] = [];
-
-      const pendingRequest = result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-
-      act(() => {
-        result.current.cancel();
-      });
-
-      await act(async () => {
-        records = await pendingRequest;
-      });
-
-      expect(records).toEqual([]);
-    });
-
-    it('should rethrow non-abort errors', async () => {
-      const networkError = new Error('Network failure');
-      mockFetchEsql.mockRejectedValue(networkError);
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      await expect(
-        result.current({
-          nodeType: 'leaf',
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        })
-      ).rejects.toThrow('Network failure');
-    });
-
-    it('should cancel pending requests on unmount', async () => {
-      const { result, unmount } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      // Start a request
-      const pendingRequestPromise = result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-
-      // Unmount the hook
-      unmount();
-
-      // The abort controller should have been called
-      // Request should complete gracefully
-      await expect(pendingRequestPromise).resolves.toBeDefined();
-    });
-  });
-
   describe('useDataCascadeRowExpansionHandlers', () => {
-    const createMockCascadeFetchClient = () => {
-      const mockFetch = jest.fn().mockResolvedValue([]) as jest.Mock & { cancel: jest.Mock };
-      mockFetch.cancel = jest.fn();
-      return mockFetch as unknown as ReturnType<typeof useScopedESQLQueryFetchClient>;
+    const createMockFetcher = () =>
+      ({
+        fetchCascadedDocuments: jest.fn().mockResolvedValue([]),
+        cancelFetch: jest.fn(),
+      } as unknown as CascadedDocumentsFetcher);
+
+    const createWrapper = (overrides?: Partial<CascadedDocumentsContext>) => {
+      const esqlQuery: AggregateQuery = { esql: 'FROM logs | STATS count() BY category' };
+
+      const contextValue: CascadedDocumentsContext = {
+        availableCascadeGroups: ['category'],
+        selectedCascadeGroups: ['category'],
+        cascadedDocumentsFetcher: createMockFetcher(),
+        esqlQuery,
+        esqlVariables: undefined,
+        timeRange: undefined,
+        viewModeToggle: undefined,
+        cascadeGroupingChangeHandler: jest.fn(),
+        onUpdateESQLQuery: jest.fn(),
+        openInNewTab: jest.fn(),
+        registerCascadeRequestsInspectorAdapter: jest.fn(),
+        ...overrides,
+      };
+
+      const Wrapper = ({ children }: { children: ReactNode }) =>
+        createElement(CascadedDocumentsProvider, { value: contextValue }, children);
+
+      return { Wrapper, contextValue };
     };
 
     const createMockRowData = (): ESQLDataGroupNode => ({
@@ -410,13 +232,12 @@ describe('data_fetching related hooks', () => {
     });
 
     it('should return all four expansion handlers', () => {
-      const mockCascadeFetchClient = createMockCascadeFetchClient();
+      const { Wrapper } = createWrapper();
+      const dataView = dataViewWithTimefieldMock;
 
-      const { result } = renderHook(() =>
-        useDataCascadeRowExpansionHandlers({
-          cascadeFetchClient: mockCascadeFetchClient,
-        })
-      );
+      const { result } = renderHook(() => useDataCascadeRowExpansionHandlers({ dataView }), {
+        wrapper: Wrapper,
+      });
 
       expect(result.current.onCascadeGroupNodeExpanded).toBeInstanceOf(Function);
       expect(result.current.onCascadeGroupNodeCollapsed).toBeInstanceOf(Function);
@@ -425,42 +246,35 @@ describe('data_fetching related hooks', () => {
     });
 
     describe('onCascadeGroupNodeExpanded', () => {
-      it('should call cascadeFetchClient with nodeType "group"', async () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
+      it('should return an empty array and not fetch', async () => {
         const mockRow = createMockRowData();
+        const { Wrapper, contextValue } = createWrapper();
+        const dataView = dataViewWithTimefieldMock;
 
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
-
-        await act(async () => {
-          await result.current.onCascadeGroupNodeExpanded({
-            row: mockRow,
-            nodePath: ['category', 'subcategory'],
-            nodePathMap: { category: 'A', subcategory: 'X' },
-          });
+        const { result } = renderHook(() => useDataCascadeRowExpansionHandlers({ dataView }), {
+          wrapper: Wrapper,
         });
 
-        expect(mockCascadeFetchClient).toHaveBeenCalledWith({
+        const response = await result.current.onCascadeGroupNodeExpanded({
+          row: mockRow,
           nodePath: ['category', 'subcategory'],
           nodePathMap: { category: 'A', subcategory: 'X' },
-          nodeType: 'group',
         });
+
+        expect(response).toEqual([]);
+        expect(contextValue.cascadedDocumentsFetcher.fetchCascadedDocuments).not.toHaveBeenCalled();
       });
     });
 
     describe('onCascadeGroupNodeCollapsed', () => {
-      it('should call cascadeFetchClient.cancel', () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
+      it('should not cancel any fetches', () => {
         const mockRow = createMockRowData();
+        const { Wrapper, contextValue } = createWrapper();
+        const dataView = dataViewWithTimefieldMock;
 
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
+        const { result } = renderHook(() => useDataCascadeRowExpansionHandlers({ dataView }), {
+          wrapper: Wrapper,
+        });
 
         result.current.onCascadeGroupNodeCollapsed!({
           row: mockRow,
@@ -468,20 +282,19 @@ describe('data_fetching related hooks', () => {
           nodePathMap: { category: 'A' },
         });
 
-        expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
+        expect(contextValue.cascadedDocumentsFetcher.cancelFetch).not.toHaveBeenCalled();
       });
     });
 
     describe('onCascadeLeafNodeExpanded', () => {
-      it('should call cascadeFetchClient with nodeType "leaf"', async () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
+      it('should call cascadedDocumentsFetcher.fetchCascadedDocuments', async () => {
         const mockRow = createMockRowData();
+        const { Wrapper, contextValue } = createWrapper();
+        const dataView = dataViewWithTimefieldMock;
 
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
+        const { result } = renderHook(() => useDataCascadeRowExpansionHandlers({ dataView }), {
+          wrapper: Wrapper,
+        });
 
         await act(async () => {
           await result.current.onCascadeLeafNodeExpanded({
@@ -491,24 +304,28 @@ describe('data_fetching related hooks', () => {
           });
         });
 
-        expect(mockCascadeFetchClient).toHaveBeenCalledWith({
+        expect(contextValue.cascadedDocumentsFetcher.fetchCascadedDocuments).toHaveBeenCalledWith({
+          nodeId: mockRow.id,
+          nodeType: 'leaf',
           nodePath: ['category'],
           nodePathMap: { category: 'A' },
-          nodeType: 'leaf',
+          query: contextValue.esqlQuery,
+          esqlVariables: contextValue.esqlVariables,
+          timeRange: contextValue.timeRange,
+          dataView,
         });
       });
     });
 
     describe('onCascadeLeafNodeCollapsed', () => {
-      it('should call cascadeFetchClient.cancel', () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
+      it('should call cascadedDocumentsFetcher.cancelFetch', () => {
         const mockRow = createMockRowData();
+        const { Wrapper, contextValue } = createWrapper();
+        const dataView = dataViewWithTimefieldMock;
 
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
+        const { result } = renderHook(() => useDataCascadeRowExpansionHandlers({ dataView }), {
+          wrapper: Wrapper,
+        });
 
         result.current.onCascadeLeafNodeCollapsed!({
           row: mockRow,
@@ -516,17 +333,17 @@ describe('data_fetching related hooks', () => {
           nodePathMap: { category: 'A' },
         });
 
-        expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
+        expect(contextValue.cascadedDocumentsFetcher.cancelFetch).toHaveBeenCalledWith(mockRow.id);
       });
     });
 
     it('should memoize handlers and return same references on rerender', () => {
-      const mockCascadeFetchClient = createMockCascadeFetchClient();
+      const { Wrapper } = createWrapper();
+      const dataView = dataViewWithTimefieldMock;
 
-      const { result, rerender } = renderHook(() =>
-        useDataCascadeRowExpansionHandlers({
-          cascadeFetchClient: mockCascadeFetchClient,
-        })
+      const { result, rerender } = renderHook(
+        () => useDataCascadeRowExpansionHandlers({ dataView }),
+        { wrapper: Wrapper }
       );
 
       const firstResult = result.current;
@@ -542,30 +359,6 @@ describe('data_fetching related hooks', () => {
       expect(result.current.onCascadeLeafNodeExpanded).toBe(firstResult.onCascadeLeafNodeExpanded);
       expect(result.current.onCascadeLeafNodeCollapsed).toBe(
         firstResult.onCascadeLeafNodeCollapsed
-      );
-    });
-
-    it('should update handlers when cascadeFetchClient changes', () => {
-      const mockCascadeFetchClient1 = createMockCascadeFetchClient();
-      const mockCascadeFetchClient2 = createMockCascadeFetchClient();
-
-      const { result, rerender } = renderHook(
-        ({ cascadeFetchClient }) =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient,
-          }),
-        {
-          initialProps: { cascadeFetchClient: mockCascadeFetchClient1 },
-        }
-      );
-
-      const firstResult = result.current;
-
-      rerender({ cascadeFetchClient: mockCascadeFetchClient2 });
-
-      // Handlers should be new references after dependency change
-      expect(result.current.onCascadeGroupNodeExpanded).not.toBe(
-        firstResult.onCascadeGroupNodeExpanded
       );
     });
   });

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
@@ -214,7 +214,6 @@ describe('data_fetching related hooks', () => {
         cascadeGroupingChangeHandler: jest.fn(),
         onUpdateESQLQuery: jest.fn(),
         openInNewTab: jest.fn(),
-        registerCascadeRequestsInspectorAdapter: jest.fn(),
         ...overrides,
       };
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
@@ -207,6 +207,8 @@ describe('data_fetching related hooks', () => {
         availableCascadeGroups: ['category'],
         selectedCascadeGroups: ['category'],
         cascadedDocumentsFetcher: createMockFetcher(),
+        dataCascadeUiState: undefined,
+        setDataCascadeUiState: jest.fn(),
         esqlQuery,
         esqlVariables: undefined,
         timeRange: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
@@ -7,566 +7,566 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook, act } from '@testing-library/react';
-import { RequestAdapter } from '@kbn/inspector-plugin/common';
-import type { DataTableRecord } from '@kbn/discover-utils';
-import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
-import { dataViewWithTimefieldMock } from '../../../../../../__mocks__/data_view_with_timefield';
-import { discoverServiceMock } from '../../../../../../__mocks__/services';
-import {
-  useGroupedCascadeData,
-  useScopedESQLQueryFetchClient,
-  useDataCascadeRowExpansionHandlers,
-} from './data_fetching';
-import { fetchEsql } from '../../../../data_fetching/fetch_esql';
-import { constructCascadeQuery } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
-import { apm } from '@elastic/apm-rum';
-import type { ESQLStatsQueryMeta } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
-import type { ESQLDataGroupNode } from '../blocks';
-import type { RecordsFetchResponse } from '../../../../../types';
-
-jest.mock('../../../../data_fetching/fetch_esql', () => ({
-  fetchEsql: jest.fn(),
-}));
-
-jest.mock('@kbn/esql-utils/src/utils/cascaded_documents_helpers', () => ({
-  ...jest.requireActual('@kbn/esql-utils/src/utils/cascaded_documents_helpers'),
-  constructCascadeQuery: jest.fn(),
-}));
-
-jest.mock('@elastic/apm-rum', () => ({
-  apm: {
-    captureError: jest.fn(),
-  },
-}));
-
-const mockFetchEsql = fetchEsql as jest.MockedFunction<typeof fetchEsql>;
-const mockConstructCascadeQuery = constructCascadeQuery as jest.MockedFunction<
-  typeof constructCascadeQuery
->;
-const mockApmCaptureError = apm.captureError as jest.MockedFunction<typeof apm.captureError>;
-
-describe('data_fetching related hooks', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  describe('useGroupedCascadeData', () => {
-    const createMockRows = (data: Array<Record<string, unknown>>): DataTableRecord[] =>
-      data.map((item, idx) => ({
-        id: String(idx),
-        raw: item,
-        flattened: item,
-      }));
-
-    const defaultQueryMeta: ESQLStatsQueryMeta = {
-      groupByFields: [{ field: 'category', type: 'column' }],
-      appliedFunctions: [{ identifier: 'count', aggregation: 'count' }],
-    };
-
-    const defaultSelectedCascadeGroups = ['category'];
-
-    it('should return empty array when rows are undefined', () => {
-      const { result } = renderHook(() =>
-        useGroupedCascadeData({
-          selectedCascadeGroups: defaultSelectedCascadeGroups,
-          rows: undefined,
-          queryMeta: defaultQueryMeta,
-          esqlVariables: undefined,
-        })
-      );
-
-      expect(result.current).toEqual([]);
-    });
-
-    it('should return empty array when rows are empty', () => {
-      const { result } = renderHook(() =>
-        useGroupedCascadeData({
-          selectedCascadeGroups: defaultSelectedCascadeGroups,
-          rows: [],
-          queryMeta: defaultQueryMeta,
-          esqlVariables: undefined,
-        })
-      );
-
-      expect(result.current).toEqual([]);
-    });
-
-    it('should group rows by selected cascade groups', () => {
-      const mockRows = createMockRows([
-        { category: 'A', count: 10 },
-        { category: 'A', count: 5 },
-        { category: 'B', count: 20 },
-      ]);
-
-      const { result } = renderHook(() =>
-        useGroupedCascadeData({
-          selectedCascadeGroups: defaultSelectedCascadeGroups,
-          rows: mockRows,
-          queryMeta: defaultQueryMeta,
-          esqlVariables: undefined,
-        })
-      );
-
-      expect(result.current).toHaveLength(2);
-      expect(result.current[0].groupValue).toBe('A');
-      expect(result.current[0].aggregatedValues.count).toBe(15); // 10 + 5 aggregated
-      expect(result.current[1].groupValue).toBe('B');
-      expect(result.current[1].aggregatedValues.count).toBe(20);
-    });
-
-    it('should skip undefined and null values in grouping', () => {
-      const mockRows = createMockRows([
-        { category: 'A', count: 10 },
-        { category: undefined, count: 5 },
-        { category: null, count: 15 },
-        { category: 'B', count: 20 },
-      ]);
-
-      const { result } = renderHook(() =>
-        useGroupedCascadeData({
-          selectedCascadeGroups: defaultSelectedCascadeGroups,
-          rows: mockRows,
-          queryMeta: defaultQueryMeta,
-          esqlVariables: undefined,
-        })
-      );
-
-      expect(result.current).toHaveLength(2);
-      expect(result.current.find((r) => r.groupValue === 'A')).toBeDefined();
-      expect(result.current.find((r) => r.groupValue === 'B')).toBeDefined();
-    });
-
-    it('should aggregate multiple applied functions', () => {
-      const mockRows = createMockRows([
-        { category: 'A', count: 10, sum: 100 },
-        { category: 'A', count: 5, sum: 50 },
-      ]);
-
-      const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
-        groupByFields: [{ field: 'category', type: 'column' }],
-        appliedFunctions: [
-          { identifier: 'count', aggregation: 'count' },
-          { identifier: 'sum', aggregation: 'sum' },
-        ],
-      };
-
-      const { result } = renderHook(() =>
-        useGroupedCascadeData({
-          selectedCascadeGroups: defaultSelectedCascadeGroups,
-          rows: mockRows,
-          queryMeta: queryMetaWithMultipleFunctions,
-          esqlVariables: undefined,
-        })
-      );
-
-      expect(result.current).toHaveLength(1);
-      expect(result.current[0].aggregatedValues.count).toBe(15);
-      expect(result.current[0].aggregatedValues.sum).toBe(150);
-    });
-
-    it('should aggregate multiple applied functions with array values', () => {
-      const mockRows = createMockRows([
-        { category: 'A', count: 10, ext: ['css', 'js'] },
-        { category: 'A', count: 5, ext: ['deb', 'rpm'] },
-      ]);
-
-      const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
-        groupByFields: [{ field: 'category', type: 'column' }],
-        appliedFunctions: [
-          { identifier: 'count', aggregation: 'count' },
-          { identifier: 'ext', aggregation: 'ext' },
-        ],
-      };
-
-      const { result } = renderHook(() =>
-        useGroupedCascadeData({
-          selectedCascadeGroups: defaultSelectedCascadeGroups,
-          rows: mockRows,
-          queryMeta: queryMetaWithMultipleFunctions,
-          esqlVariables: undefined,
-        })
-      );
-
-      expect(result.current).toHaveLength(1);
-      expect(result.current[0].aggregatedValues.count).toBe(15);
-      expect(result.current[0].aggregatedValues.ext).toEqual(['css', 'js', 'deb', 'rpm']);
-    });
-
-    it('should resolve esql variable for group key', () => {
-      const mockRows = createMockRows([
-        { actualField: 'X', count: 10 },
-        { actualField: 'X', count: 5 },
-        { actualField: 'Y', count: 20 },
-      ]);
-
-      const esqlVariables: ESQLControlVariable[] = [
-        { key: 'myVar', value: 'actualField', type: ESQLVariableType.FIELDS },
-      ];
-
-      const { result } = renderHook(() =>
-        useGroupedCascadeData({
-          selectedCascadeGroups: ['??myVar'],
-          rows: mockRows,
-          queryMeta: defaultQueryMeta,
-          esqlVariables,
-        })
-      );
-
-      expect(result.current).toHaveLength(2);
-      expect(result.current[0].groupValue).toBe('X');
-      expect(result.current[1].groupValue).toBe('Y');
-    });
-  });
-
-  describe('useScopedESQLQueryFetchClient', () => {
-    const scopedProfilesManager = discoverServiceMock.profilesManager.createScopedProfilesManager({
-      scopedEbtManager: discoverServiceMock.ebtManager.createScopedEBTManager(),
-    });
-
-    const defaultProps = {
-      query: { esql: 'FROM logs | STATS count() BY category' },
-      dataView: dataViewWithTimefieldMock,
-      data: discoverServiceMock.data,
-      expressions: discoverServiceMock.expressions,
-      esqlVariables: undefined,
-      filters: undefined,
-      timeRange: undefined,
-      scopedProfilesManager,
-      inspectorAdapters: { requests: new RequestAdapter() },
-    };
-
-    const createMockFetchResponse = (records: DataTableRecord[] = []): RecordsFetchResponse => ({
-      records,
-      esqlQueryColumns: [],
-      esqlHeaderWarning: undefined,
-      interceptedWarnings: [],
-    });
-
-    beforeEach(() => {
-      mockFetchEsql.mockResolvedValue(createMockFetchResponse());
-      mockConstructCascadeQuery.mockReturnValue({ esql: 'FROM logs | WHERE category == "A"' });
-    });
-
-    it('should return a fetch function with cancel method', () => {
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      expect(result.current).toBeInstanceOf(Function);
-      expect(result.current.cancel).toBeInstanceOf(Function);
-    });
-
-    it('should fetch data by invoking constructCascadeQuery and fetchEsql', async () => {
-      const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
-      mockFetchEsql.mockResolvedValue(createMockFetchResponse(mockRecords));
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      let records: DataTableRecord[] = [];
-
-      await act(async () => {
-        records = await result.current({
-          nodeType: 'leaf',
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        });
-      });
-
-      expect(mockConstructCascadeQuery).toHaveBeenCalledWith({
-        query: defaultProps.query,
-        esqlVariables: undefined,
-        dataView: dataViewWithTimefieldMock,
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-      expect(mockFetchEsql).toHaveBeenCalled();
-      expect(records).toEqual(mockRecords);
-    });
-
-    it('should return empty array and capture error when constructCascadeQuery returns undefined', async () => {
-      mockConstructCascadeQuery.mockReturnValue(undefined);
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      let records: DataTableRecord[] = [];
-      await act(async () => {
-        records = await result.current({
-          nodeType: 'leaf',
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        });
-      });
-
-      expect(records).toEqual([]);
-      expect(mockApmCaptureError).toHaveBeenCalledWith(
-        new Error('Failed to construct cascade query')
-      );
-      expect(mockFetchEsql).not.toHaveBeenCalled();
-    });
-
-    it('should abort previous requests when making a new request', async () => {
-      const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
-
-      let resolveFirst: (value: RecordsFetchResponse) => void;
-      const firstPromise = new Promise<RecordsFetchResponse>((resolve) => {
-        resolveFirst = resolve;
-      });
-
-      mockFetchEsql
-        .mockImplementationOnce(() => firstPromise)
-        .mockResolvedValueOnce(createMockFetchResponse(mockRecords));
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      // Start first request (don't await)
-      result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-
-      // Start second request immediately (should abort first)
-      const secondRequest = result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'B' },
-      });
-
-      // Resolve first request after abort
-      resolveFirst!(createMockFetchResponse());
-
-      const secondRecords = await secondRequest;
-      expect(secondRecords).toEqual(mockRecords);
-    });
-
-    it('should handle abort errors gracefully', async () => {
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      let records: DataTableRecord[] = [];
-
-      const pendingRequest = result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-
-      act(() => {
-        result.current.cancel();
-      });
-
-      await act(async () => {
-        records = await pendingRequest;
-      });
-
-      expect(records).toEqual([]);
-    });
-
-    it('should rethrow non-abort errors', async () => {
-      const networkError = new Error('Network failure');
-      mockFetchEsql.mockRejectedValue(networkError);
-
-      const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      await expect(
-        result.current({
-          nodeType: 'leaf',
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        })
-      ).rejects.toThrow('Network failure');
-    });
-
-    it('should cancel pending requests on unmount', async () => {
-      const { result, unmount } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
-
-      // Start a request
-      const pendingRequestPromise = result.current({
-        nodeType: 'leaf',
-        nodePath: ['category'],
-        nodePathMap: { category: 'A' },
-      });
-
-      // Unmount the hook
-      unmount();
-
-      // The abort controller should have been called
-      // Request should complete gracefully
-      await expect(pendingRequestPromise).resolves.toBeDefined();
-    });
-  });
-
-  describe('useDataCascadeRowExpansionHandlers', () => {
-    const createMockCascadeFetchClient = () => {
-      const mockFetch = jest.fn().mockResolvedValue([]) as jest.Mock & { cancel: jest.Mock };
-      mockFetch.cancel = jest.fn();
-      return mockFetch as unknown as ReturnType<typeof useScopedESQLQueryFetchClient>;
-    };
-
-    const createMockRowData = (): ESQLDataGroupNode => ({
-      id: '1',
-      groupColumn: 'category',
-      groupValue: 'A',
-      aggregatedValues: {},
-    });
-
-    it('should return all four expansion handlers', () => {
-      const mockCascadeFetchClient = createMockCascadeFetchClient();
-
-      const { result } = renderHook(() =>
-        useDataCascadeRowExpansionHandlers({
-          cascadeFetchClient: mockCascadeFetchClient,
-        })
-      );
-
-      expect(result.current.onCascadeGroupNodeExpanded).toBeInstanceOf(Function);
-      expect(result.current.onCascadeGroupNodeCollapsed).toBeInstanceOf(Function);
-      expect(result.current.onCascadeLeafNodeExpanded).toBeInstanceOf(Function);
-      expect(result.current.onCascadeLeafNodeCollapsed).toBeInstanceOf(Function);
-    });
-
-    describe('onCascadeGroupNodeExpanded', () => {
-      it('should call cascadeFetchClient with nodeType "group"', async () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
-        const mockRow = createMockRowData();
-
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
-
-        await act(async () => {
-          await result.current.onCascadeGroupNodeExpanded({
-            row: mockRow,
-            nodePath: ['category', 'subcategory'],
-            nodePathMap: { category: 'A', subcategory: 'X' },
-          });
-        });
-
-        expect(mockCascadeFetchClient).toHaveBeenCalledWith({
-          nodePath: ['category', 'subcategory'],
-          nodePathMap: { category: 'A', subcategory: 'X' },
-          nodeType: 'group',
-        });
-      });
-    });
-
-    describe('onCascadeGroupNodeCollapsed', () => {
-      it('should call cascadeFetchClient.cancel', () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
-        const mockRow = createMockRowData();
-
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
-
-        result.current.onCascadeGroupNodeCollapsed!({
-          row: mockRow,
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        });
-
-        expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
-      });
-    });
-
-    describe('onCascadeLeafNodeExpanded', () => {
-      it('should call cascadeFetchClient with nodeType "leaf"', async () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
-        const mockRow = createMockRowData();
-
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
-
-        await act(async () => {
-          await result.current.onCascadeLeafNodeExpanded({
-            row: mockRow,
-            nodePath: ['category'],
-            nodePathMap: { category: 'A' },
-          });
-        });
-
-        expect(mockCascadeFetchClient).toHaveBeenCalledWith({
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-          nodeType: 'leaf',
-        });
-      });
-    });
-
-    describe('onCascadeLeafNodeCollapsed', () => {
-      it('should call cascadeFetchClient.cancel', () => {
-        const mockCascadeFetchClient = createMockCascadeFetchClient();
-        const mockRow = createMockRowData();
-
-        const { result } = renderHook(() =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient: mockCascadeFetchClient,
-          })
-        );
-
-        result.current.onCascadeLeafNodeCollapsed!({
-          row: mockRow,
-          nodePath: ['category'],
-          nodePathMap: { category: 'A' },
-        });
-
-        expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
-      });
-    });
-
-    it('should memoize handlers and return same references on rerender', () => {
-      const mockCascadeFetchClient = createMockCascadeFetchClient();
-
-      const { result, rerender } = renderHook(() =>
-        useDataCascadeRowExpansionHandlers({
-          cascadeFetchClient: mockCascadeFetchClient,
-        })
-      );
-
-      const firstResult = result.current;
-
-      rerender();
-
-      expect(result.current.onCascadeGroupNodeExpanded).toBe(
-        firstResult.onCascadeGroupNodeExpanded
-      );
-      expect(result.current.onCascadeGroupNodeCollapsed).toBe(
-        firstResult.onCascadeGroupNodeCollapsed
-      );
-      expect(result.current.onCascadeLeafNodeExpanded).toBe(firstResult.onCascadeLeafNodeExpanded);
-      expect(result.current.onCascadeLeafNodeCollapsed).toBe(
-        firstResult.onCascadeLeafNodeCollapsed
-      );
-    });
-
-    it('should update handlers when cascadeFetchClient changes', () => {
-      const mockCascadeFetchClient1 = createMockCascadeFetchClient();
-      const mockCascadeFetchClient2 = createMockCascadeFetchClient();
-
-      const { result, rerender } = renderHook(
-        ({ cascadeFetchClient }) =>
-          useDataCascadeRowExpansionHandlers({
-            cascadeFetchClient,
-          }),
-        {
-          initialProps: { cascadeFetchClient: mockCascadeFetchClient1 },
-        }
-      );
-
-      const firstResult = result.current;
-
-      rerender({ cascadeFetchClient: mockCascadeFetchClient2 });
-
-      // Handlers should be new references after dependency change
-      expect(result.current.onCascadeGroupNodeExpanded).not.toBe(
-        firstResult.onCascadeGroupNodeExpanded
-      );
-    });
-  });
-});
+// import { renderHook, act } from '@testing-library/react';
+// import { RequestAdapter } from '@kbn/inspector-plugin/common';
+// import type { DataTableRecord } from '@kbn/discover-utils';
+// import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
+// import { dataViewWithTimefieldMock } from '../../../../../../__mocks__/data_view_with_timefield';
+// import { discoverServiceMock } from '../../../../../../__mocks__/services';
+// import {
+//   useGroupedCascadeData,
+//   useScopedESQLQueryFetchClient,
+//   useDataCascadeRowExpansionHandlers,
+// } from './data_fetching';
+// import { fetchEsql } from '../../../../data_fetching/fetch_esql';
+// import { constructCascadeQuery } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
+// import { apm } from '@elastic/apm-rum';
+// import type { ESQLStatsQueryMeta } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
+// import type { ESQLDataGroupNode } from '../blocks';
+// import type { RecordsFetchResponse } from '../../../../../types';
+
+// jest.mock('../../../../data_fetching/fetch_esql', () => ({
+//   fetchEsql: jest.fn(),
+// }));
+
+// jest.mock('@kbn/esql-utils/src/utils/cascaded_documents_helpers', () => ({
+//   ...jest.requireActual('@kbn/esql-utils/src/utils/cascaded_documents_helpers'),
+//   constructCascadeQuery: jest.fn(),
+// }));
+
+// jest.mock('@elastic/apm-rum', () => ({
+//   apm: {
+//     captureError: jest.fn(),
+//   },
+// }));
+
+// const mockFetchEsql = fetchEsql as jest.MockedFunction<typeof fetchEsql>;
+// const mockConstructCascadeQuery = constructCascadeQuery as jest.MockedFunction<
+//   typeof constructCascadeQuery
+// >;
+// const mockApmCaptureError = apm.captureError as jest.MockedFunction<typeof apm.captureError>;
+
+// describe('data_fetching related hooks', () => {
+//   beforeEach(() => {
+//     jest.clearAllMocks();
+//   });
+
+//   describe('useGroupedCascadeData', () => {
+//     const createMockRows = (data: Array<Record<string, unknown>>): DataTableRecord[] =>
+//       data.map((item, idx) => ({
+//         id: String(idx),
+//         raw: item,
+//         flattened: item,
+//       }));
+
+//     const defaultQueryMeta: ESQLStatsQueryMeta = {
+//       groupByFields: [{ field: 'category', type: 'column' }],
+//       appliedFunctions: [{ identifier: 'count', aggregation: 'count' }],
+//     };
+
+//     const defaultSelectedCascadeGroups = ['category'];
+
+//     it('should return empty array when rows are undefined', () => {
+//       const { result } = renderHook(() =>
+//         useGroupedCascadeData({
+//           selectedCascadeGroups: defaultSelectedCascadeGroups,
+//           rows: undefined,
+//           queryMeta: defaultQueryMeta,
+//           esqlVariables: undefined,
+//         })
+//       );
+
+//       expect(result.current).toEqual([]);
+//     });
+
+//     it('should return empty array when rows are empty', () => {
+//       const { result } = renderHook(() =>
+//         useGroupedCascadeData({
+//           selectedCascadeGroups: defaultSelectedCascadeGroups,
+//           rows: [],
+//           queryMeta: defaultQueryMeta,
+//           esqlVariables: undefined,
+//         })
+//       );
+
+//       expect(result.current).toEqual([]);
+//     });
+
+//     it('should group rows by selected cascade groups', () => {
+//       const mockRows = createMockRows([
+//         { category: 'A', count: 10 },
+//         { category: 'A', count: 5 },
+//         { category: 'B', count: 20 },
+//       ]);
+
+//       const { result } = renderHook(() =>
+//         useGroupedCascadeData({
+//           selectedCascadeGroups: defaultSelectedCascadeGroups,
+//           rows: mockRows,
+//           queryMeta: defaultQueryMeta,
+//           esqlVariables: undefined,
+//         })
+//       );
+
+//       expect(result.current).toHaveLength(2);
+//       expect(result.current[0].groupValue).toBe('A');
+//       expect(result.current[0].aggregatedValues.count).toBe(15); // 10 + 5 aggregated
+//       expect(result.current[1].groupValue).toBe('B');
+//       expect(result.current[1].aggregatedValues.count).toBe(20);
+//     });
+
+//     it('should skip undefined and null values in grouping', () => {
+//       const mockRows = createMockRows([
+//         { category: 'A', count: 10 },
+//         { category: undefined, count: 5 },
+//         { category: null, count: 15 },
+//         { category: 'B', count: 20 },
+//       ]);
+
+//       const { result } = renderHook(() =>
+//         useGroupedCascadeData({
+//           selectedCascadeGroups: defaultSelectedCascadeGroups,
+//           rows: mockRows,
+//           queryMeta: defaultQueryMeta,
+//           esqlVariables: undefined,
+//         })
+//       );
+
+//       expect(result.current).toHaveLength(2);
+//       expect(result.current.find((r) => r.groupValue === 'A')).toBeDefined();
+//       expect(result.current.find((r) => r.groupValue === 'B')).toBeDefined();
+//     });
+
+//     it('should aggregate multiple applied functions', () => {
+//       const mockRows = createMockRows([
+//         { category: 'A', count: 10, sum: 100 },
+//         { category: 'A', count: 5, sum: 50 },
+//       ]);
+
+//       const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
+//         groupByFields: [{ field: 'category', type: 'column' }],
+//         appliedFunctions: [
+//           { identifier: 'count', aggregation: 'count' },
+//           { identifier: 'sum', aggregation: 'sum' },
+//         ],
+//       };
+
+//       const { result } = renderHook(() =>
+//         useGroupedCascadeData({
+//           selectedCascadeGroups: defaultSelectedCascadeGroups,
+//           rows: mockRows,
+//           queryMeta: queryMetaWithMultipleFunctions,
+//           esqlVariables: undefined,
+//         })
+//       );
+
+//       expect(result.current).toHaveLength(1);
+//       expect(result.current[0].aggregatedValues.count).toBe(15);
+//       expect(result.current[0].aggregatedValues.sum).toBe(150);
+//     });
+
+//     it('should aggregate multiple applied functions with array values', () => {
+//       const mockRows = createMockRows([
+//         { category: 'A', count: 10, ext: ['css', 'js'] },
+//         { category: 'A', count: 5, ext: ['deb', 'rpm'] },
+//       ]);
+
+//       const queryMetaWithMultipleFunctions: ESQLStatsQueryMeta = {
+//         groupByFields: [{ field: 'category', type: 'column' }],
+//         appliedFunctions: [
+//           { identifier: 'count', aggregation: 'count' },
+//           { identifier: 'ext', aggregation: 'ext' },
+//         ],
+//       };
+
+//       const { result } = renderHook(() =>
+//         useGroupedCascadeData({
+//           selectedCascadeGroups: defaultSelectedCascadeGroups,
+//           rows: mockRows,
+//           queryMeta: queryMetaWithMultipleFunctions,
+//           esqlVariables: undefined,
+//         })
+//       );
+
+//       expect(result.current).toHaveLength(1);
+//       expect(result.current[0].aggregatedValues.count).toBe(15);
+//       expect(result.current[0].aggregatedValues.ext).toEqual(['css', 'js', 'deb', 'rpm']);
+//     });
+
+//     it('should resolve esql variable for group key', () => {
+//       const mockRows = createMockRows([
+//         { actualField: 'X', count: 10 },
+//         { actualField: 'X', count: 5 },
+//         { actualField: 'Y', count: 20 },
+//       ]);
+
+//       const esqlVariables: ESQLControlVariable[] = [
+//         { key: 'myVar', value: 'actualField', type: ESQLVariableType.FIELDS },
+//       ];
+
+//       const { result } = renderHook(() =>
+//         useGroupedCascadeData({
+//           selectedCascadeGroups: ['??myVar'],
+//           rows: mockRows,
+//           queryMeta: defaultQueryMeta,
+//           esqlVariables,
+//         })
+//       );
+
+//       expect(result.current).toHaveLength(2);
+//       expect(result.current[0].groupValue).toBe('X');
+//       expect(result.current[1].groupValue).toBe('Y');
+//     });
+//   });
+
+//   describe('useScopedESQLQueryFetchClient', () => {
+//     const scopedProfilesManager = discoverServiceMock.profilesManager.createScopedProfilesManager({
+//       scopedEbtManager: discoverServiceMock.ebtManager.createScopedEBTManager(),
+//     });
+
+//     const defaultProps = {
+//       query: { esql: 'FROM logs | STATS count() BY category' },
+//       dataView: dataViewWithTimefieldMock,
+//       data: discoverServiceMock.data,
+//       expressions: discoverServiceMock.expressions,
+//       esqlVariables: undefined,
+//       filters: undefined,
+//       timeRange: undefined,
+//       scopedProfilesManager,
+//       inspectorAdapters: { requests: new RequestAdapter() },
+//     };
+
+//     const createMockFetchResponse = (records: DataTableRecord[] = []): RecordsFetchResponse => ({
+//       records,
+//       esqlQueryColumns: [],
+//       esqlHeaderWarning: undefined,
+//       interceptedWarnings: [],
+//     });
+
+//     beforeEach(() => {
+//       mockFetchEsql.mockResolvedValue(createMockFetchResponse());
+//       mockConstructCascadeQuery.mockReturnValue({ esql: 'FROM logs | WHERE category == "A"' });
+//     });
+
+//     it('should return a fetch function with cancel method', () => {
+//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+//       expect(result.current).toBeInstanceOf(Function);
+//       expect(result.current.cancel).toBeInstanceOf(Function);
+//     });
+
+//     it('should fetch data by invoking constructCascadeQuery and fetchEsql', async () => {
+//       const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
+//       mockFetchEsql.mockResolvedValue(createMockFetchResponse(mockRecords));
+
+//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+//       let records: DataTableRecord[] = [];
+
+//       await act(async () => {
+//         records = await result.current({
+//           nodeType: 'leaf',
+//           nodePath: ['category'],
+//           nodePathMap: { category: 'A' },
+//         });
+//       });
+
+//       expect(mockConstructCascadeQuery).toHaveBeenCalledWith({
+//         query: defaultProps.query,
+//         esqlVariables: undefined,
+//         dataView: dataViewWithTimefieldMock,
+//         nodeType: 'leaf',
+//         nodePath: ['category'],
+//         nodePathMap: { category: 'A' },
+//       });
+//       expect(mockFetchEsql).toHaveBeenCalled();
+//       expect(records).toEqual(mockRecords);
+//     });
+
+//     it('should return empty array and capture error when constructCascadeQuery returns undefined', async () => {
+//       mockConstructCascadeQuery.mockReturnValue(undefined);
+
+//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+//       let records: DataTableRecord[] = [];
+//       await act(async () => {
+//         records = await result.current({
+//           nodeType: 'leaf',
+//           nodePath: ['category'],
+//           nodePathMap: { category: 'A' },
+//         });
+//       });
+
+//       expect(records).toEqual([]);
+//       expect(mockApmCaptureError).toHaveBeenCalledWith(
+//         new Error('Failed to construct cascade query')
+//       );
+//       expect(mockFetchEsql).not.toHaveBeenCalled();
+//     });
+
+//     it('should abort previous requests when making a new request', async () => {
+//       const mockRecords: DataTableRecord[] = [{ id: '1', raw: {}, flattened: { category: 'A' } }];
+
+//       let resolveFirst: (value: RecordsFetchResponse) => void;
+//       const firstPromise = new Promise<RecordsFetchResponse>((resolve) => {
+//         resolveFirst = resolve;
+//       });
+
+//       mockFetchEsql
+//         .mockImplementationOnce(() => firstPromise)
+//         .mockResolvedValueOnce(createMockFetchResponse(mockRecords));
+
+//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+//       // Start first request (don't await)
+//       result.current({
+//         nodeType: 'leaf',
+//         nodePath: ['category'],
+//         nodePathMap: { category: 'A' },
+//       });
+
+//       // Start second request immediately (should abort first)
+//       const secondRequest = result.current({
+//         nodeType: 'leaf',
+//         nodePath: ['category'],
+//         nodePathMap: { category: 'B' },
+//       });
+
+//       // Resolve first request after abort
+//       resolveFirst!(createMockFetchResponse());
+
+//       const secondRecords = await secondRequest;
+//       expect(secondRecords).toEqual(mockRecords);
+//     });
+
+//     it('should handle abort errors gracefully', async () => {
+//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+//       let records: DataTableRecord[] = [];
+
+//       const pendingRequest = result.current({
+//         nodeType: 'leaf',
+//         nodePath: ['category'],
+//         nodePathMap: { category: 'A' },
+//       });
+
+//       act(() => {
+//         result.current.cancel();
+//       });
+
+//       await act(async () => {
+//         records = await pendingRequest;
+//       });
+
+//       expect(records).toEqual([]);
+//     });
+
+//     it('should rethrow non-abort errors', async () => {
+//       const networkError = new Error('Network failure');
+//       mockFetchEsql.mockRejectedValue(networkError);
+
+//       const { result } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+//       await expect(
+//         result.current({
+//           nodeType: 'leaf',
+//           nodePath: ['category'],
+//           nodePathMap: { category: 'A' },
+//         })
+//       ).rejects.toThrow('Network failure');
+//     });
+
+//     it('should cancel pending requests on unmount', async () => {
+//       const { result, unmount } = renderHook(() => useScopedESQLQueryFetchClient(defaultProps));
+
+//       // Start a request
+//       const pendingRequestPromise = result.current({
+//         nodeType: 'leaf',
+//         nodePath: ['category'],
+//         nodePathMap: { category: 'A' },
+//       });
+
+//       // Unmount the hook
+//       unmount();
+
+//       // The abort controller should have been called
+//       // Request should complete gracefully
+//       await expect(pendingRequestPromise).resolves.toBeDefined();
+//     });
+//   });
+
+//   describe('useDataCascadeRowExpansionHandlers', () => {
+//     const createMockCascadeFetchClient = () => {
+//       const mockFetch = jest.fn().mockResolvedValue([]) as jest.Mock & { cancel: jest.Mock };
+//       mockFetch.cancel = jest.fn();
+//       return mockFetch as unknown as ReturnType<typeof useScopedESQLQueryFetchClient>;
+//     };
+
+//     const createMockRowData = (): ESQLDataGroupNode => ({
+//       id: '1',
+//       groupColumn: 'category',
+//       groupValue: 'A',
+//       aggregatedValues: {},
+//     });
+
+//     it('should return all four expansion handlers', () => {
+//       const mockCascadeFetchClient = createMockCascadeFetchClient();
+
+//       const { result } = renderHook(() =>
+//         useDataCascadeRowExpansionHandlers({
+//           cascadeFetchClient: mockCascadeFetchClient,
+//         })
+//       );
+
+//       expect(result.current.onCascadeGroupNodeExpanded).toBeInstanceOf(Function);
+//       expect(result.current.onCascadeGroupNodeCollapsed).toBeInstanceOf(Function);
+//       expect(result.current.onCascadeLeafNodeExpanded).toBeInstanceOf(Function);
+//       expect(result.current.onCascadeLeafNodeCollapsed).toBeInstanceOf(Function);
+//     });
+
+//     describe('onCascadeGroupNodeExpanded', () => {
+//       it('should call cascadeFetchClient with nodeType "group"', async () => {
+//         const mockCascadeFetchClient = createMockCascadeFetchClient();
+//         const mockRow = createMockRowData();
+
+//         const { result } = renderHook(() =>
+//           useDataCascadeRowExpansionHandlers({
+//             cascadeFetchClient: mockCascadeFetchClient,
+//           })
+//         );
+
+//         await act(async () => {
+//           await result.current.onCascadeGroupNodeExpanded({
+//             row: mockRow,
+//             nodePath: ['category', 'subcategory'],
+//             nodePathMap: { category: 'A', subcategory: 'X' },
+//           });
+//         });
+
+//         expect(mockCascadeFetchClient).toHaveBeenCalledWith({
+//           nodePath: ['category', 'subcategory'],
+//           nodePathMap: { category: 'A', subcategory: 'X' },
+//           nodeType: 'group',
+//         });
+//       });
+//     });
+
+//     describe('onCascadeGroupNodeCollapsed', () => {
+//       it('should call cascadeFetchClient.cancel', () => {
+//         const mockCascadeFetchClient = createMockCascadeFetchClient();
+//         const mockRow = createMockRowData();
+
+//         const { result } = renderHook(() =>
+//           useDataCascadeRowExpansionHandlers({
+//             cascadeFetchClient: mockCascadeFetchClient,
+//           })
+//         );
+
+//         result.current.onCascadeGroupNodeCollapsed!({
+//           row: mockRow,
+//           nodePath: ['category'],
+//           nodePathMap: { category: 'A' },
+//         });
+
+//         expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
+//       });
+//     });
+
+//     describe('onCascadeLeafNodeExpanded', () => {
+//       it('should call cascadeFetchClient with nodeType "leaf"', async () => {
+//         const mockCascadeFetchClient = createMockCascadeFetchClient();
+//         const mockRow = createMockRowData();
+
+//         const { result } = renderHook(() =>
+//           useDataCascadeRowExpansionHandlers({
+//             cascadeFetchClient: mockCascadeFetchClient,
+//           })
+//         );
+
+//         await act(async () => {
+//           await result.current.onCascadeLeafNodeExpanded({
+//             row: mockRow,
+//             nodePath: ['category'],
+//             nodePathMap: { category: 'A' },
+//           });
+//         });
+
+//         expect(mockCascadeFetchClient).toHaveBeenCalledWith({
+//           nodePath: ['category'],
+//           nodePathMap: { category: 'A' },
+//           nodeType: 'leaf',
+//         });
+//       });
+//     });
+
+//     describe('onCascadeLeafNodeCollapsed', () => {
+//       it('should call cascadeFetchClient.cancel', () => {
+//         const mockCascadeFetchClient = createMockCascadeFetchClient();
+//         const mockRow = createMockRowData();
+
+//         const { result } = renderHook(() =>
+//           useDataCascadeRowExpansionHandlers({
+//             cascadeFetchClient: mockCascadeFetchClient,
+//           })
+//         );
+
+//         result.current.onCascadeLeafNodeCollapsed!({
+//           row: mockRow,
+//           nodePath: ['category'],
+//           nodePathMap: { category: 'A' },
+//         });
+
+//         expect(mockCascadeFetchClient.cancel).toHaveBeenCalled();
+//       });
+//     });
+
+//     it('should memoize handlers and return same references on rerender', () => {
+//       const mockCascadeFetchClient = createMockCascadeFetchClient();
+
+//       const { result, rerender } = renderHook(() =>
+//         useDataCascadeRowExpansionHandlers({
+//           cascadeFetchClient: mockCascadeFetchClient,
+//         })
+//       );
+
+//       const firstResult = result.current;
+
+//       rerender();
+
+//       expect(result.current.onCascadeGroupNodeExpanded).toBe(
+//         firstResult.onCascadeGroupNodeExpanded
+//       );
+//       expect(result.current.onCascadeGroupNodeCollapsed).toBe(
+//         firstResult.onCascadeGroupNodeCollapsed
+//       );
+//       expect(result.current.onCascadeLeafNodeExpanded).toBe(firstResult.onCascadeLeafNodeExpanded);
+//       expect(result.current.onCascadeLeafNodeCollapsed).toBe(
+//         firstResult.onCascadeLeafNodeCollapsed
+//       );
+//     });
+
+//     it('should update handlers when cascadeFetchClient changes', () => {
+//       const mockCascadeFetchClient1 = createMockCascadeFetchClient();
+//       const mockCascadeFetchClient2 = createMockCascadeFetchClient();
+
+//       const { result, rerender } = renderHook(
+//         ({ cascadeFetchClient }) =>
+//           useDataCascadeRowExpansionHandlers({
+//             cascadeFetchClient,
+//           }),
+//         {
+//           initialProps: { cascadeFetchClient: mockCascadeFetchClient1 },
+//         }
+//       );
+
+//       const firstResult = result.current;
+
+//       rerender({ cascadeFetchClient: mockCascadeFetchClient2 });
+
+//       // Handlers should be new references after dependency change
+//       expect(result.current.onCascadeGroupNodeExpanded).not.toBe(
+//         firstResult.onCascadeGroupNodeExpanded
+//       );
+//     });
+//   });
+// });

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
@@ -149,7 +149,7 @@ export function useDataCascadeRowExpansionHandlers({
   >(
     ({ row, nodePath, nodePathMap }) => {
       return cascadedDocumentsFetcher.fetchCascadedDocuments({
-        rowId: row.id,
+        nodeId: row.id,
         nodeType: 'group',
         nodePath,
         nodePathMap,
@@ -186,7 +186,7 @@ export function useDataCascadeRowExpansionHandlers({
   >(
     ({ row, nodePath, nodePathMap }) => {
       return cascadedDocumentsFetcher.fetchCascadedDocuments({
-        rowId: row.id,
+        nodeId: row.id,
         nodeType: 'leaf',
         nodePath,
         nodePathMap,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
@@ -156,7 +156,10 @@ export function useDataCascadeRowExpansionHandlers({
     NonNullable<
       DataCascadeRowProps<ESQLDataGroupNode, DataTableRecord>['onCascadeGroupNodeExpanded']
     >
-  >(() => Promise.resolve([]));
+  >(() => {
+    // TODO: We don't support nested groups yet.
+    return Promise.resolve([]);
+  });
 
   /**
    * Callback invoked when a group node gets collapsed, cancels any pending requests for the group node if necessary.
@@ -165,7 +168,9 @@ export function useDataCascadeRowExpansionHandlers({
     NonNullable<
       DataCascadeRowProps<ESQLDataGroupNode, DataTableRecord>['onCascadeGroupNodeCollapsed']
     >
-  >(() => {});
+  >(() => {
+    // TODO: We don't support nested groups yet.
+  });
 
   /**
    * Callback invoked when a leaf node gets expanded, used to fetch data for leaf nodes.

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.ts
@@ -7,17 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useRef, useEffect } from 'react';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
-import type { CascadeQueryArgs } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
-import {
-  type ESQLStatsQueryMeta,
-  constructCascadeQuery,
-} from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
-import { i18n } from '@kbn/i18n';
-import type { AggregateQuery } from '@kbn/es-query';
+import { type ESQLStatsQueryMeta } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
 import { useCallback, useMemo } from 'react';
-import { apm } from '@elastic/apm-rum';
 import {
   type DataCascadeRowProps,
   type DataCascadeRowCellProps,
@@ -25,9 +17,10 @@ import {
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { v5 as uuidv5 } from 'uuid';
 import { isNil } from 'lodash';
-import { fetchEsql } from '../../../../data_fetching/fetch_esql';
+import type { DataView } from '@kbn/data-views-plugin/common';
 import { type ESQLDataGroupNode } from '../blocks';
 import type { CascadedDocumentsContext } from '../cascaded_documents_provider';
+import { useCascadedDocumentsContext } from '../cascaded_documents_provider';
 
 interface UseGroupedCascadeDataProps
   extends Pick<UnifiedDataTableProps, 'rows'>,
@@ -131,144 +124,11 @@ export const useGroupedCascadeData = ({
   );
 };
 
-interface UseScopedESQLQueryFetchClientProps
-  extends Pick<
-    Parameters<typeof fetchEsql>[0],
-    | 'dataView'
-    | 'data'
-    | 'expressions'
-    | 'timeRange'
-    | 'scopedProfilesManager'
-    | 'esqlVariables'
-    | 'inspectorAdapters'
-  > {
-  query: AggregateQuery;
-}
-
-/**
- * Returns a function that fetches the data for the scoped ESQL query.
- */
-export function useScopedESQLQueryFetchClient({
-  query,
-  dataView,
-  data,
-  expressions,
-  esqlVariables,
-  timeRange,
-  scopedProfilesManager,
-  inspectorAdapters,
-}: UseScopedESQLQueryFetchClientProps) {
-  const abortController = useRef<AbortController | null>(null);
-
-  const cancelRequest = useCallback((reason?: string) => {
-    abortController.current?.abort(reason);
-  }, []);
-
-  const scopedESQLQueryFetch = useCallback(
-    (esqlQuery: AggregateQuery, abortSignal: AbortSignal) =>
-      fetchEsql({
-        query: esqlQuery,
-        esqlVariables,
-        dataView,
-        data,
-        expressions,
-        abortSignal,
-        timeRange,
-        scopedProfilesManager,
-        inspectorAdapters,
-        inspectorConfig: {
-          title: i18n.translate('discover.dataCascade.inspector.cascadeQueryTitle', {
-            defaultMessage: 'Cascade Row Data Query',
-          }),
-          description: i18n.translate('discover.dataCascade.inspector.cascadeQueryDescription', {
-            defaultMessage:
-              'This request queries Elasticsearch to fetch the documents matching the value of the expanded cascade row.',
-          }),
-        },
-      }),
-    [
-      data,
-      dataView,
-      esqlVariables,
-      expressions,
-      inspectorAdapters,
-      scopedProfilesManager,
-      timeRange,
-    ]
-  );
-
-  const baseFetch = useCallback(
-    async ({
-      nodeType,
-      nodePath,
-      nodePathMap,
-    }: Omit<CascadeQueryArgs, 'query' | 'dataView' | 'esqlVariables'>) => {
-      const newQuery = constructCascadeQuery({
-        query,
-        esqlVariables,
-        dataView,
-        nodeType,
-        nodePath,
-        nodePathMap,
-      });
-
-      if (!newQuery) {
-        // maybe track the inputted query, to learn about the kind of queries that bug
-        apm.captureError(new Error('Failed to construct cascade query'));
-        return [];
-      }
-
-      if (!abortController.current?.signal?.aborted) {
-        cancelRequest('starting new request');
-      }
-
-      abortController.current = new AbortController();
-
-      const { records } = await scopedESQLQueryFetch(
-        newQuery,
-        abortController.current!.signal
-      ).catch((error) => {
-        // handle abort errors gracefully
-        if (error.message.includes('aborted')) {
-          return { records: [] };
-        }
-        // rethrow other errors
-        throw error;
-      });
-
-      return records;
-    },
-    [scopedESQLQueryFetch, esqlVariables, dataView, query, cancelRequest]
-  );
-
-  useEffect(
-    // handle cleanup for when the component unmounts
-    () => () => {
-      // cancel any pending requests
-      cancelRequest('unmount cleanup');
-    },
-    [cancelRequest]
-  );
-
-  return useMemo(
-    () =>
-      Object.assign(baseFetch, {
-        /**
-         * Cancels any pending requests for the cascade fetch client.
-         */
-        cancel: cancelRequest.bind(null, 'request cancellation'),
-      }),
-    [baseFetch, cancelRequest]
-  );
-}
-
-interface UseDataCascadePropsProps {
-  cascadeFetchClient: ReturnType<typeof useScopedESQLQueryFetchClient>;
-}
-
 export function useDataCascadeRowExpansionHandlers({
-  cascadeFetchClient,
-}: UseDataCascadePropsProps): Pick<
+  dataView,
+}: {
+  dataView: DataView;
+}): Pick<
   DataCascadeRowProps<ESQLDataGroupNode, DataTableRecord>,
   'onCascadeGroupNodeExpanded' | 'onCascadeGroupNodeCollapsed'
 > &
@@ -276,6 +136,9 @@ export function useDataCascadeRowExpansionHandlers({
     DataCascadeRowCellProps<ESQLDataGroupNode, DataTableRecord>,
     'onCascadeLeafNodeExpanded' | 'onCascadeLeafNodeCollapsed'
   > {
+  const { cascadedDocumentsFetcher, esqlQuery, esqlVariables, timeRange } =
+    useCascadedDocumentsContext();
+
   /**
    * Callback invoked when a group node gets expanded, used to fetch data for group nodes.
    */
@@ -284,14 +147,19 @@ export function useDataCascadeRowExpansionHandlers({
       DataCascadeRowProps<ESQLDataGroupNode, DataTableRecord>['onCascadeGroupNodeExpanded']
     >
   >(
-    ({ nodePath, nodePathMap }) => {
-      return cascadeFetchClient({
+    ({ row, nodePath, nodePathMap }) => {
+      return cascadedDocumentsFetcher.fetchCascadedDocuments({
+        rowId: row.id,
+        nodeType: 'group',
         nodePath,
         nodePathMap,
-        nodeType: 'group',
+        query: esqlQuery,
+        esqlVariables,
+        timeRange,
+        dataView,
       }) as unknown as Promise<ESQLDataGroupNode[]>;
     },
-    [cascadeFetchClient]
+    [cascadedDocumentsFetcher, dataView, esqlQuery, esqlVariables, timeRange]
   );
 
   /**
@@ -301,9 +169,12 @@ export function useDataCascadeRowExpansionHandlers({
     NonNullable<
       DataCascadeRowProps<ESQLDataGroupNode, DataTableRecord>['onCascadeGroupNodeCollapsed']
     >
-  >(() => {
-    return cascadeFetchClient.cancel();
-  }, [cascadeFetchClient]);
+  >(
+    ({ row }) => {
+      cascadedDocumentsFetcher.cancelFetch(row.id);
+    },
+    [cascadedDocumentsFetcher]
+  );
 
   /**
    * Callback invoked when a leaf node gets expanded, used to fetch data for leaf nodes.
@@ -313,14 +184,19 @@ export function useDataCascadeRowExpansionHandlers({
       DataCascadeRowCellProps<ESQLDataGroupNode, DataTableRecord>
     >['onCascadeLeafNodeExpanded']
   >(
-    ({ nodePath, nodePathMap }) => {
-      return cascadeFetchClient({
+    ({ row, nodePath, nodePathMap }) => {
+      return cascadedDocumentsFetcher.fetchCascadedDocuments({
+        rowId: row.id,
+        nodeType: 'leaf',
         nodePath,
         nodePathMap,
-        nodeType: 'leaf',
+        query: esqlQuery,
+        esqlVariables,
+        timeRange,
+        dataView,
       });
     },
-    [cascadeFetchClient]
+    [cascadedDocumentsFetcher, dataView, esqlQuery, esqlVariables, timeRange]
   );
 
   /**
@@ -330,9 +206,12 @@ export function useDataCascadeRowExpansionHandlers({
     NonNullable<
       DataCascadeRowCellProps<ESQLDataGroupNode, DataTableRecord>['onCascadeLeafNodeCollapsed']
     >
-  >(() => {
-    return cascadeFetchClient.cancel();
-  }, [cascadeFetchClient]);
+  >(
+    ({ row }) => {
+      cascadedDocumentsFetcher.cancelFetch(row.id);
+    },
+    [cascadedDocumentsFetcher]
+  );
 
   return {
     onCascadeGroupNodeExpanded,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/index.ts
@@ -7,8 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export {
-  useDataCascadeRowExpansionHandlers,
-  useGroupedCascadeData,
-  useScopedESQLQueryFetchClient,
-} from './data_fetching';
+export { useDataCascadeRowExpansionHandlers, useGroupedCascadeData } from './data_fetching';

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -522,9 +522,6 @@ function DiscoverDocumentsComponent({
       },
       onUpdateESQLQuery,
       openInNewTab: (params) => dispatch(internalStateActions.openInNewTab(params)),
-      registerCascadeRequestsInspectorAdapter: (requestAdapter) => {
-        stateContainer.dataState.inspectorAdapters.cascadeRequests = requestAdapter;
-      },
     };
   }, [
     availableCascadeGroups,
@@ -536,7 +533,6 @@ function DiscoverDocumentsComponent({
     requestParams.timeRangeAbsolute,
     selectedCascadeGroups,
     setSelectedCascadeGroups,
-    stateContainer.dataState.inspectorAdapters,
     viewModeToggle,
   ]);
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -48,14 +48,17 @@ import {
 } from '@kbn/discover-utils';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { DiscoverGridSettings } from '@kbn/saved-search-plugin/common';
-import { useQuerySubscriber } from '@kbn/unified-field-list';
 import type { DocViewerApi, DocViewerRestorableState } from '@kbn/unified-doc-viewer';
 import useLatest from 'react-use/lib/useLatest';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { DISCOVER_CELL_ACTIONS_TRIGGER_ID } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { DiscoverGrid } from '../../../../components/discover_grid';
 import { getDefaultRowsPerPage } from '../../../../../common/constants';
-import { useAppStateSelector, useCurrentTabRuntimeState } from '../../state_management/redux';
+import {
+  selectTabCombinedFilters,
+  useAppStateSelector,
+  useCurrentTabRuntimeState,
+} from '../../state_management/redux';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { FetchStatus } from '../../../types';
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
@@ -303,7 +306,7 @@ function DiscoverDocumentsComponent({
         : undefined,
     [documentState.esqlQueryColumns]
   );
-  const { filters } = useQuerySubscriber({ data: services.data });
+  const filters = useCurrentTabSelector(selectTabCombinedFilters);
 
   const extensionActions = useMemo(
     () => ({

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -55,7 +55,7 @@ import { isOfAggregateQueryType } from '@kbn/es-query';
 import { DISCOVER_CELL_ACTIONS_TRIGGER_ID } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { DiscoverGrid } from '../../../../components/discover_grid';
 import { getDefaultRowsPerPage } from '../../../../../common/constants';
-import { useAppStateSelector } from '../../state_management/redux';
+import { useAppStateSelector, useCurrentTabRuntimeState } from '../../state_management/redux';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { FetchStatus } from '../../../types';
 import type { DiscoverStateContainer } from '../../state_management/discover_state';
@@ -487,13 +487,17 @@ function DiscoverDocumentsComponent({
     [viewModeToggle, callouts, loadingIndicator, isDataGridFullScreen]
   );
 
-  const esqlVariables = useCurrentTabSelector((tab) => tab.esqlVariables);
+  const cascadedDocumentsFetcher = useCurrentTabRuntimeState(
+    stateContainer.runtimeStateManager,
+    (runtimeState) => runtimeState.cascadedDocumentsFetcher$
+  );
   const { availableCascadeGroups, selectedCascadeGroups } = useCurrentTabSelector(
     (tab) => tab.cascadedDocumentsState
   );
   const setSelectedCascadeGroups = useCurrentTabAction(
     internalStateActions.setSelectedCascadeGroups
   );
+  const esqlVariables = useCurrentTabSelector((tab) => tab.esqlVariables);
   const cascadedDocumentsContext = useMemo<CascadedDocumentsContext | undefined>(() => {
     if (
       !isCascadedDocumentsVisible(availableCascadeGroups, query) ||
@@ -503,6 +507,7 @@ function DiscoverDocumentsComponent({
     }
 
     return {
+      cascadedDocumentsFetcher,
       availableCascadeGroups,
       selectedCascadeGroups,
       esqlQuery: query,
@@ -520,6 +525,7 @@ function DiscoverDocumentsComponent({
     };
   }, [
     availableCascadeGroups,
+    cascadedDocumentsFetcher,
     dispatch,
     esqlVariables,
     onUpdateESQLQuery,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -497,9 +497,11 @@ function DiscoverDocumentsComponent({
   const { availableCascadeGroups, selectedCascadeGroups } = useCurrentTabSelector(
     (tab) => tab.cascadedDocumentsState
   );
+  const dataCascadeUiState = useCurrentTabSelector((tab) => tab.uiState.dataCascade);
   const setSelectedCascadeGroups = useCurrentTabAction(
     internalStateActions.setSelectedCascadeGroups
   );
+  const setDataCascadeUiState = useCurrentTabAction(internalStateActions.setDataCascadeUiState);
   const esqlVariables = useCurrentTabSelector((tab) => tab.esqlVariables);
   const cascadedDocumentsContext = useMemo<CascadedDocumentsContext | undefined>(() => {
     if (
@@ -513,6 +515,9 @@ function DiscoverDocumentsComponent({
       cascadedDocumentsFetcher,
       availableCascadeGroups,
       selectedCascadeGroups,
+      dataCascadeUiState,
+      setDataCascadeUiState: (nextUiState) =>
+        dispatch(setDataCascadeUiState({ dataCascadeUiState: nextUiState })),
       esqlQuery: query,
       esqlVariables,
       timeRange: requestParams.timeRangeAbsolute,
@@ -526,12 +531,14 @@ function DiscoverDocumentsComponent({
   }, [
     availableCascadeGroups,
     cascadedDocumentsFetcher,
+    dataCascadeUiState,
     dispatch,
     esqlVariables,
     onUpdateESQLQuery,
     query,
     requestParams.timeRangeAbsolute,
     selectedCascadeGroups,
+    setDataCascadeUiState,
     setSelectedCascadeGroups,
     viewModeToggle,
   ]);

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
@@ -12,6 +12,7 @@ import type { AggregateQuery } from '@kbn/es-query';
 import { AbortReason } from '@kbn/kibana-utils-plugin/common';
 import { constructCascadeQuery } from '@kbn/esql-utils';
 import { apm } from '@elastic/apm-rum';
+import { RequestAdapter } from '@kbn/inspector-plugin/public';
 import { dataViewWithTimefieldMock } from '../../../__mocks__/data_view_with_timefield';
 import { createDiscoverServicesMock } from '../../../__mocks__/services';
 import type {
@@ -132,6 +133,9 @@ describe('CascadedDocumentsFetcher', () => {
         expressions: discoverServices.expressions,
         timeRange: params.timeRange,
         scopedProfilesManager,
+        inspectorAdapters: {
+          requests: expect.any(RequestAdapter),
+        },
       })
     );
     expect(stateManager.setCascadedDocuments).toHaveBeenCalledWith(params.nodeId, records);

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { buildDataTableRecord, type DataTableRecord } from '@kbn/discover-utils';
+import type { AggregateQuery } from '@kbn/es-query';
+import { AbortReason } from '@kbn/kibana-utils-plugin/common';
+import { constructCascadeQuery } from '@kbn/esql-utils';
+import { apm } from '@elastic/apm-rum';
+import { dataViewWithTimefieldMock } from '../../../__mocks__/data_view_with_timefield';
+import { createDiscoverServicesMock } from '../../../__mocks__/services';
+import type {
+  CascadedDocumentsStateManager,
+  FetchCascadedDocumentsParams,
+} from './cascaded_documents_fetcher';
+import { CascadedDocumentsFetcher } from './cascaded_documents_fetcher';
+import { fetchEsql } from './fetch_esql';
+
+jest.mock('./fetch_esql', () => ({
+  fetchEsql: jest.fn(),
+}));
+
+jest.mock('@kbn/esql-utils', () => {
+  const actual = jest.requireActual('@kbn/esql-utils');
+  return {
+    ...actual,
+    constructCascadeQuery: jest.fn(actual.constructCascadeQuery),
+  };
+});
+
+jest.mock('@elastic/apm-rum', () => ({
+  apm: {
+    captureError: jest.fn(),
+  },
+}));
+
+const mockFetchEsql = jest.mocked(fetchEsql);
+const mockConstructCascadeQuery = jest.mocked(constructCascadeQuery);
+const mockApmCaptureError = jest.mocked(apm.captureError);
+
+const createStateManager = (): CascadedDocumentsStateManager => {
+  const recordsById = new Map<string, DataTableRecord[]>();
+  return {
+    getIsActiveInstance: jest.fn(() => true),
+    getCascadedDocuments: jest.fn((nodeId: string) => recordsById.get(nodeId)),
+    setCascadedDocuments: jest.fn((nodeId: string, records: DataTableRecord[]) => {
+      recordsById.set(nodeId, records);
+    }),
+  };
+};
+
+const createFetcher = () => {
+  const discoverServices = createDiscoverServicesMock();
+  const scopedProfilesManager = discoverServices.profilesManager.createScopedProfilesManager({
+    scopedEbtManager: discoverServices.ebtManager.createScopedEBTManager(),
+  });
+  const stateManager = createStateManager();
+
+  return {
+    stateManager,
+    fetcher: new CascadedDocumentsFetcher(discoverServices, scopedProfilesManager, stateManager),
+    scopedProfilesManager,
+    discoverServices,
+  };
+};
+
+const createFetchParams = (
+  overrides: Partial<FetchCascadedDocumentsParams> = {}
+): FetchCascadedDocumentsParams => {
+  return {
+    nodeId: 'node-1',
+    nodeType: 'leaf',
+    nodePath: ['extension'],
+    nodePathMap: { extension: 'png' },
+    query: { esql: 'from logs | stats count by extension' },
+    esqlVariables: undefined,
+    dataView: dataViewWithTimefieldMock,
+    timeRange: { from: 'now-15m', to: 'now' },
+    ...overrides,
+  };
+};
+
+describe('CascadedDocumentsFetcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns cached records without fetching', async () => {
+    const { stateManager, fetcher } = createFetcher();
+    const cached = [buildDataTableRecord({ _id: '1', _index: 'logs' }, dataViewWithTimefieldMock)];
+
+    stateManager.setCascadedDocuments('node-1', cached);
+
+    const result = await fetcher.fetchCascadedDocuments(createFetchParams());
+
+    expect(result).toBe(cached);
+    expect(mockFetchEsql).not.toHaveBeenCalled();
+    expect(mockConstructCascadeQuery).not.toHaveBeenCalled();
+  });
+
+  it('constructs a cascade query, fetches records, and caches them', async () => {
+    const { stateManager, fetcher, scopedProfilesManager, discoverServices } = createFetcher();
+    const records = [buildDataTableRecord({ _id: '1', _index: 'logs' }, dataViewWithTimefieldMock)];
+    const cascadeQuery: AggregateQuery = { esql: 'from logs' };
+
+    mockConstructCascadeQuery.mockReturnValueOnce(cascadeQuery);
+    mockFetchEsql.mockResolvedValue({ records });
+
+    const params = createFetchParams({ nodeId: 'node-2' });
+    const result = await fetcher.fetchCascadedDocuments(params);
+
+    expect(result).toEqual(records);
+    expect(mockConstructCascadeQuery).toHaveBeenCalledWith({
+      query: params.query,
+      esqlVariables: params.esqlVariables,
+      dataView: params.dataView,
+      nodeType: params.nodeType,
+      nodePath: params.nodePath,
+      nodePathMap: params.nodePathMap,
+    });
+    expect(mockFetchEsql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: cascadeQuery,
+        esqlVariables: params.esqlVariables,
+        dataView: params.dataView,
+        data: discoverServices.data,
+        expressions: discoverServices.expressions,
+        timeRange: params.timeRange,
+        scopedProfilesManager,
+      })
+    );
+    expect(stateManager.setCascadedDocuments).toHaveBeenCalledWith(params.nodeId, records);
+  });
+
+  it('captures an error when the cascade query cannot be constructed', async () => {
+    const { stateManager, fetcher } = createFetcher();
+
+    mockConstructCascadeQuery.mockReturnValueOnce(undefined);
+
+    const result = await fetcher.fetchCascadedDocuments(createFetchParams());
+
+    expect(result).toEqual([]);
+    expect(mockFetchEsql).not.toHaveBeenCalled();
+    expect(stateManager.setCascadedDocuments).not.toHaveBeenCalled();
+    expect(mockApmCaptureError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Failed to construct cascade query' })
+    );
+  });
+
+  it('swallows abort errors and returns empty records', async () => {
+    const { fetcher } = createFetcher();
+    const delay = Promise.withResolvers<void>();
+
+    mockFetchEsql.mockImplementation(async ({ abortSignal }) => {
+      await delay.promise;
+      abortSignal?.throwIfAborted();
+      throw Error('should have been AbortError');
+    });
+
+    const fetchPromise = fetcher.fetchCascadedDocuments(createFetchParams({ nodeId: 'node-3' }));
+
+    fetcher.cancelFetch('node-3', AbortReason.CANCELED);
+    delay.resolve();
+
+    await expect(fetchPromise).resolves.toEqual([]);
+  });
+
+  it('aborts all active fetches', async () => {
+    const { fetcher } = createFetcher();
+    const delay = Promise.withResolvers<void>();
+
+    mockFetchEsql.mockImplementation(async ({ abortSignal }) => {
+      await delay.promise;
+      abortSignal?.throwIfAborted();
+      throw Error('should have been AbortError');
+    });
+
+    const first = fetcher.fetchCascadedDocuments(createFetchParams({ nodeId: 'node-4' }));
+    const second = fetcher.fetchCascadedDocuments(createFetchParams({ nodeId: 'node-5' }));
+
+    fetcher.cancelAllFetches(AbortReason.CANCELED);
+    delay.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([[], []]);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { constructCascadeQuery } from '@kbn/esql-utils';
+import type { TimeRange } from '@kbn/es-query';
+import type { CascadeQueryArgs } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
+import { apm } from '@elastic/apm-rum';
+import { i18n } from '@kbn/i18n';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { AbortReason } from '@kbn/kibana-utils-plugin/common';
+import type { DiscoverServices } from '../../../build_services';
+import { fetchEsql } from './fetch_esql';
+import type { ScopedProfilesManager } from '../../../context_awareness';
+
+interface FetchCascadedDocumentsParams extends CascadeQueryArgs {
+  rowId: string;
+  timeRange: TimeRange | undefined;
+}
+
+export interface CascadedDocumentsStateManager {
+  getCascadedDocuments(rowId: string): DataTableRecord[] | undefined;
+  setCascadedDocuments(rowId: string, records: DataTableRecord[]): void;
+}
+
+export class CascadedDocumentsFetcher {
+  private readonly abortControllers: Map<string, AbortController> = new Map();
+
+  constructor(
+    private readonly services: DiscoverServices,
+    private readonly scopedProfilesManager: ScopedProfilesManager,
+    private readonly stateManager: CascadedDocumentsStateManager
+  ) {}
+
+  async fetchCascadedDocuments({
+    rowId,
+    nodeType,
+    nodePath,
+    nodePathMap,
+    query,
+    esqlVariables,
+    dataView,
+    timeRange,
+  }: FetchCascadedDocumentsParams) {
+    this.cancelFetch(rowId);
+
+    const existingRecords = this.stateManager.getCascadedDocuments(rowId);
+
+    if (existingRecords) {
+      return existingRecords;
+    }
+
+    const abortController = new AbortController();
+
+    this.abortControllers.set(rowId, abortController);
+
+    let records: DataTableRecord[] = [];
+
+    try {
+      const cascadeQuery = constructCascadeQuery({
+        query,
+        esqlVariables,
+        dataView,
+        nodeType,
+        nodePath,
+        nodePathMap,
+      });
+
+      if (!cascadeQuery) {
+        // maybe track the inputted query, to learn about the kind of queries that bug
+        apm.captureError(new Error('Failed to construct cascade query'));
+        return [];
+      }
+
+      ({ records } = await fetchEsql({
+        query: cascadeQuery,
+        esqlVariables,
+        dataView,
+        data: this.services.data,
+        expressions: this.services.expressions,
+        abortSignal: abortController.signal,
+        timeRange,
+        scopedProfilesManager: this.scopedProfilesManager,
+        // TODO: get inspector adapters
+        inspectorAdapters: {},
+        inspectorConfig: {
+          title: i18n.translate('discover.dataCascade.inspector.cascadeQueryTitle', {
+            defaultMessage: 'Cascade Row Data Query',
+          }),
+          description: i18n.translate('discover.dataCascade.inspector.cascadeQueryDescription', {
+            defaultMessage:
+              'This request queries Elasticsearch to fetch the documents matching the value of the expanded cascade row.',
+          }),
+        },
+      }));
+
+      this.stateManager.setCascadedDocuments(rowId, records);
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        throw error;
+      }
+    } finally {
+      this.abortControllers.delete(rowId);
+    }
+
+    return records;
+  }
+
+  cancelFetch(rowId: string, reason: AbortReason = AbortReason.CANCELED) {
+    const abortController = this.abortControllers.get(rowId);
+
+    if (abortController) {
+      abortController.abort(reason);
+      this.abortControllers.delete(rowId);
+    }
+  }
+
+  cancelAllFetches(reason: AbortReason = AbortReason.CANCELED) {
+    this.abortControllers.forEach((abortController) => abortController.abort(reason));
+    this.abortControllers.clear();
+  }
+}

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
@@ -18,7 +18,7 @@ import type { DiscoverServices } from '../../../build_services';
 import { fetchEsql } from './fetch_esql';
 import type { ScopedProfilesManager } from '../../../context_awareness';
 
-interface FetchCascadedDocumentsParams extends CascadeQueryArgs {
+export interface FetchCascadedDocumentsParams extends CascadeQueryArgs {
   nodeId: string;
   timeRange: TimeRange | undefined;
 }

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
@@ -14,6 +14,7 @@ import { apm } from '@elastic/apm-rum';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { AbortReason } from '@kbn/kibana-utils-plugin/common';
+import { RequestAdapter } from '@kbn/inspector-plugin/public';
 import type { DiscoverServices } from '../../../build_services';
 import { fetchEsql } from './fetch_esql';
 import type { ScopedProfilesManager } from '../../../context_awareness';
@@ -31,12 +32,17 @@ export interface CascadedDocumentsStateManager {
 
 export class CascadedDocumentsFetcher {
   private readonly abortControllers: Map<string, AbortController> = new Map();
+  private readonly requestAdapter = new RequestAdapter();
 
   constructor(
     private readonly services: DiscoverServices,
     private readonly scopedProfilesManager: ScopedProfilesManager,
     private readonly stateManager: CascadedDocumentsStateManager
   ) {}
+
+  getRequestAdapter(): RequestAdapter {
+    return this.requestAdapter;
+  }
 
   async fetchCascadedDocuments({
     nodeId,
@@ -87,8 +93,7 @@ export class CascadedDocumentsFetcher {
         abortSignal: abortController.signal,
         timeRange,
         scopedProfilesManager: this.scopedProfilesManager,
-        // TODO: get inspector adapters
-        inspectorAdapters: {},
+        inspectorAdapters: { requests: this.requestAdapter },
         inspectorConfig: {
           title: i18n.translate('discover.dataCascade.inspector.cascadeQueryTitle', {
             defaultMessage: 'Cascade Row Data Query',

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
@@ -24,6 +24,7 @@ interface FetchCascadedDocumentsParams extends CascadeQueryArgs {
 }
 
 export interface CascadedDocumentsStateManager {
+  getIsActiveInstance(): boolean;
   getCascadedDocuments(nodeId: string): DataTableRecord[] | undefined;
   setCascadedDocuments(nodeId: string, records: DataTableRecord[]): void;
 }
@@ -112,6 +113,10 @@ export class CascadedDocumentsFetcher {
   }
 
   cancelFetch(nodeId: string, reason: AbortReason = AbortReason.CANCELED) {
+    if (!this.stateManager.getIsActiveInstance()) {
+      return;
+    }
+
     const abortController = this.abortControllers.get(nodeId);
 
     if (abortController) {

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
@@ -13,7 +13,6 @@ import type { CascadeQueryArgs } from '@kbn/esql-utils/src/utils/cascaded_docume
 import { apm } from '@elastic/apm-rum';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { AbortReason } from '@kbn/kibana-utils-plugin/common';
 import { RequestAdapter } from '@kbn/inspector-plugin/public';
 import type { DiscoverServices } from '../../../build_services';
 import { fetchEsql } from './fetch_esql';
@@ -106,10 +105,6 @@ export class CascadedDocumentsFetcher {
       }));
 
       this.stateManager.setCascadedDocuments(nodeId, records);
-    } catch (error) {
-      if (error.name !== 'AbortError') {
-        throw error;
-      }
     } finally {
       this.abortControllers.delete(nodeId);
     }
@@ -117,7 +112,7 @@ export class CascadedDocumentsFetcher {
     return records;
   }
 
-  cancelFetch(nodeId: string, reason: AbortReason = AbortReason.CANCELED) {
+  cancelFetch(nodeId: string) {
     if (!this.stateManager.getIsActiveInstance()) {
       return;
     }
@@ -125,13 +120,13 @@ export class CascadedDocumentsFetcher {
     const abortController = this.abortControllers.get(nodeId);
 
     if (abortController) {
-      abortController.abort(reason);
+      abortController.abort();
       this.abortControllers.delete(nodeId);
     }
   }
 
-  cancelAllFetches(reason: AbortReason = AbortReason.CANCELED) {
-    this.abortControllers.forEach((abortController) => abortController.abort(reason));
+  cancelAllFetches() {
+    this.abortControllers.forEach((abortController) => abortController.abort());
     this.abortControllers.clear();
   }
 }

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
@@ -30,22 +30,7 @@ interface EsqlErrorResponse {
   type: 'error';
 }
 
-export function fetchEsql({
-  query,
-  inputQuery,
-  filters,
-  timeRange,
-  dataView,
-  abortSignal,
-  inspectorAdapters,
-  data,
-  expressions,
-  scopedProfilesManager,
-  esqlVariables,
-  searchSessionId,
-  projectRouting,
-  inspectorConfig,
-}: {
+export interface FetchEsqlParams {
   query: Query | AggregateQuery;
   inputQuery?: Query;
   filters?: Filter[];
@@ -63,7 +48,24 @@ export function fetchEsql({
     title: string;
     description: string;
   };
-}): Promise<RecordsFetchResponse> {
+}
+
+export function fetchEsql({
+  query,
+  inputQuery,
+  filters,
+  timeRange,
+  dataView,
+  abortSignal,
+  inspectorAdapters,
+  data,
+  expressions,
+  scopedProfilesManager,
+  esqlVariables,
+  searchSessionId,
+  projectRouting,
+  inspectorConfig,
+}: FetchEsqlParams): Promise<RecordsFetchResponse> {
   const props = getTextBasedQueryStateToAstProps({
     query,
     inputQuery,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -535,7 +535,7 @@ export function getDataStateContainer({
       getCurrentTab().id
     );
 
-    cascadedDocumentsFetcher$.getValue().cancelAllFetches(reason);
+    cascadedDocumentsFetcher$.getValue().cancelAllFetches();
     abortController?.abort(reason);
     abortControllerFetchMore?.abort(reason);
   };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -134,7 +134,6 @@ export interface DiscoverDataStateContainer {
   inspectorAdapters: {
     requests: RequestAdapter;
     lensRequests?: RequestAdapter;
-    cascadeRequests?: RequestAdapter;
   };
   /**
    * Return the initial fetch status

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -296,8 +296,7 @@ export function getDataStateContainer({
             getCurrentTab,
           };
 
-          abortController?.abort(AbortReason.REPLACED);
-          abortControllerFetchMore?.abort(AbortReason.REPLACED);
+          cancel(AbortReason.REPLACED);
 
           if (options.fetchMore) {
             abortControllerFetchMore = new AbortController();
@@ -328,6 +327,15 @@ export function getDataStateContainer({
                 timeRangeRelative: timefilter.getTime(),
                 searchSessionId,
                 isSearchSessionRestored,
+              },
+            })
+          );
+
+          internalState.dispatch(
+            injectCurrentTab(internalStateActions.setCascadedDocumentsState)({
+              cascadedDocumentsState: {
+                ...getCurrentTab().cascadedDocumentsState,
+                cascadedDocumentsMap: {},
               },
             })
           );
@@ -413,6 +421,7 @@ export function getDataStateContainer({
                 internalState.dispatch(
                   injectCurrentTab(internalStateActions.setCascadedDocumentsState)({
                     cascadedDocumentsState: {
+                      ...getCurrentTab().cascadedDocumentsState,
                       availableCascadeGroups: newAvailableGroups,
                       selectedCascadeGroups: newSelectedGroups,
                     },
@@ -422,6 +431,7 @@ export function getDataStateContainer({
                 internalState.dispatch(
                   injectCurrentTab(internalStateActions.setCascadedDocumentsState)({
                     cascadedDocumentsState: {
+                      ...getCurrentTab().cascadedDocumentsState,
                       availableCascadeGroups: [],
                       selectedCascadeGroups: [],
                     },
@@ -520,9 +530,15 @@ export function getDataStateContainer({
     sendResetMsg(dataSubjects, getInitialFetchStatus());
   };
 
-  const cancel = () => {
-    abortController?.abort(AbortReason.CANCELED);
-    abortControllerFetchMore?.abort(AbortReason.CANCELED);
+  const cancel = (reason: AbortReason = AbortReason.CANCELED) => {
+    const { cascadedDocumentsFetcher$ } = selectTabRuntimeState(
+      runtimeStateManager,
+      getCurrentTab().id
+    );
+
+    cascadedDocumentsFetcher$.getValue().cancelAllFetches(reason);
+    abortController?.abort(reason);
+    abortControllerFetchMore?.abort(reason);
   };
 
   const getAbortController = () => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -339,6 +339,10 @@ export function getDataStateContainer({
             })
           );
 
+          internalState.dispatch(
+            injectCurrentTab(internalStateActions.resetDataCascadeUiState)({})
+          );
+
           await scopedProfilesManager.resolveDataSourceProfile(
             {
               dataSource: getCurrentTab().appState.dataSource,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/__mocks__/runtime_state.mocks.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/__mocks__/runtime_state.mocks.ts
@@ -18,6 +18,7 @@ import {
   type ReactiveTabRuntimeState,
   type RuntimeStateManager,
 } from '../runtime_state';
+import type { CascadedDocumentsFetcher } from '../../../data_fetching/cascaded_documents_fetcher';
 
 export function getTabRuntimeStateMock(
   attrs: Partial<ReactiveTabRuntimeState> = {}
@@ -30,6 +31,9 @@ export function getTabRuntimeStateMock(
     unifiedHistogramConfig$: new BehaviorSubject({ layoutPropsMap: {} }),
     scopedProfilesManager$: new BehaviorSubject({} as ScopedProfilesManager),
     scopedEbtManager$: new BehaviorSubject({} as ScopedDiscoverEBTManager),
+    cascadedDocumentsFetcher$: new BehaviorSubject<CascadedDocumentsFetcher>(
+      {} as CascadedDocumentsFetcher
+    ),
     currentDataView$: new BehaviorSubject<DataView | undefined>(undefined),
     unsubscribeFn$: new BehaviorSubject<(() => void) | undefined>(undefined),
     ...attrs,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -45,7 +45,6 @@ import { parseAppLocatorParams } from '../../../../../../common/app_locator_get_
 import { fetchData } from './tab_state';
 import { fromSavedObjectTabToTabState } from '../tab_mapping_utils';
 import { initializeAndSync, stopSyncing } from './tab_sync';
-import type { CascadedDocumentsStateManager } from '../../../data_fetching/cascaded_documents_fetcher';
 
 export const setTabs: InternalStateThunkActionCreator<
   [Parameters<typeof internalStateSlice.actions.setTabs>[0]]
@@ -53,7 +52,7 @@ export const setTabs: InternalStateThunkActionCreator<
   function setTabsThunkFn(
     dispatch,
     getState,
-    { runtimeStateManager, tabsStorageManager, services }
+    { runtimeStateManager, tabsStorageManager, services, getCascadedDocumentsStateManager }
   ) {
     const previousState = getState();
     const discoverSessionChanged =
@@ -86,32 +85,9 @@ export const setTabs: InternalStateThunkActionCreator<
     }
 
     for (const tab of addedTabs) {
-      const cascadedDocumentsStateManager: CascadedDocumentsStateManager = {
-        getCascadedDocuments: (rowId) => {
-          const currentTab = selectTab(getState(), tab.id);
-          return currentTab.cascadedDocumentsState.cascadedDocumentsMap[rowId];
-        },
-        setCascadedDocuments: (rowId, records) => {
-          const currentTab = selectTab(getState(), tab.id);
-          const cascadedDocumentsState = currentTab.cascadedDocumentsState;
-          dispatch(
-            internalStateSlice.actions.setCascadedDocumentsState({
-              tabId: tab.id,
-              cascadedDocumentsState: {
-                ...cascadedDocumentsState,
-                cascadedDocumentsMap: {
-                  ...cascadedDocumentsState.cascadedDocumentsMap,
-                  [rowId]: records,
-                },
-              },
-            })
-          );
-        },
-      };
-
       runtimeStateManager.tabs.byId[tab.id] = createTabRuntimeState({
         services,
-        cascadedDocumentsStateManager,
+        cascadedDocumentsStateManager: getCascadedDocumentsStateManager(tab.id),
         initialValues: {
           unifiedHistogramLayoutPropsMap: tab.duplicatedFromId
             ? selectInitialUnifiedHistogramLayoutPropsMap(runtimeStateManager, tab.duplicatedFromId)

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/cascaded_documents_state_manager.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/cascaded_documents_state_manager.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CascadedDocumentsStateManager } from '../../data_fetching/cascaded_documents_fetcher';
+import type { InternalStateStore } from './internal_state';
+import { internalStateSlice } from './internal_state';
+import { selectTab } from './selectors';
+
+export const createCascadedDocumentsStateManager = ({
+  internalState,
+  tabId,
+}: {
+  internalState: InternalStateStore;
+  tabId: string;
+}): CascadedDocumentsStateManager => ({
+  getCascadedDocuments(nodeId) {
+    const currentTab = selectTab(internalState.getState(), tabId);
+    return currentTab.cascadedDocumentsState.cascadedDocumentsMap[nodeId];
+  },
+  setCascadedDocuments(nodeId, records) {
+    const currentTab = selectTab(internalState.getState(), tabId);
+    const cascadedDocumentsState = currentTab.cascadedDocumentsState;
+    internalState.dispatch(
+      internalStateSlice.actions.setCascadedDocumentsState({
+        tabId,
+        cascadedDocumentsState: {
+          ...cascadedDocumentsState,
+          cascadedDocumentsMap: {
+            ...cascadedDocumentsState.cascadedDocumentsMap,
+            [nodeId]: records,
+          },
+        },
+      })
+    );
+  },
+});

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/cascaded_documents_state_manager.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/cascaded_documents_state_manager.ts
@@ -19,6 +19,9 @@ export const createCascadedDocumentsStateManager = ({
   internalState: InternalStateStore;
   tabId: string;
 }): CascadedDocumentsStateManager => ({
+  getIsActiveInstance() {
+    return internalState.getState().tabs.unsafeCurrentId === tabId;
+  },
   getCascadedDocuments(nodeId) {
     const currentTab = selectTab(internalState.getState(), tabId);
     return currentTab.cascadedDocumentsState.cascadedDocumentsMap[nodeId];

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -32,6 +32,7 @@ export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
   cascadedDocumentsState: {
     availableCascadeGroups: [],
     selectedCascadeGroups: [],
+    cascadedDocumentsMap: {},
   },
   esqlVariables: [],
   resetDefaultProfileState: {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
@@ -48,6 +48,7 @@ export {
   selectRecentlyClosedTabs,
   selectTab,
   selectTabAppState,
+  selectTabCombinedFilters,
   selectIsTabsBarHidden,
   selectHasUnsavedChanges,
 } from './selectors';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
@@ -18,6 +18,8 @@ export {
   type DiscoverAppState,
   type InternalStateDataRequestParams,
   type CascadedDocumentsState,
+  type DataCascadeUiState,
+  type DataCascadeLeafUiState,
   TabInitializationStatus,
 } from './types';
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -45,6 +45,8 @@ import { type HasUnsavedChangesResult, selectTab } from './selectors';
 import type { TabsStorageManager } from '../tabs_storage_manager';
 import type { DiscoverSearchSessionManager } from '../discover_search_session';
 import { createEsqlDataSource } from '../../../../../common/data_sources';
+import type { CascadedDocumentsStateManager } from '../../data_fetching/cascaded_documents_fetcher';
+import { createCascadedDocumentsStateManager } from './cascaded_documents_state_manager';
 
 const MIDDLEWARE_THROTTLE_MS = 300;
 const MIDDLEWARE_THROTTLE_OPTIONS = { leading: false, trailing: true };
@@ -552,16 +554,23 @@ export interface InternalStateDependencies {
   tabsStorageManager: TabsStorageManager;
   searchSessionManager: DiscoverSearchSessionManager;
   getInternalState$: () => Observable<DiscoverInternalState>;
+  getCascadedDocumentsStateManager: (tabId: string) => CascadedDocumentsStateManager;
 }
 
 const IS_JEST_ENVIRONMENT = typeof jest !== 'undefined';
 
 export const createInternalStateStore = (
-  options: Omit<InternalStateDependencies, 'getInternalState$'>
+  options: Omit<InternalStateDependencies, 'getInternalState$' | 'getCascadedDocumentsStateManager'>
 ) => {
   const optionsWithStore: InternalStateDependencies = {
     ...options,
     getInternalState$: () => from(internalState),
+    getCascadedDocumentsStateManager: (tabId) => {
+      return createCascadedDocumentsStateManager({
+        internalState,
+        tabId,
+      });
+    },
   };
 
   const internalState = configureStore({

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -396,6 +396,29 @@ export const internalStateSlice = createSlice({
       withTab(state, action.payload, (tab) => {
         tab.uiState.docViewer = action.payload.docViewerUiState;
       }),
+
+    setDataCascadeUiState: (
+      state,
+      action: TabAction<{ dataCascadeUiState: Partial<TabState['uiState']['dataCascade']> }>
+    ) =>
+      withTab(state, action.payload, (tab) => {
+        const nextUiState = action.payload.dataCascadeUiState;
+        const previousUiState = tab.uiState.dataCascade;
+
+        tab.uiState.dataCascade = {
+          ...previousUiState,
+          ...nextUiState,
+          leafUiState: {
+            ...previousUiState?.leafUiState,
+            ...nextUiState?.leafUiState,
+          },
+        };
+      }),
+
+    resetDataCascadeUiState: (state, action: TabAction) =>
+      withTab(state, action.payload, (tab) => {
+        tab.uiState.dataCascade = undefined;
+      }),
   },
   extraReducers: (builder) => {
     builder.addCase(loadDataViewList.fulfilled, (state, action) => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/index.ts
@@ -12,6 +12,7 @@ export {
   selectRecentlyClosedTabs,
   selectTab,
   selectTabAppState,
+  selectTabCombinedFilters,
   selectIsTabsBarHidden,
 } from './tabs';
 export { type HasUnsavedChangesResult, selectHasUnsavedChanges } from './unsaved_changes';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
@@ -96,6 +96,7 @@ describe('tab mapping utils', () => {
           },
           "cascadedDocumentsState": Object {
             "availableCascadeGroups": Array [],
+            "cascadedDocumentsMap": Object {},
             "selectedCascadeGroups": Array [],
           },
           "dataRequestParams": Object {
@@ -183,6 +184,7 @@ describe('tab mapping utils', () => {
           },
           "cascadedDocumentsState": Object {
             "availableCascadeGroups": Array [],
+            "cascadedDocumentsMap": Object {},
             "selectedCascadeGroups": Array [],
           },
           "dataRequestParams": Object {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -121,6 +121,7 @@ export interface DiscoverAppState {
 export interface CascadedDocumentsState {
   availableCascadeGroups: string[];
   selectedCascadeGroups: string[];
+  cascadedDocumentsMap: Record<string, DataTableRecord[] | undefined>;
 }
 
 export enum TabInitializationStatus {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -20,6 +20,7 @@ import type {
   VIEW_MODE,
 } from '@kbn/saved-search-plugin/common';
 import type { DataGridDensity, UnifiedDataTableRestorableState } from '@kbn/unified-data-table';
+import type { ExpandedState, RowSelectionState } from '@tanstack/react-table';
 import type {
   UnifiedFieldListRestorableState,
   UnifiedFieldListSidebarContainerProps,
@@ -124,6 +125,21 @@ export interface CascadedDocumentsState {
   cascadedDocumentsMap: Record<string, DataTableRecord[] | undefined>;
 }
 
+export interface DataCascadeLeafUiState {
+  selectedColumns?: string[];
+  density?: DataGridDensity;
+  isFullScreen?: boolean;
+  expandedDocId?: string;
+  scrollOffset?: number;
+}
+
+export interface DataCascadeUiState {
+  expanded?: ExpandedState;
+  rowSelection?: RowSelectionState;
+  scrollOffset?: number;
+  leafUiState?: Record<string, DataCascadeLeafUiState>;
+}
+
 export enum TabInitializationStatus {
   NotStarted = 'NotStarted',
   InProgress = 'InProgress',
@@ -176,6 +192,7 @@ export interface TabState extends TabItem {
     searchDraft?: Partial<UnifiedSearchDraft>;
     metricsGrid?: Partial<UnifiedMetricsGridRestorableState>;
     docViewer?: Partial<DocViewerRestorableState>;
+    dataCascade?: Partial<DataCascadeUiState>;
   };
   expandedDoc: DataTableRecord | undefined;
   initialDocViewerTabId?: string;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -20,7 +20,7 @@ import type {
   VIEW_MODE,
 } from '@kbn/saved-search-plugin/common';
 import type { DataGridDensity, UnifiedDataTableRestorableState } from '@kbn/unified-data-table';
-import type { ExpandedState, RowSelectionState } from '@tanstack/react-table';
+import type { DataCascadeUISnapshot } from '@kbn/shared-ux-document-data-cascade';
 import type {
   UnifiedFieldListRestorableState,
   UnifiedFieldListSidebarContainerProps,
@@ -34,6 +34,7 @@ import type { SerializedError } from '@reduxjs/toolkit';
 import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
 import type { DiscoverDataSource } from '../../../../../common/data_sources';
 import type { DiscoverLayoutRestorableState } from '../../components/layout/discover_layout_restorable_state';
+import type { ESQLDataGroupNode } from '../../components/layout/cascaded_documents/blocks/types';
 
 export interface InternalStateDataRequestParams {
   timeRangeAbsolute: TimeRange | undefined;
@@ -134,9 +135,9 @@ export interface DataCascadeLeafUiState {
 }
 
 export interface DataCascadeUiState {
-  expanded?: ExpandedState;
-  rowSelection?: RowSelectionState;
-  scrollOffset?: number;
+  expanded?: DataCascadeUISnapshot<ESQLDataGroupNode, DataTableRecord>['expanded'];
+  rowSelection?: DataCascadeUISnapshot<ESQLDataGroupNode, DataTableRecord>['rowSelection'];
+  scrollOffset?: DataCascadeUISnapshot<ESQLDataGroupNode, DataTableRecord>['scrollOffset'];
   leafUiState?: Record<string, DataCascadeLeafUiState>;
 }
 

--- a/src/platform/test/functional/apps/discover/cascade_layout/_data_fetching.ts
+++ b/src/platform/test/functional/apps/discover/cascade_layout/_data_fetching.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const { discover, unifiedTabs } = getPageObjects(['discover', 'unifiedTabs']);
+
+  const monacoEditor = getService('monacoEditor');
+  const testSubjects = getService('testSubjects');
+  const find = getService('find');
+  const inspector = getService('inspector');
+
+  describe('grouping data fetching', function () {
+    const statsQuery =
+      'FROM logstash-* | STATS count = COUNT(bytes), average = AVG(memory) BY clientip';
+    const cascadeRequestTitle = 'Cascade Row Data Query';
+
+    const runCascadeQuery = async () => {
+      await discover.selectTextBaseLang();
+      await discover.waitUntilTabIsLoaded();
+      await monacoEditor.setCodeEditorValue(statsQuery);
+      await testSubjects.click('querySubmitButton');
+      await discover.waitUntilTabIsLoaded();
+      expect(await discover.isShowingCascadeLayout()).to.be(true);
+    };
+
+    const getRootRowIds = async () => {
+      const rootRows = await find.allByCssSelector('[data-row-type="root"]');
+      return Promise.all(rootRows.map(async (row) => (await row.getAttribute('id')) ?? ''));
+    };
+
+    const toggleRow = async (rowId: string) => {
+      await testSubjects.click(`toggle-row-${rowId}-button`);
+    };
+
+    const getRequestTimestampFromStats = (requestStats: string[][]) => {
+      const requestStatsRow = requestStats.find((row) => row?.[0]?.includes('Request timestamp'));
+      return requestStatsRow?.[1] ?? '';
+    };
+
+    const getCascadeRequestTimestamp = async () => {
+      await inspector.open();
+      try {
+        const requestNames = await inspector.getRequestNames();
+
+        if (!requestNames) {
+          return '';
+        }
+
+        const names = requestNames.split(',').map((name) => name.trim());
+        if (!names.includes(cascadeRequestTitle)) {
+          return '';
+        }
+
+        await inspector.openRequestByName(cascadeRequestTitle);
+        const requestStats = await inspector.getTableData();
+        return getRequestTimestampFromStats(requestStats);
+      } finally {
+        await inspector.close();
+      }
+    };
+
+    const expectCascadeRequestTimestampToChange = async (baseline: string, waitForFetch = true) => {
+      if (waitForFetch) {
+        await discover.waitForDocTableLoadingComplete();
+      }
+      expect(await getCascadeRequestTimestamp()).not.to.be(baseline);
+    };
+
+    const expectCascadeRequestTimestampToStay = async (expected: string) => {
+      await discover.waitForDocTableLoadingComplete();
+      expect(await getCascadeRequestTimestamp()).to.be(expected);
+    };
+
+    it('does not refetch when returning to a previously expanded group', async () => {
+      await runCascadeQuery();
+
+      const [firstRowId, secondRowId] = await getRootRowIds();
+      const baseline = await getCascadeRequestTimestamp();
+
+      await toggleRow(firstRowId);
+      await expectCascadeRequestTimestampToChange(baseline);
+
+      const firstTimestamp = await getCascadeRequestTimestamp();
+
+      await toggleRow(secondRowId);
+      await expectCascadeRequestTimestampToChange(firstTimestamp);
+
+      const secondTimestamp = await getCascadeRequestTimestamp();
+
+      await toggleRow(firstRowId);
+      await expectCascadeRequestTimestampToStay(secondTimestamp);
+    });
+
+    it('does not refetch when re-expanding a group after switching tabs', async () => {
+      await runCascadeQuery();
+
+      const [firstRowId] = await getRootRowIds();
+      const baseline = await getCascadeRequestTimestamp();
+
+      await toggleRow(firstRowId);
+      await expectCascadeRequestTimestampToChange(baseline);
+
+      const firstTimestamp = await getCascadeRequestTimestamp();
+
+      await unifiedTabs.createNewTab();
+      await runCascadeQuery();
+
+      const [secondTabRowId] = await getRootRowIds();
+      const secondTabBaseline = await getCascadeRequestTimestamp();
+
+      await toggleRow(secondTabRowId);
+      await expectCascadeRequestTimestampToChange(secondTabBaseline);
+
+      await unifiedTabs.selectTab(0);
+      await discover.waitUntilTabIsLoaded();
+
+      await toggleRow(firstRowId);
+      await expectCascadeRequestTimestampToStay(firstTimestamp);
+    });
+
+    it('keeps the fetch active when switching tabs quickly', async () => {
+      await runCascadeQuery();
+      await unifiedTabs.createNewTab();
+      await runCascadeQuery();
+
+      await unifiedTabs.selectTab(0);
+      await discover.waitUntilTabIsLoaded();
+
+      const [firstRowId] = await getRootRowIds();
+      const baseline = await getCascadeRequestTimestamp();
+
+      await toggleRow(firstRowId);
+      await unifiedTabs.selectTab(1);
+
+      await unifiedTabs.selectTab(0);
+      await discover.waitUntilTabIsLoaded();
+
+      await expectCascadeRequestTimestampToChange(baseline, false);
+    });
+  });
+}

--- a/src/platform/test/functional/apps/discover/cascade_layout/index.ts
+++ b/src/platform/test/functional/apps/discover/cascade_layout/index.ts
@@ -62,5 +62,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
     });
 
     loadTestFile(require.resolve('./_grouping_selection'));
+    loadTestFile(require.resolve('./_data_fetching'));
   });
 }


### PR DESCRIPTION
## Summary

WIP.

Resolves #249456.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.