### PR TITLE
[Security Solution] Fix rule details Overview responsiveness

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/components/rule_execution_status/rule_status_failed_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/components/rule_execution_status/rule_status_failed_callout.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/react';
-import { EuiCallOut, EuiCodeBlock } from '@elastic/eui';
+import { EuiCallOut, EuiCodeBlock, EuiSpacer } from '@elastic/eui';
 
 import { NewChat } from '@kbn/elastic-assistant';
 import { FormattedDate } from '../../../../common/components/formatted_date';
@@ -78,7 +78,6 @@ const RuleStatusFailedCallOutComponent: React.FC<RuleStatusFailedCallOutProps> =
     <div
       css={css`
         pre {
-          margin-block-end: 0;
           margin-right: 24px; // Otherwise the copy button overlaps the scrollbar
           padding-inline-end: 0;
         }
@@ -131,6 +130,7 @@ const RuleStatusFailedCallOutComponent: React.FC<RuleStatusFailedCallOutProps> =
           )}
         </>
       </EuiCallOut>
+      <EuiSpacer size="m" />
     </div>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_about_rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_about_rule_details/index.tsx
@@ -89,13 +89,13 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
       {loading && (
         <>
           <EuiProgress size="xs" color="accent" position="absolute" />
-          <HeaderSection title={i18n.ABOUT_TEXT} />
+          <HeaderSection title={i18n.ABOUT_TEXT} border={true} hideSubtitle={true} />
         </>
       )}
       {stepData != null && stepDataDetails != null && (
         <EuiFlexGroup gutterSize="xs" direction="column" className={fullHeight}>
           <EuiFlexItem grow={false} key="header">
-            <HeaderSection title={i18n.ABOUT_TEXT}>
+            <HeaderSection title={i18n.ABOUT_TEXT} border={true} hideSubtitle={true}>
               {toggleOptions.length > 0 && (
                 <EuiButtonGroup
                   options={toggleOptions}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_about_rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_about_rule_details/index.tsx
@@ -89,13 +89,13 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
       {loading && (
         <>
           <EuiProgress size="xs" color="accent" position="absolute" />
-          <HeaderSection title={i18n.ABOUT_TEXT} border={true} hideSubtitle={true} />
+          <HeaderSection title={i18n.ABOUT_TEXT} border hideSubtitle />
         </>
       )}
       {stepData != null && stepDataDetails != null && (
         <EuiFlexGroup gutterSize="xs" direction="column" className={fullHeight}>
           <EuiFlexItem grow={false} key="header">
-            <HeaderSection title={i18n.ABOUT_TEXT} border={true} hideSubtitle={true}>
+            <HeaderSection title={i18n.ABOUT_TEXT} border hideSubtitle>
               {toggleOptions.length > 0 && (
                 <EuiButtonGroup
                   options={toggleOptions}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_panel/index.tsx
@@ -9,12 +9,14 @@ import { EuiPanel, EuiProgress } from '@elastic/eui';
 import React, { memo } from 'react';
 import styled from 'styled-components';
 
+import type { HeaderSectionProps } from '../../../../common/components/header_section';
 import { HeaderSection } from '../../../../common/components/header_section';
 
 interface StepPanelProps {
   children: React.ReactNode;
   loading: boolean;
   title?: string;
+  headerProps?: Omit<HeaderSectionProps, 'title'>;
 }
 
 const MyPanel = styled(EuiPanel)`
@@ -23,7 +25,12 @@ const MyPanel = styled(EuiPanel)`
 
 MyPanel.displayName = 'MyPanel';
 
-const StepPanelComponent: React.FC<StepPanelProps> = ({ children, loading, title }) => (
+const StepPanelComponent: React.FC<StepPanelProps> = ({
+  children,
+  loading,
+  title,
+  headerProps,
+}) => (
   <MyPanel hasBorder>
     {loading && (
       <EuiProgress
@@ -33,7 +40,7 @@ const StepPanelComponent: React.FC<StepPanelProps> = ({ children, loading, title
         data-test-subj="stepPanelProgress"
       />
     )}
-    {title && <HeaderSection title={title} />}
+    {title && <HeaderSection title={title} {...headerProps} />}
     {children}
   </MyPanel>
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -204,11 +204,14 @@ const defaultGroupingOptions = [
   },
 ];
 
-const defaultPanelOptions = {
+const DEFAULT_PANEL_HEADER_OPTIONS = {
   border: true,
   hideSubtitle: true,
-};
+} as const;
 
+/**
+ * Cutoff at which the About and Definition sections stack vertically to prevent content squishing (600px for About and 400px for Definition)
+ */
 const ABOUT_CONTENT_STACK_WIDTH_THRESHOLD = 1000;
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -787,7 +790,7 @@ export const RuleDetailsPage = connector(
                                     <StepPanel
                                       loading={isLoading}
                                       title={ruleI18n.DEFINITION}
-                                      headerProps={defaultPanelOptions}
+                                      headerProps={DEFAULT_PANEL_HEADER_OPTIONS}
                                     >
                                       {rule !== null && !isStartingJobs && (
                                         <RuleDefinitionSection
@@ -806,7 +809,7 @@ export const RuleDetailsPage = connector(
                                     <StepPanel
                                       loading={isLoading}
                                       title={ruleI18n.SCHEDULE}
-                                      headerProps={defaultPanelOptions}
+                                      headerProps={DEFAULT_PANEL_HEADER_OPTIONS}
                                     >
                                       {rule != null && <RuleScheduleSection rule={rule} />}
                                     </StepPanel>
@@ -820,7 +823,7 @@ export const RuleDetailsPage = connector(
                                       <StepPanel
                                         loading={isLoading}
                                         title={ruleI18n.ACTIONS}
-                                        headerProps={defaultPanelOptions}
+                                        headerProps={DEFAULT_PANEL_HEADER_OPTIONS}
                                       >
                                         <StepRuleActionsReadOnly
                                           addPadding={false}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -8,12 +8,14 @@
 /* eslint-disable complexity */
 // TODO: Disabling complexity is temporary till this component is refactored as part of lists UI integration
 
+import type { EuiResizeObserverProps } from '@elastic/eui';
 import {
   EuiButtonIcon,
   EuiConfirmModal,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
+  EuiResizeObserver,
   EuiSpacer,
   EuiToolTip,
   EuiWindowEvent,
@@ -168,13 +170,6 @@ const StyledFullHeightContainer = styled.div`
 `;
 
 /**
- * Sets min-height on tab container to minimize page hop when switching to tabs with less content
- */
-const StyledMinHeightTabContainer = styled.div`
-  min-height: 800px;
-`;
-
-/**
  * Wrapper for the About, Definition and Schedule sections.
  * - Allows for overflow wrapping of extremely long text, that might otherwise break the layout.
  */
@@ -208,6 +203,13 @@ const defaultGroupingOptions = [
     key: 'destination.address',
   },
 ];
+
+const defaultPanelOptions = {
+  border: true,
+  hideSubtitle: true,
+};
+
+const ABOUT_CONTENT_STACK_WIDTH_THRESHOLD = 1000;
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   clearSelected: ({ id }: { id: string }) => dispatch(dataTableActions.clearSelected({ id })),
@@ -296,6 +298,7 @@ export const RuleDetailsPage = connector(
 
     const { pollForSignalIndex } = useSignalHelpers();
     const [rule, setRule] = useState<RuleResponse | null>(null);
+    const [shouldStackAboutContent, setShouldStackAboutContent] = useState(false);
     const isLoading = useMemo(() => ruleLoading && rule == null, [rule, ruleLoading]);
 
     const { starting: isStartingJobs, startMlJobs } = useStartMlJobs();
@@ -492,6 +495,7 @@ export const RuleDetailsPage = connector(
             date={lastExecutionDate}
             message={lastExecutionMessage}
           />
+          <EuiSpacer size="m" />
         </>
       );
     }, [
@@ -565,6 +569,14 @@ export const RuleDetailsPage = connector(
         );
       },
       [alertMergedFilters, refreshRule]
+    );
+
+    const onResize: EuiResizeObserverProps['onResize'] = useCallback(
+      (dimensions) => {
+        if (!dimensions) return;
+        setShouldStackAboutContent(dimensions.width < ABOUT_CONTENT_STACK_WIDTH_THRESHOLD);
+      },
+      [setShouldStackAboutContent]
     );
 
     const {
@@ -742,68 +754,87 @@ export const RuleDetailsPage = connector(
                   {ruleError}
                   <LegacyUrlConflictCallOut rule={rule} spacesApi={spacesApi} />
                 </Display>
-                <StyledMinHeightTabContainer>
+                <div>
                   <Routes>
                     <Route path={`/rules/id/:detailName/:tabName(${RuleDetailTabs.overview})`}>
                       <RuleFieldsSectionWrapper>
-                        <EuiFlexGroup>
-                          <StyledEuiFlexItem
-                            data-test-subj="aboutRule"
-                            component="section"
-                            flexBasis={60}
-                          >
-                            {rule !== null && (
-                              <StepAboutRuleToggleDetails
-                                loading={isLoading}
-                                stepData={aboutRuleData}
-                                stepDataDetails={modifiedAboutRuleDetailsData}
-                                rule={rule}
-                              />
-                            )}
-                          </StyledEuiFlexItem>
-                          <StyledEuiFlexItem grow={1} component="section" flexBasis={40}>
-                            <EuiFlexGroup direction="column">
-                              <EuiFlexItem component="section" grow={1} data-test-subj="defineRule">
-                                <StepPanel
-                                  loading={isLoading}
-                                  title={ruleI18n.DEFINITION}
-                                  headerProps={{ border: true, hideSubtitle: true }}
-                                >
-                                  {rule !== null && !isStartingJobs && (
-                                    <RuleDefinitionSection
-                                      rule={rule}
-                                      isInteractive
-                                      dataTestSubj="definitionRule"
-                                    />
-                                  )}
-                                </StepPanel>
-                              </EuiFlexItem>
-                              <EuiFlexItem data-test-subj="schedule" component="section" grow={1}>
-                                <StepPanel
-                                  loading={isLoading}
-                                  title={ruleI18n.SCHEDULE}
-                                  headerProps={{ border: true, hideSubtitle: true }}
-                                >
-                                  {rule != null && <RuleScheduleSection rule={rule} />}
-                                </StepPanel>
-                              </EuiFlexItem>
-                              {hasActions && (
-                                <EuiFlexItem data-test-subj="actions" component="section" grow={1}>
-                                  <StepPanel
+                        <EuiResizeObserver onResize={onResize}>
+                          {(resizeRef) => (
+                            <EuiFlexGroup
+                              direction={shouldStackAboutContent ? 'column' : 'row'}
+                              ref={resizeRef}
+                            >
+                              <StyledEuiFlexItem
+                                data-test-subj="aboutRule"
+                                component="section"
+                                flexBasis={60}
+                              >
+                                {rule !== null && (
+                                  <StepAboutRuleToggleDetails
                                     loading={isLoading}
-                                    title={ruleI18n.ACTIONS}
-                                    headerProps={{ border: true, hideSubtitle: true }}
+                                    stepData={aboutRuleData}
+                                    stepDataDetails={modifiedAboutRuleDetailsData}
+                                    rule={rule}
+                                  />
+                                )}
+                              </StyledEuiFlexItem>
+                              <StyledEuiFlexItem grow={1} component="section" flexBasis={40}>
+                                <EuiFlexGroup direction="column">
+                                  <EuiFlexItem
+                                    component="section"
+                                    grow={1}
+                                    data-test-subj="defineRule"
                                   >
-                                    <StepRuleActionsReadOnly
-                                      addPadding={false}
-                                      defaultValues={ruleActionsData}
-                                    />
-                                  </StepPanel>
-                                </EuiFlexItem>
-                              )}
+                                    <StepPanel
+                                      loading={isLoading}
+                                      title={ruleI18n.DEFINITION}
+                                      headerProps={defaultPanelOptions}
+                                    >
+                                      {rule !== null && !isStartingJobs && (
+                                        <RuleDefinitionSection
+                                          rule={rule}
+                                          isInteractive
+                                          dataTestSubj="definitionRule"
+                                        />
+                                      )}
+                                    </StepPanel>
+                                  </EuiFlexItem>
+                                  <EuiFlexItem
+                                    data-test-subj="schedule"
+                                    component="section"
+                                    grow={1}
+                                  >
+                                    <StepPanel
+                                      loading={isLoading}
+                                      title={ruleI18n.SCHEDULE}
+                                      headerProps={defaultPanelOptions}
+                                    >
+                                      {rule != null && <RuleScheduleSection rule={rule} />}
+                                    </StepPanel>
+                                  </EuiFlexItem>
+                                  {hasActions && (
+                                    <EuiFlexItem
+                                      data-test-subj="actions"
+                                      component="section"
+                                      grow={1}
+                                    >
+                                      <StepPanel
+                                        loading={isLoading}
+                                        title={ruleI18n.ACTIONS}
+                                        headerProps={defaultPanelOptions}
+                                      >
+                                        <StepRuleActionsReadOnly
+                                          addPadding={false}
+                                          defaultValues={ruleActionsData}
+                                        />
+                                      </StepPanel>
+                                    </EuiFlexItem>
+                                  )}
+                                </EuiFlexGroup>
+                              </StyledEuiFlexItem>
                             </EuiFlexGroup>
-                          </StyledEuiFlexItem>
-                        </EuiFlexGroup>
+                          )}
+                        </EuiResizeObserver>
                       </RuleFieldsSectionWrapper>
                     </Route>
                     <Route path={`/rules/id/:detailName/:tabName(${RuleDetailTabs.alerts})`}>
@@ -900,7 +931,7 @@ export const RuleDetailsPage = connector(
                       <ExecutionEventsTable ruleId={ruleId} />
                     </Route>
                   </Routes>
-                </StyledMinHeightTabContainer>
+                </div>
               </SecuritySolutionPageWrapper>
             </RuleCustomizationsContextProvider>
           </RuleDetailsContextProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -765,7 +765,11 @@ export const RuleDetailsPage = connector(
                           <StyledEuiFlexItem grow={1} component="section" flexBasis={40}>
                             <EuiFlexGroup direction="column">
                               <EuiFlexItem component="section" grow={1} data-test-subj="defineRule">
-                                <StepPanel loading={isLoading} title={ruleI18n.DEFINITION}>
+                                <StepPanel
+                                  loading={isLoading}
+                                  title={ruleI18n.DEFINITION}
+                                  headerProps={{ border: true, hideSubtitle: true }}
+                                >
                                   {rule !== null && !isStartingJobs && (
                                     <RuleDefinitionSection
                                       rule={rule}
@@ -776,13 +780,21 @@ export const RuleDetailsPage = connector(
                                 </StepPanel>
                               </EuiFlexItem>
                               <EuiFlexItem data-test-subj="schedule" component="section" grow={1}>
-                                <StepPanel loading={isLoading} title={ruleI18n.SCHEDULE}>
+                                <StepPanel
+                                  loading={isLoading}
+                                  title={ruleI18n.SCHEDULE}
+                                  headerProps={{ border: true, hideSubtitle: true }}
+                                >
                                   {rule != null && <RuleScheduleSection rule={rule} />}
                                 </StepPanel>
                               </EuiFlexItem>
                               {hasActions && (
                                 <EuiFlexItem data-test-subj="actions" component="section" grow={1}>
-                                  <StepPanel loading={isLoading} title={ruleI18n.ACTIONS}>
+                                  <StepPanel
+                                    loading={isLoading}
+                                    title={ruleI18n.ACTIONS}
+                                    headerProps={{ border: true, hideSubtitle: true }}
+                                  >
                                     <StepRuleActionsReadOnly
                                       addPadding={false}
                                       defaultValues={ruleActionsData}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -741,7 +741,6 @@ export const RuleDetailsPage = connector(
                   <TabNavigation navTabs={pageTabs} />
                   {ruleError}
                   <LegacyUrlConflictCallOut rule={rule} spacesApi={spacesApi} />
-                  <EuiSpacer />
                 </Display>
                 <StyledMinHeightTabContainer>
                   <Routes>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -495,7 +495,6 @@ export const RuleDetailsPage = connector(
             date={lastExecutionDate}
             message={lastExecutionMessage}
           />
-          <EuiSpacer size="m" />
         </>
       );
     }, [

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/constants.ts
@@ -7,8 +7,17 @@
 
 import type { DiffableAllFields } from '../../../../../common/api/detection_engine';
 
-export const DEFAULT_DESCRIPTION_LIST_COLUMN_WIDTHS: [string, string] = ['50%', '50%'];
-export const LARGE_DESCRIPTION_LIST_COLUMN_WIDTHS: [string, string] = ['30%', '70%'];
+/**
+ * We subtract 4px from each column width to account for the 8px gap between the columns
+ */
+export const DEFAULT_DESCRIPTION_LIST_COLUMN_WIDTHS: [string, string] = [
+  'calc(50% - 4px)',
+  'calc(50% - 4px)',
+];
+export const LARGE_DESCRIPTION_LIST_COLUMN_WIDTHS: [string, string] = [
+  'calc(30% - 4px)',
+  'calc(70% - 4px)',
+];
 
 export const ABOUT_UPGRADE_FIELD_ORDER: Array<keyof DiffableAllFields> = [
   'version',

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_about_section.tsx
@@ -122,7 +122,7 @@ export const SeverityMappingItem = ({ severityMappingItem }: SeverityMappingItem
       </EuiToolTip>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiIcon type={'sortRight'} />
+      <EuiIcon type={'sortRight'} aria-label="Sort right" />
     </EuiFlexItem>
     <EuiFlexItem>
       <SeverityBadge
@@ -160,7 +160,7 @@ export const RiskScoreMappingItem = ({ riskScoreMappingItem }: RiskScoreMappingI
       </EuiToolTip>
     </OverrideColumn>
     <EuiFlexItem grow={false}>
-      <EuiIcon type={'sortRight'} />
+      <EuiIcon type={'sortRight'} aria-label="Sort right" />
     </EuiFlexItem>
     <EuiFlexItem data-test-subj="riskScoreOverridePropertyOverride">{ALERT_RISK_SCORE}</EuiFlexItem>
   </EuiFlexGroup>
@@ -515,10 +515,10 @@ export const RuleAboutSection = ({
   });
 
   return (
-    <div>
+    <div className={'eui-xScroll'}>
       <EuiSpacer size="m" />
       <EuiDescriptionList
-        type={descriptionListProps.type ?? 'column'}
+        type={descriptionListProps.type ?? 'responsiveColumn'}
         rowGutterSize={descriptionListProps.rowGutterSize ?? 'm'}
         listItems={aboutSectionListItems}
         columnWidths={columnWidths}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_about_section.tsx
@@ -515,10 +515,10 @@ export const RuleAboutSection = ({
   });
 
   return (
-    <div className={'eui-xScroll'}>
+    <div className="eui-xScroll">
       <EuiSpacer size="m" />
       <EuiDescriptionList
-        type={descriptionListProps.type ?? 'responsiveColumn'}
+        type={descriptionListProps.type ?? 'column'}
         rowGutterSize={descriptionListProps.rowGutterSize ?? 'm'}
         listItems={aboutSectionListItems}
         columnWidths={columnWidths}


### PR DESCRIPTION
## Summary

**Resolves: #206504**
**Resolves: #147367**

Small styling improvements to prevent overflow of MITRE Attack coverage fields on the Rule Details page and improve white space usage to match [figma](https://www.figma.com/design/uHWdktfGUf5kgmNiQgYjl3/Detection-rule-changes-history-and-comparison-of-revisions--12367?node-id=5135-6149&t=dCdbxW6U5PChOenh-0]) (internal) and provide a better user experience.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Screenshots

#### Before
<img width="1727" height="899" alt="Screenshot 2026-02-19 at 7 26 53 AM" src="https://github.com/user-attachments/assets/0c7b2d60-6a49-4edf-8a51-989ec79fa21e" />
<img width="1399" height="894" alt="Screenshot 2026-02-19 at 7 27 01 AM" src="https://github.com/user-attachments/assets/ac329a59-bde1-440e-af88-62da06e35c64" />
<img width="1019" height="895" alt="Screenshot 2026-02-19 at 7 27 10 AM" src="https://github.com/user-attachments/assets/bb0ec58b-874e-4851-a349-956ddd8d1ff1" />
<img width="729" height="898" alt="Screenshot 2026-02-19 at 7 27 21 AM" src="https://github.com/user-attachments/assets/67fb4320-5d0a-4c88-87db-e8235a5de940" />
<img width="432" height="719" alt="Screenshot 2026-02-19 at 7 27 58 AM" src="https://github.com/user-attachments/assets/696e6f22-1a6d-4cec-a9cc-a3b321abcad9" />


#### After

<img width="1727" height="887" alt="Screenshot 2026-02-19 at 7 22 00 AM" src="https://github.com/user-attachments/assets/e87b1e19-d6d9-4340-aaa0-8cf978209adc" />
<img width="1397" height="900" alt="Screenshot 2026-02-19 at 7 22 10 AM" src="https://github.com/user-attachments/assets/029814bc-21c4-48a9-b85f-e7a1d288930b" />
<img width="1087" height="902" alt="Screenshot 2026-02-19 at 7 22 30 AM" src="https://github.com/user-attachments/assets/870ef13a-1de9-4b88-85b2-93435915452c" />
<img width="611" height="798" alt="Screenshot 2026-02-19 at 7 22 56 AM" src="https://github.com/user-attachments/assets/4d3fed6c-7b3c-4575-9e53-3ebabbb8b331" />
<img width="446" height="733" alt="Screenshot 2026-02-19 at 7 23 07 AM" src="https://github.com/user-attachments/assets/95b88a11-1e25-4fca-a2ea-b28a2074ae1d" />



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->