### PR TITLE
[Streams] Add draft mode support for wired streams

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/index.ts
@@ -12,7 +12,9 @@ export {
   transpile as transpileEsql,
   conditionToESQL,
   conditionToESQLAst,
+  generatePrelude,
 } from './src/transpilers/esql';
+export type { PreludeField, PreludeFieldType } from './src/transpilers/esql';
 export * from './types/processors';
 export * from './types/conditions';
 export type * from './types/ui';

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`transpile - Streamlang DSL to ES|QL) prelude support should include prelude when preludeFields are provided 1`] = `
+"INSIST_🐔 \`attributes.foo\`
+  | INSIST_🐔 \`body.message\`
+  | EVAL \`attributes.foo\` = \`attributes.foo\`::INTEGER
+  | EVAL \`body.message\` = \`body.message\`::STRING
+  | EVAL \`attributes.status\` = \\"active\\""
+`;
+
+exports[`transpile - Streamlang DSL to ES|QL) prelude support should prepend INSIST_🐔 and typed EVAL casts in deterministic order 1`] = `
+"INSIST_🐔 a_field
+  | INSIST_🐔 m_field
+  | INSIST_🐔 z_field
+  | EVAL a_field = a_field::BOOLEAN
+  | EVAL z_field = z_field::LONG
+  | EVAL \`attributes.status\` = \\"active\\""
+`;
+
 exports[`transpile - Streamlang DSL to ES|QL) should handle not conditions 1`] = `
 "  | EVAL \`attributes.not_flag\` = CASE(NOT \`attributes.status\` == \\"active\\", \\"not-active\\", \`attributes.not_flag\`)
   | EVAL \`attributes.not_nested\` = CASE(NOT (\`attributes.a\` == 1 OR \`attributes.b\` == 2), \\"not-a-or-b\\", \`attributes.not_nested\`)"
@@ -13,6 +30,7 @@ Object {
   | EVAL \`attributes.numeric_450_test\` = CASE(\`attributes.status_code\` == 450 AND \`attributes.status_code_str\` == \\"450\\" AND \`attributes.other_code\` != 450 AND \`attributes.other_code_str\` != \\"450\\", \\"matched_450_test\\", \`attributes.numeric_450_test\`)
   | EVAL \`attributes.mixed_coercion_test\` = CASE(\`attributes.response_time\` > 100 AND \`attributes.response_time_str\` > \\"100\\" AND \`attributes.port\` >= \\"8000\\" AND \`attributes.port\` <= \\"9000\\" AND \`attributes.is_enabled\` == TRUE AND \`attributes.count_str\` == \\"42\\", \\"matched_mixed_coercion\\", \`attributes.mixed_coercion_test\`)",
   ],
+  "prelude": undefined,
   "query": "  | EVAL \`attributes.boolean_true_test\` = CASE(\`attributes.is_active\` == TRUE AND \`attributes.is_active_str\` == \\"true\\" AND \`attributes.is_inactive\` != TRUE AND \`attributes.is_inactive_str\` != \\"true\\", \\"matched_true_test\\", \`attributes.boolean_true_test\`)
   | EVAL \`attributes.boolean_false_test\` = CASE(\`attributes.is_disabled\` == FALSE AND \`attributes.is_disabled_str\` == \\"false\\" AND \`attributes.is_enabled\` != FALSE AND \`attributes.is_enabled_str\` != \\"false\\", \\"matched_false_test\\", \`attributes.boolean_false_test\`)
   | EVAL \`attributes.numeric_450_test\` = CASE(\`attributes.status_code\` == 450 AND \`attributes.status_code_str\` == \\"450\\" AND \`attributes.other_code\` != 450 AND \`attributes.other_code_str\` != \\"450\\", \\"matched_450_test\\", \`attributes.numeric_450_test\`)

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`transpile - Streamlang DSL to ES|QL) prelude support should include prelude when preludeFields are provided 1`] = `
 "INSIST_🐔 \`attributes.foo\`
   | INSIST_🐔 \`body.message\`
-  | EVAL \`attributes.foo\` = \`attributes.foo\`::INTEGER
-  | EVAL \`body.message\` = \`body.message\`::STRING
+  | EVAL \`attributes.foo\` = COALESCE(NULL, \`attributes.foo\`::INTEGER)
+  | EVAL \`body.message\` = COALESCE(NULL, \`body.message\`::STRING)
   | EVAL \`attributes.status\` = \\"active\\""
 `;
 
