### PR TITLE
[Streams] Avoid streams crashing if a policy has empty phases

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.test.ts
@@ -180,8 +180,12 @@ describe('helpers', () => {
   });
 
   describe('getILMRatios', () => {
-    it('should return undefined if no phases', () => {
+    it('should return undefined if phases is undefined', () => {
       expect(getILMRatios(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if phases is an empty object', () => {
+      expect(getILMRatios({ phases: {} })).toBeUndefined();
     });
 
     it('should calculate grow ratios correctly for multiple phases', () => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.ts
@@ -60,6 +60,9 @@ export const getILMRatios = (
   if (!value) return undefined;
 
   const orderedPhases = orderIlmPhases(value.phases);
+
+  if (orderedPhases.length === 0) return undefined;
+
   const totalDuration = parseDurationInSeconds(last(orderedPhases)!.min_age);
 
   return orderedPhases.map((phase, index, phases) => {


### PR DESCRIPTION
## Summary

There was an bug in the Streams helpers that made the page crush when getting the `getILMRatios` for a policy that haven't any phase configured. The error was `TypeError can't access property min_age g.first is undefined`.

To fix that, this PR introduces a guard of the `orderedPhases` before trying to access `min_age`.

### How to test

Create a policy with no phases
```
PUT _ilm/policy/empty_policy
{
  "policy": {
    "phases": {
    }
  }
}
```
Assign it to a stream and verify it doesn't break the page


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->