### PR TITLE
[Cascade] add imperative API to get state changes within the cascade component

### DIFF
--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
@@ -12,6 +12,7 @@ export type {
   GroupNode,
   LeafNode,
   DataCascadeProps,
+  DataCascadeImplRef,
   DataCascadeRowProps,
   DataCascadeRowCellProps,
   CascadeRowCellNestedVirtualizationAnchorProps,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -64,6 +64,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
   enableRowSelection = false,
   enableStickyGroupHeader = true,
   allowMultipleRowToggle = false,
+  initialScrollOffset,
   cascadeRef,
 }: DataCascadeImplProps<G, L>) {
   const rowElement = Children.only(children);
@@ -147,6 +148,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     enableStickyGroupHeader,
     estimatedRowHeight: size === 's' ? 32 : size === 'm' ? 40 : 48,
     onStateChange: collectVirtualizerStateChanges,
+    initialOffset: initialScrollOffset,
   });
 
   const {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -26,6 +26,7 @@ import {
   calculateActiveStickyIndex,
   type VirtualizedCascadeListProps,
 } from '../../lib/core/virtualizer';
+import { useExposePublicApi } from '../../lib/core/api';
 import {
   useRegisterCascadeAccessibilityHelpers,
   useTreeGridContainerARIAAttributes,
@@ -63,6 +64,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
   enableRowSelection = false,
   enableStickyGroupHeader = true,
   allowMultipleRowToggle = false,
+  cascadeRef,
 }: DataCascadeImplProps<G, L>) {
   const rowElement = Children.only(children);
 
@@ -132,6 +134,11 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     rowCell: cascadeRowCell,
   });
 
+  const { collectVirtualizerStateChanges } = useExposePublicApi<G, L>(cascadeRef, {
+    rows,
+    enableStickyGroupHeader,
+  });
+
   // persist the virtualizer instance to ref, so that invocations of getVirtualizer will always return the latest instance
   virtualizerInstance.current = useCascadeVirtualizer<G>({
     rows,
@@ -139,6 +146,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     getScrollElement,
     enableStickyGroupHeader,
     estimatedRowHeight: size === 's' ? 32 : size === 'm' ? 40 : 48,
+    onStateChange: collectVirtualizerStateChanges,
   });
 
   const {
@@ -160,6 +168,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     enableStickyGroupHeader
   );
 
+  // register handlers for accessibility
   useRegisterCascadeAccessibilityHelpers<G>({
     tableRows: rows,
     tableWrapperElement: cascadeWrapperRef.current!,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -65,6 +65,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
   enableStickyGroupHeader = true,
   allowMultipleRowToggle = false,
   initialScrollOffset,
+  initialRect,
   cascadeRef,
 }: DataCascadeImplProps<G, L>) {
   const rowElement = Children.only(children);
@@ -149,6 +150,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     estimatedRowHeight: size === 's' ? 32 : size === 'm' ? 40 : 48,
     onStateChange: collectVirtualizerStateChanges,
     initialOffset: initialScrollOffset,
+    initialRect,
   });
 
   const {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -172,7 +172,6 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     enableStickyGroupHeader
   );
 
-  // register handlers for accessibility
   useRegisterCascadeAccessibilityHelpers<G>({
     tableRows: rows,
     tableWrapperElement: cascadeWrapperRef.current!,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.tsx
@@ -118,11 +118,6 @@ export function CascadeRowCellPrimitive<G extends GroupNode, L extends LeafNode>
   // Keep a reference to the virtualizer for cleanup and scroll-to operations
   const rootVirtualizer = useMemo(() => getVirtualizer(), [getVirtualizer]);
 
-  const virtualRow = useMemo(
-    () => rootVirtualizer.getVirtualItems().find((v) => v.index === row.index),
-    [rootVirtualizer, row]
-  );
-
   const getScrollElement = useCallback(() => rootVirtualizer.scrollElement, [rootVirtualizer]);
 
   /**
@@ -132,26 +127,6 @@ export function CascadeRowCellPrimitive<G extends GroupNode, L extends LeafNode>
   const preventSizeChangePropagation = useCallback(() => {
     return rootVirtualizer.preventRowSizeChangePropagation(row.index);
   }, [rootVirtualizer, row.index]);
-
-  useEffect(
-    () => () => {
-      // ensure that for a row that's been scrolled,
-      // if said row is technically still in view because it's cell is being rendered,
-      // when we are unmounting because the expand action from the cell's row was clicked,
-      // we want to ensure said row is the top most item in our list
-      if (
-        virtualRow?.index &&
-        !rootVirtualizer.isScrolling &&
-        getScrollOffset() > getScrollMargin()
-      ) {
-        rootVirtualizer.scrollToVirtualizedIndex(virtualRow.index, {
-          align: 'start',
-          behavior: 'auto',
-        });
-      }
-    },
-    [rootVirtualizer, virtualRow?.index, getScrollOffset, getScrollMargin]
-  );
 
   const memoizedChild = useMemo(() => {
     return React.createElement(children, {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -257,6 +257,10 @@ interface DataCascadeImplBaseProps<G extends GroupNode, L extends LeafNode>
    * Whether to allow multiple group rows to be expanded at the same time, default is false.
    */
   allowMultipleRowToggle?: boolean;
+  /**
+   * Initial vertical scroll position in pixels. When set, the list and scroll container start at this offset.
+   */
+  initialScrollOffset?: number;
   children: React.ReactElement<DataCascadeRowProps<G, L>>;
   cascadeRef: React.ForwardedRef<DataCascadeImplRef<G, L>>;
 }

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -13,6 +13,7 @@ import type { Table, CellContext, Row } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
 import type { GroupNode, LeafNode } from '../../store_provider';
 import type { CascadeVirtualizerProps, useCascadeVirtualizer } from '../../lib/core/virtualizer';
+import type { DataCascadeImplRef } from '../../lib/core/api';
 import type { SelectionDropdownProps } from './data_cascade_header/group_selection_combobox/selection_dropdown';
 
 /**
@@ -257,6 +258,7 @@ interface DataCascadeImplBaseProps<G extends GroupNode, L extends LeafNode>
    */
   allowMultipleRowToggle?: boolean;
   children: React.ReactElement<DataCascadeRowProps<G, L>>;
+  cascadeRef: React.ForwardedRef<DataCascadeImplRef<G, L>>;
 }
 
 export type DataCascadeImplProps<

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -261,6 +261,10 @@ interface DataCascadeImplBaseProps<G extends GroupNode, L extends LeafNode>
    * Initial vertical scroll position in pixels. When set, the list and scroll container start at this offset.
    */
   initialScrollOffset?: number;
