### PR TITLE
[Usage data] Migrate off GET _cat/indices

### DIFF
--- a/src/core/packages/usage-data/server-internal/src/core_usage_data_service.test.ts
+++ b/src/core/packages/usage-data/server-internal/src/core_usage_data_service.test.ts
@@ -435,6 +435,104 @@ describe('CoreUsageDataService', () => {
         `);
       });
 
+      it('calls indices.stats with expected telemetry request args', async () => {
+        const http = httpServiceMock.createInternalSetupContract();
+        const metrics = metricsServiceMock.createInternalSetupContract();
+        const savedObjectsStartPromise = Promise.resolve(
+          savedObjectsServiceMock.createStartContract()
+        );
+        const changedDeprecatedConfigPath$ = new BehaviorSubject({
+          set: ['new.path'],
+          unset: ['deprecated.path'],
+        });
+        service.setup({ http, metrics, savedObjectsStartPromise, changedDeprecatedConfigPath$ });
+        const elasticsearch = elasticsearchServiceMock.createStart();
+        elasticsearch.client.asInternalUser.indices.stats.mockResponseOnce({
+          _all: {
+            primaries: {
+              docs: {
+                count: 10,
+                deleted: 10,
+              },
+              store: {
+                size_in_bytes: 2000,
+              },
+            },
+            total: {
+              store: {
+                size_in_bytes: 1000,
+              },
+            },
+          },
+        } as any);
+        elasticsearch.client.asInternalUser.count.mockResponseOnce({ count: '15' } as any);
+        elasticsearch.client.asInternalUser.indices.stats.mockResponseOnce({
+          _all: {
+            primaries: {
+              docs: {
+                count: 20,
+                deleted: 20,
+              },
+              store: {
+                size_in_bytes: 4000,
+              },
+            },
+            total: {
+              store: {
+                size_in_bytes: 2000,
+              },
+            },
+          },
+        } as any);
+        elasticsearch.client.asInternalUser.count.mockResponseOnce({ count: '10' } as any);
+        elasticsearch.client.asInternalUser.search.mockResponseOnce({
+          hits: { total: { value: 6 } },
+          aggregations: {
+            aliases: {
+              buckets: {
+                active: { doc_count: 1 },
+                disabled: { doc_count: 2 },
+              },
+            },
+          },
+        } as any);
+
+        const typeRegistry = savedObjectsServiceMock.createTypeRegistryMock();
+        typeRegistry.getAllTypes.mockReturnValue([
+          { name: 'type 1', indexPattern: '.kibana' },
+          { name: 'type 2', indexPattern: '.kibana_task_manager' },
+        ] as any);
+
+        const { getCoreUsageData } = service.start({
+          savedObjects: savedObjectsServiceMock.createInternalStartContract(typeRegistry),
+          exposedConfigsToUsage: new Map(),
+          elasticsearch,
+        });
+
+        await getCoreUsageData();
+
+        expect(elasticsearch.client.asInternalUser.indices.stats).toHaveBeenNthCalledWith(1, {
+          index: '.kibana',
+          metric: ['docs', 'store'],
+          filter_path: [
+            '_all.primaries.docs.count',
+            '_all.primaries.docs.deleted',
+            '_all.total.store.size_in_bytes',
+            '_all.primaries.store.size_in_bytes',
+          ],
+        });
+        expect(elasticsearch.client.asInternalUser.indices.stats).toHaveBeenNthCalledWith(2, {
+          index: '.kibana_task_manager',
+          metric: ['docs', 'store'],
+          filter_path: [
+            '_all.primaries.docs.count',
+            '_all.primaries.docs.deleted',
+            '_all.total.store.size_in_bytes',
+            '_all.primaries.store.size_in_bytes',
+          ],
+        });
+      });
+
       it('returns zeroed index stats when indices stats are unavailable', async () => {
         const http = httpServiceMock.createInternalSetupContract();
         const metrics = metricsServiceMock.createInternalSetupContract();

--- a/src/core/packages/usage-data/server-internal/src/core_usage_data_service.test.ts
+++ b/src/core/packages/usage-data/server-internal/src/core_usage_data_service.test.ts
@@ -438,7 +438,9 @@ describe('CoreUsageDataService', () => {
       it('returns zeroed index stats when indices stats are unavailable', async () => {
         const http = httpServiceMock.createInternalSetupContract();
         const metrics = metricsServiceMock.createInternalSetupContract();
-        const savedObjectsStartPromise = Promise.resolve(savedObjectsServiceMock.createStartContract());
+        const savedObjectsStartPromise = Promise.resolve(
+          savedObjectsServiceMock.createStartContract()
+        );
         const changedDeprecatedConfigPath$ = new BehaviorSubject({
           set: ['new.path'],
           unset: ['deprecated.path'],
@@ -505,7 +507,9 @@ describe('CoreUsageDataService', () => {
       it('throws when fetching index stats fails', async () => {
         const http = httpServiceMock.createInternalSetupContract();
         const metrics = metricsServiceMock.createInternalSetupContract();
-        const savedObjectsStartPromise = Promise.resolve(savedObjectsServiceMock.createStartContract());
+        const savedObjectsStartPromise = Promise.resolve(
+          savedObjectsServiceMock.createStartContract()
+        );
         const changedDeprecatedConfigPath$ = new BehaviorSubject({
           set: ['new.path'],
           unset: ['deprecated.path'],

--- a/src/core/packages/usage-data/server-internal/src/core_usage_data_service.test.ts
+++ b/src/core/packages/usage-data/server-internal/src/core_usage_data_service.test.ts
@@ -213,27 +213,45 @@ describe('CoreUsageDataService', () => {
         });
         service.setup({ http, metrics, savedObjectsStartPromise, changedDeprecatedConfigPath$ });
         const elasticsearch = elasticsearchServiceMock.createStart();
-        elasticsearch.client.asInternalUser.cat.indices.mockResponseOnce([
-          {
-            name: '.kibana_task_manager_1',
-            'docs.count': '10',
-            'docs.deleted': '10',
-            'store.size': '1000',
-            'pri.store.size': '2000',
+        elasticsearch.client.asInternalUser.indices.stats.mockResponseOnce({
+          _all: {
+            primaries: {
+              docs: {
+                count: 10,
+                deleted: 10,
+              },
+              store: {
+                size_in_bytes: 2000,
+              },
+            },
+            total: {
+              store: {
+                size_in_bytes: 1000,
+              },
+            },
           },
-        ] as any);
+        } as any);
         elasticsearch.client.asInternalUser.count.mockResponseOnce({
           count: '15',
         } as any);
-        elasticsearch.client.asInternalUser.cat.indices.mockResponseOnce([
-          {
-            name: '.kibana_1',
-            'docs.count': '20',
-            'docs.deleted': '20',
-            'store.size': '2000',
-            'pri.store.size': '4000',
+        elasticsearch.client.asInternalUser.indices.stats.mockResponseOnce({
+          _all: {
+            primaries: {
+              docs: {
+                count: 20,
+                deleted: 20,
+              },
+              store: {
+                size_in_bytes: 4000,
+              },
+            },
+            total: {
+              store: {
+                size_in_bytes: 2000,
+              },
+            },
           },
-        ] as any);
+        } as any);
         elasticsearch.client.asInternalUser.count.mockResponseOnce({
           count: '10',
         } as any);
@@ -415,6 +433,112 @@ describe('CoreUsageDataService', () => {
             },
           }
         `);
+      });
+
+      it('returns zeroed index stats when indices stats are unavailable', async () => {
+        const http = httpServiceMock.createInternalSetupContract();
+        const metrics = metricsServiceMock.createInternalSetupContract();
+        const savedObjectsStartPromise = Promise.resolve(savedObjectsServiceMock.createStartContract());
+        const changedDeprecatedConfigPath$ = new BehaviorSubject({
+          set: ['new.path'],
+          unset: ['deprecated.path'],
+        });
+        service.setup({ http, metrics, savedObjectsStartPromise, changedDeprecatedConfigPath$ });
+        const elasticsearch = elasticsearchServiceMock.createStart();
+        elasticsearch.client.asInternalUser.indices.stats.mockResponseOnce({} as any);
+        elasticsearch.client.asInternalUser.count.mockResponseOnce({
+          count: '15',
+        } as any);
+        elasticsearch.client.asInternalUser.indices.stats.mockResponseOnce({} as any);
+        elasticsearch.client.asInternalUser.count.mockResponseOnce({
+          count: '10',
+        } as any);
+        elasticsearch.client.asInternalUser.search.mockResponseOnce({
+          hits: { total: { value: 6 } },
+          aggregations: {
+            aliases: {
+              buckets: {
+                active: { doc_count: 1 },
+                disabled: { doc_count: 2 },
+              },
+            },
+          },
+        } as any);
+        const typeRegistry = savedObjectsServiceMock.createTypeRegistryMock();
+        typeRegistry.getAllTypes.mockReturnValue([
+          { name: 'type 1', indexPattern: '.kibana' },
+          { name: 'type 2', indexPattern: '.kibana_task_manager' },
+        ] as any);
+
+        const { getCoreUsageData } = service.start({
+          savedObjects: savedObjectsServiceMock.createInternalStartContract(typeRegistry),
+          exposedConfigsToUsage: new Map(),
+          elasticsearch,
+        });
+
+        await expect(getCoreUsageData()).resolves.toEqual(
+          expect.objectContaining({
+            services: {
+              savedObjects: expect.objectContaining({
+                indices: [
+                  expect.objectContaining({
+                    alias: '.kibana',
+                    docsCount: 0,
+                    docsDeleted: 0,
+                    storeSizeBytes: 0,
+                    primaryStoreSizeBytes: 0,
+                  }),
+                  expect.objectContaining({
+                    alias: '.kibana_task_manager',
+                    docsCount: 0,
+                    docsDeleted: 0,
+                    storeSizeBytes: 0,
+                    primaryStoreSizeBytes: 0,
+                  }),
+                ],
+              }),
+            },
+          })
+        );
+      });
+
+      it('throws when fetching index stats fails', async () => {
+        const http = httpServiceMock.createInternalSetupContract();
+        const metrics = metricsServiceMock.createInternalSetupContract();
+        const savedObjectsStartPromise = Promise.resolve(savedObjectsServiceMock.createStartContract());
+        const changedDeprecatedConfigPath$ = new BehaviorSubject({
+          set: ['new.path'],
+          unset: ['deprecated.path'],
+        });
+        service.setup({ http, metrics, savedObjectsStartPromise, changedDeprecatedConfigPath$ });
+        const elasticsearch = elasticsearchServiceMock.createStart();
+        elasticsearch.client.asInternalUser.indices.stats.mockRejectedValueOnce(
+          new Error('stats boom')
+        );
+        elasticsearch.client.asInternalUser.search.mockResponseOnce({
+          hits: { total: { value: 6 } },
+          aggregations: {
+            aliases: {
+              buckets: {
+                active: { doc_count: 1 },
+                disabled: { doc_count: 2 },
+              },
+            },
+          },
+        } as any);
+        const typeRegistry = savedObjectsServiceMock.createTypeRegistryMock();
+        typeRegistry.getAllTypes.mockReturnValue([
+          { name: 'type 1', indexPattern: '.kibana' },
+          { name: 'type 2', indexPattern: '.kibana_task_manager' },
+        ] as any);
+
+        const { getCoreUsageData } = service.start({
+          savedObjects: savedObjectsServiceMock.createInternalStartContract(typeRegistry),
+          exposedConfigsToUsage: new Map(),
+          elasticsearch,
+        });
+
+        await expect(getCoreUsageData()).rejects.toThrow('stats boom');
       });
 
       describe('elasticsearch.principal', () => {

--- a/src/core/packages/usage-data/server-internal/src/core_usage_data_service.ts
+++ b/src/core/packages/usage-data/server-internal/src/core_usage_data_service.ts
@@ -136,8 +136,6 @@ export class CoreUsageDataService
           .stats({
             index,
             metric: ['docs', 'store'],
-            ignore_unavailable: true,
-            allow_no_indices: true,
           })
           .then((body) => {
             const stats = body._all;

--- a/src/core/packages/usage-data/server-internal/src/core_usage_data_service.ts
+++ b/src/core/packages/usage-data/server-internal/src/core_usage_data_service.ts
@@ -136,6 +136,12 @@ export class CoreUsageDataService
           .stats({
             index,
             metric: ['docs', 'store'],
+            filter_path: [
+              '_all.primaries.docs.count',
+              '_all.primaries.docs.deleted',
+              '_all.total.store.size_in_bytes',
+              '_all.primaries.store.size_in_bytes',
+            ],
           })
           .then((body) => {
             const stats = body._all;

--- a/src/core/packages/usage-data/server-internal/src/core_usage_data_service.ts
+++ b/src/core/packages/usage-data/server-internal/src/core_usage_data_service.ts
@@ -129,26 +129,25 @@ export class CoreUsageDataService
           }, new Set<string>())
           .values()
       ).map(async (index) => {
-        // The _cat/indices API returns the _index_ and doesn't return a way
-        // to map back from the index to the alias. So we have to make an API
-        // call for every alias. The document count is the lucene document count.
-        const catIndicesResults = await elasticsearch.client.asInternalUser.cat
-          .indices({
+        // Use indices stats instead of CAT since this data is consumed by telemetry.
+        // We make one request per alias/index-pattern and rely on `_all` to aggregate
+        // matching concrete indices while preserving the alias identifier we report.
+        const indexStatsResults = await elasticsearch.client.asInternalUser.indices
+          .stats({
             index,
-            format: 'JSON',
-            bytes: 'b',
+            metric: ['docs', 'store'],
+            ignore_unavailable: true,
+            allow_no_indices: true,
           })
           .then((body) => {
-            const stats = body[0];
+            const stats = body._all;
 
             return {
               alias: index,
-              docsCount: stats['docs.count'] ? parseInt(stats['docs.count'], 10) : 0,
-              docsDeleted: stats['docs.deleted'] ? parseInt(stats['docs.deleted'], 10) : 0,
-              storeSizeBytes: stats['store.size'] ? parseInt(stats['store.size'], 10) : 0,
-              primaryStoreSizeBytes: stats['pri.store.size']
-                ? parseInt(stats['pri.store.size'], 10)
-                : 0,
+              docsCount: stats?.primaries?.docs?.count ?? 0,
+              docsDeleted: stats?.primaries?.docs?.deleted ?? 0,
+              storeSizeBytes: stats?.total?.store?.size_in_bytes ?? 0,
+              primaryStoreSizeBytes: stats?.primaries?.store?.size_in_bytes ?? 0,
             };
           });
         // We use the GET <index>/_count API to get the number of saved objects
@@ -163,13 +162,13 @@ export class CoreUsageDataService
             };
           });
         this.logger.debug(
-          `Lucene documents count ${catIndicesResults.docsCount} from index ${catIndicesResults.alias}`
+          `Lucene documents count ${indexStatsResults.docsCount} from index ${indexStatsResults.alias}`
         );
         this.logger.debug(
-          `Saved objects documents count ${savedObjectsCounts.savedObjectsDocsCount} from index ${catIndicesResults.alias}`
+          `Saved objects documents count ${savedObjectsCounts.savedObjectsDocsCount} from index ${indexStatsResults.alias}`
         );
         return {
-          ...catIndicesResults,
+          ...indexStatsResults,
           ...savedObjectsCounts,
         };
       })

--- a/x-pack/platform/test/api_integration/apis/telemetry/telemetry_local.ts
+++ b/x-pack/platform/test/api_integration/apis/telemetry/telemetry_local.ts
@@ -215,5 +215,33 @@ export default function ({ getService }: FtrProviderContext) {
 
       expect(expected.every((m) => actual.includes(m))).to.be.ok();
     });
+
+    it('should include core saved objects indices usage stats', () => {
+      const indices = stats.stack_stats.kibana.plugins.core.services.savedObjects.indices;
+
+      expect(indices).to.be.an('array');
+      expect(indices.length).to.be.greaterThan(0);
+
+      const kibanaIndex = indices.find(({ alias }: { alias: string }) => alias === '.kibana');
+      const taskManagerIndex = indices.find(
+        ({ alias }: { alias: string }) => alias === '.kibana_task_manager'
+      );
+
+      expect(kibanaIndex).to.be.an('object');
+      expect(taskManagerIndex).to.be.an('object');
+
+      [kibanaIndex, taskManagerIndex].forEach((index) => {
+        expect(index.docsCount).to.be.a('number');
+        expect(index.docsCount).to.be.greaterThan(-1);
+        expect(index.docsDeleted).to.be.a('number');
+        expect(index.docsDeleted).to.be.greaterThan(-1);
+        expect(index.storeSizeBytes).to.be.a('number');
+        expect(index.storeSizeBytes).to.be.greaterThan(-1);
+        expect(index.primaryStoreSizeBytes).to.be.a('number');
+        expect(index.primaryStoreSizeBytes).to.be.greaterThan(-1);
+        expect(index.savedObjectsDocsCount).to.be.a('number');
+        expect(index.savedObjectsDocsCount).to.be.greaterThan(-1);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
close https://github.com/elastic/kibana/issues/253219

- Replace core usage data collection of saved objects index metrics from `cat.indices` with `indices.stats` to avoid relying on a human-oriented API.
- Keep the telemetry payload shape unchanged and add fallback/error-path unit coverage.
- Add an API integration assertion that telemetry includes `core.services.savedObjects.indices` stats for `.kibana` and `.kibana_task_manager`.

## Test plan
- [x] `yarn test:jest src/core/packages/usage-data/server-internal/src/core_usage_data_service.test.ts`
- [x] API integration suite (`x-pack/platform/test/api_integration/apis/telemetry/telemetry_local.ts`)

Made with [Cursor](https://cursor.com)