### PR TITLE
[CI / FIPS] Remove 9.3 from FIPS daily

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
@@ -35,12 +35,6 @@ spec:
           cronline: 0 5 * * * America/New_York
           env:
             TEST_ENABLE_FIPS_VERSION: '140-2'
-        '140-2 Daily build (9.3)':
-          message: 140-2 Daily build
-          branch: '9.3'
-          cronline: 0 5 * * * America/New_York
-          env:
-            TEST_ENABLE_FIPS_VERSION: '140-2'
         '140-2 Daily build (8.19)':
           message: 140-2 Daily build
           branch: '8.19'
@@ -50,12 +44,6 @@ spec:
         '140-3 Daily build (main)':
           message: 140-3 Daily build
           branch: main
-          cronline: 0 5 * * * America/New_York
-          env:
-            TEST_ENABLE_FIPS_VERSION: '140-3'
-        '140-3 Daily build (9.3)':
-          message: 140-3 Daily build
-          branch: '9.3'
           cronline: 0 5 * * * America/New_York
           env:
             TEST_ENABLE_FIPS_VERSION: '140-3'


### PR DESCRIPTION
## Summary

`9.3` runs were accidently started for daily FIPS runs in #251993. We only need to run for `main` and `8.19`. See https://github.com/elastic/kibana/pull/251993#discussion_r2775328450

