### PR TITLE
[content-list] Add selection and bulk actions

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -26,7 +26,7 @@ export type {
 // Hooks.
 export { useContentListItems, useContentListState } from './src/state';
 export type { ContentListQueryData } from './src/state';
-export { useContentListSort, useContentListSearch } from './src/features';
+export { useContentListSort, useContentListSearch, useContentListSelection } from './src/features';
 export { useContentListPagination } from './src/features';
 
 // State.
@@ -46,6 +46,7 @@ export type {
   UseContentListPaginationReturn,
   SearchConfig,
   UseContentListSearchReturn,
+  UseContentListSelectionReturn,
 } from './src/features';
 export type {
   ActiveFilters,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
@@ -76,13 +76,15 @@ export const ContentListProvider = ({
   const queryKeyScope = queryKeyScopeProp ?? `${id}-listing`;
 
   // Resolve feature support flags.
+  // Selection is disabled when explicitly set to `false` or when the list is read-only.
   const supports: ContentListSupports = useMemo(
     () => ({
       sorting: features.sorting !== false,
       pagination: features.pagination !== false,
       search: features.search !== false,
+      selection: features.selection !== false && !isReadOnly,
     }),
-    [features.sorting, features.pagination, features.search]
+    [features.sorting, features.pagination, features.search, features.selection, isReadOnly]
   );
 
   // Create context value.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
@@ -22,3 +22,7 @@ export { useContentListPagination } from './pagination';
 // Search feature.
 export type { SearchConfig, UseContentListSearchReturn } from './search';
 export { useContentListSearch } from './search';
+
+// Selection feature.
+export type { UseContentListSelectionReturn } from './selection';
+export { useContentListSelection } from './selection';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/index.ts
@@ -7,6 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { useColumns } from './use_columns';
-export { useSorting } from './use_sorting';
-export { useSelection, type UseSelectionReturn } from './use_selection';
+export type { UseContentListSelectionReturn } from './types';
+export { useContentListSelection } from './use_content_list_selection';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/types.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ContentListItem } from '../../item';
+
+/**
+ * Return type for the {@link useContentListSelection} hook.
+ */
+export interface UseContentListSelectionReturn {
+  /** IDs of currently selected items. */
+  selectedIds: string[];
+  /** Currently selected items resolved from the loaded items list. */
+  selectedItems: ContentListItem[];
+  /** Number of currently selected items. */
+  selectedCount: number;
+  /** Whether a specific item is selected. */
+  isSelected: (id: string) => boolean;
+  /**
+   * Replace the selection with the given items.
+   * Typically called by `EuiBasicTable`'s `onSelectionChange` callback.
+   */
+  setSelection: (items: ContentListItem[]) => void;
+  /** Clear all selected items. */
+  clearSelection: () => void;
+  /** Whether selection is supported (enabled via features, not read-only). */
+  isSupported: boolean;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/use_content_list_selection.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/use_content_list_selection.test.tsx
@@ -1,0 +1,263 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ContentListProvider } from '../../context';
+import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import { useContentListSelection } from './use_content_list_selection';
+
+const mockItems = [
+  { id: '1', title: 'Dashboard A' },
+  { id: '2', title: 'Dashboard B' },
+  { id: '3', title: 'Dashboard C' },
+];
+
+describe('useContentListSelection', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: mockItems,
+      total: mockItems.length,
+    })
+  );
+
+  const createWrapper = (options?: { selectionDisabled?: boolean; isReadOnly?: boolean }) => {
+    const { selectionDisabled, isReadOnly } = options ?? {};
+
+    return ({ children }: { children: React.ReactNode }) => (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+        dataSource={{ findItems: mockFindItems }}
+        isReadOnly={isReadOnly}
+        features={{
+          ...(selectionDisabled !== undefined && { selection: !selectionDisabled }),
+        }}
+      >
+        {children}
+      </ContentListProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('returns empty selection by default', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.selectedIds).toEqual([]);
+      expect(result.current.selectedItems).toEqual([]);
+      expect(result.current.selectedCount).toBe(0);
+    });
+
+    it('returns `isSupported` true by default', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it('returns `isSupported` false when selection is disabled', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper({ selectionDisabled: true }),
+      });
+
+      expect(result.current.isSupported).toBe(false);
+    });
+
+    it('returns `isSupported` false when `isReadOnly` is true', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper({ isReadOnly: true }),
+      });
+
+      expect(result.current.isSupported).toBe(false);
+    });
+  });
+
+  describe('setSelection', () => {
+    it('updates `selectedIds` and `selectedCount`', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0], mockItems[2]]);
+      });
+
+      expect(result.current.selectedIds).toEqual(['1', '3']);
+      expect(result.current.selectedCount).toBe(2);
+    });
+
+    it('resolves `selectedItems` from the loaded items list', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0], mockItems[2]]);
+      });
+
+      expect(result.current.selectedItems).toEqual([
+        expect.objectContaining({ id: '1', title: 'Dashboard A' }),
+        expect.objectContaining({ id: '3', title: 'Dashboard C' }),
+      ]);
+    });
+
+    it('is a no-op when selection is disabled', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper({ selectionDisabled: true }),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0]]);
+      });
+
+      expect(result.current.selectedIds).toEqual([]);
+      expect(result.current.selectedCount).toBe(0);
+    });
+
+    it('is a no-op when `isReadOnly` is true', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper({ isReadOnly: true }),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0]]);
+      });
+
+      expect(result.current.selectedIds).toEqual([]);
+      expect(result.current.selectedCount).toBe(0);
+    });
+
+    it('replaces the previous selection entirely', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0], mockItems[1]]);
+      });
+
+      expect(result.current.selectedIds).toEqual(['1', '2']);
+
+      act(() => {
+        result.current.setSelection([mockItems[2]]);
+      });
+
+      expect(result.current.selectedIds).toEqual(['3']);
+    });
+  });
+
+  describe('clearSelection', () => {
+    it('clears all selected items', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0], mockItems[1]]);
+      });
+
+      expect(result.current.selectedCount).toBe(2);
+
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      expect(result.current.selectedIds).toEqual([]);
+      expect(result.current.selectedCount).toBe(0);
+    });
+
+    it('is a no-op when selection is disabled', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper({ selectionDisabled: true }),
+      });
+
+      // Should not throw.
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      expect(result.current.selectedIds).toEqual([]);
+    });
+  });
+
+  describe('isSelected', () => {
+    it('returns true for selected items', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0], mockItems[2]]);
+      });
+
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(true);
+    });
+
+    it('returns false for unselected items', () => {
+      const { result } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSelection([mockItems[0]]);
+      });
+
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+    });
+  });
+
+  describe('function stability', () => {
+    it('provides stable `setSelection` reference across renders', () => {
+      const { result, rerender } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      const firstSetSelection = result.current.setSelection;
+      rerender();
+      const secondSetSelection = result.current.setSelection;
+
+      expect(firstSetSelection).toBe(secondSetSelection);
+    });
+
+    it('provides stable `clearSelection` reference across renders', () => {
+      const { result, rerender } = renderHook(() => useContentListSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      const firstClearSelection = result.current.clearSelection;
+      rerender();
+      const secondClearSelection = result.current.clearSelection;
+
+      expect(firstClearSelection).toBe(secondClearSelection);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws when used outside provider', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useContentListSelection());
+      }).toThrow(
+        'ContentListContext is missing. Ensure your component is wrapped with ContentListProvider.'
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/use_content_list_selection.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/use_content_list_selection.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback, useMemo } from 'react';
+import type { ContentListItem } from '../../item';
+import { useContentListState } from '../../state/use_content_list_state';
+import { useContentListConfig } from '../../context';
+import { CONTENT_LIST_ACTIONS } from '../../state/types';
+import type { UseContentListSelectionReturn } from './types';
+
+/**
+ * Hook to access and control item selection.
+ *
+ * Provides the current selection state and functions to modify it.
+ * When selection is disabled (via `features.selection: false` or `isReadOnly`),
+ * `setSelection` and `clearSelection` become no-ops and `isSupported` returns `false`.
+ *
+ * @throws Error if used outside `ContentListProvider`.
+ * @returns Object containing selection state, mutation functions, and support flag.
+ *
+ * @example
+ * ```tsx
+ * const { selectedItems, selectedCount, clearSelection, isSupported } = useContentListSelection();
+ *
+ * if (!isSupported) return null;
+ *
+ * return (
+ *   <div>
+ *     {selectedCount} items selected
+ *     <button onClick={clearSelection}>Clear</button>
+ *   </div>
+ * );
+ * ```
+ */
+export const useContentListSelection = (): UseContentListSelectionReturn => {
+  const { supports } = useContentListConfig();
+  const { state, dispatch } = useContentListState();
+
+  const { selectedIds } = state.selection;
+  const { items } = state;
+
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  // Note: `selectedItems` only resolves against the currently loaded `items` array.
+  // If pagination is introduced, IDs from other pages will not appear here.
+  const selectedItems = useMemo(
+    () => items.filter((item) => selectedIdSet.has(item.id)),
+    [items, selectedIdSet]
+  );
+
+  const isSelected = useCallback((id: string) => selectedIdSet.has(id), [selectedIdSet]);
+
+  const setSelection = useCallback(
+    (selectedItemsList: ContentListItem[]) => {
+      if (!supports.selection) {
+        return;
+      }
+      dispatch({
+        type: CONTENT_LIST_ACTIONS.SET_SELECTION,
+        payload: { ids: selectedItemsList.map((item) => item.id) },
+      });
+    },
+    [dispatch, supports.selection]
+  );
+
+  const clearSelection = useCallback(() => {
+    if (!supports.selection) {
+      return;
+    }
+    dispatch({ type: CONTENT_LIST_ACTIONS.CLEAR_SELECTION });
+  }, [dispatch, supports.selection]);
+
+  return {
+    selectedIds,
+    selectedItems,
+    selectedCount: selectedIds.length,
+    isSelected,
+    setSelection,
+    clearSelection,
+    isSupported: supports.selection,
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/use_content_list_selection.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/selection/use_content_list_selection.ts
@@ -47,8 +47,9 @@ export const useContentListSelection = (): UseContentListSelectionReturn => {
 
   const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
 
-  // Note: `selectedItems` only resolves against the currently loaded `items` array.
-  // If pagination is introduced, IDs from other pages will not appear here.
+  // Only resolves against the currently loaded `items` array. Selection is
+  // automatically cleared by the reducer when search, filters, sort, or
+  // pagination change, so stale cross-page IDs should not accumulate.
   const selectedItems = useMemo(
     () => items.filter((item) => selectedIdSet.has(item.id)),
     [items, selectedIdSet]

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
@@ -21,6 +21,13 @@ export interface ContentListFeatures {
   pagination?: PaginationConfig | boolean;
   /** Search configuration. */
   search?: SearchConfig | boolean;
+  /**
+   * Selection configuration.
+   * When `true` (default), row selection checkboxes are shown and bulk
+   * actions are enabled. Set to `false` to disable selection entirely.
+   * Selection is automatically disabled when `isReadOnly` is `true`.
+   */
+  selection?: boolean;
 }
 
 /**
@@ -76,4 +83,6 @@ export interface ContentListSupports {
   pagination: boolean;
   /** Whether search is supported. */
   search: boolean;
+  /** Whether item selection and bulk actions are supported. */
+  selection: boolean;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/index.ts
@@ -10,7 +10,7 @@
 export { ContentListStateProvider } from './state_provider';
 export { useContentListState, ContentListStateContext } from './use_content_list_state';
 export { useContentListItems } from './use_content_list_items';
-export { reducer } from './state_reducer';
+export { reducer, DEFAULT_SELECTION } from './state_reducer';
 export type {
   ContentListState,
   ContentListAction,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
@@ -17,7 +17,7 @@ import { isSortingConfig, isPaginationConfig, isSearchConfig } from '../features
 import { DEFAULT_PAGE_SIZE } from '../features/pagination';
 import { getPersistedPageSize } from '../features/pagination';
 import type { PaginationConfig } from '../features/pagination';
-import { reducer } from './state_reducer';
+import { reducer, DEFAULT_SELECTION } from './state_reducer';
 import { useContentListItemsQuery } from '../query';
 
 /**
@@ -52,7 +52,7 @@ const resolveInitialPageSize = (
  * Internal provider component that manages the runtime state of the content list.
  *
  * This provider:
- * - Manages client-controlled state (search, filters, sort, pagination) via reducer.
+ * - Manages client-controlled state (search, filters, sort, pagination, selection) via reducer.
  * - Uses React Query for data fetching with caching and deduplication.
  * - Combines client state with query data for a unified state interface.
  *
@@ -88,13 +88,14 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
     return undefined;
   }, [search]);
 
-  // Initial client state (search, filters, sort, page).
+  // Initial client state (search, filters, sort, page, selection).
   const initialClientState: ContentListClientState = useMemo(
     () => ({
       search: { queryText: initialSearch ?? '' },
       filters: { ...DEFAULT_FILTERS, search: initialSearch },
       sort: initialSort,
       page: { index: 0, size: initialPageSize },
+      selection: { ...DEFAULT_SELECTION },
     }),
     [initialSort, initialPageSize, initialSearch]
   );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
@@ -69,6 +69,20 @@ describe('state_reducer', () => {
 
       expect(newState.filters).toEqual({ search: 'test query' });
     });
+
+    it('clears selection when sort changes', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SORT,
+        payload: { field: 'title', direction: 'asc' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
+    });
   });
 
   describe('SET_PAGE_INDEX', () => {
@@ -110,6 +124,20 @@ describe('state_reducer', () => {
 
       expect(newState.filters).toEqual({ search: 'test query' });
       expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+
+    it('clears selection when page index changes', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_PAGE_INDEX,
+        payload: { index: 2 },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
     });
   });
 
@@ -257,6 +285,20 @@ describe('state_reducer', () => {
       expect(newState.search.queryText).toBe('');
       expect(newState.filters).toEqual({ search: undefined });
     });
+
+    it('clears selection when search changes', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'dashboard', filters: { search: 'dashboard' } },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
+    });
   });
 
   describe('CLEAR_FILTERS', () => {
@@ -316,6 +358,21 @@ describe('state_reducer', () => {
       expect(newState.page.index).toBe(0);
       expect(newState.page.size).toBe(20);
     });
+
+    it('clears selection when filters are cleared', () => {
+      const initialState = createInitialState({
+        filters: { search: 'test' },
+        search: { queryText: 'test' },
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
+    });
   });
 
   describe('SET_PAGE_SIZE', () => {
@@ -357,6 +414,20 @@ describe('state_reducer', () => {
 
       expect(newState.filters).toEqual({ search: 'test query' });
       expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+
+    it('clears selection when page size changes', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_PAGE_SIZE,
+        payload: { size: 50 },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { reducer } from './state_reducer';
+import { reducer, DEFAULT_SELECTION } from './state_reducer';
 import { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
 import type { ContentListClientState, ContentListAction } from './types';
 
@@ -15,7 +15,7 @@ describe('state_reducer', () => {
   /**
    * Creates initial client state for testing.
    *
-   * Note: The reducer only manages client-controlled state (search, filters, sort, pagination).
+   * Note: The reducer only manages client-controlled state (search, filters, sort, pagination, selection).
    * Query data (items, isLoading, error) is managed by React Query directly.
    */
   const createInitialState = (
@@ -25,6 +25,7 @@ describe('state_reducer', () => {
     filters: DEFAULT_FILTERS,
     sort: { field: 'updatedAt', direction: 'desc' },
     page: { index: 0, size: 20 },
+    selection: { ...DEFAULT_SELECTION },
     ...overrides,
   });
 
@@ -103,6 +104,81 @@ describe('state_reducer', () => {
       const action: ContentListAction = {
         type: CONTENT_LIST_ACTIONS.SET_PAGE_INDEX,
         payload: { index: 1 },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual({ search: 'test query' });
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+  });
+
+  describe('SET_SELECTION', () => {
+    it('sets selected IDs', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SELECTION,
+        payload: { ids: ['1', '3'] },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual(['1', '3']);
+    });
+
+    it('replaces existing selection', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SELECTION,
+        payload: { ids: ['3'] },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual(['3']);
+    });
+
+    it('preserves sort and filters when setting selection', () => {
+      const initialState = createInitialState({
+        filters: { search: 'test query' },
+        sort: { field: 'title', direction: 'asc' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SELECTION,
+        payload: { ids: ['1'] },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual({ search: 'test query' });
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+  });
+
+  describe('CLEAR_SELECTION', () => {
+    it('clears all selected IDs', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2', '3'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_SELECTION,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
+    });
+
+    it('preserves sort and filters when clearing selection', () => {
+      const initialState = createInitialState({
+        filters: { search: 'test query' },
+        sort: { field: 'title', direction: 'asc' },
+        selection: { selectedIds: ['1'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_SELECTION,
       };
 
       const newState = reducer(initialState, action);
@@ -327,6 +403,7 @@ describe('state_reducer', () => {
       const initialState = createInitialState();
       const originalSort = initialState.sort;
       const originalFilters = initialState.filters;
+      const originalSelection = initialState.selection;
 
       reducer(initialState, {
         type: CONTENT_LIST_ACTIONS.SET_SORT,
@@ -335,6 +412,32 @@ describe('state_reducer', () => {
 
       expect(initialState.sort).toBe(originalSort);
       expect(initialState.filters).toBe(originalFilters);
+      expect(initialState.selection).toBe(originalSelection);
+    });
+
+    it('returns a new state object for SET_SELECTION', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SELECTION,
+        payload: { ids: ['1'] },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState).not.toBe(initialState);
+    });
+
+    it('returns a new state object for CLEAR_SELECTION', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_SELECTION,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState).not.toBe(initialState);
     });
 
     it('returns a new state object for SET_SEARCH', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
@@ -23,6 +23,9 @@ export const DEFAULT_SELECTION = {
  * Handles user-driven state mutations (search, filters, sort, pagination, selection).
  * Query data (items, loading, error) is managed by React Query directly.
  *
+ * Selection is cleared whenever search, filters, sort, or pagination change so that
+ * `selectedIds` never references items the user can no longer see.
+ *
  * @param state - Current client state.
  * @param action - Action to apply.
  * @returns New client state.
@@ -37,8 +40,8 @@ export const reducer = (
         ...state,
         search: { queryText: action.payload.queryText },
         filters: action.payload.filters,
-        // Reset to first page when search changes to avoid stale page offsets.
         page: { ...state.page, index: 0 },
+        selection: { ...DEFAULT_SELECTION },
       };
 
     case CONTENT_LIST_ACTIONS.CLEAR_FILTERS:
@@ -46,8 +49,8 @@ export const reducer = (
         ...state,
         filters: { ...DEFAULT_FILTERS },
         search: { queryText: '' },
-        // Reset to first page when filters are cleared to avoid stale page offsets.
         page: { ...state.page, index: 0 },
+        selection: { ...DEFAULT_SELECTION },
       };
 
     case CONTENT_LIST_ACTIONS.SET_SORT:
@@ -57,20 +60,22 @@ export const reducer = (
           field: action.payload.field,
           direction: action.payload.direction,
         },
-        // Reset to first page when sort changes to avoid stale page offsets.
         page: { ...state.page, index: 0 },
+        selection: { ...DEFAULT_SELECTION },
       };
 
     case CONTENT_LIST_ACTIONS.SET_PAGE_INDEX:
       return {
         ...state,
         page: { ...state.page, index: action.payload.index },
+        selection: { ...DEFAULT_SELECTION },
       };
 
     case CONTENT_LIST_ACTIONS.SET_PAGE_SIZE:
       return {
         ...state,
         page: { index: 0, size: action.payload.size },
+        selection: { ...DEFAULT_SELECTION },
       };
 
     case CONTENT_LIST_ACTIONS.SET_SELECTION:

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
@@ -11,9 +11,16 @@ import type { ContentListClientState, ContentListAction } from './types';
 import { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
 
 /**
+ * Default selection state.
+ */
+export const DEFAULT_SELECTION = {
+  selectedIds: [] as string[],
+};
+
+/**
  * State reducer for client-controlled state.
  *
- * Handles user-driven state mutations (search, filters, sort, pagination).
+ * Handles user-driven state mutations (search, filters, sort, pagination, selection).
  * Query data (items, loading, error) is managed by React Query directly.
  *
  * @param state - Current client state.
@@ -64,6 +71,20 @@ export const reducer = (
       return {
         ...state,
         page: { index: 0, size: action.payload.size },
+      };
+
+    case CONTENT_LIST_ACTIONS.SET_SELECTION:
+      return {
+        ...state,
+        selection: {
+          selectedIds: action.payload.ids,
+        },
+      };
+
+    case CONTENT_LIST_ACTIONS.CLEAR_SELECTION:
+      return {
+        ...state,
+        selection: { ...DEFAULT_SELECTION },
       };
 
     default:

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
@@ -8,8 +8,8 @@
  */
 
 import type { Dispatch } from 'react';
-import type { ContentListItem } from '../item';
 import type { ActiveFilters } from '../datasource';
+import type { ContentListItem } from '../item';
 
 /**
  * Action type constants for state reducer.
@@ -25,6 +25,8 @@ export const CONTENT_LIST_ACTIONS = {
   SET_PAGE_INDEX: 'SET_PAGE_INDEX',
   /** Set page size. */
   SET_PAGE_SIZE: 'SET_PAGE_SIZE',
+  SET_SELECTION: 'SET_SELECTION',
+  CLEAR_SELECTION: 'CLEAR_SELECTION',
 } as const;
 
 /**
@@ -71,6 +73,11 @@ export interface ContentListClientState {
     index: number;
     /** Current number of items per page. */
     size: number;
+  };
+  /** Selection state - IDs of currently selected items. */
+  selection: {
+    /** IDs of selected items. */
+    selectedIds: string[];
   };
 }
 
@@ -141,7 +148,9 @@ export type ContentListAction =
   | ClearFiltersAction
   | SetSortAction
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_INDEX; payload: { index: number } }
-  | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_SIZE; payload: { size: number } };
+  | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_SIZE; payload: { size: number } }
+  | { type: typeof CONTENT_LIST_ACTIONS.SET_SELECTION; payload: { ids: string[] } }
+  | { type: typeof CONTENT_LIST_ACTIONS.CLEAR_SELECTION };
 
 /**
  * Context value provided by `ContentListStateProvider`.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
@@ -43,5 +43,8 @@ export {
 } from './src/action';
 export type { ActionNamespace, ActionProps } from './src/action';
 
+// Selection hook.
+export { useSelection, type UseSelectionReturn } from './src/hooks';
+
 // Empty state.
 export { EmptyState, type EmptyStateProps } from './src/empty_state';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
@@ -23,6 +23,7 @@ dependsOn:
   - '@kbn/content-list-mock-data'
   - '@kbn/i18n'
   - '@kbn/i18n-react'
+  - '@kbn/content-list-toolbar'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
@@ -19,7 +19,7 @@ const defaultContext: ActionBuilderContext = {
   },
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true },
 };
 
 describe('delete action builder', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
@@ -17,7 +17,7 @@ const defaultContext: ActionBuilderContext = {
   },
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true },
 };
 
 describe('edit action builder', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
@@ -26,7 +26,7 @@ const defaultContext: ColumnBuilderContext = {
   },
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true },
 };
 
 describe('actions column builder', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
@@ -20,7 +20,7 @@ const defaultContext: ColumnBuilderContext = {
   itemConfig: undefined,
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: false },
+  supports: { sorting: true, pagination: true, search: false, selection: true },
 };
 
 describe('name column builder', () => {
@@ -65,7 +65,7 @@ describe('name column builder', () => {
     it('forces sortable false when sorting is unsupported', () => {
       const context: ColumnBuilderContext = {
         ...defaultContext,
-        supports: { sorting: false, pagination: true, search: false },
+        supports: { sorting: false, pagination: true, search: false, selection: true },
       };
 
       const result = buildNameColumn({}, context);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
@@ -22,7 +22,7 @@ const defaultContext: ColumnBuilderContext = {
   itemConfig: undefined,
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true },
 };
 
 describe('updated at column builder', () => {
@@ -67,7 +67,7 @@ describe('updated at column builder', () => {
     it('forces sortable false when sorting is unsupported', () => {
       const context: ColumnBuilderContext = {
         ...defaultContext,
-        supports: { sorting: false, pagination: true, search: true },
+        supports: { sorting: false, pagination: true, search: true, selection: true },
       };
 
       const result = buildUpdatedAtColumn({}, context);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
@@ -29,6 +29,7 @@ import {
   useContentListSearch,
   useContentListPagination,
   useContentListConfig,
+  useContentListSelection,
 } from '@kbn/content-list-provider';
 import type {
   ContentListItem,
@@ -36,6 +37,7 @@ import type {
   FindItemsParams,
   FindItemsResult,
 } from '@kbn/content-list-provider';
+import { ContentListToolbar } from '@kbn/content-list-toolbar';
 import { MOCK_DASHBOARDS, createMockFindItems } from '@kbn/content-list-mock-data/storybook';
 import { ContentListTable } from './content_list_table';
 
@@ -58,6 +60,8 @@ const createStoryFindItems = (options?: {
 }) => {
   const { items = MOCK_DASHBOARDS, delay = 0, isEmpty = false } = options ?? {};
 
+  const availableItems = items;
+
   return async (params: FindItemsParams): Promise<FindItemsResult> => {
     // Simulate network delay.
     if (delay > 0) {
@@ -70,7 +74,7 @@ const createStoryFindItems = (options?: {
     }
 
     // Use mock findItems for sorting logic.
-    const mockFindItems = createMockFindItems({ items });
+    const mockFindItems = createMockFindItems({ items: availableItems });
     const result = await mockFindItems({
       searchQuery: params.searchQuery,
       filters: {},
@@ -107,6 +111,8 @@ interface StateDiagnosticPanelProps {
   showActions?: boolean;
   /** Whether custom actions (Share, Archive) are mixed in alongside presets. */
   showCustomActions?: boolean;
+  /** Whether selection is enabled. */
+  showSelection?: boolean;
 }
 
 /**
@@ -118,16 +124,24 @@ const StateDiagnosticPanel = ({
   showTypeColumn = true,
   showActions = false,
   showCustomActions = false,
+  showSelection = false,
 }: StateDiagnosticPanelProps) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const { items, totalItems, isLoading, isFetching, error } = useContentListItems();
   const { field: sortField, direction: sortDirection } = useContentListSort();
   const { search } = useContentListSearch();
   const pagination = useContentListPagination();
+  const { selectedIds, selectedCount } = useContentListSelection();
   const config = useContentListConfig();
 
   // Generate JSX code based on current configuration.
   const tableJsx = useMemo(() => {
+    const parts: string[] = [];
+
+    if (showSelection) {
+      parts.push('<ContentListToolbar />');
+    }
+
     const columnChildren: string[] = [];
 
     // Name column with optional description.
@@ -163,15 +177,17 @@ const StateDiagnosticPanel = ({
       columnChildren.push(`  <Column.Actions>\n${actionLines.join('\n')}\n  </Column.Actions>`);
     }
 
-    return `<ContentListTable title="…">
+    parts.push(`<ContentListTable title="…">
 ${columnChildren.join('\n')}
-</ContentListTable>`;
-  }, [showDescription, showTypeColumn, showActions, showCustomActions]);
+</ContentListTable>`);
+
+    return parts.join('\n');
+  }, [showDescription, showTypeColumn, showActions, showCustomActions, showSelection]);
 
   return (
     <>
       <EuiSpacer size="l" />
-      <EuiPanel color="subdued" hasBorder paddingSize={isOpen ? 'm' : 's'}>
+      <EuiPanel color="plain" hasBorder={false} hasShadow={false} paddingSize={isOpen ? 'm' : 's'}>
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiButtonIcon
@@ -193,6 +209,11 @@ ${columnChildren.join('\n')}
                   {items.length}/{totalItems} items
                 </EuiBadge>
               </EuiFlexItem>
+              {selectedCount > 0 && (
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="accent">{selectedCount} selected</EuiBadge>
+                </EuiFlexItem>
+              )}
               {isLoading && (
                 <EuiFlexItem grow={false}>
                   <EuiBadge color="primary">Loading…</EuiBadge>
@@ -222,6 +243,16 @@ ${columnChildren.join('\n')}
                   )}
                 </EuiText>
               </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  <strong>Selection:</strong>{' '}
+                  {config.supports.selection ? (
+                    <EuiBadge color="success">Enabled</EuiBadge>
+                  ) : (
+                    <EuiBadge color="hollow">Disabled</EuiBadge>
+                  )}
+                </EuiText>
+              </EuiFlexItem>
             </EuiFlexGroup>
 
             <EuiSpacer size="m" />
@@ -231,7 +262,7 @@ ${columnChildren.join('\n')}
                 <EuiTitle size="xxs">
                   <h3>Sort</h3>
                 </EuiTitle>
-                <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                <EuiCodeBlock language="json" fontSize="s" paddingSize="s" transparentBackground>
                   {JSON.stringify({ field: sortField, direction: sortDirection }, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
@@ -239,7 +270,7 @@ ${columnChildren.join('\n')}
                 <EuiTitle size="xxs">
                   <h3>Search</h3>
                 </EuiTitle>
-                <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                <EuiCodeBlock language="json" fontSize="s" paddingSize="s" transparentBackground>
                   {JSON.stringify({ search, isFetching }, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
@@ -248,7 +279,7 @@ ${columnChildren.join('\n')}
                   <EuiTitle size="xxs">
                     <h3>Pagination</h3>
                   </EuiTitle>
-                  <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                  <EuiCodeBlock language="json" fontSize="s" paddingSize="s" transparentBackground>
                     {JSON.stringify(
                       {
                         pageIndex: pagination.pageIndex,
@@ -261,11 +292,25 @@ ${columnChildren.join('\n')}
                   </EuiCodeBlock>
                 </EuiFlexItem>
               )}
+              {showSelection && (
+                <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                  <EuiTitle size="xxs">
+                    <h3>Selection</h3>
+                  </EuiTitle>
+                  <EuiCodeBlock language="json" fontSize="s" paddingSize="s" transparentBackground>
+                    {JSON.stringify(
+                      { selectedCount, selectedIds: selectedIds.slice(0, 5) },
+                      null,
+                      2
+                    )}
+                  </EuiCodeBlock>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={2} style={{ minWidth: 300 }}>
                 <EuiTitle size="xxs">
                   <h3>Table JSX</h3>
                 </EuiTitle>
-                <EuiCodeBlock language="tsx" fontSize="s" paddingSize="s">
+                <EuiCodeBlock language="tsx" fontSize="s" paddingSize="s" transparentBackground>
                   {tableJsx}
                 </EuiCodeBlock>
               </EuiFlexItem>
@@ -323,6 +368,7 @@ interface PlaygroundArgs {
   showTypeColumn: boolean;
   showActions: boolean;
   showCustomActions: boolean;
+  showSelection: boolean;
   hasClickableRows: boolean;
   showDiagnostics: boolean;
 }
@@ -333,7 +379,7 @@ const { Column, Action } = ContentListTable;
 
 /**
  * Wrapper component for the Playground story.
- * Handles stable prop references via useMemo.
+ * Handles stable prop references via `useMemo`.
  */
 const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
@@ -361,6 +407,10 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
     return { findItems };
   }, [args.isLoading, args.hasItems]);
 
+  // Use a ref to keep `getHref` stable while still logging to the actions panel.
+  const entityNameRef = useRef(args.entityName);
+  entityNameRef.current = args.entityName;
+
   const itemConfig = useMemo(() => {
     const config: ContentListItemConfig = {};
 
@@ -370,9 +420,6 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
 
     if (args.showActions) {
       config.getEditUrl = (item) => `#/${args.entityName}/${item.id}/edit`;
-      // NOTE: `Action.Delete` is currently a no-op stub. This handler exists so
-      // `buildDeleteAction` sees `onDelete` and renders the trash icon. The toast
-      // below won't fire until the Delete Orchestration PR wires the actual flow.
       config.onDelete = async (items) => {
         await new Promise((resolve) => setTimeout(resolve, 500));
         const names = items.map((item) => item.title).join(', ');
@@ -404,7 +451,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
   );
 
   // Key forces re-mount when configuration changes.
-  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}-${args.hasPagination}-${args.showActions}`;
+  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}-${args.hasPagination}-${args.showActions}-${args.showSelection}`;
 
   return (
     <>
@@ -420,59 +467,65 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
             initialSort: { field: 'title', direction: 'asc' },
           },
           pagination: args.hasPagination ? { initialPageSize: 10 } : (false as const),
+          selection: args.showSelection,
         }}
       >
-        <ContentListTable
-          title={`${args.entityNamePlural} table`}
-          compressed={args.compressed}
-          tableLayout={args.tableLayout}
-        >
-          <Column.Name showDescription={args.showDescription} />
-          <Column.UpdatedAt />
-          {args.showTypeColumn && (
-            <Column
-              id="type"
-              name="Type"
-              width="20%"
-              render={(item) => <EuiBadge color="hollow">{item.type ?? 'unknown'}</EuiBadge>}
+        <EuiPanel paddingSize="xl">
+          <ContentListToolbar />
+          <EuiSpacer size="m" />
+          <ContentListTable
+            title={`${args.entityNamePlural} table`}
+            compressed={args.compressed}
+            tableLayout={args.tableLayout}
+          >
+            <Column.Name showDescription={args.showDescription} />
+            <Column.UpdatedAt />
+            {args.showTypeColumn && (
+              <Column
+                id="type"
+                name="Type"
+                width="20%"
+                render={(item) => <EuiBadge color="hollow">{item.type ?? 'unknown'}</EuiBadge>}
+              />
+            )}
+            {args.showActions && (
+              <Column.Actions>
+                <Action.Edit />
+                {args.showCustomActions && (
+                  <>
+                    <Action
+                      id="share"
+                      name="Share"
+                      description="Share with team"
+                      icon="share"
+                      type="icon"
+                      onClick={handleShare}
+                    />
+                    <Action
+                      id="archive"
+                      name="Archive"
+                      description="Move to archive"
+                      icon="folderClosed"
+                      type="icon"
+                      onClick={handleArchive}
+                    />
+                  </>
+                )}
+                <Action.Delete />
+              </Column.Actions>
+            )}
+          </ContentListTable>
+          {args.showDiagnostics && (
+            <StateDiagnosticPanel
+              defaultOpen
+              showDescription={args.showDescription}
+              showTypeColumn={args.showTypeColumn}
+              showActions={args.showActions}
+              showCustomActions={args.showCustomActions}
+              showSelection={args.showSelection}
             />
           )}
-          {args.showActions && (
-            <Column.Actions>
-              <Action.Edit />
-              {args.showCustomActions && (
-                <>
-                  <Action
-                    id="share"
-                    name="Share"
-                    description="Share with team"
-                    icon="share"
-                    type="icon"
-                    onClick={handleShare}
-                  />
-                  <Action
-                    id="archive"
-                    name="Archive"
-                    description="Move to archive"
-                    icon="folderClosed"
-                    type="icon"
-                    onClick={handleArchive}
-                  />
-                </>
-              )}
-              <Action.Delete />
-            </Column.Actions>
-          )}
-        </ContentListTable>
-        {args.showDiagnostics && (
-          <StateDiagnosticPanel
-            defaultOpen
-            showDescription={args.showDescription}
-            showTypeColumn={args.showTypeColumn}
-            showActions={args.showActions}
-            showCustomActions={args.showCustomActions}
-          />
-        )}
+        </EuiPanel>
       </ContentListProvider>
       <EuiGlobalToastList toasts={toasts} dismissToast={removeToast} toastLifeTimeMs={3000} />
     </>
@@ -492,6 +545,7 @@ export const Table: PlaygroundStory = {
     showTypeColumn: false,
     showActions: true,
     showCustomActions: false,
+    showSelection: true,
     hasClickableRows: true,
     showDescription: true,
     entityName: 'dashboard',
@@ -563,6 +617,12 @@ export const Table: PlaygroundStory = {
         'Mix in custom Share and Archive actions alongside the built-in presets, demonstrating custom `Action` components.',
       table: { category: 'Actions' },
       if: { arg: 'showActions' },
+    },
+    showSelection: {
+      control: 'boolean',
+      description:
+        'Enable row selection with checkboxes. Shows a delete button in the toolbar that clears the selection when clicked.',
+      table: { category: 'Selection' },
     },
     hasClickableRows: {
       control: 'boolean',

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -13,7 +13,7 @@ import { EuiBasicTable } from '@elastic/eui';
 import { useContentListItems, type ContentListItem } from '@kbn/content-list-provider';
 import { Column as BaseColumn, NameColumn, UpdatedAtColumn, ActionsColumn } from './column';
 import { Action as BaseAction, EditAction, DeleteAction } from './action';
-import { useColumns, useSorting } from './hooks';
+import { useColumns, useSorting, useSelection } from './hooks';
 import { EmptyState } from './empty_state';
 
 /**
@@ -69,7 +69,12 @@ export const getRowId = (id: string): string => `content-list-table-row-${id}`;
  * ContentListTable - Table renderer for content listings.
  *
  * Integrates with EUI's EuiBasicTable and ContentListProvider for state management.
- * Supports configurable columns via compound components, and empty states.
+ * Supports configurable columns via compound components, row selection with
+ * checkboxes, and empty states.
+ *
+ * Selection checkboxes are automatically added when `features.selection` is enabled
+ * (the default). Selection state is managed by the provider and accessible to the
+ * toolbar for bulk actions via {@link useContentListSelection}.
  *
  * @example Basic usage (defaults to Name column)
  * ```tsx
@@ -90,6 +95,14 @@ export const getRowId = (id: string): string => `content-list-table-row-${id}`;
  *   </Column.Actions>
  * </ContentListTable>
  * ```
+ *
+ * @example With selection and toolbar
+ * ```tsx
+ * <ContentListProvider {...config}>
+ *   <ContentListToolbar />
+ *   <ContentListTable title="Dashboards" />
+ * </ContentListProvider>
+ * ```
  */
 const ContentListTableComponent = ({
   title,
@@ -105,6 +118,7 @@ const ContentListTableComponent = ({
 
   const columns = useColumns(children);
   const { sorting, onChange } = useSorting();
+  const { selection } = useSelection();
 
   const isTableEmpty = !loading && !error && items.length === 0;
 
@@ -124,6 +138,7 @@ const ContentListTableComponent = ({
       loading={loading}
       onChange={onChange}
       sorting={sorting}
+      selection={selection}
       tableLayout={tableLayout}
       data-test-subj={dataTestSubj}
     />

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { ContentListProvider } from '@kbn/content-list-provider';
+import type { FindItemsResult, FindItemsParams, ContentListItem } from '@kbn/content-list-provider';
+import { useSelection } from './use_selection';
+
+const mockItems: ContentListItem[] = [
+  { id: '1', title: 'Dashboard A' },
+  { id: '2', title: 'Dashboard B' },
+];
+
+describe('useSelection', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: mockItems,
+      total: mockItems.length,
+    })
+  );
+
+  const createWrapper = (options?: { selectionDisabled?: boolean; isReadOnly?: boolean }) => {
+    const { selectionDisabled, isReadOnly } = options ?? {};
+
+    return ({ children }: { children: React.ReactNode }) => (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+        dataSource={{ findItems: mockFindItems }}
+        isReadOnly={isReadOnly}
+        features={{
+          ...(selectionDisabled !== undefined && { selection: !selectionDisabled }),
+        }}
+      >
+        {children}
+      </ContentListProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when selection is supported', () => {
+    it('returns a selection config object', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.selection).toBeDefined();
+      expect(result.current.selection).toHaveProperty('onSelectionChange');
+      expect(result.current.selection).toHaveProperty('selected');
+      expect(result.current.selection).toHaveProperty('selectable');
+    });
+
+    it('returns `selectable` function that always returns true', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      const { selectable } = result.current.selection!;
+      expect(selectable!(mockItems[0])).toBe(true);
+      expect(selectable!(mockItems[1])).toBe(true);
+    });
+
+    it('provides `selected` array for controlled selection', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      // Initially empty since no items are selected.
+      expect(result.current.selection!.selected).toEqual([]);
+    });
+  });
+
+  describe('when selection is disabled', () => {
+    it('returns `undefined` when selection feature is disabled', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper({ selectionDisabled: true }),
+      });
+
+      expect(result.current.selection).toBeUndefined();
+    });
+
+    it('returns `undefined` when in read-only mode', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper({ isReadOnly: true }),
+      });
+
+      expect(result.current.selection).toBeUndefined();
+    });
+  });
+
+  describe('stability', () => {
+    it('returns a stable selection config across re-renders', () => {
+      const { result, rerender } = renderHook(() => useSelection(), {
+        wrapper: createWrapper(),
+      });
+
+      const firstSelection = result.current.selection;
+      rerender();
+      const secondSelection = result.current.selection;
+
+      expect(firstSelection).toBe(secondSelection);
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo } from 'react';
+import type { EuiTableSelectionType } from '@elastic/eui';
+import {
+  useContentListConfig,
+  useContentListSelection,
+  type ContentListItem,
+} from '@kbn/content-list-provider';
+
+/**
+ * Return type for the {@link useSelection} hook.
+ */
+export interface UseSelectionReturn {
+  /**
+   * Selection configuration for `EuiBasicTable`'s `selection` prop.
+   * Returns `undefined` when selection is not supported (e.g., read-only mode).
+   */
+  selection?: EuiTableSelectionType<ContentListItem>;
+}
+
+/**
+ * Hook to integrate content list selection with `EuiBasicTable`.
+ *
+ * Bridges the provider's selection state with `EuiBasicTable`'s `selection` prop
+ * using **controlled mode** (`selected`). This ensures programmatic selection
+ * changes (e.g., clearing after delete) are reflected in the table checkboxes.
+ *
+ * @returns Object containing the `selection` prop for `EuiBasicTable`.
+ */
+export const useSelection = (): UseSelectionReturn => {
+  const { supports } = useContentListConfig();
+  const { selectedItems, setSelection } = useContentListSelection();
+
+  const selection: EuiTableSelectionType<ContentListItem> | undefined = useMemo(() => {
+    if (!supports.selection) {
+      return undefined;
+    }
+
+    // TODO: Accept an optional `selectable` predicate from the provider config to
+    // support per-row selectability (e.g., permission-gated rows).
+    return {
+      onSelectionChange: setSelection,
+      selected: selectedItems,
+      selectable: () => true,
+    };
+  }, [supports.selection, setSelection, selectedItems]);
+
+  return { selection };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/content-list-mock-data",
     "@kbn/i18n",
     "@kbn/i18n-react",
+    "@kbn/content-list-toolbar",
   ],
   "exclude": [
     "target/**/*"

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
@@ -13,8 +13,11 @@
  * Provides toolbar components for content list UIs, including filters and actions.
  */
 
-// Main component (includes `ContentListToolbar.Filters` namespace).
+// Main component (includes `ContentListToolbar.Filters` and `ContentListToolbar.SelectionBar` namespaces).
 export { ContentListToolbar, type ContentListToolbarProps } from './src/content_list_toolbar';
 
 // Filter declarative components for direct imports.
 export { Filters, SortFilter, type FiltersProps, type SortFilterProps } from './src/filters';
+
+// Selection bar component for direct imports.
+export { SelectionBar, type SelectionBarProps } from './src/selection_bar';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/index.ts
@@ -7,6 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { useColumns } from './use_columns';
-export { useSorting } from './use_sorting';
-export { useSelection, type UseSelectionReturn } from './use_selection';
+export { SelectionBar, type SelectionBarProps } from './selection_bar';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { ContentListProvider, useContentListSelection } from '@kbn/content-list-provider';
+import type { FindItemsResult, FindItemsParams, ContentListItem } from '@kbn/content-list-provider';
+import { SelectionBar } from './selection_bar';
+
+const mockItems: ContentListItem[] = [
+  { id: '1', title: 'Dashboard A' },
+  { id: '2', title: 'Dashboard B' },
+  { id: '3', title: 'Dashboard C' },
+];
+
+/**
+ * Helper component that selects items before rendering the `SelectionBar`.
+ * Uses the `useContentListSelection` hook to set the selection programmatically.
+ */
+const SelectionBarWithSetup = ({ itemsToSelect }: { itemsToSelect: ContentListItem[] }) => {
+  const { setSelection, selectedCount } = useContentListSelection();
+
+  // Select items on first render.
+  React.useEffect(() => {
+    setSelection(itemsToSelect);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  return <SelectionBar />;
+};
+
+describe('SelectionBar', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: mockItems,
+      total: mockItems.length,
+    })
+  );
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+        dataSource={{ findItems: mockFindItems }}
+      >
+        {children}
+      </ContentListProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a delete button with item count and entity name', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <SelectionBarWithSetup itemsToSelect={[mockItems[0], mockItems[1]]} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete 2 dashboards')).toBeInTheDocument();
+    });
+  });
+
+  it('renders singular entity name for single selection', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <SelectionBarWithSetup itemsToSelect={[mockItems[0]]} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete 1 dashboard')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a danger button with trash icon', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <SelectionBarWithSetup itemsToSelect={[mockItems[0]]} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      const button = screen.getByTestId('contentListSelectionBar-deleteButton');
+      expect(button).toBeInTheDocument();
+      // EUI uses Emotion CSS-in-JS; check for `danger` in the class string.
+      expect(button.className).toContain('danger');
+    });
+  });
+
+  it('returns null when no items are selected', () => {
+    const Wrapper = createWrapper();
+    const { container } = render(
+      <Wrapper>
+        <SelectionBar />
+      </Wrapper>
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('has the correct test subject on the button', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <SelectionBarWithSetup itemsToSelect={[mockItems[0]]} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contentListSelectionBar-deleteButton')).toBeInTheDocument();
+    });
+  });
+
+  it('clears the selection when the delete button is clicked', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <SelectionBarWithSetup itemsToSelect={[mockItems[0], mockItems[1]]} />
+      </Wrapper>
+    );
+
+    // Wait for the button to appear.
+    await waitFor(() => {
+      expect(screen.getByTestId('contentListSelectionBar-deleteButton')).toBeInTheDocument();
+    });
+
+    // Click the delete button.
+    fireEvent.click(screen.getByTestId('contentListSelectionBar-deleteButton'));
+
+    // The selection is cleared, so `SelectionBarWithSetup` renders null.
+    await waitFor(() => {
+      expect(screen.queryByTestId('contentListSelectionBar-deleteButton')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo } from 'react';
+import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useContentListConfig, useContentListSelection } from '@kbn/content-list-provider';
+
+export interface SelectionBarProps {
+  /** Optional `data-test-subj` attribute for testing. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Selection actions rendered as `toolsLeft` inside the `EuiSearchBar`.
+ *
+ * When items are selected, renders a danger button labelled
+ * "Delete {count} {entity}" matching the existing `TableListView` pattern.
+ *
+ * The button currently **clears the selection** as a placeholder action.
+ * Delete orchestration will be wired in a follow-up PR that adds
+ * provider-level delete support.
+ *
+ * Returns `null` when nothing is selected.
+ *
+ * @internal Rendered automatically by {@link ContentListToolbar}.
+ */
+export const SelectionBar = ({
+  'data-test-subj': dataTestSubj = 'contentListSelectionBar',
+}: SelectionBarProps) => {
+  const { labels } = useContentListConfig();
+  const { selectedCount, clearSelection } = useContentListSelection();
+
+  const buttonLabel = useMemo(
+    () =>
+      i18n.translate('contentManagement.contentList.toolbar.selectionBar.deleteButton', {
+        defaultMessage: 'Delete {itemCount} {entityName}',
+        values: {
+          itemCount: selectedCount,
+          entityName: selectedCount === 1 ? labels.entity : labels.entityPlural,
+        },
+      }),
+    [selectedCount, labels.entity, labels.entityPlural]
+  );
+
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  return (
+    <EuiButton
+      color="danger"
+      iconType="trash"
+      // TODO: Wire to `useDeleteAction().requestDelete` once the delete orchestration PR lands.
+      onClick={clearSelection}
+      data-test-subj={`${dataTestSubj}-deleteButton`}
+    >
+      {buttonLabel}
+    </EuiButton>
+  );
+};


### PR DESCRIPTION
## Summary

Adds multi-select checkboxes to `ContentListTable` with a "Delete N {entities}" button in the toolbar. The delete button clears the selection as a placeholder -- delete orchestration will be wired by the last-to-merge PR in the three-PR split.

This PR introduces selection as a new feature module following the same patterns established by sorting: a provider-level hook (`useContentListSelection`), a table bridge hook (`useSelection`), and a toolbar UI component (`SelectionBar`).

### What's included

- **Selection feature module** (`kbn-content-list-provider`) -- `useContentListSelection` hook exposing `selectedIds`, `selectedItems`, `selectedCount`, `isSelected`, `setSelection`, `clearSelection`, and `isSupported`. Selection is a no-op when disabled or read-only.
- **State layer** -- `SET_SELECTION` and `CLEAR_SELECTION` reducer actions with `selection: { selectedIds: string[] }` on `ContentListClientState`.
- **Feature flag** -- `features.selection` (default `true`) and `supports.selection` (auto-disabled when `isReadOnly`).
- **Table integration** (`kbn-content-list-table`) -- `useSelection` bridge hook provides controlled-mode `EuiBasicTable` selection config.
- **Toolbar integration** (`kbn-content-list-toolbar`) -- `SelectionBar` renders a danger "Delete N {entity}" button in `EuiSearchBar`'s `toolsLeft` when items are selected, matching the existing `TableListView` pattern.
- **Storybook** -- `showSelection` toggle, `ContentListToolbar` in the story layout, diagnostic panel with selection state display.

### What's intentionally excluded

All delete orchestration code lives in a separate PR: `useDeleteAction`, `DeleteConfirmation`, delete state/actions, `supports.delete`, and `onDelete` on `ContentListItemConfig`. This keeps the PR focused on pure selection infrastructure.

### Merge-order wiring

This PR is one of three independent PRs (Selection, Actions Column, Delete Orchestration) that can merge in any order. When this PR merges first, no wiring is needed -- the other PRs carry placeholders. The only merge conflict surface is a one-line change in `selection_bar.tsx` (`clearSelection` -> `requestDelete`).

## Test plan

- [ ] `yarn test:jest kbn-content-list-provider` -- 66 tests pass (16 selection hook + 7 reducer selection tests).
- [ ] `yarn test:jest kbn-content-list-table` -- 60 tests pass (6 `useSelection` bridge tests).
- [ ] `yarn test:jest kbn-content-list-toolbar` -- 47 tests pass (6 `SelectionBar` tests).
- [ ] Type check passes for all three packages.
- [ ] ESLint clean.
- [ ] Storybook: toggle "Show Selection" on -- checkboxes appear; select rows -- "Delete N dashboards" button appears in toolbar; click delete button -- selection clears.