### PR TITLE
[Security Solution] Speed up rule bulk rule deletion

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/bulk_delete_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_delete/bulk_delete_rules.ts
@@ -176,7 +176,11 @@ const bulkDeleteWithOCC = async (
     { name: 'Get rules, collect them and their attributes', type: 'rules' },
     async () => {
       for await (const response of rulesFinder.find()) {
-        await bulkMigrateLegacyActions({ context, rules: response.saved_objects });
+        await bulkMigrateLegacyActions({
+          context,
+          rules: response.saved_objects,
+          skipActionsValidation: true,
+        });
         for (const rule of response.saved_objects) {
           if (rule.attributes.apiKey && !rule.attributes.apiKeyCreatedByUser) {
             apiKeyToRuleIdMapping[rule.id] = rule.attributes.apiKey;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -273,6 +273,8 @@ export const performBulkActionRoute = (
             case BulkActionTypeEnum.delete: {
               // during dry run return early for delete, as no validations needed for this action
               if (isDryRun) {
+                // Populate `deleted` so the summary reflects the correct count of affected rules
+                deleted = rules;
                 break;
               }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -271,27 +271,16 @@ export const performBulkActionRoute = (
               break;
             }
             case BulkActionTypeEnum.delete: {
-              const bulkActionOutcome = await initPromisePool({
-                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-                items: rules,
-                executor: async (rule) => {
-                  // during dry run return early for delete, as no validations needed for this action
-                  if (isDryRun) {
-                    return null;
-                  }
+              // during dry run return early for delete, as no validations needed for this action
+              if (isDryRun) {
+                break;
+              }
 
-                  await detectionRulesClient.deleteRule({
-                    ruleId: rule.id,
-                  });
+              const ruleIds = rules.map((rule) => rule.id);
+              const bulkDeleteResult = await detectionRulesClient.bulkDeleteRules({ ruleIds });
 
-                  return null;
-                },
-                abortSignal: abortController.signal,
-              });
-              errors.push(...bulkActionOutcome.errors);
-              deleted = bulkActionOutcome.results
-                .map(({ item }) => item)
-                .filter((rule): rule is RuleAlertType => rule !== null);
+              errors.push(...bulkDeleteResult.errors);
+              deleted = bulkDeleteResult.rules;
               break;
             }
             case BulkActionTypeEnum.duplicate: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
@@ -16,6 +16,7 @@ const createDetectionRulesClientMock = () => {
     updateRule: jest.fn(),
     patchRule: jest.fn(),
     deleteRule: jest.fn(),
+    bulkDeleteRules: jest.fn(),
     upgradePrebuiltRule: jest.fn(),
     revertPrebuiltRule: jest.fn(),
     importRule: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
@@ -18,6 +18,8 @@ import type { ProductFeaturesService } from '../../../../product_features_servic
 import { createPrebuiltRuleAssetsClient } from '../../../prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
 import type { RuleImportErrorObject } from '../import/errors';
 import type {
+  BulkDeleteRulesArgs,
+  BulkDeleteRulesReturn,
   CreateCustomRuleArgs,
   CreatePrebuiltRuleArgs,
   DeleteRuleArgs,
@@ -30,6 +32,7 @@ import type {
   UpgradePrebuiltRuleArgs,
 } from './detection_rules_client_interface';
 import { createRule } from './methods/create_rule';
+import { bulkDeleteRules } from './methods/bulk_delete_rules';
 import { deleteRule } from './methods/delete_rule';
 import { importRule } from './methods/import_rule';
 import { importRules } from './methods/import_rules';
@@ -136,6 +139,12 @@ export const createDetectionRulesClient = ({
     async deleteRule({ ruleId }: DeleteRuleArgs): Promise<void> {
       return withSecuritySpan('DetectionRulesClient.deleteRule', async () => {
         return deleteRule({ rulesClient, ruleId });
+      });
+    },
+
+    async bulkDeleteRules({ ruleIds }: BulkDeleteRulesArgs): Promise<BulkDeleteRulesReturn> {
+      return withSecuritySpan('DetectionRulesClient.bulkDeleteRules', async () => {
+        return bulkDeleteRules({ rulesClient, ruleIds });
       });
     },
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { BulkOperationError } from '@kbn/alerting-plugin/server';
 import type {
   RuleCreateProps,
   RuleUpdateProps,
@@ -18,6 +19,7 @@ import type { IRuleSourceImporter } from '../import/rule_source_importer';
 import type { RuleImportErrorObject } from '../import/errors';
 import type { PrebuiltRuleAsset } from '../../../prebuilt_rules';
 import type { PrebuiltRulesCustomizationStatus } from '../../../../../../common/detection_engine/prebuilt_rules/prebuilt_rule_customization_status';
+import type { RuleAlertType } from '../../../rule_schema';
 
 export interface IDetectionRulesClient {
   getRuleCustomizationStatus: () => PrebuiltRulesCustomizationStatus;
@@ -26,6 +28,7 @@ export interface IDetectionRulesClient {
   updateRule: (args: UpdateRuleArgs) => Promise<RuleResponse>;
   patchRule: (args: PatchRuleArgs) => Promise<RuleResponse>;
   deleteRule: (args: DeleteRuleArgs) => Promise<void>;
+  bulkDeleteRules: (args: BulkDeleteRulesArgs) => Promise<BulkDeleteRulesReturn>;
   upgradePrebuiltRule: (args: UpgradePrebuiltRuleArgs) => Promise<RuleResponse>;
   revertPrebuiltRule: (args: RevertPrebuiltRuleArgs) => Promise<RuleResponse>;
   importRule: (args: ImportRuleArgs) => Promise<RuleResponse>;
@@ -50,6 +53,15 @@ export interface PatchRuleArgs {
 
 export interface DeleteRuleArgs {
   ruleId: RuleObjectId;
+}
+
+export interface BulkDeleteRulesArgs {
+  ruleIds: RuleObjectId[];
+}
+
+export interface BulkDeleteRulesReturn {
+  rules: RuleAlertType[];
+  errors: BulkOperationError[];
 }
 
 export interface UpgradePrebuiltRuleArgs {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_delete_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_delete_rules.ts
@@ -10,6 +10,9 @@ import type { RulesClient, BulkOperationError } from '@kbn/alerting-plugin/serve
 import type { RuleObjectId } from '../../../../../../../common/api/detection_engine';
 import type { RuleAlertType } from '../../../../rule_schema';
 
+// The `rulesClient.bulkDeleteRules` method converts IDs into a KQL "OR" query,
+// which is limited by Elasticsearch's `max_clause_count` (default 1024). The alerting
+// schema enforces a maxSize of 1000 per call to stay within that limit.
 const CHUNK_SIZE = 1000;
 
 interface BulkDeleteRulesParams {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_delete_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_delete_rules.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { chunk } from 'lodash';
+import type { RulesClient, BulkOperationError } from '@kbn/alerting-plugin/server';
+import type { RuleObjectId } from '../../../../../../../common/api/detection_engine';
+import type { RuleAlertType } from '../../../../rule_schema';
+
+const CHUNK_SIZE = 1000;
+
+interface BulkDeleteRulesParams {
+  rulesClient: RulesClient;
+  ruleIds: RuleObjectId[];
+}
+
+export const bulkDeleteRules = async ({
+  rulesClient,
+  ruleIds,
+}: BulkDeleteRulesParams): Promise<{ rules: RuleAlertType[]; errors: BulkOperationError[] }> => {
+  const chunks = chunk(ruleIds, CHUNK_SIZE);
+  const allRules: RuleAlertType[] = [];
+  const allErrors: BulkOperationError[] = [];
+
+  for (const idsChunk of chunks) {
+    const result = await rulesClient.bulkDeleteRules({ ids: idsChunk });
+    allRules.push(...(result.rules as RuleAlertType[]));
+    allErrors.push(...result.errors);
+  }
+
+  return { rules: allRules, errors: allErrors };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_delete_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_delete_rules.ts
@@ -29,9 +29,9 @@ export const bulkDeleteRules = async ({
   const allErrors: BulkOperationError[] = [];
 
   for (const idsChunk of chunks) {
-    const result = await rulesClient.bulkDeleteRules({ ids: idsChunk });
-    allRules.push(...(result.rules as RuleAlertType[]));
-    allErrors.push(...result.errors);
+    const { rules, errors } = await rulesClient.bulkDeleteRules({ ids: idsChunk });
+    allRules.push(...(rules as RuleAlertType[]));
+    allErrors.push(...errors);
   }
 
   return { rules: allRules, errors: allErrors };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk_legacy.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk_legacy.ts
@@ -80,6 +80,7 @@ export default ({ getService }: FtrProviderContext): void => {
                 'Hourly\nRule {{context.rule.name}} generated {{state.signals_count}} alerts',
             },
             frequency: { summary: true, throttle: '1h', notifyWhen: 'onThrottleInterval' },
+            uuid: expect.any(String),
           },
         ]);
       });
@@ -135,6 +136,7 @@ export default ({ getService }: FtrProviderContext): void => {
             message: 'Hourly\nRule {{context.rule.name}} generated {{state.signals_count}} alerts',
           },
           frequency: { summary: true, throttle: '1h', notifyWhen: 'onThrottleInterval' },
+          uuid: expect.any(String),
         });
         expect(actions).toContainEqual({
           id: hookAction2.id,
@@ -144,6 +146,7 @@ export default ({ getService }: FtrProviderContext): void => {
             message: 'Hourly\nRule {{context.rule.name}} generated {{state.signals_count}} alerts',
           },
           frequency: { summary: true, throttle: '1h', notifyWhen: 'onThrottleInterval' },
+          uuid: expect.any(String),
         });
       });
 


### PR DESCRIPTION
**Related SDH: https://github.com/elastic/sdh-security-team/issues/1578**

## Summary

This PR speeds up bulk rule deletion via the `api/detection_engine/rules/_bulk_action`. This is achieved by using `rulesClient.bulkDeleteRules` instead of `rulesClient.delete`.

Testing on a local machine showed that the new implementation is 9x faster when deleting all installed prebuilt rules (around 1600 rules).

Deleting 1600 prebuilt rules. First request – old implementation (1.5 min), second request - this PR (11 sec)
<img width="836" height="72" alt="Screenshot 2026-02-13 at 19 35 25" src="https://github.com/user-attachments/assets/fe4931bc-6f23-4830-b588-7699742f5a48" />




## Changes
- Added a new `detectionRulesClient.bulkDeleteRules`, which uses `rulesClient.bulkDeleteRules` under the hood.
- Updated the `api/detection_engine/rules/_bulk_action` route handler to use the new `rulesClient.bulkDeleteRules`.
- **Updated `rulesClient.bulkDeleteRules` to skip validating legacy actions**. There's no need to validate actions on rules that are about to be deleted. This matches the existing behavior for [single-rule deletion](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/delete/delete_rule.ts#L99), which already passes skipActionsValidation: true.





<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->