### PR TITLE
[Cases] Add isLatest flag to template SO

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/api/template/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/template/v1.ts
@@ -7,11 +7,24 @@
 
 import { z } from '@kbn/zod';
 import { TemplateSchema } from '../../domain/template/v1';
-
 /**
- * Sort field for templates — any key of the Template schema
+ * Sort field for templates.
+ *
+ * Keep this list aligned with indexed scalar mapping fields in the template SO type.
  */
-export const TemplateSortFieldSchema = TemplateSchema.keyof();
+export const TemplateSortFieldSchema = z.enum([
+  'templateId',
+  'name',
+  'templateVersion',
+  'owner',
+  'deletedAt',
+  'author',
+  'usageCount',
+  'fieldCount',
+  'lastUsedAt',
+  'isDefault',
+  'isLatest',
+]);
 
 export type TemplateSortField = z.infer<typeof TemplateSortFieldSchema>;
 

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/v1.ts
@@ -81,6 +81,11 @@ export const TemplateSchema = z.object({
    * Whether this is the default template
    */
   isDefault: z.boolean().optional(),
+
+  /**
+   * Whether this is the latest version for a templateId
+   */
+  isLatest: z.boolean().optional(),
 });
 
 export type Template = z.infer<typeof TemplateSchema>;

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/parse_template.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/parse_template.ts
@@ -31,7 +31,7 @@ export const parseTemplate = (template: Template): ParsedTemplate => {
     fieldNames: template.fieldNames,
     lastUsedAt: template.lastUsedAt,
     isDefault: template.isDefault,
-    isLatest: true,
+    isLatest: template.isLatest ?? false,
     latestVersion: 1,
   };
 };

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.test.ts
@@ -41,6 +41,9 @@ describe('caseTemplateSavedObjectType', () => {
           "isDefault": Object {
             "type": "boolean",
           },
+          "isLatest": Object {
+            "type": "boolean",
+          },
           "lastUsedAt": Object {
             "type": "date",
           },

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/templates/index.ts
@@ -58,6 +58,9 @@ const mappings = {
     isDefault: {
       type: 'boolean',
     },
+    isLatest: {
+      type: 'boolean',
+    },
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Given that template saved object **has not been deployed anywhere yet**, I did the following changes:

- Reworked template retrieval to use ES-native search/sort/pagination instead of in-memory aggregation sorting.
- Introduced isLatest as the source of truth for latest template version reads: new templates are created with isLatest: true, updates create a new latest version and demote the previous latest to isLatest: false.
- Tightened template sortField API validation to indexed, ES-sortable fields only.
- Updated template parsing and server tests to reflect persisted isLatest behavior and new query flow.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



