### PR TITLE
[9.2] [Automatic Migration] Introduce option to update mapping with index patterns instead of individual indices  (#252431)

### DIFF
--- a/x-pack/solutions/security/packages/data-stream-adapter/src/create_or_update_data_stream.test.ts
+++ b/x-pack/solutions/security/packages/data-stream-adapter/src/create_or_update_data_stream.test.ts
@@ -31,7 +31,7 @@ describe('updateDataStreams', () => {
     jest.clearAllMocks();
   });
 
-  it(`should update data streams`, async () => {
+  it(`should update data streams when expandIndexPattern is true`, async () => {
     const dataStreamName = 'test_data_stream-default';
     esClient.indices.getDataStream.mockResolvedValueOnce({
       data_streams: [{ name: dataStreamName } as IndicesDataStream],
@@ -42,6 +42,7 @@ describe('updateDataStreams', () => {
       logger,
       name,
       totalFieldsLimit,
+      expandIndexPattern: true,
     });
 
     expect(esClient.indices.getDataStream).toHaveBeenCalledWith({ name, expand_wildcards: 'all' });
@@ -59,7 +60,27 @@ describe('updateDataStreams', () => {
     });
   });
 
-  it(`should update multiple data streams`, async () => {
+  it(`should update multiple data streams when expandIndexPattern is true`, async () => {
+    const dataStreamName1 = 'test_data_stream-1';
+    const dataStreamName2 = 'test_data_stream-2';
+    esClient.indices.getDataStream.mockResolvedValueOnce({
+      data_streams: [{ name: dataStreamName1 }, { name: dataStreamName2 }] as IndicesDataStream[],
+    });
+
+    await updateDataStreams({
+      esClient,
+      logger,
+      name,
+      totalFieldsLimit,
+      expandIndexPattern: true,
+    });
+
+    expect(esClient.indices.putSettings).toHaveBeenCalledTimes(2);
+    expect(esClient.indices.simulateIndexTemplate).toHaveBeenCalledTimes(2);
+    expect(esClient.indices.putMapping).toHaveBeenCalledTimes(2);
+  });
+
+  it('should update data stream pattern by default', async () => {
     const dataStreamName1 = 'test_data_stream-1';
     const dataStreamName2 = 'test_data_stream-2';
     esClient.indices.getDataStream.mockResolvedValueOnce({
@@ -73,9 +94,9 @@ describe('updateDataStreams', () => {
       totalFieldsLimit,
     });
 
-    expect(esClient.indices.putSettings).toHaveBeenCalledTimes(2);
-    expect(esClient.indices.simulateIndexTemplate).toHaveBeenCalledTimes(2);
-    expect(esClient.indices.putMapping).toHaveBeenCalledTimes(2);
+    expect(esClient.indices.putSettings).toHaveBeenCalledTimes(1);
+    expect(esClient.indices.simulateIndexTemplate).toHaveBeenCalledTimes(1);
+    expect(esClient.indices.putMapping).toHaveBeenCalledTimes(1);
   });
 
   it(`should not update data streams when not exist`, async () => {

--- a/x-pack/solutions/security/packages/data-stream-adapter/src/create_or_update_data_stream.ts
+++ b/x-pack/solutions/security/packages/data-stream-adapter/src/create_or_update_data_stream.ts
@@ -221,6 +221,7 @@ export interface CreateOrUpdateSpacesDataStreamParams {
   esClient: ElasticsearchClient;
   totalFieldsLimit: number;
   writeIndexOnly?: boolean;
+  expandIndexPattern?: boolean;
 }
 
 export async function updateDataStreams({
@@ -229,6 +230,7 @@ export async function updateDataStreams({
   name,
   totalFieldsLimit,
   writeIndexOnly,
+  expandIndexPattern = false,
 }: CreateOrUpdateSpacesDataStreamParams): Promise<void> {
   logger.info(`Updating data streams - ${name}`);
 
@@ -251,7 +253,7 @@ export async function updateDataStreams({
       logger,
       esClient,
       totalFieldsLimit,
-      indexNames: dataStreams.map((dataStream) => dataStream.name),
+      indexNames: expandIndexPattern ? dataStreams.map((dataStream) => dataStream.name) : [name],
       writeIndexOnly,
     });
   }

--- a/x-pack/solutions/security/packages/data-stream-adapter/src/data_stream_spaces_adapter.ts
+++ b/x-pack/solutions/security/packages/data-stream-adapter/src/data_stream_spaces_adapter.ts
@@ -34,6 +34,7 @@ export class DataStreamSpacesAdapter extends IndexPatternAdapter {
         logger,
         totalFieldsLimit: this.totalFieldsLimit,
         writeIndexOnly: this.writeIndexOnly,
+        expandIndexPattern: this.expandIndexPattern,
       }),
       `update space data streams`
     );

--- a/x-pack/solutions/security/packages/index-adapter/src/create_or_update_index.ts
+++ b/x-pack/solutions/security/packages/index-adapter/src/create_or_update_index.ts
@@ -214,6 +214,8 @@ export interface CreateOrUpdateSpacesIndexParams {
   esClient: ElasticsearchClient;
   totalFieldsLimit: number;
   writeIndexOnly?: boolean;
+  /** whether to expand index names based on pattern */
+  expandIndexPattern?: boolean;
 }
 
 export async function updateIndices({
@@ -222,6 +224,7 @@ export async function updateIndices({
   name,
   totalFieldsLimit,
   writeIndexOnly,
+  expandIndexPattern = false,
 }: CreateOrUpdateSpacesIndexParams): Promise<void> {
   logger.info(`Updating indices - ${name}`);
 
@@ -239,12 +242,13 @@ export async function updateIndices({
       throw error;
     }
   }
+
   if (indices.length > 0) {
     await updateIndexMappings({
       logger,
       esClient,
       totalFieldsLimit,
-      indexNames: indices,
+      indexNames: expandIndexPattern ? indices : [name],
       writeIndexOnly,
     });
   }

--- a/x-pack/solutions/security/packages/index-adapter/src/index_pattern_adapter.ts
+++ b/x-pack/solutions/security/packages/index-adapter/src/index_pattern_adapter.ts
@@ -10,12 +10,21 @@ import { IndexAdapter, type IndexAdapterParams, type InstallParams } from './ind
 
 export type InstallIndex = (indexSuffix: string) => Promise<void>;
 
+export type IndexPatternAdapterParams = IndexAdapterParams & {
+  /** should expand the list of indices based on pattern */
+  expandIndexPattern?: boolean;
+};
+
 export class IndexPatternAdapter extends IndexAdapter {
   protected installationPromises: Map<string, Promise<void>>;
   protected installIndexPromise?: Promise<InstallIndex>;
+  protected readonly expandIndexPattern: boolean;
 
-  constructor(protected readonly prefix: string, options: IndexAdapterParams) {
-    super(`${prefix}-*`, options); // make indexTemplate `indexPatterns` match all index names
+  constructor(protected readonly prefix: string, options: IndexPatternAdapterParams) {
+    const { expandIndexPattern = false, ...restOptions } = options;
+    super(`${prefix}-*`, restOptions); // make indexTemplate `indexPatterns` match all index names
+    this.expandIndexPattern = expandIndexPattern;
+
     this.installationPromises = new Map();
   }
 
@@ -41,6 +50,7 @@ export class IndexPatternAdapter extends IndexAdapter {
         logger,
         totalFieldsLimit: this.totalFieldsLimit,
         writeIndexOnly: this.writeIndexOnly,
+        expandIndexPattern: this.expandIndexPattern,
       }),
       `update specific indices`
     );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Automatic Migration] Introduce option to update mapping with index patterns instead of individual indices  (#252431)](https://github.com/elastic/kibana/pull/252431)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2026-02-13T04:17:52Z","message":"[Automatic Migration] Introduce option to update mapping with index patterns instead of individual indices  (#252431)\n\n## Summary\n\nThis PR changes `IndexPatternAdapter` & `DataStreamSpacesAdapter` to\ninclude support to expand the index patterns when needed. Previously, it\nwas always expanding indices based on the pattern given and\nsettings/mappings were applied on individual indices.\n\nThis would increase the number of calls to `Elasticsearch` based on the\nnumber of output indices. Now, same result can be achieved with one call\nper index-pattern. See below example for `AI Assistant` and `SIEM\nMigrations`.\n\nAfter this change, number of calls to `spaces` based indices is constant\nin contrast to one call for each index per space.\n\n### SIEM Migrations\n\nNumber of calls to Elasticsearch is now limited 1 for all the spaces. \n\n#### Before\n\n<img width=\"1083\" height=\"755\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e39a35db-0880-4313-92f6-763ecc6fa4ac\"\n/>\n\n#### After\n\n<img width=\"1111\" height=\"197\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/742bf974-cc56-44e8-b582-c2e378f587bb\"\n/>\n\n### AI Assistant\n\nNumber of calls to Elasticsearch is now limited 1 per space. \n\n#### Before\n\n<img width=\"876\" height=\"1078\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b8ff3e5e-28e4-4224-9656-c746242b321a\"\n/>\n\n\n#### After\n\n<img width=\"1122\" height=\"198\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d79e19c2-0373-4234-b0dc-82d6b0deb200\"\n/>","sha":"06e62c13ab8e20e3ab51cbb2a4896c94855a5a67","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting","backport:version","v9.2.0","v9.3.0","v9.4.0","v9.3.1","v9.2.6"],"title":"[Automatic Migration] Introduce option to update mapping with index patterns instead of individual indices ","number":252431,"url":"https://github.com/elastic/kibana/pull/252431","mergeCommit":{"message":"[Automatic Migration] Introduce option to update mapping with index patterns instead of individual indices  (#252431)\n\n## Summary\n\nThis PR changes `IndexPatternAdapter` & `DataStreamSpacesAdapter` to\ninclude support to expand the index patterns when needed. Previously, it\nwas always expanding indices based on the pattern given and\nsettings/mappings were applied on individual indices.\n\nThis would increase the number of calls to `Elasticsearch` based on the\nnumber of output indices. Now, same result can be achieved with one call\nper index-pattern. See below example for `AI Assistant` and `SIEM\nMigrations`.\n\nAfter this change, number of calls to `spaces` based indices is constant\nin contrast to one call for each index per space.\n\n### SIEM Migrations\n\nNumber of calls to Elasticsearch is now limited 1 for all the spaces. \n\n#### Before\n\n<img width=\"1083\" height=\"755\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e39a35db-0880-4313-92f6-763ecc6fa4ac\"\n/>\n\n#### After\n\n<img width=\"1111\" height=\"197\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/742bf974-cc56-44e8-b582-c2e378f587bb\"\n/>\n\n### AI Assistant\n\nNumber of calls to Elasticsearch is now limited 1 per space. \n\n#### Before\n\n<img width=\"876\" height=\"1078\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b8ff3e5e-28e4-4224-9656-c746242b321a\"\n/>\n\n\n#### After\n\n<img width=\"1122\" height=\"198\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d79e19c2-0373-4234-b0dc-82d6b0deb200\"\n/>","sha":"06e62c13ab8e20e3ab51cbb2a4896c94855a5a67"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/252992","number":252992,"state":"MERGED","mergeCommit":{"sha":"cde3f59b7b693e9bda10bd28e1b0b255951dc566","message":"[9.3] [Automatic Migration] Introduce option to update mapping with index patterns instead of individual indices  (#252431) (#252992)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Automatic Migration] Introduce option to update mapping with index\npatterns instead of individual indices\n(#252431)](https://github.com/elastic/kibana/pull/252431)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jatin Kathuria <jatin.kathuria@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252431","number":252431,"mergeCommit":{"message":"[Automatic Migration] Introduce option to update mapping with index patterns instead of individual indices  (#252431)\n\n## Summary\n\nThis PR changes `IndexPatternAdapter` & `DataStreamSpacesAdapter` to\ninclude support to expand the index patterns when needed. Previously, it\nwas always expanding indices based on the pattern given and\nsettings/mappings were applied on individual indices.\n\nThis would increase the number of calls to `Elasticsearch` based on the\nnumber of output indices. Now, same result can be achieved with one call\nper index-pattern. See below example for `AI Assistant` and `SIEM\nMigrations`.\n\nAfter this change, number of calls to `spaces` based indices is constant\nin contrast to one call for each index per space.\n\n### SIEM Migrations\n\nNumber of calls to Elasticsearch is now limited 1 for all the spaces. \n\n#### Before\n\n<img width=\"1083\" height=\"755\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e39a35db-0880-4313-92f6-763ecc6fa4ac\"\n/>\n\n#### After\n\n<img width=\"1111\" height=\"197\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/742bf974-cc56-44e8-b582-c2e378f587bb\"\n/>\n\n### AI Assistant\n\nNumber of calls to Elasticsearch is now limited 1 per space. \n\n#### Before\n\n<img width=\"876\" height=\"1078\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b8ff3e5e-28e4-4224-9656-c746242b321a\"\n/>\n\n\n#### After\n\n<img width=\"1122\" height=\"198\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d79e19c2-0373-4234-b0dc-82d6b0deb200\"\n/>","sha":"06e62c13ab8e20e3ab51cbb2a4896c94855a5a67"}}]}] BACKPORT-->