### PR TITLE
[One Workflow][Fix] validate parent YAML hierarchy in JSON Schema path inference

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/json_schema/get_json_schema_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/json_schema/get_json_schema_suggestions.ts
@@ -282,10 +282,7 @@ function shouldProvidePropertyKeySuggestions(
  * Check if a line is under an `inputs:` root-level key by walking backward
  * to find a 0-indent `inputs:` key before hitting any other root-level key.
  */
-function isUnderInputsRoot(
-  model: monaco.editor.ITextModel,
-  fromLineNum: number
-): boolean {
+function isUnderInputsRoot(model: monaco.editor.ITextModel, fromLineNum: number): boolean {
   for (let lineNum = fromLineNum - 1; lineNum >= 1; lineNum--) {
     const line = model.getLineContent(lineNum);
     if (line.trim() === '') continue;
@@ -301,10 +298,7 @@ function isUnderInputsRoot(
  * Check if a line is under `inputs.properties` by walking backward
  * to find `properties:` at 2-space indent, then `inputs:` at root.
  */
-function isUnderInputsProperties(
-  model: monaco.editor.ITextModel,
-  fromLineNum: number
-): boolean {
+function isUnderInputsProperties(model: monaco.editor.ITextModel, fromLineNum: number): boolean {
   for (let lineNum = fromLineNum - 1; lineNum >= 1; lineNum--) {
     const line = model.getLineContent(lineNum);
     if (line.trim() === '') continue;


### PR DESCRIPTION
## Summary

Fixes CMD+I (Trigger Suggest) showing irrelevant JSON Schema property suggestions (`type`, `format`, `enum`, `default`, etc.) when the cursor is inside `steps` or `triggers` blocks.

### Before

<img width="1192" height="926" alt="image" src="https://github.com/user-attachments/assets/5d3f105b-aa20-472a-8de9-d3d661eb5d46" />

### After

<img width="1506" height="733" alt="image" src="https://github.com/user-attachments/assets/37c1c493-20ee-442e-b1a0-059e53c7f551" />

## Root Cause

When the YAML parser returns an empty `path` (which happens on empty lines or between YAML nodes), `getJsonSchemaSuggestions` falls back to a **backward line scan** to infer the cursor's location. The heuristic only checked indentation levels without verifying the actual YAML parent hierarchy:

```yaml
steps:
  - name: my-step
    type: webhook     # ← matched ^\s{4}([a-zA-Z_]...)\s*: 
    with:
      url:
        |             # ← cursor here, path is empty, indent >= 6
```

The 4-space-indented `with:` (or `type:`) matched `^\s{4}([a-zA-Z_][a-zA-Z0-9_-]*)\s*:`, causing the code to blindly infer `['inputs', 'properties', 'with']` — which passes `isInInputsPropertiesContext()` and triggers JSON Schema suggestions in the wrong context.

## Fix

The path inference now **walks further backward to validate the full parent chain** before setting the inferred path:

- A 4-space key must be preceded by `properties:` at 2-space indent
- `properties:` must be preceded by `inputs:` at root level

If any ancestor doesn't match, the path is not inferred and no JSON Schema suggestions appear.

## References

Closes elastic/security-team#15508
