### PR TITLE
[Obs AI] Add AGENTS.md documentation for AI Insights and OpenTelemetry Demo

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md
+++ b/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md
@@ -1,10 +1,16 @@
-# Developer & Agent Instructions
+# Synthtrace Scenarios for Observability Agent Builder
 
-## Context: File Locations & Paths
+**Audience**: LLM coding agents working on Synthtrace scenarios for Agent Builder tools and AI Insights.
 
-- **Tools Source:** `@x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/`
-- **Tests:** `@x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/`
-- **Synthtrace Scenarios:** `@src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/tools/`
+Every tool and AI Insight must have a Synthtrace scenario that generates realistic synthetic data for testing. Scenarios live under `tools/` and `ai_insights/` subdirectories respectively.
+
+> **See also**: [Tool Development Guidelines](../../../../../../x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md) for tool design principles and APM data types.
+
+## File Locations
+
+- **Tools Source:** `x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/`
+- **Tests:** `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/`
+- **Synthtrace Scenarios:** `src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/`
 
 ## How to Validate Tools
 

--- a/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md
+++ b/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md
@@ -4,7 +4,7 @@
 
 Every tool and AI Insight must have a Synthtrace scenario that generates realistic synthetic data for testing. Scenarios live under `tools/` and `ai_insights/` subdirectories respectively.
 
-> **See also**: [Tool Development Guidelines](../../../../../../x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md) for tool design principles and APM data types.
+> **See also**: [Tool Development Guidelines](../../../../../../../../x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md) for tool design principles and APM data types.
 
 ## File Locations
 
@@ -40,6 +40,7 @@ To execute a tool via the Kibana API, use the following `curl` command.
 curl -X POST http://localhost:5601/api/agent_builder/tools/_execute \
   -u elastic:changeme \
   -H 'kbn-xsrf: true' \
+  -H 'x-elastic-internal-origin: kibana' \
   -H 'Content-Type: application/json' \
   -d '{
         "tool_id": "observability.<tool_name>",
@@ -68,6 +69,7 @@ node scripts/synthtrace src/platform/packages/shared/kbn-synthtrace/src/scenario
 curl -X POST http://localhost:5601/internal/observability_agent_builder/ai_insights/alert \
   -u elastic:changeme \
   -H 'kbn-xsrf: true' \
+  -H 'x-elastic-internal-origin: kibana' \
   -H 'Content-Type: application/json' \
   -d '{
         "alert_id": "my_alert_id"

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/AGENTS.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/AGENTS.md
@@ -1,0 +1,17 @@
+# Observability Agent Builder
+
+**Audience**: LLM coding agents working on the Observability Agent Builder plugin.
+
+The Observability Agent Builder plugin provides LLM-powered tools and insights for Site Reliability Engineers (SREs) investigating incidents. It exposes Observability data (logs, metrics, traces) to LLM agents and delivers one-click AI-generated summaries in the Kibana UI.
+
+---
+
+## Domain-Specific Guides
+
+- **[Tools](./server/tools/AGENTS.md)** (`server/tools/AGENTS.md`) — Tool design principles, ECS/OTel compatibility, APM data types, parameter conventions, testing workflows, and the pre-merge checklist for Observability tools.
+
+- **[AI Insights](./server/routes/ai_insights/AGENTS.md)** (`server/routes/ai_insights/AGENTS.md`) — Architecture of one-click AI Insights (prefetched context, hardcoded prompts), prompt design, UI integration, conversation handoff, and testing.
+
+- **[API Integration Tests](../../../test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md)** (`x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md`) — How to run API integration tests, test structure guidelines, and shared utilities.
+
+- **[Synthtrace Scenarios](../../../../../src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md)** (`src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md`) — How to generate synthetic test data for tools and AI Insights using Synthtrace scenarios.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/AGENTS.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/AGENTS.md
@@ -12,6 +12,6 @@ The Observability Agent Builder plugin provides LLM-powered tools and insights f
 
 - **[AI Insights](./server/routes/ai_insights/AGENTS.md)** (`server/routes/ai_insights/AGENTS.md`) — Architecture of one-click AI Insights (prefetched context, hardcoded prompts), prompt design, UI integration, conversation handoff, and testing.
 