+  /**
+   * Initial scroll rectangle dimensions. When set, the list and scroll container start at this size.
+   */
+  initialRect?: { width: number; height: number };
   children: React.ReactElement<DataCascadeRowProps<G, L>>;
   cascadeRef: React.ForwardedRef<DataCascadeImplRef<G, L>>;
 }

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -42,6 +42,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     initialGroupColumn,
     customTableHeader,
     tableTitleSlot,
+    initialExpandedRowIds,
     ...restProps
   }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
   ref: ForwardedRef<DataCascadeImplRef<G, L>>
@@ -54,6 +55,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     <DataCascadeProvider<G, L>
       cascadeGroups={cascadeGroups}
       initialGroupColumn={initialGroupColumn}
+      initialExpandedRowIds={initialExpandedRowIds}
     >
       <DataCascadeImpl<G, L> {...cascadeImplProps} />
     </DataCascadeProvider>

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -7,26 +7,55 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type ComponentProps } from 'react';
+import React, { forwardRef, type ComponentProps, type ForwardedRef } from 'react';
 import { DataCascadeImpl, type DataCascadeImplProps } from './data_cascade_impl';
+import type { DataCascadeImplRef } from '../lib/core/api';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../store_provider';
 
-export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps };
+export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps, DataCascadeImplRef };
+
 export { DataCascadeRow, DataCascadeRowCell } from './data_cascade_impl';
+
 export type {
   DataCascadeRowProps,
   DataCascadeRowCellProps,
   CascadeRowCellNestedVirtualizationAnchorProps,
 } from './data_cascade_impl';
 
-export function DataCascade<G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>({
-  cascadeGroups,
-  initialGroupColumn,
-  ...props
-}: DataCascadeImplProps<G, L> & ComponentProps<typeof DataCascadeProvider>) {
+type DataCascadeProviderProps = ComponentProps<typeof DataCascadeProvider>;
+
+type DataCascadeComponent = <G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>(
+  props: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> &
+    DataCascadeProviderProps & { ref?: React.Ref<DataCascadeImplRef<G, L>> }
+) => React.ReactElement;
+
+/**
+ * Public data cascade component. Forwards the ref to DataCascadeImpl so consumers
+ * receive the imperative handle on the ref.
+ */
+export const DataCascade = forwardRef(function DataCascadeWithProvider<
+  G extends GroupNode,
+  L extends LeafNode
+>(
+  {
+    cascadeGroups,
+    initialGroupColumn,
+    customTableHeader,
+    tableTitleSlot,
+    ...restProps
+  }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
+  ref: ForwardedRef<DataCascadeImplRef<G, L>>
+) {
+  const cascadeImplProps: DataCascadeImplProps<G, L> = customTableHeader
+    ? { ...restProps, customTableHeader, cascadeRef: ref }
+    : { ...restProps, tableTitleSlot: tableTitleSlot!, cascadeRef: ref };
+
   return (
-    <DataCascadeProvider cascadeGroups={cascadeGroups} initialGroupColumn={initialGroupColumn}>
-      <DataCascadeImpl<G, L> {...props} />
+    <DataCascadeProvider<G, L>
+      cascadeGroups={cascadeGroups}
+      initialGroupColumn={initialGroupColumn}
+    >
+      <DataCascadeImpl<G, L> {...cascadeImplProps} />
     </DataCascadeProvider>
   );
-}
+}) as DataCascadeComponent;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -44,6 +44,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     tableTitleSlot,
     initialTableState,
     initialScrollOffset,
+    initialRect,
     ...restProps
   }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
   ref: ForwardedRef<DataCascadeImplRef<G, L>>
@@ -51,6 +52,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
   // create a stable reference for the component initializer props
   const initialTableStateRef = useRef(initialTableState);
   const initialScrollOffsetRef = useRef(initialScrollOffset);
+  const initialRectRef = useRef(initialRect);
 
   const cascadeImplProps = useMemo<DataCascadeImplProps<G, L>>(
     () =>
@@ -70,6 +72,7 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
         <DataCascadeImpl<G, L>
           {...cascadeImplProps}
           initialScrollOffset={initialScrollOffsetRef.current}
+          initialRect={initialRectRef.current}
         />
       </DataCascadeProvider>
     ),

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -45,7 +45,14 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     initialTableState,
     initialScrollOffset,
     initialRect,
