### PR TITLE
[Cloud Security Posture] Fix unauthenticated access to CDR data views setup

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/setup_routes.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/setup_routes.ts
@@ -53,7 +53,7 @@ export function setupRoutes({
   defineGetCspBenchmarkRulesStatesRoute(router);
   defineGraphRoute(router);
 
-  core.http.registerOnPreRouting(async (request, response, toolkit) => {
+  core.http.registerOnPostAuth(async (request, response, toolkit) => {
     if (request.url.pathname.includes(CLOUD_SECURITY_INTERTAL_PREFIX_ROUTE_PATH)) {
       try {
         const [coreStart, startDeps] = await core.getStartServices();


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/security/issues/8448

- Switch the `registerOnPreRouting` lifecycle hook to `registerOnPostAuth` for the CDR data views setup handler
- `registerOnPreRouting` runs before authentication, allowing unauthenticated requests to trigger `setupCdrDataViews` with internal ES/SO clients
- `registerOnPostAuth` ensures the handler only executes after the user has been authenticated

## Test plan

- [ ] Start Kibana locally and curl an internal CSP route with wrong credentials: 

```
curl -s 'http://localhost:5601/kbn/s/default/internal/cloud_security_posture/x' \
  -u elastic:changeme1 \
  -H 'kbn-xsrf: true'
```

the following should be the response:
<img width="1132" height="99" alt="image" src="https://github.com/user-attachments/assets/0a663dff-e8e3-4cab-8de0-929ea002090d" />

- [ ] Curl the same route with valid credentials — verify the handler runs as expected
- [ ] Verify existing CSP UI functionality still works (data views are created on first authenticated request)