-- **[API Integration Tests](../../../test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md)** (`x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md`) — How to run API integration tests, test structure guidelines, and shared utilities.
+- **[API Integration Tests](../../test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md)** (`x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md`) — How to run API integration tests, test structure guidelines, and shared utilities.
 
 - **[Synthtrace Scenarios](../../../../../src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md)** (`src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/AGENTS.md`) — How to generate synthetic test data for tools and AI Insights using Synthtrace scenarios.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/AGENTS.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## About This Document
 
-**Audience**: LLM coding agents working on Observability AI Insights.
+**Audience**: LLM coding agents working on AI Insights, Observability Agent or Agent Builder in general.
 
-**Purpose**: AI Insights are one-click, LLM-powered explanations for Observability data — alerts, APM errors, and log entries. The user clicks a button in the Kibana UI (e.g., "Help me understand this alert") and receives an AI-generated summary without writing a prompt or starting a conversation.
+**Purpose**: AI Insights are one-click, LLM-powered explanations for Observability data — logs, metrics, traces and alerts. The user clicks a button in the Kibana UI (e.g., "Help me understand this alert") and receives an AI-generated summary without needing to write a prompt or starting a conversation.
 
 Two characteristics define AI Insights and distinguish them from the Observability Agent:
 
@@ -12,22 +12,17 @@ Two characteristics define AI Insights and distinguish them from the Observabili
 
 2. **Hardcoded prompts** — The system and user prompts are static and defined in code. There is no user-provided prompt. Each insight type has a fixed question (e.g., "analyze this alert and summarize the cause, impact, and next steps") and a fixed output structure. The only variable input is the prefetched context.
 
-**Include**: Architecture, data flow, context assembly, prompt design, and UI integration specific to AI Insights.
-
-**Exclude**: Generic LLM/streaming knowledge, Agent Builder tool conventions (see `server/tools/AGENTS.md`).
-
 ---
 
 ## 1. How AI Insights Differ from Tools
 
-| Aspect            | Observability Agent                      | AI Insights                                                                           |
-| ----------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
-| **Trigger**       | User writes a conversational prompt      | User clicks a button (no prompt)                                                      |
-| **Data fetching** | LLM decides what to fetch via tool calls | Predetermined — all context is prefetched without LLM involvement                     |
-| **Prompt**        | User-provided, open-ended                | Hardcoded per insight type (static question + fixed output structure)                 |
-| **Output**        | Conversational response from the agent   | Streamed markdown rendered directly to the user                                       |
-| **API surface**   | `POST /api/agent_builder/converse`       | `POST /internal/observability_agent_builder/ai_insights/{type}`                       |
-| **Conversation**  | Multi-turn agent loop                    | Standalone; user can optionally continue into a conversation via "Start conversation" |
+| Aspect            | Observability Agent                        | AI Insights                                                           |
+| ----------------- | ------------------------------------------ | --------------------------------------------------------------------- |
+| **Trigger**       | User writes a conversational prompt        | User clicks a button (no prompt)                                      |
+| **Data fetching** | LLM decides what to fetch via tool calling | Predetermined — all context is prefetched without LLM involvement     |
+| **Prompt**        | User-provided, open-ended                  | Hardcoded per insight type (static question + fixed output structure) |
+| **API surface**   | `POST /api/agent_builder/converse`         | `POST /internal/observability_agent_builder/ai_insights/{type}`       |
+| **Conversation**  | Multi-turn agent loop                      | Single-turn; user can optionally continue into a conversation         |
 
 ---
 
@@ -45,24 +40,14 @@ To understand which data sources a specific insight prefetches, read the corresp
 
 ### Data Flow
 
