### PR TITLE
[CI] Remove check_oas_snapshot as dependency

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -201,9 +201,9 @@ steps:
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
-      JEST_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
+      JEST_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_types'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
-      FTR_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
+      FTR_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_types'
     retry:
       automatic:
         - exit_status: '*'
@@ -222,7 +222,7 @@ steps:
     depends_on:
       - build
     env:
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_types'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:
       automatic:
@@ -256,7 +256,6 @@ steps:
       - checks
       - linting
       - linting_with_types
-      - check_oas_snapshot
       - check_types
 
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
@@ -275,7 +274,6 @@ steps:
       - checks
       - linting
       - linting_with_types
-      - check_oas_snapshot
       - check_types
     timeout_in_minutes: 80
     retry:
@@ -298,7 +296,6 @@ steps:
       - checks
       - linting
       - linting_with_types
-      - check_oas_snapshot
       - check_types
     timeout_in_minutes: 60
     soft_fail: true
@@ -323,7 +320,6 @@ steps:
       - checks
       - linting
       - linting_with_types
-      - check_oas_snapshot
       - check_types
     timeout_in_minutes: 30
     retry:

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -4,7 +4,6 @@ x-on-merge-gates: &on_merge_gates
 - checks
 - linting
 - linting_with_types
-- check_oas_snapshot
 - check_types
 
 steps:

--- a/.buildkite/pipelines/pull_request/agent_builder_smoke_tests.yml
+++ b/.buildkite/pipelines/pull_request/agent_builder_smoke_tests.yml
@@ -8,7 +8,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     steps:
       - label: '🔍 Discover EIS Models'
         command: .buildkite/scripts/steps/test/discover_eis_models.sh

--- a/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
+++ b/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
@@ -8,7 +8,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     steps:
       - command: .buildkite/scripts/steps/test/ftr_configs.sh
         env:

--- a/.buildkite/pipelines/pull_request/apm_cypress.yml
+++ b/.buildkite/pipelines/pull_request/apm_cypress.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 3
     retry:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -112,9 +112,9 @@ steps:
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
-      JEST_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
+      JEST_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_types'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
-      FTR_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
+      FTR_CONFIGS_DEPS: 'build,quick_checks,checks,linting,linting_with_types,check_types'
     retry:
       automatic:
         - exit_status: '*'
@@ -129,7 +129,7 @@ steps:
     depends_on:
       - build
     env:
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_oas_snapshot,check_types'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,quick_checks,checks,linting,linting_with_types,check_types'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
     retry:
       automatic:
@@ -163,7 +163,6 @@ steps:
       - checks
       - linting
       - linting_with_types
-      - check_oas_snapshot
       - check_types
     timeout_in_minutes: 90
     retry:

--- a/.buildkite/pipelines/pull_request/build_cloud_fips_image.yml
+++ b/.buildkite/pipelines/pull_request/build_cloud_fips_image.yml
@@ -11,7 +11,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/build_cloud_image.yml
+++ b/.buildkite/pipelines/pull_request/build_cloud_image.yml
@@ -11,7 +11,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/deploy_cloud.yml
+++ b/.buildkite/pipelines/pull_request/deploy_cloud.yml
@@ -11,7 +11,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 30
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/exploratory_view_plugin.yml
+++ b/.buildkite/pipelines/pull_request/exploratory_view_plugin.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     artifact_paths:
       - 'x-pack/solutions/observability/plugins/exploratory_view/e2e/.journeys/**/*'

--- a/.buildkite/pipelines/pull_request/fips.yml
+++ b/.buildkite/pipelines/pull_request/fips.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/fleet_cypress.yml
+++ b/.buildkite/pipelines/pull_request/fleet_cypress.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 50
     parallelism: 6
     retry:

--- a/.buildkite/pipelines/pull_request/kbn_handlebars.yml
+++ b/.buildkite/pipelines/pull_request/kbn_handlebars.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 5
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 11
     retry:

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/scout_uiam_tests.yml
+++ b/.buildkite/pipelines/pull_request/scout_uiam_tests.yml
@@ -13,7 +13,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/cspm_agentless_scout.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cspm_agentless_scout.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -13,7 +13,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     soft_fail: true
     parallelism: 1
