### PR TITLE
fix(NA): use correct zones for bench jobs

### DIFF
--- a/.buildkite/pipelines/pull_request/ftr_bench.yml
+++ b/.buildkite/pipelines/pull_request/ftr_bench.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
+      zones: us-central1-c,us-central1-a
       diskSizeGb: 200
     key: ftr_bench
     timeout_in_minutes: 120

--- a/.buildkite/pipelines/pull_request/jest_bench.yml
+++ b/.buildkite/pipelines/pull_request/jest_bench.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
+      zones: us-central1-c,us-central1-a
       diskSizeGb: 100
     key: jest_bench
     timeout_in_minutes: 60


### PR DESCRIPTION
Just noted `us-central1-f` is not compatible with the machines we are using on those jobs and sometimes its erroring out on CI. Fixing it on this change.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->