### PR TITLE
[Fleet] Fix flaky automatic agent upgrades tests

### DIFF
--- a/x-pack/platform/test/fleet_tasks/tests/automatic_upgrades.ts
+++ b/x-pack/platform/test/fleet_tasks/tests/automatic_upgrades.ts
@@ -57,6 +57,17 @@ export default function (providerContext: FtrProviderContextWithServices) {
     });
 
     afterEach(async () => {
+      // Reset required_versions on the policy to prevent the background task from acting
+      // on stale policy config when the next test creates new agents.
+      await supertest
+        .put(`/api/fleet/agent_policies/${policyId}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'Test policy',
+          namespace: 'default',
+          required_versions: [],
+        })
+        .expect(200);
       await cleanupAgentDocs(providerContext);
       await es.deleteByQuery({
         index: '.fleet-actions',
@@ -101,6 +112,7 @@ export default function (providerContext: FtrProviderContextWithServices) {
       expect(res.body.item.upgrade_started_at).to.be(undefined);
       expect(res.body.item.upgrade_attempts).to.be(undefined);
 
+      await es.indices.refresh({ index: '.fleet-actions' });
       const actionRes = await es.search({
         index: '.fleet-actions',
         query: {
@@ -109,8 +121,8 @@ export default function (providerContext: FtrProviderContextWithServices) {
           },
         },
       });
-      // verify that the expiration is set to 1 month
-      const expirationDate = new Date((actionRes.hits.hits[0]?._source as any).expiration);
+      expect(actionRes.hits.hits.length).to.be.greaterThan(0);
+      const expirationDate = new Date((actionRes.hits.hits[0]._source as any).expiration);
       const expectedExpiration = moment(new Date())
         .add(EXPIRATION_DURATION_SECONDS, 'seconds')
         .toDate();
@@ -138,7 +150,13 @@ export default function (providerContext: FtrProviderContextWithServices) {
           ],
         })
         .expect(200);
-      await waitForTask();
+      // Wait until at least one agent has been upgraded, then verify exact counts.
+      await waitForResult(async () => {
+        const res = await supertest.get('/api/fleet/agents').set('kbn-xsrf', 'xxx').expect(200);
+        return (
+          res.body.items.filter((item: any) => item.upgrade_started_at !== undefined).length >= 1
+        );
+      });
       // Check that only one agent on 8.17.0 was upgraded.
       const res = await supertest.get('/api/fleet/agents').set('kbn-xsrf', 'xxx').expect(200);
       expect(res.body.items.length).to.be(4);
@@ -172,8 +190,17 @@ export default function (providerContext: FtrProviderContextWithServices) {
           ],
         })
         .expect(200);
-      await waitForTask();
-      // Check that two agents on 8.17.0 were upgraded.
+      // Wait until at least one agent has been upgraded, then verify exact counts.
+      await waitForResult(async () => {
+        const res = await supertest
+          .get('/api/fleet/agents?showInactive=true')
+          .set('kbn-xsrf', 'xxx')
+          .expect(200);
+        return (
+          res.body.items.filter((item: any) => item.upgrade_started_at !== undefined).length >= 1
+        );
+      });
+      // Check that only one agent on 8.17.0 was upgraded.
       const res = await supertest
         .get('/api/fleet/agents?showInactive=true')
         .set('kbn-xsrf', 'xxx')


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/245377
Closes https://github.com/elastic/kibana/issues/245236

Attempt to fix flakiness in `x-pack/platform/test/fleet_tasks/tests/automatic_upgrades.ts`:
* https://github.com/elastic/kibana/issues/245377
   * Add a guard assertion to check that the action exists - if it doesn't, the failure will be more meaningful (no TypeError)
   * Add an index refresh before getting the action - not sure yet if this will help, but since at this stage of the test the agent was upgraded, it should exist
* Closes https://github.com/elastic/kibana/issues/245236
   * Looks like a possible race condition between `waitForTask` and the task interval (both 30 seconds)
   * Add `afterEach` reset of `required_versions`, preventing the background task from acting on stale policy config when the next test creates new agents
   * Replaced `waitForTask` with `waitForResult` that waits until at least 1 agent has `upgrade_started_at` set

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Test fix only





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->