-```
-User clicks button in UI (e.g., "Help me understand this alert")
-  → Insight component calls the corresponding AI Insights API endpoint
-  → Server prefetches the primary document + all related context (no LLM involvement)
-  → Prefetched context is injected into hardcoded prompts
-  → LLM generates a streamed markdown response (single call, no tool use)
-  → Summary is rendered in real time in an accordion
-  → Optional: "Start conversation" opens Agent flyout with the insight as context
-```
+User clicks button in UI (e.g., "Help me understand this alert"):
 
-### Server-Side Pattern
-
-Every insight follows the same pattern:
-
-1. **Fetch the primary document** (alert, error, or log) from Elasticsearch.
-2. **Prefetch all related context** from predetermined data sources. The set of sources is hardcoded per insight type — the LLM has no influence on what is fetched. Alert and error insights use the data registry and tool handlers; log insights use direct ES queries.
-3. **Inject context into hardcoded prompts**. The system prompt defines the LLM's role (SRE Assistant) and output structure. The user prompt contains the prefetched context and a static task directive.
-4. **Stream the LLM response** back to the client. This is a single LLM call with no agentic loop or tool use — the LLM simply summarizes the provided context.
+- Insight component calls the corresponding AI Insights API endpoint
+- Server prefetches the primary document + all related context (no LLM involvement)
+- Prefetched context and static prompts are sent to an LLM
+- LLM generates a markdown response (single call, no tool use)
+- Summary is dislayed to the user
+- Optional: "Start conversation" opens Agent flyout with the insight as context
 
 ---
 
@@ -116,12 +101,26 @@ After viewing an insight, users can click "Start conversation" to open the Agent
 
 ### File Locations
 
-| Type           | Path                                                                                                                    |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Server routes  | `server/routes/ai_insights/`                                                                                            |
-| UI components  | `public/components/insights/`, `public/components/ai_insight/`                                                          |
-| API tests      | `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/ai_insights/` |
-| Test utilities | `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/utils/`       |
+| Type          | Path                                                                                                                    |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Server routes | `server/routes/ai_insights/`                                                                                            |
+| UI components | `public/components/insights/`, `public/components/ai_insight/`                                                          |
+| API tests     | `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/ai_insights/` |
+
+### Invoking AI Insights Locally
+
+All endpoints are internal and return SSE streams. Example using the log insight:
+
+```bash
+curl -X POST http://localhost:5601/internal/observability_agent_builder/ai_insights/log \
+  -u elastic:changeme \
+  -H 'kbn-xsrf: true' \
+  -H 'x-elastic-internal-origin: kibana' \
+  -H 'Content-Type: application/json' \
+  -d '{ "index": "<log_index>", "id": "<document_id>" }'
+```
+
+The endpoint pattern is `POST /internal/observability_agent_builder/ai_insights/{type}`. Each type has its own required body parameters — check `route.ts` for the schema.
 
 ### Running API Tests
 
