### PR TITLE
[8.19] [Scout] Register Node require hook for `.peggy` files (#252377)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/moon.yml
+++ b/src/platform/packages/shared/kbn-scout/moon.yml
@@ -35,6 +35,7 @@ dependsOn:
   - '@kbn/zod'
   - '@kbn/core-http-common'
   - '@kbn/axe-config'
+  - '@kbn/peggy'
   - '@kbn/apm-synthtrace'
   - '@kbn/apm-synthtrace-client'
 tags:

--- a/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
@@ -7,6 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+// Needed for Scout tests dependent on .peggy grammar files (`@kbn/tinymath`)
+import './peggy_setup';
+
 // Config and utilities
 export { createPlaywrightConfig } from './config';
 export { createLazyPageObject } from './page_objects/utils';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/peggy_setup.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/peggy_setup.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Initialize Peggy require hook for .peggy grammar files.
+ * This is required for @kbn/tinymath and other packages that use Peggy grammars.
+ *
+ * Playwright needs to load it as @kbn/scout is dependent on @kbn/streamlang which uses Peggy (`@kbn/tinymath`).
+ * Without this, all Playwright tests would fail with: `"whitespace" SyntaxError: Unexpected string`
+ *
+ * This is similar to the Jest Peggy setup in src/platform/packages/shared/kbn-test/src/jest/transforms/peggy.js.
+ */
+import { requireHook } from '@kbn/peggy';
+requireHook();

--- a/src/platform/packages/shared/kbn-scout/tsconfig.json
+++ b/src/platform/packages/shared/kbn-scout/tsconfig.json
@@ -31,6 +31,7 @@
     "@kbn/zod",
     "@kbn/core-http-common",
     "@kbn/axe-config",
+    "@kbn/peggy",
     "@kbn/apm-synthtrace",
     "@kbn/apm-synthtrace-client",
   ]

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/async_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/async_dashboard.spec.ts
@@ -81,9 +81,12 @@ spaceTest.describe('Flights dashboard (sample data)', { tag: tags.deploymentAgno
         .poll(async () => await pageObjects.dashboard.getSavedSearchRowCount())
         .toBeGreaterThan(10);
 
-      // Checking tag clouds rendered
-      const legendLabels = page.locator('[data-testid="echLegendItemLabel"]');
-      const legendTexts = await legendLabels.allInnerTexts();
+      // Checking legends rendered (elastic-charts)
+      const legendLabels = page.locator(
+        '.echLegendItem__label, [data-testid="echLegendItemLabel"]'
+      );
+      await expect.poll(async () => await legendLabels.count()).toBeGreaterThan(0);
+      const legendTexts = (await legendLabels.allInnerTexts()).map((t) => t.trim()).filter(Boolean);
       ['Sunny', 'Rain', 'Clear', 'Cloudy', 'Hail'].forEach((value) => {
         expect(legendTexts).toContain(value);
       });

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
@@ -14,10 +14,8 @@ import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '.
 // may include "observabilityGroup" panel group (and other panel groups)
 const DASHBOARD_PANEL_GROUP_ORDER = [
   'visualizationsGroup',
-  'controlsGroup',
   'annotation-and-navigationGroup',
   'mlGroup',
-  'legacyGroup',
 ];
 
 const DASHBOARD_PANEL_TYPE_COUNT = 18;

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
@@ -14,14 +14,12 @@ import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '.
 // includes "observabilityGroup" panel group
 const DASHBOARD_PANEL_GROUP_ORDER = [
   'visualizationsGroup',
-  'controlsGroup',
   'annotation-and-navigationGroup',
   'mlGroup',
   'observabilityGroup',
-  'legacyGroup',
 ];
 
-const DASHBOARD_PANEL_TYPE_COUNT = 24;
+const DASHBOARD_PANEL_TYPE_COUNT = 21;
 
 spaceTest.describe(
   'Dashboard panel listing (includes observability group)',

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
@@ -71,16 +71,19 @@ spaceTest.describe('Panel titles (dashboard)', { tag: tags.deploymentAgnostic },
     });
   });
 
