### PR TITLE
[9.2] [Streams] Avoid streams crashing if a policy has empty phases (#253211)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.test.ts
@@ -180,8 +180,12 @@ describe('helpers', () => {
   });
 
   describe('getILMRatios', () => {
-    it('should return undefined if no phases', () => {
+    it('should return undefined if phases is undefined', () => {
       expect(getILMRatios(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if phases is an empty object', () => {
+      expect(getILMRatios({ phases: {} })).toBeUndefined();
     });
 
     it('should calculate grow ratios correctly for multiple phases', () => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.ts
@@ -44,8 +44,8 @@ export function orderIlmPhases(phases: IlmPolicyPhases) {
 export const getILMRatios = (
   value:
     | {
-      phases: IlmPolicyPhases;
-    }
+        phases: IlmPolicyPhases;
+      }
     | undefined
 ) => {
   if (!value) return undefined;
@@ -53,7 +53,6 @@ export const getILMRatios = (
   const orderedPhases = orderIlmPhases(value.phases).reverse();
 
   if (orderedPhases.length === 0) return undefined;
-
 
   const totalDuration = parseDurationInSeconds(first(orderedPhases)!.min_age);
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/helpers.ts
@@ -44,13 +44,17 @@ export function orderIlmPhases(phases: IlmPolicyPhases) {
 export const getILMRatios = (
   value:
     | {
-        phases: IlmPolicyPhases;
-      }
+      phases: IlmPolicyPhases;
+    }
     | undefined
 ) => {
   if (!value) return undefined;
 
   const orderedPhases = orderIlmPhases(value.phases).reverse();
+
+  if (orderedPhases.length === 0) return undefined;
+
+
   const totalDuration = parseDurationInSeconds(first(orderedPhases)!.min_age);
 
   return orderedPhases.map((phase, index, phases) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Streams] Avoid streams crashing if a policy has empty phases (#253211)](https://github.com/elastic/kibana/pull/253211)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2026-02-16T13:18:57Z","message":"[Streams] Avoid streams crashing if a policy has empty phases (#253211)\n\n## Summary\n\nThere was an bug in the Streams helpers that made the page crush when\ngetting the `getILMRatios` for a policy that haven't any phase\nconfigured. The error was `TypeError can't access property min_age\ng.first is undefined`.\n\nTo fix that, this PR introduces a guard of the `orderedPhases` before\ntrying to access `min_age`.\n\n### How to test\n\nCreate a policy with no phases\n```\nPUT _ilm/policy/empty_policy\n{\n  \"policy\": {\n    \"phases\": {\n    }\n  }\n}\n```\nAssign it to a stream and verify it doesn't break the page","sha":"5a58a08259b58cf959e66347ce72aca358d427fc","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:version","Feature:Streams","v9.4.0","v9.3.1","v9.2.6"],"title":"[Streams] Avoid streams crashing if a policy has empty phases","number":253211,"url":"https://github.com/elastic/kibana/pull/253211","mergeCommit":{"message":"[Streams] Avoid streams crashing if a policy has empty phases (#253211)\n\n## Summary\n\nThere was an bug in the Streams helpers that made the page crush when\ngetting the `getILMRatios` for a policy that haven't any phase\nconfigured. The error was `TypeError can't access property min_age\ng.first is undefined`.\n\nTo fix that, this PR introduces a guard of the `orderedPhases` before\ntrying to access `min_age`.\n\n### How to test\n\nCreate a policy with no phases\n```\nPUT _ilm/policy/empty_policy\n{\n  \"policy\": {\n    \"phases\": {\n    }\n  }\n}\n```\nAssign it to a stream and verify it doesn't break the page","sha":"5a58a08259b58cf959e66347ce72aca358d427fc"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253211","number":253211,"mergeCommit":{"message":"[Streams] Avoid streams crashing if a policy has empty phases (#253211)\n\n## Summary\n\nThere was an bug in the Streams helpers that made the page crush when\ngetting the `getILMRatios` for a policy that haven't any phase\nconfigured. The error was `TypeError can't access property min_age\ng.first is undefined`.\n\nTo fix that, this PR introduces a guard of the `orderedPhases` before\ntrying to access `min_age`.\n\n### How to test\n\nCreate a policy with no phases\n```\nPUT _ilm/policy/empty_policy\n{\n  \"policy\": {\n    \"phases\": {\n    }\n  }\n}\n```\nAssign it to a stream and verify it doesn't break the page","sha":"5a58a08259b58cf959e66347ce72aca358d427fc"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->