@@ -130,33 +129,3 @@ node scripts/functional_test_runner \
   --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts \
   --grep="ai_insights"
 ```
-
-Or use the alias:
-
-```bash
-oia-test-api-runner-stateful --grep="ai_insights"
-```
-
-**Note**: All AI Insights tests are tagged `skipCloud` because they use an LLM proxy to mock AI responses.
-
-### Test Architecture
-
-Tests use an LLM proxy that intercepts LLM requests and returns canned responses. The proxy also captures the messages sent to the LLM, enabling assertions on both:
-
-- **Response content**: Verify the streamed summary and context.
-- **LLM prompt content**: Verify that the system and user messages contain expected context (e.g., `<ErrorDetails>`, `<DownstreamDependencies>`, `<CorrelatedLogSequence>`).
-
-### Test Data
-
-Each insight test has a synthtrace scenario that generates the required Observability data (e.g., APM errors, distributed traces, log entries). These live alongside the test specs or in the shared `utils/synthtrace_scenarios/ai_insights/` directory.
-
----
-
-## 7. Adding a New Insight Type
-
-1. **Server**: Create a `get_<type>_ai_insights.ts` in `server/routes/ai_insights/`. Follow the existing pattern: fetch document → assemble context → build prompts → stream LLM response.
-2. **Route**: Register the endpoint in `route.ts`. Use `POST /internal/observability_agent_builder/ai_insights/<type>`, require `apiPrivileges.readAgentBuilder`, return SSE stream.
-3. **UI component**: Create a component in `public/components/insights/`. Follow the existing insight components for the streaming and attachment patterns.
-4. **Registration**: Register the component either via a feature registry (like Discover) or expose a factory function for consuming plugins.
-5. **Attachment type**: If needed, add a new attachment type constant in `common/constants.ts` and register its UI definition.
-6. **Tests**: Add an API test in `ai_insights/` with synthtrace data, LLM proxy, and assertions on both the response and the LLM prompt content.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/AGENTS.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/AGENTS.md
@@ -1,0 +1,162 @@
+# AI Insights
+
+## About This Document
+
+**Audience**: LLM coding agents working on Observability AI Insights.
+
+**Purpose**: AI Insights are one-click, LLM-powered explanations for Observability data — alerts, APM errors, and log entries. The user clicks a button in the Kibana UI (e.g., "Help me understand this alert") and receives an AI-generated summary without writing a prompt or starting a conversation.
+
+Two characteristics define AI Insights and distinguish them from the Observability Agent:
+
+1. **Prefetched context** — All data is fetched up front via predetermined queries, without consulting the LLM. The Agent, by contrast, decides what data to fetch on-the-fly via LLM-selected tool calls. AI Insights hardcode which data sources to query for each insight type (e.g., an alert insight always fetches service summary, downstream dependencies, change points, log groups, and runtime metrics).
+
+2. **Hardcoded prompts** — The system and user prompts are static and defined in code. There is no user-provided prompt. Each insight type has a fixed question (e.g., "analyze this alert and summarize the cause, impact, and next steps") and a fixed output structure. The only variable input is the prefetched context.
+
+**Include**: Architecture, data flow, context assembly, prompt design, and UI integration specific to AI Insights.
+
+**Exclude**: Generic LLM/streaming knowledge, Agent Builder tool conventions (see `server/tools/AGENTS.md`).
+
+---
+
+## 1. How AI Insights Differ from Tools
+
+| Aspect            | Observability Agent                      | AI Insights                                                                           |
+| ----------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Trigger**       | User writes a conversational prompt      | User clicks a button (no prompt)                                                      |
+| **Data fetching** | LLM decides what to fetch via tool calls | Predetermined — all context is prefetched without LLM involvement                     |
+| **Prompt**        | User-provided, open-ended                | Hardcoded per insight type (static question + fixed output structure)                 |
+| **Output**        | Conversational response from the agent   | Streamed markdown rendered directly to the user                                       |
+| **API surface**   | `POST /api/agent_builder/converse`       | `POST /internal/observability_agent_builder/ai_insights/{type}`                       |
+| **Conversation**  | Multi-turn agent loop                    | Standalone; user can optionally continue into a conversation via "Start conversation" |
+
+---
+
+## 2. Context Assembly
+
+Each insight type defines its own set of predetermined data sources. The server fetches all of them before calling the LLM. Context sources are specific to the domain — for example, the alert insight (`get_alert_ai_insights.ts`) fetches the alert document, APM service summary, downstream dependencies, change points, log groups, and runtime metrics, each with a hardcoded time window relative to the alert start time.
+
+Each context source is wrapped in XML-style tags (e.g., `<ErrorDetails>`, `<DownstreamDependencies>`, `<CorrelatedLogSequence>`) with JSON payloads, making it easy for the LLM to distinguish between sources.
+
+To understand which data sources a specific insight prefetches, read the corresponding `get_*_ai_insights.ts` or `generate_*_ai_insight.ts` file in `server/routes/ai_insights/`.
+
+---
+
+## 3. Architecture
+
+### Data Flow
+
+```
+User clicks button in UI (e.g., "Help me understand this alert")
+  → Insight component calls the corresponding AI Insights API endpoint
+  → Server prefetches the primary document + all related context (no LLM involvement)
+  → Prefetched context is injected into hardcoded prompts
+  → LLM generates a streamed markdown response (single call, no tool use)
+  → Summary is rendered in real time in an accordion
+  → Optional: "Start conversation" opens Agent flyout with the insight as context
+```
+
+### Server-Side Pattern
+
+Every insight follows the same pattern:
+
+1. **Fetch the primary document** (alert, error, or log) from Elasticsearch.
+2. **Prefetch all related context** from predetermined data sources. The set of sources is hardcoded per insight type — the LLM has no influence on what is fetched. Alert and error insights use the data registry and tool handlers; log insights use direct ES queries.
+3. **Inject context into hardcoded prompts**. The system prompt defines the LLM's role (SRE Assistant) and output structure. The user prompt contains the prefetched context and a static task directive.
+4. **Stream the LLM response** back to the client. This is a single LLM call with no agentic loop or tool use — the LLM simply summarizes the provided context.
+
+---
+
+## 4. Prompt Design
+
+### Guardrails (all insight types)
+
+- **Strict factuality**: The LLM must only reference data provided in the context. No speculation or hallucination.
+- **Structured output**: Each insight type defines a specific output format (e.g., Summary / Assessment / Next Steps for alerts).
+- **SRE audience**: Language should be technical and actionable, appropriate for incident responders.
+- **Entity linking**: Prompts include instructions for generating Kibana deep links to services, traces, errors, and other entities via markdown links.
+
+### System Prompt Role
+
+All insight types use a system prompt that establishes the LLM as an "SRE Assistant" analyzing Observability data. The system prompt specifies:
+
+- The exact output sections expected
+- Rules against speculation
+- Formatting requirements (markdown)
+
+### User Prompt Structure
+
+The user prompt provides the assembled context and a task directive. Context is structured using XML-style tags for clear delineation (e.g., `<AlertDetails>`, `<ErrorContext>`, `<CorrelatedLogSequence>`).
+
+---
+
+## 5. UI Integration
+
+### Components
+
+Each insight type has a React component in `public/components/insights/` (e.g., `AlertAiInsight`). These are thin wrappers that define which API endpoint to call and what attachments to build for conversation handoff — the shared rendering logic lives in `public/components/ai_insight/`.
+
+Insight components are registered with their host surfaces via factory functions (e.g., `createAlertAIInsight`) or feature registries (e.g., `LogAiInsight` registers with Discover's shared features registry). Consuming plugins (APM, Alerts, Discover) call these to get a React component they can render.
+
+### Visibility Prerequisites
+
+The insight accordion only renders when ALL of these are true:
+
+- At least one GenAI connector is configured
+- Agent Builder plugin is available
+- Agent chat experience is enabled
+- Enterprise license
+
+### Conversation Handoff
+
+After viewing an insight, users can click "Start conversation" to open the Agent flyout. This passes **attachments** containing the generated summary, the raw prefetched context, and domain-specific identifiers (e.g., `alertId`, `errorId`). This gives the Agent full context to continue the investigation without the user repeating information.
+
+---
+
+## 6. Testing and Development
+
+### File Locations
+
+| Type           | Path                                                                                                                    |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Server routes  | `server/routes/ai_insights/`                                                                                            |
+| UI components  | `public/components/insights/`, `public/components/ai_insight/`                                                          |
+| API tests      | `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/ai_insights/` |
+| Test utilities | `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/utils/`       |
+
+### Running API Tests
+
+```bash
+node scripts/functional_test_runner \
+  --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts \
+  --grep="ai_insights"
+```
+
+Or use the alias:
+
+```bash
+oia-test-api-runner-stateful --grep="ai_insights"
+```
+
+**Note**: All AI Insights tests are tagged `skipCloud` because they use an LLM proxy to mock AI responses.
+
+### Test Architecture
+
+Tests use an LLM proxy that intercepts LLM requests and returns canned responses. The proxy also captures the messages sent to the LLM, enabling assertions on both:
+
+- **Response content**: Verify the streamed summary and context.
+- **LLM prompt content**: Verify that the system and user messages contain expected context (e.g., `<ErrorDetails>`, `<DownstreamDependencies>`, `<CorrelatedLogSequence>`).
+
+### Test Data
+
+Each insight test has a synthtrace scenario that generates the required Observability data (e.g., APM errors, distributed traces, log entries). These live alongside the test specs or in the shared `utils/synthtrace_scenarios/ai_insights/` directory.
+
+---
+
+## 7. Adding a New Insight Type
+
+1. **Server**: Create a `get_<type>_ai_insights.ts` in `server/routes/ai_insights/`. Follow the existing pattern: fetch document → assemble context → build prompts → stream LLM response.
+2. **Route**: Register the endpoint in `route.ts`. Use `POST /internal/observability_agent_builder/ai_insights/<type>`, require `apiPrivileges.readAgentBuilder`, return SSE stream.
+3. **UI component**: Create a component in `public/components/insights/`. Follow the existing insight components for the streaming and attachment patterns.
+4. **Registration**: Register the component either via a feature registry (like Discover) or expose a factory function for consuming plugins.
+5. **Attachment type**: If needed, add a new attachment type constant in `common/constants.ts` and register its UI definition.
+6. **Tests**: Add an API test in `ai_insights/` with synthtrace data, LLM proxy, and assertions on both the response and the LLM prompt content.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md
@@ -283,7 +283,7 @@ x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.t
 
 ## 8. Testing with OpenTelemetry Demo
 
-The [OpenTelemetry Demo](https://github.com/elastic/opentelemetry-demo) is a microservices application that generates realistic Observability data (traces, logs, metrics) and supports feature flags to simulate various failure scenarios. Use it to test tools against real-world-like incidents.
+The [OpenTelemetry Demo](https://github.com/elastic/opentelemetry-demo) is a microservices application that generates realistic Observability data (traces, logs, metrics) and supports feature flags to simulate various failure scenarios. Use it to validate the Observability Agent and individual tools against real-world-like incidents.
 
 ### Starting the OTel Demo
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md
@@ -281,7 +281,111 @@ x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.t
 
 ---
 
-## 8. Pre-Merge Checklist
+## 8. Testing with OpenTelemetry Demo
+
+The [OpenTelemetry Demo](https://github.com/elastic/opentelemetry-demo) is a microservices application that generates realistic Observability data (traces, logs, metrics) and supports feature flags to simulate various failure scenarios. Use it to test tools against real-world-like incidents.
+
+### Starting the OTel Demo
+
+Clone the repo and start the demo, configured to send data to your local Elasticsearch:
+
+```bash
+cd /path/to/opentelemetry-demo
+
+# Create an API key for the demo
+API_KEY=$(curl -s -X POST "http://localhost:9200/_security/api_key" \
+  -u elastic:changeme \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "opentelemetry-demo" }' | jq -r .encoded)
+
+sed -i '' -E "s|^ELASTICSEARCH_ENDPOINT=.*|ELASTICSEARCH_ENDPOINT=\"http://host.docker.internal:9200\"|" .env.override
+sed -i '' -E "s|^ELASTICSEARCH_API_KEY=.*|ELASTICSEARCH_API_KEY=$API_KEY|" .env.override
+
+# Start all services
+make start
+```
+
+This starts ~28 Docker containers. Wait for all containers to be healthy before proceeding. The demo sends data to the local Elasticsearch instance at `localhost:9200`.
+
+### Feature Flags
+
+Feature flags are configured via the `flagd` service. Edit the file:
+
+```
+/path/to/opentelemetry-demo/src/flagd/demo.flagd.json
+```
+
+Flagd watches this file for changes — edits take effect automatically (no restart needed).
+
+To enable a flag, change its `defaultVariant` from `"off"` to `"on"` (or to a specific variant for flags with multiple levels):
+
+```json
+"paymentUnreachable": {
+  "defaultVariant": "on",
+  ...
+}
+```
+
+To disable a flag, set `defaultVariant` back to `"off"`.
+
+Full list of available feature flags: https://opentelemetry.io/docs/demo/feature-flags/
+
+### Cleaning Data Between Test Runs
+
+Between test runs, delete all APM data streams to avoid data from previous scenarios polluting results:
+
+```bash
+for ds in traces-apm-default \
+           logs-apm.error-default \
+           metrics-apm.internal-default \
+           metrics-apm.transaction.1m-default \
+           metrics-apm.service_destination.1m-default \
+           metrics-apm.service_transaction.1m-default \
+           metrics-apm.service_summary.1m-default; do
+  curl -s -X DELETE "http://elastic:changeme@localhost:9200/_data_stream/$ds" | jq -r '.acknowledged // .error.type'
+done
+```
+
+### Wait for Data Accumulation
+
+After enabling feature flags and cleaning data, **wait at least 10 minutes** before running an investigation. This ensures enough metric rollups and trace data have been generated for meaningful analysis.
+
+When running the investigation tool, use a lookback window that matches the wait time:
+
+```bash
+curl -s --max-time 600 -X POST http://localhost:5601/api/agent_builder/tools/_execute \
+  -u elastic:changeme \
+  -H 'kbn-xsrf: true' \
+  -H 'x-elastic-internal-origin: kibana' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "tool_id": "observability.run_investigation",
+    "tool_params": { "start": "now-10m", "end": "now" }
+  }'
+```
+
+Note: the `run_investigation` tool makes multiple internal LLM calls and may take 60–120 seconds to complete. Use `--max-time 600` to avoid curl timeouts.
+
+### Full Test Workflow
+
+```
+1. Start OTel demo:          (see "Starting the OTel Demo" above)
+2. Clean APM data:           (delete data streams — see above)
+3. Enable feature flag(s):   Edit demo.flagd.json
+4. Wait 30 minutes:          sleep 600
+5. Run investigation:        curl ... run_investigation with start=now-30m
+6. Review results
+7. Disable feature flag(s):  Reset defaultVariant to "off"
+8. Repeat from step 2 for next scenario
+```
+
+### Resetting All Feature Flags
+
+After testing, reset all flags to `"off"` by setting each `defaultVariant` back to `"off"` in `demo.flagd.json`. Verify no flags are accidentally left enabled — leftover flags cause confusing results in subsequent tests.
+
+---
+
+## 9. Pre-Merge Checklist
 
 - [ ] Tool added to `allow_lists.ts`
 - [ ] Works with both ECS and OTel data (where applicable)

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/AGENTS.md
@@ -1,5 +1,7 @@
 # API Integration Tests for Observability Agent Builder
 
+**Audience**: LLM coding agents working on API integration tests for Agent Builder tools and AI Insights.
+
 > **See also**: [Tool Development Guidelines](../../../../plugins/observability_agent_builder/server/tools/AGENTS.md) for tool design principles, APM data types, and ECS/OTel compatibility.
 
 ## Running Tests
@@ -14,7 +16,7 @@ node scripts/functional_test_runner \
 ```bash
 node scripts/functional_test_runner \
   --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts \
-  --grep "<tool_name>"
+  --grep="<tool_name>"
 ```
 
 ## Test Structure Guidelines


### PR DESCRIPTION
Adds `AGENTS.md` files for the AI Insights and OpenTelemetry Demo to help coding agents.

- AI Insights are one-click, LLM-powered explanations for Observability data (alerts, APM errors, log entries). 
- OpenTelemetry demo is a pseudo-realistic  Observability data generator