### PR TITLE
[8.19] [Stack Connectors] Add `region` to Bedrock Connector schema (#252956)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -2387,6 +2387,27 @@ Object {
       ],
       "type": "string",
     },
+    "region": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
   },
   "type": "object",
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/common/bedrock/schema.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/bedrock/schema.ts
@@ -16,6 +16,7 @@ export const TelemtryMetadataSchema = schema.object({
 // Connector schema
 export const ConfigSchema = schema.object({
   apiUrl: schema.string(),
+  region: schema.maybe(schema.string()),
   defaultModel: schema.string({ defaultValue: DEFAULT_BEDROCK_MODEL }),
 });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Stack Connectors] Add `region` to Bedrock Connector schema (#252956)](https://github.com/elastic/kibana/pull/252956)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Garrett Spong","email":"spong@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-13T05:43:59Z","message":"[Stack Connectors] Add `region` to Bedrock Connector schema (#252956)\n\n## Summary\n\nThere have been on-going issues with `region` extraction from the\nconfigured URL in the Bedrock Connector. Initial efforts to remove the\ndefault fallback region (https://github.com/elastic/kibana/pull/241157)\nwere unsuccessful, so we're going to go ahead and add a dedicated\n_optional_ `region` field for users to explicitly specify.\n\nThis PR introduces the schema change that's required to add this setting\nto the Bedrock Connector.\nThe schema change needs to be released first in order to not break older\nKibana versions.\n\nFollow up PR to add this setting to the Bedrock connector UI and use\nthis setting in the Bedrock client -\nhttps://github.com/elastic/kibana/pull/252960\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n_PR developed with cursor-cli + GPT 5.2-high_","sha":"f5f7893f8704816b4194820fa95905c11e7be4af","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team: SecuritySolution","Feature:Actions/ConnectorTypes","backport:version","v9.4.0","v9.3.1","v9.2.6","v8.19.12"],"title":"[Stack Connectors] Add `region` to Bedrock Connector schema","number":252956,"url":"https://github.com/elastic/kibana/pull/252956","mergeCommit":{"message":"[Stack Connectors] Add `region` to Bedrock Connector schema (#252956)\n\n## Summary\n\nThere have been on-going issues with `region` extraction from the\nconfigured URL in the Bedrock Connector. Initial efforts to remove the\ndefault fallback region (https://github.com/elastic/kibana/pull/241157)\nwere unsuccessful, so we're going to go ahead and add a dedicated\n_optional_ `region` field for users to explicitly specify.\n\nThis PR introduces the schema change that's required to add this setting\nto the Bedrock Connector.\nThe schema change needs to be released first in order to not break older\nKibana versions.\n\nFollow up PR to add this setting to the Bedrock connector UI and use\nthis setting in the Bedrock client -\nhttps://github.com/elastic/kibana/pull/252960\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n_PR developed with cursor-cli + GPT 5.2-high_","sha":"f5f7893f8704816b4194820fa95905c11e7be4af"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252956","number":252956,"mergeCommit":{"message":"[Stack Connectors] Add `region` to Bedrock Connector schema (#252956)\n\n## Summary\n\nThere have been on-going issues with `region` extraction from the\nconfigured URL in the Bedrock Connector. Initial efforts to remove the\ndefault fallback region (https://github.com/elastic/kibana/pull/241157)\nwere unsuccessful, so we're going to go ahead and add a dedicated\n_optional_ `region` field for users to explicitly specify.\n\nThis PR introduces the schema change that's required to add this setting\nto the Bedrock Connector.\nThe schema change needs to be released first in order to not break older\nKibana versions.\n\nFollow up PR to add this setting to the Bedrock connector UI and use\nthis setting in the Bedrock client -\nhttps://github.com/elastic/kibana/pull/252960\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n_PR developed with cursor-cli + GPT 5.2-high_","sha":"f5f7893f8704816b4194820fa95905c11e7be4af"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/252999","number":252999,"state":"MERGED","mergeCommit":{"sha":"7874da92db22aa1bbcc3a9a88b3975012a9e00ec","message":"[9.3] [Stack Connectors] Add `region` to Bedrock Connector schema (#252956) (#252999)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Stack Connectors] Add `region` to Bedrock Connector schema\n(#252956)](https://github.com/elastic/kibana/pull/252956)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Garrett Spong <spong@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.12","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->