### PR TITLE
[content-list] Delete orchestration

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -28,6 +28,11 @@ export { useContentListItems, useContentListState } from './src/state';
 export type { ContentListQueryData } from './src/state';
 export { useContentListSort, useContentListSearch, useContentListSelection } from './src/features';
 export { useContentListPagination } from './src/features';
+export {
+  DeleteConfirmationModal,
+  DeleteConfirmationComponent,
+  useDeleteConfirmation,
+} from './src/features';
 
 // State.
 export { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './src/state';
@@ -47,6 +52,10 @@ export type {
   SearchConfig,
   UseContentListSearchReturn,
   UseContentListSelectionReturn,
+  DeleteConfirmationModalProps,
+  DeleteConfirmationComponentProps,
+  UseDeleteConfirmationOptions,
+  UseDeleteConfirmationReturn,
 } from './src/features';
 export type {
   ActiveFilters,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/moon.yml
@@ -20,6 +20,7 @@ project:
 dependsOn:
   - '@kbn/react-query'
   - '@kbn/content-list-mock-data'
+  - '@kbn/i18n'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/README.md
@@ -1,0 +1,16 @@
+# Components
+
+Shared presentational components and consumer-side hooks that don't manage
+global provider state. They live in `kbn-content-list-provider` because they
+depend on provider context (`useContentListConfig`, `useContentListState`), but
+are architecturally distinct from `features/` — which manages shared state via
+the reducer.
+
+If more components accumulate here, this directory is a candidate for extraction
+into a dedicated `kbn-content-list-components` package.
+
+## Current residents
+
+| Directory | Contents |
+|-----------|----------|
+| `delete/` | `DeleteConfirmationComponent` — stateless presentational modal driven entirely by props. `DeleteConfirmationModal` — connected wrapper that reads config from context and manages its own loading/error state. `useDeleteConfirmation` — hook that encapsulates modal open/close state for consumers. |

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.component.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.component.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiConfirmModal, EuiCallOut, EuiSpacer, useGeneratedHtmlId } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ContentListItem } from '../../item';
+
+/**
+ * Props for the presentational {@link DeleteConfirmationComponent}.
+ */
+export interface DeleteConfirmationComponentProps {
+  /** Items being deleted. */
+  items: ContentListItem[];
+  /** Singular entity name (e.g., "dashboard"). */
+  entityName: string;
+  /** Plural entity name (e.g., "dashboards"). */
+  entityNamePlural: string;
+  /** Whether a delete operation is currently executing. */
+  isDeleting: boolean;
+  /** Error message from the last failed attempt, displayed inline. */
+  error?: string | null;
+  /** Called when the user cancels. */
+  onCancel: () => void;
+  /** Called when the user confirms. */
+  onConfirm: () => void;
+}
+
+/**
+ * Presentational confirmation modal for delete operations.
+ *
+ * Stateless — all data and callbacks are provided via props.
+ * Use {@link DeleteConfirmationModal} for the connected version that
+ * reads from content list context.
+ */
+export const DeleteConfirmationComponent = ({
+  items,
+  entityName,
+  entityNamePlural,
+  isDeleting,
+  error,
+  onCancel,
+  onConfirm,
+}: DeleteConfirmationComponentProps) => {
+  const titleId = useGeneratedHtmlId({ prefix: 'contentListDeleteConfirmationTitle' });
+  const itemCount = items.length;
+  const displayEntityName = itemCount === 1 ? entityName : entityNamePlural;
+
+  return (
+    <EuiConfirmModal
+      aria-labelledby={titleId}
+      title={i18n.translate('contentManagement.contentList.deleteConfirmation.title', {
+        defaultMessage: 'Delete {itemCount} {displayEntityName}?',
+        values: { itemCount, displayEntityName },
+      })}
+      titleProps={{ id: titleId }}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      cancelButtonText={i18n.translate('contentManagement.contentList.deleteConfirmation.cancel', {
+        defaultMessage: 'Cancel',
+      })}
+      confirmButtonText={
+        isDeleting
+          ? i18n.translate('contentManagement.contentList.deleteConfirmation.deleting', {
+              defaultMessage: 'Deleting',
+            })
+          : i18n.translate('contentManagement.contentList.deleteConfirmation.confirm', {
+              defaultMessage: 'Delete',
+            })
+      }
+      defaultFocusedButton="cancel"
+      buttonColor="danger"
+      isLoading={isDeleting}
+      data-test-subj="contentListDeleteConfirmation"
+    >
+      <p>
+        {i18n.translate('contentManagement.contentList.deleteConfirmation.body', {
+          defaultMessage: "You can't recover deleted {entityNamePlural}.",
+          values: { entityNamePlural },
+        })}
+      </p>
+      {error && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiCallOut
+            announceOnMount
+            size="s"
+            color="danger"
+            title={i18n.translate('contentManagement.contentList.deleteConfirmation.error', {
+              defaultMessage: 'Unable to delete {entityNamePlural}',
+              values: { entityNamePlural },
+            })}
+            data-test-subj="contentListDeleteError"
+          >
+            <p>{error}</p>
+          </EuiCallOut>
+        </>
+      )}
+    </EuiConfirmModal>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.test.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ContentListProvider } from '../../context';
+import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import { DeleteConfirmationModal } from './delete_confirmation';
+
+const mockFindItems = jest.fn(
+  async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+    items: [],
+    total: 0,
+  })
+);
+
+const mockOnDelete = jest.fn(async () => {});
+
+const createWrapper =
+  (options?: { onDelete?: typeof mockOnDelete }) =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+        dataSource={{ findItems: mockFindItems }}
+        item={{ onDelete: options?.onDelete ?? mockOnDelete }}
+      >
+        {children}
+      </ContentListProvider>
+    );
+
+const defaultItems = [{ id: '1', title: 'Item 1' }];
+
+describe('DeleteConfirmationModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the confirmation modal', () => {
+      render(<DeleteConfirmationModal items={defaultItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByTestId('contentListDeleteConfirmation')).toBeInTheDocument();
+    });
+
+    it('uses singular entity label for single item', () => {
+      render(<DeleteConfirmationModal items={defaultItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText(/Delete 1 dashboard\?/)).toBeInTheDocument();
+    });
+
+    it('uses plural entity label for multiple items', () => {
+      const items = [
+        { id: '1', title: 'Item 1' },
+        { id: '2', title: 'Item 2' },
+        { id: '3', title: 'Item 3' },
+      ];
+      render(<DeleteConfirmationModal items={items} onClose={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText(/Delete 3 dashboards\?/)).toBeInTheDocument();
+    });
+
+    it('always uses plural entity name in body text', () => {
+      render(<DeleteConfirmationModal items={defaultItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText(/You can't recover deleted dashboards\./)).toBeInTheDocument();
+    });
+
+    it('focuses the cancel button by default', async () => {
+      render(<DeleteConfirmationModal items={defaultItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirmModalCancelButton')).toHaveFocus();
+      });
+    });
+  });
+
+  describe('cancel', () => {
+    it('calls `onClose` when cancel button is clicked', async () => {
+      const onClose = jest.fn();
+      render(<DeleteConfirmationModal items={defaultItems} onClose={onClose} />, {
+        wrapper: createWrapper(),
+      });
+
+      await userEvent.click(screen.getByText('Cancel'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('confirm', () => {
+    it('calls `onDelete` with the items and then `onClose` on success', async () => {
+      const onClose = jest.fn();
+      render(<DeleteConfirmationModal items={defaultItems} onClose={onClose} />, {
+        wrapper: createWrapper(),
+      });
+
+      await userEvent.click(screen.getByText('Delete'));
+
+      await waitFor(() => {
+        expect(mockOnDelete).toHaveBeenCalledWith(defaultItems);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('shows loading state while deleting', async () => {
+      let resolveDelete: () => void;
+      const slowDelete = jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDelete = resolve;
+          })
+      );
+
+      render(<DeleteConfirmationModal items={defaultItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ onDelete: slowDelete }),
+      });
+
+      await userEvent.click(screen.getByText('Delete'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Deleting')).toBeInTheDocument();
+      });
+
+      resolveDelete!();
+    });
+
+    it('shows error and keeps modal open on failure', async () => {
+      const failingDelete = jest.fn(async () => {
+        throw new Error('Network failure');
+      });
+      const onClose = jest.fn();
+
+      render(<DeleteConfirmationModal items={defaultItems} onClose={onClose} />, {
+        wrapper: createWrapper({ onDelete: failingDelete }),
+      });
+
+      await userEvent.click(screen.getByText('Delete'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('contentListDeleteError')).toBeInTheDocument();
+        expect(screen.getByText('Network failure')).toBeInTheDocument();
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('handles non-Error thrown values with an entity-aware fallback message', async () => {
+      const failingDelete = jest.fn(async () => {
+        throw 'string error'; // eslint-disable-line no-throw-literal
+      });
+
+      render(<DeleteConfirmationModal items={defaultItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ onDelete: failingDelete }),
+      });
+
+      await userEvent.click(screen.getByText('Delete'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'The dashboards could not be deleted. Check the Kibana server logs or try again.'
+          )
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useRef, useState, useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
+import { useContentListConfig } from '../../context';
+import { useContentListState } from '../../state/use_content_list_state';
+import { DeleteConfirmationComponent } from './delete_confirmation.component';
+import type { ContentListItem } from '../../item';
+
+/**
+ * Props for the connected {@link DeleteConfirmationModal}.
+ */
+export interface DeleteConfirmationModalProps {
+  /** Items to delete. */
+  items: ContentListItem[];
+  /** Called when the modal should close (cancel or successful delete). */
+  onClose: () => void;
+}
+
+/**
+ * Connected confirmation modal for delete operations.
+ *
+ * Reads `item.onDelete` and entity labels from the provider config, calls
+ * `refetch` on success, and manages `isDeleting`/`error` locally.
+ * Delegates rendering to {@link DeleteConfirmationComponent}.
+ *
+ * @example
+ * ```tsx
+ * {showDeleteModal && (
+ *   <DeleteConfirmationModal
+ *     items={selectedItems}
+ *     onClose={() => setShowDeleteModal(false)}
+ *   />
+ * )}
+ * ```
+ */
+export const DeleteConfirmationModal = ({ items, onClose }: DeleteConfirmationModalProps) => {
+  const { labels, item: itemConfig } = useContentListConfig();
+  const { refetch } = useContentListState();
+
+  const deletingRef = useRef(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConfirm = useCallback(async () => {
+    if (!itemConfig?.onDelete || deletingRef.current) {
+      return;
+    }
+
+    deletingRef.current = true;
+    setIsDeleting(true);
+    setError(null);
+
+    try {
+      await itemConfig.onDelete(items);
+      refetch();
+      onClose();
+    } catch (e) {
+      deletingRef.current = false;
+      setIsDeleting(false);
+      setError(
+        e instanceof Error
+          ? e.message
+          : i18n.translate('contentManagement.contentList.deleteConfirmation.unknownError', {
+              defaultMessage:
+                'The {entityNamePlural} could not be deleted. Check the Kibana server logs or try again.',
+              values: { entityNamePlural: labels.entityPlural },
+            })
+      );
+    }
+  }, [itemConfig, items, labels.entityPlural, refetch, onClose]);
+
+  return (
+    <DeleteConfirmationComponent
+      {...{ items, isDeleting, error }}
+      entityName={labels.entity}
+      entityNamePlural={labels.entityPlural}
+      onCancel={onClose}
+      onConfirm={onConfirm}
+    />
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type { DeleteConfirmationModalProps } from './delete_confirmation';
+export { DeleteConfirmationModal } from './delete_confirmation';
+export type { DeleteConfirmationComponentProps } from './delete_confirmation.component';
+export { DeleteConfirmationComponent } from './delete_confirmation.component';
+export type {
+  UseDeleteConfirmationOptions,
+  UseDeleteConfirmationReturn,
+} from './use_delete_confirmation';
+export { useDeleteConfirmation } from './use_delete_confirmation';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ContentListProvider } from '../../context';
+import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import { useDeleteConfirmation } from './use_delete_confirmation';
+
+const mockFindItems = jest.fn(
+  async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+    items: [],
+    total: 0,
+  })
+);
+
+const mockOnDelete = jest.fn(async () => {});
+
+const createWrapper =
+  () =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+        dataSource={{ findItems: mockFindItems }}
+        item={{ onDelete: mockOnDelete }}
+      >
+        {children}
+      </ContentListProvider>
+    );
+
+const testItems = [{ id: '1', title: 'Item 1' }];
+
+const TestHarness = ({ onClose }: { onClose?: () => void }) => {
+  const { requestDelete, deleteModal } = useDeleteConfirmation({ onClose });
+  return (
+    <>
+      <button onClick={() => requestDelete(testItems)}>trigger</button>
+      {deleteModal}
+    </>
+  );
+};
+
+describe('useDeleteConfirmation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns `null` for `deleteModal` initially', () => {
+    render(<TestHarness />, { wrapper: createWrapper() });
+
+    expect(screen.queryByTestId('contentListDeleteConfirmation')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal after `requestDelete` is called', async () => {
+    render(<TestHarness />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByText('trigger'));
+
+    expect(screen.getByTestId('contentListDeleteConfirmation')).toBeInTheDocument();
+    expect(screen.getByText(/Delete 1 dashboard\?/)).toBeInTheDocument();
+  });
+
+  it('closes the modal when the user cancels', async () => {
+    render(<TestHarness />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByText('trigger'));
+    await userEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('contentListDeleteConfirmation')).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls the `onClose` callback when the modal closes', async () => {
+    const onClose = jest.fn();
+    render(<TestHarness onClose={onClose} />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByText('trigger'));
+    await userEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('closes the modal after a successful delete', async () => {
+    const onClose = jest.fn();
+    render(<TestHarness onClose={onClose} />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByText('trigger'));
+    await userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(mockOnDelete).toHaveBeenCalledWith(testItems);
+      expect(screen.queryByTestId('contentListDeleteConfirmation')).not.toBeInTheDocument();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import type { ContentListItem } from '../../item/types';
+import { DeleteConfirmationModal } from './delete_confirmation';
+
+/**
+ * Options for {@link useDeleteConfirmation}.
+ */
+export interface UseDeleteConfirmationOptions {
+  /**
+   * Called after the modal closes (cancel or successful delete).
+   * Use for side effects like clearing selection state.
+   */
+  onClose?: () => void;
+}
+
+/**
+ * Return value of {@link useDeleteConfirmation}.
+ */
+export interface UseDeleteConfirmationReturn {
+  /** Trigger the delete confirmation modal for the given items. */
+  requestDelete: (items: ContentListItem[]) => void;
+  /** The modal element to render, or `null` when inactive. */
+  deleteModal: ReactNode;
+}
+
+/**
+ * Encapsulates the open/close state for a {@link DeleteConfirmationModal}.
+ *
+ * Consumers call `requestDelete(items)` to open the modal and render
+ * `deleteModal` in their JSX. The modal handles confirmation, deletion
+ * (via the provider's `onDelete`), loading, and error display internally.
+ *
+ * @example Row-level delete (table)
+ * ```tsx
+ * const { requestDelete, deleteModal } = useDeleteConfirmation();
+ * // pass requestDelete to action builder context
+ * return <>{table}{deleteModal}</>;
+ * ```
+ *
+ * @example Bulk delete (toolbar selection bar)
+ * ```tsx
+ * const { requestDelete, deleteModal } = useDeleteConfirmation({
+ *   onClose: clearSelection,
+ * });
+ * return (
+ *   <>
+ *     <EuiButton onClick={() => requestDelete(selectedItems)}>Delete</EuiButton>
+ *     {deleteModal}
+ *   </>
+ * );
+ * ```
+ */
+export const useDeleteConfirmation = (
+  options?: UseDeleteConfirmationOptions
+): UseDeleteConfirmationReturn => {
+  const { onClose: onCloseCallback } = options ?? {};
+  const [items, setItems] = useState<ContentListItem[] | null>(null);
+
+  const requestDelete = useCallback((toDelete: ContentListItem[]) => setItems(toDelete), []);
+
+  const close = useCallback(() => {
+    setItems(null);
+    onCloseCallback?.();
+  }, [onCloseCallback]);
+
+  const deleteModal = items ? <DeleteConfirmationModal {...{ items }} onClose={close} /> : null;
+
+  return { requestDelete, deleteModal };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
@@ -26,3 +26,16 @@ export { useContentListSearch } from './search';
 // Selection feature.
 export type { UseContentListSelectionReturn } from './selection';
 export { useContentListSelection } from './selection';
+
+// Delete feature.
+export type {
+  DeleteConfirmationModalProps,
+  DeleteConfirmationComponentProps,
+  UseDeleteConfirmationOptions,
+  UseDeleteConfirmationReturn,
+} from '../components/delete';
+export {
+  DeleteConfirmationModal,
+  DeleteConfirmationComponent,
+  useDeleteConfirmation,
+} from '../components/delete';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
@@ -63,7 +63,7 @@ export interface ContentListItemConfig {
 
   /**
    * Callback invoked to delete one or more items.
-   * When provided, enables the delete action on rows.
+   * When provided, enables the delete action on rows and the bulk-delete flow.
    * The callback should handle the actual deletion and return a resolved promise on success.
    */
   onDelete?: (items: ContentListItem[]) => Promise<void>;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
@@ -171,7 +171,7 @@ const SortControls = () => {
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="sortable" aria-label="Sortable" />
+        <EuiIcon type="sortable" aria-hidden={true} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiText size="s">Sort by:</EuiText>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/tsconfig.json
@@ -12,6 +12,7 @@
   ],
   "kbn_references": [
     "@kbn/react-query",
-    "@kbn/content-list-mock-data"
+    "@kbn/content-list-mock-data",
+    "@kbn/i18n"
   ]
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
@@ -13,6 +13,8 @@ import '@testing-library/jest-dom';
 import type { ActionBuilderContext, DeleteActionProps } from '../types';
 import { buildDeleteAction } from './delete_action';
 
+const onDelete = jest.fn();
+
 const defaultContext: ActionBuilderContext = {
   itemConfig: {
     onDelete: jest.fn(async () => {}),
@@ -20,6 +22,7 @@ const defaultContext: ActionBuilderContext = {
   isReadOnly: false,
   entityName: 'dashboard',
   supports: { sorting: true, pagination: true, search: true, selection: true },
+  actions: { onDelete },
 };
 
 describe('delete action builder', () => {
@@ -40,7 +43,6 @@ describe('delete action builder', () => {
         'data-test-subj': 'content-list-table-action-delete',
       });
 
-      // `name` is a ReactNode wrapping the label in danger-colored text.
       const { getByText } = render(<>{result!.name as ReactNode}</>);
       expect(getByText('Delete')).toBeInTheDocument();
     });
@@ -80,22 +82,27 @@ describe('delete action builder', () => {
       expect(getByText('Remove')).toBeInTheDocument();
     });
 
-    it('has a no-op `onClick` handler (stub for delete orchestration)', () => {
+    it('calls `actions.onDelete` with the item wrapped in an array', () => {
       const result = buildDeleteAction({}, defaultContext);
-
-      expect(result?.onClick).toBeInstanceOf(Function);
-
-      // Clicking should not throw or call `onDelete` directly.
-      const onDelete = jest.fn();
-      const context: ActionBuilderContext = {
-        ...defaultContext,
-        itemConfig: { onDelete },
-      };
-      const stubResult = buildDeleteAction({}, context);
       const item = { id: '1', title: 'Test' };
 
-      stubResult?.onClick?.(item, {} as React.MouseEvent);
-      expect(onDelete).not.toHaveBeenCalled();
+      result?.onClick?.(item, {} as React.MouseEvent);
+
+      expect(onDelete).toHaveBeenCalledWith([item]);
+    });
+
+    it('does not call `itemConfig.onDelete` directly', () => {
+      const itemOnDelete = jest.fn();
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: { onDelete: itemOnDelete },
+      };
+      const result = buildDeleteAction({}, context);
+      const item = { id: '1', title: 'Test' };
+
+      result?.onClick?.(item, {} as React.MouseEvent);
+
+      expect(itemOnDelete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.tsx
@@ -68,8 +68,8 @@ const DEFAULT_DELETE_DESCRIPTION = i18n.translate(
  * - The table is in read-only mode.
  * - No delete handler (`onDelete`) is configured on the item config.
  *
- * The `onClick` handler is a **no-op stub**. The actual delete flow (confirmation
- * modal, provider-level delete state) will be wired by the Delete Orchestration PR.
+ * The `onClick` handler calls {@link BuilderContextActions.onDelete} to open
+ * the delete confirmation modal at the table level.
  *
  * @param attributes - The declarative attributes from the parsed `Action.Delete` element.
  * @param context - Builder context with provider configuration.
@@ -79,7 +79,7 @@ export const buildDeleteAction = (
   attributes: DeleteActionProps,
   context: ActionBuilderContext
 ): ActionOutput | undefined => {
-  const { itemConfig, isReadOnly } = context;
+  const { itemConfig, isReadOnly, actions } = context;
 
   if (isReadOnly) {
     return undefined;
@@ -97,8 +97,7 @@ export const buildDeleteAction = (
     type: 'icon',
     color: 'danger',
     isPrimary: true,
-    // TODO: Wire to provider-level delete orchestration.
-    onClick: () => {},
+    onClick: (item) => actions?.onDelete?.([item]),
     'data-test-subj': 'content-list-table-action-delete',
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
@@ -22,10 +22,6 @@ export type ActionOutput = DefaultItemAction<ContentListItem>;
 
 /**
  * Context passed to action builder functions.
- *
- * Extends {@link BuilderContext} with action-specific fields. Today it is
- * identical to the base; the Delete Orchestration PR will add
- * `onRequestDelete` and related callbacks here.
  */
 export type ActionBuilderContext = BuilderContext;
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
@@ -113,10 +113,6 @@ export const buildActionsColumn = (
     return undefined;
   }
 
-  // `ColumnBuilderContext` and `ActionBuilderContext` share the same
-  // `BuilderContext` base, so the column context is directly usable as
-  // the action context. This will need a mapping step when
-  // `ActionBuilderContext` gains action-specific fields.
   const actionContext: ActionBuilderContext = context;
 
   // Resolve each action part into an EUI action definition.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
@@ -65,7 +65,12 @@ describe('name column builder', () => {
     it('forces sortable false when sorting is unsupported', () => {
       const context: ColumnBuilderContext = {
         ...defaultContext,
-        supports: { sorting: false, pagination: true, search: false, selection: true },
+        supports: {
+          sorting: false,
+          pagination: true,
+          search: false,
+          selection: true,
+        },
       };
 
       const result = buildNameColumn({}, context);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/types.ts
@@ -7,15 +7,27 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ContentListItemConfig, ContentListSupports } from '@kbn/content-list-provider';
+import type {
+  ContentListItem,
+  ContentListItemConfig,
+  ContentListSupports,
+} from '@kbn/content-list-provider';
+
+/**
+ * Callbacks for action orchestration (e.g., delete confirmation).
+ *
+ * Provides table-level handlers that action builders use to trigger
+ * flows requiring UI outside the action itself (modals, toasts, etc.).
+ */
+export interface BuilderContextActions {
+  /** Opens the delete confirmation modal for the given items. */
+  onDelete?: (items: ContentListItem[]) => void;
+}
 
 /**
  * Shared context available to all builder functions (columns, actions).
  *
- * Provides provider-level configuration common to every builder. Specific
- * builder context interfaces extend this base when they need additional fields
- * (e.g., `ActionBuilderContext` will add delete orchestration callbacks in a
- * future PR).
+ * Provides provider-level configuration common to every builder.
  */
 export interface BuilderContext {
   /** Item configuration from the content list provider. */
@@ -26,6 +38,8 @@ export interface BuilderContext {
   entityName?: string;
   /** Feature support flags from the provider. */
   supports?: ContentListSupports;
+  /** Callbacks for action orchestration. */
+  actions?: BuilderContextActions;
 }
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
@@ -67,7 +67,12 @@ describe('updated at column builder', () => {
     it('forces sortable false when sorting is unsupported', () => {
       const context: ColumnBuilderContext = {
         ...defaultContext,
-        supports: { sorting: false, pagination: true, search: true, selection: true },
+        supports: {
+          sorting: false,
+          pagination: true,
+          search: true,
+          selection: true,
+        },
       };
 
       const result = buildUpdatedAtColumn({}, context);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -10,7 +10,11 @@
 import React, { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { EuiBasicTable } from '@elastic/eui';
-import { useContentListItems, type ContentListItem } from '@kbn/content-list-provider';
+import {
+  useContentListItems,
+  useDeleteConfirmation,
+  type ContentListItem,
+} from '@kbn/content-list-provider';
 import { Column as BaseColumn, NameColumn, UpdatedAtColumn, ActionsColumn } from './column';
 import { Action as BaseAction, EditAction, DeleteAction } from './action';
 import { useColumns, useSorting, useSelection } from './hooks';
@@ -116,7 +120,9 @@ const ContentListTableComponent = ({
   const { items: rawItems, isLoading: loading, error } = useContentListItems();
   const items = useMemo(() => (filter ? rawItems.filter(filter) : rawItems), [rawItems, filter]);
 
-  const columns = useColumns(children);
+  const { requestDelete, deleteModal } = useDeleteConfirmation();
+
+  const columns = useColumns(children, requestDelete);
   const { sorting, onChange } = useSorting();
   const { selection } = useSelection();
 
@@ -128,20 +134,23 @@ const ContentListTableComponent = ({
   }
 
   return (
-    <EuiBasicTable
-      tableCaption={title}
-      columns={columns}
-      compressed={compressed}
-      error={error?.message}
-      itemId={(item) => getRowId(item.id)}
-      items={items}
-      loading={loading}
-      onChange={onChange}
-      sorting={sorting}
-      selection={selection}
-      tableLayout={tableLayout}
-      data-test-subj={dataTestSubj}
-    />
+    <>
+      <EuiBasicTable
+        tableCaption={title}
+        columns={columns}
+        compressed={compressed}
+        error={error?.message}
+        itemId={(item) => getRowId(item.id)}
+        items={items}
+        loading={loading}
+        onChange={onChange}
+        sorting={sorting}
+        selection={selection}
+        tableLayout={tableLayout}
+        data-test-subj={dataTestSubj}
+      />
+      {deleteModal}
+    </>
   );
 };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.ts
@@ -53,7 +53,10 @@ const parseColumnParts = (children: ReactNode): ParsedPart[] => {
  * @param children - React children containing `Column` declarative components.
  * @returns Array of EUI table columns ready for `EuiBasicTable`.
  */
-export const useColumns = (children: ReactNode): Array<EuiBasicTableColumn<ContentListItem>> => {
+export const useColumns = (
+  children: ReactNode,
+  onDelete?: (items: ContentListItem[]) => void
+): Array<EuiBasicTableColumn<ContentListItem>> => {
   const { item: itemConfig, isReadOnly, labels, supports } = useContentListConfig();
 
   return useMemo(() => {
@@ -63,6 +66,7 @@ export const useColumns = (children: ReactNode): Array<EuiBasicTableColumn<Conte
       isReadOnly,
       entityName: labels.entity,
       supports,
+      actions: { onDelete },
     };
 
     return parts
@@ -72,5 +76,5 @@ export const useColumns = (children: ReactNode): Array<EuiBasicTableColumn<Conte
     // parent render, so including them would defeat memoization. Re-running when context
     // deps change is sufficient.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemConfig, isReadOnly, labels.entity, supports]);
+  }, [itemConfig, isReadOnly, labels.entity, supports, onDelete]);
 };


### PR DESCRIPTION
## Summary

Adds provider-level delete orchestration to `@kbn/content-list-provider` — state management, confirmation modal, and the `useDeleteAction` hook. This is the infrastructure layer; wiring to table row actions and selection will follow in subsequent PRs.

### Commits

| # | Commit | Description |
|---|--------|-------------|
| 1 | [`Boilerplate`](92731c525052) | Scaffolds the `features/delete/` module directory with barrel exports, types, and `moon.yml` update. |
| 2 | [`[content-list] Add delete orchestration to provider`](e06f8398d33f) | State actions (`REQUEST_DELETE`, `CONFIRM_DELETE_START`, `CANCEL_DELETE`, `DELETE_COMPLETED`), reducer handlers, `useDeleteAction` hook, `DeleteConfirmation` modal with `React.lazy` wrapper, and provider integration via `supports.delete`. |
| 3 | [`Tests and Storybooks`](5107e46ad2d8) | Unit tests for reducer, hook, and modal (11 modal tests including cancel, confirm, failure, double-click protection). `DeleteOrchestration` Storybook story with controls for `enableDelete`, `isReadOnly`, `deleteDelay`, and `deleteShouldFail`. |

### What's included

- **State**: `REQUEST_DELETE`, `CONFIRM_DELETE_START`, `CANCEL_DELETE`, `DELETE_COMPLETED` actions and corresponding reducer handlers for `deleteRequest` and `isDeleting` state.
- **`useDeleteAction` hook**: Public API for requesting a delete. Returns `requestDelete`, `isSupported`, and `isDeleting`. Gated by the `supports.delete` flag (derived from `item.onDelete` + `!isReadOnly`).
- **`DeleteConfirmation` modal**: Internal `EuiConfirmModal` matching `TableListView`'s `ConfirmDeleteModal` design — same copy, `defaultFocusedButton="cancel"`, `aria-labelledby`, and `isLoading` state. Calls `item.onDelete`, refetches on success, dismisses on failure.
- **`LazyDeleteConfirmation`**: `React.lazy` wrapper that only loads the modal chunk when a delete request is pending. Auto-rendered by `ContentListProvider` when `supports.delete` is true.
- **Storybook story**: `DeleteOrchestration` story with controls for `enableDelete`, `isReadOnly`, `deleteDelay`, and `deleteShouldFail`.

### Tests

- 72 unit tests (all passing), including:
  - State reducer tests for all four delete actions (10 tests).
  - `useDeleteAction` hook tests (4 tests).
  - `DeleteConfirmation` modal tests covering rendering, labels, cancel, confirm success/failure, double-click protection, body text, and cancel-button focus (11 tests).

### Coverage

| File | Lines | Coverage |
|------|-------|----------|
| `context/provider.tsx` | 13/13 | 100% |
| `delete/delete_confirmation.tsx` | 19/21 | 90.5% |
| `delete/lazy_delete_confirmation.tsx` | 7/7 | 100% |
| `delete/use_delete_action.ts` | 8/8 | 100% |
| `state/state_provider.tsx` | 15/15 | 100% |
| `state/state_reducer.ts` | 9/9 | 100% |

## Test plan

- [x] Unit tests pass: `yarn jest src/platform/packages/shared/content-management/content_list/kbn-content-list-provider`
- [x] Storybook renders: `yarn storybook content_management` → Content List / Provider / Delete Orchestration
- [ ] Delete single item via row action
- [ ] Bulk delete via toolbar button
- [ ] Cancel dismisses modal, no side effects
- [ ] Failed delete dismisses modal, items unchanged
- [ ] `isReadOnly` hides delete controls