### PR TITLE
[SLO] Add public SLO Time Series Query API for historical SLI data

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/get_slo_timeseries.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/get_slo_timeseries.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import * as t from 'io-ts';
+import { sloIdSchema } from '../../schema/slo';
+import { allOrAnyString, dateType, errorBudgetSchema, statusSchema } from '../../schema/common';
+
+const getSLOTimeseriesParamsSchema = t.type({
+  path: t.type({
+    id: sloIdSchema,
+  }),
+  query: t.intersection([
+    t.type({
+      from: dateType,
+      to: dateType,
+    }),
+    t.partial({
+      instanceId: allOrAnyString,
+      remoteName: t.string,
+      bucketInterval: t.string,
+      includeRaw: t.union([t.literal('true'), t.literal('false')]),
+    }),
+  ]),
+});
+
+const timeseriesDataPointSchema = t.intersection([
+  t.type({
+    date: dateType,
+    sliValue: t.number,
+    status: statusSchema,
+    errorBudget: errorBudgetSchema,
+  }),
+  t.partial({
+    numerator: t.number,
+    denominator: t.number,
+  }),
+]);
+
+const getSLOTimeseriesResponseSchema = t.type({
+  sloId: sloIdSchema,
+  instanceId: allOrAnyString,
+  dataPoints: t.array(timeseriesDataPointSchema),
+});
+
+type GetSLOTimeseriesParams = t.TypeOf<typeof getSLOTimeseriesParamsSchema>;
+type GetSLOTimeseriesResponse = t.OutputOf<typeof getSLOTimeseriesResponseSchema>;
+
+export { getSLOTimeseriesParamsSchema, getSLOTimeseriesResponseSchema };
+export type { GetSLOTimeseriesParams, GetSLOTimeseriesResponse };

--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/index.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/index.ts
@@ -31,3 +31,4 @@ export * from './slo_templates';
 export * from './health_scan';
 export * from './search_slo_definitions';
 export * from './get_grouped_stats';
+export * from './get_slo_timeseries';

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
@@ -87,6 +87,14 @@ export const sloKeys = {
     };
     groupBy?: string[];
   }) => [...sloKeys.all, 'preview', params] as const,