@@ -34,7 +33,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     soft_fail: true
     parallelism: 1
@@ -54,7 +52,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -74,7 +71,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 50
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -14,7 +14,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 20
     retry:
@@ -37,7 +36,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 14
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 5
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 4
     retry:
@@ -54,7 +52,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 5
     retry:
@@ -75,7 +72,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 3
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 3
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 2
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/explore.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/explore.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 3
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 2
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml
@@ -8,7 +8,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     steps:
       - command: .buildkite/scripts/steps/test/ftr_configs.sh
         env:

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 8
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 10
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 8
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 8
     retry:

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 5
     retry:
@@ -33,7 +32,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -54,7 +52,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -75,7 +72,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -96,7 +92,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -117,7 +112,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 4
     retry:
@@ -138,7 +132,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -159,7 +152,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -180,7 +172,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -201,7 +192,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     parallelism: 1
     retry:

--- a/.buildkite/pipelines/pull_request/synthetics_plugin.yml
+++ b/.buildkite/pipelines/pull_request/synthetics_plugin.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     artifact_paths:
       - 'x-pack/solutions/observability/plugins/synthetics/e2e/.journeys/**/*'

--- a/.buildkite/pipelines/pull_request/uptime_plugin.yml
+++ b/.buildkite/pipelines/pull_request/uptime_plugin.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     artifact_paths:
       - 'x-pack/solutions/observability/plugins/synthetics/e2e/.journeys/**/*'

--- a/.buildkite/pipelines/pull_request/ux_plugin_e2e.yml
+++ b/.buildkite/pipelines/pull_request/ux_plugin_e2e.yml
@@ -12,7 +12,6 @@ steps:
       - linting
       - linting_with_types
       - check_types
-      - check_oas_snapshot
     timeout_in_minutes: 60
     artifact_paths:
       - 'x-pack/solutions/observability/plugins/ux/e2e/.journeys/**/*'


### PR DESCRIPTION
It's not an actual dependency of downstream steps, but was added more to provide as a cost cutting gate. However, there are times it delays downstream steps without any added value.

Here's the provenance for `check_oas_snapshot` in the pull-request pipeline.

### 1. OAS snapshot capture first added to CI (inside "Checks")

- [PR #183338](https://github.com/elastic/kibana/pull/183338) / commit [`975eeed255d0`](https://github.com/elastic/kibana/commit/975eeed255d0) (May 30, 2024) —
 "[HTTP/OAS] Commit OAS snapshot"
- Added `.buildkite/scripts/steps/capture_oas_snapshot.sh` and wired it into `.buildkite/scripts/steps/checks.sh` (so it ran as part of the Checks step, not a
standalone pipeline step yet).

### 2. Standalone "Check OAS Snapshot" step added to PR pipeline

- [PR #196534](https://github.com/elastic/kibana/pull/196534) / commit [`2fbc843e0d69`](https://github.com/elastic/kibana/commit/2fbc843e0d69) (Oct 17, 2024) —
 "[ci] Extract OAS check + add retry"
- Motivation (from the PR summary): the capture step was flaky and was breaking Checks; they extracted it into its own heavy step (starts ES+Kibana) and added
retries.
- This is where it gets added as its own step in `.buildkite/pipelines/pull_request/base.yml`, running
`.buildkite/scripts/steps/checks/capture_oas_snapshot.sh`.

### 3. `depends_on: check_oas_snapshot` added across PR test suite pipelines

- [PR #198452](https://github.com/elastic/kibana/pull/198452) / commit [`cbb211abe0cd`](https://github.com/elastic/kibana/commit/cbb211abe0cd) (Nov 4, 2024) —
"[ci] Run checks before tests"
- This commit added `key: check_oas_snapshot` in `.buildkite/pipelines/pull_request/base.yml` and updated many PR suite pipeline YAMLs to depend on it (and on
`checks`) before running.
- Example change: `.buildkite/pipelines/pull_request/response_ops.yml` adds `- check_oas_snapshot` under `depends_on` in that commit.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->