### PR TITLE
[ML] Log rate/pattern analysis and Change point detection a11y headings fix

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_points_table.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_points_table.tsx
@@ -326,12 +326,12 @@ export const ChangePointsTable: FC<ChangePointsTableProps> = ({
           <EuiEmptyPrompt
             iconType="search"
             title={
-              <h2>
+              <h3>
                 <FormattedMessage
                   id="xpack.aiops.changePointDetection.fetchingChangePointsTitle"
                   defaultMessage="Fetching change points..."
                 />
-              </h2>
+              </h3>
             }
           />
         ) : (

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_points_table.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_points_table.tsx
@@ -333,6 +333,7 @@ export const ChangePointsTable: FC<ChangePointsTableProps> = ({
                 />
               </h3>
             }
+            titleSize="xs"
           />
         ) : (
           <NoDataFoundWarning />

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/no_data_warning.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/no_data_warning.tsx
@@ -24,6 +24,7 @@ export const NoDataFoundWarning = (props: { onRenderComplete?: () => void }) => 
           />
         </h3>
       }
+      titleSize="xs"
       body={
         <p>
           <FormattedMessage

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/no_data_warning.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/no_data_warning.tsx
@@ -17,12 +17,12 @@ export const NoDataFoundWarning = (props: { onRenderComplete?: () => void }) => 
       data-test-subj="aiopsNoDataFoundWarning"
       iconType="search"
       title={
-        <h2>
+        <h3>
           <FormattedMessage
             id="xpack.aiops.changePointDetection.noDataFoundTitle"
             defaultMessage="No data found"
           />
-        </h2>
+        </h3>
       }
       body={
         <p>

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/information_text.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/information_text.tsx
@@ -33,12 +33,12 @@ export const InformationText: FC<Props> = ({
     return (
       <EuiEmptyPrompt
         title={
-          <h2>
+          <h3>
             <FormattedMessage
               id="xpack.aiops.logCategorization.noTextFieldsTitle"
               defaultMessage="No text fields found"
             />
-          </h2>
+          </h3>
         }
         titleSize="xs"
         body={
@@ -58,12 +58,12 @@ export const InformationText: FC<Props> = ({
     return (
       <EuiEmptyPrompt
         title={
-          <h2>
+          <h3>
             <FormattedMessage
               id="xpack.aiops.logCategorization.noDocsTitle"
               defaultMessage="No documents found"
             />
-          </h2>
+          </h3>
         }
         titleSize="xs"
         body={
@@ -83,12 +83,12 @@ export const InformationText: FC<Props> = ({
     return (
       <EuiEmptyPrompt
         title={
-          <h2>
+          <h3>
             <FormattedMessage
               id="xpack.aiops.logCategorization.emptyPromptTitle"
               defaultMessage="Select a text field and click run pattern analysis to start analysis"
             />
-          </h2>
+          </h3>
         }
         titleSize="xs"
         body={
@@ -108,12 +108,12 @@ export const InformationText: FC<Props> = ({
     return (
       <EuiEmptyPrompt
         title={
-          <h2>
+          <h3>
             <FormattedMessage
               id="xpack.aiops.logCategorization.noCategoriesTitle"
               defaultMessage="No patterns found"
             />
-          </h2>
+          </h3>
         }
         titleSize="xs"
         body={

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_content.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_content.tsx
@@ -282,7 +282,7 @@ export const LogRateAnalysisContent: FC<LogRateAnalysisContentProps> = ({
           hasBorder={false}
           css={{ minWidth: '100%' }}
           title={
-            <h2>
+            <h3>
               {changePointType === LOG_RATE_ANALYSIS_TYPE.SPIKE && (
                 <FormattedMessage
                   id="xpack.aiops.logRateAnalysis.page.changePointSpikePromptTitle"
@@ -302,7 +302,7 @@ export const LogRateAnalysisContent: FC<LogRateAnalysisContentProps> = ({
                     defaultMessage="Log rate change point detected"
                   />
                 )}
-            </h2>
+            </h3>
           }
           titleSize="xs"
           body={
@@ -334,12 +334,12 @@ export const LogRateAnalysisContent: FC<LogRateAnalysisContentProps> = ({
           hasBorder={false}
           css={{ minWidth: '100%' }}
           title={
-            <h2>
+            <h3>
               <FormattedMessage
                 id="xpack.aiops.logRateAnalysis.page.emptyPromptTitle"
                 defaultMessage="Start by clicking a spike or dip in the histogram chart."
               />
-            </h2>
+            </h3>
           }
           titleSize="xs"
           body={

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
@@ -439,12 +439,12 @@ export const LogRateAnalysisResults: FC<LogRateAnalysisResultsProps> = ({
         <EuiEmptyPrompt
           data-test-subj="aiopsNoResultsFoundEmptyPrompt"
           title={
-            <h2>
+            <h3>
               <FormattedMessage
                 id="xpack.aiops.logRateAnalysis.page.noResultsPromptTitle"
                 defaultMessage="The analysis did not return any results."
               />
-            </h2>
+            </h3>
           }
           titleSize="xs"
           body={

--- a/x-pack/platform/plugins/shared/aiops/public/components/page_header/page_header.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/page_header/page_header.tsx
@@ -9,7 +9,7 @@ import { css } from '@emotion/react';
 import type { FC } from 'react';
 import React, { useCallback, useMemo } from 'react';
 
-import { EuiPageHeader } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 
 import { useUrlState } from '@kbn/ml-url-state';
 import { useStorage } from '@kbn/ml-local-storage';
@@ -29,9 +29,10 @@ import {
   type AiOpsStorageMapped,
 } from '../../types/storage';
 
-const dataViewTitleHeader = css({
-  minWidth: '300px',
-});
+const maxInlineSizeStyles = css`
+  max-inline-size: 100%;
+  min-inline-size: 0;
+`;
 
 export const PageHeader: FC = () => {
   const [, setGlobalState] = useUrlState('_g');
@@ -69,30 +70,41 @@ export const PageHeader: FC = () => {
   );
 
   return (
-    <EuiPageHeader
-      pageTitle={<div css={dataViewTitleHeader}>{dataView.getName()}</div>}
-      rightSideGroupProps={{
-        gutterSize: 's',
-        'data-test-subj': 'aiopsTimeRangeSelectorSection',
-      }}
-      rightSideItems={[
-        <DatePickerWrapper
-          isAutoRefreshOnly={!hasValidTimeField}
-          showRefresh={!hasValidTimeField}
-          width="full"
-        />,
-        hasValidTimeField && (
-          <FullTimeRangeSelector
-            frozenDataPreference={frozenDataPreference}
-            setFrozenDataPreference={setFrozenDataPreference}
-            dataView={dataView}
-            query={undefined}
-            disabled={false}
-            timefilter={timefilter}
-            callback={updateTimeState}
-          />
-        ),
-      ].filter(Boolean)}
-    />
+    <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s" wrap={true}>
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="l">
+          <h2>{dataView.getName()}</h2>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false} css={maxInlineSizeStyles}>
+        <EuiFlexGroup
+          css={maxInlineSizeStyles}
+          alignItems="center"
+          gutterSize="s"
+          data-test-subj="aiopsTimeRangeSelectorSection"
+        >
+          {hasValidTimeField && (
+            <EuiFlexItem grow={false}>
+              <FullTimeRangeSelector
+                frozenDataPreference={frozenDataPreference}
+                setFrozenDataPreference={setFrozenDataPreference}
+                dataView={dataView}
+                query={undefined}
+                disabled={false}
+                timefilter={timefilter}
+                callback={updateTimeState}
+              />
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={false} css={maxInlineSizeStyles}>
+            <DatePickerWrapper
+              isAutoRefreshOnly={!hasValidTimeField}
+              showRefresh={!hasValidTimeField}
+              width="full"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/194997?reload=1

This PR fixes the issue with heading elements that were not properly tagged. 

| Before | After |
|--------|-------|
| <img width="1726" height="694" alt="log-rate-before" src="https://github.com/user-attachments/assets/4690415e-8f13-4029-a3cb-cdaa00a1c393" /> | <img width="1613" height="756" alt="rate-after" src="https://github.com/user-attachments/assets/39f49f9b-9b93-4eb9-bec7-02d7a21f8fcb" /> |
| <img width="1728" height="701" alt="pattern-before" src="https://github.com/user-attachments/assets/d264c945-c388-4d10-bb9c-2db05ceec8a9" /> | <img width="1657" height="794" alt="pattern-after" src="https://github.com/user-attachments/assets/6f95fd26-4cfa-4838-941d-7e62b43256c7" /> |
| <img width="1728" height="772" alt="change-before" src="https://github.com/user-attachments/assets/67eb72d7-0dd2-48ab-bd2c-813f20620e8f" /> | <img width="1655" height="841" alt="change-after" src="https://github.com/user-attachments/assets/fa78a4fd-17c4-43a4-ba5e-df0956bca75f" /> |
| <img width="1605" height="773" alt="Screenshot 2026-03-05 at 12 06 29" src="https://github.com/user-attachments/assets/0d3fb9e8-ea71-4d96-bdf9-26425c921711" /> | <img width="1632" height="903" alt="Screenshot 2026-03-05 at 12 10 09" src="https://github.com/user-attachments/assets/6e0705ef-682c-42f7-a437-81ab9be4b8d4" /> |
| <img width="1541" height="819" alt="Screenshot 2026-03-05 at 12 49 10" src="https://github.com/user-attachments/assets/b71f4515-7d84-4f72-8173-4f47343d714c" /> | <img width="1629" height="835" alt="Screenshot 2026-03-05 at 14 07 17" src="https://github.com/user-attachments/assets/a9dbf744-dfb0-4ac4-88b0-356a0ab025cc" /> |
| <img width="1638" height="883" alt="Screenshot 2026-03-05 at 12 50 08" src="https://github.com/user-attachments/assets/f8247ea3-11c9-4ee3-9056-1775e2f222c8" /> | <img width="1633" height="909" alt="Screenshot 2026-03-05 at 14 10 32" src="https://github.com/user-attachments/assets/48159eff-9d24-43e9-841b-012c468eef6e" /> |

#### Additional screenshots with `h3` elements
<img width="1309" height="875" alt="Screenshot 2026-02-16 at 11 58 22" src="https://github.com/user-attachments/assets/b03570aa-e927-450b-9a6c-947286f15f36" />
<img width="1660" height="798" alt="Screenshot 2026-02-16 at 11 56 16" src="https://github.com/user-attachments/assets/e7cf729f-2c04-4f52-89c4-f25cb223c850" />
<img width="1611" height="804" alt="Screenshot 2026-02-16 at 11 51 42" src="https://github.com/user-attachments/assets/32a41bc4-3637-4f09-afd4-4840a5d04ad7" />
<img width="1610" height="800" alt="Screenshot 2026-02-16 at 11 50 50" src="https://github.com/user-attachments/assets/f56c7f32-5ffa-480f-b718-8c0c5ecd2a57" />




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

