### PR TITLE
[Discover][Logs] Stabilize log doc viewer “flyout already open” tests by retrying leading-control clicks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1814,6 +1814,7 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 
 # obs-exploration-team 
 /x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/ @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/serverless/functional/utils/ @elastic/obs-exploration-team
 /src/platform/test/functional/apps/discover/observability/logs/ @elastic/obs-exploration-team
 
 # obs-onboarding-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1812,6 +1812,10 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 /x-pack/solutions/observability/test/serverless/functional/test_suites @elastic/observability-ui
 /src/platform/test/functional/apps/discover/observability @elastic/observability-ui
 
+# obs-exploration-team 
+/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/ @elastic/obs-exploration-team
+/src/platform/test/functional/apps/discover/observability/logs/ @elastic/obs-exploration-team
+
 # obs-onboarding-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/configs/config.* @elastic/obs-onboarding-team

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/_get_doc_viewer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/_get_doc_viewer.ts
@@ -14,6 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'discover', 'svlCommonPage']);
   const testSubjects = getService('testSubjects');
   const dataGrid = getService('dataGrid');
+  const retry = getService('retry');
   const dataViews = getService('dataViews');
   const synthtrace = getService('svlLogsSynthtraceClient');
   const queryBar = getService('queryBar');
@@ -245,88 +246,95 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
       });
 
-      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of same row and flyout is already open with some other tab', async () => {
-        await dataGrid.clickRowToggle({ rowIndex: 0 });
+      describe('when flyout is already open on a different tab', () => {
+        const clickWithRetry = async (action: () => Promise<void>) => {
+          await retry.tryForTime(10 * 1000, async () => {
+            await action();
+          });
+        };
+        it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of same row', async () => {
+          await dataGrid.clickRowToggle({ rowIndex: 0 });
 
-        // Switch to JSON tab
-        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
-        await jsonTabButton.click();
+          // Switch to JSON tab
+          const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+          await jsonTabButton.click();
 
-        // Click to open Quality Issue control on the same row
-        await dataGrid.clickQualityIssueLeadingControl(0);
+          // Click to open Quality Issue control on the same row
+          await clickWithRetry(() => dataGrid.clickQualityIssueLeadingControl(0));
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
-          'true'
-        );
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
+            'true'
+          );
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewStacktraceAccordion',
-          'false'
-        );
-      });
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewStacktraceAccordion',
+            'false'
+          );
+        });
 
-      it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of different row and flyout is already open with some other tab', async () => {
-        await dataGrid.clickRowToggle({ rowIndex: 0 });
+        it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of different row', async () => {
+          await dataGrid.clickRowToggle({ rowIndex: 0 });
 
-        // Switch to JSON tab
-        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
-        await jsonTabButton.click();
+          // Switch to JSON tab
+          const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+          await jsonTabButton.click();
 
-        // Click to open Quality Issue control on the same row
-        await dataGrid.clickQualityIssueLeadingControl(1);
+          // Click to open Quality Issue control on the same row
+          await clickWithRetry(() => dataGrid.clickQualityIssueLeadingControl(1));
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
-          'true'
-        );
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
+            'true'
+          );
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewStacktraceAccordion',
-          'false'
-        );
-      });
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewStacktraceAccordion',
+            'false'
+          );
+        });
 
-      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of same row and flyout is already open with some other tab', async () => {
-        await dataGrid.clickRowToggle({ rowIndex: 0 });
+        it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of same row', async () => {
+          await dataGrid.clickRowToggle({ rowIndex: 0 });
 
-        // Switch to JSON tab
-        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
-        await jsonTabButton.click();
+          // Switch to JSON tab
+          const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+          await jsonTabButton.click();
 
-        // Click to open Quality Issue control on the same row
-        await dataGrid.clickStacktraceLeadingControl(0);
+          // Click to open Stacktrace control on the same row
+          await clickWithRetry(() => dataGrid.clickStacktraceLeadingControl(0));
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
-          'false'
-        );
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
+            'false'
+          );
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewStacktraceAccordion',
-          'true'
-        );
-      });
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewStacktraceAccordion',
+            'true'
+          );
+        });
 
-      it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of different row and flyout is already open with some other tab', async () => {
-        await dataGrid.clickRowToggle({ rowIndex: 0 });
+        it('should switch tab to logs overview and open stacktrace accordion, when user clicks on stacktrace control of different row', async () => {
+          await dataGrid.clickRowToggle({ rowIndex: 0 });
 
-        // Switch to JSON tab
-        const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
-        await jsonTabButton.click();
+          // Switch to JSON tab
+          const jsonTabButton = await testSubjects.find('docViewerTab-doc_view_source');
+          await jsonTabButton.click();
 
-        // Click to open Quality Issue control on the same row
-        await dataGrid.clickStacktraceLeadingControl(1);
+          // Click to open Stacktrace control on a different row
+          await clickWithRetry(() => dataGrid.clickStacktraceLeadingControl(1));
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
-          'false'
-        );
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
+            'false'
+          );
 
