### PR TITLE
[content-list] Add Updated At column, sort option

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
@@ -23,6 +23,12 @@ export {
 
 // Column components.
 export { NameColumn, NameCell, type NameColumnProps, type NameCellProps } from './src/column';
+export {
+  UpdatedAtColumn,
+  UpdatedAtCell,
+  type UpdatedAtColumnProps,
+  type UpdatedAtCellProps,
+} from './src/column';
 export type { ColumnNamespace, ColumnProps } from './src/column';
 
 // Empty state.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
@@ -22,6 +22,7 @@ dependsOn:
   - '@kbn/content-list-provider'
   - '@kbn/content-list-mock-data'
   - '@kbn/i18n'
+  - '@kbn/i18n-react'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
@@ -13,6 +13,7 @@ import type { ContentListItem } from '@kbn/content-list-provider';
 import { table } from '../assembly';
 import type { ColumnBuilderContext } from './types';
 import type { NameColumnProps } from './name/name_builder';
+import type { UpdatedAtColumnProps } from './updated_at/updated_at_builder';
 
 /**
  * Props for the `Column` component (custom columns).
@@ -51,11 +52,13 @@ export interface ColumnProps {
 export interface ColumnNamespace {
   (props: ColumnProps): ReactNode;
   Name: (props: NameColumnProps) => ReactNode;
+  UpdatedAt: (props: UpdatedAtColumnProps) => ReactNode;
 }
 
 /** Preset-to-props mapping for table columns. */
 export interface ColumnPresets {
   name: NameColumnProps;
+  updatedAt: UpdatedAtColumnProps;
 }
 
 /** Part factory for table columns. */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/index.ts
@@ -7,15 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// Declarative components and props.
-export { Column, type ColumnProps } from './part';
-export { NameColumn, type NameColumnProps, NameCell, type NameCellProps } from './name';
 export {
   UpdatedAtColumn,
+  buildUpdatedAtColumn,
   type UpdatedAtColumnProps,
-  UpdatedAtCell,
-  type UpdatedAtCellProps,
-} from './updated_at';
-
-// Namespace type for TypeScript typing of `Column`.
-export type { ColumnNamespace } from './part';
+} from './updated_at_builder';
+export { UpdatedAtCell, type UpdatedAtCellProps } from './updated_at_cell';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { EuiTableFieldDataColumnType } from '@elastic/eui';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ColumnBuilderContext } from '../types';
+import { buildUpdatedAtColumn, type UpdatedAtColumnProps } from './updated_at_builder';
+
+/** The column returned by `buildUpdatedAtColumn` is always a field column with a render function. */
+type UpdatedAtColumn = EuiTableFieldDataColumnType<ContentListItem>;
+
+const defaultContext: ColumnBuilderContext = {
+  itemConfig: undefined,
+  isReadOnly: false,
+  entityName: 'dashboard',
+  supports: { sorting: true },
+};
+
+describe('updated at column builder', () => {
+  describe('buildUpdatedAtColumn', () => {
+    it('returns a column with defaults when props are empty', () => {
+      const result = buildUpdatedAtColumn({}, defaultContext);
+
+      expect(result).toMatchObject({
+        field: 'updatedAt',
+        name: 'Last updated',
+        sortable: true,
+        'data-test-subj': 'content-list-table-column-updatedAt',
+      });
+    });
+
+    it('uses custom column title', () => {
+      const props: UpdatedAtColumnProps = { columnTitle: 'Modified' };
+      const result = buildUpdatedAtColumn(props, defaultContext);
+
+      expect(result).toMatchObject({ name: 'Modified' });
+    });
+
+    it('applies custom width', () => {
+      const props: UpdatedAtColumnProps = { width: '150px' };
+      const result = buildUpdatedAtColumn(props, defaultContext);
+
+      expect(result).toMatchObject({ width: '150px' });
+    });
+
+    it('does not include width when not specified', () => {
+      const result = buildUpdatedAtColumn({}, defaultContext);
+      expect(result).not.toHaveProperty('width');
+    });
+
+    it('respects sortable false', () => {
+      const props: UpdatedAtColumnProps = { sortable: false };
+      const result = buildUpdatedAtColumn(props, defaultContext);
+
+      expect(result).toMatchObject({ sortable: false });
+    });
+
+    it('forces sortable false when sorting is unsupported', () => {
+      const context: ColumnBuilderContext = {
+        ...defaultContext,
+        supports: { sorting: false },
+      };
+
+      const result = buildUpdatedAtColumn({}, context);
+
+      expect(result).toMatchObject({ sortable: false });
+    });
+
+    it('provides a render function', () => {
+      const result = buildUpdatedAtColumn({}, defaultContext) as UpdatedAtColumn;
+      expect(result.render).toBeInstanceOf(Function);
+    });
+
+    it('renders an UpdatedAtCell with the item date', () => {
+      const result = buildUpdatedAtColumn({}, defaultContext) as UpdatedAtColumn;
+      const item: ContentListItem = {
+        id: '1',
+        title: 'Test',
+        updatedAt: new Date('2025-01-15T10:30:00Z'),
+      };
+
+      const element = result.render?.(item.updatedAt, item);
+      const { container } = render(<I18nProvider>{element}</I18nProvider>);
+      expect(
+        container.querySelector('[data-test-subj="content-list-table-updatedAt-value"]')
+      ).toBeInTheDocument();
+    });
+
+    it('renders an UpdatedAtCell with a dash for missing dates', () => {
+      const result = buildUpdatedAtColumn({}, defaultContext) as UpdatedAtColumn;
+      const item: ContentListItem = { id: '1', title: 'Test' };
+
+      const element = result.render?.(undefined, item);
+      render(<I18nProvider>{element}</I18nProvider>);
+      expect(screen.getByTestId('content-list-table-updatedAt-unknown')).toHaveTextContent('-');
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import type { ColumnBuilderContext } from '../types';
+import { column } from '../part';
+import { UpdatedAtCell } from './updated_at_cell';
+
+/** Default i18n-translated column title for the updated at column. */
+const DEFAULT_UPDATED_AT_COLUMN_TITLE = i18n.translate(
+  'contentManagement.contentList.table.column.updatedAt.title',
+  { defaultMessage: 'Last updated' }
+);
+
+/**
+ * Props for the `Column.UpdatedAt` preset component.
+ *
+ * These are the declarative attributes consumers pass in JSX. The builder
+ * reads them directly from the parsed attributes.
+ */
+export interface UpdatedAtColumnProps {
+  /** Column width (CSS value like `'150px'` or `'20%'`). */
+  width?: string;
+  /** Custom column title. Defaults to `'Last updated'`. */
+  columnTitle?: string;
+  /**
+   * Whether the column is sortable.
+   *
+   * @default true
+   */
+  sortable?: boolean;
+}
+
+/**
+ * Build an `EuiBasicTableColumn` from `Column.UpdatedAt` declarative attributes.
+ *
+ * @param attributes - The declarative attributes from the parsed `Column.UpdatedAt` element.
+ * @param context - Builder context with provider configuration.
+ * @returns An `EuiBasicTableColumn<ContentListItem>` for the updated at column.
+ */
+export const buildUpdatedAtColumn = (
+  attributes: UpdatedAtColumnProps,
+  context: ColumnBuilderContext
+): EuiBasicTableColumn<ContentListItem> => {
+  const { columnTitle, width, sortable: sortableProp } = attributes;
+
+  const supportsSorting = context.supports?.sorting ?? true;
+
+  // Default sortable to `true` for the updatedAt field, when sorting is supported.
+  const sortable = supportsSorting ? sortableProp ?? true : false;
+
+  return {
+    field: 'updatedAt',
+    name: columnTitle ?? DEFAULT_UPDATED_AT_COLUMN_TITLE,
+    sortable,
+    ...(width && { width }),
+    'data-test-subj': 'content-list-table-column-updatedAt',
+    render: (_value: Date | undefined, item: ContentListItem) => {
+      return <UpdatedAtCell updatedAt={item.updatedAt} />;
+    },
+  };
+};
+
+/**
+ * UpdatedAt column specification component for `ContentListTable`.
+ *
+ * This is a declarative component that doesn't render anything.
+ * It's used to specify the UpdatedAt column configuration as React children.
+ *
+ * @example Basic usage
+ * ```tsx
+ * const { Column } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.UpdatedAt />
+ * </ContentListTable>
+ * ```
+ *
+ * @example With custom configuration
+ * ```tsx
+ * const { Column } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.UpdatedAt
+ *     columnTitle="Modified"
+ *     width="150px"
+ *   />
+ * </ContentListTable>
+ * ```
+ */
+export const UpdatedAtColumn = column.createPreset({
+  name: 'updatedAt',
+  resolve: buildUpdatedAtColumn,
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_cell.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_cell.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import moment from 'moment';
+import { I18nProvider } from '@kbn/i18n-react';
+import { UpdatedAtCell } from './updated_at_cell';
+
+/** Wraps children in `I18nProvider` so `FormattedRelative` can resolve. */
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <I18nProvider>{children}</I18nProvider>
+);
+
+// Pin "now" so relative time assertions are deterministic.
+const NOW = new Date('2025-06-15T12:00:00Z');
+
+describe('UpdatedAtCell', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders a dash when `updatedAt` is undefined', () => {
+    render(
+      <Wrapper>
+        <UpdatedAtCell />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('content-list-table-updatedAt-unknown')).toHaveTextContent('-');
+  });
+
+  it('renders relative time for recent dates (within 7 days)', () => {
+    const twoHoursAgo = new Date(NOW.getTime() - 2 * 60 * 60 * 1000);
+    render(
+      <Wrapper>
+        <UpdatedAtCell updatedAt={twoHoursAgo} />
+      </Wrapper>
+    );
+
+    const element = screen.getByTestId('content-list-table-updatedAt-value');
+    expect(element).toHaveTextContent('2 hours ago');
+  });
+
+  it('renders abbreviated date for older dates (more than 7 days)', () => {
+    const thirtyDaysAgo = new Date(NOW.getTime() - 30 * 24 * 60 * 60 * 1000);
+    render(
+      <Wrapper>
+        <UpdatedAtCell updatedAt={thirtyDaysAgo} />
+      </Wrapper>
+    );
+
+    const element = screen.getByTestId('content-list-table-updatedAt-value');
+    const expectedText = moment(thirtyDaysAgo).format('ll');
+    expect(element).toHaveTextContent(expectedText);
+  });
+
+  it('renders relative time for very recent dates', () => {
+    const justNow = new Date(NOW.getTime() - 10 * 1000);
+    render(
+      <Wrapper>
+        <UpdatedAtCell updatedAt={justNow} />
+      </Wrapper>
+    );
+
+    const element = screen.getByTestId('content-list-table-updatedAt-value');
+    expect(element).toHaveTextContent('10 seconds ago');
+  });
+
+  it('does not render the unknown indicator when a date is present', () => {
+    const date = new Date('2025-06-14T10:30:00Z');
+    render(
+      <Wrapper>
+        <UpdatedAtCell updatedAt={date} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('content-list-table-updatedAt-unknown')).not.toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_cell.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_cell.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { memo } from 'react';
+import { EuiToolTip, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedRelative } from '@kbn/i18n-react';
+import moment from 'moment';
+
+export interface UpdatedAtCellProps {
+  /** The `updatedAt` value from the content list item. */
+  updatedAt?: Date;
+}
+
+const UNKNOWN_LABEL = i18n.translate(
+  'contentManagement.contentList.table.column.updatedAt.unknownLabel',
+  { defaultMessage: 'Last updated unknown' }
+);
+
+/** Number of days within which relative time formatting is used. */
+const RELATIVE_TIME_THRESHOLD_DAYS = 7;
+
+/**
+ * Cell renderer for the `UpdatedAt` column.
+ *
+ * Displays the last updated timestamp with the following formatting:
+ * - Within the last 7 days: locale-aware relative time via `FormattedRelative`
+ *   from `@kbn/i18n-react` (e.g., "2 hours ago"). Auto-updates as time passes.
+ * - Older than 7 days: abbreviated absolute date (e.g., "Jan 5, 2025").
+ * - Missing value: dash with tooltip "Last updated unknown".
+ *
+ * A tooltip always shows the full date and time (e.g., "January 5, 2025 3:42 PM").
+ *
+ * Memoized to prevent unnecessary re-renders when parent table re-renders.
+ */
+export const UpdatedAtCell = memo(({ updatedAt }: UpdatedAtCellProps) => {
+  let content: React.ReactNode = '-';
+  let testSubj = 'content-list-table-updatedAt-unknown';
+  let tooltip = UNKNOWN_LABEL;
+
+  if (updatedAt) {
+    testSubj = 'content-list-table-updatedAt-value';
+    const now = moment();
+    const updatedAtMoment = moment(updatedAt);
+    tooltip = updatedAtMoment.format('LL LT');
+    const isRecent = updatedAtMoment.diff(now, 'days') > -RELATIVE_TIME_THRESHOLD_DAYS;
+
+    if (isRecent) {
+      content = <FormattedRelative value={updatedAt} />;
+    } else {
+      content = updatedAtMoment.format('ll');
+    }
+  }
+
+  return (
+    <EuiToolTip content={tooltip}>
+      <EuiText size="s" color="subdued" tabIndex={0} data-test-subj={testSubj}>
+        {content}
+      </EuiText>
+    </EuiToolTip>
+  );
+});
+
+UpdatedAtCell.displayName = 'UpdatedAtCell';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
@@ -314,6 +314,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
         tableLayout={args.tableLayout}
       >
         <Column.Name showDescription={args.showDescription} />
+        <Column.UpdatedAt />
         {args.showTypeColumn && (
           <Column
             id="type"

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -11,7 +11,7 @@ import React, { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { EuiBasicTable } from '@elastic/eui';
 import { useContentListItems, type ContentListItem } from '@kbn/content-list-provider';
-import { Column as BaseColumn, NameColumn } from './column';
+import { Column as BaseColumn, NameColumn, UpdatedAtColumn } from './column';
 import { useColumns, useSorting } from './hooks';
 import { EmptyState } from './empty_state';
 
@@ -133,6 +133,7 @@ const ContentListTableComponent = ({
 // Create Column namespace with sub-components.
 export const Column = Object.assign(BaseColumn, {
   Name: NameColumn,
+  UpdatedAt: UpdatedAtColumn,
 });
 
 export const ContentListTable = Object.assign(ContentListTableComponent, {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
@@ -25,6 +25,7 @@
     "@kbn/content-list-provider",
     "@kbn/content-list-mock-data",
     "@kbn/i18n",
+    "@kbn/i18n-react",
   ],
   "exclude": [
     "target/**/*"

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/sort/sort_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/sort/sort_renderer.test.tsx
@@ -183,7 +183,7 @@ describe('SortRenderer', () => {
       expect(screen.getByText('Active → Draft')).toBeInTheDocument();
     });
 
-    it('uses generic labels for non-title fields when labels are not provided', () => {
+    it('uses date labels for date-like fields when labels are not provided', () => {
       const Wrapper = createWrapper({
         sortFields: [{ field: 'updatedAt', name: 'Last updated' }],
       });
@@ -195,16 +195,51 @@ describe('SortRenderer', () => {
 
       fireEvent.click(screen.getByTestId('contentListSortRenderer'));
 
-      // Without explicit labels, non-title fields get generic labels.
+      // Date-like fields get date-specific labels.
+      expect(screen.getByRole('option', { name: /Oldest first/i })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /Newest first/i })).toBeInTheDocument();
+      // No generic ascending/descending labels.
       expect(
-        screen.getByRole('option', { name: /Last updated \(ascending\)/i })
-      ).toBeInTheDocument();
+        screen.queryByRole('option', { name: /Last updated \(ascending\)/i })
+      ).not.toBeInTheDocument();
       expect(
-        screen.getByRole('option', { name: /Last updated \(descending\)/i })
-      ).toBeInTheDocument();
-      // No heuristic date labels.
-      expect(screen.queryByRole('option', { name: /Old-Recent/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('option', { name: /Recent-Old/i })).not.toBeInTheDocument();
+        screen.queryByRole('option', { name: /Last updated \(descending\)/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('uses generic labels for non-title, non-date fields', () => {
+      const Wrapper = createWrapper({
+        sortFields: [{ field: 'status', name: 'Status' }],
+      });
+      render(
+        <Wrapper>
+          <SortRenderer query={mockQuery} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('contentListSortRenderer'));
+
+      // Non-title, non-date fields get generic labels.
+      expect(screen.getByRole('option', { name: /Status \(ascending\)/i })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /Status \(descending\)/i })).toBeInTheDocument();
+    });
+
+    it('does not apply date labels to fields that merely end with lowercase "at"', () => {
+      const Wrapper = createWrapper({
+        sortFields: [{ field: 'format', name: 'Format' }],
+      });
+      render(
+        <Wrapper>
+          <SortRenderer query={mockQuery} />
+        </Wrapper>
+      );
+
+      fireEvent.click(screen.getByTestId('contentListSortRenderer'));
+
+      // "format" ends in "at" but is not a date field — should use generic labels.
+      expect(screen.getByRole('option', { name: /Format \(ascending\)/i })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /Format \(descending\)/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Oldest first/i })).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a `Column.UpdatedAt` preset to the Content List system, giving consumers a declarative "Last updated" column with smart date formatting and integrated sort support.

> [!NOTE]
> This is PR 5 of the Content List implementation plan derived from https://github.com/elastic/kibana/pull/247778.
>
> This PR was written in Cursor with the assistance of `claude-opus-4.6-high`.

### What changed

- **`Column.UpdatedAt` preset** (`@kbn/content-list-table`): New column preset following the same declarative builder pattern as `Column.Name`. Consumers add it with `<Column.UpdatedAt />` — sortable by default, with optional `columnTitle`, `width`, and `sortable` overrides.

- **`UpdatedAtCell` renderer**: Displays the `updatedAt` timestamp with context-aware formatting:
  - **Within 7 days**: locale-aware, auto-updating relative time via `FormattedRelative` from `@kbn/i18n-react` (e.g., "2 hours ago").
  - **Older than 7 days**: abbreviated absolute date via `moment.format('ll')` (e.g., "Jan 5, 2025").
  - **Missing value**: dash (`-`) with a "Last updated unknown" tooltip.
  - All states show the full date/time in a tooltip (`LL LT` format). Memoized with `React.memo`.

- **Date-aware sort labels** (`@kbn/content-list-toolbar`): The `SortRenderer` now automatically applies "Oldest first" / "Newest first" labels to date-like sort fields. A new `isDateLikeField` heuristic matches known fields (`updatedAt`, `createdAt`, `date`, `timestamp`), camelCase `*At` conventions (`deletedAt`, `publishedAt`), and `*date` suffixes (`startDate`, `endDate`). Consumers can always override with explicit `ascLabel` / `descLabel`.

- **Accessibility**: Sort icons use `aria-hidden={true}` since labels already convey meaning. `EuiToolTip` children use `tabIndex={0}` for keyboard focusability.
