### PR TITLE
[1Feedback] Adjust 1Feedback send button behavior

### DIFF
--- a/src/platform/packages/shared/feedback-components/src/components/body/email/email_input.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/body/email/email_input.tsx
@@ -18,6 +18,7 @@ export interface EmailInputProps {
   handleChangeEmail: (email: string) => void;
   onValidationChange: (isValid: boolean) => void;
   getCurrentUserEmail: () => Promise<string | undefined>;
+  forceShowError?: boolean;
 }
 
 const validateEmail = (value: string): boolean => {
@@ -37,13 +38,14 @@ export const EmailInput = ({
   handleChangeEmail,
   onValidationChange,
   getCurrentUserEmail,
+  forceShowError = false,
 }: EmailInputProps) => {
   const hasFetchedEmailRef = useRef(false);
   const [touched, setTouched] = useState(false);
 
   const isValid = useMemo(() => validateEmail(email), [email]);
 
-  const showError = touched && !isValid;
+  const showError = (touched || forceShowError) && !isValid;
 
   useEffect(() => {
     onValidationChange(isValid);

--- a/src/platform/packages/shared/feedback-components/src/components/body/email/email_section.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/body/email/email_section.tsx
@@ -19,6 +19,7 @@ export interface EmailSectionProps {
   handleChangeEmail: (email: string) => void;
   onEmailValidationChange: (isValid: boolean) => void;
   getCurrentUserEmail: () => Promise<string | undefined>;
+  forceShowEmailError?: boolean;
 }
 
 export const EmailSection = ({
@@ -28,6 +29,7 @@ export const EmailSection = ({
   handleChangeEmail,
   onEmailValidationChange,
   getCurrentUserEmail,
+  forceShowEmailError = false,
 }: EmailSectionProps) => {
   return (
     <EuiFormRow display="center">
@@ -45,6 +47,7 @@ export const EmailSection = ({
               handleChangeEmail={handleChangeEmail}
               onValidationChange={onEmailValidationChange}
               getCurrentUserEmail={getCurrentUserEmail}
+              forceShowError={forceShowEmailError}
             />
           </EuiFlexItem>
         )}

--- a/src/platform/packages/shared/feedback-components/src/components/body/feedback_body.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/body/feedback_body.tsx
@@ -30,6 +30,7 @@ export interface FeedbackBodyProps {
   handleChangeEmail: (email: string) => void;
   onEmailValidationChange: (isValid: boolean) => void;
   getCurrentUserEmail: () => Promise<string | undefined>;
+  forceShowEmailError?: boolean;
 }
 
 export const FeedbackBody = ({
@@ -45,6 +46,7 @@ export const FeedbackBody = ({
   handleChangeEmail,
   onEmailValidationChange,
   getCurrentUserEmail,
+  forceShowEmailError = false,
 }: FeedbackBodyProps) => {
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
@@ -92,6 +94,7 @@ export const FeedbackBody = ({
             handleChangeEmail={handleChangeEmail}
             onEmailValidationChange={onEmailValidationChange}
             getCurrentUserEmail={getCurrentUserEmail}
+            forceShowEmailError={forceShowEmailError}
           />
         </EuiForm>
       </EuiFlexItem>

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_container.test.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_container.test.tsx
@@ -126,7 +126,7 @@ describe('FeedbackContainer', () => {
     });
   });
 
-  it('should disable send button when email is invalid and email consent is checked', async () => {
+  it('should block submission and show email error when email is invalid and email consent is checked', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
     const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
@@ -140,10 +140,15 @@ describe('FeedbackContainer', () => {
     await userEvent.clear(emailInput);
     await userEvent.type(emailInput, 'invalid-email');
 
+    const sendButton = screen.getByTestId('feedbackFooterSendFeedbackButton');
+    expect(sendButton).not.toBeDisabled();
+
+    await userEvent.click(sendButton);
+
     await waitFor(() => {
-      const sendButton = screen.getByTestId('feedbackFooterSendFeedbackButton');
-      expect(sendButton).toBeDisabled();
+      expect(screen.getByText('Enter a valid email address')).toBeInTheDocument();
     });
+    expect(mockProps.sendFeedback).not.toHaveBeenCalled();
   });
 
   it('should enable send button when email is valid and email consent is checked', async () => {
@@ -165,7 +170,8 @@ describe('FeedbackContainer', () => {
     });
   });
 
-  it('should disable send button when email is empty and email consent is checked', async () => {
+  it('should block submission and show email error when email is empty and email consent is checked', async () => {
+    mockProps.getCurrentUserEmail.mockResolvedValue(undefined);
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
     const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
@@ -176,10 +182,15 @@ describe('FeedbackContainer', () => {
 
     await screen.findByTestId('feedbackEmailInput');
 
+    const sendButton = screen.getByTestId('feedbackFooterSendFeedbackButton');
+    expect(sendButton).not.toBeDisabled();
+
+    await userEvent.click(sendButton);
+
     await waitFor(() => {
-      const sendButton = screen.getByTestId('feedbackFooterSendFeedbackButton');
-      expect(sendButton).toBeDisabled();
+      expect(screen.getByText('Enter a valid email address')).toBeInTheDocument();
     });
+    expect(mockProps.sendFeedback).not.toHaveBeenCalled();
   });
 
   it('should enable send button when email consent is unchecked', async () => {

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_container.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_container.tsx
@@ -41,6 +41,7 @@ export const FeedbackContainer = ({
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isEmailValid, setIsEmailValid] = useState(true);
+  const [forceShowEmailError, setForceShowEmailError] = useState(false);
 
   const { title: appTitle, id: appId, url: appUrl } = getAppDetails();
   const questions = getQuestions(appId);
@@ -49,9 +50,7 @@ export const FeedbackContainer = ({
     selectedCsatOptionId ||
     Object.values(questionAnswers).some((answer) => answer.trim().length > 0);
 
-  const isEmailFilled = !allowEmailContact || isEmailValid;
-
-  const isSendFeedbackButtonDisabled = !isFormFilled || !isEmailFilled;
+  const isSendFeedbackButtonDisabled = !isFormFilled;
 
   const handleChangeCsatOptionId = (optionId: string) => {
     setSelectedCsatOptionId(optionId);
@@ -77,6 +76,12 @@ export const FeedbackContainer = ({
   };
 
   const submitFeedback = async () => {
+    // Check if email is required but invalid
+    if (allowEmailContact && !isEmailValid) {
+      setForceShowEmailError(true);
+      return;
+    }
+
     try {
       setIsSubmitting(true);
 
@@ -144,6 +149,7 @@ export const FeedbackContainer = ({
         handleChangeEmail={handleChangeEmail}
         onEmailValidationChange={handleEmailValidationChange}
         getCurrentUserEmail={getCurrentUserEmail}
+        forceShowEmailError={forceShowEmailError}
       />
       <FeedbackFooter
         isSendFeedbackButtonDisabled={isSendFeedbackButtonDisabled}


### PR DESCRIPTION
## Summary

This PR updates the send button disabled behavior to not be disabled when email input is empty and instead force the email input to be in error state when send button is clicked, blocking the submission but not disabling the button.