-        await testSubjects.waitForAccordionState(
-          'unifiedDocViewLogsOverviewStacktraceAccordion',
-          'true'
-        );
+          await testSubjects.waitForAccordionState(
+            'unifiedDocViewLogsOverviewStacktraceAccordion',
+            'true'
+          );
+        });
       });
     });
   });

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/_get_doc_viewer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/_get_doc_viewer.ts
@@ -9,6 +9,7 @@ import moment from 'moment/moment';
 import { log, timerange } from '@kbn/synthtrace-client';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 import { MORE_THAN_1024_CHARS, STACKTRACE_MESSAGE } from '../const';
+import { clickWithRetry } from '../../../utils/click_with_retry';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'discover', 'svlCommonPage']);
@@ -18,6 +19,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataViews = getService('dataViews');
   const synthtrace = getService('svlLogsSynthtraceClient');
   const queryBar = getService('queryBar');
+
+  const click = (action: () => Promise<void>, timeoutMs?: number) =>
+    clickWithRetry(retry, action, timeoutMs);
 
   const start = moment().subtract(30, 'minutes').valueOf();
   const end = moment().add(30, 'minutes').valueOf();
@@ -247,11 +251,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       describe('when flyout is already open on a different tab', () => {
-        const clickWithRetry = async (action: () => Promise<void>) => {
-          await retry.tryForTime(10 * 1000, async () => {
-            await action();
-          });
-        };
         it('should switch tab to logs overview and open quality issues accordion, when user clicks on quality issue control of same row', async () => {
           await dataGrid.clickRowToggle({ rowIndex: 0 });
 
@@ -260,7 +259,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await jsonTabButton.click();
 
           // Click to open Quality Issue control on the same row
-          await clickWithRetry(() => dataGrid.clickQualityIssueLeadingControl(0));
+          await click(() => dataGrid.clickQualityIssueLeadingControl(0));
 
           await testSubjects.waitForAccordionState(
             'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
@@ -281,7 +280,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await jsonTabButton.click();
 
           // Click to open Quality Issue control on the same row
-          await clickWithRetry(() => dataGrid.clickQualityIssueLeadingControl(1));
+          await click(() => dataGrid.clickQualityIssueLeadingControl(1));
 
           await testSubjects.waitForAccordionState(
             'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
@@ -302,7 +301,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await jsonTabButton.click();
 
           // Click to open Stacktrace control on the same row
-          await clickWithRetry(() => dataGrid.clickStacktraceLeadingControl(0));
+          await click(() => dataGrid.clickStacktraceLeadingControl(0));
 
           await testSubjects.waitForAccordionState(
             'unifiedDocViewLogsOverviewDegradedFieldsAccordion',
@@ -323,7 +322,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await jsonTabButton.click();
 
           // Click to open Stacktrace control on a different row
-          await clickWithRetry(() => dataGrid.clickStacktraceLeadingControl(1));
+          await click(() => dataGrid.clickStacktraceLeadingControl(1));
 
           await testSubjects.waitForAccordionState(
             'unifiedDocViewLogsOverviewDegradedFieldsAccordion',

--- a/x-pack/solutions/observability/test/serverless/functional/utils/click_with_retry.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/utils/click_with_retry.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RetryService } from '@kbn/ftr-common-functional-services';
+
+const DEFAULT_CLICK_RETRY_TIMEOUT_MS = 10 * 1000;
+
+export const clickWithRetry = async (
+  retry: RetryService,
+  action: () => Promise<void>,
+  timeoutMs: number = DEFAULT_CLICK_RETRY_TIMEOUT_MS
+): Promise<void> => {
+  await retry.tryForTime(timeoutMs, async () => {
+    await action();
+  });
+};


### PR DESCRIPTION
## Summary

This PR reduces flakiness in the serverless Observability Discover logs doc viewer suite by retrying the leading-control click actions (Quality issues / Stacktrace) in the scenarios where the flyout is already open on another tab.

### Context / Why now

These tests started failing intermittently this week with `StaleElementReferenceError` (element becomes stale during click).

Flakiness started around 2026-02-10,  might be correlated with [EUI v112.3.0 upgrade](https://github.com/elastic/kibana/commit/57b3c88d1a6138061f1759efe2f37800245233d0) and/or Discover state changes, both of which can increase grid/flyout re-renders and cause stale element references during leading-control clicks.

###  Why this approach
The failure happens during the click, not after it, so waiting after the click doesn’t help. 
Retrying the click lets the test find the element again and click it once the UI has settled, which matches what we saw locally (adding a short sleep before the click reduced the flake).

### Test in local
````
yarn test:ftr --config x-pack/solutions/observability/test/serverless/functional/configs/config.logs_essentials.ts --grep "flyout is already open"
````