### PR TITLE
Only show currently enabled integrations during o11y onboarding

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/package_list_search_form/package_list_search_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/package_list_search_form/package_list_search_form.tsx
@@ -13,6 +13,7 @@ import React, { useRef, useMemo } from 'react';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
 import { useCardUrlRewrite } from './use_card_url_rewrite';
 import { PackageList } from '../package_list/package_list';
+import { useFleetSettings } from '../../hooks/use_fleet_settings';
 
 interface Props {
   searchQuery: string;
@@ -29,6 +30,7 @@ interface Props {
 
 type WrapperProps = Props & {
   useAvailablePackages: AvailablePackagesHookType;
+  prereleaseIntegrationsEnabled: boolean;
 };
 
 const fetchAvailablePackagesHook = (): Promise<AvailablePackagesHookType> =>
@@ -46,9 +48,10 @@ const PackageListGridWrapper = ({
   customCards,
   flowCategory,
   excludePackageIdList = [],
+  prereleaseIntegrationsEnabled,
 }: WrapperProps) => {
   const { filteredCards: integrationCards, isLoading } = useAvailablePackages({
-    prereleaseIntegrationsEnabled: true,
+    prereleaseIntegrationsEnabled,
   });
   const rewriteUrl = useCardUrlRewrite({ category: flowCategory, search: searchQuery });
 
@@ -87,6 +90,7 @@ const PackageListGridWrapper = ({
 export const PackageListSearchForm = React.forwardRef(
   (props: Props, packageListRef?: React.Ref<HTMLDivElement>) => {
     const ref = useRef<AvailablePackagesHookType | null>(null);
+    const { prereleaseIntegrationsEnabled, isLoading: isLoadingSettings } = useFleetSettings();
 
     const {
       error: errorLoading,
@@ -127,13 +131,14 @@ export const PackageListSearchForm = React.forwardRef(
         </EuiCallOut>
       );
 
-    if (asyncLoading || ref.current === null) return <Loading />;
+    if (asyncLoading || ref.current === null || isLoadingSettings) return <Loading />;
 
     return (
       <PackageListGridWrapper
         {...props}
         useAvailablePackages={ref.current}
         packageListRef={packageListRef}
+        prereleaseIntegrationsEnabled={prereleaseIntegrationsEnabled}
       />
     );
   }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/components/beta_integrations_toggle/beta_integrations_toggle.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/components/beta_integrations_toggle/beta_integrations_toggle.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { EuiSwitch, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { HttpFetchOptions } from '@kbn/core/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { ObservabilityOnboardingContextValue } from '../..';
+
+interface BetaIntegrationsToggleProps {
+  /** Current state of the prerelease integrations setting */
+  prereleaseIntegrationsEnabled: boolean;
+  /** Callback when the setting changes */
+  onToggle: (enabled: boolean) => void;
+  /** Whether the toggle is disabled (e.g., while loading) */
+  disabled?: boolean;
+}
+
+export const BetaIntegrationsToggle: React.FC<BetaIntegrationsToggleProps> = ({
+  prereleaseIntegrationsEnabled,
+  onToggle,
+  disabled = false,
+}) => {
+  const {
+    services: { http, fleet, notifications },
+  } = useKibana<ObservabilityOnboardingContextValue>();
+
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [localChecked, setLocalChecked] = useState<boolean | undefined>(undefined);
+
+  // Check if user has permission to update Fleet settings
+  const canUpdateSettings = fleet?.authz?.fleet?.allSettings ?? false;
+
+  const handleToggle = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.checked;
+
+      if (!http) return;
+
+      try {
+        setIsUpdating(true);
+        setLocalChecked(newValue);
+
+        const options: HttpFetchOptions = {
+          headers: { 'Elastic-Api-Version': '2023-10-31' },
+          body: JSON.stringify({
+            prerelease_integrations_enabled: newValue,
+          }),
+        };
+
+        await http.put('/api/fleet/settings', options);
+        onToggle(newValue);
+      } catch (error) {
+        // Revert local state on error
+        setLocalChecked(!newValue);
+        notifications?.toasts?.addError(error as Error, {
+          title: i18n.translate(
+            'xpack.observability_onboarding.betaIntegrationsToggle.errorUpdatingSettings',
+            {
+              defaultMessage: 'Error updating beta integrations setting',
+            }
+          ),
+        });
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [http, notifications, onToggle]
+  );
+
+  // Don't render if user doesn't have permission
+  if (!canUpdateSettings) {
+    return null;
+  }
+
+  const currentValue = localChecked ?? prereleaseIntegrationsEnabled;
+
+  return (
+    <EuiToolTip
+      content={i18n.translate(
+        'xpack.observability_onboarding.betaIntegrationsToggle.tooltip',
+        {
+          defaultMessage:
+            'Beta integrations are not recommended for production environments. This setting also applies to Fleet Integrations.',
+        }
+      )}
+    >
+      <EuiSwitch
+        label={i18n.translate(
+          'xpack.observability_onboarding.betaIntegrationsToggle.label',
+          {
+            defaultMessage: 'Display beta integrations',
+          }
+        )}
+        checked={currentValue}
+        onChange={handleToggle}
+        disabled={disabled || isUpdating}
+        compressed
+        data-test-subj="observabilityOnboardingBetaIntegrationsToggle"
+      />
+    </EuiToolTip>
+  );
+};

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/components/beta_integrations_toggle/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/components/beta_integrations_toggle/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { BetaIntegrationsToggle } from './beta_integrations_toggle';

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.test.ts
@@ -169,4 +169,53 @@ describe('useFleetSettings', () => {
     // Should not make API call when fleet is not available
     expect(mockGet).not.toHaveBeenCalled();
   });
+
+  it('provides canUpdateSettings based on fleet.allSettings authorization', async () => {
+    mockGet.mockResolvedValue({
+      item: {
+        prerelease_integrations_enabled: true,
+      },
+    });
+
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        http: {
+          get: mockGet,
+        },
+        fleet: {
+          authz: {
+            fleet: {
+              readSettings: true,
+              allSettings: true,
+            },
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.canUpdateSettings).toBe(true);
+  });
+
+  it('provides refetch function to reload settings', async () => {
+    mockGet.mockResolvedValue({
+      item: {
+        prerelease_integrations_enabled: false,
+      },
+    });
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.refetch).toBeDefined();
+    expect(typeof result.current.refetch).toBe('function');
+  });
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.test.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useFleetSettings } from './use_fleet_settings';
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: jest.fn(),
+}));
+
+describe('useFleetSettings', () => {
+  const mockGet = jest.fn();
+
+  const createMockServices = (overrides = {}) => ({
+    services: {
+      http: {
+        get: mockGet,
+      },
+      fleet: {
+        authz: {
+          fleet: {
+            readSettings: true,
+          },
+        },
+      },
+      ...overrides,
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue(createMockServices());
+  });
+
+  it('returns prereleaseIntegrationsEnabled as true when setting is enabled', async () => {
+    mockGet.mockResolvedValue({
+      item: {
+        prerelease_integrations_enabled: true,
+      },
+    });
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    // Initially loading
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prereleaseIntegrationsEnabled).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(mockGet).toHaveBeenCalledWith('/api/fleet/settings', {
+      headers: { 'Elastic-Api-Version': '2023-10-31' },
+    });
+  });
+
+  it('returns prereleaseIntegrationsEnabled as false when setting is disabled', async () => {
+    mockGet.mockResolvedValue({
+      item: {
+        prerelease_integrations_enabled: false,
+      },
+    });
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prereleaseIntegrationsEnabled).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('defaults to false when setting is undefined', async () => {
+    mockGet.mockResolvedValue({
+      item: {},
+    });
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prereleaseIntegrationsEnabled).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('defaults to false and sets error when API call fails', async () => {
+    const error = new Error('API Error');
+    mockGet.mockRejectedValue(error);
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prereleaseIntegrationsEnabled).toBe(false);
+    expect(result.current.error).toEqual(error);
+  });
+
+  it('defaults to false when http service is not available', async () => {
+    (useKibana as jest.Mock).mockReturnValue(
+      createMockServices({
+        http: undefined,
+      })
+    );
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prereleaseIntegrationsEnabled).toBe(false);
+  });
+
+  it('defaults to false when user lacks readSettings permission', async () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        http: {
+          get: mockGet,
+        },
+        fleet: {
+          authz: {
+            fleet: {
+              readSettings: false,
+            },
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prereleaseIntegrationsEnabled).toBe(false);
+    // Should not make API call when user lacks permission
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('defaults to false when fleet service is not available', async () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        http: {
+          get: mockGet,
+        },
+        fleet: undefined,
+      },
+    });
+
+    const { result } = renderHook(() => useFleetSettings());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prereleaseIntegrationsEnabled).toBe(false);
+    // Should not make API call when fleet is not available
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.ts
@@ -22,6 +22,8 @@ interface UseFleetSettingsResult {
   prereleaseIntegrationsEnabled: boolean;
   isLoading: boolean;
   error: Error | null;
+  canUpdateSettings: boolean;
+  refetch: () => void;
 }
 
 export const useFleetSettings = (): UseFleetSettingsResult => {
@@ -33,8 +35,9 @@ export const useFleetSettings = (): UseFleetSettingsResult => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  // Check if user has permission to read Fleet settings
+  // Check if user has permission to read/update Fleet settings
   const canReadSettings = fleet?.authz?.fleet?.readSettings ?? false;
+  const canUpdateSettings = fleet?.authz?.fleet?.allSettings ?? false;
 
   const fetchSettings = useCallback(async () => {
     if (!http) {
@@ -75,5 +78,7 @@ export const useFleetSettings = (): UseFleetSettingsResult => {
     prereleaseIntegrationsEnabled,
     isLoading,
     error,
+    canUpdateSettings,
+    refetch: fetchSettings,
   };
 };

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/hooks/use_fleet_settings.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { HttpFetchOptions } from '@kbn/core/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { ObservabilityOnboardingContextValue } from '..';
+
+interface FleetSettings {
+  prerelease_integrations_enabled?: boolean;
+}
+
+interface FleetSettingsResponse {
+  item: FleetSettings;
+}
+
+interface UseFleetSettingsResult {
+  prereleaseIntegrationsEnabled: boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export const useFleetSettings = (): UseFleetSettingsResult => {
+  const {
+    services: { http, fleet },
+  } = useKibana<ObservabilityOnboardingContextValue>();
+
+  const [prereleaseIntegrationsEnabled, setPrereleaseIntegrationsEnabled] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Check if user has permission to read Fleet settings
+  const canReadSettings = fleet?.authz?.fleet?.readSettings ?? false;
+
+  const fetchSettings = useCallback(async () => {
+    if (!http) {
+      setIsLoading(false);
+      return;
+    }
+
+    // If user doesn't have permission to read settings, default to false (no beta integrations)
+    if (!canReadSettings) {
+      setPrereleaseIntegrationsEnabled(false);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const options: HttpFetchOptions = {
+        headers: { 'Elastic-Api-Version': '2023-10-31' },
+      };
+
+      const response = await http.get<FleetSettingsResponse>('/api/fleet/settings', options);
+      setPrereleaseIntegrationsEnabled(response.item.prerelease_integrations_enabled ?? false);
+      setError(null);
+    } catch (err) {
+      // If fetching settings fails (e.g., permissions), default to false (no beta integrations)
+      setPrereleaseIntegrationsEnabled(false);
+      setError(err instanceof Error ? err : new Error('Failed to fetch Fleet settings'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [http, canReadSettings]);
+
+  useEffect(() => {
+    fetchSettings();
+  }, [fetchSettings]);
+
+  return {
+    prereleaseIntegrationsEnabled,
+    isLoading,
+    error,
+  };
+};


### PR DESCRIPTION
This PR fixes an issue where the Observability add data onboarding displayed beta integrations even when the "Enable beta integrations" setting was disabled in Fleet, leading to errors when attempting to load them.

The solution involves:
1.  **Introducing a `useFleetSettings` hook:** This new hook fetches the `prerelease_integrations_enabled` setting from the Fleet API.
2.  **Updating `PackageListSearchForm`:** The component now uses the `prereleaseIntegrationsEnabled` value from the `useFleetSettings` hook to filter the displayed integrations, ensuring beta integrations are only shown when enabled in Fleet. It also waits for the settings to load before rendering.
3.  **Updating `useInstallIntegrations`:** This hook now uses the Fleet `prereleaseIntegrationsEnabled` setting (via a ref) when making API calls to install integrations, ensuring that installation requests respect the user's preference for beta integrations.

This ensures consistency with Fleet settings and prevents errors when users attempt to interact with disabled beta integrations.