### PR TITLE
Add elasticsearch.healthCheck.onFailureDelay config for faster recovery polling

### DIFF
--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
@@ -157,6 +157,7 @@ export const configSchema = schema.object({
   apiVersion: schema.string({ defaultValue: DEFAULT_API_VERSION }),
   healthCheck: schema.object({
     delay: schema.duration({ defaultValue: 2500 }),
+    onFailureDelay: schema.maybe(schema.duration()),
     startupDelay: schema.duration({ defaultValue: 500 }),
     retry: schema.number({ defaultValue: DEFAULT_HEALTH_CHECK_RETRY, min: 1 }),
   }),
@@ -353,6 +354,10 @@ export class ElasticsearchConfig implements IElasticsearchConfig {
    */
   public readonly healthCheckDelay: Duration;
   /**
+   * The interval between health check requests Kibana sends to the Elasticsearch during failure.
+   */
+  public readonly healthCheckFailureInterval: Duration;
+  /**
    * The number of times to retry the health check request
    */
   public readonly healthCheckRetry: number;
@@ -499,6 +504,7 @@ export class ElasticsearchConfig implements IElasticsearchConfig {
     this.sniffOnConnectionFault = rawConfig.sniffOnConnectionFault;
     this.sniffInterval = rawConfig.sniffInterval;
     this.healthCheckDelay = rawConfig.healthCheck.delay;
+    this.healthCheckFailureInterval = rawConfig.healthCheck.onFailureDelay;
     this.healthCheckStartupDelay = rawConfig.healthCheck.startupDelay;
     this.healthCheckRetry = rawConfig.healthCheck.retry;
     this.username = rawConfig.username;

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
@@ -356,7 +356,7 @@ export class ElasticsearchConfig implements IElasticsearchConfig {
   /**
    * The interval between health check requests Kibana sends to the Elasticsearch during failure.
    */
-  public readonly healthCheckFailureInterval: Duration;
+  public readonly healthCheckFailureInterval: Duration | undefined;
   /**
    * The number of times to retry the health check request
    */

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.ts
@@ -110,7 +110,7 @@ export class ElasticsearchService
       kibanaVersion: this.kibanaVersion,
       ignoreVersionMismatch: config.ignoreVersionMismatch,
       healthCheckInterval: config.healthCheckDelay.asMilliseconds(),
-      healthCheckFailureInterval: config.healthCheckFailureInterval.asMilliseconds(),
+      healthCheckFailureInterval: config.healthCheckFailureInterval?.asMilliseconds(),
       healthCheckStartupInterval: config.healthCheckStartupDelay.asMilliseconds(),
       healthCheckRetry: config.healthCheckRetry,
       log: this.log,

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.ts
@@ -110,6 +110,7 @@ export class ElasticsearchService
       kibanaVersion: this.kibanaVersion,
       ignoreVersionMismatch: config.ignoreVersionMismatch,
       healthCheckInterval: config.healthCheckDelay.asMilliseconds(),
+      healthCheckFailureInterval: config.healthCheckFailureInterval.asMilliseconds(),
       healthCheckStartupInterval: config.healthCheckStartupDelay.asMilliseconds(),
       healthCheckRetry: config.healthCheckRetry,
       log: this.log,

--- a/src/core/packages/elasticsearch/server/src/elasticsearch_config.ts
+++ b/src/core/packages/elasticsearch/server/src/elasticsearch_config.ts
@@ -24,6 +24,11 @@ export interface IElasticsearchConfig {
   readonly healthCheckDelay: Duration;
 
   /**
+   * The interval between health check requests Kibana sends to the Elasticsearch during failure.
+   */
+  readonly healthCheckFailureInterval: Duration | undefined;
+
+  /**
    * The number of times to retry the health check request
    */
   readonly healthCheckRetry: number;

--- a/src/platform/plugins/shared/console/server/services/es_legacy_config_service.ts
+++ b/src/platform/plugins/shared/console/server/services/es_legacy_config_service.ts
@@ -9,19 +9,19 @@
 
 import type { Observable, Subscription } from 'rxjs';
 import { firstValueFrom } from 'rxjs';
-import type { ElasticsearchConfig } from '@kbn/core/server';
+import type { IElasticsearchConfig } from '@kbn/core-elasticsearch-server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 
 export class EsLegacyConfigService {
   /**
    * The elasticsearch config value at a given point in time.
    */
-  private config?: ElasticsearchConfig;
+  private config?: IElasticsearchConfig;
 
   /**
    * An observable that emits elasticsearch config.
    */
-  private config$?: Observable<ElasticsearchConfig>;
+  private config$?: Observable<IElasticsearchConfig>;
 
   /**
    * A reference to the subscription to the elasticsearch observable
@@ -33,7 +33,7 @@ export class EsLegacyConfigService {
    */
   private cloudUrl?: string;
 
-  setup(config$: Observable<ElasticsearchConfig>, cloud?: CloudSetup) {
+  setup(config$: Observable<IElasticsearchConfig>, cloud?: CloudSetup) {
     this.config$ = config$;
     this.configSub = this.config$.subscribe((config) => {
       this.config = config;
@@ -47,7 +47,7 @@ export class EsLegacyConfigService {
     }
   }
 
-  async readConfig(): Promise<ElasticsearchConfig> {
+  async readConfig(): Promise<IElasticsearchConfig> {
     if (!this.config$) {
       throw new Error('Could not read elasticsearch config, this service has not been setup!');
     }


### PR DESCRIPTION
## Summary

Adds a new `elasticsearch.healthCheck.onFailureDelay` configuration option that controls the polling interval when the `nodes.info` API call is failing. This allows Kibana to poll Elasticsearch more frequently during failures, enabling faster recovery detection. When not configured, it defaults to the existing `healthCheck.delay` value, preserving current behavior.

Changes:
- New optional `elasticsearch.healthCheck.onFailureDelay` duration config
- `pollEsNodesVersion` now tracks failure state via `isCheckFailing$` and switches to the failure interval when errors occur
- Marble test covering the interval switch on failure and recovery back to the normal interval

### Issue resolution

The issue requested a way to independently control retry frequency when health checks are failing, to reduce Kibana's recovery time after ES comes back. This PR adds `elasticsearch.healthCheck.onFailureDelay` which is used as the polling interval during failures, allowing more frequent checks without affecting the normal polling cadence.

Closes https://github.com/elastic/kibana-team/issues/2608

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

None.