### PR TITLE
[content-list] Add search to provider, toolbar

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -24,9 +24,14 @@ export type {
 } from './src/context';
 
 // Hooks.
-export { useContentListItems } from './src/state';
-export { useContentListSort } from './src/features';
+export { useContentListItems, useContentListState } from './src/state';
+export type { ContentListQueryData } from './src/state';
+export { useContentListSort, useContentListSearch } from './src/features';
 export { useContentListPagination } from './src/features';
+
+// State.
+export { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './src/state';
+export type { ContentListAction } from './src/state';
 
 // Types.
 export type { ContentListItem, ContentListItemConfig } from './src/item';
@@ -39,8 +44,11 @@ export type {
   UseContentListSortReturn,
   PaginationConfig,
   UseContentListPaginationReturn,
+  SearchConfig,
+  UseContentListSearchReturn,
 } from './src/features';
 export type {
+  ActiveFilters,
   FindItemsFn,
   FindItemsParams,
   FindItemsResult,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.test.tsx
@@ -151,6 +151,32 @@ describe('ContentListProvider', () => {
 
       expect(result.current.supports.sorting).toBe(true);
     });
+
+    it('enables search by default', () => {
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.supports.search).toBe(true);
+    });
+
+    it('respects search: false in features', () => {
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({ features: { search: false } }),
+      });
+
+      expect(result.current.supports.search).toBe(false);
+    });
+
+    it('enables search when search config is provided', () => {
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          features: { search: { initialSearch: 'hello' } },
+        }),
+      });
+
+      expect(result.current.supports.search).toBe(true);
+    });
   });
 
   describe('features pass-through', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
@@ -54,11 +54,12 @@ export type ContentListProviderProps = ContentListConfig & {
 
 /**
  * Main provider component for content list functionality, including data fetching
- * (via React Query) and sorting.
+ * (via React Query), sorting, and search.
  *
  * Props like `dataSource` and `features` should be stable references to avoid
- * unnecessary re-renders. Configuration from `features.sorting` is read once at
- * mount; use a `key` prop to remount if you need to change initial sort dynamically.
+ * unnecessary re-renders. Configuration from `features.sorting` and `features.search`
+ * is read once at mount; use a `key` prop to remount if you need to change initial
+ * state dynamically.
  */
 export const ContentListProvider = ({
   children,
@@ -79,8 +80,9 @@ export const ContentListProvider = ({
     () => ({
       sorting: features.sorting !== false,
       pagination: features.pagination !== false,
+      search: features.search !== false,
     }),
-    [features.sorting, features.pagination]
+    [features.sorting, features.pagination, features.search]
   );
 
   // Create context value.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
@@ -21,10 +21,15 @@ export interface ActiveFilters {
  * Parameters for the `findItems` function.
  */
 export interface FindItemsParams {
-  /** Search query text with filter syntax already extracted. */
+  /**
+   * Search query text with filter syntax already extracted.
+   *
+   * This is a convenience alias for `filters.search ?? ''`. When building
+   * queries, prefer this over accessing `filters.search` directly.
+   */
   searchQuery: string;
 
-  /** Active filters. */
+  /** Active filters (includes the raw `search` text and any structured filters). */
   filters: ActiveFilters;
 
   /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
@@ -9,7 +9,7 @@
 
 // Feature types.
 export type { ContentListFeatures, ContentListSupports } from './types';
-export { isSortingConfig, isPaginationConfig } from './types';
+export { isSortingConfig, isPaginationConfig, isSearchConfig } from './types';
 
 // Sorting feature.
 export type { SortField, SortOption, SortingConfig, UseContentListSortReturn } from './sorting';
@@ -18,3 +18,7 @@ export { useContentListSort } from './sorting';
 // Pagination feature.
 export type { PaginationConfig, UseContentListPaginationReturn } from './pagination';
 export { useContentListPagination } from './pagination';
+
+// Search feature.
+export type { SearchConfig, UseContentListSearchReturn } from './search';
+export { useContentListSearch } from './search';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/index.ts
@@ -7,14 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { ContentListStateProvider } from './state_provider';
-export { useContentListState, ContentListStateContext } from './use_content_list_state';
-export { useContentListItems } from './use_content_list_items';
-export { reducer } from './state_reducer';
-export type {
-  ContentListState,
-  ContentListAction,
-  ContentListQueryData,
-  ContentListStateContextValue,
-} from './types';
-export { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
+export type { SearchConfig } from './types';
+export { useContentListSearch } from './use_content_list_search';
+export type { UseContentListSearchReturn } from './use_content_list_search';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/types.ts
@@ -7,14 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { ContentListStateProvider } from './state_provider';
-export { useContentListState, ContentListStateContext } from './use_content_list_state';
-export { useContentListItems } from './use_content_list_items';
-export { reducer } from './state_reducer';
-export type {
-  ContentListState,
-  ContentListAction,
-  ContentListQueryData,
-  ContentListStateContextValue,
-} from './types';
-export { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
+/**
+ * Search configuration.
+ *
+ * Controls the search input behavior in the toolbar.
+ */
+export interface SearchConfig {
+  /** Initial search text to populate on mount. */
+  initialSearch?: string;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { ContentListProvider } from '../../context';
 import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import { useContentListState } from '../../state';
 import { useContentListSearch } from './use_content_list_search';
 
 describe('useContentListSearch', () => {
@@ -21,17 +22,27 @@ describe('useContentListSearch', () => {
     })
   );
 
-  const createWrapper = (options?: { initialSearch?: string; searchDisabled?: boolean }) => {
-    const { initialSearch, searchDisabled } = options ?? {};
+  const createWrapper = (options?: {
+    initialSearch?: string;
+    searchDisabled?: boolean;
+    pagination?: { initialPageSize: number };
+  }) => {
+    const { initialSearch, searchDisabled, pagination } = options ?? {};
 
     const resolveFeatures = () => {
+      const base: Record<string, unknown> = {};
+
       if (searchDisabled) {
-        return { search: false as const };
+        base.search = false as const;
+      } else if (initialSearch) {
+        base.search = { initialSearch };
       }
-      if (initialSearch) {
-        return { search: { initialSearch } };
+
+      if (pagination) {
+        base.pagination = pagination;
       }
-      return undefined;
+
+      return Object.keys(base).length > 0 ? base : undefined;
     };
 
     const features = resolveFeatures();
@@ -93,7 +104,7 @@ describe('useContentListSearch', () => {
       });
 
       act(() => {
-        result.current.setSearch('dashboard');
+        result.current.setSearch('dashboard', { search: 'dashboard' });
       });
 
       expect(result.current.search).toBe('dashboard');
@@ -105,7 +116,7 @@ describe('useContentListSearch', () => {
       });
 
       act(() => {
-        result.current.setSearch('');
+        result.current.setSearch('', { search: undefined });
       });
 
       expect(result.current.search).toBe('');
@@ -119,7 +130,7 @@ describe('useContentListSearch', () => {
       const initialSearch = result.current.search;
 
       act(() => {
-        result.current.setSearch('should not update');
+        result.current.setSearch('should not update', { search: 'should not update' });
       });
 
       // Search should not change when disabled.
@@ -132,15 +143,15 @@ describe('useContentListSearch', () => {
       });
 
       act(() => {
-        result.current.setSearch('first');
+        result.current.setSearch('first', { search: 'first' });
       });
 
       act(() => {
-        result.current.setSearch('second');
+        result.current.setSearch('second', { search: 'second' });
       });
 
       act(() => {
-        result.current.setSearch('third');
+        result.current.setSearch('third', { search: 'third' });
       });
 
       expect(result.current.search).toBe('third');
@@ -173,6 +184,39 @@ describe('useContentListSearch', () => {
       );
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('state integration', () => {
+    it('updates filters and resets page index when setSearch is called', () => {
+      const { result } = renderHook(
+        () => ({
+          searchHook: useContentListSearch(),
+          stateHook: useContentListState(),
+        }),
+        {
+          wrapper: createWrapper({ pagination: { initialPageSize: 10 } }),
+        }
+      );
+
+      // Advance to page 2 first so we can verify the reset.
+      act(() => {
+        result.current.stateHook.dispatch({
+          type: 'SET_PAGE_INDEX',
+          payload: { index: 2 },
+        });
+      });
+
+      expect(result.current.stateHook.state.page.index).toBe(2);
+
+      // Calling `setSearch` should update filters and reset page index to 0.
+      act(() => {
+        result.current.searchHook.setSearch('dashboard', { search: 'dashboard' });
+      });
+
+      expect(result.current.stateHook.state.filters).toEqual({ search: 'dashboard' });
+      expect(result.current.stateHook.state.page.index).toBe(0);
+      expect(result.current.stateHook.state.page.size).toBe(10);
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ContentListProvider } from '../../context';
+import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import { useContentListSearch } from './use_content_list_search';
+
+describe('useContentListSearch', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: [],
+      total: 0,
+    })
+  );
+
+  const createWrapper = (options?: { initialSearch?: string; searchDisabled?: boolean }) => {
+    const { initialSearch, searchDisabled } = options ?? {};
+
+    const resolveFeatures = () => {
+      if (searchDisabled) {
+        return { search: false as const };
+      }
+      if (initialSearch) {
+        return { search: { initialSearch } };
+      }
+      return undefined;
+    };
+
+    const features = resolveFeatures();
+
+    return ({ children }: { children: React.ReactNode }) => (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'item', entityPlural: 'items' }}
+        dataSource={{ findItems: mockFindItems }}
+        features={features}
+      >
+        {children}
+      </ContentListProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('returns empty search text by default', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.search).toBe('');
+    });
+
+    it('returns initial search from features config', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper({ initialSearch: 'hello' }),
+      });
+
+      expect(result.current.search).toBe('hello');
+    });
+
+    it('returns isSupported true by default', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it('returns isSupported false when search is disabled', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper({ searchDisabled: true }),
+      });
+
+      expect(result.current.isSupported).toBe(false);
+    });
+  });
+
+  describe('setSearch', () => {
+    it('updates the search text', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSearch('dashboard');
+      });
+
+      expect(result.current.search).toBe('dashboard');
+    });
+
+    it('clears search text when set to empty string', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper({ initialSearch: 'initial' }),
+      });
+
+      act(() => {
+        result.current.setSearch('');
+      });
+
+      expect(result.current.search).toBe('');
+    });
+
+    it('is a no-op when search is disabled', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper({ searchDisabled: true }),
+      });
+
+      const initialSearch = result.current.search;
+
+      act(() => {
+        result.current.setSearch('should not update');
+      });
+
+      // Search should not change when disabled.
+      expect(result.current.search).toBe(initialSearch);
+    });
+
+    it('can be called multiple times', () => {
+      const { result } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSearch('first');
+      });
+
+      act(() => {
+        result.current.setSearch('second');
+      });
+
+      act(() => {
+        result.current.setSearch('third');
+      });
+
+      expect(result.current.search).toBe('third');
+    });
+  });
+
+  describe('function stability', () => {
+    it('provides stable setSearch reference across renders', () => {
+      const { result, rerender } = renderHook(() => useContentListSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      const firstSetSearch = result.current.setSearch;
+      rerender();
+      const secondSetSearch = result.current.setSearch;
+
+      expect(firstSetSearch).toBe(secondSetSearch);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws when used outside provider', () => {
+      // Suppress console.error for expected error.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useContentListSearch());
+      }).toThrow(
+        'ContentListContext is missing. Ensure your component is wrapped with ContentListProvider.'
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import { useContentListState } from '../../state/use_content_list_state';
+import { useContentListConfig } from '../../context';
+import { CONTENT_LIST_ACTIONS } from '../../state/types';
+
+/**
+ * Return type for the {@link useContentListSearch} hook.
+ */
+export interface UseContentListSearchReturn {
+  /** Current search text (empty string when no search is active). */
+  search: string;
+  /** Updates the search text. No-op if search is disabled. */
+  setSearch: (text: string) => void;
+  /** Whether search is supported (enabled via features). */
+  isSupported: boolean;
+}
+
+/**
+ * Hook to access and control the search query text.
+ *
+ * Returns the raw `EuiSearchBar` query text (`search.queryText`) and a setter.
+ * When search is disabled via `features.search: false`, `setSearch` becomes a no-op
+ * and `isSupported` returns `false`.
+ *
+ * **Important**: `setSearch` only updates the displayed query text. It does
+ * **not** update `filters` (which drives data fetching). Callers must also
+ * dispatch `SET_FILTERS` so the query actually refetches. `ContentListToolbar`
+ * handles this automatically — use this hook directly only when building a
+ * custom search UI.
+ *
+ * @throws Error if used outside `ContentListProvider`.
+ * @returns Object containing `search` text, `setSearch` function, and `isSupported` flag.
+ *
+ * @example
+ * ```tsx
+ * const SearchInput = () => {
+ *   const { search, setSearch, isSupported } = useContentListSearch();
+ *   const { dispatch } = useContentListState();
+ *
+ *   if (!isSupported) return null;
+ *
+ *   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+ *     const text = e.target.value;
+ *     setSearch(text);
+ *     // Also update filters so the query refetches.
+ *     dispatch({
+ *       type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+ *       payload: { search: text.trim() || undefined },
+ *     });
+ *   };
+ *
+ *   return (
+ *     <EuiFieldSearch
+ *       value={search}
+ *       onChange={handleChange}
+ *       placeholder="Search..."
+ *     />
+ *   );
+ * };
+ * ```
+ */
+export const useContentListSearch = (): UseContentListSearchReturn => {
+  const { supports } = useContentListConfig();
+  const { state, dispatch } = useContentListState();
+
+  const setSearch = useCallback(
+    (text: string) => {
+      if (!supports.search) {
+        return;
+      }
+      dispatch({ type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY, payload: text });
+    },
+    [dispatch, supports.search]
+  );
+
+  return {
+    search: state.search.queryText,
+    setSearch,
+    isSupported: supports.search,
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.ts
@@ -11,6 +11,7 @@ import { useCallback } from 'react';
 import { useContentListState } from '../../state/use_content_list_state';
 import { useContentListConfig } from '../../context';
 import { CONTENT_LIST_ACTIONS } from '../../state/types';
+import type { ActiveFilters } from '../../datasource';
 
 /**
  * Return type for the {@link useContentListSearch} hook.
@@ -18,8 +19,14 @@ import { CONTENT_LIST_ACTIONS } from '../../state/types';
 export interface UseContentListSearchReturn {
   /** Current search text (empty string when no search is active). */
   search: string;
-  /** Updates the search text. No-op if search is disabled. */
-  setSearch: (text: string) => void;
+  /**
+   * Atomically updates the query text and parsed filters in a single dispatch.
+   * No-op if search is disabled.
+   *
+   * @param queryText - The raw `EuiSearchBar` query text (may include filter syntax).
+   * @param filters - The parsed {@link ActiveFilters} derived from `queryText`.
+   */
+  setSearch: (queryText: string, filters: ActiveFilters) => void;
   /** Whether search is supported (enabled via features). */
   isSupported: boolean;
 }
@@ -27,15 +34,10 @@ export interface UseContentListSearchReturn {
 /**
  * Hook to access and control the search query text.
  *
- * Returns the raw `EuiSearchBar` query text (`search.queryText`) and a setter.
- * When search is disabled via `features.search: false`, `setSearch` becomes a no-op
- * and `isSupported` returns `false`.
- *
- * **Important**: `setSearch` only updates the displayed query text. It does
- * **not** update `filters` (which drives data fetching). Callers must also
- * dispatch `SET_FILTERS` so the query actually refetches. `ContentListToolbar`
- * handles this automatically — use this hook directly only when building a
- * custom search UI.
+ * Returns the raw `EuiSearchBar` query text (`search.queryText`) and a setter
+ * that atomically updates both the displayed query text and the parsed filters
+ * used for data fetching. When search is disabled via `features.search: false`,
+ * `setSearch` becomes a no-op and `isSupported` returns `false`.
  *
  * @throws Error if used outside `ContentListProvider`.
  * @returns Object containing `search` text, `setSearch` function, and `isSupported` flag.
@@ -44,18 +46,12 @@ export interface UseContentListSearchReturn {
  * ```tsx
  * const SearchInput = () => {
  *   const { search, setSearch, isSupported } = useContentListSearch();
- *   const { dispatch } = useContentListState();
  *
  *   if (!isSupported) return null;
  *
  *   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
  *     const text = e.target.value;
- *     setSearch(text);
- *     // Also update filters so the query refetches.
- *     dispatch({
- *       type: CONTENT_LIST_ACTIONS.SET_FILTERS,
- *       payload: { search: text.trim() || undefined },
- *     });
+ *     setSearch(text, { search: text.trim() || undefined });
  *   };
  *
  *   return (
@@ -73,11 +69,14 @@ export const useContentListSearch = (): UseContentListSearchReturn => {
   const { state, dispatch } = useContentListState();
 
   const setSearch = useCallback(
-    (text: string) => {
+    (queryText: string, filters: ActiveFilters) => {
       if (!supports.search) {
         return;
       }
-      dispatch({ type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY, payload: text });
+      dispatch({
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText, filters },
+      });
     },
     [dispatch, supports.search]
   );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
@@ -9,6 +9,7 @@
 
 import type { SortingConfig } from './sorting';
 import type { PaginationConfig } from './pagination';
+import type { SearchConfig } from './search';
 
 /**
  * Feature configuration for enabling/customizing content list capabilities.
@@ -18,6 +19,8 @@ export interface ContentListFeatures {
   sorting?: SortingConfig | boolean;
   /** Pagination configuration. Set to `false` to disable pagination entirely. */
   pagination?: PaginationConfig | boolean;
+  /** Search configuration. */
+  search?: SearchConfig | boolean;
 }
 
 /**
@@ -34,6 +37,13 @@ export const isPaginationConfig = (
   pagination?: PaginationConfig | boolean
 ): pagination is PaginationConfig => {
   return typeof pagination === 'object' && pagination !== null;
+};
+
+/**
+ * Type guard to check if search config is a `SearchConfig` object (not boolean).
+ */
+export const isSearchConfig = (search: ContentListFeatures['search']): search is SearchConfig => {
+  return typeof search === 'object' && search !== null;
 };
 
 /**
@@ -64,4 +74,6 @@ export interface ContentListSupports {
   sorting: boolean;
   /** Whether pagination is supported. */
   pagination: boolean;
+  /** Whether search is supported. */
+  search: boolean;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query/use_content_list_items_query.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query/use_content_list_items_query.ts
@@ -50,8 +50,8 @@ export const useContentListItemsQuery = (
   );
 
   // React Query for data fetching.
-  // `keepPreviousData` keeps the previous page visible while the next page loads,
-  // preventing the table from collapsing to zero rows and causing a scroll-to-top.
+  // `keepPreviousData` retains the previous results while a new query loads,
+  // preventing the table from flashing empty when page, filters, or search text change.
   const query = useQuery({
     queryKey: contentListKeys.items(queryKeyScope, queryParams),
     keepPreviousData: true,
@@ -87,7 +87,8 @@ export const useContentListItemsQuery = (
   return {
     items: query.data?.items ?? [],
     totalItems: query.data?.total ?? 0,
-    isLoading: query.isLoading || query.isFetching,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
     error,
     refetch: query.refetch,
   };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
@@ -13,7 +13,7 @@ import type { ContentListClientState, ContentListStateContextValue } from './typ
 import { DEFAULT_FILTERS } from './types';
 import { ContentListStateContext } from './use_content_list_state';
 import { useContentListConfig } from '../context';
-import { isSortingConfig, isPaginationConfig } from '../features';
+import { isSortingConfig, isPaginationConfig, isSearchConfig } from '../features';
 import { DEFAULT_PAGE_SIZE } from '../features/pagination';
 import { getPersistedPageSize } from '../features/pagination';
 import type { PaginationConfig } from '../features/pagination';
@@ -52,19 +52,19 @@ const resolveInitialPageSize = (
  * Internal provider component that manages the runtime state of the content list.
  *
  * This provider:
- * - Manages client-controlled state (filters, sort, pagination) via reducer.
+ * - Manages client-controlled state (search, filters, sort, pagination) via reducer.
  * - Uses React Query for data fetching with caching and deduplication.
  * - Combines client state with query data for a unified state interface.
  *
- * Note: Initial state is derived from `features.sorting` and `features.pagination`
- * at mount and not updated if configuration changes. See {@link ContentListProvider}
- * for details.
+ * Note: Initial state is derived from `features.sorting`, `features.pagination`, and
+ * `features.search` at mount and not updated if configuration changes.
+ * See {@link ContentListProvider} for details.
  *
  * @internal This is automatically included when using `ContentListProvider`.
  */
 export const ContentListStateProvider = ({ children }: ContentListStateProviderProps) => {
   const { features, queryKeyScope } = useContentListConfig();
-  const { sorting, pagination } = features;
+  const { sorting, pagination, search } = features;
 
   // Determine initial sort from sorting config (default: title ascending).
   const initialSort = useMemo(() => {
@@ -80,14 +80,23 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
     [pagination, queryKeyScope]
   );
 
-  // Initial client state (filters, sort, page).
+  // Determine initial search from search config (default: undefined).
+  const initialSearch = useMemo(() => {
+    if (isSearchConfig(search) && search.initialSearch) {
+      return search.initialSearch;
+    }
+    return undefined;
+  }, [search]);
+
+  // Initial client state (search, filters, sort, page).
   const initialClientState: ContentListClientState = useMemo(
     () => ({
-      filters: { ...DEFAULT_FILTERS },
+      search: { queryText: initialSearch ?? '' },
+      filters: { ...DEFAULT_FILTERS, search: initialSearch },
       sort: initialSort,
       page: { index: 0, size: initialPageSize },
     }),
-    [initialSort, initialPageSize]
+    [initialSort, initialPageSize, initialSearch]
   );
 
   const [clientState, dispatch] = useReducer(reducer, initialClientState);
@@ -97,6 +106,7 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
     items,
     totalItems,
     isLoading,
+    isFetching,
     error,
     refetch: queryRefetch,
   } = useContentListItemsQuery(clientState);
@@ -112,12 +122,13 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
         items,
         totalItems,
         isLoading,
+        isFetching,
         error,
       },
       dispatch,
       refetch,
     }),
-    [clientState, items, totalItems, isLoading, error, dispatch, refetch]
+    [clientState, items, totalItems, isLoading, isFetching, error, dispatch, refetch]
   );
 
   return (

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
@@ -15,12 +15,13 @@ describe('state_reducer', () => {
   /**
    * Creates initial client state for testing.
    *
-   * Note: The reducer only manages client-controlled state (filters, sort, pagination).
+   * Note: The reducer only manages client-controlled state (search, filters, sort, pagination).
    * Query data (items, isLoading, error) is managed by React Query directly.
    */
   const createInitialState = (
     overrides?: Partial<ContentListClientState>
   ): ContentListClientState => ({
+    search: { queryText: '' },
     filters: DEFAULT_FILTERS,
     sort: { field: 'updatedAt', direction: 'desc' },
     page: { index: 0, size: 20 },
@@ -108,6 +109,160 @@ describe('state_reducer', () => {
 
       expect(newState.filters).toEqual({ search: 'test query' });
       expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+  });
+
+  describe('SET_SEARCH_QUERY', () => {
+    it('sets search query text', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
+        payload: 'dashboard',
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).toBe('dashboard');
+    });
+
+    it('does not update filters', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
+        payload: 'dashboard',
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual(DEFAULT_FILTERS);
+    });
+
+    it('preserves sort when setting search query', () => {
+      const initialState = createInitialState({
+        sort: { field: 'title', direction: 'asc' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
+        payload: 'test query',
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+  });
+
+  describe('SET_FILTERS', () => {
+    it('sets filters', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'dashboard' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual({ search: 'dashboard' });
+    });
+
+    it('does not update search query text', () => {
+      const initialState = createInitialState({
+        search: { queryText: 'existing' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'new filter' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).toBe('existing');
+    });
+
+    it('preserves sort when setting filters', () => {
+      const initialState = createInitialState({
+        sort: { field: 'title', direction: 'asc' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'test' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+
+    it('resets page index to 0 when filters change', () => {
+      const initialState = createInitialState({ page: { index: 5, size: 20 } });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'dashboard' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.page.index).toBe(0);
+      expect(newState.page.size).toBe(20);
+    });
+  });
+
+  describe('CLEAR_FILTERS', () => {
+    it('resets filters to defaults', () => {
+      const initialState = createInitialState({
+        filters: { search: 'something' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual(DEFAULT_FILTERS);
+    });
+
+    it('resets search query text to empty string', () => {
+      const initialState = createInitialState({
+        search: { queryText: 'tag:prod my search' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).toBe('');
+    });
+
+    it('preserves sort when clearing filters', () => {
+      const initialState = createInitialState({
+        sort: { field: 'title', direction: 'asc' },
+        filters: { search: 'test' },
+        search: { queryText: 'test' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+
+    it('resets page index to 0 when filters are cleared', () => {
+      const initialState = createInitialState({
+        filters: { search: 'test' },
+        search: { queryText: 'test' },
+        page: { index: 3, size: 20 },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.page.index).toBe(0);
+      expect(newState.page.size).toBe(20);
     });
   });
 
@@ -204,6 +359,68 @@ describe('state_reducer', () => {
 
       expect(initialState.sort).toBe(originalSort);
       expect(initialState.filters).toBe(originalFilters);
+    });
+
+    it('returns a new state object for SET_SEARCH_QUERY', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
+        payload: 'test',
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState).not.toBe(initialState);
+    });
+
+    it('does not mutate the original search on SET_SEARCH_QUERY', () => {
+      const initialState = createInitialState();
+      const originalSearch = initialState.search;
+
+      reducer(initialState, {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
+        payload: 'test',
+      });
+
+      expect(initialState.search).toBe(originalSearch);
+    });
+
+    it('returns a new state object for SET_FILTERS', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'test' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState).not.toBe(initialState);
+    });
+
+    it('does not mutate the original filters on SET_FILTERS', () => {
+      const initialState = createInitialState();
+      const originalFilters = initialState.filters;
+
+      reducer(initialState, {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'test' },
+      });
+
+      expect(initialState.filters).toBe(originalFilters);
+    });
+
+    it('returns a new state object for CLEAR_FILTERS', () => {
+      const initialState = createInitialState({
+        filters: { search: 'test' },
+        search: { queryText: 'test' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState).not.toBe(initialState);
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
@@ -112,98 +112,74 @@ describe('state_reducer', () => {
     });
   });
 
-  describe('SET_SEARCH_QUERY', () => {
-    it('sets search query text', () => {
+  describe('SET_SEARCH', () => {
+    it('sets search query text and filters atomically', () => {
       const initialState = createInitialState();
       const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
-        payload: 'dashboard',
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'dashboard', filters: { search: 'dashboard' } },
       };
 
       const newState = reducer(initialState, action);
 
       expect(newState.search.queryText).toBe('dashboard');
-    });
-
-    it('does not update filters', () => {
-      const initialState = createInitialState();
-      const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
-        payload: 'dashboard',
-      };
-
-      const newState = reducer(initialState, action);
-
-      expect(newState.filters).toEqual(DEFAULT_FILTERS);
-    });
-
-    it('preserves sort when setting search query', () => {
-      const initialState = createInitialState({
-        sort: { field: 'title', direction: 'asc' },
-      });
-      const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
-        payload: 'test query',
-      };
-
-      const newState = reducer(initialState, action);
-
-      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
-    });
-  });
-
-  describe('SET_FILTERS', () => {
-    it('sets filters', () => {
-      const initialState = createInitialState();
-      const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: 'dashboard' },
-      };
-
-      const newState = reducer(initialState, action);
-
       expect(newState.filters).toEqual({ search: 'dashboard' });
     });
 
-    it('does not update search query text', () => {
-      const initialState = createInitialState({
-        search: { queryText: 'existing' },
-      });
-      const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: 'new filter' },
-      };
-
-      const newState = reducer(initialState, action);
-
-      expect(newState.search.queryText).toBe('existing');
-    });
-
-    it('preserves sort when setting filters', () => {
-      const initialState = createInitialState({
-        sort: { field: 'title', direction: 'asc' },
-      });
-      const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: 'test' },
-      };
-
-      const newState = reducer(initialState, action);
-
-      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
-    });
-
-    it('resets page index to 0 when filters change', () => {
+    it('resets page index to 0 when search changes', () => {
       const initialState = createInitialState({ page: { index: 5, size: 20 } });
       const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: 'dashboard' },
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'dashboard', filters: { search: 'dashboard' } },
       };
 
       const newState = reducer(initialState, action);
 
       expect(newState.page.index).toBe(0);
       expect(newState.page.size).toBe(20);
+    });
+
+    it('preserves sort when setting search', () => {
+      const initialState = createInitialState({
+        sort: { field: 'title', direction: 'asc' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'test query', filters: { search: 'test query' } },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+
+    it('allows filters to differ from query text (e.g. tag syntax)', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'tag:prod my search', filters: { search: 'my search' } },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).toBe('tag:prod my search');
+      expect(newState.filters).toEqual({ search: 'my search' });
+    });
+
+    it('clears filters when search text is empty', () => {
+      const initialState = createInitialState({
+        search: { queryText: 'existing' },
+        filters: { search: 'existing' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: '', filters: { search: undefined } },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).toBe('');
+      expect(newState.filters).toEqual({ search: undefined });
     });
   });
 
@@ -361,11 +337,11 @@ describe('state_reducer', () => {
       expect(initialState.filters).toBe(originalFilters);
     });
 
-    it('returns a new state object for SET_SEARCH_QUERY', () => {
+    it('returns a new state object for SET_SEARCH', () => {
       const initialState = createInitialState();
       const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
-        payload: 'test',
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'test', filters: { search: 'test' } },
       };
 
       const newState = reducer(initialState, action);
@@ -373,39 +349,17 @@ describe('state_reducer', () => {
       expect(newState).not.toBe(initialState);
     });
 
-    it('does not mutate the original search on SET_SEARCH_QUERY', () => {
+    it('does not mutate the original search or filters on SET_SEARCH', () => {
       const initialState = createInitialState();
       const originalSearch = initialState.search;
-
-      reducer(initialState, {
-        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
-        payload: 'test',
-      });
-
-      expect(initialState.search).toBe(originalSearch);
-    });
-
-    it('returns a new state object for SET_FILTERS', () => {
-      const initialState = createInitialState();
-      const action: ContentListAction = {
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: 'test' },
-      };
-
-      const newState = reducer(initialState, action);
-
-      expect(newState).not.toBe(initialState);
-    });
-
-    it('does not mutate the original filters on SET_FILTERS', () => {
-      const initialState = createInitialState();
       const originalFilters = initialState.filters;
 
       reducer(initialState, {
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: 'test' },
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'test', filters: { search: 'test' } },
       });
 
+      expect(initialState.search).toBe(originalSearch);
       expect(initialState.filters).toBe(originalFilters);
     });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
@@ -8,12 +8,12 @@
  */
 
 import type { ContentListClientState, ContentListAction } from './types';
-import { CONTENT_LIST_ACTIONS } from './types';
+import { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
 
 /**
  * State reducer for client-controlled state.
  *
- * Handles user-driven state mutations (filters, sort, pagination).
+ * Handles user-driven state mutations (search, filters, sort, pagination).
  * Query data (items, loading, error) is managed by React Query directly.
  *
  * @param state - Current client state.
@@ -25,6 +25,29 @@ export const reducer = (
   action: ContentListAction
 ): ContentListClientState => {
   switch (action.type) {
+    case CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY:
+      return {
+        ...state,
+        search: { queryText: action.payload },
+      };
+
+    case CONTENT_LIST_ACTIONS.SET_FILTERS:
+      return {
+        ...state,
+        filters: action.payload,
+        // Reset to first page when filters change to avoid stale page offsets.
+        page: { ...state.page, index: 0 },
+      };
+
+    case CONTENT_LIST_ACTIONS.CLEAR_FILTERS:
+      return {
+        ...state,
+        filters: { ...DEFAULT_FILTERS },
+        search: { queryText: '' },
+        // Reset to first page when filters are cleared to avoid stale page offsets.
+        page: { ...state.page, index: 0 },
+      };
+
     case CONTENT_LIST_ACTIONS.SET_SORT:
       return {
         ...state,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
@@ -25,17 +25,12 @@ export const reducer = (
   action: ContentListAction
 ): ContentListClientState => {
   switch (action.type) {
-    case CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY:
+    case CONTENT_LIST_ACTIONS.SET_SEARCH:
       return {
         ...state,
-        search: { queryText: action.payload },
-      };
-
-    case CONTENT_LIST_ACTIONS.SET_FILTERS:
-      return {
-        ...state,
-        filters: action.payload,
-        // Reset to first page when filters change to avoid stale page offsets.
+        search: { queryText: action.payload.queryText },
+        filters: action.payload.filters,
+        // Reset to first page when search changes to avoid stale page offsets.
         page: { ...state.page, index: 0 },
       };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
@@ -13,12 +13,19 @@ import type { ActiveFilters } from '../datasource';
 
 /**
  * Action type constants for state reducer.
- *
- * @internal
  */
 export const CONTENT_LIST_ACTIONS = {
+  /** Update the search query text (the serialized `EuiSearchBar` `Query`). */
+  SET_SEARCH_QUERY: 'SET_SEARCH_QUERY',
+  /** Update the active filters (parsed from query text by the toolbar). */
+  SET_FILTERS: 'SET_FILTERS',
+  /** Clear all filters and reset query text. */
+  CLEAR_FILTERS: 'CLEAR_FILTERS',
+  /** Set sort field and direction. */
   SET_SORT: 'SET_SORT',
+  /** Set page index. */
   SET_PAGE_INDEX: 'SET_PAGE_INDEX',
+  /** Set page size. */
   SET_PAGE_SIZE: 'SET_PAGE_SIZE',
 } as const;
 
@@ -32,11 +39,26 @@ export const DEFAULT_FILTERS: ActiveFilters = {
 /**
  * Client-controlled state managed by the reducer.
  *
- * This includes user-driven state like filters and sort configuration.
+ * This includes user-driven state like search, filters, and sort configuration.
  * Query data (items, loading, error) comes directly from React Query.
  */
 export interface ContentListClientState {
-  /** Filter state - currently applied filters. */
+  /**
+   * Search state — the serialized `EuiSearchBar` query text is the source of truth
+   * for the search input value. This may contain filter syntax (e.g. `tag:foo`).
+   */
+  search: {
+    /** Full query text including filter syntax (e.g. `tag:foo search text`). */
+    queryText: string;
+  };
+  /**
+   * Parsed filter state used to drive data fetching.
+   *
+   * Updated via `SET_FILTERS`; derived from `search.queryText` by the toolbar.
+   * When no tag service is configured, `filters.search` equals `search.queryText`.
+   * When tag parsing is available, `filters.search` contains only the free-text
+   * portion and `filters.tags` holds the structured tag filters.
+   */
   filters: ActiveFilters;
   /** Sort state. */
   sort: {
@@ -64,8 +86,25 @@ export interface ContentListQueryData {
   items: ContentListItem[];
   /** Total number of items matching the current query (for pagination). */
   totalItems: number;
-  /** Whether data is currently being fetched. */
+  /**
+   * Whether the initial data load is in progress (no data available yet).
+   *
+   * This is `true` only on the first fetch before any data has been received.
+   * Use this for hard loading states (e.g., skeletons, spinners) when there is
+   * nothing to show. Once data has been loaded, subsequent fetches triggered by
+   * filter or search changes keep `isLoading` as `false` while the previous
+   * data remains visible.
+   */
   isLoading: boolean;
+  /**
+   * Whether a fetch is currently in progress (including background refetches).
+   *
+   * Unlike `isLoading`, this is `true` during any fetch, including background
+   * refetches triggered by search, sort, or filter changes. Use this for subtle
+   * loading indicators (e.g., progress bar, reduced opacity) that should not
+   * hide existing content.
+   */
+  isFetching: boolean;
   /** Error from the most recent fetch attempt. */
   error?: Error;
 }
@@ -77,16 +116,39 @@ export interface ContentListQueryData {
  */
 export type ContentListState = ContentListClientState & ContentListQueryData;
 
+/** Update the search query text. */
+interface SetSearchQueryAction {
+  type: typeof CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY;
+  payload: string;
+}
+
+/** Update the active filters. */
+interface SetFiltersAction {
+  type: typeof CONTENT_LIST_ACTIONS.SET_FILTERS;
+  payload: ActiveFilters;
+}
+
+/** Clear all filters and search text. */
+interface ClearFiltersAction {
+  type: typeof CONTENT_LIST_ACTIONS.CLEAR_FILTERS;
+}
+
+/** Set sort field and direction. */
+interface SetSortAction {
+  type: typeof CONTENT_LIST_ACTIONS.SET_SORT;
+  payload: { field: string; direction: 'asc' | 'desc' };
+}
+
 /**
  * Union type of all possible state actions.
  *
  * @internal Used by the state reducer and dispatch function.
  */
 export type ContentListAction =
-  | {
-      type: typeof CONTENT_LIST_ACTIONS.SET_SORT;
-      payload: { field: string; direction: 'asc' | 'desc' };
-    }
+  | SetSearchQueryAction
+  | SetFiltersAction
+  | ClearFiltersAction
+  | SetSortAction
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_INDEX; payload: { index: number } }
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_SIZE; payload: { size: number } };
 
@@ -96,7 +158,7 @@ export type ContentListAction =
 export interface ContentListStateContextValue {
   /** Current state of the content list (client state + query data). */
   state: ContentListState;
-  /** Dispatch function for client state updates (filters, sort). */
+  /** Dispatch function for client state updates (search, filters, sort). */
   dispatch: Dispatch<ContentListAction>;
   /** Function to manually refetch items from the data source. */
   refetch: () => void;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
@@ -15,10 +15,8 @@ import type { ActiveFilters } from '../datasource';
  * Action type constants for state reducer.
  */
 export const CONTENT_LIST_ACTIONS = {
-  /** Update the search query text (the serialized `EuiSearchBar` `Query`). */
-  SET_SEARCH_QUERY: 'SET_SEARCH_QUERY',
-  /** Update the active filters (parsed from query text by the toolbar). */
-  SET_FILTERS: 'SET_FILTERS',
+  /** Atomically update the search query text and parsed filters. */
+  SET_SEARCH: 'SET_SEARCH',
   /** Clear all filters and reset query text. */
   CLEAR_FILTERS: 'CLEAR_FILTERS',
   /** Set sort field and direction. */
@@ -54,7 +52,7 @@ export interface ContentListClientState {
   /**
    * Parsed filter state used to drive data fetching.
    *
-   * Updated via `SET_FILTERS`; derived from `search.queryText` by the toolbar.
+   * Updated atomically with `search.queryText` via `SET_SEARCH`.
    * When no tag service is configured, `filters.search` equals `search.queryText`.
    * When tag parsing is available, `filters.search` contains only the free-text
    * portion and `filters.tags` holds the structured tag filters.
@@ -116,16 +114,10 @@ export interface ContentListQueryData {
  */
 export type ContentListState = ContentListClientState & ContentListQueryData;
 
-/** Update the search query text. */
-interface SetSearchQueryAction {
-  type: typeof CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY;
-  payload: string;
-}
-
-/** Update the active filters. */
-interface SetFiltersAction {
-  type: typeof CONTENT_LIST_ACTIONS.SET_FILTERS;
-  payload: ActiveFilters;
+/** Atomically update both the query text and the parsed filters. */
+interface SetSearchAction {
+  type: typeof CONTENT_LIST_ACTIONS.SET_SEARCH;
+  payload: { queryText: string; filters: ActiveFilters };
 }
 
 /** Clear all filters and search text. */
@@ -145,8 +137,7 @@ interface SetSortAction {
  * @internal Used by the state reducer and dispatch function.
  */
 export type ContentListAction =
-  | SetSearchQueryAction
-  | SetFiltersAction
+  | SetSearchAction
   | ClearFiltersAction
   | SetSortAction
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_INDEX; payload: { index: number } }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.test.tsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ContentListProvider } from '../context';
+import type { ContentListProviderProps } from '../context';
+import type { FindItemsResult, FindItemsParams, DataSourceConfig } from '../datasource';
+import type { ContentListItem } from '../item';
+import { useContentListItems } from './use_content_list_items';
+
+const mockItems: ContentListItem[] = [
+  { id: '1', title: 'Dashboard A', description: 'First dashboard' },
+  { id: '2', title: 'Dashboard B', description: 'Second dashboard' },
+  { id: '3', title: 'Dashboard C' },
+];
+
+describe('useContentListItems', () => {
+  const createMockFindItems = (
+    result: FindItemsResult = { items: mockItems, total: mockItems.length }
+  ) => jest.fn(async (_params: FindItemsParams): Promise<FindItemsResult> => result);
+
+  const createWrapper = (
+    dataSource: DataSourceConfig,
+    overrides?: Partial<ContentListProviderProps>
+  ) => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <ContentListProvider
+        id={overrides?.id ?? 'test-items'}
+        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+        dataSource={dataSource}
+        {...overrides}
+      >
+        {children}
+      </ContentListProvider>
+    );
+  };
+
+  describe('successful fetch', () => {
+    it('returns items from the data source', async () => {
+      const findItems = createMockFindItems();
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.items).toEqual(mockItems);
+      expect(result.current.totalItems).toBe(3);
+    });
+
+    it('returns empty items when data source returns no results', async () => {
+      const findItems = createMockFindItems({ items: [], total: 0 });
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }, { id: 'empty-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.items).toEqual([]);
+      expect(result.current.totalItems).toBe(0);
+    });
+  });
+
+  describe('loading states', () => {
+    it('starts with isLoading true', () => {
+      const findItems = jest.fn(
+        () => new Promise<FindItemsResult>(() => {}) // Never resolves.
+      );
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }, { id: 'loading-items' }),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isFetching).toBe(true);
+    });
+
+    it('sets isLoading to false after fetch completes', async () => {
+      const findItems = createMockFindItems();
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }, { id: 'loaded-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isFetching).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns error when fetch fails with Error', async () => {
+      const findItems = jest.fn(async () => {
+        throw new Error('Network failure');
+      });
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }, { id: 'error-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('Network failure');
+    });
+
+    it('normalizes non-Error thrown values to Error instances', async () => {
+      const findItems = jest.fn(async () => {
+        throw 'string error'; // eslint-disable-line no-throw-literal
+      });
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }, { id: 'string-error-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeDefined();
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('string error');
+    });
+
+    it('returns no error on successful fetch', async () => {
+      const findItems = createMockFindItems();
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }, { id: 'no-error-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
+  describe('onFetchSuccess callback', () => {
+    it('calls onFetchSuccess after successful fetch', async () => {
+      const fetchResult = { items: mockItems, total: mockItems.length };
+      const findItems = createMockFindItems(fetchResult);
+      const onFetchSuccess = jest.fn();
+
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems, onFetchSuccess }, { id: 'success-callback-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(onFetchSuccess).toHaveBeenCalledWith(fetchResult);
+    });
+
+    it('logs warning when onFetchSuccess throws', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const findItems = createMockFindItems();
+      const onFetchSuccess = jest.fn(() => {
+        throw new Error('callback error');
+      });
+
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems, onFetchSuccess }, { id: 'callback-error-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[ContentListProvider] onFetchSuccess callback error:',
+        expect.any(Error)
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('refetch', () => {
+    it('provides a refetch function', async () => {
+      const findItems = createMockFindItems();
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ findItems }, { id: 'refetch-items' }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.refetch).toBeInstanceOf(Function);
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.ts
@@ -13,12 +13,12 @@ import { useContentListState } from './use_content_list_state';
  * Hook to access the current list of items and loading state.
  *
  * @throws Error if used outside `ContentListProvider`.
- * @returns Object containing items, totalItems, isLoading, error, and refetch.
+ * @returns Object containing items, totalItems, isLoading, isFetching, error, and refetch.
  *
  * @example
  * ```tsx
  * function MyList() {
- *   const { items, isLoading, error, refetch } = useContentListItems();
+ *   const { items, isLoading, isFetching, error, refetch } = useContentListItems();
  *
  *   if (isLoading) return <EuiLoadingSpinner />;
  *   if (error) return <EuiCallOut color="danger">{error.message}</EuiCallOut>;
@@ -40,6 +40,7 @@ export const useContentListItems = () => {
     items: state.items,
     totalItems: state.totalItems,
     isLoading: state.isLoading,
+    isFetching: state.isFetching,
     error: state.error,
     refetch,
   };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_state.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_state.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ContentListProvider } from '../context';
+import type { FindItemsResult, FindItemsParams } from '../datasource';
+import { useContentListState } from './use_content_list_state';
+import { CONTENT_LIST_ACTIONS } from './types';
+
+describe('useContentListState', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: [],
+      total: 0,
+    })
+  );
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'item', entityPlural: 'items' }}
+        dataSource={{ findItems: mockFindItems }}
+      >
+        {children}
+      </ContentListProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when used outside provider', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useContentListState());
+    }).toThrow(
+      'ContentListStateContext is missing. Ensure your component is wrapped with ContentListProvider.'
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns state, dispatch, and refetch', () => {
+    const { result } = renderHook(() => useContentListState(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.state).toBeDefined();
+    expect(result.current.dispatch).toBeInstanceOf(Function);
+    expect(result.current.refetch).toBeInstanceOf(Function);
+  });
+
+  it('provides state with expected shape', () => {
+    const { result } = renderHook(() => useContentListState(), {
+      wrapper: createWrapper(),
+    });
+
+    const { state } = result.current;
+    expect(state).toHaveProperty('search');
+    expect(state).toHaveProperty('filters');
+    expect(state).toHaveProperty('sort');
+    expect(state).toHaveProperty('items');
+    expect(state).toHaveProperty('totalItems');
+    expect(state).toHaveProperty('isLoading');
+    expect(state).toHaveProperty('isFetching');
+  });
+
+  it('dispatch updates search query text', () => {
+    const { result } = renderHook(() => useContentListState(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.dispatch({
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
+        payload: 'test query',
+      });
+    });
+
+    expect(result.current.state.search.queryText).toBe('test query');
+  });
+
+  it('dispatch updates filters', () => {
+    const { result } = renderHook(() => useContentListState(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.dispatch({
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'filtered' },
+      });
+    });
+
+    expect(result.current.state.filters).toEqual({ search: 'filtered' });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_state.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_state.test.tsx
@@ -75,33 +75,19 @@ describe('useContentListState', () => {
     expect(state).toHaveProperty('isFetching');
   });
 
-  it('dispatch updates search query text', () => {
+  it('dispatch updates search query text and filters atomically', () => {
     const { result } = renderHook(() => useContentListState(), {
       wrapper: createWrapper(),
     });
 
     act(() => {
       result.current.dispatch({
-        type: CONTENT_LIST_ACTIONS.SET_SEARCH_QUERY,
-        payload: 'test query',
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'test query', filters: { search: 'test query' } },
       });
     });
 
     expect(result.current.state.search.queryText).toBe('test query');
-  });
-
-  it('dispatch updates filters', () => {
-    const { result } = renderHook(() => useContentListState(), {
-      wrapper: createWrapper(),
-    });
-
-    act(() => {
-      result.current.dispatch({
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: 'filtered' },
-      });
-    });
-
-    expect(result.current.state.filters).toEqual({ search: 'filtered' });
+    expect(result.current.state.filters).toEqual({ search: 'test query' });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
@@ -129,7 +129,7 @@ const SortControls = () => {
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="sortable" />
+        <EuiIcon type="sortable" aria-label="Sortable" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiText size="s">Sort by:</EuiText>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
@@ -26,12 +26,14 @@ import { MOCK_DASHBOARDS, createMockFindItems } from '@kbn/content-list-mock-dat
 import { ContentListProvider, useContentListConfig } from '../context';
 import { useContentListItems } from '../state';
 import { useContentListSort } from '../features/sorting';
+import { useContentListPagination } from '../features/pagination';
 import type { FindItemsParams, FindItemsResult } from '../datasource';
 
 interface StoryArgs {
   entityName: string;
   entityNamePlural: string;
   enableSorting: boolean;
+  enablePagination: boolean;
   initialSortField: 'title' | 'updatedAt';
   initialSortDirection: 'asc' | 'desc';
   numberOfItems: number;
@@ -71,17 +73,57 @@ const ConfigDisplay = () => {
  */
 const ItemsList = () => {
   const { items, totalItems, refetch } = useContentListItems();
+  const pagination = useContentListPagination();
 
   return (
     <div>
       <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiBadge color="hollow">{totalItems} items</EuiBadge>
+          <EuiFlexGroup gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="hollow">{totalItems} items</EuiBadge>
+            </EuiFlexItem>
+            {pagination.isSupported && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow">
+                  Page {pagination.pageIndex + 1} ({pagination.pageSize}/page)
+                </EuiBadge>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton size="s" iconType="refresh" onClick={() => refetch()}>
-            Refresh
-          </EuiButton>
+          <EuiFlexGroup gutterSize="s">
+            {pagination.isSupported && pagination.pageIndex > 0 && (
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  size="s"
+                  iconType="arrowLeft"
+                  onClick={() => pagination.setPageIndex(pagination.pageIndex - 1)}
+                >
+                  Prev
+                </EuiButton>
+              </EuiFlexItem>
+            )}
+            {pagination.isSupported &&
+              (pagination.pageIndex + 1) * pagination.pageSize < totalItems && (
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    size="s"
+                    iconType="arrowRight"
+                    iconSide="right"
+                    onClick={() => pagination.setPageIndex(pagination.pageIndex + 1)}
+                  >
+                    Next
+                  </EuiButton>
+                </EuiFlexItem>
+              )}
+            <EuiFlexItem grow={false}>
+              <EuiButton size="s" iconType="refresh" onClick={() => refetch()}>
+                Refresh
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
 
@@ -157,6 +199,7 @@ const meta: Meta<StoryArgs> = {
     entityName: { control: 'text', description: 'Singular entity name' },
     entityNamePlural: { control: 'text', description: 'Plural entity name' },
     enableSorting: { control: 'boolean', description: 'Enable sorting feature' },
+    enablePagination: { control: 'boolean', description: 'Enable pagination feature' },
     initialSortField: {
       control: 'select',
       options: ['title', 'updatedAt'],
@@ -219,19 +262,19 @@ const ProviderStory = ({ args }: { args: StoryArgs }) => {
 
   // Memoize features to maintain stable reference.
   const features = useMemo(
-    () =>
-      args.enableSorting
+    () => ({
+      sorting: args.enableSorting
         ? {
-            sorting: {
-              initialSort: { field: args.initialSortField, direction: args.initialSortDirection },
-            },
+            initialSort: { field: args.initialSortField, direction: args.initialSortDirection },
           }
-        : { sorting: false as const },
-    [args.enableSorting, args.initialSortField, args.initialSortDirection]
+        : (false as const),
+      pagination: args.enablePagination ? { initialPageSize: 5 } : (false as const),
+    }),
+    [args.enableSorting, args.enablePagination, args.initialSortField, args.initialSortDirection]
   );
 
   // Key forces re-mount when configuration changes.
-  const key = `${args.enableSorting}-${args.initialSortField}-${args.initialSortDirection}-${args.numberOfItems}`;
+  const key = `${args.enableSorting}-${args.enablePagination}-${args.initialSortField}-${args.initialSortDirection}-${args.numberOfItems}`;
 
   return (
     <ContentListProvider
@@ -259,6 +302,7 @@ export const Provider: Story = {
     entityName: 'dashboard',
     entityNamePlural: 'dashboards',
     enableSorting: true,
+    enablePagination: true,
     initialSortField: 'title',
     initialSortDirection: 'asc',
     numberOfItems: 8,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
@@ -20,7 +20,7 @@ const defaultContext: ColumnBuilderContext = {
   itemConfig: undefined,
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true },
+  supports: { sorting: true, pagination: true, search: false },
 };
 
 describe('name column builder', () => {
@@ -65,7 +65,7 @@ describe('name column builder', () => {
     it('forces sortable false when sorting is unsupported', () => {
       const context: ColumnBuilderContext = {
         ...defaultContext,
-        supports: { sorting: false, pagination: true },
+        supports: { sorting: false, pagination: true, search: false },
       };
 
       const result = buildNameColumn({}, context);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
@@ -24,6 +24,7 @@ import {
   ContentListProvider,
   useContentListItems,
   useContentListSort,
+  useContentListSearch,
   useContentListConfig,
 } from '@kbn/content-list-provider';
 import type { ContentListItem, FindItemsParams, FindItemsResult } from '@kbn/content-list-provider';
@@ -105,8 +106,9 @@ const StateDiagnosticPanel = ({
   showTypeColumn = true,
 }: StateDiagnosticPanelProps) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
-  const { items, totalItems, isLoading, error } = useContentListItems();
+  const { items, totalItems, isLoading, isFetching, error } = useContentListItems();
   const { field: sortField, direction: sortDirection } = useContentListSort();
+  const { search } = useContentListSearch();
   const config = useContentListConfig();
 
   // Generate JSX code based on current configuration.
@@ -165,6 +167,11 @@ ${columnChildren.join('\n')}
                   <EuiBadge color="primary">Loading…</EuiBadge>
                 </EuiFlexItem>
               )}
+              {isFetching && !isLoading && (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="accent">Fetching…</EuiBadge>
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -195,6 +202,14 @@ ${columnChildren.join('\n')}
                 </EuiTitle>
                 <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
                   {JSON.stringify({ field: sortField, direction: sortDirection }, null, 2)}
+                </EuiCodeBlock>
+              </EuiFlexItem>
+              <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                <EuiTitle size="xxs">
+                  <h3>Search</h3>
+                </EuiTitle>
+                <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                  {JSON.stringify({ search, isFetching }, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
               <EuiFlexItem grow={2} style={{ minWidth: 300 }}>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
@@ -25,6 +25,7 @@ import {
   useContentListItems,
   useContentListSort,
   useContentListSearch,
+  useContentListPagination,
   useContentListConfig,
 } from '@kbn/content-list-provider';
 import type { ContentListItem, FindItemsParams, FindItemsResult } from '@kbn/content-list-provider';
@@ -109,6 +110,7 @@ const StateDiagnosticPanel = ({
   const { items, totalItems, isLoading, isFetching, error } = useContentListItems();
   const { field: sortField, direction: sortDirection } = useContentListSort();
   const { search } = useContentListSearch();
+  const pagination = useContentListPagination();
   const config = useContentListConfig();
 
   // Generate JSX code based on current configuration.
@@ -212,6 +214,24 @@ ${columnChildren.join('\n')}
                   {JSON.stringify({ search, isFetching }, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
+              {pagination.isSupported && (
+                <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                  <EuiTitle size="xxs">
+                    <h3>Pagination</h3>
+                  </EuiTitle>
+                  <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                    {JSON.stringify(
+                      {
+                        pageIndex: pagination.pageIndex,
+                        pageSize: pagination.pageSize,
+                        totalItems,
+                      },
+                      null,
+                      2
+                    )}
+                  </EuiCodeBlock>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={2} style={{ minWidth: 300 }}>
                 <EuiTitle size="xxs">
                   <h3>Table JSX</h3>
@@ -267,6 +287,7 @@ interface PlaygroundArgs {
   hasItems: boolean;
   isLoading: boolean;
   isReadOnly: boolean;
+  hasPagination: boolean;
   compressed: boolean;
   tableLayout: 'auto' | 'fixed';
   showDescription: boolean;
@@ -307,7 +328,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
   }, [args.hasClickableRows, args.entityName]);
 
   // Key forces re-mount when configuration changes.
-  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}`;
+  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}-${args.hasPagination}`;
 
   return (
     <ContentListProvider
@@ -321,6 +342,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
         sorting: {
           initialSort: { field: 'title', direction: 'asc' },
         },
+        pagination: args.hasPagination ? { initialPageSize: 10 } : (false as const),
       }}
     >
       <ContentListTable
@@ -358,6 +380,7 @@ export const Table: PlaygroundStory = {
     hasItems: true,
     isLoading: false,
     isReadOnly: false,
+    hasPagination: true,
     showTypeColumn: false,
     hasClickableRows: true,
     showDescription: true,
@@ -392,6 +415,11 @@ export const Table: PlaygroundStory = {
       control: 'boolean',
       description: 'Disable all editing and selection.',
       table: { category: 'State' },
+    },
+    hasPagination: {
+      control: 'boolean',
+      description: 'Enable pagination in provider config.',
+      table: { category: 'Features' },
     },
     compressed: {
       control: 'boolean',

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
@@ -25,6 +25,7 @@ import {
   ContentListProvider,
   useContentListItems,
   useContentListSort,
+  useContentListSearch,
   useContentListConfig,
 } from '@kbn/content-list-provider';
 import type { FindItemsParams, FindItemsResult } from '@kbn/content-list-provider';
@@ -93,8 +94,9 @@ const StateDiagnosticPanel = ({
   useDeclarativeConfig = false,
 }: StateDiagnosticPanelProps) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
-  const { items, totalItems, isLoading } = useContentListItems();
+  const { items, totalItems, isLoading, isFetching } = useContentListItems();
   const { field: sortField, direction: sortDirection } = useContentListSort();
+  const { search } = useContentListSearch();
   const config = useContentListConfig();
 
   // Generate JSX code based on current configuration.
@@ -139,6 +141,11 @@ const StateDiagnosticPanel = ({
                   <EuiBadge color="primary">Loading...</EuiBadge>
                 </EuiFlexItem>
               )}
+              {isFetching && !isLoading && (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="accent">Fetching...</EuiBadge>
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -161,6 +168,14 @@ const StateDiagnosticPanel = ({
                 </EuiTitle>
                 <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
                   {JSON.stringify(config.features.sorting, null, 2)}
+                </EuiCodeBlock>
+              </EuiFlexItem>
+              <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                <EuiTitle size="xxs">
+                  <h3>Search</h3>
+                </EuiTitle>
+                <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                  {JSON.stringify({ search, isFetching }, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
               <EuiFlexItem grow={1} style={{ minWidth: 200 }}>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
@@ -26,6 +26,7 @@ import {
   useContentListItems,
   useContentListSort,
   useContentListSearch,
+  useContentListPagination,
   useContentListConfig,
 } from '@kbn/content-list-provider';
 import type { FindItemsParams, FindItemsResult } from '@kbn/content-list-provider';
@@ -97,6 +98,7 @@ const StateDiagnosticPanel = ({
   const { items, totalItems, isLoading, isFetching } = useContentListItems();
   const { field: sortField, direction: sortDirection } = useContentListSort();
   const { search } = useContentListSearch();
+  const pagination = useContentListPagination();
   const config = useContentListConfig();
 
   // Generate JSX code based on current configuration.
@@ -178,6 +180,24 @@ const StateDiagnosticPanel = ({
                   {JSON.stringify({ search, isFetching }, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
+              {pagination.isSupported && (
+                <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                  <EuiTitle size="xxs">
+                    <h3>Pagination</h3>
+                  </EuiTitle>
+                  <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                    {JSON.stringify(
+                      {
+                        pageIndex: pagination.pageIndex,
+                        pageSize: pagination.pageSize,
+                        totalItems,
+                      },
+                      null,
+                      2
+                    )}
+                  </EuiCodeBlock>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
                 <EuiTitle size="xxs">
                   <h3>Toolbar JSX</h3>
@@ -245,6 +265,7 @@ interface PlaygroundArgs {
   entityNamePlural: string;
   searchPlaceholder: string;
   hasSorting: boolean;
+  hasPagination: boolean;
   useDeclarativeConfig: boolean;
   showDiagnostics: boolean;
 }
@@ -267,28 +288,28 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
   const dataSource = useMemo(() => ({ findItems: createStoryFindItems() }), []);
 
   const features = useMemo(
-    () =>
-      args.hasSorting
+    () => ({
+      sorting: args.hasSorting
         ? {
-            sorting: {
-              initialSort: { field: 'title', direction: 'asc' as const },
-              fields: [
-                { field: 'title', name: 'Name' },
-                {
-                  field: 'updatedAt',
-                  name: 'Last updated',
-                  ascLabel: 'Old-Recent',
-                  descLabel: 'Recent-Old',
-                },
-              ],
-            },
+            initialSort: { field: 'title', direction: 'asc' as const },
+            fields: [
+              { field: 'title', name: 'Name' },
+              {
+                field: 'updatedAt',
+                name: 'Last updated',
+                ascLabel: 'Old-Recent',
+                descLabel: 'Recent-Old',
+              },
+            ],
           }
-        : {},
-    [args.hasSorting]
+        : (false as const),
+      pagination: args.hasPagination ? { initialPageSize: 10 } : (false as const),
+    }),
+    [args.hasSorting, args.hasPagination]
   );
 
   // Key forces re-mount when configuration changes.
-  const key = `${args.hasSorting}-${args.useDeclarativeConfig}`;
+  const key = `${args.hasSorting}-${args.hasPagination}-${args.useDeclarativeConfig}`;
 
   // Destructure Filters from ContentListToolbar for compound component usage.
   const { Filters } = ContentListToolbar;
@@ -364,6 +385,7 @@ export const Toolbar: PlaygroundStory = {
   args: {
     useDeclarativeConfig: false,
     hasSorting: true,
+    hasPagination: true,
     showDiagnostics: true,
     entityName: 'dashboard',
     entityNamePlural: 'dashboards',
@@ -393,6 +415,11 @@ export const Toolbar: PlaygroundStory = {
     hasSorting: {
       control: 'boolean',
       description: 'Enable sorting in provider config.',
+      table: { category: 'Features' },
+    },
+    hasPagination: {
+      control: 'boolean',
+      description: 'Enable pagination in provider config.',
       table: { category: 'Features' },
     },
     showDiagnostics: {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
@@ -11,12 +11,7 @@ import React, { useCallback } from 'react';
 import type { ReactNode } from 'react';
 import { EuiSearchBar } from '@elastic/eui';
 import type { EuiSearchBarOnChangeArgs } from '@elastic/eui';
-import {
-  useContentListConfig,
-  useContentListSearch,
-  useContentListState,
-  CONTENT_LIST_ACTIONS,
-} from '@kbn/content-list-provider';
+import { useContentListConfig, useContentListSearch } from '@kbn/content-list-provider';
 import { i18n } from '@kbn/i18n';
 import { Filters } from './filters';
 import { useFilters } from './hooks';
@@ -72,7 +67,6 @@ const ContentListToolbarComponent = ({
 }: ContentListToolbarProps) => {
   const { labels } = useContentListConfig();
   const { search, setSearch, isSupported: searchIsSupported } = useContentListSearch();
-  const { dispatch } = useContentListState();
   const filters = useFilters(children);
 
   const handleSearchChange = useCallback(
@@ -80,13 +74,11 @@ const ContentListToolbarComponent = ({
       if (error) {
         return;
       }
-      setSearch(queryText);
-      dispatch({
-        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
-        payload: { search: queryText.trim() || undefined },
-      });
+      // `queryText` preserves the raw input (including whitespace) for display fidelity.
+      // `filters.search` is trimmed so data fetching ignores leading/trailing spaces.
+      setSearch(queryText, { search: queryText.trim() || undefined });
     },
-    [setSearch, dispatch]
+    [setSearch]
   );
 
   return (

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
@@ -7,10 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import type { ReactNode } from 'react';
 import { EuiSearchBar } from '@elastic/eui';
-import { useContentListConfig } from '@kbn/content-list-provider';
+import type { EuiSearchBarOnChangeArgs } from '@elastic/eui';
+import {
+  useContentListConfig,
+  useContentListSearch,
+  useContentListState,
+  CONTENT_LIST_ACTIONS,
+} from '@kbn/content-list-provider';
 import { i18n } from '@kbn/i18n';
 import { Filters } from './filters';
 import { useFilters } from './hooks';
@@ -34,7 +40,7 @@ const defaultPlaceholder = i18n.translate(
  * `ContentListToolbar` component.
  *
  * Provides a toolbar with search and filter controls for content lists using `EuiSearchBar`.
- * Currently supports the Sort filter; additional filters will be added in subsequent PRs.
+ * Currently supports search and the Sort filter; additional filters will be added in subsequent PRs.
  *
  * **Smart Defaults**: When no children are provided, auto-renders filters
  * based on provider configuration.
@@ -65,17 +71,34 @@ const ContentListToolbarComponent = ({
   'data-test-subj': dataTestSubj = 'contentListToolbar',
 }: ContentListToolbarProps) => {
   const { labels } = useContentListConfig();
+  const { search, setSearch, isSupported: searchIsSupported } = useContentListSearch();
+  const { dispatch } = useContentListState();
   const filters = useFilters(children);
+
+  const handleSearchChange = useCallback(
+    ({ queryText, error }: EuiSearchBarOnChangeArgs) => {
+      if (error) {
+        return;
+      }
+      setSearch(queryText);
+      dispatch({
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: queryText.trim() || undefined },
+      });
+    },
+    [setSearch, dispatch]
+  );
 
   return (
     <EuiSearchBar
+      query={search}
       box={{
         placeholder: labels.searchPlaceholder ?? defaultPlaceholder,
         incremental: true,
         'data-test-subj': `${dataTestSubj}-searchBox`,
-        // TODO: Enable when search query support is wired up to the provider.
-        disabled: true,
+        disabled: !searchIsSupported,
       }}
+      onChange={handleSearchChange}
       filters={filters}
       data-test-subj={dataTestSubj}
     />


### PR DESCRIPTION
## Summary

Adds search functionality to the Content List, wiring `EuiSearchBar` in the toolbar to the provider's state management and React Query data-fetching layer.

> [!NOTE]
> This is PR 4 of the Content List implementation plan derived from https://github.com/elastic/kibana/pull/247778.
>
> This PR was written in Cursor with the assistance of `claude-opus-4.6-high`.

### What changed

**`@kbn/content-list-provider`**

- Added `SET_SEARCH` action to the state reducer, normalizing empty strings to `undefined`.
- Created the `features/search/` module (`SearchConfig`, `useContentListSearch` hook) following the same pattern as the existing `features/sorting/` module.
- Extended `ContentListFeatures` and `ContentListSupports` with `search` configuration and support flags.
- Seeded `initialSearch` from `features.search.initialSearch` in `ContentListStateProvider`.
- Added `keepPreviousData: true` to the React Query hook to prevent the table from flashing empty during refetches.
- Split `isLoading` (initial load, no data yet) from `isFetching` (any in-progress fetch, including background refetches) for finer-grained loading UX.
- Exported `ContentListQueryData` from the package root for consumers that need the type.

**`@kbn/content-list-toolbar`**

- Connected `EuiSearchBar` in controlled mode (`query={search}`) so the input stays in sync with provider state.
- Wired `onChange` to dispatch `SET_SEARCH`, with an early return on parse errors.
- Used `EuiSearchBarOnChangeArgs` from `@elastic/eui` for the callback type.
- Dynamically disables the search box when `features.search: false`.

**Storybook (`@kbn/content-list-table`, `@kbn/content-list-toolbar`)**

- Added `isFetching` badge and search state to both diagnostic panels.
