### PR TITLE
[content-list] Actions column with stubbed delete

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
@@ -38,4 +38,33 @@ export interface ContentListItemConfig {
    * When provided, item titles become clickable links.
    */
   getHref?: (item: ContentListItem) => string;
+
+  /**
+   * Function to generate the edit URL for an item.
+   * When provided, the edit action renders as an `<a>` link with this `href`,
+   * preserving native link behavior (right-click, middle-click, screen reader
+   * announcement).
+   *
+   * Composable with `onEdit`: when both are provided, the action renders as a
+   * link (`href`) and also calls `onEdit` on click (e.g., for analytics tracking).
+   */
+  getEditUrl?: (item: ContentListItem) => string;
+
+  /**
+   * Callback invoked when the edit action is clicked.
+   * Use this for side effects such as opening a flyout, tracking analytics,
+   * or programmatic navigation.
+   *
+   * When provided alone, the action renders as a button with an `onClick` handler.
+   * When provided alongside `getEditUrl`, both are applied: the action renders
+   * as a link and the callback fires on click.
+   */
+  onEdit?: (item: ContentListItem) => void;
+
+  /**
+   * Callback invoked to delete one or more items.
+   * When provided, enables the delete action on rows.
+   * The callback should handle the actual deletion and return a resolved promise on success.
+   */
+  onDelete?: (items: ContentListItem[]) => Promise<void>;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
@@ -17,6 +17,7 @@
 export {
   ContentListTable,
   Column,
+  Action,
   getRowId,
   type ContentListTableProps,
 } from './src/content_list_table';
@@ -24,12 +25,23 @@ export {
 // Column components.
 export { NameColumn, NameCell, type NameColumnProps, type NameCellProps } from './src/column';
 export {
+  ActionsColumn,
+  type ActionsColumnProps,
   UpdatedAtColumn,
   UpdatedAtCell,
   type UpdatedAtColumnProps,
   type UpdatedAtCellProps,
 } from './src/column';
 export type { ColumnNamespace, ColumnProps } from './src/column';
+
+// Action components.
+export {
+  EditAction,
+  DeleteAction,
+  type EditActionProps,
+  type DeleteActionProps,
+} from './src/action';
+export type { ActionNamespace, ActionProps } from './src/action';
 
 // Empty state.
 export { EmptyState, type EmptyStateProps } from './src/empty_state';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { ActionBuilderContext, DeleteActionProps } from '../types';
+import { buildDeleteAction } from './delete_action';
+
+const defaultContext: ActionBuilderContext = {
+  itemConfig: {
+    onDelete: jest.fn(async () => {}),
+  },
+  isReadOnly: false,
+  entityName: 'dashboard',
+  supports: { sorting: true, pagination: true, search: true },
+};
+
+describe('delete action builder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildDeleteAction', () => {
+    it('returns an action with defaults when props are empty and `onDelete` is configured', () => {
+      const result = buildDeleteAction({}, defaultContext);
+
+      expect(result).toMatchObject({
+        description: expect.any(String),
+        icon: 'trash',
+        type: 'icon',
+        color: 'danger',
+        isPrimary: true,
+        'data-test-subj': 'content-list-table-action-delete',
+      });
+
+      // `name` is a ReactNode wrapping the label in danger-colored text.
+      const { getByText } = render(<>{result!.name as ReactNode}</>);
+      expect(getByText('Delete')).toBeInTheDocument();
+    });
+
+    it('returns `undefined` when in read-only mode', () => {
+      const context: ActionBuilderContext = { ...defaultContext, isReadOnly: true };
+      const result = buildDeleteAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns `undefined` when no `onDelete` handler is configured', () => {
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: {},
+      };
+      const result = buildDeleteAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns `undefined` when `itemConfig` is undefined', () => {
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: undefined,
+      };
+      const result = buildDeleteAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('uses custom label when provided', () => {
+      const props: DeleteActionProps = { label: 'Remove' };
+      const result = buildDeleteAction(props, defaultContext);
+
+      const { getByText } = render(<>{result!.name as ReactNode}</>);
+      expect(getByText('Remove')).toBeInTheDocument();
+    });
+
+    it('has a no-op `onClick` handler (stub for delete orchestration)', () => {
+      const result = buildDeleteAction({}, defaultContext);
+
+      expect(result?.onClick).toBeInstanceOf(Function);
+
+      // Clicking should not throw or call `onDelete` directly.
+      const onDelete = jest.fn();
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: { onDelete },
+      };
+      const stubResult = buildDeleteAction({}, context);
+      const item = { id: '1', title: 'Test' };
+
+      stubResult?.onClick?.(item, {} as React.MouseEvent);
+      expect(onDelete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useLayoutEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { EuiTextColor, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { DeleteActionProps, ActionOutput, ActionBuilderContext } from '../types';
+
+/**
+ * Action label that applies danger color to both the text and the sibling icon
+ * in EUI's collapsed overflow menu.
+ *
+ * EUI renders icons in the overflow menu with `color: inherit`, so they pick up
+ * the parent button's text color. This component uses a ref to find the parent
+ * `.euiBasicTable__collapsedAction` button and set its color to `textDanger`,
+ * making the icon inherit the danger color. In the inline (expanded) context,
+ * no matching parent exists and the effect is a no-op.
+ *
+ * FRAGILE: Depends on EUI internal class `.euiBasicTable__collapsedAction`.
+ * `DefaultItemAction.color` only applies to the expanded (inline) view; the
+ * collapsed overflow menu ignores it. This workaround will break if EUI
+ * renames that class. Tracked upstream: https://github.com/elastic/eui/issues/9384
+ */
+const DangerActionName = ({ children }: { children: ReactNode }) => {
+  const ref = useRef<HTMLSpanElement>(null);
+  const { euiTheme } = useEuiTheme();
+
+  useLayoutEffect(() => {
+    const button = ref.current?.closest<HTMLElement>('.euiBasicTable__collapsedAction');
+    if (button) {
+      button.style.color = euiTheme.colors.textDanger;
+      return () => {
+        button.style.color = '';
+      };
+    }
+  }, [euiTheme.colors.textDanger]);
+
+  return (
+    <EuiTextColor color="danger">
+      <span ref={ref}>{children}</span>
+    </EuiTextColor>
+  );
+};
+
+/** Default i18n-translated label for the delete action. */
+const DEFAULT_DELETE_LABEL = i18n.translate(
+  'contentManagement.contentList.table.action.delete.label',
+  { defaultMessage: 'Delete' }
+);
+
+/** Default i18n-translated description for the delete action. */
+const DEFAULT_DELETE_DESCRIPTION = i18n.translate(
+  'contentManagement.contentList.table.action.delete.description',
+  { defaultMessage: 'Delete this item' }
+);
+
+/**
+ * Build a `DefaultItemAction` for the delete action preset.
+ *
+ * Returns `undefined` when:
+ * - The table is in read-only mode.
+ * - No delete handler (`onDelete`) is configured on the item config.
+ *
+ * The `onClick` handler is a **no-op stub**. The actual delete flow (confirmation
+ * modal, provider-level delete state) will be wired by the Delete Orchestration PR.
+ *
+ * @param attributes - The declarative attributes from the parsed `Action.Delete` element.
+ * @param context - Builder context with provider configuration.
+ * @returns A `DefaultItemAction<ContentListItem>` for the delete action, or `undefined` to skip.
+ */
+export const buildDeleteAction = (
+  attributes: DeleteActionProps,
+  context: ActionBuilderContext
+): ActionOutput | undefined => {
+  const { itemConfig, isReadOnly } = context;
+
+  if (isReadOnly) {
+    return undefined;
+  }
+  if (typeof itemConfig?.onDelete !== 'function') {
+    return undefined;
+  }
+
+  const label = attributes.label ?? DEFAULT_DELETE_LABEL;
+
+  return {
+    name: <DangerActionName>{label}</DangerActionName>,
+    description: DEFAULT_DELETE_DESCRIPTION,
+    icon: 'trash',
+    type: 'icon',
+    color: 'danger',
+    isPrimary: true,
+    // TODO: Wire to provider-level delete orchestration.
+    onClick: () => {},
+    'data-test-subj': 'content-list-table-action-delete',
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { buildDeleteAction } from './delete_action';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type React from 'react';
+import type { ActionBuilderContext, EditActionProps } from '../types';
+import { buildEditAction } from './edit_action';
+
+const defaultContext: ActionBuilderContext = {
+  itemConfig: {
+    getEditUrl: (item) => `/edit/${item.id}`,
+  },
+  isReadOnly: false,
+  entityName: 'dashboard',
+  supports: { sorting: true, pagination: true, search: true },
+};
+
+describe('edit action builder', () => {
+  describe('buildEditAction', () => {
+    it('returns an action with defaults when props are empty and `getEditUrl` is configured', () => {
+      const result = buildEditAction({}, defaultContext);
+
+      expect(result).toMatchObject({
+        name: 'Edit',
+        description: expect.any(String),
+        icon: 'pencil',
+        type: 'icon',
+        isPrimary: true,
+        'data-test-subj': 'content-list-table-action-edit',
+      });
+    });
+
+    it('returns `undefined` when in read-only mode', () => {
+      const context: ActionBuilderContext = { ...defaultContext, isReadOnly: true };
+      const result = buildEditAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns `undefined` when no edit handler is configured', () => {
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: {},
+      };
+      const result = buildEditAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns `undefined` when `itemConfig` is undefined', () => {
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: undefined,
+      };
+      const result = buildEditAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('uses custom label when provided', () => {
+      const props: EditActionProps = { label: 'Modify' };
+      const result = buildEditAction(props, defaultContext);
+
+      expect(result).toMatchObject({ name: 'Modify' });
+    });
+
+    it('provides `href` when `getEditUrl` is configured', () => {
+      const result = buildEditAction({}, defaultContext);
+
+      expect(result).toHaveProperty('href');
+      expect(result).not.toHaveProperty('onClick');
+    });
+
+    it('generates correct href for an item', () => {
+      const result = buildEditAction({}, defaultContext);
+      const href = (result?.href as (item: { id: string }) => string)({ id: '123' });
+
+      expect(href).toBe('/edit/123');
+    });
+
+    it('provides `onClick` when only `onEdit` is configured (no `getEditUrl`)', () => {
+      const onEdit = jest.fn();
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: { onEdit },
+      };
+      const result = buildEditAction({}, context);
+
+      expect(result).toHaveProperty('onClick');
+      expect(result).not.toHaveProperty('href');
+    });
+
+    it('calls `onEdit` when onClick is triggered', () => {
+      const onEdit = jest.fn();
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: { onEdit },
+      };
+      const result = buildEditAction({}, context);
+      const item = { id: '1', title: 'Test' };
+
+      result?.onClick?.(item, {} as React.MouseEvent);
+      expect(onEdit).toHaveBeenCalledWith(item);
+    });
+
+    it('composes both `href` and `onClick` when `getEditUrl` and `onEdit` are provided', () => {
+      const onEdit = jest.fn();
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: {
+          getEditUrl: (item) => `/edit/${item.id}`,
+          onEdit,
+        },
+      };
+      const result = buildEditAction({}, context);
+
+      expect(result).toHaveProperty('href');
+      expect(result).toHaveProperty('onClick');
+    });
+
+    it('calls `onEdit` on click even when `getEditUrl` is also provided', () => {
+      const onEdit = jest.fn();
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: {
+          getEditUrl: (item) => `/edit/${item.id}`,
+          onEdit,
+        },
+      };
+      const result = buildEditAction({}, context);
+      const item = { id: '1', title: 'Test' };
+
+      result?.onClick?.(item, {} as React.MouseEvent);
+      expect(onEdit).toHaveBeenCalledWith(item);
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { EditActionProps, ActionOutput, ActionBuilderContext } from '../types';
+
+/** Default i18n-translated label for the edit action. */
+const DEFAULT_EDIT_LABEL = i18n.translate('contentManagement.contentList.table.action.edit.label', {
+  defaultMessage: 'Edit',
+});
+
+/** Default i18n-translated description for the edit action. */
+const DEFAULT_EDIT_DESCRIPTION = i18n.translate(
+  'contentManagement.contentList.table.action.edit.description',
+  { defaultMessage: 'Edit this item' }
+);
+
+/**
+ * Build a `DefaultItemAction` for the edit action preset.
+ *
+ * Returns `undefined` when:
+ * - The table is in read-only mode.
+ * - No edit handler (`onEdit`) or edit URL generator (`getEditUrl`) is configured.
+ *
+ * When both `getEditUrl` and `onEdit` are provided, the action renders as a link
+ * (`href`) and also fires `onEdit` on click. This enables composable behavior
+ * such as navigating to an edit page while also tracking analytics.
+ *
+ * @param attributes - The declarative attributes from the parsed `Action.Edit` element.
+ * @param context - Builder context with provider configuration.
+ * @returns A `DefaultItemAction<ContentListItem>` for the edit action, or `undefined` to skip.
+ */
+export const buildEditAction = (
+  attributes: EditActionProps,
+  context: ActionBuilderContext
+): ActionOutput | undefined => {
+  const { itemConfig, isReadOnly } = context;
+
+  if (isReadOnly || !itemConfig) {
+    return undefined;
+  }
+
+  const { getEditUrl, onEdit } = itemConfig;
+
+  if (!getEditUrl && !onEdit) {
+    return undefined;
+  }
+
+  const label = attributes.label ?? DEFAULT_EDIT_LABEL;
+
+  return {
+    name: label,
+    description: DEFAULT_EDIT_DESCRIPTION,
+    icon: 'pencil',
+    type: 'icon',
+    isPrimary: true,
+    ...(getEditUrl && { href: (item) => getEditUrl(item) }),
+    ...(onEdit && { onClick: (item) => onEdit(item) }),
+    'data-test-subj': 'content-list-table-action-edit',
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { buildEditAction } from './edit_action';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/index.ts
@@ -7,16 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// Declarative components and props.
-export { Column, type ColumnProps } from './part';
-export { NameColumn, type NameColumnProps, NameCell, type NameCellProps } from './name';
-export { ActionsColumn, type ActionsColumnProps } from './actions';
-export {
-  UpdatedAtColumn,
-  type UpdatedAtColumnProps,
-  UpdatedAtCell,
-  type UpdatedAtCellProps,
-} from './updated_at';
+// Declarative components.
+export { Action, EditAction, DeleteAction, action } from './part';
 
-// Namespace type for TypeScript typing of `Column`.
-export type { ColumnNamespace } from './part';
+// Types.
+export type {
+  ActionProps,
+  ActionNamespace,
+  EditActionProps,
+  DeleteActionProps,
+  ActionOutput,
+  ActionBuilderContext,
+} from './types';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/part.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { table } from '../assembly';
+import type {
+  EditActionProps,
+  DeleteActionProps,
+  ActionOutput,
+  ActionBuilderContext,
+  ActionProps,
+} from './types';
+import { buildEditAction } from './edit/edit_action';
+import { buildDeleteAction } from './delete/delete_action';
+
+/**
+ * Preset-to-props mapping for table actions.
+ */
+export interface ActionPresets {
+  edit: EditActionProps;
+  delete: DeleteActionProps;
+}
+
+/** Part factory for table actions. */
+export const action = table.definePart<ActionPresets, ActionOutput, ActionBuilderContext>({
+  name: 'action',
+});
+
+/**
+ * Build a `DefaultItemAction` from a custom (non-preset) action.
+ *
+ * Registered as the fallback resolver via `createComponent({ resolve })`.
+ * Custom actions are identified by `props.id` rather than a preset name.
+ */
+const resolveCustomAction = (
+  {
+    id,
+    name,
+    description,
+    icon,
+    type: actionType,
+    color,
+    onClick,
+    href,
+    enabled,
+    available,
+    'data-test-subj': dataTestSubj,
+  }: ActionProps,
+  _context: ActionBuilderContext
+): ActionOutput => {
+  // Default `type` to `'icon'` when an icon is provided, ensuring the object
+  // satisfies EUI's discriminated union (`DefaultItemIconButtonAction` requires
+  // both `icon` and `type`). Without this, the conditional spread loses the
+  // discriminant and requires a cast.
+  const resolvedType = actionType ?? (icon ? 'icon' : undefined);
+
+  // Cast required: EUI's `DefaultItemAction` is a discriminated union keyed on
+  // `icon`. The spread-conditional pattern loses the discriminant, but the
+  // `resolvedType` guard above ensures the runtime object is always valid.
+  return {
+    name,
+    ...(description && { description }),
+    ...(icon && { icon }),
+    ...(resolvedType && { type: resolvedType }),
+    ...(color && { color }),
+    ...(onClick && { onClick }),
+    ...(href && { href }),
+    ...(enabled && { enabled }),
+    ...(available && { available }),
+    'data-test-subj': dataTestSubj ?? `content-list-table-action-${id}`,
+  } as ActionOutput;
+};
+
+/**
+ * Edit action preset component for `ContentListTable`.
+ *
+ * This is a declarative component that doesn't render anything.
+ * It specifies the edit action within a `Column.Actions` context.
+ *
+ * @example
+ * ```tsx
+ * const { Column, Action } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.Actions>
+ *     <Action.Edit />
+ *   </Column.Actions>
+ * </ContentListTable>
+ * ```
+ */
+export const EditAction = action.createPreset({ name: 'edit', resolve: buildEditAction });
+
+/**
+ * Delete action preset component for `ContentListTable`.
+ *
+ * This is a declarative component that doesn't render anything.
+ * It specifies the delete action (with confirmation) within a `Column.Actions` context.
+ *
+ * @example
+ * ```tsx
+ * const { Column, Action } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.Actions>
+ *     <Action.Delete />
+ *   </Column.Actions>
+ * </ContentListTable>
+ * ```
+ */
+export const DeleteAction = action.createPreset({ name: 'delete', resolve: buildDeleteAction });
+
+/**
+ * Custom action component for `ContentListTable`.
+ *
+ * Use this for custom row actions not covered by the built-in presets.
+ *
+ * @example
+ * ```tsx
+ * const { Column, Action } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.Actions>
+ *     <Action.Edit />
+ *     <Action id="duplicate" name="Duplicate" icon="copy" onClick={handleDuplicate} />
+ *     <Action.Delete />
+ *   </Column.Actions>
+ * </ContentListTable>
+ * ```
+ */
+export const Action = action.createComponent<ActionProps>({ resolve: resolveCustomAction });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+import type { DefaultItemAction, EuiButtonIconProps } from '@elastic/eui';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import type { BuilderContext } from '../column/types';
+
+/**
+ * Output type for resolved action presets.
+ *
+ * Each action preset resolves to an EUI `DefaultItemAction` suitable for
+ * use in an `EuiTableActionsColumnType.actions` array.
+ */
+export type ActionOutput = DefaultItemAction<ContentListItem>;
+
+/**
+ * Context passed to action builder functions.
+ *
+ * Extends {@link BuilderContext} with action-specific fields. Today it is
+ * identical to the base; the Delete Orchestration PR will add
+ * `onRequestDelete` and related callbacks here.
+ */
+export type ActionBuilderContext = BuilderContext;
+
+/**
+ * Props for the `Action` component (custom actions).
+ *
+ * Custom actions are identified by `props.id` and provide their own
+ * behavior. Pre-built actions (like `Action.Edit`) have dedicated
+ * preset components with their own props interfaces.
+ */
+export interface ActionProps {
+  /** Unique identifier for the action. */
+  id: string;
+  /** Display name for the action (shown in menu and tooltip). */
+  name: string | ((item: ContentListItem) => ReactNode);
+  /** Accessible description for the action. */
+  description?: string;
+  /** Icon type (EUI icon name). */
+  icon?: string;
+  /** Render type: `'icon'` (compact) or `'button'` (full). */
+  type?: 'icon' | 'button';
+  /** Icon/button color (matches EUI button color palette). */
+  color?: EuiButtonIconProps['color'];
+  /** Click handler. */
+  onClick?: (item: ContentListItem) => void;
+  /** Link href (string or function returning href per item). */
+  href?: string | ((item: ContentListItem) => string);
+  /** Whether the action is enabled for a given item. */
+  enabled?: (item: ContentListItem) => boolean;
+  /** Whether the action is available (visible) for a given item. */
+  available?: (item: ContentListItem) => boolean;
+  /** Test subject for testing. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Namespace interface for `Action` sub-components.
+ *
+ * The base `Action` accepts {@link ActionProps}; pre-built actions
+ * are properties (e.g., `Action.Edit`, `Action.Delete`).
+ */
+export interface ActionNamespace {
+  (props: ActionProps): ReactNode;
+  Edit: (props: EditActionProps) => ReactNode;
+  Delete: (props: DeleteActionProps) => ReactNode;
+}
+
+/**
+ * Props for the `Action.Edit` preset component.
+ */
+export interface EditActionProps {
+  /** Custom label for the edit action. Defaults to `'Edit'`. */
+  label?: string;
+}
+
+/**
+ * Props for the `Action.Delete` preset component.
+ */
+export interface DeleteActionProps {
+  /** Custom label for the delete action. Defaults to `'Delete'`. */
+  label?: string;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { EuiTableActionsColumnType } from '@elastic/eui';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import type { ColumnBuilderContext } from '../types';
+import { buildActionsColumn, type ActionsColumnProps } from './actions_builder';
+import { EditAction, DeleteAction } from '../../action';
+
+/** Helper to cast the result to the actions column type for assertions. */
+type ActionsColumn = EuiTableActionsColumnType<ContentListItem> & {
+  'data-test-subj'?: string;
+};
+
+const defaultContext: ColumnBuilderContext = {
+  itemConfig: {
+    getEditUrl: (item) => `/edit/${item.id}`,
+    onDelete: jest.fn(async () => {}),
+  },
+  isReadOnly: false,
+  entityName: 'dashboard',
+  supports: { sorting: true, pagination: true, search: true },
+};
+
+describe('actions column builder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildActionsColumn', () => {
+    describe('default actions (no children)', () => {
+      it('returns an actions column when edit and delete are configured', () => {
+        const result = buildActionsColumn({}, defaultContext) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.name).toBe('Actions');
+        expect(result.actions).toHaveLength(2);
+        expect(result['data-test-subj']).toBe('content-list-table-column-actions');
+      });
+
+      it('includes edit action when `getEditUrl` is configured', () => {
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          itemConfig: { getEditUrl: (item) => `/edit/${item.id}` },
+        };
+        const result = buildActionsColumn({}, context) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        expect(result.actions[0]).toMatchObject({
+          icon: 'pencil',
+          'data-test-subj': 'content-list-table-action-edit',
+        });
+      });
+
+      it('includes edit action when `onEdit` is configured', () => {
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          itemConfig: { onEdit: jest.fn() },
+        };
+        const result = buildActionsColumn({}, context) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        expect(result.actions[0]).toMatchObject({
+          icon: 'pencil',
+        });
+      });
+
+      it('includes delete action when `onDelete` is configured', () => {
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          itemConfig: { onDelete: jest.fn(async () => {}) },
+        };
+        const result = buildActionsColumn({}, context) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        expect(result.actions[0]).toMatchObject({
+          icon: 'trash',
+          color: 'danger',
+          'data-test-subj': 'content-list-table-action-delete',
+        });
+      });
+
+      it('returns `undefined` when no actions are available', () => {
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          itemConfig: {},
+        };
+        const result = buildActionsColumn({}, context);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns `undefined` in read-only mode', () => {
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          isReadOnly: true,
+        };
+        const result = buildActionsColumn({}, context);
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('explicit children', () => {
+      it('renders only specified actions in order', () => {
+        const props: ActionsColumnProps = {
+          children: (
+            <>
+              <EditAction />
+              <DeleteAction />
+            </>
+          ),
+        };
+        const result = buildActionsColumn(props, defaultContext) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(2);
+        expect(result.actions[0]).toMatchObject({ icon: 'pencil' });
+        expect(result.actions[1]).toMatchObject({ icon: 'trash' });
+      });
+
+      it('renders only edit when only edit child is provided', () => {
+        const props: ActionsColumnProps = {
+          children: <EditAction />,
+        };
+        const result = buildActionsColumn(props, defaultContext) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        expect(result.actions[0]).toMatchObject({ icon: 'pencil' });
+      });
+
+      it('renders only delete when only delete child is provided', () => {
+        const props: ActionsColumnProps = {
+          children: <DeleteAction />,
+        };
+        const result = buildActionsColumn(props, defaultContext) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        expect(result.actions[0]).toMatchObject({ icon: 'trash' });
+      });
+    });
+
+    describe('custom configuration', () => {
+      it('applies custom width', () => {
+        const props: ActionsColumnProps = { width: '150px' };
+        const result = buildActionsColumn(props, defaultContext);
+
+        expect(result).toMatchObject({ width: '150px' });
+      });
+
+      it('does not include width when not specified', () => {
+        const result = buildActionsColumn({}, defaultContext);
+
+        expect(result).not.toHaveProperty('width');
+      });
+
+      it('applies custom column title', () => {
+        const props: ActionsColumnProps = { columnTitle: 'Row Actions' };
+        const result = buildActionsColumn(props, defaultContext);
+
+        expect(result).toMatchObject({ name: 'Row Actions' });
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import type { ParsedPart } from '@kbn/content-list-assembly';
+import type { ColumnBuilderContext } from '../types';
+import { column } from '../part';
+import { action, type ActionOutput, type ActionBuilderContext } from '../../action';
+
+/** Default i18n-translated column title for the actions column. */
+const DEFAULT_ACTIONS_COLUMN_TITLE = i18n.translate(
+  'contentManagement.contentList.table.column.actions.title',
+  { defaultMessage: 'Actions' }
+);
+
+/**
+ * Props for the `Column.Actions` preset component.
+ *
+ * These are the declarative attributes consumers pass in JSX. The actions builder
+ * reads them directly from the parsed attributes.
+ */
+export interface ActionsColumnProps {
+  /** Column width (CSS value like `'100px'`). */
+  width?: string;
+  /** Custom column title. Defaults to `'Actions'`. */
+  columnTitle?: string;
+  /**
+   * Action children.
+   *
+   * When provided, only the specified actions are rendered in the given order.
+   * When omitted, actions are determined automatically from the provider config
+   * (e.g., edit is shown if `getEditUrl` or `onEdit` is configured, delete is
+   * shown if `onDelete` is configured).
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Build default action parts based on the current context.
+ *
+ * When `Column.Actions` has no children, this function determines which actions
+ * to show based on the provider configuration. For example, edit is included
+ * when `getEditUrl` or `onEdit` is configured, and delete is included when
+ * `onDelete` is configured.
+ */
+const getDefaultActionParts = (context: ColumnBuilderContext): ParsedPart[] => {
+  const parts: ParsedPart[] = [];
+  const { itemConfig, isReadOnly } = context;
+
+  if (isReadOnly) {
+    return parts;
+  }
+
+  const hasEdit = itemConfig?.getEditUrl || itemConfig?.onEdit;
+  const hasDelete = itemConfig?.onDelete;
+
+  if (hasEdit) {
+    parts.push({
+      type: 'part',
+      part: 'action',
+      preset: 'edit',
+      instanceId: 'edit',
+      attributes: {},
+    });
+  }
+
+  if (hasDelete) {
+    parts.push({
+      type: 'part',
+      part: 'action',
+      preset: 'delete',
+      instanceId: 'delete',
+      attributes: {},
+    });
+  }
+
+  return parts;
+};
+
+/**
+ * Build an `EuiBasicTableColumn` (actions column) from `Column.Actions` declarative attributes.
+ *
+ * Parses action children to determine which row actions to render. When no children
+ * are provided, defaults are inferred from the provider configuration. Returns
+ * `undefined` when no actions are available (e.g., read-only mode, no handlers configured).
+ *
+ * @param attributes - The declarative attributes from the parsed `Column.Actions` element.
+ * @param context - Builder context with provider configuration.
+ * @returns An `EuiBasicTableColumn<ContentListItem>` for the actions column, or `undefined` to skip.
+ */
+export const buildActionsColumn = (
+  attributes: ActionsColumnProps,
+  context: ColumnBuilderContext
+): EuiBasicTableColumn<ContentListItem> | undefined => {
+  const { children, width, columnTitle } = attributes;
+
+  // Parse action children from the Column.Actions element.
+  const actionParts = children !== undefined ? action.parseChildren(children) : [];
+
+  // Use explicit children if provided, otherwise determine defaults from context.
+  const parts = actionParts.length > 0 ? actionParts : getDefaultActionParts(context);
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  // `ColumnBuilderContext` and `ActionBuilderContext` share the same
+  // `BuilderContext` base, so the column context is directly usable as
+  // the action context. This will need a mapping step when
+  // `ActionBuilderContext` gains action-specific fields.
+  const actionContext: ActionBuilderContext = context;
+
+  // Resolve each action part into an EUI action definition.
+  const actions = parts
+    .map((part) => action.resolve(part, actionContext))
+    .filter((a): a is ActionOutput => a !== undefined);
+
+  if (actions.length === 0) {
+    return undefined;
+  }
+
+  return {
+    name: columnTitle ?? DEFAULT_ACTIONS_COLUMN_TITLE,
+    actions,
+    ...(width && { width }),
+    'data-test-subj': 'content-list-table-column-actions',
+  };
+};
+
+/**
+ * Actions column specification component for `ContentListTable`.
+ *
+ * This is a declarative component that doesn't render anything.
+ * It specifies the Actions column configuration as React children.
+ * Action children control which row actions are displayed and in what order.
+ *
+ * @example Default actions (inferred from provider config)
+ * ```tsx
+ * const { Column } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.Actions />
+ * </ContentListTable>
+ * ```
+ *
+ * @example Explicit actions
+ * ```tsx
+ * const { Column, Action } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.Actions>
+ *     <Action.Edit />
+ *     <Action.Delete />
+ *   </Column.Actions>
+ * </ContentListTable>
+ * ```
+ */
+export const ActionsColumn = column.createPreset({
+  name: 'actions',
+  resolve: buildActionsColumn,
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { ActionsColumn, buildActionsColumn, type ActionsColumnProps } from './actions_builder';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
@@ -14,6 +14,7 @@ import { table } from '../assembly';
 import type { ColumnBuilderContext } from './types';
 import type { NameColumnProps } from './name/name_builder';
 import type { UpdatedAtColumnProps } from './updated_at/updated_at_builder';
+import type { ActionsColumnProps } from './actions/actions_builder';
 
 /**
  * Props for the `Column` component (custom columns).
@@ -47,18 +48,20 @@ export interface ColumnProps {
  * Namespace interface for `Column` sub-components.
  *
  * The base `Column` accepts {@link ColumnProps}; pre-built columns
- * are properties (e.g., `Column.Name`).
+ * are properties (e.g., `Column.Name`, `Column.Actions`).
  */
 export interface ColumnNamespace {
   (props: ColumnProps): ReactNode;
   Name: (props: NameColumnProps) => ReactNode;
   UpdatedAt: (props: UpdatedAtColumnProps) => ReactNode;
+  Actions: (props: ActionsColumnProps) => ReactNode;
 }
 
 /** Preset-to-props mapping for table columns. */
 export interface ColumnPresets {
   name: NameColumnProps;
   updatedAt: UpdatedAtColumnProps;
+  actions: ActionsColumnProps;
 }
 
 /** Part factory for table columns. */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/types.ts
@@ -10,12 +10,14 @@
 import type { ContentListItemConfig, ContentListSupports } from '@kbn/content-list-provider';
 
 /**
- * Context passed to column builder functions.
+ * Shared context available to all builder functions (columns, actions).
  *
- * Provides provider-level configuration needed to build
- * `EuiBasicTableColumn` definitions from parsed declarative props.
+ * Provides provider-level configuration common to every builder. Specific
+ * builder context interfaces extend this base when they need additional fields
+ * (e.g., `ActionBuilderContext` will add delete orchestration callbacks in a
+ * future PR).
  */
-export interface ColumnBuilderContext {
+export interface BuilderContext {
   /** Item configuration from the content list provider. */
   itemConfig?: ContentListItemConfig;
   /** Whether the table is in read-only mode. */
@@ -25,3 +27,11 @@ export interface ColumnBuilderContext {
   /** Feature support flags from the provider. */
   supports?: ContentListSupports;
 }
+
+/**
+ * Context passed to column builder functions.
+ *
+ * Identical to {@link BuilderContext} today. Kept as a named alias so column
+ * builders have their own type that can diverge independently if needed.
+ */
+export type ColumnBuilderContext = BuilderContext;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -11,7 +11,8 @@ import React, { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { EuiBasicTable } from '@elastic/eui';
 import { useContentListItems, type ContentListItem } from '@kbn/content-list-provider';
-import { Column as BaseColumn, NameColumn, UpdatedAtColumn } from './column';
+import { Column as BaseColumn, NameColumn, UpdatedAtColumn, ActionsColumn } from './column';
+import { Action as BaseAction, EditAction, DeleteAction } from './action';
 import { useColumns, useSorting } from './hooks';
 import { EmptyState } from './empty_state';
 
@@ -77,17 +78,16 @@ export const getRowId = (id: string): string => `content-list-table-row-${id}`;
  * </ContentListProvider>
  * ```
  *
- * @example Custom columns
+ * @example With actions column
  * ```tsx
- * const { Column } = ContentListTable;
+ * const { Column, Action } = ContentListTable;
  *
  * <ContentListTable title="My Dashboards">
  *   <Column.Name width="40%" />
- *   <Column
- *     id="status"
- *     name="Status"
- *     render={(item) => <Badge>{item.status}</Badge>}
- *   />
+ *   <Column.Actions>
+ *     <Action.Edit />
+ *     <Action.Delete />
+ *   </Column.Actions>
  * </ContentListTable>
  * ```
  */
@@ -134,8 +134,16 @@ const ContentListTableComponent = ({
 export const Column = Object.assign(BaseColumn, {
   Name: NameColumn,
   UpdatedAt: UpdatedAtColumn,
+  Actions: ActionsColumn,
+});
+
+// Create Action namespace with sub-components.
+export const Action = Object.assign(BaseAction, {
+  Edit: EditAction,
+  Delete: DeleteAction,
 });
 
 export const ContentListTable = Object.assign(ContentListTableComponent, {
   Column,
+  Action,
 });


### PR DESCRIPTION
## Summary

Adds the **Actions Column** to `@kbn/content-list-table` with declarative row actions (`Edit`, `Delete`, and custom) for `ContentListTable`. `Action.Edit` is fully functional. `Action.Delete` is visually present (trash icon, danger color) but is a **no-op** — the actual delete flow (confirmation modal, delete state) will be wired by the Delete Orchestration PR.

> [!NOTE]
> This is PR 6 of the Content List implementation plan derived from elastic/kibana#247778. This PR was written in Cursor with the assistance of `claude-opus-4.6-high`.

## What's included

- **`Action.Edit`** — renders as a link (`href`) when `getEditUrl` is configured, a button (`onClick`) when `onEdit` is configured, or both when both are provided. Supports custom labels.
- **`Action.Delete`** — visually present (trash icon, danger color) but `onClick` is a **no-op stub**. The actual delete flow will be wired by the Delete Orchestration PR. Supports custom labels.
- **`Action` (custom)** — a generic component for arbitrary row actions with full control over icon, color, click handler, href, and visibility.
- **`Column.Actions`** — wraps actions into an EUI actions column. Falls back to auto-detecting available actions from `itemConfig` when no children are specified.
- **`BuilderContext`** — shared base interface for column and action builder contexts, reducing duplication. `ColumnBuilderContext` and `ActionBuilderContext` are type aliases today; the Delete Orchestration PR will extend `ActionBuilderContext` with action-specific fields.
- **Provider types** — extends `ContentListItemConfig` with `getEditUrl`, `onEdit`, and `onDelete` handlers.

## What's NOT included (deferred to Delete Orchestration PR)

- `DeleteConfirmationModal` — no confirmation modal in the table.
- Table-level delete state (`itemsToDelete`, `isDeleting`).
- `onRequestDelete` callback plumbing through builder contexts.

## Usage

```tsx
const { Column, Action } = ContentListTable;

<ContentListTable title="Dashboards">
  <Column.Name width="40%" />
  <Column.Actions>
    <Action.Edit />
    <Action.Delete />
  </Column.Actions>
</ContentListTable>
```

When no `<Column.Actions>` children are specified, actions are auto-detected from `itemConfig`:

```tsx
// Edit and delete actions appear automatically based on provider config.
<ContentListTable title="Dashboards">
  <Column.Name />
  <Column.Actions />
</ContentListTable>
```

## Changes

| Area | Files | Description |
|------|-------|-------------|
| `@kbn/content-list-provider` | 1 | Added `getEditUrl`, `onEdit`, `onDelete` to `ContentListItemConfig`. |
| `action/` (new) | 8 | Action part factory, edit/delete builders, custom action resolver, types, barrel exports. |
| `column/actions/` (new) | 3 | Actions column builder with auto-detection and explicit children support, plus tests. |
| `column/` | 2 | Extracted shared `BuilderContext` base; added `Actions` to column presets. |
| `content_list_table.tsx` | 1 | Integrated `Action`/`Column.Actions` namespaces. |
| `hooks/use_columns.ts` | 0 | Simplified — no `onRequestDelete` plumbing needed (change net-zero vs. main). |
| `index.ts` | 1 | Re-exported `Action` and `Column` namespaces. |
| `stories` | 1 | Playground story for actions column, custom actions, diagnostic panel updates. |

**19 files changed** — 1,282 additions, 57 deletions.

## Merge-order wiring

This PR is one of three independent PRs that can merge in any order:

| Last to merge | Wiring needed |
|---------------|---------------|
| **This PR** | Wire `Action.Delete`'s `onClick` to `onRequestDelete` + confirmation flow using already-available infra. |
| **Selection PR** | Import already-available `useDeleteAction` in `SelectionBar` instead of the `clearSelection` placeholder. |
| **Delete PR** | Replace `SelectionBar`'s `clearSelection` with `requestDelete`. Wire `Action.Delete` to `onRequestDelete`. |

## Architecture

Actions follow the same **declarative part** pattern as columns:

1. **Declare** — `<Action.Edit />` / `<Action.Delete />` are non-rendering components that carry props.
2. **Parse** — `Column.Actions` collects action children and extracts their preset names + props.
3. **Build** — Each action's builder function (`buildEditAction`, `buildDeleteAction`) receives parsed props and an `ActionBuilderContext` to produce an EUI `DefaultItemAction`.
4. **Render** — The resulting actions array is passed to `EuiTableActionsColumnType`.

## Known limitations

- **Danger color in overflow menu** — EUI's `DefaultItemAction.color` only applies to the expanded (inline) view; the collapsed overflow menu ignores it. `DangerActionName` works around this with `useLayoutEffect` + DOM traversal targeting the internal `.euiBasicTable__collapsedAction` class. This is fragile and tracked upstream at elastic/eui#9384.
- **`resolveCustomAction` cast** — EUI's `DefaultItemAction` is a discriminated union keyed on `icon`. A defensive `type: 'icon'` default is applied when `icon` is provided, but the `as ActionOutput` cast is still needed because the conditional spread pattern loses the discriminant.

## Test plan

- [x] 83 unit tests passing (0 failures).
- [x] ~96.5% line coverage across the package.
- [ ] Storybook: verify `Action.Edit` navigates, `Action.Delete` icon renders but is a no-op, custom actions fire toasts.
- [ ] Storybook: verify read-only mode hides all actions.
- [ ] Storybook: verify auto-detection shows edit/delete when `itemConfig` has handlers.
