### PR TITLE
[agent builder] fix event emitting for skill tools

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/tool_manager.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/tool_manager.ts
@@ -29,7 +29,6 @@ export interface ExecutableToolInput {
   type: ToolManagerToolType.executable;
   tools: ExecutableTool | ExecutableTool[];
   logger: Logger;
-  eventEmitter?: AgentEventEmitterFn;
 }
 
 export interface BrowserToolInput {
@@ -44,6 +43,12 @@ export type AddToolInput = ExecutableToolInput | BrowserToolInput;
  * Handles both static and dynamic tools with LRU eviction for dynamic tools.
  */
 export interface ToolManager {
+  /**
+   * Sets the event emitter to use for all tools added to this manager.
+   * Should be called once per run before adding tools.
+   */
+  setEventEmitter(eventEmitter: AgentEventEmitterFn): void;
+
   /**
    * Adds tools to the tool manager.
    * Supports both executable tools and browser API tools.

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
@@ -126,12 +126,13 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
     runner: context.runner,
   });
 
+  toolManager.setEventEmitter(eventEmitter);
+
   await Promise.all([
     toolManager.addTools({
       type: ToolManagerToolType.executable,
       tools: staticTools,
       logger,
-      eventEmitter,
     }),
     toolManager.addTools({
       type: ToolManagerToolType.browser,
@@ -142,7 +143,6 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
         type: ToolManagerToolType.executable,
         tools: dynamicTools,
         logger,
-        eventEmitter,
       },
       {
         dynamic: true,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
@@ -104,6 +104,8 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
   const eventEmitter: AgentEventEmitterFn = (event) => {
     manualEvents$.next(event);
   };
+  toolManager.setEventEmitter(eventEmitter);
+
   // Pass action so regenerate uses the last round's original input instead of request input
   const processedConversation = await prepareConversation({
     nextInput,
@@ -125,8 +127,6 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
     spaceId: context.spaceId,
     runner: context.runner,
   });
-
-  toolManager.setEventEmitter(eventEmitter);
 
   await Promise.all([
     toolManager.addTools({

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
@@ -126,6 +126,7 @@ export const createSkillsServiceMock = (): SkillsServiceMock => {
 
 export const createToolManagerMock = (): ToolManagerMock => {
   return {
+    setEventEmitter: jest.fn(),
     addTools: jest.fn(),
     list: jest.fn(),
     recordToolUse: jest.fn(),


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/12910

Fix a bug where tools loaded from skills (via filestore.read -> loadSkillTools) could not emit events because the eventEmitter was not propagated to toolManager.addTools().

**Root cause**: The AgentEventEmitterFn was passed as a per-call parameter on each addTools() invocation. When loadSkillTools called addTools() to register skill-bound tools, it had no access to the emitter and omitted it, causing toolToLangchain to receive sendEvent: undefined -- making those tools unable to emit any events.

**Fix**: Move the event emitter from a per-addTools parameter to a ToolManager-level concern via a new setEventEmitter() method. The emitter is set once per run and automatically applies to all tools added afterwards, including those added dynamically by skills. This is safe because the ToolManager is scoped per-run.

**Changes**:
- Removed eventEmitter from ExecutableToolInput interface
- Added setEventEmitter(emitter) to the ToolManager interface and implementation
- Updated run_chat_agent.ts to call toolManager.setEventEmitter() once before adding tools
- Added unit tests for the new behavior