-    ...restProps
+    onCascadeGroupingChange,
+    size,
+    enableStickyGroupHeader,
+    allowMultipleRowToggle,
+    children,
+    enableRowSelection,
+    data,
+    overscan,
   }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
   ref: ForwardedRef<DataCascadeImplRef<G, L>>
 ) {
@@ -54,15 +61,37 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
   const initialScrollOffsetRef = useRef(initialScrollOffset);
   const initialRectRef = useRef(initialRect);
 
-  const cascadeImplProps = useMemo<DataCascadeImplProps<G, L>>(
-    () =>
-      customTableHeader
-        ? { ...restProps, customTableHeader, cascadeRef: ref }
-        : { ...restProps, tableTitleSlot: tableTitleSlot!, cascadeRef: ref },
-    [customTableHeader, restProps, tableTitleSlot, ref]
-  );
+  const cascadeImplProps = useMemo<DataCascadeImplProps<G, L>>(() => {
+    const props = {
+      onCascadeGroupingChange,
+      size,
+      enableStickyGroupHeader,
+      allowMultipleRowToggle,
+      enableRowSelection,
+      data,
+      overscan,
+      children,
+      cascadeRef: ref,
+    };
 
-  return React.useMemo(
+    return customTableHeader
+      ? { ...props, customTableHeader }
+      : { ...props, tableTitleSlot: tableTitleSlot! };
+  }, [
+    allowMultipleRowToggle,
+    children,
+    customTableHeader,
+    data,
+    enableRowSelection,
+    overscan,
+    onCascadeGroupingChange,
+    size,
+    enableStickyGroupHeader,
+    tableTitleSlot,
+    ref,
+  ]);
+
+  return useMemo(
     () => (
       <DataCascadeProvider<G, L>
         cascadeGroups={cascadeGroups}

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -7,13 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { forwardRef, type ComponentProps, type ForwardedRef } from 'react';
+import React, { forwardRef, useMemo, useRef, type ComponentProps, type ForwardedRef } from 'react';
 import { DataCascadeImpl, type DataCascadeImplProps } from './data_cascade_impl';
 import type { DataCascadeImplRef } from '../lib/core/api';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../store_provider';
 
 export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps, DataCascadeImplRef };
-
+export type { DataCascadeUISnapshot } from '../lib/core/api';
 export { DataCascadeRow, DataCascadeRowCell } from './data_cascade_impl';
 
 export type {
@@ -24,7 +24,7 @@ export type {
 
 type DataCascadeProviderProps = ComponentProps<typeof DataCascadeProvider>;
 
-type DataCascadeComponent = <G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>(
+export type DataCascadeComponent = <G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>(
   props: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> &
     DataCascadeProviderProps & { ref?: React.Ref<DataCascadeImplRef<G, L>> }
 ) => React.ReactElement;
@@ -42,22 +42,37 @@ export const DataCascade = forwardRef(function DataCascadeWithProvider<
     initialGroupColumn,
     customTableHeader,
     tableTitleSlot,
-    initialExpandedRowIds,
+    initialTableState,
+    initialScrollOffset,
     ...restProps
   }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
   ref: ForwardedRef<DataCascadeImplRef<G, L>>
 ) {
-  const cascadeImplProps: DataCascadeImplProps<G, L> = customTableHeader
-    ? { ...restProps, customTableHeader, cascadeRef: ref }
-    : { ...restProps, tableTitleSlot: tableTitleSlot!, cascadeRef: ref };
+  // create a stable reference for the component initializer props
+  const initialTableStateRef = useRef(initialTableState);
+  const initialScrollOffsetRef = useRef(initialScrollOffset);
 
-  return (
-    <DataCascadeProvider<G, L>
-      cascadeGroups={cascadeGroups}
-      initialGroupColumn={initialGroupColumn}
-      initialExpandedRowIds={initialExpandedRowIds}
-    >
-      <DataCascadeImpl<G, L> {...cascadeImplProps} />
-    </DataCascadeProvider>
+  const cascadeImplProps = useMemo<DataCascadeImplProps<G, L>>(
+    () =>
+      customTableHeader
+        ? { ...restProps, customTableHeader, cascadeRef: ref }
+        : { ...restProps, tableTitleSlot: tableTitleSlot!, cascadeRef: ref },
+    [customTableHeader, restProps, tableTitleSlot, ref]
+  );
+
+  return React.useMemo(
+    () => (
+      <DataCascadeProvider<G, L>
+        cascadeGroups={cascadeGroups}
+        initialGroupColumn={initialGroupColumn}
+        initialTableState={initialTableStateRef.current}
+      >
+        <DataCascadeImpl<G, L>
+          {...cascadeImplProps}
+          initialScrollOffset={initialScrollOffsetRef.current}
+        />
+      </DataCascadeProvider>
+    ),
+    [cascadeGroups, cascadeImplProps, initialGroupColumn]
   );
 }) as DataCascadeComponent;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useSyncExternalStore } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useExposePublicApi, type DataCascadeImplRef } from '.';
+import { DataCascadeProvider, type GroupNode, type LeafNode } from '../../../store_provider';
+import type { CascadeVirtualizerReturnValue } from '../virtualizer';
+
+describe('useExposePublicApi', () => {
+  it('should return the correct value', () => {
+    const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+      current: null,
+    };
+
+    const { result } = renderHook(
+      () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+      {
+        wrapper: ({ children }) => (
+          <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+        ),
+      }
+    );
+
+    expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+    // ref should be populated with public API method after mount
+    expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+  });
+
+  describe('getUISnapshotStore', () => {
+    it('should return a store snapshot with the correct initial state', () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const snapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      expect(snapshotStore!.getSnapshot()).toEqual({
+        scrollOffset: 0,
+        range: null,
+        isScrolling: false,
+        activeStickyIndex: null,
+        totalRowCount: 0,
+        totalSize: 0,
+        expanded: {},
+        rowSelection: {},
+      });
+    });
+
+    it('changes on the virtualizer instance should notify subscribers, and reflect changes in the store snapshot', () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const uiSnapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      const subscriptionSpy = jest.fn();
+
+      const unsubscribe = uiSnapshotStore!.subscribe(subscriptionSpy);
+
+      const virtualizerInstance = {
+        range: { startIndex: 0, endIndex: 10 },
+        scrollOffset: 100,
+        isScrolling: false,
+        // it's fine to cast to unknown
+        // because we only need a minimal implementation of the virtualizer instance for the test
+      } as unknown as CascadeVirtualizerReturnValue;
+
+      // simulate changes in the virtualizer instance
+      act(() => {
+        result.current.collectVirtualizerStateChanges(virtualizerInstance);
+      });
+
+      expect(subscriptionSpy).toHaveBeenCalled();
+
+      const updatedUISnapshot = uiSnapshotStore!.getSnapshot();
+
+      expect(updatedUISnapshot).toHaveProperty('scrollOffset', virtualizerInstance.scrollOffset);
+      expect(updatedUISnapshot).toHaveProperty('range', virtualizerInstance.range);
+      expect(updatedUISnapshot).toHaveProperty('isScrolling', virtualizerInstance.isScrolling);
+
+      // these properties did not change because we did not provide updates for them
+      expect(updatedUISnapshot).toHaveProperty('activeStickyIndex', null);
+      expect(updatedUISnapshot).toHaveProperty('totalRowCount', 0);
+      expect(updatedUISnapshot).toHaveProperty('totalSize', 0);
+      expect(updatedUISnapshot).toHaveProperty('expanded', {});
+      expect(updatedUISnapshot).toHaveProperty('rowSelection', {});
+
+      unsubscribe();
+    });
+
+    it('should be compatible with the useSyncExternalStore hook', () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const snapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      const { result: externalSyncResult } = renderHook(() =>
+        useSyncExternalStore(
+          snapshotStore!.subscribe,
+          snapshotStore!.getSnapshot,
+          snapshotStore!.getServerSnapshot
+        )
+      );
+
+      expect(externalSyncResult.current).toEqual({
+        scrollOffset: 0,
+        range: null,
+        isScrolling: false,
+        activeStickyIndex: null,
+        totalRowCount: 0,
+        totalSize: 0,
+        expanded: {},
+        rowSelection: {},
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
@@ -124,7 +124,7 @@ describe('useExposePublicApi', () => {
       unsubscribe();
     });
 
-    it('should be compatible with the useSyncExternalStore hook', () => {
+    it('should be compatible with the useSyncExternalStore hook', async () => {
       const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
         current: null,
       };
@@ -161,6 +161,30 @@ describe('useExposePublicApi', () => {
         expanded: {},
         rowSelection: {},
         scrollRect: { width: 0, height: 0 },
+      });
+
+      act(() => {
+        result.current.collectVirtualizerStateChanges({
+          range: { startIndex: 0, endIndex: 10 },
+          scrollOffset: 100,
+          isScrolling: false,
+          scrollRect: { width: 0, height: 0 },
+          getTotalSize: () => 0,
+        } as unknown as UseVirtualizerReturnType);
+      });
+
+      await waitFor(() => {
+        expect(externalSyncResult.current).toEqual({
+          scrollOffset: 100,
+          range: { startIndex: 0, endIndex: 10 },
+          isScrolling: false,
+          activeStickyIndex: null,
+          totalRowCount: 0,
+          totalSize: 0,
+          expanded: {},
+          rowSelection: {},
+          scrollRect: { width: 0, height: 0 },
+        });
       });
     });
   });

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useSyncExternalStore } from 'react';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useExposePublicApi, type DataCascadeImplRef } from '.';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../../../store_provider';
 import type { UseVirtualizerReturnType } from '../virtualizer';
@@ -62,10 +62,11 @@ describe('useExposePublicApi', () => {
         totalSize: 0,
         expanded: {},
         rowSelection: {},
+        scrollRect: { width: 0, height: 0 },
       });
     });
 
-    it('changes on the virtualizer instance should notify subscribers, and reflect changes in the store snapshot', () => {
+    it('changes on the virtualizer instance should notify subscribers, and reflect changes in the store snapshot', async () => {
       const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
         current: null,
       };
@@ -101,7 +102,10 @@ describe('useExposePublicApi', () => {
         result.current.collectVirtualizerStateChanges(virtualizerInstance);
       });
 
-      expect(subscriptionSpy).toHaveBeenCalled();
+      await waitFor(() => {
+        // wait for the debounce to complete
+        expect(subscriptionSpy).toHaveBeenCalled();
+      });
 
       const updatedUISnapshot = uiSnapshotStore!.getSnapshot();
 
@@ -115,6 +119,7 @@ describe('useExposePublicApi', () => {
       expect(updatedUISnapshot).toHaveProperty('totalSize', 0);
       expect(updatedUISnapshot).toHaveProperty('expanded', {});
       expect(updatedUISnapshot).toHaveProperty('rowSelection', {});
+      expect(updatedUISnapshot).toHaveProperty('scrollRect', { width: 0, height: 0 });
 
       unsubscribe();
     });
@@ -155,6 +160,7 @@ describe('useExposePublicApi', () => {
         totalSize: 0,
         expanded: {},
         rowSelection: {},
+        scrollRect: { width: 0, height: 0 },
       });
     });
   });

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
@@ -11,7 +11,7 @@ import React, { useSyncExternalStore } from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { useExposePublicApi, type DataCascadeImplRef } from '.';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../../../store_provider';
-import type { CascadeVirtualizerReturnValue } from '../virtualizer';
+import type { UseVirtualizerReturnType } from '../virtualizer';
 
 describe('useExposePublicApi', () => {
   it('should return the correct value', () => {
@@ -94,7 +94,7 @@ describe('useExposePublicApi', () => {
         isScrolling: false,
         // it's fine to cast to unknown
         // because we only need a minimal implementation of the virtualizer instance for the test
-      } as unknown as CascadeVirtualizerReturnValue;
+      } as unknown as UseVirtualizerReturnType;
 
       // simulate changes in the virtualizer instance
       act(() => {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Row } from '@tanstack/react-table';
+import { useCallback, useLayoutEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import {
+  useDataCascadeState,
+  type GroupNode,
+  type LeafNode,
+  type IStoreState,
+} from '../../../store_provider';
+import {
+  calculateActiveStickyIndex,
+  type CascadeVirtualizerReturnValue,
+  type UseVirtualizerReturnType,
+} from '../virtualizer';
+
+/**
+ * Snapshot of data cascade ui state for use with useSyncExternalStore.
+ * Includes virtualizer-derived state and specific table state.
+ */
+export interface DataCascadeUISnapshot<G extends GroupNode, L extends LeafNode>
+  extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
+  scrollOffset: number;
+  range: { startIndex: number; endIndex: number } | null;
+  isScrolling: boolean;
+  activeStickyIndex: number | null;
+  totalRowCount: number;
+  totalSize: number;
+}
+
+/**
+ * useSyncExternalStore-compatible store for data cascade ui state.
+ */
+export interface DataCascadeUISnapshotStore<G extends GroupNode, L extends LeafNode> {
+  subscribe(onStoreChange: () => void): () => void;
+  getSnapshot(): DataCascadeUISnapshot<G, L>;
+  getServerSnapshot(): DataCascadeUISnapshot<G, L>;
+}
+
+/**
+ * Options for useExposePublicApi. Supplies table/UI state needed to build the snapshot.
+ */
+export interface UseExposePublicApiOptions<G extends GroupNode> {
+  rows: Row<G>[];
+  enableStickyGroupHeader: boolean;
+}
+
+/**
+ * Return value of useExposePublicApi.
+ */
+export interface UseExposePublicApiReturnValue {
+  /** Updates the store snapshot from virtualizer instance changes */
+  collectVirtualizerStateChanges: (
+    instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined
+  ) => void;
+}
+
+const createDefaultUISnapshot = <G extends GroupNode, L extends LeafNode>(): DataCascadeUISnapshot<
+  G,
+  L
+> => ({
+  scrollOffset: 0,
+  range: null,
+  isScrolling: false,
+  activeStickyIndex: null,
+  totalRowCount: 0,
+  totalSize: 0,
+  expanded: {},
+  rowSelection: {},
+});
+
+/**
+ * Definition of the public API ref for the data cascade component.
+ */
+export interface DataCascadeImplRef<G extends GroupNode, L extends LeafNode> {
+  /**
+   * Returns helpers to access a minimal readonly state of the data cascade component.
+   * This can be used as-is or put together leveraging useSyncExternalStore to create a more reactive
+   * component state.
+   *
+   * @example
+   * ```ts
+   * export function useDataCascadeSnapshot(ref: React.RefObject<DataCascadeImplRef | null>): DataCascadeSnapshot {
+   *   return useSyncExternalStore(
+   *     (onStoreChange) => ref.current?.getUISnapshotStore()?.subscribe(onStoreChange) ?? (() => {}),
+   *     () => ref.current?.getUISnapshotStore()?.getSnapshot() ?? DEFAULT_SNAPSHOT,
+   *     () => ref.current?.getUISnapshotStore()?.getServerSnapshot() ?? DEFAULT_SNAPSHOT
+   *   );
+   * }
+   * ```
+   */
+  getUISnapshotStore: () => DataCascadeUISnapshotStore<G, L> | null;
+}
+
+/**
+ * Hook that owns the public API ref: aggregates state + virtualizer into a snapshot store,
+ * updates the store when inputs change, and exposes getStateStore via useImperativeHandle.
+ * Call from the cascade impl with the ref and options; the ref will be populated after mount.
+ */
+export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
+  ref: React.Ref<DataCascadeImplRef<G, L>>,
+  options: UseExposePublicApiOptions<G>
+): UseExposePublicApiReturnValue {
+  // Use a stable handle object and only update its method.
+  const handleRef = useRef<DataCascadeImplRef<G, L>>({
+    getUISnapshotStore: () => null,
+  });
+
+  const { rows } = options;
+  const state = useDataCascadeState<G, L>();
+
+  const expanded = useMemo<DataCascadeUISnapshot<G, L>['expanded']>(
+    () =>
+      typeof state.table.expanded === 'object' && state.table.expanded !== null
+        ? state.table.expanded
+        : {},
+    [state.table.expanded]
+  );
+
+  const rowSelection = useMemo<DataCascadeUISnapshot<G, L>['rowSelection']>(
+    () => state.table.rowSelection ?? {},
+    [state.table.rowSelection]
+  );
+
+  const optionsRef = useRef(options);
+  const latestStateRef = useRef({ expanded, rowSelection });
+  optionsRef.current = options;
+  latestStateRef.current = { expanded, rowSelection };
+
+  const storeRef = useRef<{
+    listeners: Set<() => void>;
+    snapshot: DataCascadeUISnapshot<G, L>;
+  }>({
+    listeners: new Set(),
+    snapshot: createDefaultUISnapshot(),
+  });
+
+  const subscribe = useCallback((onUISnapshotChange: () => void) => {
+    storeRef.current.listeners.add(onUISnapshotChange);
+    return () => {
+      storeRef.current.listeners.delete(onUISnapshotChange);
+    };
+  }, []);
+
+  const getSnapshot = useCallback((): DataCascadeUISnapshot<G, L> => storeRef.current.snapshot, []);
+  const getServerSnapshot = useCallback(
+    (): DataCascadeUISnapshot<G, L> => storeRef.current.snapshot,
+    []
+  );
+
+  /** Notifies all subscribed listeners that the store snapshot may have changed. */
+  const notifyListeners = useCallback(() => {
+    const opts = optionsRef.current;
+    const { expanded: exp, rowSelection: sel } = latestStateRef.current;
+    const snap = storeRef.current.snapshot;
+
+    snap.totalRowCount = opts.rows.length;
+    snap.expanded = exp;
+    snap.rowSelection = sel;
+
+    storeRef.current.listeners.forEach((listener) => listener());
+  }, []);
+
+  /** scans updates from virtualizer instance and updates the store snapshot. */
+  const collectVirtualizerStateChanges = useCallback(
+    (instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined) => {
+      const opts = optionsRef.current;
+      const snap = storeRef.current.snapshot;
+      // if the virtualizer instance is not null, update the store snapshot
+      if (instance != null) {
+        const range =
+          instance.range != null
+            ? { startIndex: instance.range.startIndex, endIndex: instance.range.endIndex }
+            : null;
+        const activeStickyIndex = calculateActiveStickyIndex(
+          opts.rows,
+          range?.startIndex ?? 0,
+          opts.enableStickyGroupHeader
+        );
+        snap.scrollOffset = instance.scrollOffset ?? 0;
+        snap.range = range;
+        snap.isScrolling = instance.isScrolling ?? false;
+        snap.activeStickyIndex = activeStickyIndex;
+        snap.totalSize = instance.getTotalSize ? instance.getTotalSize() : 0;
+
+        notifyListeners();
+      }
+    },
+    [notifyListeners]
+  );
+
+  useLayoutEffect(() => {
+    notifyListeners();
+  }, [notifyListeners, expanded, rowSelection, rows.length]);
+
+  const getStateStore = useCallback(
+    (): DataCascadeUISnapshotStore<G, L> => ({
+      subscribe,
+      getSnapshot,
+      getServerSnapshot,
+    }),
+    [subscribe, getSnapshot, getServerSnapshot]
+  );
+
+  handleRef.current = {
+    getUISnapshotStore: getStateStore,
+  };
+
+  // Magic happens here, the ref is populated after mount and consumers can use it to access the public API
+  useImperativeHandle(ref, () => handleRef.current, []);
+
+  return { collectVirtualizerStateChanges };
+}

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Row } from '@tanstack/react-table';
+import { debounce } from 'lodash';
 import { useCallback, useLayoutEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import {
   useDataCascadeState,
@@ -15,11 +16,7 @@ import {
   type LeafNode,
   type IStoreState,
 } from '../../../store_provider';
-import {
-  calculateActiveStickyIndex,
-  type CascadeVirtualizerReturnValue,
-  type UseVirtualizerReturnType,
-} from '../virtualizer';
+import { calculateActiveStickyIndex, type UseVirtualizerReturnType } from '../virtualizer';
 
 /**
  * Snapshot of data cascade ui state for use with useSyncExternalStore.
@@ -29,6 +26,7 @@ export interface DataCascadeUISnapshot<
   G extends GroupNode = GroupNode,
   L extends LeafNode = LeafNode
 > extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
+  scrollRect: { width: number; height: number };
   scrollOffset: number;
   range: { startIndex: number; endIndex: number } | null;
   isScrolling: boolean;
@@ -59,9 +57,7 @@ export interface UseExposePublicApiOptions<G extends GroupNode> {
  */
 export interface UseExposePublicApiReturnValue {
   /** Updates the store snapshot from virtualizer instance changes */
-  collectVirtualizerStateChanges: (
-    instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined
-  ) => void;
+  collectVirtualizerStateChanges: (instance: UseVirtualizerReturnType | undefined) => void;
 }
 
 const createDefaultUISnapshot = <G extends GroupNode, L extends LeafNode>(): DataCascadeUISnapshot<
@@ -69,6 +65,7 @@ const createDefaultUISnapshot = <G extends GroupNode, L extends LeafNode>(): Dat
   L
 > => ({
   scrollOffset: 0,
+  scrollRect: { width: 0, height: 0 },
   range: null,
   isScrolling: false,
   activeStickyIndex: null,
@@ -176,7 +173,7 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
 
   /** scans updates from virtualizer instance and updates the store snapshot. */
   const collectVirtualizerStateChanges = useCallback(
-    (instance: UseVirtualizerReturnType | CascadeVirtualizerReturnValue | undefined) => {
+    (instance: UseVirtualizerReturnType | undefined) => {
       const opts = optionsRef.current;
       const snap = storeRef.current.snapshot;
       // if the virtualizer instance is not null, update the store snapshot
@@ -194,6 +191,7 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
         snap.range = range;
         snap.isScrolling = instance.isScrolling ?? false;
         snap.activeStickyIndex = activeStickyIndex;
+        snap.scrollRect = instance.scrollRect ?? { width: 0, height: 0 };
         snap.totalSize = instance.getTotalSize ? instance.getTotalSize() : 0;
 
         notifyListeners();

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -25,8 +25,10 @@ import {
  * Snapshot of data cascade ui state for use with useSyncExternalStore.
  * Includes virtualizer-derived state and specific table state.
  */
-export interface DataCascadeUISnapshot<G extends GroupNode, L extends LeafNode>
-  extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
+export interface DataCascadeUISnapshot<
+  G extends GroupNode = GroupNode,
+  L extends LeafNode = LeafNode
+> extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
   scrollOffset: number;
   range: { startIndex: number; endIndex: number } | null;
   isScrolling: boolean;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -160,11 +160,13 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
       debounce(() => {
         const opts = optionsRef.current;
         const { expanded: exp, rowSelection: sel } = latestStateRef.current;
-        const snap = storeRef.current.snapshot;
 
-        snap.totalRowCount = opts.rows.length;
-        snap.expanded = exp;
-        snap.rowSelection = sel;
+        storeRef.current.snapshot = {
+          ...storeRef.current.snapshot,
+          totalRowCount: opts.rows.length,
+          expanded: exp,
+          rowSelection: sel,
+        };
 
         storeRef.current.listeners.forEach((listener) => listener());
       }, 100),
@@ -175,7 +177,7 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
   const collectVirtualizerStateChanges = useCallback(
     (instance: UseVirtualizerReturnType | undefined) => {
       const opts = optionsRef.current;
-      const snap = storeRef.current.snapshot;
+
       // if the virtualizer instance is not null, update the store snapshot
       if (instance != null) {
         const range =
@@ -187,12 +189,16 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
           range?.startIndex ?? 0,
           opts.enableStickyGroupHeader
         );
-        snap.scrollOffset = instance.scrollOffset ?? 0;
-        snap.range = range;
-        snap.isScrolling = instance.isScrolling ?? false;
-        snap.activeStickyIndex = activeStickyIndex;
-        snap.scrollRect = instance.scrollRect ?? { width: 0, height: 0 };
-        snap.totalSize = instance.getTotalSize ? instance.getTotalSize() : 0;
+
+        storeRef.current.snapshot = {
+          ...storeRef.current.snapshot,
+          scrollOffset: instance.scrollOffset ?? 0,
+          range,
+          isScrolling: instance.isScrolling ?? false,
+          activeStickyIndex,
+          scrollRect: instance.scrollRect ?? { width: 0, height: 0 },
+          totalSize: instance.getTotalSize ? instance.getTotalSize() : 0,
+        };
 
         notifyListeners();
       }
@@ -217,7 +223,7 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
     getUISnapshotStore: getStateStore,
   };
 
-  // Magic happens here, the ref is populated after mount and consumers can use it to access the public API
+  // Populate the forwarded ref with the stable handle after mount
   useImperativeHandle(ref, () => handleRef.current, []);
 
   return { collectVirtualizerStateChanges };

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -158,17 +158,21 @@ export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
   );
 
   /** Notifies all subscribed listeners that the store snapshot may have changed. */
-  const notifyListeners = useCallback(() => {
-    const opts = optionsRef.current;
-    const { expanded: exp, rowSelection: sel } = latestStateRef.current;
-    const snap = storeRef.current.snapshot;
+  const notifyListeners = useMemo(
+    () =>
+      debounce(() => {
+        const opts = optionsRef.current;
+        const { expanded: exp, rowSelection: sel } = latestStateRef.current;
+        const snap = storeRef.current.snapshot;
 
-    snap.totalRowCount = opts.rows.length;
-    snap.expanded = exp;
-    snap.rowSelection = sel;
+        snap.totalRowCount = opts.rows.length;
+        snap.expanded = exp;
+        snap.rowSelection = sel;
 
-    storeRef.current.listeners.forEach((listener) => listener());
-  }, []);
+        storeRef.current.listeners.forEach((listener) => listener());
+      }, 100),
+    []
+  );
 
   /** scans updates from virtualizer instance and updates the store snapshot. */
   const collectVirtualizerStateChanges = useCallback(

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -13,7 +13,7 @@ import { useVirtualizer, defaultRangeExtractor, type VirtualItem } from '@tansta
 import type { GroupNode } from '../../../store_provider';
 
 type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
-type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
+export type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
 
 export interface CascadeVirtualizerProps<G extends GroupNode>
   extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan'> {
@@ -24,6 +24,11 @@ export interface CascadeVirtualizerProps<G extends GroupNode>
    */
   enableStickyGroupHeader: boolean;
   estimatedRowHeight?: number;
+  /**
+   * Called whenever the virtualizer updates (scroll, range, size, etc.).
+   * Used to conduit values into external state (e.g. public API store).
+   */
+  onStateChange?: (instance: UseVirtualizerReturnType) => void;
 }
 
 export interface UseVirtualizedRowScrollStateStoreOptions {
@@ -168,6 +173,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   estimatedRowHeight = 0,
   rows,
   getScrollElement,
+  onStateChange,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
 
@@ -202,9 +208,11 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
         // but it not included in the type definition because it is marked as a private property,
         // see {@link https://github.com/TanStack/virtual/blob/v3.13.2/packages/virtual-core/src/index.ts#L360}
         virtualizedRowsSizeCacheRef.current = rowVirtualizerInstance.itemSizeCache;
+        // propagate virtualizer state changes
+        onStateChange?.(rowVirtualizerInstance);
       },
     }),
-    [estimatedRowHeight, getScrollElement, overscan, rangeExtractor, rows.length]
+    [estimatedRowHeight, getScrollElement, overscan, rangeExtractor, rows.length, onStateChange]
   );
 
   const virtualizerImpl = useVirtualizer(virtualizerOptions);

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -16,7 +16,10 @@ type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
 export type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
 
 export interface CascadeVirtualizerProps<G extends GroupNode>
-  extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan' | 'initialOffset'> {
+  extends Pick<
+    UseVirtualizerOptions,
+    'getScrollElement' | 'overscan' | 'initialOffset' | 'initialRect'
+  > {
   rows: Row<G>[];
   /**
    * setting a value of true causes the active group root row
@@ -175,6 +178,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   getScrollElement,
   onStateChange,
   initialOffset,
+  initialRect,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
 
@@ -205,6 +209,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       overscan,
       rangeExtractor,
       initialOffset,
+      initialRect,
       onChange: (rowVirtualizerInstance) => {
         // @ts-expect-error -- the itemsSizeCache property does exist,
         // but it not included in the type definition because it is marked as a private property,
@@ -218,6 +223,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       estimatedRowHeight,
       getScrollElement,
       initialOffset,
+      initialRect,
       overscan,
       rangeExtractor,
       rows.length,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -16,7 +16,7 @@ type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
 export type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
 
 export interface CascadeVirtualizerProps<G extends GroupNode>
-  extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan'> {
+  extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan' | 'initialOffset'> {
   rows: Row<G>[];
   /**
    * setting a value of true causes the active group root row
@@ -174,6 +174,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   rows,
   getScrollElement,
   onStateChange,
+  initialOffset,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
 
@@ -203,6 +204,7 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       getScrollElement,
       overscan,
       rangeExtractor,
+      initialOffset,
       onChange: (rowVirtualizerInstance) => {
         // @ts-expect-error -- the itemsSizeCache property does exist,
         // but it not included in the type definition because it is marked as a private property,
@@ -212,7 +214,15 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
         onStateChange?.(rowVirtualizerInstance);
       },
     }),
-    [estimatedRowHeight, getScrollElement, overscan, rangeExtractor, rows.length, onStateChange]
+    [
+      estimatedRowHeight,
+      getScrollElement,
+      initialOffset,
+      overscan,
+      rangeExtractor,
+      rows.length,
+      onStateChange,
+    ]
   );
 
   const virtualizerImpl = useVirtualizer(virtualizerOptions);

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/store_provider/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/store_provider/index.tsx
@@ -20,15 +20,14 @@ import {
 } from './reducers';
 export type { GroupNode, LeafNode, IStoreState } from './reducers';
 
-interface IDataCascadeProviderProps {
+export interface IDataCascadeProviderProps {
   initialGroupColumn?: string[];
-  /**
-   * Row ids (from rowData.id) to expand on mount. For a nested row to be visible,
-   * include the full path from root to that row (e.g. ['root-id', 'child-id', 'leaf-id']).
-   * Order in the array does not matter.
-   */
-  initialExpandedRowIds?: string[];
   cascadeGroups: string[];
+  /**
+   * Properties to set the initial table state on mount.
+   * Only expanded and rowSelection properties are supported for now.
+   */
+  initialTableState?: Pick<Partial<TableState>, 'expanded' | 'rowSelection'>;
 }
 
 interface IStoreContext<G extends GroupNode, L extends LeafNode> {
@@ -75,7 +74,7 @@ export function useCascadeLeafNode<G extends GroupNode, L extends LeafNode>(cach
 export function DataCascadeProvider<G extends GroupNode, L extends LeafNode>({
   cascadeGroups,
   initialGroupColumn,
-  initialExpandedRowIds,
+  initialTableState,
   children,
 }: PropsWithChildren<IDataCascadeProviderProps>) {
   const StoreContext = createStoreContext<G, L>();
@@ -86,19 +85,9 @@ export function DataCascadeProvider<G extends GroupNode, L extends LeafNode>({
     return initialGroupColumn.filter((col) => cascadeGroups.includes(col));
   }, [initialGroupColumn, cascadeGroups]);
 
-  const initialTableState = useMemo<TableState>(() => {
-    if (initialExpandedRowIds?.length) {
-      return {
-        expanded: Object.fromEntries(initialExpandedRowIds.map((id) => [id, true])),
-      } as TableState;
-    }
-    return {} as TableState;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally empty: only use initialExpandedRowIds on mount
-  }, []);
-
   const { state, actions } = useCreateStore({
     initialState: {
-      table: initialTableState,
+      table: (initialTableState ?? {}) as TableState,
       groupNodes: [] as G[],
       leafNodes: new Map<string, L[]>(), // TODO: consider externalizing this so the consumer might provide their own external cache
       groupByColumns: cascadeGroups,


### PR DESCRIPTION
## Summary

# Data Cascade – API and state restoration

This PR adds support for restoring the cascade to a previous UI state: ref-based snapshot store, generic ref/snapshot types, and initial scroll/rect/table state props.

---

## Public API

### Ref and imperative handle

- **`DataCascade`** accepts a **ref** (via `forwardRef`), typed as **`DataCascadeImplRef<G, L>`** (generic over group and leaf nodes).
- **`DataCascadeImplRef<G, L>`** exposes **`getUISnapshotStore(): DataCascadeUISnapshotStore<G, L> | null`**.
- **`DataCascadeUISnapshotStore<G, L>`** is a `useSyncExternalStore`-compatible store with **`subscribe(onStoreChange)`**, **`getSnapshot()`**, and **`getServerSnapshot()`**, all operating on **`DataCascadeUISnapshot<G, L>`**.

### Snapshot shape

**`DataCascadeUISnapshot<G, L>`** extends table state (`expanded`, `rowSelection`) and includes virtualizer-derived fields:

- **`scrollRect`** – `{ width: number; height: number }` (scroll container size)
- **`scrollOffset`** – number
- **`range`** – `{ startIndex: number; endIndex: number } | null`
- **`isScrolling`** – boolean
- **`activeStickyIndex`** – number | null
- **`totalRowCount`** – number
- **`totalSize`** – number
- **`expanded`** / **`rowSelection`** – from table state

Store updates are **debounced (100ms)**.

### Internal API

- **`useExposePublicApi(ref, options)`** returns **`collectVirtualizerStateChanges(instance)`**, which updates the UI snapshot from the virtualizer (including `scrollRect`) and triggers store listeners. Ref is passed into the impl as the **`cascadeRef`** prop.

---

## New props

### On `DataCascade` / `DataCascadeProvider`

**`initialTableState?: Pick<Partial<TableState>, 'expanded' | 'rowSelection'>`**

- **Where:** **`DataCascadeProvider`** (used by **`DataCascade`**).
- **Meaning:** Initial table state on mount. Supports **`expanded`** and **`rowSelection`**.
- **Semantics:** For a nested row to be visible, the full path from root to that row must be expanded (e.g. set the right ids in `expanded`). Only affects initial state; later behavior still follows `allowMultipleRowToggle` and user interaction.
- **Usage:** “Open this path on load” or “Restore expansion/selection from a saved snapshot” (e.g. from URL or persisted `DataCascadeUISnapshot`).

**`initialScrollOffset?: number`**

- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`** and the cascade virtualizer).
- **Meaning:** Initial vertical scroll position in **pixels**. When set, the list and scroll container start at this offset on mount.
- **Semantics:** Passed to the virtualizer as TanStack Virtual’s **`initialOffset`**. Intended to be used with a sync of the scroll container’s `scrollTop` (or equivalent) so DOM and virtualizer stay in sync on first paint.
- **Usage:** “Restore scroll position on load” (e.g. from `DataCascadeUISnapshot.scrollOffset` or URL).

**`initialRect?: { width: number; height: number }`**

- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`** and the cascade virtualizer).
- **Meaning:** Initial scroll container dimensions. When set, the virtualizer uses this size before the scroll element is measured.
- **Semantics:** Passed to the virtualizer as **`initialRect`** (TanStack Virtual option). Helps avoid layout jump when restoring a snapshot that includes **`scrollRect`**.
- **Usage:** “Restore scroll container size on load” (e.g. from `DataCascadeUISnapshot.scrollRect`).

**Note:** `DataCascade` uses refs for **`initialTableState`**, **`initialScrollOffset`**, and **`initialRect`** so they are read only on first render and do not force re-mounts when the parent re-renders.

---

## Summary for reviewers

- **Ref:** Optional. When passed, consumers use **`ref.current?.getUISnapshotStore()`** and the returned **`DataCascadeUISnapshotStore<G, L>`** for subscription and snapshots (**`DataCascadeUISnapshot<G, L>`**).
- **Generics:** **`DataCascadeImplRef<G, L>`**, **`DataCascadeUISnapshot<G, L>`**, and **`DataCascadeUISnapshotStore<G, L>`** are generic over group and leaf node types.
- **Snapshot:** Includes **`scrollRect`** (width/height) in addition to scrollOffset, range, isScrolling, activeStickyIndex, totalRowCount, totalSize, expanded, and rowSelection. Updates are debounced (100ms).
- **Initial state:** **`initialTableState`** seeds expanded/rowSelection on mount. **`initialScrollOffset`** and **`initialRect`** seed the virtualizer (and optionally the scroll container) so scroll position and size can be restored from a persisted snapshot.
- **Breaking changes:** None; ref and new props are additive.

### Example: subscribe and restore

```ts
const subscriptionRef = useRef<() => void)>(null);

const acquireSnapshotSubscription = useCallback((_ref) => {
  if (!subscriptionRef.current) {
    subscriptionRef.current = _ref?.getUISnapshotStore()?.subscribe(() => {
      const snapshot = store.getSnapshot();
	  console.log('snapshot changed:: %o \n', { snapshot });
      // Persist snapshot (e.g. scrollOffset, scrollRect, expanded, rowSelection)
      // so you can pass them back as initialScrollOffset, initialRect, initialTableState.
    });
  }
}, []);

useEffect(() => () => {
  if (subscriptionRef.current) {
   subscriptionRef.current()
  }
}, []);

const initialTableState = useMemo(() => ({
    expanded: savedSnapshot?.expanded,
    rowSelection: savedSnapshot?.rowSelection,
}), []);

// Restore on remount
<DataCascade
  ref={acquireSnapshotSubscription}
  data={data}
  initialScrollOffset={savedSnapshot?.scrollOffset}
  initialRect={savedSnapshot?.scrollRect}
  initialTableState={initialTableState}
  cascadeGroups={cascadeGroups}
  initialGroupColumn={initialGroupColumn}
  tableTitleSlot={...}
  ...
/>
```

---

_P.S. it's also possible to use the returned `getUISnapshotStore` with the react primitive [`useSyncExternalStore`
](https://react.dev/reference/react/useSyncExternalStore) ask your favorite LLM about this._

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...
-->