@@ -12,8 +12,8 @@ exports[`transpile - Streamlang DSL to ES|QL) prelude support should prepend INS
 "INSIST_🐔 a_field
   | INSIST_🐔 m_field
   | INSIST_🐔 z_field
-  | EVAL a_field = a_field::BOOLEAN
-  | EVAL z_field = z_field::LONG
+  | EVAL a_field = COALESCE(NULL, a_field::BOOLEAN)
+  | EVAL z_field = COALESCE(NULL, z_field::LONG)
   | EVAL \`attributes.status\` = \\"active\\""
 `;
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
@@ -4,7 +4,7 @@ exports[`transpile - Streamlang DSL to ES|QL) prelude support should include pre
 "INSIST_🐔 \`attributes.foo\`
   | INSIST_🐔 \`body.message\`
   | EVAL \`attributes.foo\` = COALESCE(NULL, \`attributes.foo\`::INTEGER)
-  | EVAL \`body.message\` = COALESCE(NULL, \`body.message\`::STRING)
+  | EVAL \`body.message\` = COALESCE(NULL, \`body.message\`::KEYWORD)
   | EVAL \`attributes.status\` = \\"active\\""
 `;
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/index.ts
@@ -12,20 +12,37 @@ import { streamlangDSLSchema } from '../../../types/streamlang';
 import { flattenSteps } from '../shared/flatten_steps';
 import { convertConditionToESQL, convertStreamlangDSLToESQLCommands } from './conversions';
 import type { Condition } from '../../../types/conditions';
+import type { PreludeField } from './prelude';
+import { generatePrelude } from './prelude';
 
 const DEFAULT_PIPE_TAB = '  ';
 
 export { conditionToESQLAst } from './condition_to_esql';
+export {
+  generatePrelude,
+  generateInsistCommands,
+  generateTypedEvalCasts,
+  type PreludeField,
+  type PreludeOptions,
+  type PreludeFieldType,
+} from './prelude';
 
 export interface ESQLTranspilationOptions {
   pipeTab: BasicPrettyPrinterOptions['pipeTab'];
   sourceIndex?: string;
   limit?: number;
+  /**
+   * Prelude fields for draft stream execution.
+   * When provided, INSIST_🐔 and typed EVAL casts are prepended to the query.
+   */
+  preludeFields?: PreludeField[];
 }
 
 export interface ESQLTranspilationResult {
   query: string;
   commands: string[];
+  /** Prelude query fragment (INSIST_🐔 + type casts) if preludeFields were provided */
+  prelude?: string;
 }
 
 export const conditionToESQL = (condition: Condition): string => {
@@ -44,8 +61,19 @@ export const transpile = (
 
   const commandsArray = [esqlCommandsFromStreamlang].filter(Boolean);
 
+  // Generate prelude if fields are provided
+  let preludeQuery = '';
+  if (transpilationOptions.preludeFields && transpilationOptions.preludeFields.length > 0) {
+    const preludeResult = generatePrelude({ fields: transpilationOptions.preludeFields });
+    preludeQuery = preludeResult.query;
+  }
+
+  // Combine prelude with main commands
+  const queryParts = [preludeQuery, `  | ${commandsArray.join('\n|')}`].filter(Boolean);
+
   return {
-    query: `  | ${commandsArray.join('\n|')}`,
+    query: queryParts.join('\n'),
     commands: commandsArray,
+    prelude: preludeQuery || undefined,
   };
 };

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.test.ts
@@ -68,7 +68,7 @@ describe('ESQL Prelude', () => {
 
       expect(formatted).toMatchInlineSnapshot(`
         "EVAL count = COALESCE(NULL, count::INTEGER)
-        | EVAL name = COALESCE(NULL, name::STRING)"
+        | EVAL name = COALESCE(NULL, name::KEYWORD)"
       `);
     });
 
@@ -144,11 +144,11 @@ describe('ESQL Prelude', () => {
         | EVAL field_half_float = COALESCE(NULL, field_half_float::DOUBLE)
         | EVAL field_integer = COALESCE(NULL, field_integer::INTEGER)
         | EVAL field_ip = COALESCE(NULL, field_ip::IP)
-        | EVAL field_keyword = COALESCE(NULL, field_keyword::STRING)
+        | EVAL field_keyword = COALESCE(NULL, field_keyword::KEYWORD)
         | EVAL field_long = COALESCE(NULL, field_long::LONG)
-        | EVAL field_match_only_text = COALESCE(NULL, field_match_only_text::STRING)
+        | EVAL field_match_only_text = COALESCE(NULL, field_match_only_text::KEYWORD)
         | EVAL field_short = COALESCE(NULL, field_short::INTEGER)
-        | EVAL field_text = COALESCE(NULL, field_text::STRING)
+        | EVAL field_text = COALESCE(NULL, field_text::KEYWORD)
         | EVAL field_unsigned_long = COALESCE(NULL, field_unsigned_long::UNSIGNED_LONG)
         | EVAL field_version = COALESCE(NULL, field_version::VERSION)"
       `);
@@ -187,7 +187,7 @@ describe('ESQL Prelude', () => {
         "INSIST_🐔 \`attributes.count\`
           | INSIST_🐔 \`attributes.status\`
           | EVAL \`attributes.count\` = COALESCE(NULL, \`attributes.count\`::INTEGER)
-          | EVAL \`attributes.status\` = COALESCE(NULL, \`attributes.status\`::STRING)"
+          | EVAL \`attributes.status\` = COALESCE(NULL, \`attributes.status\`::KEYWORD)"
       `);
     });
 
@@ -233,7 +233,7 @@ describe('ESQL Prelude', () => {
         "INSIST_🐔 a_field
           | INSIST_🐔 m_field
           | INSIST_🐔 z_field
-          | EVAL a_field = COALESCE(NULL, a_field::STRING)
+          | EVAL a_field = COALESCE(NULL, a_field::KEYWORD)
           | EVAL m_field = COALESCE(NULL, m_field::BOOLEAN)
           | EVAL z_field = COALESCE(NULL, z_field::LONG)"
       `);

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.test.ts
@@ -67,8 +67,8 @@ describe('ESQL Prelude', () => {
       const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
 
       expect(formatted).toMatchInlineSnapshot(`
-        "EVAL count = count::INTEGER
-        | EVAL name = name::STRING"
+        "EVAL count = COALESCE(NULL, count::INTEGER)
+        | EVAL name = COALESCE(NULL, name::STRING)"
       `);
     });
 
@@ -85,7 +85,9 @@ describe('ESQL Prelude', () => {
       const query = Builder.expression.query(commands);
       const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
 
-      expect(formatted).toMatchInlineSnapshot(`"EVAL typed_field = typed_field::LONG"`);
+      expect(formatted).toMatchInlineSnapshot(
+        `"EVAL typed_field = COALESCE(NULL, typed_field::LONG)"`
+      );
     });
 
     it('sorts fields alphabetically for deterministic output', () => {
@@ -100,8 +102,8 @@ describe('ESQL Prelude', () => {
       const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
 
       expect(formatted).toMatchInlineSnapshot(`
-        "EVAL a_field = a_field::DOUBLE
-        | EVAL z_field = z_field::BOOLEAN"
+        "EVAL a_field = COALESCE(NULL, a_field::DOUBLE)
+        | EVAL z_field = COALESCE(NULL, z_field::BOOLEAN)"
       `);
     });
 
@@ -132,23 +134,23 @@ describe('ESQL Prelude', () => {
       const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
 
       expect(formatted).toMatchInlineSnapshot(`
-        "EVAL field_boolean = field_boolean::BOOLEAN
-        | EVAL field_byte = field_byte::INTEGER
-        | EVAL field_date = field_date::DATETIME
-        | EVAL field_date_nanos = field_date_nanos::DATETIME
-        | EVAL field_double = field_double::DOUBLE
-        | EVAL field_float = field_float::DOUBLE
-        | EVAL field_geo_point = field_geo_point::GEO_POINT
-        | EVAL field_half_float = field_half_float::DOUBLE
-        | EVAL field_integer = field_integer::INTEGER
-        | EVAL field_ip = field_ip::IP
-        | EVAL field_keyword = field_keyword::STRING
-        | EVAL field_long = field_long::LONG
-        | EVAL field_match_only_text = field_match_only_text::STRING
-        | EVAL field_short = field_short::INTEGER
-        | EVAL field_text = field_text::STRING
-        | EVAL field_unsigned_long = field_unsigned_long::UNSIGNED_LONG
-        | EVAL field_version = field_version::VERSION"
+        "EVAL field_boolean = COALESCE(NULL, field_boolean::BOOLEAN)
+        | EVAL field_byte = COALESCE(NULL, field_byte::INTEGER)
+        | EVAL field_date = COALESCE(NULL, field_date::DATETIME)
+        | EVAL field_date_nanos = COALESCE(NULL, field_date_nanos::DATETIME)
+        | EVAL field_double = COALESCE(NULL, field_double::DOUBLE)
+        | EVAL field_float = COALESCE(NULL, field_float::DOUBLE)
+        | EVAL field_geo_point = COALESCE(NULL, field_geo_point::GEO_POINT)
+        | EVAL field_half_float = COALESCE(NULL, field_half_float::DOUBLE)
+        | EVAL field_integer = COALESCE(NULL, field_integer::INTEGER)
+        | EVAL field_ip = COALESCE(NULL, field_ip::IP)
+        | EVAL field_keyword = COALESCE(NULL, field_keyword::STRING)
+        | EVAL field_long = COALESCE(NULL, field_long::LONG)
+        | EVAL field_match_only_text = COALESCE(NULL, field_match_only_text::STRING)
+        | EVAL field_short = COALESCE(NULL, field_short::INTEGER)
+        | EVAL field_text = COALESCE(NULL, field_text::STRING)
+        | EVAL field_unsigned_long = COALESCE(NULL, field_unsigned_long::UNSIGNED_LONG)
+        | EVAL field_version = COALESCE(NULL, field_version::VERSION)"
       `);
     });
 
@@ -161,7 +163,7 @@ describe('ESQL Prelude', () => {
       const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
 
       expect(formatted).toMatchInlineSnapshot(
-        `"EVAL \`attributes.count\` = \`attributes.count\`::INTEGER"`
+        `"EVAL \`attributes.count\` = COALESCE(NULL, \`attributes.count\`::INTEGER)"`
       );
     });
 
@@ -184,8 +186,8 @@ describe('ESQL Prelude', () => {
       expect(result.query).toMatchInlineSnapshot(`
         "INSIST_🐔 \`attributes.count\`
           | INSIST_🐔 \`attributes.status\`
-          | EVAL \`attributes.count\` = \`attributes.count\`::INTEGER
-          | EVAL \`attributes.status\` = \`attributes.status\`::STRING"
+          | EVAL \`attributes.count\` = COALESCE(NULL, \`attributes.count\`::INTEGER)
+          | EVAL \`attributes.status\` = COALESCE(NULL, \`attributes.status\`::STRING)"
       `);
     });
 
@@ -231,9 +233,9 @@ describe('ESQL Prelude', () => {
         "INSIST_🐔 a_field
           | INSIST_🐔 m_field
           | INSIST_🐔 z_field
-          | EVAL a_field = a_field::STRING
-          | EVAL m_field = m_field::BOOLEAN
-          | EVAL z_field = z_field::LONG"
+          | EVAL a_field = COALESCE(NULL, a_field::STRING)
+          | EVAL m_field = COALESCE(NULL, m_field::BOOLEAN)
+          | EVAL z_field = COALESCE(NULL, z_field::LONG)"
       `);
     });
 
@@ -246,7 +248,7 @@ describe('ESQL Prelude', () => {
       expect(result.query).toMatchInlineSnapshot(`
         "INSIST_🐔 typed_field
           | INSIST_🐔 untyped_field
-          | EVAL typed_field = typed_field::INTEGER"
+          | EVAL typed_field = COALESCE(NULL, typed_field::INTEGER)"
       `);
     });
   });

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.test.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BasicPrettyPrinter, Builder } from '@kbn/esql-language';
+import {
+  generateInsistCommands,
+  generateTypedEvalCasts,
+  generatePrelude,
+  type PreludeField,
+} from './prelude';
+
+describe('ESQL Prelude', () => {
+  describe('generateInsistCommands', () => {
+    it('generates INSIST_🐔 commands for each field', () => {
+      const commands = generateInsistCommands(['field_a', 'field_b']);
+
+      expect(commands).toHaveLength(2);
+      expect(commands[0].name).toBe('insist_🐔');
+      expect(commands[1].name).toBe('insist_🐔');
+    });
+
+    it('sorts fields alphabetically for deterministic output', () => {
+      const commands = generateInsistCommands(['zebra', 'alpha', 'middle']);
+
+      const query = Builder.expression.query(commands);
+      const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
+
+      expect(formatted).toMatchInlineSnapshot(`
+        "INSIST_🐔 alpha
+        | INSIST_🐔 middle
+        | INSIST_🐔 zebra"
+      `);
+    });
+
+    it('handles dotted field names', () => {
+      const commands = generateInsistCommands(['attributes.foo', 'body.message']);
+
+      const query = Builder.expression.query(commands);
+      const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
+
+      expect(formatted).toMatchInlineSnapshot(`
+        "INSIST_🐔 \`attributes.foo\`
+        | INSIST_🐔 \`body.message\`"
+      `);
+    });
+
+    it('returns empty array for empty input', () => {
+      const commands = generateInsistCommands([]);
+      expect(commands).toHaveLength(0);
+    });
+  });
+
+  describe('generateTypedEvalCasts', () => {
+    it('generates EVAL casts for typed fields', () => {
+      const fields: PreludeField[] = [
+        { name: 'count', type: 'integer' },
+        { name: 'name', type: 'keyword' },
+      ];
+
+      const commands = generateTypedEvalCasts(fields);
+
+      const query = Builder.expression.query(commands);
+      const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
+
+      expect(formatted).toMatchInlineSnapshot(`
+        "EVAL count = count::INTEGER
+        | EVAL name = name::STRING"
+      `);
+    });
+
+    it('skips fields without type', () => {
+      const fields: PreludeField[] = [
+        { name: 'typed_field', type: 'long' },
+        { name: 'untyped_field' },
+      ];
+
+      const commands = generateTypedEvalCasts(fields);
+
+      expect(commands).toHaveLength(1);
+
+      const query = Builder.expression.query(commands);
+      const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
+
+      expect(formatted).toMatchInlineSnapshot(`"EVAL typed_field = typed_field::LONG"`);
+    });
+
+    it('sorts fields alphabetically for deterministic output', () => {
+      const fields: PreludeField[] = [
+        { name: 'z_field', type: 'boolean' },
+        { name: 'a_field', type: 'double' },
+      ];
+
+      const commands = generateTypedEvalCasts(fields);
+
+      const query = Builder.expression.query(commands);
+      const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
+
+      expect(formatted).toMatchInlineSnapshot(`
+        "EVAL a_field = a_field::DOUBLE
+        | EVAL z_field = z_field::BOOLEAN"
+      `);
+    });
+
+    it('handles all supported field types', () => {
+      const fields: PreludeField[] = [
+        { name: 'field_keyword', type: 'keyword' },
+        { name: 'field_text', type: 'text' },
+        { name: 'field_match_only_text', type: 'match_only_text' },
+        { name: 'field_long', type: 'long' },
+        { name: 'field_integer', type: 'integer' },
+        { name: 'field_short', type: 'short' },
+        { name: 'field_byte', type: 'byte' },
+        { name: 'field_double', type: 'double' },
+        { name: 'field_float', type: 'float' },
+        { name: 'field_half_float', type: 'half_float' },
+        { name: 'field_unsigned_long', type: 'unsigned_long' },
+        { name: 'field_boolean', type: 'boolean' },
+        { name: 'field_date', type: 'date' },
+        { name: 'field_date_nanos', type: 'date_nanos' },
+        { name: 'field_ip', type: 'ip' },
+        { name: 'field_version', type: 'version' },
+        { name: 'field_geo_point', type: 'geo_point' },
+      ];
+
+      const commands = generateTypedEvalCasts(fields);
+
+      const query = Builder.expression.query(commands);
+      const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
+
+      expect(formatted).toMatchInlineSnapshot(`
+        "EVAL field_boolean = field_boolean::BOOLEAN
+        | EVAL field_byte = field_byte::INTEGER
+        | EVAL field_date = field_date::DATETIME
+        | EVAL field_date_nanos = field_date_nanos::DATETIME
+        | EVAL field_double = field_double::DOUBLE
+        | EVAL field_float = field_float::DOUBLE
+        | EVAL field_geo_point = field_geo_point::GEO_POINT
+        | EVAL field_half_float = field_half_float::DOUBLE
+        | EVAL field_integer = field_integer::INTEGER
+        | EVAL field_ip = field_ip::IP
+        | EVAL field_keyword = field_keyword::STRING
+        | EVAL field_long = field_long::LONG
+        | EVAL field_match_only_text = field_match_only_text::STRING
+        | EVAL field_short = field_short::INTEGER
+        | EVAL field_text = field_text::STRING
+        | EVAL field_unsigned_long = field_unsigned_long::UNSIGNED_LONG
+        | EVAL field_version = field_version::VERSION"
+      `);
+    });
+
+    it('handles dotted field names', () => {
+      const fields: PreludeField[] = [{ name: 'attributes.count', type: 'integer' }];
+
+      const commands = generateTypedEvalCasts(fields);
+
+      const query = Builder.expression.query(commands);
+      const formatted = BasicPrettyPrinter.multiline(query, { pipeTab: '' });
+
+      expect(formatted).toMatchInlineSnapshot(
+        `"EVAL \`attributes.count\` = \`attributes.count\`::INTEGER"`
+      );
+    });
+
+    it('returns empty array for empty input', () => {
+      const commands = generateTypedEvalCasts([]);
+      expect(commands).toHaveLength(0);
+    });
+  });
+
+  describe('generatePrelude', () => {
+    it('generates combined INSIST_🐔 and EVAL commands', () => {
+      const result = generatePrelude({
+        fields: [
+          { name: 'attributes.status', type: 'keyword' },
+          { name: 'attributes.count', type: 'integer' },
+        ],
+      });
+
+      expect(result.commands).toHaveLength(4); // 2 INSIST + 2 EVAL
+      expect(result.query).toMatchInlineSnapshot(`
+        "INSIST_🐔 \`attributes.count\`
+          | INSIST_🐔 \`attributes.status\`
+          | EVAL \`attributes.count\` = \`attributes.count\`::INTEGER
+          | EVAL \`attributes.status\` = \`attributes.status\`::STRING"
+      `);
+    });
+
+    it('generates only INSIST_🐔 for untyped fields', () => {
+      const result = generatePrelude({
+        fields: [{ name: 'attributes.foo' }, { name: 'body.message' }],
+      });
+
+      expect(result.commands).toHaveLength(2); // 2 INSIST only
+      expect(result.query).toMatchInlineSnapshot(`
+        "INSIST_🐔 \`attributes.foo\`
+          | INSIST_🐔 \`body.message\`"
+      `);
+    });
+
+    it('returns empty results for empty fields', () => {
+      const result = generatePrelude({ fields: [] });
+
+      expect(result.commands).toHaveLength(0);
+      expect(result.query).toBe('');
+    });
+
+    it('maintains deterministic order (sorted by field name)', () => {
+      const result1 = generatePrelude({
+        fields: [
+          { name: 'z_field', type: 'long' },
+          { name: 'a_field', type: 'keyword' },
+          { name: 'm_field', type: 'boolean' },
+        ],
+      });
+
+      const result2 = generatePrelude({
+        fields: [
+          { name: 'm_field', type: 'boolean' },
+          { name: 'a_field', type: 'keyword' },
+          { name: 'z_field', type: 'long' },
+        ],
+      });
+
+      // Both should produce the same output regardless of input order
+      expect(result1.query).toBe(result2.query);
+      expect(result1.query).toMatchInlineSnapshot(`
+        "INSIST_🐔 a_field
+          | INSIST_🐔 m_field
+          | INSIST_🐔 z_field
+          | EVAL a_field = a_field::STRING
+          | EVAL m_field = m_field::BOOLEAN
+          | EVAL z_field = z_field::LONG"
+      `);
+    });
+
+    it('handles mixed typed and untyped fields', () => {
+      const result = generatePrelude({
+        fields: [{ name: 'typed_field', type: 'integer' }, { name: 'untyped_field' }],
+      });
+
+      expect(result.commands).toHaveLength(3); // 2 INSIST + 1 EVAL
+      expect(result.query).toMatchInlineSnapshot(`
+        "INSIST_🐔 typed_field
+          | INSIST_🐔 untyped_field
+          | EVAL typed_field = typed_field::INTEGER"
+      `);
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.ts
@@ -62,7 +62,7 @@ function getEsqlCastOperator(type: PreludeFieldType): string | undefined {
     case 'keyword':
     case 'text':
     case 'match_only_text':
-      return 'string';
+      return 'keyword';
     case 'long':
       return 'long';
     case 'integer':
@@ -179,7 +179,7 @@ export function generateTypedEvalCasts(fields: PreludeField[]): ESQLAstCommand[]
  * // | INSIST_🐔 `attributes.count`
  * // | INSIST_🐔 `attributes.status`
  * // | EVAL `attributes.count` = COALESCE(null, `attributes.count`::integer)
- * // | EVAL `attributes.status` = COALESCE(null, `attributes.status`::string)
+ * // | EVAL `attributes.status` = COALESCE(null, `attributes.status`::keyword)
  * ```
  *
  * @param options - Prelude generation options

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/prelude.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ESQLAstCommand } from '@kbn/esql-language';
+import { Builder, BasicPrettyPrinter } from '@kbn/esql-language';
+
+/**
+ * Supported field types for ESQL prelude type casting.
+ * These map to ES|QL cast operators (e.g., `field::integer`).
+ */
+export type PreludeFieldType =
+  | 'keyword'
+  | 'text'
+  | 'match_only_text'
+  | 'long'
+  | 'integer'
+  | 'short'
+  | 'byte'
+  | 'double'
+  | 'float'
+  | 'half_float'
+  | 'unsigned_long'
+  | 'boolean'
+  | 'date'
+  | 'date_nanos'
+  | 'ip'
+  | 'version'
+  | 'geo_point';
+
+/**
+ * A field definition for prelude generation.
+ * Includes the field name and optionally its expected type.
+ */
+export interface PreludeField {
+  /** Field name (e.g., 'attributes.foo') */
+  name: string;
+  /**
+   * Field type for casting. If provided, an EVAL cast will be generated.
+   * If omitted, only the INSIST_🐔 command is generated without type casting.
+   */
+  type?: PreludeFieldType;
+}
+
+/**
+ * Options for generating the ESQL prelude.
+ */
+export interface PreludeOptions {
+  /** Fields to include in the prelude with optional type information */
+  fields: PreludeField[];
+}
+
+/**
+ * Maps stream/mapping field types to ES|QL cast operator names.
+ * Returns undefined for types that don't need explicit casting or aren't supported.
+ */
+function getEsqlCastOperator(type: PreludeFieldType): string | undefined {
+  switch (type) {
+    case 'keyword':
+    case 'text':
+    case 'match_only_text':
+      return 'string';
+    case 'long':
+      return 'long';
+    case 'integer':
+    case 'short':
+    case 'byte':
+      return 'integer';
+    case 'double':
+    case 'float':
+    case 'half_float':
+      return 'double';
+    case 'unsigned_long':
+      return 'unsigned_long';
+    case 'boolean':
+      return 'boolean';
+    case 'date':
+    case 'date_nanos':
+      return 'datetime';
+    case 'ip':
+      return 'ip';
+    case 'version':
+      return 'version';
+    case 'geo_point':
+      return 'geo_point';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Generates INSIST_🐔 commands for the given fields.
+ * INSIST_🐔 ensures the field exists in the schema for subsequent operations.
+ *
+ * @param fieldNames - List of field names to generate INSIST_🐔 commands for
+ * @returns Array of ESQL AST commands
+ */
+export function generateInsistCommands(fieldNames: string[]): ESQLAstCommand[] {
+  // Sort field names for deterministic output
+  const sortedFieldNames = [...fieldNames].sort();
+
+  return sortedFieldNames.map((fieldName) =>
+    Builder.command({
+      name: 'insist_🐔',
+      args: [Builder.expression.column(fieldName)],
+    })
+  );
+}
+
+/**
+ * Generates typed EVAL cast commands for fields with known types.
+ * Uses the ES|QL inline cast operator syntax (e.g., `EVAL field = field::integer`).
+ *
+ * @param fields - List of fields with type information
+ * @returns Array of ESQL AST commands for type casts
+ */
+export function generateTypedEvalCasts(fields: PreludeField[]): ESQLAstCommand[] {
+  // Sort by field name for deterministic output
+  const sortedFields = [...fields].sort((a, b) => a.name.localeCompare(b.name));
+
+  const commands: ESQLAstCommand[] = [];
+
+  for (const field of sortedFields) {
+    if (!field.type) {
+      continue;
+    }
+
+    const castOperator = getEsqlCastOperator(field.type);
+    if (!castOperator) {
+      continue;
+    }
+
+    const column = Builder.expression.column(field.name);
+
+    // Build inline cast expression: field::type
+    const castExpression = Builder.expression.inlineCast({
+      value: column,
+      castType: castOperator,
+    });
+
+    commands.push(
+      Builder.command({
+        name: 'eval',
+        args: [Builder.expression.func.binary('=', [column, castExpression])],
+      })
+    );
+  }
+
+  return commands;
+}
+
+/**
+ * Generates the complete ESQL prelude for draft stream execution.
+ * The prelude consists of:
+ * 1. INSIST_🐔 commands for each field (ensures field exists)
+ * 2. EVAL casts for typed fields (ensures correct type)
+ *
+ * The order is deterministic (sorted by field name) to ensure consistent output.
+ *
+ * @example
+ * ```typescript
+ * const prelude = generatePrelude({
+ *   fields: [
+ *     { name: 'attributes.status', type: 'keyword' },
+ *     { name: 'attributes.count', type: 'integer' },
+ *   ],
+ * });
+ * // Returns commands for:
+ * // | INSIST_🐔 `attributes.count`
+ * // | INSIST_🐔 `attributes.status`
+ * // | EVAL `attributes.count` = `attributes.count`::integer
+ * // | EVAL `attributes.status` = `attributes.status`::string
+ * ```
+ *
+ * @param options - Prelude generation options
+ * @returns Object containing AST commands and formatted query string
+ */
+export function generatePrelude(options: PreludeOptions): {
+  commands: ESQLAstCommand[];
+  query: string;
+} {
+  const { fields } = options;
+
+  if (fields.length === 0) {
+    return { commands: [], query: '' };
+  }
+
+  const fieldNames = fields.map((f) => f.name);
+
+  // Generate INSIST_🐔 commands first
+  const insistCommands = generateInsistCommands(fieldNames);
+
+  // Then generate typed EVAL casts
+  const evalCasts = generateTypedEvalCasts(fields);
+
+  const commands = [...insistCommands, ...evalCasts];
+
+  // Format as query string
+  const query = commands.length > 0 ? formatPreludeQuery(commands) : '';
+
+  return { commands, query };
+}
+
+/**
+ * Formats prelude commands into an ESQL query string fragment.
+ * Each command is prefixed with a pipe separator.
+ */
+function formatPreludeQuery(commands: ESQLAstCommand[]): string {
+  if (commands.length === 0) {
+    return '';
+  }
+
+  const query = Builder.expression.query(commands);
+  return BasicPrettyPrinter.multiline(query, { pipeTab: '  ' });
+}

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/transpiler.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/transpiler.test.ts
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
-import { transpile } from '.';
+import { transpile, type PreludeField } from '.';
 import {
   comprehensiveTestDSL,
   manualIngestPipelineTestDSL,
   notConditionsTestDSL,
   typeCoercionsTestDSL,
 } from '../shared/mocks/test_dsls';
+import type { StreamlangDSL } from '../../../types/streamlang';
+import type { SetProcessor } from '../../../types/processors';
 
 describe('transpile - Streamlang DSL to ES|QL)', () => {
   it('should transpile a variety of processor steps and where blocks', () => {
@@ -32,5 +34,63 @@ describe('transpile - Streamlang DSL to ES|QL)', () => {
   it('should warn when manual_ingest_pipeline is used', () => {
     const result = transpile(manualIngestPipelineTestDSL);
     expect(result.query).toMatchSnapshot();
+  });
+
+  describe('prelude support', () => {
+    const simpleTestDSL: StreamlangDSL = {
+      steps: [
+        {
+          action: 'set',
+          to: 'attributes.status',
+          value: 'active',
+        } as SetProcessor,
+      ],
+    };
+
+    it('should include prelude when preludeFields are provided', () => {
+      const preludeFields: PreludeField[] = [
+        { name: 'attributes.foo', type: 'integer' },
+        { name: 'body.message', type: 'keyword' },
+      ];
+
+      const result = transpile(simpleTestDSL, { pipeTab: '  ', preludeFields });
+
+      expect(result.prelude).toBeDefined();
+      expect(result.query).toMatchSnapshot();
+    });
+
+    it('should return undefined prelude when no preludeFields provided', () => {
+      const result = transpile(simpleTestDSL, { pipeTab: '  ' });
+
+      expect(result.prelude).toBeUndefined();
+    });
+
+    it('should return undefined prelude when preludeFields is empty', () => {
+      const result = transpile(simpleTestDSL, { pipeTab: '  ', preludeFields: [] });
+
+      expect(result.prelude).toBeUndefined();
+    });
+
+    it('should prepend INSIST_🐔 and typed EVAL casts in deterministic order', () => {
+      const preludeFields: PreludeField[] = [
+        { name: 'z_field', type: 'long' },
+        { name: 'a_field', type: 'boolean' },
+        { name: 'm_field' }, // untyped
+      ];
+
+      const result = transpile(simpleTestDSL, { pipeTab: '  ', preludeFields });
+
+      // Verify the query starts with sorted INSIST commands
+      expect(result.query).toContain('INSIST_🐔 a_field');
+      expect(result.query).toContain('INSIST_🐔 m_field');
+      expect(result.query).toContain('INSIST_🐔 z_field');
+
+      // Verify typed EVALs are included (only for typed fields)
+      expect(result.query).toContain('a_field::BOOLEAN');
+      expect(result.query).toContain('z_field::LONG');
+      expect(result.query).not.toContain('m_field::'); // untyped field has no cast
+
+      expect(result.query).toMatchSnapshot();
+    });
   });
 });

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/get_discover_esql_query.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/get_discover_esql_query.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getDiscoverEsqlQuery } from './get_discover_esql_query';
+import type { Streams } from '../models/streams';
+import { getEsqlViewName } from '../models/query/view_name';
+
+describe('getDiscoverEsqlQuery', () => {
+  describe('wired streams', () => {
+    const createWiredStreamDefinition = (
+      name: string,
+      draft?: boolean
+    ): Streams.WiredStream.Definition => ({
+      name,
+      description: '',
+      updated_at: new Date().toISOString(),
+      ingest: {
+        lifecycle: { inherit: {} },
+        processing: { steps: [], updated_at: new Date().toISOString() },
+        settings: {},
+        wired: {
+          fields: {},
+          routing: [],
+          ...(draft !== undefined ? { draft } : {}),
+        },
+        failure_store: { inherit: {} },
+      },
+    });
+
+    it('returns index patterns for non-draft wired streams', () => {
+      const definition = createWiredStreamDefinition('logs');
+      const result = getDiscoverEsqlQuery({ definition });
+      expect(result).toBe('FROM logs, logs.*');
+    });
+
+    it('returns ESQL view query for draft wired streams', () => {
+      const definition = createWiredStreamDefinition('logs.draft', true);
+      const result = getDiscoverEsqlQuery({ definition });
+      expect(result).toBe(`FROM ${getEsqlViewName('logs.draft')}`);
+    });
+
+    it('returns index patterns when draft is explicitly false', () => {
+      const definition = createWiredStreamDefinition('logs.child', false);
+      const result = getDiscoverEsqlQuery({ definition });
+      expect(result).toBe('FROM logs.child, logs.child.*');
+    });
+
+    it('uses TS command for time_series index mode', () => {
+      const definition = createWiredStreamDefinition('metrics');
+      const result = getDiscoverEsqlQuery({ definition, indexMode: 'time_series' });
+      expect(result).toBe('TS metrics, metrics.*');
+    });
+
+    it('includes METADATA _source when includeMetadata is true', () => {
+      const definition = createWiredStreamDefinition('logs');
+      const result = getDiscoverEsqlQuery({ definition, includeMetadata: true });
+      expect(result).toBe('FROM logs, logs.* METADATA _source');
+    });
+  });
+
+  describe('query streams', () => {
+    const createQueryStreamDefinition = (name: string): Streams.QueryStream.Definition => ({
+      name,
+      description: '',
+      updated_at: new Date().toISOString(),
+      query: {
+        esql: 'FROM logs | WHERE level == "error"',
+        view: '$.logs.errors',
+      },
+    });
+
+    it('returns the view name for query streams', () => {
+      const definition = createQueryStreamDefinition('logs.errors');
+      const result = getDiscoverEsqlQuery({ definition });
+      expect(result).toBe('FROM $.logs.errors');
+    });
+  });
+
+  describe('classic streams', () => {
+    const createClassicStreamDefinition = (name: string): Streams.ClassicStream.Definition => ({
+      name,
+      description: '',
+      updated_at: new Date().toISOString(),
+      ingest: {
+        lifecycle: { dsl: {} },
+        processing: { steps: [], updated_at: new Date().toISOString() },
+        settings: {},
+        classic: {},
+        failure_store: { disabled: {} },
+      },
+    });
+
+    it('returns stream name for classic streams', () => {
+      const definition = createClassicStreamDefinition('my-logs');
+      const result = getDiscoverEsqlQuery({ definition });
+      // Classic streams use the stream name
+      expect(result).toBe('FROM my-logs');
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/get_discover_esql_query.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/get_discover_esql_query.ts
@@ -7,6 +7,7 @@
 
 import type { IngestStreamIndexMode } from '../models/ingest/base';
 import { Streams } from '../models/streams';
+import { getEsqlViewName } from '../models/query/view_name';
 import { getIndexPatternsForStream } from './hierarchy_helpers';
 
 export interface GetDiscoverEsqlQueryOptions {
@@ -54,6 +55,15 @@ export function getDiscoverEsqlQuery(options: GetDiscoverEsqlQueryOptions): stri
   if (Streams.QueryStream.Definition.is(definition)) {
     // Use the ES|QL view name as the query source
     return `FROM ${definition.query.view}`;
+  }
+
+  // For draft wired streams, use the ESQL view instead of the data stream
+  // (data streams don't exist for draft streams)
+  if (
+    Streams.WiredStream.Definition.is(definition) &&
+    definition.ingest.wired.draft === true
+  ) {
+    return `FROM ${getEsqlViewName(definition.name)}`;
   }
 
   const indexPatterns = getIndexPatternsForStream(definition);

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.ts
@@ -28,6 +28,7 @@ interface IngestWired {
   wired: {
     fields: FieldDefinition;
     routing: RoutingDefinition[];
+    draft?: boolean;
   };
 }
 
@@ -35,6 +36,7 @@ const IngestWired: z.Schema<IngestWired> = z.object({
   wired: z.object({
     fields: fieldDefinitionSchema,
     routing: routingDefinitionListSchema,
+    draft: z.boolean().optional(),
   }),
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -295,17 +295,23 @@ export class StreamsClient {
 
   /**
    * Forks a stream into a child with a specific condition.
+   *
+   * @param draft - If true, creates a draft child stream that is persisted but not materialized
+   *                in Elasticsearch (no templates, pipelines, or data streams). Draft streams
+   *                can be previewed via ESQL queries and later materialized by removing the draft flag.
    */
   async forkStream({
     parent,
     name,
     where: condition,
     status,
+    draft,
   }: {
     parent: string;
     name: string;
     where: Condition;
     status: RoutingStatus;
+    draft?: boolean;
   }): Promise<ForkStreamResponse> {
     const parentDefinition = Streams.WiredStream.Definition.parse(await this.getStream(parent));
 
@@ -350,6 +356,7 @@ export class StreamsClient {
               wired: {
                 fields: {},
                 routing: [],
+                ...(draft ? { draft: true } : {}),
               },
               failure_store: { inherit: {} },
             },

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -87,12 +87,35 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
     query_streams: false,
   };
 
+  /**
+   * Tracks if this stream is transitioning from draft to non-draft.
+   * When true, the stream needs full ES materialization (templates, pipelines, etc.)
+   * even though it's an "update" operation.
+   */
+  private _fromDraftToNonDraft: boolean = false;
+
   constructor(definition: Streams.WiredStream.Definition, dependencies: StateDependencies) {
     super(definition, dependencies);
   }
 
   protected doClone(): StreamActiveRecord<Streams.WiredStream.Definition> {
-    return new WiredStream(cloneDeep(this._definition), this.dependencies);
+    const clone = new WiredStream(cloneDeep(this._definition), this.dependencies);
+    clone._fromDraftToNonDraft = this._fromDraftToNonDraft;
+    return clone;
+  }
+
+  /**
+   * Returns true if this stream is transitioning from draft to non-draft (materialization).
+   */
+  public isFromDraftToNonDraft(): boolean {
+    return this._fromDraftToNonDraft;
+  }
+
+  /**
+   * Returns true if this stream is a draft stream.
+   */
+  public isDraft(): boolean {
+    return Boolean(this._definition.ingest.wired.draft);
   }
 
   protected async doHandleUpsertChange(
@@ -107,8 +130,25 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
         Streams.WiredStream.Definition.is(definition) &&
         isDescendantOf(definition.name, this._definition.name);
 
+      // Check if a child stream is transitioning from draft to non-draft.
+      // In this case, we need to update the parent's routing pipeline.
+      const childGoesFromDraftToNonDraft =
+        Streams.WiredStream.Definition.is(definition) &&
+        isChildOf(this._definition.name, definition.name) &&
+        !definition.ingest.wired.draft &&
+        (startingState.get(definition.name) as WiredStream | undefined)?._definition.ingest.wired
+          .draft;
+
+      if (childGoesFromDraftToNonDraft) {
+        // Mark routing as changed so we regenerate the reroute pipeline
+        this._changes.routing = true;
+      }
+
       return {
-        changeStatus: ancestorHasChanged && !this.isDeleted() ? 'upserted' : this.changeStatus,
+        changeStatus:
+          (ancestorHasChanged || childGoesFromDraftToNonDraft) && !this.isDeleted()
+            ? 'upserted'
+            : this.changeStatus,
         cascadingChanges: [],
       };
     }
@@ -126,6 +166,27 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
       !Streams.WiredStream.Definition.is(startingStateStreamDefinition)
     ) {
       throw new StatusError('Unexpected starting state stream type', 400);
+    }
+
+    // Validate draft mode transitions:
+    // - Cannot change a non-draft stream back to a draft stream
+    // - Can change a draft stream to a non-draft stream (materialization)
+    if (
+      startingStateStreamDefinition &&
+      !startingStateStreamDefinition.ingest.wired.draft &&
+      this._definition.ingest.wired.draft
+    ) {
+      throw new StatusError('Cannot change a non-draft stream to a draft stream', 400);
+    }
+
+    // Track if we're going from draft to non-draft (materialization)
+    const goFromDraftToNonDraft =
+      startingStateStreamDefinition &&
+      startingStateStreamDefinition.ingest.wired.draft &&
+      !this._definition.ingest.wired.draft;
+
+    if (goFromDraftToNonDraft) {
+      this._fromDraftToNonDraft = true;
     }
 
     this._changes.ownFields =
@@ -229,6 +290,8 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
                 wired: {
                   fields: {},
                   routing: [],
+                  // Child streams inherit draft status from their parent
+                  ...(this._definition.ingest.wired.draft ? { draft: true } : {}),
                 },
                 failure_store: { inherit: {} },
               },
@@ -444,6 +507,45 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
         };
       }
       children.add(routing.destination);
+    }
+
+    // Validate draft routing constraints:
+    // 1. Draft streams must come after non-draft streams in routing order
+    // 2. Draft streams cannot have non-draft children
+    const isDraft = this._definition.ingest.wired.draft;
+    let seenDraftChild = false;
+
+    for (const routing of this._definition.ingest.wired.routing) {
+      const childDefinition = desiredState.get(routing.destination)?.definition;
+      if (childDefinition && Streams.WiredStream.Definition.is(childDefinition)) {
+        const childIsDraft = Boolean(childDefinition.ingest.wired.draft);
+
+        // Check routing order: once we've seen a draft child, all subsequent children must be drafts
+        if (childIsDraft) {
+          seenDraftChild = true;
+        } else if (seenDraftChild) {
+          return {
+            isValid: false,
+            errors: [
+              new Error(
+                `Cannot route a non-draft stream "${routing.destination}" after a draft stream in the routing of "${this._definition.name}". Draft streams must come last in routing order.`
+              ),
+            ],
+          };
+        }
+
+        // Check draft parent constraint: draft streams cannot have non-draft children
+        if (isDraft && !childIsDraft) {
+          return {
+            isValid: false,
+            errors: [
+              new Error(
+                `Cannot create draft stream "${this._definition.name}" with a non-draft child stream "${routing.destination}". All children of a draft stream must also be drafts.`
+              ),
+            ],
+          };
+        }
+      }
     }
 
     for (const stream of desiredState.all()) {
@@ -673,6 +775,17 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
   }
 
   protected async doDetermineCreateActions(desiredState: State): Promise<ElasticsearchAction[]> {
+    // For draft streams, only persist the definition document - skip ES materialization
+    // (no templates, pipelines, data streams, etc.)
+    if (this._definition.ingest.wired.draft) {
+      return [
+        {
+          type: 'upsert_dot_streams_document',
+          request: this._definition,
+        },
+      ];
+    }
+
     const ancestors = getAncestorsAndSelf(this._definition.name).map(
       (id) => desiredState.get(id)!.definition as Streams.WiredStream.Definition
     );
@@ -800,6 +913,22 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
     startingState: State,
     startingStateStream: WiredStream
   ): Promise<ElasticsearchAction[]> {
+    // If transitioning from draft to non-draft, perform full materialization
+    // (same as creating a new non-draft stream)
+    if (this._fromDraftToNonDraft) {
+      return this.doDetermineCreateActions(desiredState);
+    }
+
+    // For draft streams, only update the definition document
+    if (this._definition.ingest.wired.draft) {
+      return [
+        {
+          type: 'upsert_dot_streams_document',
+          request: this._definition,
+        },
+      ];
+    }
+
     const actions: ElasticsearchAction[] = [];
     if (this.hasChangedFields()) {
       actions.push({
@@ -942,6 +1071,18 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
   }
 
   protected async doDetermineDeleteActions(): Promise<ElasticsearchAction[]> {
+    // For draft streams, only delete the definition document - no ES artifacts exist
+    if (this._definition.ingest.wired.draft) {
+      return [
+        {
+          type: 'delete_dot_streams_document',
+          request: {
+            name: this._definition.name,
+          },
+        },
+      ];
+    }
+
     return [
       {
         type: 'delete_index_template',

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream_draft.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream_draft.test.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Streams } from '@kbn/streams-schema';
+import { WiredStream } from './wired_stream';
+import { State } from '../state';
+import type { StateDependencies } from '../types';
+import type { LockManagerService } from '@kbn/lock-manager';
+
+const createMockDependencies = (): StateDependencies => ({
+  storageClient: {
+    search: jest.fn().mockResolvedValue({ hits: { hits: [], total: { value: 0 } } }),
+    get: jest.fn(),
+    index: jest.fn(),
+    delete: jest.fn(),
+  } as any,
+  scopedClusterClient: {
+    asCurrentUser: {
+      indices: {
+        getDataStream: jest.fn().mockRejectedValue({ statusCode: 404 }),
+        get: jest.fn().mockRejectedValue({ statusCode: 404 }),
+      },
+      ingest: {
+        putPipeline: jest.fn(),
+        deletePipeline: jest.fn(),
+      },
+      cluster: {
+        putComponentTemplate: jest.fn(),
+        deleteComponentTemplate: jest.fn(),
+      },
+    },
+    asInternalUser: {
+      indices: {
+        getDataStream: jest.fn().mockRejectedValue({ statusCode: 404 }),
+      },
+    },
+  } as any,
+  lockManager: {
+    withLock: (_: any, cb: () => Promise<any>) => cb(),
+  } as LockManagerService,
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as any,
+  isServerless: false,
+  isDev: true,
+  streamsClient: {
+    getStream: jest.fn(),
+  } as any,
+  systemClient: {} as any,
+  attachmentClient: {} as any,
+  queryClient: {} as any,
+  featureClient: {} as any,
+});
+
+const createWiredStreamDefinition = (
+  name: string,
+  overrides?: Partial<Streams.WiredStream.Definition>
+): Streams.WiredStream.Definition => {
+  const now = new Date().toISOString();
+  return {
+    name,
+    description: '',
+    updated_at: now,
+    ingest: {
+      lifecycle: { inherit: {} },
+      processing: { steps: [], updated_at: now },
+      settings: {},
+      wired: {
+        fields: {},
+        routing: [],
+      },
+      failure_store: { inherit: {} },
+    },
+    ...overrides,
+  };
+};
+
+const createDraftStreamDefinition = (
+  name: string,
+  overrides?: Partial<Streams.WiredStream.Definition>
+): Streams.WiredStream.Definition => {
+  return createWiredStreamDefinition(name, {
+    ingest: {
+      lifecycle: { inherit: {} },
+      processing: { steps: [], updated_at: new Date().toISOString() },
+      settings: {},
+      wired: {
+        fields: {},
+        routing: [],
+        draft: true,
+      },
+      failure_store: { inherit: {} },
+    },
+    ...overrides,
+  });
+};
+
+describe('WiredStream draft mode', () => {
+  let mockDependencies: StateDependencies;
+
+  beforeEach(() => {
+    mockDependencies = createMockDependencies();
+    jest.clearAllMocks();
+  });
+
+  describe('isDraft', () => {
+    it('returns true for draft streams', () => {
+      const definition = createDraftStreamDefinition('logs.draft');
+      const stream = new WiredStream(definition, mockDependencies);
+      expect(stream.isDraft()).toBe(true);
+    });
+
+    it('returns false for non-draft streams', () => {
+      const definition = createWiredStreamDefinition('logs.nondraft');
+      const stream = new WiredStream(definition, mockDependencies);
+      expect(stream.isDraft()).toBe(false);
+    });
+  });
+
+  describe('isFromDraftToNonDraft', () => {
+    it('returns false initially', () => {
+      const definition = createWiredStreamDefinition('logs.test');
+      const stream = new WiredStream(definition, mockDependencies);
+      expect(stream.isFromDraftToNonDraft()).toBe(false);
+    });
+  });
+
+  describe('doDetermineCreateActions', () => {
+    it('only persists definition for draft streams', async () => {
+      const definition = createDraftStreamDefinition('logs.draft');
+      const stream = new WiredStream(definition, mockDependencies);
+
+      // Mock the state to include the root stream
+      const mockState = {
+        get: (name: string) => {
+          if (name === 'logs') {
+            return new WiredStream(createWiredStreamDefinition('logs'), mockDependencies);
+          }
+          return undefined;
+        },
+      } as unknown as State;
+
+      const actions = await (stream as any).doDetermineCreateActions(mockState);
+
+      // Draft streams should only have the document upsert action
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe('upsert_dot_streams_document');
+    });
+
+    it('includes all ES materialization actions for non-draft streams', async () => {
+      const definition = createWiredStreamDefinition('logs.nondraft');
+      const stream = new WiredStream(definition, mockDependencies);
+
+      // Mock getMatchingDataStream to return no conflicts
+      (stream as any).getMatchingDataStream = jest.fn().mockResolvedValue({
+        existsAsManagedDataStream: false,
+        existsAsIndex: false,
+        existsAsDataStream: false,
+      });
+
+      // Mock the state to include the root stream
+      const rootDefinition = createWiredStreamDefinition('logs');
+      rootDefinition.ingest.lifecycle = { dsl: { data_retention: '7d' } };
+      rootDefinition.ingest.failure_store = { disabled: {} };
+
+      const mockState = {
+        get: (name: string) => {
+          if (name === 'logs') {
+            return new WiredStream(rootDefinition, mockDependencies);
+          }
+          if (name === 'logs.nondraft') {
+            return stream;
+          }
+          return undefined;
+        },
+      } as unknown as State;
+
+      const actions = await (stream as any).doDetermineCreateActions(mockState);
+
+      // Non-draft streams should have all materialization actions
+      const actionTypes = actions.map((a: any) => a.type);
+      expect(actionTypes).toContain('upsert_component_template');
+      expect(actionTypes).toContain('upsert_ingest_pipeline');
+      expect(actionTypes).toContain('upsert_index_template');
+      expect(actionTypes).toContain('upsert_datastream');
+      expect(actionTypes).toContain('update_lifecycle');
+      expect(actionTypes).toContain('upsert_dot_streams_document');
+    });
+  });
+
+  describe('doDetermineUpdateActions', () => {
+    it('only persists definition for draft stream updates', async () => {
+      const definition = createDraftStreamDefinition('logs.draft');
+      const stream = new WiredStream(definition, mockDependencies);
+
+      const mockDesiredState = {} as State;
+      const mockStartingState = {} as State;
+      const mockStartingStateStream = new WiredStream(
+        createDraftStreamDefinition('logs.draft'),
+        mockDependencies
+      );
+
+      const actions = await (stream as any).doDetermineUpdateActions(
+        mockDesiredState,
+        mockStartingState,
+        mockStartingStateStream
+      );
+
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe('upsert_dot_streams_document');
+    });
+  });
+
+  describe('doDetermineDeleteActions', () => {
+    it('only deletes definition for draft streams', async () => {
+      const definition = createDraftStreamDefinition('logs.draft');
+      const stream = new WiredStream(definition, mockDependencies);
+
+      const actions = await (stream as any).doDetermineDeleteActions();
+
+      // Draft streams should only delete the document
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe('delete_dot_streams_document');
+    });
+
+    it('includes all cleanup actions for non-draft streams', async () => {
+      const definition = createWiredStreamDefinition('logs.nondraft');
+      const stream = new WiredStream(definition, mockDependencies);
+
+      const actions = await (stream as any).doDetermineDeleteActions();
+
+      // Non-draft streams should have all cleanup actions
+      const actionTypes = actions.map((a: any) => a.type);
+      expect(actionTypes).toContain('delete_index_template');
+      expect(actionTypes).toContain('delete_component_template');
+      expect(actionTypes).toContain('delete_ingest_pipeline');
+      expect(actionTypes).toContain('delete_datastream');
+      expect(actionTypes).toContain('delete_dot_streams_document');
+    });
+  });
+
+  describe('doClone', () => {
+    it('preserves the fromDraftToNonDraft flag when cloning', () => {
+      const definition = createWiredStreamDefinition('logs.test');
+      const stream = new WiredStream(definition, mockDependencies);
+
+      // Manually set the flag (simulating a draft->non-draft transition)
+      (stream as any)._fromDraftToNonDraft = true;
+
+      const cloned = (stream as any).doClone();
+
+      expect(cloned.isFromDraftToNonDraft()).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/management/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/management/route.ts
@@ -35,6 +35,7 @@ export const forkStreamsRoute = createServerRoute({
       stream: z.object({ name: z.string() }),
       where: conditionSchema,
       status: routingStatus.optional(),
+      draft: z.boolean().optional(),
     }),
   }),
   handler: async ({ params, request, getScopedClients }): Promise<{ acknowledged: true }> => {
@@ -53,6 +54,7 @@ export const forkStreamsRoute = createServerRoute({
       where: params.body.where,
       name: params.body.stream.name,
       status: conditionStatus,
+      draft: params.body.draft,
     });
   },
 });

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/draft_streams.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/draft_streams.spec.ts
@@ -1,0 +1,748 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import { tags } from '@kbn/scout';
+import { streamsApiTest as apiTest } from '../fixtures';
+import { PUBLIC_API_HEADERS } from '../fixtures/constants';
+
+apiTest.describe(
+  'Draft streams - wired stream draft mode API (CRUD)',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    // Stream names must be exactly one level deep when forking from 'logs'
+    const streamNamePrefix = 'logs.draft';
+
+    apiTest.afterEach(async ({ apiServices }) => {
+      await apiServices.streamsTest.cleanupTestStreams(streamNamePrefix);
+    });
+
+    // Basic draft stream creation via fork
+    apiTest('should create a draft child stream via fork API', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+      const childStreamName = `${streamNamePrefix}-basic`;
+
+      const { statusCode, body } = await apiClient.post('api/streams/logs/_fork', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: {
+          stream: { name: childStreamName },
+          where: { field: 'service.name', eq: 'test-service' },
+          status: 'enabled',
+          draft: true,
+        },
+        responseType: 'json',
+      });
+
+      expect(statusCode).toBe(200);
+      expect(body.acknowledged).toBe(true);
+
+      // Verify the stream was created with draft flag
+      const { statusCode: getStatus, body: getBody } = await apiClient.get(
+        `api/streams/${childStreamName}`,
+        {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        }
+      );
+
+      expect(getStatus).toBe(200);
+      expect(getBody.stream.name).toBe(childStreamName);
+      expect(getBody.stream.ingest.wired.draft).toBe(true);
+    });
+
+    apiTest(
+      'should create a draft stream without materializing ES artifacts',
+      async ({ apiClient, samlAuth, esClient }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const childStreamName = `${streamNamePrefix}-no-es`;
+
+        // Create draft stream
+        const { statusCode } = await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: childStreamName },
+            where: { field: 'service.name', eq: 'test-service' },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+        expect(statusCode).toBe(200);
+
+        // Verify data stream does not exist - expect getDataStream to throw 404
+        const dataStreamCheck = await esClient.indices
+          .getDataStream({ name: childStreamName })
+          .then(() => ({ exists: true, statusCode: 200 }))
+          .catch((error: any) => ({ exists: false, statusCode: error.meta?.statusCode }));
+
+        expect(dataStreamCheck.exists).toBe(false);
+        expect(dataStreamCheck.statusCode).toBe(404);
+      }
+    );
+
+    // Draft stream deletion
+    apiTest('should delete a draft stream', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+      const childStreamName = `${streamNamePrefix}-to-delete`;
+
+      // Create draft stream first
+      await apiClient.post('api/streams/logs/_fork', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: {
+          stream: { name: childStreamName },
+          where: { field: 'service.name', eq: 'to-delete' },
+          status: 'enabled',
+          draft: true,
+        },
+        responseType: 'json',
+      });
+
+      // Delete the stream
+      const { statusCode } = await apiClient.delete(`api/streams/${childStreamName}`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+
+      expect(statusCode).toBe(200);
+
+      // Verify stream is deleted
+      const { statusCode: getStatus } = await apiClient.get(`api/streams/${childStreamName}`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+      expect(getStatus).toBe(404);
+    });
+
+    // Non-draft to draft transition (should fail)
+    apiTest(
+      'should fail to change a non-draft stream to draft',
+      async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const childStreamName = `${streamNamePrefix}-non-to-draft`;
+
+        // Create non-draft stream first
+        const { statusCode: createStatus } = await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: childStreamName },
+            where: { field: 'service.name', eq: 'non-draft' },
+            status: 'enabled',
+            // no draft flag = non-draft
+          },
+          responseType: 'json',
+        });
+        expect(createStatus).toBe(200);
+
+        // Get the stream definition
+        const { body: getBody } = await apiClient.get(`api/streams/${childStreamName}`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+
+        // Try to update to draft
+        const { updated_at: _, ...processingWithoutUpdatedAt } =
+          getBody.stream.ingest.processing || {};
+        const { statusCode: updateStatus } = await apiClient.put(
+          `api/streams/${childStreamName}/_ingest`,
+          {
+            headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+            body: {
+              ingest: {
+                ...getBody.stream.ingest,
+                processing: processingWithoutUpdatedAt,
+                wired: {
+                  ...getBody.stream.ingest.wired,
+                  draft: true,
+                },
+              },
+            },
+            responseType: 'json',
+          }
+        );
+
+        expect(updateStatus).toBe(400);
+      }
+    );
+
+    // Draft to non-draft transition (materialization)
+    apiTest(
+      'should allow draft to non-draft transition (materialization)',
+      async ({ apiClient, samlAuth, esClient }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const childStreamName = `${streamNamePrefix}-materialize`;
+
+        // Create draft stream first
+        await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: childStreamName },
+            where: { field: 'service.name', eq: 'materialize' },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+
+        // Verify it's a draft
+        const { body: getBody } = await apiClient.get(`api/streams/${childStreamName}`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+        expect(getBody.stream.ingest.wired.draft).toBe(true);
+
+        // Update to non-draft (materialize)
+        const { updated_at: _, ...processingWithoutUpdatedAt } =
+          getBody.stream.ingest.processing || {};
+        const { statusCode: updateStatus } = await apiClient.put(
+          `api/streams/${childStreamName}/_ingest`,
+          {
+            headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+            body: {
+              ingest: {
+                ...getBody.stream.ingest,
+                processing: processingWithoutUpdatedAt,
+                wired: {
+                  ...getBody.stream.ingest.wired,
+                  draft: false,
+                },
+              },
+            },
+            responseType: 'json',
+          }
+        );
+
+        expect(updateStatus).toBe(200);
+
+        // Verify it's no longer a draft
+        const { body: updatedBody } = await apiClient.get(`api/streams/${childStreamName}`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+        expect(Boolean(updatedBody.stream.ingest.wired.draft)).toBe(false);
+
+        // Verify data stream now exists
+        const dataStreamResponse = await esClient.indices.getDataStream({ name: childStreamName });
+        expect(dataStreamResponse.data_streams).toHaveLength(1);
+        expect(dataStreamResponse.data_streams[0].name).toBe(childStreamName);
+      }
+    );
+
+    // Draft child stream inherits draft from parent when auto-created
+    apiTest(
+      'should inherit draft status for auto-created child streams',
+      async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const parentStreamName = `${streamNamePrefix}-parent`;
+        const childStreamName = `${parentStreamName}.child`;
+
+        // Create draft parent
+        await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: parentStreamName },
+            where: { field: 'service.name', eq: 'parent-service' },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+
+        // Get parent stream and add routing to auto-create child
+        const { body: parentBody } = await apiClient.get(`api/streams/${parentStreamName}`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+
+        const { updated_at: _, ...processingWithoutUpdatedAt } =
+          parentBody.stream.ingest.processing || {};
+
+        // Update parent with routing to new child
+        const { statusCode: updateStatus } = await apiClient.put(
+          `api/streams/${parentStreamName}/_ingest`,
+          {
+            headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+            body: {
+              ingest: {
+                ...parentBody.stream.ingest,
+                processing: processingWithoutUpdatedAt,
+                wired: {
+                  ...parentBody.stream.ingest.wired,
+                  routing: [
+                    ...parentBody.stream.ingest.wired.routing,
+                    {
+                      destination: childStreamName,
+                      where: { field: 'log.level', eq: 'error' },
+                      status: 'enabled',
+                    },
+                  ],
+                },
+              },
+            },
+            responseType: 'json',
+          }
+        );
+        expect(updateStatus).toBe(200);
+
+        // Verify the auto-created child is also a draft
+        const { body: childBody } = await apiClient.get(`api/streams/${childStreamName}`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+        expect(childBody.stream.ingest.wired.draft).toBe(true);
+      }
+    );
+
+    // Routing order constraint: draft streams must come last
+    apiTest(
+      'should fail when non-draft stream follows draft in routing order',
+      async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const draftChildName = `${streamNamePrefix}-order-draft`;
+        const nonDraftChildName = `${streamNamePrefix}-order-nondraft`;
+
+        // Create a draft child first
+        await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: draftChildName },
+            where: { field: 'service.name', eq: 'draft-service' },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+
+        // Create a non-draft child second
+        await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: nonDraftChildName },
+            where: { field: 'service.name', eq: 'nondraft-service' },
+            status: 'enabled',
+            // non-draft
+          },
+          responseType: 'json',
+        });
+
+        // Get the logs parent stream
+        const { body: parentBody } = await apiClient.get('api/streams/logs', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+
+        // Try to reorder routing: draft child first, then non-draft child (invalid)
+        const otherRoutes = parentBody.stream.ingest.wired.routing.filter(
+          (r: { destination: string }) =>
+            r.destination !== draftChildName && r.destination !== nonDraftChildName
+        );
+
+        const draftRoute = parentBody.stream.ingest.wired.routing.find(
+          (r: { destination: string }) => r.destination === draftChildName
+        );
+        const nonDraftRoute = parentBody.stream.ingest.wired.routing.find(
+          (r: { destination: string }) => r.destination === nonDraftChildName
+        );
+
+        // Try invalid order: draft then non-draft
+        const invalidRouting = [...otherRoutes, draftRoute, nonDraftRoute];
+
+        const { updated_at: _, ...processingWithoutUpdatedAt } =
+          parentBody.stream.ingest.processing || {};
+        const { statusCode: updateStatus } = await apiClient.put('api/streams/logs/_ingest', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            ingest: {
+              ...parentBody.stream.ingest,
+              processing: processingWithoutUpdatedAt,
+              wired: {
+                ...parentBody.stream.ingest.wired,
+                routing: invalidRouting,
+              },
+            },
+          },
+          responseType: 'json',
+        });
+
+        expect(updateStatus).toBe(400);
+      }
+    );
+
+    // Draft parent cannot have non-draft children constraint
+    apiTest(
+      'should fail when draft stream has non-draft child',
+      async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const parentStreamName = `${streamNamePrefix}-draftparent`;
+        const nonDraftChildName = `${parentStreamName}.nondraft`;
+
+        // Create draft parent
+        await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: parentStreamName },
+            where: { field: 'service.name', eq: 'parent-service' },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+
+        // Try to create non-draft child of draft parent (should fail)
+        const { statusCode } = await apiClient.post(`api/streams/${parentStreamName}/_fork`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: nonDraftChildName },
+            where: { field: 'log.level', eq: 'error' },
+            status: 'enabled',
+            draft: false,
+          },
+          responseType: 'json',
+        });
+
+        expect(statusCode).toBe(400);
+      }
+    );
+
+    // Draft stream field mappings
+    apiTest('should persist field mappings for draft streams', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+      const childStreamName = `${streamNamePrefix}-fields`;
+
+      // Create draft stream
+      await apiClient.post('api/streams/logs/_fork', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: {
+          stream: { name: childStreamName },
+          where: { field: 'service.name', eq: 'fields-test' },
+          status: 'enabled',
+          draft: true,
+        },
+        responseType: 'json',
+      });
+
+      // Get the stream
+      const { body: getBody } = await apiClient.get(`api/streams/${childStreamName}`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+
+      // Add field mappings
+      const { updated_at: _, ...processingWithoutUpdatedAt } =
+        getBody.stream.ingest.processing || {};
+      const { statusCode: updateStatus } = await apiClient.put(
+        `api/streams/${childStreamName}/_ingest`,
+        {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            ingest: {
+              ...getBody.stream.ingest,
+              processing: processingWithoutUpdatedAt,
+              wired: {
+                ...getBody.stream.ingest.wired,
+                fields: {
+                  'attributes.custom_field': { type: 'keyword' },
+                  'attributes.numeric_field': { type: 'long' },
+                },
+              },
+            },
+          },
+          responseType: 'json',
+        }
+      );
+
+      expect(updateStatus).toBe(200);
+
+      // Verify field mappings were persisted
+      const { body: verifyBody } = await apiClient.get(`api/streams/${childStreamName}/_ingest`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+
+      expect(verifyBody.ingest.wired.draft).toBe(true);
+      expect(verifyBody.ingest.wired.fields['attributes.custom_field'].type).toBe('keyword');
+      expect(verifyBody.ingest.wired.fields['attributes.numeric_field'].type).toBe('long');
+    });
+
+    // Draft stream with processing steps
+    apiTest(
+      'should persist processing steps for draft streams',
+      async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const childStreamName = `${streamNamePrefix}-processing`;
+
+        // Create draft stream
+        await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: childStreamName },
+            where: { field: 'service.name', eq: 'processing-test' },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+
+        // Get the stream
+        const { body: getBody } = await apiClient.get(`api/streams/${childStreamName}`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+
+        // Add processing steps
+        const { statusCode: updateStatus } = await apiClient.put(
+          `api/streams/${childStreamName}/_ingest`,
+          {
+            headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+            body: {
+              ingest: {
+                ...getBody.stream.ingest,
+                processing: {
+                  steps: [{ action: 'set', to: 'attributes.processed', value: 'true' }],
+                },
+                wired: getBody.stream.ingest.wired,
+              },
+            },
+            responseType: 'json',
+          }
+        );
+
+        expect(updateStatus).toBe(200);
+
+        // Verify processing steps were persisted
+        const { body: verifyBody } = await apiClient.get(`api/streams/${childStreamName}/_ingest`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+
+        expect(verifyBody.ingest.wired.draft).toBe(true);
+        expect(verifyBody.ingest.processing.steps).toHaveLength(1);
+        expect(verifyBody.ingest.processing.steps[0].action).toBe('set');
+      }
+    );
+
+    // Multiple sibling draft streams
+    apiTest('should create multiple sibling draft streams', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+      const sibling1 = `${streamNamePrefix}-sibling1`;
+      const sibling2 = `${streamNamePrefix}-sibling2`;
+
+      // Create two draft sibling streams
+      for (const [streamName, serviceName] of [
+        [sibling1, 'service-a'],
+        [sibling2, 'service-b'],
+      ]) {
+        const { statusCode } = await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: streamName },
+            where: { field: 'service.name', eq: serviceName },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+        expect(statusCode).toBe(200);
+      }
+
+      // Verify both are drafts
+      for (const streamName of [sibling1, sibling2]) {
+        const { body } = await apiClient.get(`api/streams/${streamName}`, {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+        expect(body.stream.ingest.wired.draft).toBe(true);
+      }
+    });
+
+    // Nested draft streams (2 levels)
+    apiTest('should create nested draft streams (2 levels)', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+      const level1Stream = `${streamNamePrefix}-level1`;
+      const level2Stream = `${level1Stream}.level2`;
+
+      // Create first level draft child
+      await apiClient.post('api/streams/logs/_fork', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: {
+          stream: { name: level1Stream },
+          where: { field: 'service.name', eq: 'level1' },
+          status: 'enabled',
+          draft: true,
+        },
+        responseType: 'json',
+      });
+
+      // Create second level draft child (forked from level1)
+      const { statusCode } = await apiClient.post(`api/streams/${level1Stream}/_fork`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: {
+          stream: { name: level2Stream },
+          where: { field: 'log.level', eq: 'error' },
+          status: 'enabled',
+          draft: true,
+        },
+        responseType: 'json',
+      });
+
+      expect(statusCode).toBe(200);
+
+      // Verify both streams are drafts
+      const { body: l1Body } = await apiClient.get(`api/streams/${level1Stream}`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+      expect(l1Body.stream.ingest.wired.draft).toBe(true);
+
+      const { body: l2Body } = await apiClient.get(`api/streams/${level2Stream}`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+      expect(l2Body.stream.ingest.wired.draft).toBe(true);
+    });
+
+    // Update routing condition on draft stream's parent
+    apiTest('should update routing condition for draft stream', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+      const childStreamName = `${streamNamePrefix}-upd-route`;
+
+      // Create draft stream
+      await apiClient.post('api/streams/logs/_fork', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: {
+          stream: { name: childStreamName },
+          where: { field: 'service.name', eq: 'original-service' },
+          status: 'enabled',
+          draft: true,
+        },
+        responseType: 'json',
+      });
+
+      // Get the parent stream
+      const { body: parentBody } = await apiClient.get('api/streams/logs', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+
+      // Update the routing condition
+      const updatedRouting = parentBody.stream.ingest.wired.routing.map(
+        (rule: { destination: string; where: any; status: string }) => {
+          if (rule.destination === childStreamName) {
+            return {
+              ...rule,
+              where: { field: 'service.name', eq: 'updated-service' },
+            };
+          }
+          return rule;
+        }
+      );
+
+      const { updated_at: _, ...processingWithoutUpdatedAt } =
+        parentBody.stream.ingest.processing || {};
+      const { statusCode: updateStatus } = await apiClient.put('api/streams/logs/_ingest', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: {
+          ingest: {
+            ...parentBody.stream.ingest,
+            processing: processingWithoutUpdatedAt,
+            wired: {
+              ...parentBody.stream.ingest.wired,
+              routing: updatedRouting,
+            },
+          },
+        },
+        responseType: 'json',
+      });
+
+      expect(updateStatus).toBe(200);
+
+      // Verify the routing was updated
+      const { body: verifyBody } = await apiClient.get('api/streams/logs', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+
+      const updatedRule = verifyBody.stream.ingest.wired.routing.find(
+        (r: { destination: string }) => r.destination === childStreamName
+      );
+      expect(updatedRule.where.eq).toBe('updated-service');
+
+      // Verify the child is still a draft
+      const { body: childBody } = await apiClient.get(`api/streams/${childStreamName}`, {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        responseType: 'json',
+      });
+      expect(childBody.stream.ingest.wired.draft).toBe(true);
+    });
+
+    // Disabling routing rule for draft stream
+    apiTest(
+      'should allow disabling routing rule for draft stream',
+      async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+        const childStreamName = `${streamNamePrefix}-disable-route`;
+
+        // Create draft stream with enabled status
+        await apiClient.post('api/streams/logs/_fork', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            stream: { name: childStreamName },
+            where: { field: 'service.name', eq: 'disable-test' },
+            status: 'enabled',
+            draft: true,
+          },
+          responseType: 'json',
+        });
+
+        // Get parent stream
+        const { body: parentBody } = await apiClient.get('api/streams/logs', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+
+        // Update status to disabled
+        const updatedRouting = parentBody.stream.ingest.wired.routing.map(
+          (rule: { destination: string; where: any; status: string }) => {
+            if (rule.destination === childStreamName) {
+              return { ...rule, status: 'disabled' };
+            }
+            return rule;
+          }
+        );
+
+        const { updated_at: _, ...processingWithoutUpdatedAt } =
+          parentBody.stream.ingest.processing || {};
+        const { statusCode: updateStatus } = await apiClient.put('api/streams/logs/_ingest', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: {
+            ingest: {
+              ...parentBody.stream.ingest,
+              processing: processingWithoutUpdatedAt,
+              wired: {
+                ...parentBody.stream.ingest.wired,
+                routing: updatedRouting,
+              },
+            },
+          },
+          responseType: 'json',
+        });
+
+        expect(updateStatus).toBe(200);
+
+        // Verify status was updated
+        const { body: verifyBody } = await apiClient.get('api/streams/logs', {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        });
+
+        const updatedRule = verifyBody.stream.ingest.wired.routing.find(
+          (r: { destination: string }) => r.destination === childStreamName
+        );
+        expect(updatedRule.status).toBe('disabled');
+      }
+    );
+  }
+);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/new_routing_stream_entry.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/new_routing_stream_entry.tsx
@@ -5,13 +5,21 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiPanel, EuiText, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiPanel,
+  EuiSwitch,
+  EuiText,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
 import { css } from '@emotion/css';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useRef } from 'react';
 import { AddRoutingRuleControls } from './control_bars';
 import { RoutingConditionEditor } from './routing_condition_editor';
 import {
+  selectCreateAsDraft,
   selectCurrentRule,
   useStreamRoutingEvents,
   useStreamsRoutingSelector,
@@ -22,8 +30,11 @@ export function NewRoutingStreamEntry() {
   const panelRef = useRef<HTMLDivElement>(null);
   const { euiTheme } = useEuiTheme();
 
-  const { changeRule, changeRuleDebounced } = useStreamRoutingEvents();
+  const { changeRule, changeRuleDebounced, setCreateAsDraft } = useStreamRoutingEvents();
   const currentRule = useStreamsRoutingSelector((snapshot) => selectCurrentRule(snapshot.context));
+  const createAsDraft = useStreamsRoutingSelector((snapshot) =>
+    selectCreateAsDraft(snapshot.context)
+  );
 
   useEffect(() => {
     if (panelRef.current) {
@@ -68,6 +79,24 @@ export function NewRoutingStreamEntry() {
                 defaultMessage: 'Tip: You can add a condition directly from a table cell.',
               })}
             </EuiText>
+          </EuiFlexGroup>
+          <EuiFlexGroup alignItems="center" gutterSize="s">
+            <EuiToolTip
+              content={i18n.translate('xpack.streams.newRoutingStreamEntry.draftToggleTooltip', {
+                defaultMessage:
+                  'Draft streams are not materialized in Elasticsearch. Data is previewed using ES|QL queries. Materialize the stream later to start ingesting data.',
+              })}
+            >
+              <EuiSwitch
+                label={i18n.translate('xpack.streams.newRoutingStreamEntry.draftToggleLabel', {
+                  defaultMessage: 'Create as draft',
+                })}
+                checked={createAsDraft}
+                onChange={(e) => setCreateAsDraft(e.target.checked)}
+                data-test-subj="streamsAppNewRoutingStreamDraftToggle"
+                compressed
+              />
+            </EuiToolTip>
           </EuiFlexGroup>
           <AddRoutingRuleControls isStreamNameValid={isStreamNameValid} />
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/selectors.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/selectors.ts
@@ -60,3 +60,8 @@ export const selectHasRoutingChanges = createSelector(
     });
   }
 );
+
+/**
+ * Selects whether the new stream should be created as a draft.
+ */
+export const selectCreateAsDraft = (context: StreamRoutingContext) => context.createAsDraft;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/stream_actors.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/stream_actors.ts
@@ -56,6 +56,7 @@ export interface ForkStreamInput {
   where: Condition;
   status: RoutingStatus;
   destination: string;
+  draft?: boolean;
 }
 export function createForkStreamActor({
   streamsRepositoryClient,
@@ -66,11 +67,14 @@ export function createForkStreamActor({
   telemetryClient: StreamsTelemetryClient;
 }) {
   return fromPromise<ForkStreamResponse, ForkStreamInput>(async ({ input, signal }) => {
-    const body = buildRoutingForkRequestPayload({
-      where: input.where,
-      status: input.status,
-      destination: input.destination,
-    });
+    const body = buildRoutingForkRequestPayload(
+      {
+        where: input.where,
+        status: input.status,
+        destination: input.destination,
+      },
+      { draft: input.draft }
+    );
 
     const response = await streamsRepositoryClient.fetch(
       'POST /api/streams/{name}/_fork 2023-10-31',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/types.ts
@@ -41,6 +41,7 @@ export interface StreamRoutingContext {
   editingSuggestionIndex: number | null;
   editedSuggestion: PartitionSuggestion | null;
   isRefreshing: boolean;
+  createAsDraft: boolean;
 }
 
 export type StreamRoutingEvent =
@@ -53,10 +54,11 @@ export type StreamRoutingEvent =
   | { type: 'routingRule.change'; routingRule: Partial<RoutingDefinitionWithUIAttributes> }
   | { type: 'routingRule.create' }
   | { type: 'routingRule.edit'; id: string }
-  | { type: 'routingRule.fork'; routingRule?: RoutingDefinition }
+  | { type: 'routingRule.fork'; routingRule?: RoutingDefinition; draft?: boolean }
   | { type: 'routingRule.reorder'; routing: RoutingDefinitionWithUIAttributes[] }
   | { type: 'routingRule.remove' }
   | { type: 'routingRule.save' }
+  | { type: 'routingRule.setDraft'; draft: boolean }
   | { type: 'routingSamples.setDocumentMatchFilter'; filter: DocumentMatchFilterOptions }
   | { type: 'routingSamples.setSelectedPreview'; preview: RoutingSamplesContext['selectedPreview'] }
   | {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/use_stream_routing.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/state_management/stream_routing_state_machine/use_stream_routing.tsx
@@ -87,8 +87,8 @@ export const useStreamRoutingEvents = () => {
       editRule: (id: string) => {
         service.send({ type: 'routingRule.edit', id });
       },
-      forkStream: async (routingRule?: RoutingDefinition) => {
-        service.send({ type: 'routingRule.fork', routingRule });
+      forkStream: async (routingRule?: RoutingDefinition, options?: { draft?: boolean }) => {
+        service.send({ type: 'routingRule.fork', routingRule, draft: options?.draft });
 
         await waitFor(
           service,
@@ -101,6 +101,9 @@ export const useStreamRoutingEvents = () => {
         return {
           success: finalSnapshot.matches({ ready: { ingestMode: 'idle' } }),
         };
+      },
+      setCreateAsDraft: (draft: boolean) => {
+        service.send({ type: 'routingRule.setDraft', draft });
       },
       saveChanges: () => {
         service.send({ type: 'routingRule.save' });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/utils.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/utils.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildRoutingForkRequestPayload, routingConverter } from './utils';
+import type { RoutingDefinition } from '@kbn/streams-schema';
+
+describe('utils', () => {
+  describe('buildRoutingForkRequestPayload', () => {
+    const baseRule: RoutingDefinition = {
+      destination: 'logs.child',
+      where: { field: 'log.level', eq: 'error' },
+      status: 'enabled',
+    };
+
+    it('should build payload without draft flag when not specified', () => {
+      const payload = buildRoutingForkRequestPayload(baseRule);
+
+      expect(payload).toEqual({
+        where: baseRule.where,
+        status: 'enabled',
+        stream: {
+          name: 'logs.child',
+        },
+      });
+      expect(payload).not.toHaveProperty('draft');
+    });
+
+    it('should build payload without draft flag when options is undefined', () => {
+      const payload = buildRoutingForkRequestPayload(baseRule, undefined);
+
+      expect(payload).not.toHaveProperty('draft');
+    });
+
+    it('should build payload without draft flag when draft is false', () => {
+      const payload = buildRoutingForkRequestPayload(baseRule, { draft: false });
+
+      expect(payload).not.toHaveProperty('draft');
+    });
+
+    it('should build payload with draft flag when draft is true', () => {
+      const payload = buildRoutingForkRequestPayload(baseRule, { draft: true });
+
+      expect(payload).toEqual({
+        where: baseRule.where,
+        status: 'enabled',
+        stream: {
+          name: 'logs.child',
+        },
+        draft: true,
+      });
+    });
+
+    it('should include the routing status from the rule', () => {
+      const disabledRule: RoutingDefinition = {
+        ...baseRule,
+        status: 'disabled',
+      };
+
+      const payload = buildRoutingForkRequestPayload(disabledRule);
+
+      expect(payload.status).toBe('disabled');
+    });
+  });
+
+  describe('routingConverter', () => {
+    describe('toUIDefinition', () => {
+      it('should add id and default status to routing definition', () => {
+        const rule: RoutingDefinition = {
+          destination: 'logs.child',
+          where: { always: {} },
+        };
+
+        const uiDefinition = routingConverter.toUIDefinition(rule);
+
+        expect(uiDefinition).toHaveProperty('id');
+        expect(uiDefinition.status).toBe('enabled');
+        expect(uiDefinition.destination).toBe('logs.child');
+        expect(uiDefinition.where).toEqual({ always: {} });
+      });
+
+      it('should preserve existing status', () => {
+        const rule: RoutingDefinition = {
+          destination: 'logs.child',
+          where: { always: {} },
+          status: 'disabled',
+        };
+
+        const uiDefinition = routingConverter.toUIDefinition(rule);
+
+        expect(uiDefinition.status).toBe('disabled');
+      });
+    });
+
+    describe('toAPIDefinition', () => {
+      it('should remove id from UI definition', () => {
+        const uiDefinition = {
+          id: 'generated-id-123',
+          destination: 'logs.child',
+          where: { always: {} } as const,
+          status: 'enabled' as const,
+        };
+
+        const apiDefinition = routingConverter.toAPIDefinition(uiDefinition);
+
+        expect(apiDefinition).not.toHaveProperty('id');
+        expect(apiDefinition.destination).toBe('logs.child');
+        expect(apiDefinition.where).toEqual({ always: {} });
+        expect(apiDefinition.status).toBe('enabled');
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/utils.ts
@@ -66,12 +66,16 @@ export const buildRoutingSaveRequestPayload = (
   };
 };
 
-export const buildRoutingForkRequestPayload = (rule: RoutingDefinition) => {
+export const buildRoutingForkRequestPayload = (
+  rule: RoutingDefinition,
+  options?: { draft?: boolean }
+) => {
   return {
     where: rule.where,
     status: rule.status,
     stream: {
       name: rule.destination,
     },
+    ...(options?.draft ? { draft: true } : {}),
   };
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/draft_stream_badge.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/draft_stream_badge.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DraftStreamBadge } from '.';
+
+describe('DraftStreamBadge', () => {
+  it('should render draft badge with correct label', () => {
+    render(<DraftStreamBadge />);
+
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+
+  it('should render with correct test subject', () => {
+    render(<DraftStreamBadge />);
+
+    expect(screen.getByTestId('draftStreamBadge')).toBeInTheDocument();
+  });
+
+  it('should render with warning color', () => {
+    render(<DraftStreamBadge />);
+
+    const badge = screen.getByTestId('draftStreamBadge');
+    // EuiBadge with color="warning" renders with specific class pattern
+    expect(badge.className).toMatch(/warning/i);
+  });
+
+  it('should render with documentEdit icon', () => {
+    render(<DraftStreamBadge />);
+
+    const badge = screen.getByTestId('draftStreamBadge');
+    // Check that the badge contains an icon (EUI renders icons inside badges)
+    const icon = badge.querySelector('[data-euiicon-type="documentEdit"]');
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
@@ -92,6 +92,32 @@ export function WiredStreamBadge() {
   );
 }
 
+export function DraftStreamBadge() {
+  return (
+    <EuiToolTip
+      position="top"
+      title={i18n.translate('xpack.streams.badges.draft.title', {
+        defaultMessage: 'Draft Stream',
+      })}
+      content={i18n.translate('xpack.streams.badges.draft.description', {
+        defaultMessage:
+          'Draft streams are not materialized in Elasticsearch. Data is previewed using ES|QL queries. Materialize the stream to start ingesting data.',
+      })}
+      anchorProps={{
+        css: css`
+          display: inline-flex;
+        `,
+      }}
+    >
+      <EuiBadge color="warning" iconType="documentEdit" iconSide="left" data-test-subj="draftStreamBadge">
+        {i18n.translate('xpack.streams.entityDetailViewWithoutParams.draftBadgeLabel', {
+          defaultMessage: 'Draft',
+        })}
+      </EuiBadge>
+    </EuiToolTip>
+  );
+}
+
 export function QueryStreamBadge() {
   const { euiTheme } = useEuiTheme();
   return (


### PR DESCRIPTION
## Summary

Adds draft mode support for wired streams where draft children are persisted in `.kibana_streams` but not fully materialized in Elasticsearch (no data streams, index templates, or ingest pipelines). Draft streams are intended for preview/query semantics using ESQL-based execution.

**Key changes:**

- **Schema**: Added `wired.draft?: boolean` to IngestWired schema
- **Server-side state management**: Draft streams only persist definition documents, skipping ES artifact materialization
- **Fork API**: Accepts `draft` parameter to create draft child streams
- **Draft transitions**: Draft streams can be materialized by removing the draft flag; non-draft to draft transitions are blocked
- **Validation constraints**: Routing order enforcement (drafts must be last), draft-child compatibility checks
- **UI updates**:
  - "Create as draft" toggle in routing form
  - Draft stream badges with warning icons and tooltips
  - Retention tab hidden for draft streams (no data stream)
  - Stream list shows '-' for documents/data quality/retention columns on drafts
- **Streamlang ESQL transpiler**: Added prelude support with `INSIST_🐔` commands for required field loading and typed `EVAL` casts for type safety

## Test plan

- [ ] Unit tests pass: state management (46 tests), prelude (15 tests), UI components (12 tests)
- [ ] Scout API integration tests pass (16 tests covering draft CRUD, constraints, inheritance)
- [ ] Manual testing: Create draft child stream via UI toggle, verify no ES artifacts created
- [ ] Manual testing: Materialize draft stream by removing draft flag, verify ES artifacts created
- [ ] Manual testing: Verify retention tab is hidden for draft streams
- [ ] Manual testing: Verify draft streams show badge in stream list and management views

Refs: https://github.com/elastic/elastic-agents/issues/362

Made with [Cursor](https://cursor.com)