### PR TITLE
[Stack Connectors] Add `region` to Bedrock Connector schema

### DIFF
--- a/src/platform/packages/shared/kbn-connector-schemas/bedrock/schemas/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/bedrock/schemas/v1.ts
@@ -21,6 +21,7 @@ export const TelemetryMetadataSchema = z
 export const ConfigSchema = z
   .object({
     apiUrl: z.string(),
+    region: z.string().optional(),
     defaultModel: z.string().default(DEFAULT_MODEL),
     contextWindowLength: z.coerce.number().optional(),
     temperature: z.coerce.number().optional(),

--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -18,6 +18,9 @@ Object {
           "default": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "type": "string",
         },
+        "region": Object {
+          "type": "string",
+        },
         "temperature": Object {
           "type": "number",
         },


### PR DESCRIPTION
## Summary

There have been on-going issues with `region` extraction from the configured URL in the Bedrock Connector. Initial efforts to remove the default fallback region (https://github.com/elastic/kibana/pull/241157) were unsuccessful, so we're going to go ahead and add a dedicated _optional_ `region` field for users to explicitly specify. 

This PR introduces the schema change that's required to add this setting to the Bedrock Connector.
The schema change needs to be released first in order to not break older Kibana versions.

Follow up PR to add this setting to the Bedrock connector UI and use this setting in the Bedrock client  - https://github.com/elastic/kibana/pull/252960


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [X] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

_PR developed with cursor-cli + GPT 5.2-high_

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.2"]} ONMERGE-->