-  spaceTest('blank title clears unsaved changes', async ({ page, pageObjects }) => {
+  spaceTest('blank title clears unsaved changes', async ({ page, pageObjects }, testInfo) => {
     await spaceTest.step('add markdown panel by value', async () => {
       await pageObjects.dashboard.addMarkdownPanel(PANEL_TITLES_MARKDOWN_CONTENT);
     });
 
-    await spaceTest.step('set blank title and save', async () => {
+    await spaceTest.step('save dashboard', async () => {
+      await pageObjects.dashboard.saveDashboard(`Panel titles - ${testInfo.title}`);
+    });
+
+    await spaceTest.step('set blank title', async () => {
       await pageObjects.dashboard.openCustomizePanel();
       await pageObjects.dashboard.setCustomPanelTitle('');
       await pageObjects.dashboard.saveCustomizePanel();
-      await pageObjects.dashboard.clearUnsavedChanges();
     });
 
     await spaceTest.step('verify title is empty and badge is gone', async () => {
@@ -89,24 +92,33 @@ spaceTest.describe('Panel titles (dashboard)', { tag: tags.deploymentAgnostic },
     });
   });
 
-  spaceTest('custom title causes unsaved changes and saving clears it', async ({ pageObjects }) => {
-    await spaceTest.step('add markdown panel by value', async () => {
-      await pageObjects.dashboard.addMarkdownPanel(PANEL_TITLES_MARKDOWN_CONTENT);
-    });
+  spaceTest(
+    'custom title causes unsaved changes and saving clears it',
+    async ({ page, pageObjects }, testInfo) => {
+      await spaceTest.step('add markdown panel by value', async () => {
+        await pageObjects.dashboard.addMarkdownPanel(PANEL_TITLES_MARKDOWN_CONTENT);
+      });
 
-    await spaceTest.step('set custom title and save', async () => {
-      await pageObjects.dashboard.openCustomizePanel();
-      await pageObjects.dashboard.setCustomPanelTitle(PANEL_TITLES_CUSTOM_TITLE);
-      await pageObjects.dashboard.saveCustomizePanel();
-    });
+      await spaceTest.step('save dashboard', async () => {
+        await pageObjects.dashboard.saveDashboard(`Panel titles - ${testInfo.title}`);
+      });
 
-    await spaceTest.step('verify title and clear unsaved changes', async () => {
-      await expect(pageObjects.dashboard.getPanelTitlesLocator()).toHaveText(
-        PANEL_TITLES_CUSTOM_TITLE
-      );
-      await pageObjects.dashboard.clearUnsavedChanges();
-    });
-  });
+      await spaceTest.step('set custom title and save', async () => {
+        await pageObjects.dashboard.openCustomizePanel();
+        await pageObjects.dashboard.setCustomPanelTitle(PANEL_TITLES_CUSTOM_TITLE);
+        await pageObjects.dashboard.saveCustomizePanel();
+        await expect(page.testSubj.locator('dashboardUnsavedChangesBadge')).toBeVisible();
+      });
+
+      await spaceTest.step('verify title and clear unsaved changes', async () => {
+        await expect(pageObjects.dashboard.getPanelTitlesLocator()).toHaveText(
+          PANEL_TITLES_CUSTOM_TITLE
+        );
+        await pageObjects.dashboard.clearUnsavedChanges();
+        await expect(page.testSubj.locator('dashboardUnsavedChangesBadge')).toHaveCount(0);
+      });
+    }
+  );
 
   spaceTest('reset title is hidden on a by value panel', async ({ pageObjects }) => {
     await spaceTest.step('add markdown panel by value', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.2` to `8.19`:
 - [[9.2] [Scout] Register Node require hook for `.peggy` files (#252377)](https://github.com/elastic/kibana/pull/250796)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2026-02-10T19:08:37Z","message":"[9.2] [Scout] Register Node require hook for `.peggy` files (#252377)\n\nThis PR backports a small set of changes introduced by\nhttps://github.com/elastic/kibana/pull/246050 to the 9.2 branch (and to\n8.19 after merging this PR).\n\n### Context\nSome Scout Playwright test configs indirectly import packages that load\n**Peggy grammar files** at runtime (e.g., `@kbn/es-query`). When\nPlaywright is invoked via the Scout CLI (`node scripts/scout.js ...`) or\nvia `node scripts/playwright`, **Kibana preloads its Node environment**\n(`@kbn/setup-node-env`), which registers the transforms/hooks needed to\nload non-JS files like `*.peggy`.\n\nHowever, when running Playwright directly (e.g., `npx playwright test\n--config ... --list`), the Kibana bootstrap is skipped / bypassed. In\nthat case, Node.js ends up trying to interpret `*.peggy` files as\nJavaScript adn fails, which breaks Playwright config loading and test\ndiscovery for some tes configs.\n\n### Background\n\nThis caused the Scout Test Run Builder CI step (`node scripts/scout.js\nupdate-test-config-manifests` more specifically) to incorrectly report\nthe number tests for\n`src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts`).\nThis PR fixes that by ensuring a `.peggy` require hook is installed\nautomatically when `@kbn/scout` is imported/used, so Scout configs can\nbe loaded reliably regardless of how Playwright is invoked.","sha":"826a13fc67eca722da9b0f3b3a7d86b69e96548e"},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:skip"],"title":"Update docker.elastic.co/wolfi/chainguard-base:latest Docker digest to a71dfa7 (9.2)","number":250796,"url":"https://github.com/elastic/kibana/pull/250796"},"sourceBranch":"9.2","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->