### PR TITLE
[Streams][Discover] Remove sparkle icon

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
@@ -7,14 +7,7 @@
 
 import { type DataTableRecord } from '@kbn/discover-utils';
 import type { StreamsRepositoryClient } from '@kbn/streams-plugin/public/api';
-import {
-  EuiLoadingSpinner,
-  EuiLink,
-  EuiFlexGroup,
-  EuiToolTip,
-  useEuiTheme,
-  EuiText,
-} from '@elastic/eui';
+import { EuiLoadingSpinner, EuiLink, EuiFlexGroup, EuiToolTip, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { DataView } from '@kbn/data-views-plugin/common';
@@ -36,7 +29,6 @@ export function DiscoverFlyoutStreamProcessingLink({
   locator,
   streamsRepositoryClient,
 }: DiscoverFlyoutStreamProcessingLinkProps) {
-  const { euiTheme } = useEuiTheme();
   const { value, loading, error } = useResolvedDefinitionName({
     streamsRepositoryClient,
     doc,

--- a/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/discover_features/discover_flyout_stream_processing_link.tsx
@@ -10,7 +10,6 @@ import type { StreamsRepositoryClient } from '@kbn/streams-plugin/public/api';
 import {
   EuiLoadingSpinner,
   EuiLink,
-  EuiIcon,
   EuiFlexGroup,
   EuiToolTip,
   useEuiTheme,
@@ -18,7 +17,6 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { css } from '@emotion/react';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { CUSTOM_SAMPLES_DATA_SOURCE_STORAGE_KEY_PREFIX } from '../../common/url_schema/common';
@@ -65,13 +63,6 @@ export function DiscoverFlyoutStreamProcessingLink({
     <EuiLink href={href}>
       <EuiToolTip content={message} display="block">
         <EuiFlexGroup alignItems="center" gutterSize="s">
-          <EuiIcon
-            type="sparkles"
-            size="s"
-            css={css`
-              margin-left: ${euiTheme.size.s};
-            `}
-          />
           <EuiText size="xs" className="eui-textTruncate">
             {message}
           </EuiText>


### PR DESCRIPTION
## Summary


<img width="1816" height="1774" alt="image (14)" src="https://github.com/user-attachments/assets/f129ca68-a3fd-4d8c-a5ae-8150aea5210f" />

Removes the sparkles icon next to the "Parse content in Streams" button as this icon implies use of an AI feature, when this is not the case in this scenario.