+  timeseries: (params: {
+    sloId: string;
+    from: Date;
+    to: Date;
+    instanceId?: string;
+    bucketInterval?: string;
+    includeRaw?: boolean;
+  }) => [...sloKeys.all, 'timeseries', params] as const,
   burnRateRules: (search: string) => [...sloKeys.all, 'burnRateRules', search],
   instances: (params: {
     sloId: string;

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_timeseries.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_timeseries.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GetSLOTimeseriesResponse } from '@kbn/slo-schema';
+import { ALL_VALUE } from '@kbn/slo-schema';
+import { useQuery } from '@kbn/react-query';
+import { sloKeys } from './query_key_factory';
+import { usePluginContext } from './use_plugin_context';
+
+export interface UseFetchSloTimeseriesResponse {
+  data: GetSLOTimeseriesResponse | undefined;
+  isInitialLoading: boolean;
+  isLoading: boolean;
+  isRefetching: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+}
+
+export interface UseFetchSloTimeseriesParams {
+  sloId: string;
+  from: Date;
+  to: Date;
+  instanceId?: string;
+  remoteName?: string;
+  bucketInterval?: string;
+  includeRaw?: boolean;
+}
+
+export function useFetchSloTimeseries({
+  sloId,
+  from,
+  to,
+  instanceId,
+  remoteName,
+  bucketInterval,
+  includeRaw,
+}: UseFetchSloTimeseriesParams): UseFetchSloTimeseriesResponse {
+  const { sloClient } = usePluginContext();
+
+  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data } = useQuery({
+    queryKey: sloKeys.timeseries({
+      sloId,
+      from,
+      to,
+      instanceId,
+      bucketInterval,
+      includeRaw,
+    }),
+    queryFn: async ({ signal }) => {
+      try {
+        return await sloClient.fetch(
+          'GET /api/observability/slos/{id}/timeseries 2023-10-31',
+          {
+            params: {
+              path: { id: sloId },
+              query: {
+                from: from.toISOString(),
+                to: to.toISOString(),
+                ...(instanceId && instanceId !== ALL_VALUE && { instanceId }),
+                ...(remoteName && { remoteName }),
+                ...(bucketInterval && { bucketInterval }),
+                ...(includeRaw && { includeRaw: 'true' as const }),
+              },
+            },
+            signal,
+          }
+        );
+      } catch (error) {
+        // ignore error
+      }
+    },
+    enabled: Boolean(sloId && from && to),
+    refetchOnWindowFocus: false,
+    keepPreviousData: true,
+  });
+
+  return {
+    data,
+    isLoading,
+    isInitialLoading,
+    isRefetching,
+    isSuccess,
+    isError,
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_timeseries.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_timeseries.ts
@@ -52,23 +52,20 @@ export function useFetchSloTimeseries({
     }),
     queryFn: async ({ signal }) => {
       try {
-        return await sloClient.fetch(
-          'GET /api/observability/slos/{id}/timeseries 2023-10-31',
-          {
-            params: {
-              path: { id: sloId },
-              query: {
-                from: from.toISOString(),
-                to: to.toISOString(),
-                ...(instanceId && instanceId !== ALL_VALUE && { instanceId }),
-                ...(remoteName && { remoteName }),
-                ...(bucketInterval && { bucketInterval }),
-                ...(includeRaw && { includeRaw: 'true' as const }),
-              },
+        return await sloClient.fetch('GET /api/observability/slos/{id}/timeseries 2023-10-31', {
+          params: {
+            path: { id: sloId },
+            query: {
+              from: from.toISOString(),
+              to: to.toISOString(),
+              ...(instanceId && instanceId !== ALL_VALUE && { instanceId }),
+              ...(remoteName && { remoteName }),
+              ...(bucketInterval && { bucketInterval }),
+              ...(includeRaw && { includeRaw: 'true' as const }),
             },
-            signal,
-          }
-        );
+          },
+          signal,
+        });
       } catch (error) {
         // ignore error
       }

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_timeseries.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/get_slo_timeseries.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALL_VALUE, getSLOTimeseriesParamsSchema } from '@kbn/slo-schema';
+import { SloTimeseriesClient } from '../../services/slo_timeseries_client';
+import { SLODefinitionClient } from '../../services/slo_definition_client';
+import { createSloServerRoute } from '../create_slo_server_route';
+import { assertPlatinumLicense } from './utils/assert_platinum_license';
+
+export const getSloTimeseriesRoute = createSloServerRoute({
+  endpoint: 'GET /api/observability/slos/{id}/timeseries 2023-10-31',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
+  },
+  params: getSLOTimeseriesParamsSchema,
+  handler: async ({ request, logger, params, plugins, getScopedClients }) => {
+    await assertPlatinumLicense(plugins);
+    const { scopedClusterClient, spaceId, repository } = await getScopedClients({
+      request,
+      logger,
+    });
+
+    const definitionClient = new SLODefinitionClient(
+      repository,
+      scopedClusterClient.asCurrentUser,
+      logger
+    );
+    const timeseriesClient = new SloTimeseriesClient(scopedClusterClient.asCurrentUser);
+
+    const { from, to, instanceId, remoteName, bucketInterval, includeRaw } = params.query;
+
+    const { slo } = await definitionClient.execute(params.path.id, spaceId, remoteName);
+
+    return await timeseriesClient.fetch({
+      slo,
+      instanceId: instanceId ?? ALL_VALUE,
+      from,
+      to,
+      remoteName,
+      bucketInterval,
+      includeRaw: includeRaw === 'true',
+    });
+  },
+});

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import { aiBulkCreateSlosRoute } from './ai_bulk_create_slos';
+import { aiDiscoverSlosRoute } from './ai_discover_slos';
+import { aiGenerateSloRoute } from './ai_generate_slo';
+import { aiSuggestSloRoute } from './ai_suggest_slo';
 import { bulkDeleteSLORoute, getBulkDeleteStatusRoute } from './bulk_delete';
 import { bulkPurgeRollupRoute } from './bulk_purge_rollup';
 import { createSLORoute } from './create_slo';
@@ -22,6 +26,7 @@ import { getDiagnosisRoute } from './get_diagnosis';
 import { getPreviewData } from './get_preview_data';
 import { getSLORoute } from './get_slo';
 import { getSloBurnRates } from './get_slo_burn_rates';
+import { getSloTimeseriesRoute } from './get_slo_timeseries';
 import { getSloSettingsRoute } from './get_slo_settings';
 import { getSLOStatsOverview } from './get_slo_stats_overview';
 import { getSLOGroupedStatsRoute } from './get_grouped_stats';
@@ -55,6 +60,7 @@ export const getSloRouteRepository = (isServerless?: boolean) => {
     ...updateSLORoute,
     ...getDiagnosisRoute,
     ...getSloBurnRates,
+    ...getSloTimeseriesRoute,
     ...getPreviewData,
     ...resetSLORoute,
     ...findSLOGroupsRoute,
@@ -71,5 +77,9 @@ export const getSloRouteRepository = (isServerless?: boolean) => {
     ...findSLOTemplatesRoute,
     ...healthScanRoutes,
     ...searchSloDefinitionsRoute,
+    ...aiBulkCreateSlosRoute,
+    ...aiDiscoverSlosRoute,
+    ...aiGenerateSloRoute,
+    ...aiSuggestSloRoute,
   };
 };

--- a/x-pack/solutions/observability/plugins/slo/server/services/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/index.ts
@@ -24,3 +24,4 @@ export * from './find_slo_groups';
 export * from './get_slo_health';
 export * from './summary_search_client/summary_search_client';
 export * from './search_slo_definitions';
+export * from './slo_timeseries_client';

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_timeseries_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_timeseries_client.test.ts
@@ -240,9 +240,7 @@ describe('SloTimeseriesClient', () => {
           body: expect.objectContaining({
             query: expect.objectContaining({
               bool: expect.objectContaining({
-                filter: expect.arrayContaining([
-                  { term: { 'slo.instanceId': 'my-service' } },
-                ]),
+                filter: expect.arrayContaining([{ term: { 'slo.instanceId': 'my-service' } }]),
               }),
             }),
           }),

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_timeseries_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_timeseries_client.test.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClientMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { ALL_VALUE } from '@kbn/slo-schema';
+import moment from 'moment';
+import { createSLO, createSLOWithTimeslicesBudgetingMethod } from './fixtures/slo';
+import { SloTimeseriesClient } from './slo_timeseries_client';
+
+const commonEsResponse = {
+  took: 100,
+  timed_out: false,
+  _shards: { total: 0, successful: 0, skipped: 0, failed: 0 },
+  hits: { hits: [] },
+};
+
+describe('SloTimeseriesClient', () => {
+  let esClientMock: ElasticsearchClientMock;
+  let client: SloTimeseriesClient;
+
+  beforeEach(() => {
+    esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    client = new SloTimeseriesClient(esClientMock);
+  });
+
+  describe('fetch', () => {
+    it('returns timeseries data points for a rolling occurrences SLO', async () => {
+      const slo = createSLO();
+      const from = moment().subtract(7, 'days').toDate();
+      const to = new Date();
+
+      esClientMock.search.mockResolvedValueOnce({
+        ...commonEsResponse,
+        aggregations: {
+          daily: {
+            buckets: [
+              {
+                key_as_string: moment(from).add(1, 'day').toISOString(),
+                key: moment(from).add(1, 'day').valueOf(),
+                doc_count: 100,
+                good: { value: 97 },
+                total: { value: 100 },
+                cumulative_good: { value: 970 },
+                cumulative_total: { value: 1000 },
+              },
+              {
+                key_as_string: moment(from).add(2, 'days').toISOString(),
+                key: moment(from).add(2, 'days').valueOf(),
+                doc_count: 100,
+                good: { value: 95 },
+                total: { value: 100 },
+                cumulative_good: { value: 1940 },
+                cumulative_total: { value: 2000 },
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await client.fetch({
+        slo,
+        instanceId: ALL_VALUE,
+        from,
+        to,
+        includeRaw: false,
+      });
+
+      expect(result.sloId).toBe(slo.id);
+      expect(result.instanceId).toBe(ALL_VALUE);
+      expect(result.dataPoints).toHaveLength(2);
+      expect(result.dataPoints[0]).toEqual(
+        expect.objectContaining({
+          sliValue: expect.any(Number),
+          status: expect.any(String),
+          errorBudget: expect.objectContaining({
+            initial: expect.any(Number),
+            consumed: expect.any(Number),
+            remaining: expect.any(Number),
+            isEstimated: expect.any(Boolean),
+          }),
+        })
+      );
+      expect(result.dataPoints[0].numerator).toBeUndefined();
+      expect(result.dataPoints[0].denominator).toBeUndefined();
+    });
+
+    it('includes raw numerator/denominator when includeRaw is true', async () => {
+      const slo = createSLO();
+      const from = moment().subtract(7, 'days').toDate();
+      const to = new Date();
+
+      esClientMock.search.mockResolvedValueOnce({
+        ...commonEsResponse,
+        aggregations: {
+          daily: {
+            buckets: [
+              {
+                key_as_string: moment(from).add(1, 'day').toISOString(),
+                key: moment(from).add(1, 'day').valueOf(),
+                doc_count: 100,
+                good: { value: 97 },
+                total: { value: 100 },
+                cumulative_good: { value: 970 },
+                cumulative_total: { value: 1000 },
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await client.fetch({
+        slo,
+        instanceId: ALL_VALUE,
+        from,
+        to,
+        includeRaw: true,
+      });
+
+      expect(result.dataPoints[0].numerator).toBe(97);
+      expect(result.dataPoints[0].denominator).toBe(100);
+    });
+
+    it('works with timeslices budgeting method', async () => {
+      const slo = createSLOWithTimeslicesBudgetingMethod();
+      const from = moment().subtract(7, 'days').toDate();
+      const to = new Date();
+
+      esClientMock.search.mockResolvedValueOnce({
+        ...commonEsResponse,
+        aggregations: {
+          daily: {
+            buckets: [
+              {
+                key_as_string: moment(from).add(1, 'day').toISOString(),
+                key: moment(from).add(1, 'day').valueOf(),
+                doc_count: 100,
+                good: { value: 95 },
+                total: { value: 100 },
+                cumulative_good: { value: 950 },
+                cumulative_total: { value: 1000 },
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await client.fetch({
+        slo,
+        instanceId: ALL_VALUE,
+        from,
+        to,
+        includeRaw: false,
+      });
+
+      expect(result.dataPoints).toHaveLength(1);
+      expect(result.dataPoints[0].sliValue).toEqual(expect.any(Number));
+      expect(result.dataPoints[0].status).toEqual(expect.any(String));
+    });
+
+    it('uses custom bucket interval when provided', async () => {
+      const slo = createSLO();
+      const from = moment().subtract(30, 'days').toDate();
+      const to = new Date();
+
+      esClientMock.search.mockResolvedValueOnce({
+        ...commonEsResponse,
+        aggregations: { daily: { buckets: [] } },
+      });
+
+      await client.fetch({
+        slo,
+        instanceId: ALL_VALUE,
+        from,
+        to,
+        bucketInterval: '1h',
+        includeRaw: false,
+      });
+
+      expect(esClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            aggs: expect.objectContaining({
+              daily: expect.objectContaining({
+                date_histogram: expect.objectContaining({
+                  fixed_interval: '1h',
+                }),
+              }),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('returns empty data points when no aggregation buckets', async () => {
+      const slo = createSLO();
+      const from = moment().subtract(7, 'days').toDate();
+      const to = new Date();
+
+      esClientMock.search.mockResolvedValueOnce({
+        ...commonEsResponse,
+        aggregations: { daily: { buckets: [] } },
+      });
+
+      const result = await client.fetch({
+        slo,
+        instanceId: ALL_VALUE,
+        from,
+        to,
+        includeRaw: false,
+      });
+
+      expect(result.dataPoints).toHaveLength(0);
+    });
+
+    it('filters by instanceId when groupBy is set', async () => {
+      const slo = createSLO({ groupBy: 'service.name' });
+      const from = moment().subtract(7, 'days').toDate();
+      const to = new Date();
+
+      esClientMock.search.mockResolvedValueOnce({
+        ...commonEsResponse,
+        aggregations: { daily: { buckets: [] } },
+      });
+
+      await client.fetch({
+        slo,
+        instanceId: 'my-service',
+        from,
+        to,
+        includeRaw: false,
+      });
+
+      expect(esClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            query: expect.objectContaining({
+              bool: expect.objectContaining({
+                filter: expect.arrayContaining([
+                  { term: { 'slo.instanceId': 'my-service' } },
+                ]),
+              }),
+            }),
+          }),
+        })
+      );
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_timeseries_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_timeseries_client.ts
@@ -1,0 +1,325 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SearchSearchRequestBody } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import {
+  ALL_VALUE,
+  calendarAlignedTimeWindowSchema,
+  occurrencesBudgetingMethodSchema,
+  rollingTimeWindowSchema,
+  timeslicesBudgetingMethodSchema,
+  toMomentUnitOfTime,
+} from '@kbn/slo-schema';
+import type { GetSLOTimeseriesResponse } from '@kbn/slo-schema';
+import { assertNever } from '@kbn/std';
+import moment from 'moment';
+import { SLI_DESTINATION_INDEX_PATTERN } from '../../common/constants';
+import type { DateRange, GroupBy, Objective, SLODefinition, TimeWindow } from '../domain/models';
+import { toCalendarAlignedTimeWindowMomentUnit } from '../domain/models';
+import { computeSLI, computeSummaryStatus, toErrorBudget } from '../domain/services';
+import { getSlicesFromDateRange } from './utils/get_slices_from_date_range';
+
+interface TimeseriesDataPoint {
+  date: string;
+  sliValue: number;
+  status: string;
+  errorBudget: {
+    initial: number;
+    consumed: number;
+    remaining: number;
+    isEstimated: boolean;
+  };
+  numerator?: number;
+  denominator?: number;
+}
+
+interface TimeseriesAggBucket {
+  key_as_string: string;
+  key: number;
+  doc_count: number;
+  good: { value: number };
+  total: { value: number };
+  cumulative_good?: { value: number };
+  cumulative_total?: { value: number };
+}
+
+interface FetchTimeseriesParams {
+  slo: SLODefinition;
+  instanceId: string;
+  from: Date;
+  to: Date;
+  remoteName?: string;
+  bucketInterval?: string;
+  includeRaw: boolean;
+}
+
+export class SloTimeseriesClient {
+  constructor(private esClient: ElasticsearchClient) {}
+
+  async fetch(params: FetchTimeseriesParams): Promise<GetSLOTimeseriesResponse> {
+    const { slo, instanceId, from, to, remoteName, bucketInterval, includeRaw } = params;
+    const { timeWindow, budgetingMethod, objective, groupBy } = slo;
+
+    const dateRange = this.getDateRange(timeWindow, { from, to });
+    const fixedInterval = bucketInterval ?? this.getAutoFixedInterval(from, to);
+
+    const searchBody = this.generateSearchQuery({
+      sloId: slo.id,
+      revision: slo.revision,
+      instanceId,
+      groupBy,
+      timeWindow,
+      budgetingMethod,
+      dateRange,
+      fixedInterval,
+    });
+
+    const index = remoteName
+      ? `${remoteName}:${SLI_DESTINATION_INDEX_PATTERN}`
+      : SLI_DESTINATION_INDEX_PATTERN;
+
+    const result = await this.esClient.search({ index, ...searchBody });
+
+    const buckets =
+      (result.aggregations?.daily as { buckets: TimeseriesAggBucket[] })?.buckets ?? [];
+
+    const dataPoints = this.computeDataPoints({
+      buckets,
+      timeWindow,
+      budgetingMethod,
+      objective,
+      dateRange,
+      includeRaw,
+    });
+
+    return {
+      sloId: slo.id,
+      instanceId: instanceId || ALL_VALUE,
+      dataPoints,
+    };
+  }
+
+  private computeDataPoints({
+    buckets,
+    timeWindow,
+    budgetingMethod,
+    objective,
+    dateRange,
+    includeRaw,
+  }: {
+    buckets: TimeseriesAggBucket[];
+    timeWindow: TimeWindow;
+    budgetingMethod: string;
+    objective: Objective;
+    dateRange: { range: DateRange; queryRange: DateRange };
+    includeRaw: boolean;
+  }): TimeseriesDataPoint[] {
+    const initialErrorBudget = 1 - objective.target;
+    const isTimeslices = timeslicesBudgetingMethodSchema.is(budgetingMethod);
+    const isRolling = rollingTimeWindowSchema.is(timeWindow);
+
+    return buckets
+      .filter((bucket) => {
+        if (isRolling) {
+          return (
+            moment(bucket.key_as_string).isSameOrAfter(dateRange.range.from) &&
+            moment(bucket.key_as_string).isSameOrBefore(dateRange.range.to)
+          );
+        }
+        return true;
+      })
+      .map((bucket) => {
+        const good = bucket.cumulative_good?.value ?? 0;
+        const total = bucket.cumulative_total?.value ?? 0;
+
+        let sliValue: number;
+        if (isTimeslices) {
+          let totalSlices: number;
+          if (isRolling) {
+            totalSlices = Math.ceil(
+              timeWindow.duration.asSeconds() / objective.timesliceWindow!.asSeconds()
+            );
+          } else {
+            totalSlices = getSlicesFromDateRange(dateRange.range, objective.timesliceWindow!);
+          }
+          sliValue = computeSLI(good, total, totalSlices);
+        } else {
+          sliValue = computeSLI(good, total);
+        }
+
+        const consumedErrorBudget = sliValue < 0 ? 0 : (1 - sliValue) / initialErrorBudget;
+        const errorBudget = toErrorBudget(
+          initialErrorBudget,
+          consumedErrorBudget,
+          calendarAlignedTimeWindowSchema.is(timeWindow) &&
+            occurrencesBudgetingMethodSchema.is(budgetingMethod)
+        );
+
+        const dataPoint: TimeseriesDataPoint = {
+          date: bucket.key_as_string,
+          sliValue,
+          status: computeSummaryStatus(objective, sliValue, errorBudget),
+          errorBudget,
+        };
+
+        if (includeRaw) {
+          dataPoint.numerator = bucket.good.value;
+          dataPoint.denominator = bucket.total.value;
+        }
+
+        return dataPoint;
+      });
+  }
+
+  private generateSearchQuery({
+    sloId,
+    revision,
+    instanceId,
+    groupBy,
+    timeWindow,
+    budgetingMethod,
+    dateRange,
+    fixedInterval,
+  }: {
+    sloId: string;
+    revision: number;
+    instanceId: string;
+    groupBy: GroupBy;
+    timeWindow: TimeWindow;
+    budgetingMethod: string;
+    dateRange: { range: DateRange; queryRange: DateRange };
+    fixedInterval: string;
+  }): { body: SearchSearchRequestBody } {
+    const unit = toMomentUnitOfTime(timeWindow.duration.unit);
+    const timeWindowDurationInDays = moment.duration(timeWindow.duration.value, unit).asDays();
+    const bucketsPerDay = this.getBucketsPerDay(fixedInterval);
+
+    const extraFilterByInstanceId =
+      !!groupBy && ![groupBy].flat().includes(ALL_VALUE) && instanceId !== ALL_VALUE
+        ? [{ term: { 'slo.instanceId': instanceId } }]
+        : [];
+
+    return {
+      body: {
+        size: 0,
+        query: {
+          bool: {
+            filter: [
+              { term: { 'slo.id': sloId } },
+              { term: { 'slo.revision': revision } },
+              {
+                range: {
+                  '@timestamp': {
+                    gte: dateRange.queryRange.from.toISOString(),
+                    lte: dateRange.queryRange.to.toISOString(),
+                  },
+                },
+              },
+              ...extraFilterByInstanceId,
+            ],
+          },
+        },
+        aggs: {
+          daily: {
+            date_histogram: {
+              field: '@timestamp',
+              fixed_interval: fixedInterval,
+              extended_bounds: {
+                min: dateRange.queryRange.from.toISOString(),
+                max: dateRange.queryRange.to.toISOString(),
+              },
+            },
+            aggs: {
+              ...(occurrencesBudgetingMethodSchema.is(budgetingMethod) && {
+                good: { sum: { field: 'slo.numerator' } },
+                total: { sum: { field: 'slo.denominator' } },
+              }),
+              ...(timeslicesBudgetingMethodSchema.is(budgetingMethod) && {
+                good: { sum: { field: 'slo.isGoodSlice' } },
+                total: { value_count: { field: 'slo.isGoodSlice' } },
+              }),
+              cumulative_good: {
+                moving_fn: {
+                  buckets_path: 'good',
+                  window: Math.ceil(timeWindowDurationInDays * bucketsPerDay),
+                  shift: 1,
+                  script: 'MovingFunctions.sum(values)',
+                  gap_policy: 'insert_zeros',
+                },
+              },
+              cumulative_total: {
+                moving_fn: {
+                  buckets_path: 'total',
+                  window: Math.ceil(timeWindowDurationInDays * bucketsPerDay),
+                  shift: 1,
+                  script: 'MovingFunctions.sum(values)',
+                  gap_policy: 'insert_zeros',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  private getDateRange(
+    timeWindow: TimeWindow,
+    range: DateRange
+  ): { range: DateRange; queryRange: DateRange } {
+    if (rollingTimeWindowSchema.is(timeWindow)) {
+      const unit = toMomentUnitOfTime(timeWindow.duration.unit);
+      return {
+        range,
+        queryRange: {
+          from: moment(range.from)
+            .subtract(timeWindow.duration.value, unit)
+            .startOf('minute')
+            .toDate(),
+          to: moment(range.to).startOf('minute').toDate(),
+        },
+      };
+    }
+
+    if (calendarAlignedTimeWindowSchema.is(timeWindow)) {
+      const unit = toCalendarAlignedTimeWindowMomentUnit(timeWindow);
+      const from = moment.utc(range.from).startOf(unit);
+      const to = moment.utc(range.to).endOf(unit);
+      const calendarRange = { from: from.toDate(), to: to.toDate() };
+      return { range: calendarRange, queryRange: calendarRange };
+    }
+
+    assertNever(timeWindow);
+  }
+
+  private getAutoFixedInterval(from: Date, to: Date): string {
+    const durationInDays = Math.ceil(moment(to).diff(from, 'days'));
+    if (durationInDays <= 3) return '30m';
+    if (durationInDays <= 7) return '1h';
+    if (durationInDays <= 30) return '4h';
+    if (durationInDays <= 90) return '12h';
+    return '1d';
+  }
+
+  private getBucketsPerDay(fixedInterval: string): number {
+    const match = fixedInterval.match(/^(\d+)(m|h|d)$/);
+    if (!match) return 1;
+    const [, valueStr, unit] = match;
+    const value = parseInt(valueStr, 10);
+    switch (unit) {
+      case 'm':
+        return (24 * 60) / value;
+      case 'h':
+        return 24 / value;
+      case 'd':
+        return 1 / value;
+      default:
+        return 1;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new **public versioned API endpoint** `GET /api/observability/slos/{id}/timeseries 2023-10-31` that exposes SLO SLI data as time series data points with optional raw numerator/denominator support.

### What this solves
Today, customers cannot query SLO values as time series data for BI/FinOps workflows. The existing internal `_historical_summary` endpoint returns pre-computed aggregated data but does not expose raw values and is not a public API. This forces customers to build complex workarounds using undocumented internal Elasticsearch mechanisms.

### Changes

- **New REST spec** (`@kbn/slo-schema`): `getSLOTimeseriesParamsSchema` and `getSLOTimeseriesResponseSchema`
- **New service** (`SloTimeseriesClient`): Queries the SLI rollup index with date_histogram + moving_fn aggregations, computes SLI values, error budgets, and status per bucket
- **New public route**: `GET /api/observability/slos/{id}/timeseries 2023-10-31` with `slo_read` privileges
- **New React Query hook**: `useFetchSloTimeseries` for frontend consumption
- **Unit tests**: Coverage for rolling/timeslices, includeRaw, custom bucket intervals, groupBy filtering

### API

```
GET /api/observability/slos/{id}/timeseries?from=2025-01-01T00:00:00Z&to=2025-02-01T00:00:00Z&includeRaw=true
```

**Query params**: `from` (required), `to` (required), `instanceId`, `remoteName`, `bucketInterval`, `includeRaw`

**Response**: `{ sloId, instanceId, dataPoints: [{ date, sliValue, status, errorBudget, numerator?, denominator? }] }`

Closes #253241

## Test plan

- [ ] Unit tests pass: `yarn test:jest x-pack/solutions/observability/plugins/slo/server/services/slo_timeseries_client.test.ts`
- [ ] API returns correct time series data for rolling occurrences SLOs
- [ ] API returns correct time series data for timeslices SLOs
- [ ] API returns correct time series data for calendar-aligned SLOs
- [ ] `includeRaw=true` includes numerator/denominator per data point
- [ ] Custom `bucketInterval` parameter is respected
- [ ] `instanceId` filtering works for grouped SLOs
- [ ] CCS support via `remoteName` parameter

Made with [Cursor](https://cursor.com)