### PR TITLE
Fix version extract logic - avoid $projectRoot

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -23,7 +23,7 @@ steps:
     id: store_cache
     soft_fail: true
     agents:
-      machineType: n2-standard-2
+      machineType: n2-highcpu-8
       diskSizeGb: 95
 
   - wait

--- a/.buildkite/pipelines/fips.yml
+++ b/.buildkite/pipelines/fips.yml
@@ -20,7 +20,7 @@ steps:
     depends_on:
       - terrazzo-initial-pipeline-upload
     agents:
-      machineType: n2-standard-2
+      machineType: n2-highcpu-8
       diskSizeGb: 95
 
   - command: .buildkite/scripts/steps/build_kibana.sh

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -27,7 +27,7 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-2
+      machineType: n2-highcpu-8
       diskSizeGb: 95
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh

--- a/.buildkite/pipelines/pull_request/store_moon_cache.yml
+++ b/.buildkite/pipelines/pull_request/store_moon_cache.yml
@@ -5,7 +5,7 @@ steps:
     id: store_cache
     soft_fail: true
     agents:
-      machineType: n2-standard-2
+      machineType: n2-highcpu-8
       diskSizeGb: 95
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/packages/kbn-eslint-config/moon.extend.yml
+++ b/packages/kbn-eslint-config/moon.extend.yml
@@ -6,7 +6,7 @@ tasks:
     command: node
     args:
      - $workspaceRoot/scripts/extract_version_dependencies.js
-     - $projectRoot/version_dependencies.txt
+     - packages/kbn-eslint-config/version_dependencies.txt
      - --collect
      - eslint
     env:

--- a/packages/kbn-eslint-config/moon.yml
+++ b/packages/kbn-eslint-config/moon.yml
@@ -31,7 +31,7 @@ tasks:
     command: node
     args:
       - $workspaceRoot/scripts/extract_version_dependencies.js
-      - $projectRoot/version_dependencies.txt
+      - packages/kbn-eslint-config/version_dependencies.txt
       - '--collect'
       - eslint
     env:

--- a/src/dev/yarn/extract_version_dependencies.ts
+++ b/src/dev/yarn/extract_version_dependencies.ts
@@ -9,11 +9,10 @@
 
 import type { RunOptions } from '@kbn/dev-cli-runner';
 import path from 'path';
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import { run } from '@kbn/dev-cli-runner';
 import { REPO_ROOT } from '@kbn/repo-info';
-import type { ToolingLog } from '@kbn/tooling-log';
 import { parseYarnLockFile } from './yarn_lock_v1';
 
 const options: RunOptions = {
@@ -27,29 +26,25 @@ const options: RunOptions = {
 };
 
 export async function runCli() {
-  return run(async ({ flagsReader, log }) => {
+  return run(async ({ flagsReader }) => {
     const outputFilePath = flagsReader.getPositionals()[0];
     const dependencies = flagsReader.arrayOfStrings('collect');
     if (typeof dependencies === 'undefined') {
       throw new Error('--collect flag is required and must specify at least one package name.');
     }
 
-    await collectDependenciesAndWriteFile(dependencies, outputFilePath, log);
+    await collectDependenciesAndWriteFile(dependencies, outputFilePath);
 
     return;
   }, options);
 }
 
-async function collectDependenciesAndWriteFile(
-  dependencies: string[],
-  outputFilePath: string,
-  log: ToolingLog
-) {
+async function collectDependenciesAndWriteFile(dependencies: string[], outputFilePath: string) {
   const resolvedDependencyMap = new Map<string, string>();
   const rootPackageJson = path.join(REPO_ROOT, 'package.json');
   const yarnLockPath = path.join(REPO_ROOT, 'yarn.lock');
 
-  const pkgJson = JSON.parse(fs.readFileSync(rootPackageJson, 'utf-8'));
+  const pkgJson = await fs.readFile(rootPackageJson, 'utf-8').then((data) => JSON.parse(data));
   const yarnLockContent = parseYarnLockFile(yarnLockPath, dependencies);
   const yarnLockEntries = Object.values(yarnLockContent);
 
@@ -70,11 +65,5 @@ async function collectDependenciesAndWriteFile(
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(([name, version]) => `${name}@${version}`);
 
-  const outputDir = path.dirname(outputFilePath);
-  if (!fs.existsSync(outputDir)) {
-    log.info(`Output directory ${outputDir} does not exist. Creating it...`);
-    fs.mkdirSync(outputDir, { recursive: true });
-  }
-
-  fs.writeFileSync(outputFilePath, outputLines.join('\n') + '\n', 'utf-8');
+  await fs.writeFile(outputFilePath, outputLines.join('\n') + '\n', 'utf-8');
 }


### PR DESCRIPTION
## Summary
We're seeing some weird errors on the newly added version creation step
```
ERROR Error: ENOENT: no such file or directory, open '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1770992171616679595/elastic/kibana-on-merge/kibana/packages/kbn-eslint-config/version_dependencies.txt'
--
at open (node:internal/fs/promises:636:25)
at Object.writeFile (node:internal/fs/promises:1205:14)
at collectDependenciesAndWriteFile (extract_version_dependencies.ts:68:3)
at extract_version_dependencies.ts:36:5
```

The issue was coming from this:
this is the kibana home: 
`/opt/buildkite-agent/builds/bk-agent-prod-gcp-1770997671417951760/elastic/kibana-pull-request/kibana/`
and this is where the task wants to create the file:
`/opt/buildkite-agent/builds/bk-agent-prod-gcp-1770997137824228574/elastic/kibana-pull-request/kibana/packages/kbn-eslint-config`

The moon task is defined like this:
```
    command: node
    args:
      - $workspaceRoot/scripts/extract_version_dependencies.js
      - $projectRoot/version_dependencies.txt
      - '--collect'
      - eslint
```
So apparently, the $projectRoot is incorrectly resolved, but the $workspaceRoot is correctly resolved, since the script is found. We can fix this by manually prescribing the output directory, without the use of the $projectRoot token. This is probably happening because we're reusing a pre-warmed cache state from a different machine, and those paths are preserved for some variables.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->