### PR TITLE
[APM] Fix error count alert flaky test

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/data_grid.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/data_grid.ts
@@ -112,6 +112,10 @@ export class EuiDataGridWrapper {
     );
   }
 
+  getAllCellLocatorByColId(colId: string): Locator {
+    return this.rows.locator(`[data-gridcell-column-id="${colId}"]`);
+  }
+
   async expandCell(rowIndex: number, columnIndex: number) {
     await this.ensureGridVisible();
 

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/alerts_controls/add_rule_flyout.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/alerts_controls/add_rule_flyout.ts
@@ -19,6 +19,8 @@ export class AddRuleFlyout {
   public readonly scheduleValueInput: Locator;
   public readonly scheduleUnitSelect: Locator;
 
+  public readonly nameInput: Locator;
+
   constructor(private readonly page: ScoutPage) {
     this.flyout = this.page.getByRole('dialog');
     this.saveButton = this.flyout.getByTestId('ruleFlyoutFooterSaveButton');
@@ -28,10 +30,17 @@ export class AddRuleFlyout {
 
     this.scheduleValueInput = this.flyout.getByTestId('ruleScheduleNumberInput');
     this.scheduleUnitSelect = this.flyout.getByTestId('ruleScheduleUnitInput');
+
+    this.nameInput = this.flyout.getByTestId('ruleDetailsNameInput');
   }
 
   public async waitForErrorCountToLoad() {
     await this.flyout.getByRole('heading', { name: 'Error count threshold' }).waitFor();
+  }
+
+  public async fillName(name: string) {
+    await this.nameInput.clear();
+    await this.nameInput.fill(name);
   }
 
   public async fillIsAbove(amount: number) {

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
@@ -6,32 +6,145 @@
  */
 
 import { tags } from '@kbn/scout-oblt';
+import type { ObltWorkerFixtures } from '@kbn/scout-oblt';
 import { expect } from '@kbn/scout-oblt/ui';
+import { faker } from '@faker-js/faker';
 import { test } from '../../fixtures';
-import { EXTENDED_TIMEOUT } from '../../fixtures/constants';
+import type { ExtendedScoutTestFixtures } from '../../fixtures';
 
 const SERVICE_NAME = 'unstable-java';
 const START_DATE = 'now-15m';
 const END_DATE = 'now';
-const RULE_NAME = 'Error count threshold';
+const RULE_NAME = `Error count threshold ${faker.string.uuid()}`;
+const APM_ALERTS_INDEX_PATTERN = '.alerts-observability.apm.alerts-*';
+const RULE_TYPE_ID = 'apm.error_rate';
+// Stateful uses rollover index with .internal prefix
+const STATEFUL_ALERTS_INDEX = '.internal.alerts-observability.apm.alerts-default-000001';
+// Serverless uses data stream without .internal prefix or numeric suffix
+const SERVERLESS_ALERTS_INDEX = '.alerts-observability.apm.alerts-default';
 
-test.describe(
-  'Alerts',
-  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
-  () => {
-    test.beforeEach(async ({ browserAuth }) => {
-      await browserAuth.loginAsAdmin();
+function createAlertDisplayTest(alertIndex: string) {
+  return async ({
+    pageObjects: { serviceDetailsPage },
+    apiServices,
+    esClient,
+  }: ExtendedScoutTestFixtures & ObltWorkerFixtures) => {
+    let ruleId: string;
+
+    await test.step('create rule via API', async () => {
+      const response = await apiServices.alerting.rules.create({
+        ruleTypeId: RULE_TYPE_ID,
+        name: RULE_NAME,
+        consumer: 'apm',
+        schedule: { interval: '1m' },
+        enabled: false,
+        params: {
+          environment: 'production',
+          threshold: 0,
+          windowSize: 1,
+          windowUnit: 'h',
+        },
+        tags: ['apm'],
+      });
+      ruleId = response.data.id;
     });
 
-    test.afterEach(async ({ apiServices }) => {
-      await apiServices.alerting.cleanup.deleteAllRules();
+    await test.step('index alert document', async () => {
+      const now = new Date().toISOString();
+
+      await esClient.index({
+        index: alertIndex,
+        refresh: 'wait_for',
+        document: {
+          '@timestamp': now,
+          'kibana.alert.uuid': faker.string.uuid(),
+          'kibana.alert.start': now,
+          'kibana.alert.status': 'active',
+          'kibana.alert.workflow_status': 'open',
+          'kibana.alert.rule.name': RULE_NAME,
+          'kibana.alert.rule.uuid': ruleId,
+          'kibana.alert.rule.rule_type_id': RULE_TYPE_ID,
+          'kibana.alert.rule.category': RULE_NAME,
+          'kibana.alert.rule.consumer': 'apm',
+          'kibana.alert.reason': `Error count is 15 in the last 1 hr for service: ${SERVICE_NAME}, env: production. Alert when > 0.`,
+          'kibana.alert.evaluation.threshold': 0,
+          'kibana.alert.evaluation.value': 15,
+          'kibana.alert.duration.us': 0,
+          'kibana.alert.time_range': {
+            gte: now,
+          },
+          'kibana.alert.instance.id': '*',
+          'service.name': SERVICE_NAME,
+          'service.environment': 'production',
+          'processor.event': 'error',
+          'kibana.space_ids': ['default'],
+          'event.kind': 'signal',
+          'event.action': 'open',
+          tags: ['apm'],
+        },
+      });
     });
 
-    test("Can create, trigger and view an 'Error count' alert from service inventory", async ({
-      page,
-      pageObjects: { serviceInventoryPage, alertsControls, serviceDetailsPage },
-      apiServices,
-    }) => {
+    await test.step('navigate to service alerts tab', async () => {
+      await serviceDetailsPage.alertsTab.goToTab({
+        serviceName: SERVICE_NAME,
+        rangeFrom: START_DATE,
+        rangeTo: END_DATE,
+      });
+    });
+
+    await test.step('verify alert is visible', async () => {
+      const ruleCell = serviceDetailsPage.alertsTab.alertsTable
+        .getAllCellLocatorByColId('kibana.alert.rule.name')
+        .filter({ hasText: RULE_NAME });
+      await expect(ruleCell).toBeVisible();
+    });
+  };
+}
+
+test.describe('Alerts', () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.afterEach(async ({ apiServices, esClient }) => {
+    const findResponse = await apiServices.alerting.rules.find({
+      search: RULE_NAME,
+      search_fields: ['name'],
+      per_page: 1,
+    });
+    const rules = findResponse.data.data;
+
+    for (const rule of rules) {
+      const ruleId = rule.id;
+
+      // Delete alert documents
+      try {
+        await esClient.deleteByQuery({
+          index: APM_ALERTS_INDEX_PATTERN,
+          query: {
+            term: { 'kibana.alert.rule.uuid': ruleId },
+          },
+          refresh: true,
+          conflicts: 'proceed',
+        });
+      } catch {
+        // Continue cleanup even if alert deletion fails
+      }
+
+      // Delete the rule
+      try {
+        await apiServices.alerting.rules.delete(ruleId);
+      } catch {
+        // Continue cleanup even if rule deletion fails
+      }
+    }
+  });
+
+  test(
+    'Can create an error count rule from service inventory',
+    { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+    async ({ page, pageObjects: { serviceInventoryPage, alertsControls } }) => {
       await test.step('land on service inventory and opens alerts context menu', async () => {
         await serviceInventoryPage.gotoServiceInventory({
           rangeFrom: START_DATE,
@@ -47,7 +160,9 @@ test.describe(
 
       await test.step('fill rule definition step', async () => {
         await expect(
-          alertsControls.addRuleFlyout.flyout.getByRole('heading', { name: RULE_NAME })
+          alertsControls.addRuleFlyout.flyout.getByRole('heading', {
+            name: 'Error count threshold',
+          })
         ).toBeVisible();
         await alertsControls.addRuleFlyout.fillIsAbove(0);
         await expect(alertsControls.addRuleFlyout.isAboveExpression).toHaveText(
@@ -55,48 +170,28 @@ test.describe(
         );
       });
 
-      await test.step('create the rule', async () => {
+      await test.step('navigate to details step and set custom rule name', async () => {
         await alertsControls.addRuleFlyout.jumpToStep('details');
+        await alertsControls.addRuleFlyout.fillName(RULE_NAME);
+        await expect(alertsControls.addRuleFlyout.nameInput).toHaveValue(RULE_NAME);
+      });
+
+      await test.step('create the rule', async () => {
         await alertsControls.addRuleFlyout.saveRule({ saveEmptyActions: true });
         await expect(page.getByTestId('euiToastHeader')).toHaveText(`Created rule "${RULE_NAME}"`);
       });
+    }
+  );
 
-      await test.step('wait for the rule to be executed', async () => {
-        const foundResponse = await apiServices.alerting.rules.find({
-          search: RULE_NAME,
-          search_fields: ['name'],
-          per_page: 1,
-          page: 1,
-        });
-        const alert = foundResponse.data.data.find((obj: any) => obj.name === RULE_NAME);
-        expect(alert).toBeDefined();
-        const runDate = new Date();
-        await apiServices.alerting.rules.runSoon(alert!.id);
-        await apiServices.alerting.waiting.waitForExecutionCount(
-          alert!.id,
-          1,
-          undefined,
-          EXTENDED_TIMEOUT,
-          runDate
-        );
-      });
+  test(
+    'Stateful - Displays an alert in the service details alerts tab',
+    { tag: tags.stateful.classic },
+    createAlertDisplayTest(STATEFUL_ALERTS_INDEX)
+  );
 
-      await test.step('see alert in service alerts tab', async () => {
-        await serviceDetailsPage.alertsTab.goToTab({
-          serviceName: SERVICE_NAME,
-          rangeFrom: START_DATE,
-          rangeTo: END_DATE,
-        });
-        // Enter full screen mode to ensure reason cell is fully rendered
-        await serviceDetailsPage.alertsTab.alertsTable.openFullScreenMode();
-        const reasonCell = serviceDetailsPage.alertsTab.alertsTable.getCellLocatorByColId(
-          0,
-          'kibana.alert.reason'
-        );
-        await expect(reasonCell).toBeVisible();
-        await reasonCell.getByRole('button').click();
-        await expect(page.getByRole('dialog').getByText(`Rule: ${RULE_NAME}`)).toBeVisible();
-      });
-    });
-  }
-);
+  test(
+    'Serverless - Displays an alert in the service details alerts tab',
+    { tag: tags.serverless.observability.complete },
+    createAlertDisplayTest(SERVERLESS_ALERTS_INDEX)
+  );
+});

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
@@ -164,9 +164,10 @@ test.describe('Alerts', () => {
             name: 'Error count threshold',
           })
         ).toBeVisible();
-        await alertsControls.addRuleFlyout.fillIsAbove(0);
+        // Ensure the rule doesn't trigger alerts to avoid polluting the test environment with active alerts that could interfere with other tests
+        await alertsControls.addRuleFlyout.fillIsAbove(1000000);
         await expect(alertsControls.addRuleFlyout.isAboveExpression).toHaveText(
-          'is above 0 errors'
+          'is above 1000000 errors'
         );
       });
 

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts
@@ -171,7 +171,7 @@ test.describe('Alerts', () => {
         );
       });
 
-      await test.step('navigate to details step and set custom rule name', async () => {
+      await test.step('navigates to details step and set custom rule name', async () => {
         await alertsControls.addRuleFlyout.jumpToStep('details');
         await alertsControls.addRuleFlyout.fillName(RULE_NAME);
         await expect(alertsControls.addRuleFlyout.nameInput).toHaveValue(RULE_NAME);


### PR DESCRIPTION
## Summary

Closes #247467

This PR aims to rework the error count alerts test to avoid flaky behaviour. When migrating this test, I chose to try and replicate the existing approach that we were doing in cypress, which was clearly a mistake.

The source of flakiness in the test comes from it's own approach. The test used to do as follows:
1. Create an alert rule via the UI. The rule definition sets conditions that ensures the next rule execution will create an alert
2. Wait for the rule to execute and create a new alert
3. Navigate to the alerts tab in service details to verify the alert displays as expected

Now the problem comes in step 2. Rule execution is an async process that cannot really be precisely controlled in the test case. Plus, the minimum interval for rule execution is 1 minute* and Scout tests have a timeout of 60 secs. This is leading to the flaky behaviour observed where sometimes the rule does execute in time and the test passes while others the rule doesn't run and the test times out. Furthermore, there are also some cases where even when the rule runs in time and the alert is created that the interaction with the alerts table data grid is also flaky and test assertions fail anyway. In order to avoid this 2 problematic situations the new testing approach does the following:

To avoid rule execution timeouts, what used to be a single test case has now been split into 2 separate cases. The first new case is concerned with step 1 as described above and is focused on verifying an error count rule can be created from the APM view. The second case covers the old step 3, where it verifies that alerts related to a given service are properly displayed from the alerts tab on the service details page.

What we gain by separating the test into 2 distinct cases is that we can decouple the alert display from the rule execution. Instead of creating the rule and waiting for it's execution within a single test run we're now removing the need for what used to be step 2 and thus removing the waiting step that could lead to timeouts. Now, case 2 includes a setup phase where, via Scout fixtures, we're manually indexing a document in the alerts index. This way we can ensure, in a deterministic and stable way, that an alert will indeed be available for the test to display. There is also a cleanup routine inside an afterEach hook that will take care of removing any data that was created during the test (rules and alerts) so that no residual test data is left after test execution which could interfere with other tests running in parallel or after.

The interaction with the alerts table data grid have also been rework to remove flaky data grid behaviour causing potential issues in the second test case.

### Checklist

- [X] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
