### PR TITLE
[One Workflow] Suppress LiquidJS relativeReference warning in workflow templates

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine.ts
@@ -82,6 +82,8 @@ export const createWorkflowLiquidEngine = (options?: LiquidOptions): Liquid => {
     ownPropertyOnly: true,
     // Use a no-op filesystem as files are not supported in workflow templates
     fs: noopFs,
+    // Disable relative references since file operations are not supported
+    relativeReference: false,
     // Use an empty in-memory template store
     templates: {},
     // Max total characters allowed in a single parse() call (150k)


### PR DESCRIPTION
Fixes a console warning (`[LiquidJS] fs.dirname and fs.sep are required for relativeReference`) that appears when entering the workflows page.
The workflow Liquid engine uses a no-op filesystem since file operations are not supported in workflow templates. However, LiquidJS still expects `fs.dirname` and `fs.sep` for its relative reference resolution. Since file-inclusion tags (include, render, layout) are already stripped from the engine, setting `relativeReference: false` is the correct fix - it disables a feature that can never be used and silences the warning.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->