### PR TITLE
[SLO] Add AI-powered auto-discover SLOs feature

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/moon.yml
+++ b/x-pack/solutions/observability/plugins/slo/moon.yml
@@ -123,6 +123,9 @@ dependsOn:
   - '@kbn/deeplinks-management'
   - '@kbn/deeplinks-observability'
   - '@kbn/observability-get-padded-alert-time-range-util'
+  - '@kbn/inference-plugin'
+  - '@kbn/management-settings-ids'
+  - '@kbn/inference-common'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_bulk_create_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_bulk_create_slos.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { useQueryClient } from '@kbn/react-query';
+import { sloKeys } from './query_key_factory';
+import { usePluginContext } from './use_plugin_context';
+import { useKibana } from './use_kibana';
+
+type ServerError = IHttpFetchError<ResponseErrorBody>;
+
+const DEFAULT_BATCH_SIZE = 5;
+
+interface BulkCreateSlosInput {
+  slos: Array<Record<string, unknown>>;
+  batchSize?: number;
+}
+
+export interface BulkCreateResult {
+  success: boolean;
+  id?: string;
+  name: string;
+  error?: string;
+}
+
+interface BulkCreateSlosResponse {
+  results: BulkCreateResult[];
+  summary: { total: number; success: number; failure: number };
+}
+
+export interface BatchProgress {
+  currentBatch: number;
+  totalBatches: number;
+  completedSlos: number;
+  totalSlos: number;
+  successCount: number;
+  failureCount: number;
+}
+
+export function useBulkCreateSlos() {
+  const {
+    notifications: { toasts },
+  } = useKibana().services;
+  const { sloClient } = usePluginContext();
+  const queryClient = useQueryClient();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [batchProgress, setBatchProgress] = useState<BatchProgress | null>(null);
+  const abortRef = useRef(false);
+
+  const mutate = useCallback(
+    async (
+      input: BulkCreateSlosInput,
+      options?: { onSuccess?: (data: BulkCreateSlosResponse) => void }
+    ) => {
+      const { slos, batchSize = DEFAULT_BATCH_SIZE } = input;
+
+      if (slos.length === 0) return;
+
+      setIsLoading(true);
+      abortRef.current = false;
+
+      const batches: Array<Array<Record<string, unknown>>> = [];
+      for (let i = 0; i < slos.length; i += batchSize) {
+        batches.push(slos.slice(i, i + batchSize));
+      }
+
+      const allResults: BulkCreateResult[] = [];
+      let totalSuccess = 0;
+      let totalFailure = 0;
+
+      setBatchProgress({
+        currentBatch: 0,
+        totalBatches: batches.length,
+        completedSlos: 0,
+        totalSlos: slos.length,
+        successCount: 0,
+        failureCount: 0,
+      });
+
+      for (let batchIdx = 0; batchIdx < batches.length; batchIdx++) {
+        if (abortRef.current) break;
+
+        const batch = batches[batchIdx];
+
+        setBatchProgress({
+          currentBatch: batchIdx + 1,
+          totalBatches: batches.length,
+          completedSlos: allResults.length,
+          totalSlos: slos.length,
+          successCount: totalSuccess,
+          failureCount: totalFailure,
+        });
+
+        try {
+          const response: BulkCreateSlosResponse = await sloClient.fetch(
+            'POST /internal/slo/ai/bulk-create',
+            {
+              params: {
+                body: { slos: batch },
+              },
+            }
+          );
+
+          allResults.push(...response.results);
+          totalSuccess += response.summary.success;
+          totalFailure += response.summary.failure;
+
+          if (response.summary.success > 0) {
+            queryClient.invalidateQueries({ queryKey: sloKeys.lists(), exact: false });
+          }
+        } catch (error) {
+          const serverError = error as ServerError;
+          const batchFailures: BulkCreateResult[] = batch.map((slo) => ({
+            success: false,
+            name: (slo.name as string) ?? 'Unknown',
+            error: serverError.body?.message ?? serverError.message ?? 'Batch request failed',
+          }));
+          allResults.push(...batchFailures);
+          totalFailure += batch.length;
+        }
+      }
+
+      const aggregated: BulkCreateSlosResponse = {
+        results: allResults,
+        summary: { total: slos.length, success: totalSuccess, failure: totalFailure },
+      };
+
+      setBatchProgress({
+        currentBatch: batches.length,
+        totalBatches: batches.length,
+        completedSlos: slos.length,
+        totalSlos: slos.length,
+        successCount: totalSuccess,
+        failureCount: totalFailure,
+      });
+
+      setIsLoading(false);
+
+      if (totalFailure === 0) {
+        toasts.addSuccess({
+          title: i18n.translate('xpack.slo.bulkCreateSlos.successNotification', {
+            defaultMessage:
+              'Successfully created {count} {count, plural, one {SLO} other {SLOs}}',
+            values: { count: totalSuccess },
+          }),
+        });
+      } else if (totalSuccess > 0) {
+        toasts.addWarning({
+          title: i18n.translate('xpack.slo.bulkCreateSlos.partialSuccessNotification', {
+            defaultMessage:
+              'Created {success} of {total} SLOs. {failure} {failure, plural, one {SLO} other {SLOs}} failed.',
+            values: { success: totalSuccess, total: slos.length, failure: totalFailure },
+          }),
+        });
+      } else {
+        toasts.addDanger({
+          title: i18n.translate('xpack.slo.bulkCreateSlos.allFailedNotification', {
+            defaultMessage: 'Failed to create all {total} SLOs',
+            values: { total: slos.length },
+          }),
+        });
+      }
+
+      if (options?.onSuccess && totalSuccess > 0) {
+        options.onSuccess(aggregated);
+      }
+    },
+    [sloClient, queryClient, toasts]
+  );
+
+  const abort = useCallback(() => {
+    abortRef.current = true;
+  }, []);
+
+  return { mutate, isLoading, batchProgress, abort };
+}

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_bulk_create_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_bulk_create_slos.ts
@@ -146,8 +146,7 @@ export function useBulkCreateSlos() {
       if (totalFailure === 0) {
         toasts.addSuccess({
           title: i18n.translate('xpack.slo.bulkCreateSlos.successNotification', {
-            defaultMessage:
-              'Successfully created {count} {count, plural, one {SLO} other {SLOs}}',
+            defaultMessage: 'Successfully created {count} {count, plural, one {SLO} other {SLOs}}',
             values: { count: totalSuccess },
           }),
         });

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_discover_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_discover_slos.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { useMutation } from '@kbn/react-query';
+import { usePluginContext } from './use_plugin_context';
+import { useKibana } from './use_kibana';
+
+type ServerError = IHttpFetchError<ResponseErrorBody>;
+
+interface DiscoverSlosInput {
+  connectorId?: string;
+}
+
+export interface ProposedSlo {
+  sloDefinition: Record<string, unknown>;
+  rationale: string;
+  category: 'availability' | 'latency' | 'correctness' | 'uptime' | 'throughput';
+  priority: 'critical' | 'high' | 'medium' | 'low';
+}
+
+interface DiscoverSlosResponse {
+  proposedSlos: ProposedSlo[];
+  summary: string;
+  clusterSummary: string;
+}
+
+export function useDiscoverSlos() {
+  const {
+    notifications: { toasts },
+  } = useKibana().services;
+  const { sloClient } = usePluginContext();
+
+  return useMutation<DiscoverSlosResponse, ServerError, DiscoverSlosInput>(
+    ['discoverSlos'],
+    ({ connectorId }) => {
+      const body = connectorId ? { connectorId } : undefined;
+      return sloClient.fetch('POST /internal/slo/ai/discover', {
+        params: {
+          ...(body ? { body } : {}),
+        },
+      });
+    },
+    {
+      onError: (error) => {
+        toasts.addError(new Error(error.body?.message ?? error.message), {
+          title: i18n.translate('xpack.slo.discoverSlos.errorNotification', {
+            defaultMessage: 'Failed to discover SLOs from cluster data',
+          }),
+        });
+      },
+    }
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_generate_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_generate_slo.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { useMutation } from '@kbn/react-query';
+import { usePluginContext } from './use_plugin_context';
+import { useKibana } from './use_kibana';
+
+type ServerError = IHttpFetchError<ResponseErrorBody>;
+
+interface GenerateSloInput {
+  prompt: string;
+  connectorId?: string;
+  previousMessages?: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+interface GenerateSloResponse {
+  sloDefinition: Record<string, unknown>;
+  explanation: string;
+}
+
+export function useGenerateSlo() {
+  const {
+    notifications: { toasts },
+  } = useKibana().services;
+  const { sloClient } = usePluginContext();
+
+  return useMutation<GenerateSloResponse, ServerError, GenerateSloInput>(
+    ['generateSlo'],
+    ({ prompt, connectorId, previousMessages }) => {
+      return sloClient.fetch('POST /internal/slo/ai/generate', {
+        params: {
+          body: {
+            prompt,
+            ...(connectorId ? { connectorId } : {}),
+            ...(previousMessages?.length ? { previousMessages } : {}),
+          },
+        },
+      });
+    },
+    {
+      onError: (error) => {
+        toasts.addError(new Error(error.body?.message ?? error.message), {
+          title: i18n.translate('xpack.slo.generateSlo.errorNotification', {
+            defaultMessage: 'Failed to generate SLO definition',
+          }),
+        });
+      },
+    }
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_suggest_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_suggest_slo.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { useMutation } from '@kbn/react-query';
+import { usePluginContext } from './use_plugin_context';
+import { useKibana } from './use_kibana';
+
+type ServerError = IHttpFetchError<ResponseErrorBody>;
+
+interface SuggestSloInput {
+  sloDefinition: Record<string, unknown>;
+  connectorId?: string;
+}
+
+export interface SloSuggestion {
+  title: string;
+  description: string;
+  field?: string;
+  suggestedValue?: unknown;
+}
+
+interface SuggestSloResponse {
+  suggestions: SloSuggestion[];
+}
+
+export function useSuggestSlo() {
+  const {
+    notifications: { toasts },
+  } = useKibana().services;
+  const { sloClient } = usePluginContext();
+
+  return useMutation<SuggestSloResponse, ServerError, SuggestSloInput>(
+    ['suggestSlo'],
+    ({ sloDefinition, connectorId }) => {
+      return sloClient.fetch('POST /internal/slo/ai/suggest', {
+        params: {
+          body: {
+            sloDefinition,
+            ...(connectorId ? { connectorId } : {}),
+          },
+        },
+      });
+    },
+    {
+      onError: (error) => {
+        toasts.addError(new Error(error.body?.message ?? error.message), {
+          title: i18n.translate('xpack.slo.suggestSlo.errorNotification', {
+            defaultMessage: 'Failed to get SLO suggestions',
+          }),
+        });
+      },
+    }
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/creation_mode_toggle.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/creation_mode_toggle.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { render } from '../../../../utils/test_helper';
 import { CreationModeToggle } from './creation_mode_toggle';
-import type { CreationMode } from './creation_mode_toggle';
 
 describe('CreationModeToggle', () => {
   const mockOnChange = jest.fn();

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/creation_mode_toggle.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/creation_mode_toggle.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '../../../../utils/test_helper';
+import { CreationModeToggle } from './creation_mode_toggle';
+import type { CreationMode } from './creation_mode_toggle';
+
+describe('CreationModeToggle', () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all three mode options', () => {
+    render(<CreationModeToggle mode="manual" onChange={mockOnChange} />);
+
+    expect(screen.getByTestId('sloCreationModeManual')).toBeTruthy();
+    expect(screen.getByTestId('sloCreationModeAiAssisted')).toBeTruthy();
+    expect(screen.getByTestId('sloCreationModeAutoDiscover')).toBeTruthy();
+  });
+
+  it('highlights the selected mode', () => {
+    render(<CreationModeToggle mode="auto_discover" onChange={mockOnChange} />);
+
+    const autoDiscoverButton = screen.getByTestId('sloCreationModeAutoDiscover');
+    expect(autoDiscoverButton.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('calls onChange when a different mode is selected', () => {
+    render(<CreationModeToggle mode="manual" onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByTestId('sloCreationModeAutoDiscover'));
+    expect(mockOnChange).toHaveBeenCalledWith('auto_discover');
+  });
+
+  it('shows technical preview badge for AI-assisted mode', () => {
+    render(<CreationModeToggle mode="ai_assisted" onChange={mockOnChange} />);
+
+    expect(screen.getByTestId('sloCreationModeTechPreviewBadge')).toBeTruthy();
+  });
+
+  it('shows technical preview badge for auto-discover mode', () => {
+    render(<CreationModeToggle mode="auto_discover" onChange={mockOnChange} />);
+
+    expect(screen.getByTestId('sloCreationModeTechPreviewBadge')).toBeTruthy();
+  });
+
+  it('does not show technical preview badge for manual mode', () => {
+    render(<CreationModeToggle mode="manual" onChange={mockOnChange} />);
+
+    expect(screen.queryByTestId('sloCreationModeTechPreviewBadge')).toBeFalsy();
+  });
+
+  it('renders the button group legend for accessibility', () => {
+    render(<CreationModeToggle mode="manual" onChange={mockOnChange} />);
+
+    expect(screen.getByTestId('sloCreationModeToggle')).toBeTruthy();
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/creation_mode_toggle.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/creation_mode_toggle.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButtonGroup, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { TechnicalPreviewBadge } from '../../../../components/technical_preview_badge';
+
+export type CreationMode = 'manual' | 'ai_assisted' | 'auto_discover';
+
+const CREATION_MODE_OPTIONS = [
+  {
+    id: 'manual',
+    label: i18n.translate('xpack.slo.sloEdit.creationMode.manual', {
+      defaultMessage: 'Manual',
+    }),
+    'data-test-subj': 'sloCreationModeManual',
+  },
+  {
+    id: 'ai_assisted',
+    label: i18n.translate('xpack.slo.sloEdit.creationMode.aiAssisted', {
+      defaultMessage: 'AI-assisted',
+    }),
+    iconType: 'sparkles',
+    'data-test-subj': 'sloCreationModeAiAssisted',
+  },
+  {
+    id: 'auto_discover',
+    label: i18n.translate('xpack.slo.sloEdit.creationMode.autoDiscover', {
+      defaultMessage: 'Auto-discover',
+    }),
+    iconType: 'magnifyWithPlus',
+    'data-test-subj': 'sloCreationModeAutoDiscover',
+  },
+];
+
+const AI_MODES: CreationMode[] = ['ai_assisted', 'auto_discover'];
+
+interface CreationModeToggleProps {
+  mode: CreationMode;
+  onChange: (mode: CreationMode) => void;
+}
+
+export function CreationModeToggle({ mode, onChange }: CreationModeToggleProps) {
+  return (
+    <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiButtonGroup
+          legend={i18n.translate('xpack.slo.sloEdit.creationMode.legend', {
+            defaultMessage: 'SLO creation mode',
+          })}
+          options={CREATION_MODE_OPTIONS}
+          idSelected={mode}
+          onChange={(id) => onChange(id as CreationMode)}
+          buttonSize="compressed"
+          color="primary"
+          data-test-subj="sloCreationModeToggle"
+        />
+      </EuiFlexItem>
+      {AI_MODES.includes(mode) && (
+        <EuiFlexItem grow={false} data-test-subj="sloCreationModeTechPreviewBadge">
+          <TechnicalPreviewBadge />
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.test.tsx
@@ -48,9 +48,7 @@ describe('DiscoveredSloCard', () => {
     );
 
     expect(screen.getByText('API Availability')).toBeTruthy();
-    expect(
-      screen.getByText('Tracks availability for the API gateway service')
-    ).toBeTruthy();
+    expect(screen.getByText('Tracks availability for the API gateway service')).toBeTruthy();
   });
 
   it('renders priority badge with correct color', () => {
@@ -77,9 +75,7 @@ describe('DiscoveredSloCard', () => {
       <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
     );
 
-    expect(
-      screen.getByText('This service handles critical user-facing traffic')
-    ).toBeTruthy();
+    expect(screen.getByText('This service handles critical user-facing traffic')).toBeTruthy();
   });
 
   it('renders the checkbox', () => {

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.test.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '../../../../utils/test_helper';
+import { DiscoveredSloCard } from './discovered_slo_card';
+import type { ProposedSlo } from '../../../../hooks/use_discover_slos';
+
+const createProposal = (overrides: Partial<ProposedSlo> = {}): ProposedSlo => ({
+  sloDefinition: {
+    name: 'API Availability',
+    description: 'Tracks availability for the API gateway service',
+    indicator: {
+      type: 'sli.apm.transactionErrorRate',
+      params: {
+        service: 'api-gateway',
+        environment: 'production',
+        index: 'metrics-apm*',
+      },
+    },
+    timeWindow: { duration: '30d', type: 'rolling' },
+    budgetingMethod: 'occurrences',
+    objective: { target: 0.995 },
+    tags: ['api', 'auto-discovered'],
+  },
+  rationale: 'This service handles critical user-facing traffic',
+  category: 'availability',
+  priority: 'critical',
+  ...overrides,
+});
+
+describe('DiscoveredSloCard', () => {
+  const mockOnToggle = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the SLO name and description', () => {
+    const proposal = createProposal();
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(screen.getByText('API Availability')).toBeTruthy();
+    expect(
+      screen.getByText('Tracks availability for the API gateway service')
+    ).toBeTruthy();
+  });
+
+  it('renders priority badge with correct color', () => {
+    const proposal = createProposal({ priority: 'critical' });
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(screen.getByText('Critical')).toBeTruthy();
+  });
+
+  it('renders category badge', () => {
+    const proposal = createProposal({ category: 'availability' });
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(screen.getByText('Availability')).toBeTruthy();
+  });
+
+  it('renders rationale text', () => {
+    const proposal = createProposal();
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(
+      screen.getByText('This service handles critical user-facing traffic')
+    ).toBeTruthy();
+  });
+
+  it('renders the checkbox', () => {
+    render(
+      <DiscoveredSloCard
+        proposal={createProposal()}
+        index={0}
+        isSelected={false}
+        onToggle={mockOnToggle}
+      />
+    );
+
+    expect(screen.getByTestId('discoveredSloCheckbox-0')).toBeTruthy();
+  });
+
+  it('marks checkbox as checked when selected', () => {
+    render(
+      <DiscoveredSloCard
+        proposal={createProposal()}
+        index={0}
+        isSelected={true}
+        onToggle={mockOnToggle}
+      />
+    );
+
+    const checkbox = screen.getByTestId('discoveredSloCheckbox-0') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('calls onToggle with the correct index when checkbox is clicked', () => {
+    render(
+      <DiscoveredSloCard
+        proposal={createProposal()}
+        index={3}
+        isSelected={false}
+        onToggle={mockOnToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('discoveredSloCheckbox-3'));
+    expect(mockOnToggle).toHaveBeenCalledWith(3);
+  });
+
+  it('renders indicator details', () => {
+    const proposal = createProposal();
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(screen.getByText('APM Availability')).toBeTruthy();
+    expect(screen.getByText('0.995%')).toBeTruthy();
+  });
+
+  it('renders service and environment for APM indicators', () => {
+    const proposal = createProposal();
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(screen.getByText('api-gateway')).toBeTruthy();
+    expect(screen.getByText('production')).toBeTruthy();
+  });
+
+  it('renders tags as badges', () => {
+    const proposal = createProposal();
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(screen.getByText('api')).toBeTruthy();
+    expect(screen.getByText('auto-discovered')).toBeTruthy();
+  });
+
+  it('renders with different priority levels', () => {
+    const priorities: Array<ProposedSlo['priority']> = ['critical', 'high', 'medium', 'low'];
+
+    for (const priority of priorities) {
+      const { unmount } = render(
+        <DiscoveredSloCard
+          proposal={createProposal({ priority })}
+          index={0}
+          isSelected={false}
+          onToggle={mockOnToggle}
+        />
+      );
+      unmount();
+    }
+  });
+
+  it('applies primary panel color when selected', () => {
+    render(
+      <DiscoveredSloCard
+        proposal={createProposal()}
+        index={0}
+        isSelected={true}
+        onToggle={mockOnToggle}
+      />
+    );
+
+    const card = screen.getByTestId('discoveredSloCard-0');
+    expect(card).toBeTruthy();
+  });
+
+  it('renders latency category correctly', () => {
+    const proposal = createProposal({ category: 'latency' });
+    render(
+      <DiscoveredSloCard proposal={proposal} index={0} isSelected={false} onToggle={mockOnToggle} />
+    );
+
+    expect(screen.getByText('Latency')).toBeTruthy();
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.tsx
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiCheckbox,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useCallback } from 'react';
+import type { ProposedSlo } from '../../../../hooks/use_discover_slos';
+
+const INDICATOR_TYPE_LABELS: Record<string, string> = {
+  'sli.kql.custom': 'Custom Query (KQL)',
+  'sli.apm.transactionDuration': 'APM Latency',
+  'sli.apm.transactionErrorRate': 'APM Availability',
+  'sli.metric.custom': 'Custom Metric',
+  'sli.metric.timeslice': 'Timeslice Metric',
+  'sli.histogram.custom': 'Histogram Metric',
+  'sli.synthetics.availability': 'Synthetics Availability',
+};
+
+const PRIORITY_COLORS: Record<string, string> = {
+  critical: 'danger',
+  high: 'warning',
+  medium: 'primary',
+  low: 'default',
+};
+
+const PRIORITY_LABELS: Record<string, string> = {
+  critical: i18n.translate('xpack.slo.discover.priority.critical', {
+    defaultMessage: 'Critical',
+  }),
+  high: i18n.translate('xpack.slo.discover.priority.high', {
+    defaultMessage: 'High',
+  }),
+  medium: i18n.translate('xpack.slo.discover.priority.medium', {
+    defaultMessage: 'Medium',
+  }),
+  low: i18n.translate('xpack.slo.discover.priority.low', {
+    defaultMessage: 'Low',
+  }),
+};
+
+const CATEGORY_ICONS: Record<string, string> = {
+  availability: 'checkInCircleFilled',
+  latency: 'clock',
+  correctness: 'check',
+  uptime: 'online',
+  throughput: 'sortUp',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  availability: i18n.translate('xpack.slo.discover.category.availability', {
+    defaultMessage: 'Availability',
+  }),
+  latency: i18n.translate('xpack.slo.discover.category.latency', {
+    defaultMessage: 'Latency',
+  }),
+  correctness: i18n.translate('xpack.slo.discover.category.correctness', {
+    defaultMessage: 'Correctness',
+  }),
+  uptime: i18n.translate('xpack.slo.discover.category.uptime', {
+    defaultMessage: 'Uptime',
+  }),
+  throughput: i18n.translate('xpack.slo.discover.category.throughput', {
+    defaultMessage: 'Throughput',
+  }),
+};
+
+interface DiscoveredSloCardProps {
+  proposal: ProposedSlo;
+  index: number;
+  isSelected: boolean;
+  onToggle: (index: number) => void;
+}
+
+export function DiscoveredSloCard({
+  proposal,
+  index,
+  isSelected,
+  onToggle,
+}: DiscoveredSloCardProps) {
+  const { sloDefinition, rationale, category, priority } = proposal;
+  const { name, description, indicator, timeWindow, budgetingMethod, objective, tags, groupBy } =
+    sloDefinition as Record<string, unknown>;
+
+  const indicatorObj = indicator as { type?: string; params?: Record<string, unknown> } | undefined;
+  const indicatorType = indicatorObj?.type ?? 'unknown';
+  const indicatorParams = indicatorObj?.params;
+
+  const objectiveObj = objective as {
+    target?: number;
+    timesliceTarget?: number;
+    timesliceWindow?: string;
+  } | undefined;
+
+  const timeWindowObj = timeWindow as { duration?: string; type?: string } | undefined;
+
+  const handleToggle = useCallback(() => {
+    onToggle(index);
+  }, [index, onToggle]);
+
+  const details: Array<{ title: string; description: string }> = [
+    {
+      title: i18n.translate('xpack.slo.discover.card.indicatorType', {
+        defaultMessage: 'Indicator',
+      }),
+      description: INDICATOR_TYPE_LABELS[indicatorType] ?? indicatorType,
+    },
+    {
+      title: i18n.translate('xpack.slo.discover.card.target', {
+        defaultMessage: 'Target',
+      }),
+      description: `${objectiveObj?.target ?? 99}%`,
+    },
+    {
+      title: i18n.translate('xpack.slo.discover.card.timeWindow', {
+        defaultMessage: 'Window',
+      }),
+      description: `${timeWindowObj?.duration ?? '30d'} (${timeWindowObj?.type === 'calendarAligned' ? 'Calendar' : 'Rolling'})`,
+    },
+    {
+      title: i18n.translate('xpack.slo.discover.card.budgeting', {
+        defaultMessage: 'Budgeting',
+      }),
+      description: (budgetingMethod as string) === 'timeslices' ? 'Timeslices' : 'Occurrences',
+    },
+  ];
+
+  if (indicatorParams?.service) {
+    details.push({
+      title: i18n.translate('xpack.slo.discover.card.service', { defaultMessage: 'Service' }),
+      description: String(indicatorParams.service),
+    });
+  }
+
+  if (indicatorParams?.environment) {
+    details.push({
+      title: i18n.translate('xpack.slo.discover.card.environment', {
+        defaultMessage: 'Environment',
+      }),
+      description: String(indicatorParams.environment),
+    });
+  }
+
+  if (indicatorParams?.index) {
+    details.push({
+      title: i18n.translate('xpack.slo.discover.card.index', { defaultMessage: 'Index' }),
+      description: String(indicatorParams.index),
+    });
+  }
+
+  if (groupBy && groupBy !== '*') {
+    details.push({
+      title: i18n.translate('xpack.slo.discover.card.groupBy', { defaultMessage: 'Group by' }),
+      description: Array.isArray(groupBy) ? (groupBy as string[]).join(', ') : String(groupBy),
+    });
+  }
+
+  return (
+    <EuiPanel
+      paddingSize="m"
+      hasBorder
+      hasShadow={false}
+      color={isSelected ? 'primary' : 'plain'}
+      data-test-subj={`discoveredSloCard-${index}`}
+    >
+      <EuiFlexGroup alignItems="flexStart" gutterSize="m" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiCheckbox
+            id={`discovered-slo-${index}`}
+            checked={isSelected}
+            onChange={handleToggle}
+            data-test-subj={`discoveredSloCheckbox-${index}`}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup direction="column" gutterSize="s">
+            <EuiFlexItem>
+              <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiTitle size="xxs">
+                    <h4>{(name as string) || 'Untitled SLO'}</h4>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup gutterSize="xs" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiToolTip
+                        content={i18n.translate('xpack.slo.discover.card.priorityTooltip', {
+                          defaultMessage: 'Priority: {priority}',
+                          values: { priority: PRIORITY_LABELS[priority] ?? priority },
+                        })}
+                      >
+                        <EuiBadge color={PRIORITY_COLORS[priority] ?? 'default'}>
+                          {PRIORITY_LABELS[priority] ?? priority}
+                        </EuiBadge>
+                      </EuiToolTip>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiBadge
+                        color="hollow"
+                        iconType={CATEGORY_ICONS[category] ?? 'questionInCircle'}
+                      >
+                        {CATEGORY_LABELS[category] ?? category}
+                      </EuiBadge>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+
+            {description && (
+              <EuiFlexItem>
+                <EuiText size="xs" color="subdued">
+                  <p>{description as string}</p>
+                </EuiText>
+              </EuiFlexItem>
+            )}
+
+            <EuiHorizontalRule margin="xs" />
+
+            <EuiFlexItem>
+              <EuiDescriptionList type="inline" compressed listItems={details} />
+            </EuiFlexItem>
+
+            {(tags as string[] | undefined)?.length ? (
+              <EuiFlexItem>
+                <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+                  {(tags as string[]).map((tag) => (
+                    <EuiFlexItem key={tag} grow={false}>
+                      <EuiBadge color="hollow">{tag}</EuiBadge>
+                    </EuiFlexItem>
+                  ))}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            ) : null}
+
+            <EuiSpacer size="xs" />
+
+            <EuiFlexItem>
+              <EuiText size="xs" color="subdued">
+                <em>{rationale}</em>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/discovered_slo_card.tsx
@@ -101,11 +101,13 @@ export function DiscoveredSloCard({
   const indicatorType = indicatorObj?.type ?? 'unknown';
   const indicatorParams = indicatorObj?.params;
 
-  const objectiveObj = objective as {
-    target?: number;
-    timesliceTarget?: number;
-    timesliceWindow?: string;
-  } | undefined;
+  const objectiveObj = objective as
+    | {
+        target?: number;
+        timesliceTarget?: number;
+        timesliceWindow?: string;
+      }
+    | undefined;
 
   const timeWindowObj = timeWindow as { duration?: string; type?: string } | undefined;
 
@@ -130,7 +132,9 @@ export function DiscoveredSloCard({
       title: i18n.translate('xpack.slo.discover.card.timeWindow', {
         defaultMessage: 'Window',
       }),
-      description: `${timeWindowObj?.duration ?? '30d'} (${timeWindowObj?.type === 'calendarAligned' ? 'Calendar' : 'Rolling'})`,
+      description: `${timeWindowObj?.duration ?? '30d'} (${
+        timeWindowObj?.type === 'calendarAligned' ? 'Calendar' : 'Rolling'
+      })`,
     },
     {
       title: i18n.translate('xpack.slo.discover.card.budgeting', {

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/nl_slo_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/nl_slo_form.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiButton,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTextArea,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useCallback, useState } from 'react';
+import { useGenerateSlo } from '../../../../hooks/use_generate_slo';
+import { useSuggestSlo } from '../../../../hooks/use_suggest_slo';
+import type { SloSuggestion } from '../../../../hooks/use_suggest_slo';
+import type { CreateSLOForm } from '../../types';
+import { SloPreview } from './slo_preview';
+import { SloSuggestions } from './slo_suggestions';
+
+interface NlSloFormProps {
+  onApply: (values: CreateSLOForm) => void;
+}
+
+export function NlSloForm({ onApply }: NlSloFormProps) {
+  const [prompt, setPrompt] = useState('');
+  const [refinement, setRefinement] = useState('');
+  const [generatedSlo, setGeneratedSlo] = useState<CreateSLOForm | null>(null);
+  const [explanation, setExplanation] = useState('');
+  const [suggestions, setSuggestions] = useState<SloSuggestion[]>([]);
+  const [conversationHistory, setConversationHistory] = useState<
+    Array<{ role: 'user' | 'assistant'; content: string }>
+  >([]);
+
+  const generateMutation = useGenerateSlo();
+  const suggestMutation = useSuggestSlo();
+
+  const handleGenerate = useCallback(() => {
+    if (!prompt.trim()) return;
+
+    generateMutation.mutate(
+      { prompt: prompt.trim() },
+      {
+        onSuccess: (response) => {
+          const sloDefinition = response.sloDefinition as unknown as CreateSLOForm;
+          setGeneratedSlo(sloDefinition);
+          setExplanation(response.explanation);
+          setConversationHistory([
+            { role: 'user', content: prompt.trim() },
+            { role: 'assistant', content: response.explanation },
+          ]);
+
+          suggestMutation.mutate(
+            { sloDefinition: response.sloDefinition },
+            {
+              onSuccess: (suggestResponse) => {
+                setSuggestions(suggestResponse.suggestions);
+              },
+            }
+          );
+        },
+      }
+    );
+  }, [prompt, generateMutation, suggestMutation]);
+
+  const handleRefine = useCallback(() => {
+    if (!refinement.trim()) return;
+
+    const previousMessages = [
+      ...conversationHistory,
+      { role: 'user' as const, content: refinement.trim() },
+    ];
+
+    generateMutation.mutate(
+      {
+        prompt: refinement.trim(),
+        previousMessages,
+      },
+      {
+        onSuccess: (response) => {
+          const sloDefinition = response.sloDefinition as unknown as CreateSLOForm;
+          setGeneratedSlo(sloDefinition);
+          setExplanation(response.explanation);
+          setConversationHistory([
+            ...previousMessages,
+            { role: 'assistant', content: response.explanation },
+          ]);
+          setRefinement('');
+
+          suggestMutation.mutate(
+            { sloDefinition: response.sloDefinition },
+            {
+              onSuccess: (suggestResponse) => {
+                setSuggestions(suggestResponse.suggestions);
+              },
+            }
+          );
+        },
+      }
+    );
+  }, [refinement, conversationHistory, generateMutation, suggestMutation]);
+
+  const handleApply = useCallback(() => {
+    if (generatedSlo) {
+      onApply(generatedSlo);
+    }
+  }, [generatedSlo, onApply]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        if (generatedSlo) {
+          handleRefine();
+        } else {
+          handleGenerate();
+        }
+      }
+    },
+    [generatedSlo, handleGenerate, handleRefine]
+  );
+
+  const isGenerating = generateMutation.isLoading;
+
+  return (
+    <EuiPanel paddingSize="l" hasShadow={false} hasBorder data-test-subj="nlSloForm">
+      <EuiFlexGroup direction="column" gutterSize="l">
+        <EuiFlexItem>
+          <EuiText size="s" color="subdued">
+            <p>
+              {i18n.translate('xpack.slo.nlSlo.description', {
+                defaultMessage:
+                  'Describe the SLO you want to create in plain language. The AI will generate a structured definition for you to review and refine.',
+              })}
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiTextArea
+            fullWidth
+            placeholder={i18n.translate('xpack.slo.nlSlo.promptPlaceholder', {
+              defaultMessage:
+                'e.g., "I want a 99.9% availability SLO for my checkout-service in production, measured over 30 days"',
+            })}
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={3}
+            disabled={isGenerating}
+            data-test-subj="nlSloPromptInput"
+          />
+          <EuiSpacer size="s" />
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                iconType="sparkles"
+                onClick={handleGenerate}
+                isLoading={isGenerating}
+                disabled={!prompt.trim()}
+                data-test-subj="nlSloGenerateButton"
+              >
+                {i18n.translate('xpack.slo.nlSlo.generateButton', {
+                  defaultMessage: 'Generate SLO',
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        {generatedSlo && (
+          <>
+            <EuiFlexItem>
+              <SloPreview sloDefinition={generatedSlo} explanation={explanation} />
+            </EuiFlexItem>
+
+            <EuiFlexItem>
+              <SloSuggestions
+                suggestions={suggestions}
+                isLoading={suggestMutation.isLoading}
+              />
+            </EuiFlexItem>
+
+            <EuiFlexItem>
+              <EuiFlexGroup gutterSize="s" alignItems="center">
+                <EuiFlexItem>
+                  <EuiFieldText
+                    fullWidth
+                    placeholder={i18n.translate('xpack.slo.nlSlo.refinePlaceholder', {
+                      defaultMessage:
+                        'Refine your SLO... e.g., "Change the target to 99.5% and add groupBy service.name"',
+                    })}
+                    value={refinement}
+                    onChange={(e) => setRefinement(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    disabled={isGenerating}
+                    prepend={i18n.translate('xpack.slo.nlSlo.refineLabel', {
+                      defaultMessage: 'Refine',
+                    })}
+                    data-test-subj="nlSloRefineInput"
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    onClick={handleRefine}
+                    isLoading={isGenerating}
+                    disabled={!refinement.trim()}
+                    iconType="refresh"
+                    data-test-subj="nlSloRefineButton"
+                  >
+                    {i18n.translate('xpack.slo.nlSlo.refineButton', {
+                      defaultMessage: 'Refine',
+                    })}
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+
+            <EuiFlexItem>
+              <EuiFlexGroup justifyContent="flexEnd" gutterSize="m">
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    fill
+                    iconType="check"
+                    onClick={handleApply}
+                    data-test-subj="nlSloApplyButton"
+                  >
+                    {i18n.translate('xpack.slo.nlSlo.applyButton', {
+                      defaultMessage: 'Apply to form',
+                    })}
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </>
+        )}
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/nl_slo_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/nl_slo_form.tsx
@@ -182,10 +182,7 @@ export function NlSloForm({ onApply }: NlSloFormProps) {
             </EuiFlexItem>
 
             <EuiFlexItem>
-              <SloSuggestions
-                suggestions={suggestions}
-                isLoading={suggestMutation.isLoading}
-              />
+              <SloSuggestions suggestions={suggestions} isLoading={suggestMutation.isLoading} />
             </EuiFlexItem>
 
             <EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { render } from '../../../../utils/test_helper';
 import { SloDiscoverForm } from './slo_discover_form';
 import { useDiscoverSlos } from '../../../../hooks/use_discover_slos';
@@ -281,10 +281,7 @@ describe('SloDiscoverForm', () => {
     fireEvent.click(screen.getByTestId('sloDiscoverSelectAll'));
     fireEvent.click(screen.getByTestId('sloDiscoverCreateButton'));
 
-    expect(mockBulkCreate).toHaveBeenCalledWith(
-      { slos: expect.any(Array) },
-      expect.any(Object)
-    );
+    expect(mockBulkCreate).toHaveBeenCalledWith({ slos: expect.any(Array) }, expect.any(Object));
 
     const { slos } = mockBulkCreate.mock.calls[0][0];
     expect(slos).toHaveLength(3);

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.test.tsx
@@ -1,0 +1,381 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { render } from '../../../../utils/test_helper';
+import { SloDiscoverForm } from './slo_discover_form';
+import { useDiscoverSlos } from '../../../../hooks/use_discover_slos';
+import { useBulkCreateSlos } from '../../../../hooks/use_bulk_create_slos';
+import { useKibana } from '../../../../hooks/use_kibana';
+import { kibanaStartMock } from '../../../../utils/kibana_react.mock';
+
+jest.mock('../../../../hooks/use_discover_slos');
+jest.mock('../../../../hooks/use_bulk_create_slos');
+
+const mockUseKibanaReturnValue = kibanaStartMock.startContract();
+
+jest.mock('../../../../hooks/use_kibana', () => ({
+  useKibana: jest.fn(() => mockUseKibanaReturnValue),
+}));
+
+const useKibanaMock = useKibana as jest.Mock;
+const useDiscoverSlosMock = useDiscoverSlos as jest.Mock;
+const useBulkCreateSlosMock = useBulkCreateSlos as jest.Mock;
+
+const mockNavigate = jest.fn();
+
+const mockProposals = [
+  {
+    sloDefinition: {
+      name: 'API Availability',
+      description: 'Tracks API error rate',
+      indicator: {
+        type: 'sli.apm.transactionErrorRate',
+        params: { service: 'api-gateway', environment: 'production', index: 'metrics-apm*' },
+      },
+      timeWindow: { duration: '30d', type: 'rolling' },
+      budgetingMethod: 'occurrences',
+      objective: { target: 0.995 },
+      tags: ['auto-discovered'],
+    },
+    rationale: 'Critical user-facing service',
+    category: 'availability',
+    priority: 'critical',
+  },
+  {
+    sloDefinition: {
+      name: 'Checkout Latency',
+      description: 'P99 checkout latency',
+      indicator: {
+        type: 'sli.apm.transactionDuration',
+        params: {
+          service: 'checkout',
+          environment: 'production',
+          index: 'metrics-apm*',
+          threshold: 500,
+        },
+      },
+      timeWindow: { duration: '30d', type: 'rolling' },
+      budgetingMethod: 'occurrences',
+      objective: { target: 0.99 },
+      tags: ['auto-discovered'],
+    },
+    rationale: 'High-traffic checkout flow',
+    category: 'latency',
+    priority: 'high',
+  },
+  {
+    sloDefinition: {
+      name: 'Log Error Rate',
+      description: 'Log-based error rate',
+      indicator: {
+        type: 'sli.kql.custom',
+        params: {
+          index: 'logs-*',
+          good: 'NOT log.level: error',
+          total: '*',
+          timestampField: '@timestamp',
+        },
+      },
+      timeWindow: { duration: '7d', type: 'rolling' },
+      budgetingMethod: 'occurrences',
+      objective: { target: 0.95 },
+      tags: ['auto-discovered'],
+    },
+    rationale: 'General log health',
+    category: 'correctness',
+    priority: 'medium',
+  },
+];
+
+describe('SloDiscoverForm', () => {
+  const mockMutate = jest.fn();
+  const mockBulkCreate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useKibanaMock.mockReturnValue({
+      services: {
+        ...mockUseKibanaReturnValue.services,
+        application: {
+          navigateToUrl: mockNavigate,
+        },
+        http: {
+          basePath: {
+            prepend: (path: string) => path,
+          },
+        },
+      },
+    });
+
+    useDiscoverSlosMock.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: false,
+    });
+
+    useBulkCreateSlosMock.mockReturnValue({
+      mutate: mockBulkCreate,
+      isLoading: false,
+      batchProgress: null,
+      abort: jest.fn(),
+    });
+  });
+
+  it('renders the initial empty prompt', () => {
+    render(<SloDiscoverForm />);
+
+    expect(screen.getByTestId('sloDiscoverForm')).toBeTruthy();
+    expect(screen.getByTestId('sloDiscoverButton')).toBeTruthy();
+    expect(screen.getByText('Auto-discover SLOs from your data')).toBeTruthy();
+  });
+
+  it('calls discover mutation when scan button is clicked', () => {
+    render(<SloDiscoverForm />);
+
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+    expect(mockMutate).toHaveBeenCalledWith({}, expect.any(Object));
+  });
+
+  it('shows loading state during discovery', () => {
+    useDiscoverSlosMock.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: true,
+    });
+
+    render(<SloDiscoverForm />);
+
+    expect(screen.getByText(/Scanning your cluster/)).toBeTruthy();
+  });
+
+  it('renders discovered proposals after successful scan', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 data sources suitable for SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByText('API Availability')).toBeTruthy();
+    expect(screen.getByText('Checkout Latency')).toBeTruthy();
+    expect(screen.getByText('Log Error Rate')).toBeTruthy();
+  });
+
+  it('auto-selects critical and high priority proposals', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByText('2 of 3 selected')).toBeTruthy();
+  });
+
+  it('shows no proposals callout when cluster has no data', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: [],
+        summary: 'No data sources found',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByText('No SLOs discovered')).toBeTruthy();
+  });
+
+  it('renders select all and deselect all buttons', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByTestId('sloDiscoverSelectAll')).toBeTruthy();
+    expect(screen.getByTestId('sloDiscoverDeselectAll')).toBeTruthy();
+  });
+
+  it('selects all proposals when select all is clicked', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    fireEvent.click(screen.getByTestId('sloDiscoverSelectAll'));
+    expect(screen.getByText('3 of 3 selected')).toBeTruthy();
+  });
+
+  it('deselects all proposals when deselect all is clicked', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    fireEvent.click(screen.getByTestId('sloDiscoverDeselectAll'));
+    expect(screen.getByText('0 of 3 selected')).toBeTruthy();
+  });
+
+  it('disables create button when no proposals are selected', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    fireEvent.click(screen.getByTestId('sloDiscoverDeselectAll'));
+
+    const createButton = screen.getByTestId('sloDiscoverCreateButton');
+    expect(createButton.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('calls bulk create with selected proposals when create button is clicked', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    fireEvent.click(screen.getByTestId('sloDiscoverSelectAll'));
+    fireEvent.click(screen.getByTestId('sloDiscoverCreateButton'));
+
+    expect(mockBulkCreate).toHaveBeenCalledWith(
+      { slos: expect.any(Array) },
+      expect.any(Object)
+    );
+
+    const { slos } = mockBulkCreate.mock.calls[0][0];
+    expect(slos).toHaveLength(3);
+  });
+
+  it('renders rescan button after discovery', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByTestId('sloDiscoverRescanButton')).toBeTruthy();
+  });
+
+  it('renders batch progress when creating', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    useBulkCreateSlosMock.mockReturnValue({
+      mutate: mockBulkCreate,
+      isLoading: true,
+      batchProgress: {
+        currentBatch: 1,
+        totalBatches: 2,
+        completedSlos: 0,
+        totalSlos: 3,
+        successCount: 0,
+        failureCount: 0,
+      },
+      abort: jest.fn(),
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByText('Creating batch 1 of 2...')).toBeTruthy();
+    expect(screen.getByText('0 of 3 SLOs processed')).toBeTruthy();
+  });
+
+  it('renders abort button during batch creation', () => {
+    useBulkCreateSlosMock.mockReturnValue({
+      mutate: mockBulkCreate,
+      isLoading: true,
+      batchProgress: {
+        currentBatch: 1,
+        totalBatches: 2,
+        completedSlos: 0,
+        totalSlos: 3,
+        successCount: 0,
+        failureCount: 0,
+      },
+      abort: jest.fn(),
+    });
+
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByTestId('sloDiscoverAbortButton')).toBeTruthy();
+  });
+
+  it('displays priority stats after discovery', () => {
+    mockMutate.mockImplementation((_input: unknown, options: { onSuccess: Function }) => {
+      options.onSuccess({
+        proposedSlos: mockProposals,
+        summary: 'Found 3 SLOs',
+        clusterSummary: '',
+      });
+    });
+
+    render(<SloDiscoverForm />);
+    fireEvent.click(screen.getByTestId('sloDiscoverButton'));
+
+    expect(screen.getByText('Discovered 3 SLOs')).toBeTruthy();
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.tsx
@@ -1,0 +1,456 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiProgress,
+  EuiSpacer,
+  EuiStat,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useDiscoverSlos } from '../../../../hooks/use_discover_slos';
+import type { ProposedSlo } from '../../../../hooks/use_discover_slos';
+import { useBulkCreateSlos } from '../../../../hooks/use_bulk_create_slos';
+import { useKibana } from '../../../../hooks/use_kibana';
+import { normalizeForCreate } from '../../../../utils/normalize_slo_for_create';
+import { paths } from '@kbn/slo-shared-plugin/common/locators/paths';
+import { DiscoveredSloCard } from './discovered_slo_card';
+
+export function SloDiscoverForm() {
+  const {
+    application: { navigateToUrl },
+    http: { basePath },
+  } = useKibana().services;
+
+  const [proposals, setProposals] = useState<ProposedSlo[]>([]);
+  const [summary, setSummary] = useState('');
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
+  const [hasDiscovered, setHasDiscovered] = useState(false);
+
+  const discoverMutation = useDiscoverSlos();
+  const { mutate: bulkCreate, isLoading: isCreating, batchProgress, abort: abortBulkCreate } =
+    useBulkCreateSlos();
+
+  const handleDiscover = useCallback(() => {
+    discoverMutation.mutate(
+      {},
+      {
+        onSuccess: (response) => {
+          setProposals(response.proposedSlos);
+          setSummary(response.summary);
+          setHasDiscovered(true);
+          const allIndices = new Set<number>(
+            response.proposedSlos
+              .filter((p) => p.priority === 'critical' || p.priority === 'high')
+              .map((_, idx) => idx)
+          );
+          setSelectedIndices(allIndices);
+        },
+      }
+    );
+  }, [discoverMutation]);
+
+  const handleToggleSelection = useCallback((index: number) => {
+    setSelectedIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedIndices(new Set(proposals.map((_, idx) => idx)));
+  }, [proposals]);
+
+  const handleDeselectAll = useCallback(() => {
+    setSelectedIndices(new Set());
+  }, []);
+
+  const handleCreateSelected = useCallback(() => {
+    const selectedSlos = proposals
+      .filter((_, idx) => selectedIndices.has(idx))
+      .map((p) => normalizeForCreate(p.sloDefinition));
+
+    bulkCreate(
+      { slos: selectedSlos },
+      {
+        onSuccess: () => {
+          navigateToUrl(basePath.prepend(paths.slos));
+        },
+      }
+    );
+  }, [proposals, selectedIndices, bulkCreate, navigateToUrl, basePath]);
+
+  const isDiscovering = discoverMutation.isLoading;
+
+  const priorityCounts = useMemo(() => {
+    const counts = { critical: 0, high: 0, medium: 0, low: 0 };
+    for (const p of proposals) {
+      if (p.priority in counts) {
+        counts[p.priority as keyof typeof counts]++;
+      }
+    }
+    return counts;
+  }, [proposals]);
+
+  const categoryCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const p of proposals) {
+      counts[p.category] = (counts[p.category] ?? 0) + 1;
+    }
+    return counts;
+  }, [proposals]);
+
+  if (!hasDiscovered) {
+    return (
+      <EuiPanel paddingSize="l" hasShadow={false} hasBorder data-test-subj="sloDiscoverForm">
+        <EuiEmptyPrompt
+          iconType="magnifyWithPlus"
+          title={
+            <h3>
+              {i18n.translate('xpack.slo.discover.emptyTitle', {
+                defaultMessage: 'Auto-discover SLOs from your data',
+              })}
+            </h3>
+          }
+          body={
+            <EuiText size="s" color="subdued">
+              <p>
+                {i18n.translate('xpack.slo.discover.emptyDescription', {
+                  defaultMessage:
+                    'Scan your cluster to automatically identify APM services, synthetics monitors, log streams, and metric sources. AI will analyze your data and propose user-centric SLOs following SRE best practices. Review the proposals and create them all with one click.',
+                })}
+              </p>
+            </EuiText>
+          }
+          actions={
+            <EuiButton
+              fill
+              iconType="sparkles"
+              onClick={handleDiscover}
+              isLoading={isDiscovering}
+              data-test-subj="sloDiscoverButton"
+            >
+              {i18n.translate('xpack.slo.discover.scanButton', {
+                defaultMessage: 'Scan cluster & discover SLOs',
+              })}
+            </EuiButton>
+          }
+        />
+        {isDiscovering && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiProgress size="xs" color="primary" />
+            <EuiSpacer size="s" />
+            <EuiText size="xs" color="subdued" textAlign="center">
+              <p>
+                {i18n.translate('xpack.slo.discover.scanning', {
+                  defaultMessage:
+                    'Scanning your cluster for APM services, synthetics monitors, logs, and metrics...',
+                })}
+              </p>
+            </EuiText>
+          </>
+        )}
+      </EuiPanel>
+    );
+  }
+
+  if (proposals.length === 0) {
+    return (
+      <EuiPanel paddingSize="l" hasShadow={false} hasBorder data-test-subj="sloDiscoverForm">
+        <EuiCallOut
+          title={i18n.translate('xpack.slo.discover.noProposals', {
+            defaultMessage: 'No SLOs discovered',
+          })}
+          color="warning"
+          iconType="alert"
+        >
+          <p>
+            {i18n.translate('xpack.slo.discover.noProposalsDescription', {
+              defaultMessage:
+                'No data sources suitable for SLO creation were found in your cluster. Ensure you have APM, synthetics, or log data being ingested.',
+            })}
+          </p>
+          <EuiSpacer size="s" />
+          <EuiButton
+            onClick={handleDiscover}
+            isLoading={isDiscovering}
+            iconType="refresh"
+            size="s"
+          >
+            {i18n.translate('xpack.slo.discover.retryButton', {
+              defaultMessage: 'Retry scan',
+            })}
+          </EuiButton>
+        </EuiCallOut>
+      </EuiPanel>
+    );
+  }
+
+  return (
+    <EuiPanel paddingSize="l" hasShadow={false} hasBorder data-test-subj="sloDiscoverForm">
+      <EuiFlexGroup direction="column" gutterSize="l">
+        {/* Summary section */}
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h3>
+              {i18n.translate('xpack.slo.discover.resultsTitle', {
+                defaultMessage: 'Discovered {count} {count, plural, one {SLO} other {SLOs}}',
+                values: { count: proposals.length },
+              })}
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="s" color="subdued">
+            <p>{summary}</p>
+          </EuiText>
+        </EuiFlexItem>
+
+        {/* Stats row */}
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="l">
+            <EuiFlexItem>
+              <EuiStat
+                title={priorityCounts.critical}
+                description={i18n.translate('xpack.slo.discover.stats.critical', {
+                  defaultMessage: 'Critical',
+                })}
+                titleColor="danger"
+                titleSize="s"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiStat
+                title={priorityCounts.high}
+                description={i18n.translate('xpack.slo.discover.stats.high', {
+                  defaultMessage: 'High',
+                })}
+                titleColor="warning"
+                titleSize="s"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiStat
+                title={priorityCounts.medium + priorityCounts.low}
+                description={i18n.translate('xpack.slo.discover.stats.other', {
+                  defaultMessage: 'Medium / Low',
+                })}
+                titleColor="primary"
+                titleSize="s"
+              />
+            </EuiFlexItem>
+            {Object.entries(categoryCounts).map(([cat, count]) => (
+              <EuiFlexItem key={cat}>
+                <EuiStat
+                  title={count}
+                  description={cat.charAt(0).toUpperCase() + cat.slice(1)}
+                  titleSize="s"
+                />
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        {/* Selection controls */}
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    size="xs"
+                    onClick={handleSelectAll}
+                    data-test-subj="sloDiscoverSelectAll"
+                  >
+                    {i18n.translate('xpack.slo.discover.selectAll', {
+                      defaultMessage: 'Select all',
+                    })}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    size="xs"
+                    onClick={handleDeselectAll}
+                    data-test-subj="sloDiscoverDeselectAll"
+                  >
+                    {i18n.translate('xpack.slo.discover.deselectAll', {
+                      defaultMessage: 'Deselect all',
+                    })}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate('xpack.slo.discover.selectedCount', {
+                  defaultMessage: '{selected} of {total} selected',
+                  values: { selected: selectedIndices.size, total: proposals.length },
+                })}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        {/* SLO proposal cards */}
+        <EuiFlexItem>
+          <EuiFlexGroup direction="column" gutterSize="s">
+            {proposals.map((proposal, index) => (
+              <EuiFlexItem key={index}>
+                <DiscoveredSloCard
+                  proposal={proposal}
+                  index={index}
+                  isSelected={selectedIndices.has(index)}
+                  onToggle={handleToggleSelection}
+                />
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        {/* Action buttons */}
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                onClick={handleDiscover}
+                isLoading={isDiscovering}
+                iconType="refresh"
+                data-test-subj="sloDiscoverRescanButton"
+              >
+                {i18n.translate('xpack.slo.discover.rescanButton', {
+                  defaultMessage: 'Re-scan cluster',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                iconType="check"
+                onClick={handleCreateSelected}
+                isLoading={isCreating}
+                disabled={selectedIndices.size === 0}
+                data-test-subj="sloDiscoverCreateButton"
+              >
+                {i18n.translate('xpack.slo.discover.createButton', {
+                  defaultMessage:
+                    'Create {count} {count, plural, one {SLO} other {SLOs}}',
+                  values: { count: selectedIndices.size },
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        {/* Batch creation progress */}
+        {isCreating && batchProgress && (
+          <EuiFlexItem>
+            <EuiPanel color="subdued" paddingSize="m" hasShadow={false}>
+              <EuiFlexGroup direction="column" gutterSize="s">
+                <EuiFlexItem>
+                  <EuiFlexGroup alignItems="center" gutterSize="s">
+                    <EuiFlexItem grow={false}>
+                      <EuiLoadingSpinner size="s" />
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiText size="s">
+                        <strong>
+                          {i18n.translate('xpack.slo.discover.batchProgress', {
+                            defaultMessage:
+                              'Creating batch {current} of {total}...',
+                            values: {
+                              current: batchProgress.currentBatch,
+                              total: batchProgress.totalBatches,
+                            },
+                          })}
+                        </strong>
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiProgress
+                    value={batchProgress.completedSlos}
+                    max={batchProgress.totalSlos}
+                    size="m"
+                    color="primary"
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFlexGroup gutterSize="l" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        {i18n.translate('xpack.slo.discover.batchCompleted', {
+                          defaultMessage:
+                            '{completed} of {total} SLOs processed',
+                          values: {
+                            completed: batchProgress.completedSlos,
+                            total: batchProgress.totalSlos,
+                          },
+                        })}
+                      </EuiText>
+                    </EuiFlexItem>
+                    {batchProgress.successCount > 0 && (
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="xs" color="success">
+                          {i18n.translate('xpack.slo.discover.batchSuccessCount', {
+                            defaultMessage: '{count} succeeded',
+                            values: { count: batchProgress.successCount },
+                          })}
+                        </EuiText>
+                      </EuiFlexItem>
+                    )}
+                    {batchProgress.failureCount > 0 && (
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="xs" color="danger">
+                          {i18n.translate('xpack.slo.discover.batchFailureCount', {
+                            defaultMessage: '{count} failed',
+                            values: { count: batchProgress.failureCount },
+                          })}
+                        </EuiText>
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFlexGroup justifyContent="flexEnd">
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty
+                        size="xs"
+                        color="danger"
+                        onClick={abortBulkCreate}
+                        data-test-subj="sloDiscoverAbortButton"
+                      >
+                        {i18n.translate('xpack.slo.discover.abortButton', {
+                          defaultMessage: 'Stop after current batch',
+                        })}
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_discover_form.tsx
@@ -22,12 +22,12 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useMemo, useState } from 'react';
+import { paths } from '@kbn/slo-shared-plugin/common/locators/paths';
 import { useDiscoverSlos } from '../../../../hooks/use_discover_slos';
 import type { ProposedSlo } from '../../../../hooks/use_discover_slos';
 import { useBulkCreateSlos } from '../../../../hooks/use_bulk_create_slos';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { normalizeForCreate } from '../../../../utils/normalize_slo_for_create';
-import { paths } from '@kbn/slo-shared-plugin/common/locators/paths';
 import { DiscoveredSloCard } from './discovered_slo_card';
 
 export function SloDiscoverForm() {
@@ -42,8 +42,12 @@ export function SloDiscoverForm() {
   const [hasDiscovered, setHasDiscovered] = useState(false);
 
   const discoverMutation = useDiscoverSlos();
-  const { mutate: bulkCreate, isLoading: isCreating, batchProgress, abort: abortBulkCreate } =
-    useBulkCreateSlos();
+  const {
+    mutate: bulkCreate,
+    isLoading: isCreating,
+    batchProgress,
+    abort: abortBulkCreate,
+  } = useBulkCreateSlos();
 
   const handleDiscover = useCallback(() => {
     discoverMutation.mutate(
@@ -192,6 +196,7 @@ export function SloDiscoverForm() {
           </p>
           <EuiSpacer size="s" />
           <EuiButton
+            data-test-subj="sloSloDiscoverFormRetryScanButton"
             onClick={handleDiscover}
             isLoading={isDiscovering}
             iconType="refresh"
@@ -351,8 +356,7 @@ export function SloDiscoverForm() {
                 data-test-subj="sloDiscoverCreateButton"
               >
                 {i18n.translate('xpack.slo.discover.createButton', {
-                  defaultMessage:
-                    'Create {count} {count, plural, one {SLO} other {SLOs}}',
+                  defaultMessage: 'Create {count} {count, plural, one {SLO} other {SLOs}}',
                   values: { count: selectedIndices.size },
                 })}
               </EuiButton>
@@ -374,8 +378,7 @@ export function SloDiscoverForm() {
                       <EuiText size="s">
                         <strong>
                           {i18n.translate('xpack.slo.discover.batchProgress', {
-                            defaultMessage:
-                              'Creating batch {current} of {total}...',
+                            defaultMessage: 'Creating batch {current} of {total}...',
                             values: {
                               current: batchProgress.currentBatch,
                               total: batchProgress.totalBatches,
@@ -399,8 +402,7 @@ export function SloDiscoverForm() {
                     <EuiFlexItem grow={false}>
                       <EuiText size="xs" color="subdued">
                         {i18n.translate('xpack.slo.discover.batchCompleted', {
-                          defaultMessage:
-                            '{completed} of {total} SLOs processed',
+                          defaultMessage: '{completed} of {total} SLOs processed',
                           values: {
                             completed: batchProgress.completedSlos,
                             total: batchProgress.totalSlos,

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_preview.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_preview.tsx
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import type { CreateSLOForm } from '../../types';
+
+const INDICATOR_TYPE_LABELS: Record<string, string> = {
+  'sli.kql.custom': 'Custom Query (KQL)',
+  'sli.apm.transactionDuration': 'APM Latency',
+  'sli.apm.transactionErrorRate': 'APM Availability',
+  'sli.metric.custom': 'Custom Metric',
+  'sli.metric.timeslice': 'Timeslice Metric',
+  'sli.histogram.custom': 'Histogram Metric',
+  'sli.synthetics.availability': 'Synthetics Availability',
+};
+
+interface SloPreviewProps {
+  sloDefinition: CreateSLOForm;
+  explanation: string;
+}
+
+export function SloPreview({ sloDefinition, explanation }: SloPreviewProps) {
+  const { name, description, indicator, timeWindow, budgetingMethod, objective, tags, groupBy } =
+    sloDefinition;
+
+  const indicatorType = indicator?.type ?? 'unknown';
+  const indicatorParams = (indicator as Record<string, unknown>)?.params as
+    | Record<string, unknown>
+    | undefined;
+
+  const sliDetails = buildSliDetails(indicatorType, indicatorParams);
+  const objectiveDetails = buildObjectiveDetails(objective, budgetingMethod, timeWindow);
+
+  return (
+    <EuiPanel paddingSize="l" hasBorder data-test-subj="sloAiPreview">
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h3>{name || i18n.translate('xpack.slo.nlSlo.preview.untitled', { defaultMessage: 'Untitled SLO' })}</h3>
+          </EuiTitle>
+          {description && (
+            <>
+              <EuiSpacer size="xs" />
+              <EuiText size="s" color="subdued">
+                <p>{description}</p>
+              </EuiText>
+            </>
+          )}
+        </EuiFlexItem>
+
+        {tags && tags.length > 0 && (
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+              {tags.map((tag) => (
+                <EuiFlexItem key={tag} grow={false}>
+                  <EuiBadge color="hollow">{tag}</EuiBadge>
+                </EuiFlexItem>
+              ))}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        )}
+
+        <EuiHorizontalRule margin="xs" />
+
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h4>
+              {i18n.translate('xpack.slo.nlSlo.preview.sliSection', {
+                defaultMessage: 'Service Level Indicator',
+              })}
+            </h4>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiDescriptionList
+            type="column"
+            compressed
+            listItems={[
+              {
+                title: i18n.translate('xpack.slo.nlSlo.preview.indicatorType', {
+                  defaultMessage: 'Indicator type',
+                }),
+                description: INDICATOR_TYPE_LABELS[indicatorType] ?? indicatorType,
+              },
+              ...sliDetails,
+            ]}
+          />
+        </EuiFlexItem>
+
+        <EuiHorizontalRule margin="xs" />
+
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h4>
+              {i18n.translate('xpack.slo.nlSlo.preview.objectiveSection', {
+                defaultMessage: 'Objective',
+              })}
+            </h4>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiDescriptionList type="column" compressed listItems={objectiveDetails} />
+        </EuiFlexItem>
+
+        {groupBy && groupBy !== '*' && (
+          <>
+            <EuiHorizontalRule margin="xs" />
+            <EuiFlexItem>
+              <EuiDescriptionList
+                type="column"
+                compressed
+                listItems={[
+                  {
+                    title: i18n.translate('xpack.slo.nlSlo.preview.groupBy', {
+                      defaultMessage: 'Group by',
+                    }),
+                    description: Array.isArray(groupBy) ? groupBy.join(', ') : String(groupBy),
+                  },
+                ]}
+              />
+            </EuiFlexItem>
+          </>
+        )}
+
+        <EuiHorizontalRule margin="xs" />
+
+        <EuiFlexItem>
+          <EuiText size="xs" color="subdued">
+            <strong>
+              {i18n.translate('xpack.slo.nlSlo.preview.explanation', {
+                defaultMessage: 'AI explanation',
+              })}
+            </strong>
+            <p>{explanation}</p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}
+
+function buildSliDetails(
+  indicatorType: string,
+  params: Record<string, unknown> | undefined
+): Array<{ title: string; description: string }> {
+  if (!params) return [];
+
+  const details: Array<{ title: string; description: string }> = [];
+
+  if (params.index) {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.index', { defaultMessage: 'Index' }),
+      description: String(params.index),
+    });
+  }
+
+  if (params.service) {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.service', { defaultMessage: 'Service' }),
+      description: String(params.service),
+    });
+  }
+
+  if (params.environment) {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.environment', {
+        defaultMessage: 'Environment',
+      }),
+      description: String(params.environment),
+    });
+  }
+
+  if (params.threshold !== undefined) {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.threshold', {
+        defaultMessage: 'Threshold',
+      }),
+      description: `${params.threshold}ms`,
+    });
+  }
+
+  if (params.good && typeof params.good === 'string') {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.goodQuery', {
+        defaultMessage: 'Good events',
+      }),
+      description: String(params.good),
+    });
+  }
+
+  if (params.total && typeof params.total === 'string') {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.totalQuery', {
+        defaultMessage: 'Total events',
+      }),
+      description: String(params.total),
+    });
+  }
+
+  if (params.filter && typeof params.filter === 'string') {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.filter', { defaultMessage: 'Filter' }),
+      description: String(params.filter),
+    });
+  }
+
+  return details;
+}
+
+function buildObjectiveDetails(
+  objective: CreateSLOForm['objective'],
+  budgetingMethod: string,
+  timeWindow: CreateSLOForm['timeWindow']
+): Array<{ title: string; description: string }> {
+  const details: Array<{ title: string; description: string }> = [];
+
+  details.push({
+    title: i18n.translate('xpack.slo.nlSlo.preview.target', { defaultMessage: 'Target' }),
+    description: `${objective?.target ?? 99}%`,
+  });
+
+  details.push({
+    title: i18n.translate('xpack.slo.nlSlo.preview.budgetingMethod', {
+      defaultMessage: 'Budgeting method',
+    }),
+    description: budgetingMethod === 'timeslices' ? 'Timeslices' : 'Occurrences',
+  });
+
+  if (budgetingMethod === 'timeslices' && objective?.timesliceTarget !== undefined) {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.timesliceTarget', {
+        defaultMessage: 'Timeslice target',
+      }),
+      description: `${(objective.timesliceTarget * 100).toFixed(1)}%`,
+    });
+  }
+
+  if (budgetingMethod === 'timeslices' && objective?.timesliceWindow) {
+    details.push({
+      title: i18n.translate('xpack.slo.nlSlo.preview.timesliceWindow', {
+        defaultMessage: 'Timeslice window',
+      }),
+      description: objective.timesliceWindow,
+    });
+  }
+
+  details.push({
+    title: i18n.translate('xpack.slo.nlSlo.preview.timeWindow', {
+      defaultMessage: 'Time window',
+    }),
+    description: `${timeWindow?.duration ?? '30d'} (${timeWindow?.type === 'calendarAligned' ? 'Calendar' : 'Rolling'})`,
+  });
+
+  return details;
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_preview.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_preview.tsx
@@ -52,7 +52,12 @@ export function SloPreview({ sloDefinition, explanation }: SloPreviewProps) {
       <EuiFlexGroup direction="column" gutterSize="m">
         <EuiFlexItem>
           <EuiTitle size="s">
-            <h3>{name || i18n.translate('xpack.slo.nlSlo.preview.untitled', { defaultMessage: 'Untitled SLO' })}</h3>
+            <h3>
+              {name ||
+                i18n.translate('xpack.slo.nlSlo.preview.untitled', {
+                  defaultMessage: 'Untitled SLO',
+                })}
+            </h3>
           </EuiTitle>
           {description && (
             <>
@@ -262,7 +267,9 @@ function buildObjectiveDetails(
     title: i18n.translate('xpack.slo.nlSlo.preview.timeWindow', {
       defaultMessage: 'Time window',
     }),
-    description: `${timeWindow?.duration ?? '30d'} (${timeWindow?.type === 'calendarAligned' ? 'Calendar' : 'Rolling'})`,
+    description: `${timeWindow?.duration ?? '30d'} (${
+      timeWindow?.type === 'calendarAligned' ? 'Calendar' : 'Rolling'
+    })`,
   });
 
   return details;

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_suggestions.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_suggestions.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiAccordion,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import type { SloSuggestion } from '../../../../hooks/use_suggest_slo';
+
+interface SloSuggestionsProps {
+  suggestions: SloSuggestion[];
+  isLoading: boolean;
+}
+
+export function SloSuggestions({ suggestions, isLoading }: SloSuggestionsProps) {
+  if (isLoading) {
+    return (
+      <EuiFlexGroup alignItems="center" gutterSize="s" data-test-subj="sloSuggestionsLoading">
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="m" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText size="s" color="subdued">
+            {i18n.translate('xpack.slo.nlSlo.suggestions.loading', {
+              defaultMessage: 'Analyzing SLO for improvement suggestions...',
+            })}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  if (suggestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <EuiAccordion
+      id="sloAiSuggestions"
+      buttonContent={
+        <EuiTitle size="xxs">
+          <h4>
+            {i18n.translate('xpack.slo.nlSlo.suggestions.title', {
+              defaultMessage: 'Enhancement suggestions ({count})',
+              values: { count: suggestions.length },
+            })}
+          </h4>
+        </EuiTitle>
+      }
+      initialIsOpen
+      data-test-subj="sloAiSuggestions"
+    >
+      <EuiSpacer size="s" />
+      <EuiFlexGroup direction="column" gutterSize="s">
+        {suggestions.map((suggestion, index) => (
+          <EuiFlexItem key={index}>
+            <EuiCallOut
+              title={suggestion.title}
+              color="primary"
+              iconType="iInCircle"
+              size="s"
+            >
+              <EuiText size="xs">
+                <p>{suggestion.description}</p>
+              </EuiText>
+              {suggestion.field && (
+                <EuiText size="xs" color="subdued">
+                  <p>
+                    {i18n.translate('xpack.slo.nlSlo.suggestions.affectedField', {
+                      defaultMessage: 'Applies to: {field}',
+                      values: { field: suggestion.field },
+                    })}
+                  </p>
+                </EuiText>
+              )}
+            </EuiCallOut>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </EuiAccordion>
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_suggestions.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/nl_slo/slo_suggestions.tsx
@@ -66,12 +66,7 @@ export function SloSuggestions({ suggestions, isLoading }: SloSuggestionsProps) 
       <EuiFlexGroup direction="column" gutterSize="s">
         {suggestions.map((suggestion, index) => (
           <EuiFlexItem key={index}>
-            <EuiCallOut
-              title={suggestion.title}
-              color="primary"
-              iconType="iInCircle"
-              size="s"
-            >
+            <EuiCallOut title={suggestion.title} color="primary" iconType="iInCircle" size="s">
               <EuiText size="xs">
                 <p>{suggestion.description}</p>
               </EuiText>

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.tsx
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { EuiLoadingSpinner } from '@elastic/eui';
+import { EuiLoadingSpinner, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useBreadcrumbs } from '@kbn/observability-shared-plugin/public';
 import { paths } from '@kbn/slo-shared-plugin/common/locators/paths';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { HeaderMenu } from '../../components/header_menu/header_menu';
 import { useKibana } from '../../hooks/use_kibana';
@@ -17,6 +17,12 @@ import { useLicense } from '../../hooks/use_license';
 import { usePermissions } from '../../hooks/use_permissions';
 import { usePluginContext } from '../../hooks/use_plugin_context';
 import { SloEditForm } from './components/slo_edit_form';
+import {
+  CreationModeToggle,
+  type CreationMode,
+} from './components/nl_slo/creation_mode_toggle';
+import { NlSloForm } from './components/nl_slo/nl_slo_form';
+import { SloDiscoverForm } from './components/nl_slo/slo_discover_form';
 import { useSloFormValues } from './hooks/use_slo_form_values';
 
 export function SloEditPage() {
@@ -32,6 +38,8 @@ export function SloEditPage() {
   const { ObservabilityPageTemplate } = usePluginContext();
   const { hasAtLeast } = useLicense();
   const hasRightLicense = hasAtLeast('platinum');
+
+  const [creationMode, setCreationMode] = useState<CreationMode>('manual');
 
   useBreadcrumbs(
     [
@@ -73,6 +81,8 @@ export function SloEditPage() {
     }
   }, [hasRightLicense, permissions, navigateToUrl, basePath]);
 
+  const showToggle = !isEditMode && !isLoading;
+
   return (
     <ObservabilityPageTemplate
       pageHeader={{
@@ -88,10 +98,39 @@ export function SloEditPage() {
       data-test-subj="sloEditPage"
     >
       <HeaderMenu />
+      {showToggle && (
+        <>
+          <CreationModeToggle mode={creationMode} onChange={setCreationMode} />
+          <EuiSpacer size="l" />
+        </>
+      )}
       {isLoading ? (
         <EuiLoadingSpinner size="xl" data-test-subj="sloEditLoadingSpinner" />
       ) : (
-        <SloEditForm slo={slo} formSettings={{ isEditMode }} initialValues={initialValues} />
+        <>
+          {creationMode === 'ai_assisted' && !isEditMode && (
+            <>
+              <NlSloForm onApply={() => setCreationMode('manual')} />
+              <EuiSpacer size="l" />
+            </>
+          )}
+          {creationMode === 'auto_discover' && !isEditMode && (
+            <SloDiscoverForm />
+          )}
+          <div
+            style={
+              (creationMode === 'ai_assisted' || creationMode === 'auto_discover') && !isEditMode
+                ? { display: 'none' }
+                : {}
+            }
+          >
+            <SloEditForm
+              slo={slo}
+              formSettings={{ isEditMode }}
+              initialValues={initialValues}
+            />
+          </div>
+        </>
       )}
     </ObservabilityPageTemplate>
   );

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.tsx
@@ -17,10 +17,7 @@ import { useLicense } from '../../hooks/use_license';
 import { usePermissions } from '../../hooks/use_permissions';
 import { usePluginContext } from '../../hooks/use_plugin_context';
 import { SloEditForm } from './components/slo_edit_form';
-import {
-  CreationModeToggle,
-  type CreationMode,
-} from './components/nl_slo/creation_mode_toggle';
+import { CreationModeToggle, type CreationMode } from './components/nl_slo/creation_mode_toggle';
 import { NlSloForm } from './components/nl_slo/nl_slo_form';
 import { SloDiscoverForm } from './components/nl_slo/slo_discover_form';
 import { useSloFormValues } from './hooks/use_slo_form_values';
@@ -114,9 +111,7 @@ export function SloEditPage() {
               <EuiSpacer size="l" />
             </>
           )}
-          {creationMode === 'auto_discover' && !isEditMode && (
-            <SloDiscoverForm />
-          )}
+          {creationMode === 'auto_discover' && !isEditMode && <SloDiscoverForm />}
           <div
             style={
               (creationMode === 'ai_assisted' || creationMode === 'auto_discover') && !isEditMode
@@ -124,11 +119,7 @@ export function SloEditPage() {
                 : {}
             }
           >
-            <SloEditForm
-              slo={slo}
-              formSettings={{ isEditMode }}
-              initialValues={initialValues}
-            />
+            <SloEditForm slo={slo} formSettings={{ isEditMode }} initialValues={initialValues} />
           </div>
         </>
       )}

--- a/x-pack/solutions/observability/plugins/slo/public/utils/normalize_slo_for_create.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/utils/normalize_slo_for_create.test.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  normalizeForCreate,
+  ensureIndicatorIndex,
+  toDurationString,
+  DEFAULT_INDEX_BY_TYPE,
+} from './normalize_slo_for_create';
+
+describe('toDurationString', () => {
+  it('returns valid duration strings unchanged', () => {
+    expect(toDurationString('1m')).toBe('1m');
+    expect(toDurationString('30d')).toBe('30d');
+    expect(toDurationString('2h')).toBe('2h');
+  });
+
+  it('converts numbers to minute-based duration strings', () => {
+    expect(toDurationString(1)).toBe('1m');
+    expect(toDurationString(10)).toBe('10m');
+  });
+
+  it('returns default 1m for invalid values', () => {
+    expect(toDurationString(undefined)).toBe('1m');
+    expect(toDurationString(null)).toBe('1m');
+    expect(toDurationString('invalid')).toBe('1m');
+  });
+});
+
+describe('ensureIndicatorIndex', () => {
+  it('returns undefined indicators unchanged', () => {
+    expect(ensureIndicatorIndex(undefined)).toBeUndefined();
+  });
+
+  it('returns indicator without type unchanged', () => {
+    const indicator = { params: { index: 'test' } };
+    expect(ensureIndicatorIndex(indicator)).toBe(indicator);
+  });
+
+  it('sets default index for APM transaction duration indicator', () => {
+    const result = ensureIndicatorIndex({
+      type: 'sli.apm.transactionDuration',
+      params: { service: 'my-service', threshold: 500 },
+    });
+
+    expect(result?.params?.index).toBe('metrics-apm*');
+    expect(result?.params?.transactionName).toBe('*');
+    expect(result?.params?.environment).toBe('*');
+    expect(result?.params?.transactionType).toBe('request');
+    expect(result?.params?.service).toBe('my-service');
+  });
+
+  it('sets default index for APM transaction error rate indicator', () => {
+    const result = ensureIndicatorIndex({
+      type: 'sli.apm.transactionErrorRate',
+      params: { service: 'my-service' },
+    });
+
+    expect(result?.params?.index).toBe('metrics-apm*');
+  });
+
+  it('does not overwrite existing index', () => {
+    const result = ensureIndicatorIndex({
+      type: 'sli.apm.transactionDuration',
+      params: { index: 'custom-index*', service: 'my-service', threshold: 500 },
+    });
+
+    expect(result?.params?.index).toBe('custom-index*');
+  });
+
+  it('sets timestampField for KQL custom indicator', () => {
+    const result = ensureIndicatorIndex({
+      type: 'sli.kql.custom',
+      params: { good: 'status: 200', total: '*' },
+    });
+
+    expect(result?.params?.index).toBe('logs-*');
+    expect(result?.params?.timestampField).toBe('@timestamp');
+  });
+
+  it('covers all expected indicator types', () => {
+    const expectedTypes = [
+      'sli.apm.transactionDuration',
+      'sli.apm.transactionErrorRate',
+      'sli.kql.custom',
+      'sli.metric.custom',
+      'sli.metric.timeslice',
+      'sli.histogram.custom',
+      'sli.synthetics.availability',
+    ];
+    expect(Object.keys(DEFAULT_INDEX_BY_TYPE).sort()).toEqual(expectedTypes.sort());
+  });
+});
+
+describe('normalizeForCreate', () => {
+  const minimalDefinition = {
+    name: 'Test SLO',
+    description: 'A test SLO',
+    indicator: {
+      type: 'sli.kql.custom',
+      params: {
+        index: 'logs-*',
+        good: 'status: 200',
+        total: '*',
+        timestampField: '@timestamp',
+      },
+    },
+    timeWindow: { duration: '30d', type: 'rolling' },
+    budgetingMethod: 'occurrences',
+    objective: { target: 0.99 },
+  };
+
+  it('returns a normalized object with only expected fields', () => {
+    const result = normalizeForCreate({
+      ...minimalDefinition,
+      extraField: 'should be stripped',
+      anotherExtra: 123,
+    });
+
+    expect(result).toHaveProperty('name');
+    expect(result).toHaveProperty('description');
+    expect(result).toHaveProperty('indicator');
+    expect(result).toHaveProperty('timeWindow');
+    expect(result).toHaveProperty('budgetingMethod');
+    expect(result).toHaveProperty('objective');
+    expect(result).not.toHaveProperty('extraField');
+    expect(result).not.toHaveProperty('anotherExtra');
+  });
+
+  it('provides defaults for missing name and description', () => {
+    const result = normalizeForCreate({
+      indicator: minimalDefinition.indicator,
+      timeWindow: minimalDefinition.timeWindow,
+      objective: minimalDefinition.objective,
+    });
+
+    expect(result.name).toBe('Untitled SLO');
+    expect(result.description).toBe('');
+    expect(result.budgetingMethod).toBe('occurrences');
+  });
+
+  it('preserves id when provided', () => {
+    const result = normalizeForCreate({ ...minimalDefinition, id: 'custom-id' });
+    expect(result.id).toBe('custom-id');
+  });
+
+  it('excludes id when not provided', () => {
+    const result = normalizeForCreate(minimalDefinition);
+    expect(result).not.toHaveProperty('id');
+  });
+
+  it('includes tags when present and non-empty', () => {
+    const result = normalizeForCreate({ ...minimalDefinition, tags: ['production', 'api'] });
+    expect(result.tags).toEqual(['production', 'api']);
+  });
+
+  it('excludes tags when empty array', () => {
+    const result = normalizeForCreate({ ...minimalDefinition, tags: [] });
+    expect(result).not.toHaveProperty('tags');
+  });
+
+  it('includes groupBy when not wildcard', () => {
+    const result = normalizeForCreate({ ...minimalDefinition, groupBy: 'service.name' });
+    expect(result.groupBy).toBe('service.name');
+  });
+
+  it('excludes groupBy when wildcard', () => {
+    const result = normalizeForCreate({ ...minimalDefinition, groupBy: '*' });
+    expect(result).not.toHaveProperty('groupBy');
+  });
+
+  it('normalizes numeric settings to duration strings', () => {
+    const result = normalizeForCreate({
+      ...minimalDefinition,
+      settings: { syncDelay: 5, frequency: 1 },
+    });
+
+    const settings = result.settings as Record<string, unknown>;
+    expect(settings.syncDelay).toBe('5m');
+    expect(settings.frequency).toBe('1m');
+  });
+
+  it('preserves valid duration string settings', () => {
+    const result = normalizeForCreate({
+      ...minimalDefinition,
+      settings: { syncDelay: '2m', frequency: '5m' },
+    });
+
+    const settings = result.settings as Record<string, unknown>;
+    expect(settings.syncDelay).toBe('2m');
+    expect(settings.frequency).toBe('5m');
+  });
+
+  it('preserves preventInitialBackfill and syncField', () => {
+    const result = normalizeForCreate({
+      ...minimalDefinition,
+      settings: { preventInitialBackfill: true, syncField: '@timestamp' },
+    });
+
+    const settings = result.settings as Record<string, unknown>;
+    expect(settings.preventInitialBackfill).toBe(true);
+    expect(settings.syncField).toBe('@timestamp');
+  });
+
+  it('excludes settings when empty after normalization', () => {
+    const result = normalizeForCreate({
+      ...minimalDefinition,
+      settings: {},
+    });
+    expect(result).not.toHaveProperty('settings');
+  });
+
+  it('normalizes indicator with missing index via ensureIndicatorIndex', () => {
+    const result = normalizeForCreate({
+      ...minimalDefinition,
+      indicator: {
+        type: 'sli.apm.transactionErrorRate',
+        params: { service: 'my-service' },
+      },
+    });
+
+    const indicator = result.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('metrics-apm*');
+    expect(indicator.params.transactionName).toBe('*');
+    expect(indicator.params.environment).toBe('*');
+    expect(indicator.params.transactionType).toBe('request');
+  });
+
+  it('handles a full AI-generated definition with all edge cases', () => {
+    const aiGenerated = {
+      name: 'Checkout Latency',
+      description: 'P99 latency for checkout flow',
+      indicator: {
+        type: 'sli.apm.transactionDuration',
+        params: {
+          service: 'checkout-service',
+          environment: 'production',
+          threshold: 500,
+        },
+      },
+      timeWindow: { duration: '30d', type: 'rolling' },
+      budgetingMethod: 'occurrences',
+      objective: { target: 0.995 },
+      tags: ['checkout', 'latency'],
+      groupBy: 'service.environment',
+      settings: { syncDelay: 1, frequency: 1, preventInitialBackfill: false },
+      priority: 'critical',
+      category: 'latency',
+      rationale: 'High-traffic checkout flow',
+    };
+
+    const result = normalizeForCreate(aiGenerated);
+
+    expect(result.name).toBe('Checkout Latency');
+    expect(result.tags).toEqual(['checkout', 'latency']);
+    expect(result.groupBy).toBe('service.environment');
+
+    expect(result).not.toHaveProperty('priority');
+    expect(result).not.toHaveProperty('category');
+    expect(result).not.toHaveProperty('rationale');
+
+    const indicator = result.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('metrics-apm*');
+    expect(indicator.params.transactionName).toBe('*');
+
+    const settings = result.settings as Record<string, unknown>;
+    expect(settings.syncDelay).toBe('1m');
+    expect(settings.frequency).toBe('1m');
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/utils/normalize_slo_for_create.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/utils/normalize_slo_for_create.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Default Elasticsearch index patterns for each SLO indicator type.
+ * Used as a client-side safety net when AI-generated definitions omit the
+ * required `index` field.
+ */
+export const DEFAULT_INDEX_BY_TYPE: Record<string, string> = {
+  'sli.apm.transactionDuration': 'metrics-apm*',
+  'sli.apm.transactionErrorRate': 'metrics-apm*',
+  'sli.kql.custom': 'logs-*',
+  'sli.metric.custom': 'metrics-*',
+  'sli.metric.timeslice': 'metrics-*',
+  'sli.histogram.custom': 'metrics-*',
+  'sli.synthetics.availability': 'synthetics-*',
+};
+
+/**
+ * Converts a value to a duration string (e.g. "1m", "5m").
+ * The SLO schema expects duration strings, but the LLM may generate numbers.
+ */
+export function toDurationString(value: unknown): string {
+  if (typeof value === 'string' && /^\d+[smhdwMy]$/.test(value)) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return `${value}m`;
+  }
+  return '1m';
+}
+
+/**
+ * Ensures the indicator params contain a valid `index` field and fills in
+ * required APM-specific defaults when missing.
+ */
+export function ensureIndicatorIndex(
+  indicator: { type?: string; params?: Record<string, unknown> } | undefined
+): { type?: string; params?: Record<string, unknown> } | undefined {
+  if (!indicator?.type || !indicator.params) return indicator;
+
+  const params = { ...indicator.params };
+
+  if (!params.index && DEFAULT_INDEX_BY_TYPE[indicator.type]) {
+    params.index = DEFAULT_INDEX_BY_TYPE[indicator.type];
+  }
+
+  if (
+    indicator.type === 'sli.apm.transactionErrorRate' ||
+    indicator.type === 'sli.apm.transactionDuration'
+  ) {
+    if (!params.transactionName) params.transactionName = '*';
+    if (!params.environment) params.environment = '*';
+    if (!params.transactionType) params.transactionType = 'request';
+    if (!params.service) params.service = '*';
+  }
+
+  if (indicator.type === 'sli.kql.custom' && !params.timestampField) {
+    params.timestampField = '@timestamp';
+  }
+
+  return { ...indicator, params };
+}
+
+/**
+ * Normalizes AI-generated SLO definitions to match the CreateSLOParams schema
+ * expected by the create SLO API, stripping any extra fields the LLM may include.
+ */
+export function normalizeForCreate(
+  sloDefinition: Record<string, unknown>
+): Record<string, unknown> {
+  const {
+    name,
+    description,
+    indicator,
+    timeWindow,
+    budgetingMethod,
+    objective,
+    tags,
+    groupBy,
+    settings,
+    id,
+  } = sloDefinition;
+
+  const normalizedIndicator = ensureIndicatorIndex(
+    indicator as { type?: string; params?: Record<string, unknown> } | undefined
+  );
+
+  const normalized: Record<string, unknown> = {
+    name: name ?? 'Untitled SLO',
+    description: description ?? '',
+    indicator: normalizedIndicator ?? indicator,
+    timeWindow,
+    budgetingMethod: budgetingMethod ?? 'occurrences',
+    objective,
+  };
+
+  if (id) {
+    normalized.id = id;
+  }
+
+  if (tags && Array.isArray(tags) && tags.length > 0) {
+    normalized.tags = tags;
+  }
+
+  if (groupBy && groupBy !== '*') {
+    normalized.groupBy = groupBy;
+  }
+
+  if (settings && typeof settings === 'object') {
+    const { preventInitialBackfill, syncDelay, frequency, syncField } = settings as Record<
+      string,
+      unknown
+    >;
+    const normalizedSettings: Record<string, unknown> = {};
+    if (typeof preventInitialBackfill === 'boolean') {
+      normalizedSettings.preventInitialBackfill = preventInitialBackfill;
+    }
+    if (syncDelay !== undefined && syncDelay !== null) {
+      normalizedSettings.syncDelay = toDurationString(syncDelay);
+    }
+    if (frequency !== undefined && frequency !== null) {
+      normalizedSettings.frequency = toDurationString(frequency);
+    }
+    if (syncField && typeof syncField === 'string') {
+      normalizedSettings.syncField = syncField;
+    }
+    if (Object.keys(normalizedSettings).length > 0) {
+      normalized.settings = normalizedSettings;
+    }
+  }
+
+  return normalized;
+}

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_bulk_create_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_bulk_create_slos.ts
@@ -67,9 +67,7 @@ export const aiBulkCreateSlosRoute = createSloServerRoute({
 
     for (const sloParams of slos) {
       try {
-        const response: CreateSLOResponse = await createSLO.execute(
-          sloParams as CreateSLOParams
-        );
+        const response: CreateSLOResponse = await createSLO.execute(sloParams as CreateSLOParams);
         results.push({
           success: true,
           id: response.id,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_bulk_create_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_bulk_create_slos.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { createSLOParamsSchema } from '@kbn/slo-schema';
+import type { CreateSLOParams, CreateSLOResponse } from '@kbn/slo-schema';
+import { CreateSLO } from '../../services';
+import { createSloServerRoute } from '../create_slo_server_route';
+import { assertPlatinumLicense } from './utils/assert_platinum_license';
+
+const sloBodySchema = createSLOParamsSchema.props.body;
+
+const aiBulkCreateSlosParamsSchema = t.type({
+  body: t.type({
+    slos: t.array(sloBodySchema),
+  }),
+});
+
+export const aiBulkCreateSlosRoute = createSloServerRoute({
+  endpoint: 'POST /internal/slo/ai/bulk-create',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
+  },
+  params: aiBulkCreateSlosParamsSchema,
+  handler: async ({ context, params, logger, request, plugins, corePlugins, getScopedClients }) => {
+    await assertPlatinumLicense(plugins);
+
+    const {
+      scopedClusterClient,
+      internalSoClient,
+      spaceId,
+      repository,
+      transformManager,
+      summaryTransformManager,
+    } = await getScopedClients({ request, logger });
+
+    const core = await context.core;
+    const userId = core.security.authc.getCurrentUser()?.username!;
+    const basePath = corePlugins.http.basePath;
+
+    const createSLO = new CreateSLO(
+      scopedClusterClient,
+      repository,
+      internalSoClient,
+      transformManager,
+      summaryTransformManager,
+      logger,
+      spaceId,
+      basePath,
+      userId
+    );
+
+    const { slos } = params.body;
+    const results: Array<{
+      success: boolean;
+      id?: string;
+      name: string;
+      error?: string;
+    }> = [];
+
+    for (const sloParams of slos) {
+      try {
+        const response: CreateSLOResponse = await createSLO.execute(
+          sloParams as CreateSLOParams
+        );
+        results.push({
+          success: true,
+          id: response.id,
+          name: sloParams.name,
+        });
+      } catch (error) {
+        logger.warn(`Failed to create SLO "${sloParams.name}": ${error.message}`);
+        results.push({
+          success: false,
+          name: sloParams.name,
+          error: error.message,
+        });
+      }
+    }
+
+    const successCount = results.filter((r) => r.success).length;
+    const failureCount = results.filter((r) => !r.success).length;
+
+    return {
+      results,
+      summary: { total: slos.length, success: successCount, failure: failureCount },
+    };
+  },
+});

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_discover_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_discover_slos.ts
@@ -1,0 +1,353 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { badRequest } from '@hapi/boom';
+import type { IScopedClusterClient, Logger } from '@kbn/core/server';
+import { createSloServerRoute } from '../create_slo_server_route';
+import { getDefaultConnectorId } from '../../services/ai/get_default_connector';
+import {
+  SLO_DISCOVER_SYSTEM_PROMPT,
+  SLO_DISCOVER_OUTPUT_SCHEMA,
+} from '../../services/ai/slo_generation_prompt';
+import { normalizeSloDefinition } from '../../services/ai/normalize_slo_definition';
+
+const aiDiscoverSlosParamsSchema = t.partial({
+  body: t.partial({
+    connectorId: t.string,
+  }),
+});
+
+export const aiDiscoverSlosRoute = createSloServerRoute({
+  endpoint: 'POST /internal/slo/ai/discover',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
+  },
+  params: aiDiscoverSlosParamsSchema,
+  handler: async ({ params, logger, request, corePlugins, getInference, getScopedClients }) => {
+    const inference = await getInference();
+
+    if (!inference) {
+      throw badRequest(
+        'AI-assisted SLO discovery is not available. The inference plugin is not enabled.'
+      );
+    }
+
+    const [coreStart] = await corePlugins.getStartServices();
+    const { scopedClusterClient } = await getScopedClients({ request, logger });
+
+    const requestedConnectorId = params.body?.connectorId;
+
+    const connectorId =
+      requestedConnectorId ??
+      (await getDefaultConnectorId({
+        coreStart,
+        inference,
+        request,
+        logger,
+      }));
+
+    const clusterSummary = await buildClusterDataSummary(scopedClusterClient, logger);
+
+    const inferenceClient = inference.getClient({ request });
+
+    const input = `Analyze the following cluster data summary and propose user-centric SLOs:\n\n${clusterSummary}`;
+
+    const response = await inferenceClient.output({
+      id: 'slo-ai-discover',
+      connectorId,
+      system: SLO_DISCOVER_SYSTEM_PROMPT,
+      input,
+      schema: SLO_DISCOVER_OUTPUT_SCHEMA,
+    });
+
+    const { proposedSlos, summary } = response.output ?? {
+      proposedSlos: [],
+      summary: 'No data sources found in the cluster.',
+    };
+
+    const normalizedSlos = Array.isArray(proposedSlos)
+      ? proposedSlos.map((proposal) => ({
+          ...proposal,
+          sloDefinition: normalizeSloDefinition(proposal.sloDefinition),
+        }))
+      : [];
+
+    return {
+      proposedSlos: normalizedSlos,
+      summary: summary ?? '',
+      clusterSummary,
+    };
+  },
+});
+
+/**
+ * Queries the cluster to build a summary of available data sources for SLO discovery.
+ */
+async function buildClusterDataSummary(
+  scopedClusterClient: IScopedClusterClient,
+  logger: Logger
+): Promise<string> {
+  const sections: string[] = [];
+
+  const [apmServices, syntheticsMonitors, logDataStreams, metricDataStreams] = await Promise.all([
+    discoverApmServices(scopedClusterClient, logger),
+    discoverSyntheticsMonitors(scopedClusterClient, logger),
+    discoverLogDataStreams(scopedClusterClient, logger),
+    discoverMetricDataStreams(scopedClusterClient, logger),
+  ]);
+
+  if (apmServices.length > 0) {
+    sections.push(`## APM Services (${apmServices.length} found)\n${apmServices.join('\n')}`);
+  }
+
+  if (syntheticsMonitors.length > 0) {
+    sections.push(
+      `## Synthetics Monitors (${syntheticsMonitors.length} found)\n${syntheticsMonitors.join('\n')}`
+    );
+  }
+
+  if (logDataStreams.length > 0) {
+    sections.push(
+      `## Log Data Streams (${logDataStreams.length} found)\n${logDataStreams.join('\n')}`
+    );
+  }
+
+  if (metricDataStreams.length > 0) {
+    sections.push(
+      `## Metric Data Streams (${metricDataStreams.length} found)\n${metricDataStreams.join('\n')}`
+    );
+  }
+
+  if (sections.length === 0) {
+    return 'No relevant data sources found in the cluster. Unable to propose SLOs.';
+  }
+
+  return sections.join('\n\n');
+}
+
+async function discoverApmServices(
+  scopedClusterClient: IScopedClusterClient,
+  logger: Logger
+): Promise<string[]> {
+  try {
+    const response = await scopedClusterClient.asCurrentUser.search({
+      index: 'traces-apm*,apm-*',
+      size: 0,
+      body: {
+        query: { range: { '@timestamp': { gte: 'now-24h' } } },
+        aggs: {
+          services: {
+            terms: { field: 'service.name', size: 50 },
+            aggs: {
+              environments: {
+                terms: { field: 'service.environment', size: 10 },
+              },
+              transaction_types: {
+                terms: { field: 'transaction.type', size: 10 },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const servicesAgg = response.aggregations?.services as
+      | {
+          buckets: Array<{
+            key: string;
+            doc_count: number;
+            environments: { buckets: Array<{ key: string }> };
+            transaction_types: { buckets: Array<{ key: string }> };
+          }>;
+        }
+      | undefined;
+
+    if (!servicesAgg?.buckets?.length) return [];
+
+    return servicesAgg.buckets.map((bucket) => {
+      const envs = bucket.environments.buckets.map((e) => e.key).join(', ') || 'unknown';
+      const txTypes = bucket.transaction_types.buckets.map((t) => t.key).join(', ') || 'request';
+      return `- Service: "${bucket.key}" | Environments: [${envs}] | Transaction types: [${txTypes}] | Events (24h): ${bucket.doc_count}`;
+    });
+  } catch (error) {
+    logger.debug(`Failed to discover APM services: ${error.message}`);
+    return [];
+  }
+}
+
+async function discoverSyntheticsMonitors(
+  scopedClusterClient: IScopedClusterClient,
+  logger: Logger
+): Promise<string[]> {
+  try {
+    const response = await scopedClusterClient.asCurrentUser.search({
+      index: 'synthetics-*',
+      size: 0,
+      body: {
+        query: { range: { '@timestamp': { gte: 'now-24h' } } },
+        aggs: {
+          monitors: {
+            terms: { field: 'monitor.id', size: 50 },
+            aggs: {
+              name: { terms: { field: 'monitor.name', size: 1 } },
+              type: { terms: { field: 'monitor.type', size: 1 } },
+              tags: { terms: { field: 'tags', size: 10 } },
+              projects: { terms: { field: 'monitor.project.id', size: 5 } },
+            },
+          },
+        },
+      },
+    });
+
+    const monitorsAgg = response.aggregations?.monitors as
+      | {
+          buckets: Array<{
+            key: string;
+            doc_count: number;
+            name: { buckets: Array<{ key: string }> };
+            type: { buckets: Array<{ key: string }> };
+            tags: { buckets: Array<{ key: string }> };
+            projects: { buckets: Array<{ key: string }> };
+          }>;
+        }
+      | undefined;
+
+    if (!monitorsAgg?.buckets?.length) return [];
+
+    return monitorsAgg.buckets.map((bucket) => {
+      const name = bucket.name.buckets[0]?.key ?? bucket.key;
+      const type = bucket.type.buckets[0]?.key ?? 'unknown';
+      const tags = bucket.tags.buckets.map((t) => t.key).join(', ') || 'none';
+      const projects = bucket.projects.buckets.map((p) => p.key).join(', ') || 'none';
+      return `- Monitor: "${name}" (id: ${bucket.key}) | Type: ${type} | Tags: [${tags}] | Projects: [${projects}] | Checks (24h): ${bucket.doc_count}`;
+    });
+  } catch (error) {
+    logger.debug(`Failed to discover synthetics monitors: ${error.message}`);
+    return [];
+  }
+}
+
+async function discoverLogDataStreams(
+  scopedClusterClient: IScopedClusterClient,
+  logger: Logger
+): Promise<string[]> {
+  try {
+    const response = await scopedClusterClient.asCurrentUser.search({
+      index: 'logs-*',
+      size: 0,
+      body: {
+        query: { range: { '@timestamp': { gte: 'now-24h' } } },
+        aggs: {
+          data_streams: {
+            terms: { field: '_index', size: 30 },
+            aggs: {
+              error_count: {
+                filter: {
+                  bool: {
+                    should: [
+                      { term: { 'log.level': 'error' } },
+                      { term: { 'log.level': 'ERROR' } },
+                      { term: { 'log.level': 'fatal' } },
+                      { term: { 'log.level': 'FATAL' } },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              },
+              services: {
+                terms: { field: 'service.name', size: 5 },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const dataStreamsAgg = response.aggregations?.data_streams as
+      | {
+          buckets: Array<{
+            key: string;
+            doc_count: number;
+            error_count: { doc_count: number };
+            services: { buckets: Array<{ key: string }> };
+          }>;
+        }
+      | undefined;
+
+    if (!dataStreamsAgg?.buckets?.length) return [];
+
+    return dataStreamsAgg.buckets
+      .filter((bucket) => bucket.doc_count > 100)
+      .map((bucket) => {
+        const errorRate =
+          bucket.doc_count > 0
+            ? ((bucket.error_count.doc_count / bucket.doc_count) * 100).toFixed(2)
+            : '0';
+        const services = bucket.services.buckets.map((s) => s.key).join(', ') || 'none';
+        return `- Index: "${bucket.key}" | Events (24h): ${bucket.doc_count} | Error rate: ${errorRate}% | Services: [${services}]`;
+      });
+  } catch (error) {
+    logger.debug(`Failed to discover log data streams: ${error.message}`);
+    return [];
+  }
+}
+
+async function discoverMetricDataStreams(
+  scopedClusterClient: IScopedClusterClient,
+  logger: Logger
+): Promise<string[]> {
+  try {
+    const response = await scopedClusterClient.asCurrentUser.search({
+      index: 'metrics-*',
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: [{ range: { '@timestamp': { gte: 'now-24h' } } }],
+            must_not: [{ prefix: { _index: 'metrics-apm' } }],
+          },
+        },
+        aggs: {
+          data_streams: {
+            terms: { field: '_index', size: 20 },
+            aggs: {
+              hosts: {
+                cardinality: { field: 'host.name' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const dataStreamsAgg = response.aggregations?.data_streams as
+      | {
+          buckets: Array<{
+            key: string;
+            doc_count: number;
+            hosts: { value: number };
+          }>;
+        }
+      | undefined;
+
+    if (!dataStreamsAgg?.buckets?.length) return [];
+
+    return dataStreamsAgg.buckets
+      .filter((bucket) => bucket.doc_count > 100)
+      .map((bucket) => {
+        return `- Index: "${bucket.key}" | Datapoints (24h): ${bucket.doc_count} | Unique hosts: ${bucket.hosts.value}`;
+      });
+  } catch (error) {
+    logger.debug(`Failed to discover metric data streams: ${error.message}`);
+    return [];
+  }
+}
+

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_discover_slos.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_discover_slos.ts
@@ -110,7 +110,9 @@ async function buildClusterDataSummary(
 
   if (syntheticsMonitors.length > 0) {
     sections.push(
-      `## Synthetics Monitors (${syntheticsMonitors.length} found)\n${syntheticsMonitors.join('\n')}`
+      `## Synthetics Monitors (${syntheticsMonitors.length} found)\n${syntheticsMonitors.join(
+        '\n'
+      )}`
     );
   }
 
@@ -350,4 +352,3 @@ async function discoverMetricDataStreams(
     return [];
   }
 }
-

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_generate_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_generate_slo.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { badRequest } from '@hapi/boom';
+import { createSloServerRoute } from '../create_slo_server_route';
+import { getDefaultConnectorId } from '../../services/ai/get_default_connector';
+import {
+  SLO_GENERATION_SYSTEM_PROMPT,
+  SLO_GENERATION_OUTPUT_SCHEMA,
+} from '../../services/ai/slo_generation_prompt';
+
+const previousMessageSchema = t.type({
+  role: t.union([t.literal('user'), t.literal('assistant')]),
+  content: t.string,
+});
+
+const aiGenerateSloParamsSchema = t.type({
+  body: t.intersection([
+    t.type({
+      prompt: t.string,
+    }),
+    t.partial({
+      connectorId: t.string,
+      previousMessages: t.array(previousMessageSchema),
+    }),
+  ]),
+});
+
+export const aiGenerateSloRoute = createSloServerRoute({
+  endpoint: 'POST /internal/slo/ai/generate',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
+  },
+  params: aiGenerateSloParamsSchema,
+  handler: async ({ params, logger, request, corePlugins, getInference }) => {
+    const inference = await getInference();
+
+    if (!inference) {
+      throw badRequest(
+        'AI-assisted SLO generation is not available. The inference plugin is not enabled.'
+      );
+    }
+
+    const [coreStart] = await corePlugins.getStartServices();
+
+    const { prompt, connectorId: requestedConnectorId, previousMessages } = params.body;
+
+    const connectorId =
+      requestedConnectorId ??
+      (await getDefaultConnectorId({
+        coreStart,
+        inference,
+        request,
+        logger,
+      }));
+
+    const inferenceClient = inference.getClient({ request });
+
+    const messages = previousMessages ?? [];
+    const input = messages.length > 0
+      ? `Previous context:\n${messages.map((m) => `${m.role}: ${m.content}`).join('\n')}\n\nNew instruction: ${prompt}`
+      : prompt;
+
+    const response = await inferenceClient.output({
+      id: 'slo-ai-generate',
+      connectorId,
+      system: SLO_GENERATION_SYSTEM_PROMPT,
+      input,
+      schema: SLO_GENERATION_OUTPUT_SCHEMA,
+    });
+
+    const { sloDefinition, explanation } = response.output ?? {
+      sloDefinition: null,
+      explanation: 'Failed to generate SLO definition.',
+    };
+
+    if (!sloDefinition) {
+      throw badRequest('The AI model was unable to generate a valid SLO definition.');
+    }
+
+    return {
+      sloDefinition: normalizeSloDefinition(sloDefinition),
+      explanation,
+    };
+  },
+});
+
+/**
+ * Normalizes the LLM output to ensure it matches the expected form values.
+ */
+function normalizeSloDefinition(definition: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...definition };
+
+  if (!normalized.tags) {
+    normalized.tags = [];
+  }
+
+  if (!normalized.groupBy) {
+    normalized.groupBy = '*';
+  }
+
+  if (!normalized.settings) {
+    normalized.settings = {
+      preventInitialBackfill: false,
+      syncDelay: 1,
+      frequency: 1,
+      syncField: null,
+    };
+  }
+
+  return normalized;
+}

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_generate_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_generate_slo.ts
@@ -65,9 +65,12 @@ export const aiGenerateSloRoute = createSloServerRoute({
     const inferenceClient = inference.getClient({ request });
 
     const messages = previousMessages ?? [];
-    const input = messages.length > 0
-      ? `Previous context:\n${messages.map((m) => `${m.role}: ${m.content}`).join('\n')}\n\nNew instruction: ${prompt}`
-      : prompt;
+    const input =
+      messages.length > 0
+        ? `Previous context:\n${messages
+            .map((m) => `${m.role}: ${m.content}`)
+            .join('\n')}\n\nNew instruction: ${prompt}`
+        : prompt;
 
     const response = await inferenceClient.output({
       id: 'slo-ai-generate',

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_suggest_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_suggest_slo.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { badRequest } from '@hapi/boom';
+import { createSloServerRoute } from '../create_slo_server_route';
+import { getDefaultConnectorId } from '../../services/ai/get_default_connector';
+import {
+  SLO_SUGGEST_SYSTEM_PROMPT,
+  SLO_SUGGEST_OUTPUT_SCHEMA,
+} from '../../services/ai/slo_generation_prompt';
+
+const aiSuggestSloParamsSchema = t.type({
+  body: t.intersection([
+    t.type({
+      sloDefinition: t.record(t.string, t.unknown),
+    }),
+    t.partial({
+      connectorId: t.string,
+    }),
+  ]),
+});
+
+export const aiSuggestSloRoute = createSloServerRoute({
+  endpoint: 'POST /internal/slo/ai/suggest',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
+  },
+  params: aiSuggestSloParamsSchema,
+  handler: async ({ params, logger, request, corePlugins, getInference }) => {
+    const inference = await getInference();
+
+    if (!inference) {
+      throw badRequest(
+        'AI-assisted SLO suggestions are not available. The inference plugin is not enabled.'
+      );
+    }
+
+    const [coreStart] = await corePlugins.getStartServices();
+
+    const { sloDefinition, connectorId: requestedConnectorId } = params.body;
+
+    const connectorId =
+      requestedConnectorId ??
+      (await getDefaultConnectorId({
+        coreStart,
+        inference,
+        request,
+        logger,
+      }));
+
+    const inferenceClient = inference.getClient({ request });
+
+    const input = `Analyze the following SLO definition and suggest improvements:\n\n${JSON.stringify(sloDefinition, null, 2)}`;
+
+    const response = await inferenceClient.output({
+      id: 'slo-ai-suggest',
+      connectorId,
+      system: SLO_SUGGEST_SYSTEM_PROMPT,
+      input,
+      schema: SLO_SUGGEST_OUTPUT_SCHEMA,
+    });
+
+    const { suggestions } = response.output ?? { suggestions: [] };
+
+    return {
+      suggestions: Array.isArray(suggestions) ? suggestions : [],
+    };
+  },
+});

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_suggest_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/ai_suggest_slo.ts
@@ -58,7 +58,11 @@ export const aiSuggestSloRoute = createSloServerRoute({
 
     const inferenceClient = inference.getClient({ request });
 
-    const input = `Analyze the following SLO definition and suggest improvements:\n\n${JSON.stringify(sloDefinition, null, 2)}`;
+    const input = `Analyze the following SLO definition and suggest improvements:\n\n${JSON.stringify(
+      sloDefinition,
+      null,
+      2
+    )}`;
 
     const response = await inferenceClient.output({
       id: 'slo-ai-suggest',

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import { aiBulkCreateSlosRoute } from './ai_bulk_create_slos';
+import { aiDiscoverSlosRoute } from './ai_discover_slos';
+import { aiGenerateSloRoute } from './ai_generate_slo';
+import { aiSuggestSloRoute } from './ai_suggest_slo';
 import { bulkDeleteSLORoute, getBulkDeleteStatusRoute } from './bulk_delete';
 import { bulkPurgeRollupRoute } from './bulk_purge_rollup';
 import { createSLORoute } from './create_slo';
@@ -71,5 +75,9 @@ export const getSloRouteRepository = (isServerless?: boolean) => {
     ...findSLOTemplatesRoute,
     ...healthScanRoutes,
     ...searchSloDefinitionsRoute,
+    ...aiBulkCreateSlosRoute,
+    ...aiDiscoverSlosRoute,
+    ...aiGenerateSloRoute,
+    ...aiSuggestSloRoute,
   };
 };

--- a/x-pack/solutions/observability/plugins/slo/server/services/ai/get_default_connector.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/ai/get_default_connector.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { CoreStart, Logger } from '@kbn/core/server';
+import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
+
+const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
+
+/**
+ * Gets the default connector ID by first checking the UI settings (genAI settings),
+ * then falling back to the inference plugin's default connector (EIS).
+ */
+export async function getDefaultConnectorId({
+  coreStart,
+  inference,
+  request,
+  logger,
+}: {
+  coreStart: CoreStart;
+  inference: InferenceServerStart;
+  request: KibanaRequest;
+  logger?: Logger;
+}): Promise<string> {
+  const soClient = coreStart.savedObjects.getScopedClient(request);
+  const uiSettingsClient = coreStart.uiSettings.asScopedToClient(soClient);
+
+  const defaultConnectorSetting = await uiSettingsClient.get<string | undefined>(
+    GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR
+  );
+
+  const hasValidDefaultConnector =
+    defaultConnectorSetting && defaultConnectorSetting !== NO_DEFAULT_CONNECTOR;
+
+  if (hasValidDefaultConnector) {
+    logger?.debug(`Using default AI connector from UI setting: ${defaultConnectorSetting}`);
+    return defaultConnectorSetting;
+  }
+
+  const connectorId = (await inference.getDefaultConnector(request))?.connectorId;
+
+  if (!connectorId) {
+    throw new Error('No AI connector configured. Please configure a default AI connector.');
+  }
+
+  logger?.debug(`Using default connector from inference plugin: ${connectorId}`);
+  return connectorId;
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/ai/normalize_slo_definition.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/ai/normalize_slo_definition.test.ts
@@ -1,0 +1,299 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  normalizeSloDefinition,
+  normalizeIndicatorIndex,
+  toDurationString,
+  DEFAULT_INDEX_BY_INDICATOR_TYPE,
+} from './normalize_slo_definition';
+
+describe('toDurationString', () => {
+  it('returns valid duration strings unchanged', () => {
+    expect(toDurationString('1m', '5m')).toBe('1m');
+    expect(toDurationString('30d', '5m')).toBe('30d');
+    expect(toDurationString('2h', '5m')).toBe('2h');
+  });
+
+  it('converts numbers to minute-based duration strings', () => {
+    expect(toDurationString(1, '5m')).toBe('1m');
+    expect(toDurationString(10, '5m')).toBe('10m');
+    expect(toDurationString(0, '5m')).toBe('0m');
+  });
+
+  it('returns default for invalid values', () => {
+    expect(toDurationString(undefined, '5m')).toBe('5m');
+    expect(toDurationString(null, '5m')).toBe('5m');
+    expect(toDurationString('invalid', '5m')).toBe('5m');
+    expect(toDurationString('', '5m')).toBe('5m');
+    expect(toDurationString({}, '5m')).toBe('5m');
+  });
+});
+
+describe('normalizeIndicatorIndex', () => {
+  it('sets default index for APM transaction duration indicator', () => {
+    const definition: Record<string, unknown> = {
+      indicator: {
+        type: 'sli.apm.transactionDuration',
+        params: { service: 'my-service', threshold: 500 },
+      },
+    };
+
+    normalizeIndicatorIndex(definition);
+
+    const indicator = definition.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('metrics-apm*');
+    expect(indicator.params.transactionName).toBe('*');
+    expect(indicator.params.environment).toBe('*');
+    expect(indicator.params.transactionType).toBe('request');
+  });
+
+  it('sets default index for APM transaction error rate indicator', () => {
+    const definition: Record<string, unknown> = {
+      indicator: {
+        type: 'sli.apm.transactionErrorRate',
+        params: { service: 'my-service' },
+      },
+    };
+
+    normalizeIndicatorIndex(definition);
+
+    const indicator = definition.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('metrics-apm*');
+  });
+
+  it('does not overwrite existing index', () => {
+    const definition: Record<string, unknown> = {
+      indicator: {
+        type: 'sli.apm.transactionDuration',
+        params: { service: 'my-service', index: 'custom-index*', threshold: 500 },
+      },
+    };
+
+    normalizeIndicatorIndex(definition);
+
+    const indicator = definition.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('custom-index*');
+  });
+
+  it('does not overwrite existing APM fields', () => {
+    const definition: Record<string, unknown> = {
+      indicator: {
+        type: 'sli.apm.transactionErrorRate',
+        params: {
+          service: 'my-service',
+          environment: 'production',
+          transactionType: 'custom',
+          transactionName: '/api/users',
+        },
+      },
+    };
+
+    normalizeIndicatorIndex(definition);
+
+    const indicator = definition.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.environment).toBe('production');
+    expect(indicator.params.transactionType).toBe('custom');
+    expect(indicator.params.transactionName).toBe('/api/users');
+    expect(indicator.params.service).toBe('my-service');
+  });
+
+  it('sets default index for KQL custom indicator', () => {
+    const definition: Record<string, unknown> = {
+      indicator: {
+        type: 'sli.kql.custom',
+        params: { good: 'status: 200', total: '*' },
+      },
+    };
+
+    normalizeIndicatorIndex(definition);
+
+    const indicator = definition.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('logs-*');
+    expect(indicator.params.timestampField).toBe('@timestamp');
+  });
+
+  it('sets default index for metric custom indicator', () => {
+    const definition: Record<string, unknown> = {
+      indicator: {
+        type: 'sli.metric.custom',
+        params: {},
+      },
+    };
+
+    normalizeIndicatorIndex(definition);
+
+    const indicator = definition.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('metrics-*');
+  });
+
+  it('sets default index for synthetics availability indicator', () => {
+    const definition: Record<string, unknown> = {
+      indicator: {
+        type: 'sli.synthetics.availability',
+        params: {},
+      },
+    };
+
+    normalizeIndicatorIndex(definition);
+
+    const indicator = definition.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('synthetics-*');
+  });
+
+  it('handles missing indicator gracefully', () => {
+    const definition: Record<string, unknown> = {};
+    normalizeIndicatorIndex(definition);
+    expect(definition.indicator).toBeUndefined();
+  });
+
+  it('handles indicator without params gracefully', () => {
+    const definition: Record<string, unknown> = {
+      indicator: { type: 'sli.kql.custom' },
+    };
+    normalizeIndicatorIndex(definition);
+    expect(definition.indicator).toEqual({ type: 'sli.kql.custom' });
+  });
+
+  it('covers all indicator types in DEFAULT_INDEX_BY_INDICATOR_TYPE', () => {
+    const expectedTypes = [
+      'sli.apm.transactionDuration',
+      'sli.apm.transactionErrorRate',
+      'sli.kql.custom',
+      'sli.metric.custom',
+      'sli.metric.timeslice',
+      'sli.histogram.custom',
+      'sli.synthetics.availability',
+    ];
+    expect(Object.keys(DEFAULT_INDEX_BY_INDICATOR_TYPE).sort()).toEqual(expectedTypes.sort());
+  });
+});
+
+describe('normalizeSloDefinition', () => {
+  it('adds auto-discovered tag when no tags exist', () => {
+    const result = normalizeSloDefinition({ name: 'test' });
+    expect(result.tags).toEqual(['auto-discovered']);
+  });
+
+  it('appends auto-discovered tag to existing tags', () => {
+    const result = normalizeSloDefinition({ name: 'test', tags: ['existing'] });
+    expect(result.tags).toEqual(['existing', 'auto-discovered']);
+  });
+
+  it('does not duplicate auto-discovered tag', () => {
+    const result = normalizeSloDefinition({ name: 'test', tags: ['auto-discovered'] });
+    expect(result.tags).toEqual(['auto-discovered']);
+  });
+
+  it('sets default groupBy when missing', () => {
+    const result = normalizeSloDefinition({ name: 'test' });
+    expect(result.groupBy).toBe('*');
+  });
+
+  it('preserves existing groupBy', () => {
+    const result = normalizeSloDefinition({ name: 'test', groupBy: 'service.name' });
+    expect(result.groupBy).toBe('service.name');
+  });
+
+  it('normalizes numeric syncDelay to duration string', () => {
+    const result = normalizeSloDefinition({
+      name: 'test',
+      settings: { syncDelay: 5 },
+    });
+    expect((result.settings as Record<string, unknown>).syncDelay).toBe('5m');
+  });
+
+  it('normalizes numeric frequency to duration string', () => {
+    const result = normalizeSloDefinition({
+      name: 'test',
+      settings: { frequency: 1 },
+    });
+    expect((result.settings as Record<string, unknown>).frequency).toBe('1m');
+  });
+
+  it('preserves valid duration string settings', () => {
+    const result = normalizeSloDefinition({
+      name: 'test',
+      settings: { syncDelay: '2m', frequency: '5m' },
+    });
+    const settings = result.settings as Record<string, unknown>;
+    expect(settings.syncDelay).toBe('2m');
+    expect(settings.frequency).toBe('5m');
+  });
+
+  it('preserves preventInitialBackfill boolean', () => {
+    const result = normalizeSloDefinition({
+      name: 'test',
+      settings: { preventInitialBackfill: true },
+    });
+    expect((result.settings as Record<string, unknown>).preventInitialBackfill).toBe(true);
+  });
+
+  it('preserves syncField string', () => {
+    const result = normalizeSloDefinition({
+      name: 'test',
+      settings: { syncField: '@timestamp' },
+    });
+    expect((result.settings as Record<string, unknown>).syncField).toBe('@timestamp');
+  });
+
+  it('strips unknown settings fields', () => {
+    const result = normalizeSloDefinition({
+      name: 'test',
+      settings: { syncDelay: '1m', unknownField: 'foo' },
+    });
+    expect((result.settings as Record<string, unknown>).unknownField).toBeUndefined();
+  });
+
+  it('normalizes indicator index via normalizeIndicatorIndex', () => {
+    const result = normalizeSloDefinition({
+      name: 'test',
+      indicator: {
+        type: 'sli.apm.transactionErrorRate',
+        params: { service: 'my-service' },
+      },
+    });
+    const indicator = result.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('metrics-apm*');
+  });
+
+  it('handles a complete AI-generated definition', () => {
+    const aiGenerated = {
+      name: 'API Availability',
+      description: 'Tracks API error rate',
+      indicator: {
+        type: 'sli.apm.transactionErrorRate',
+        params: {
+          service: 'api-gateway',
+          environment: 'production',
+        },
+      },
+      timeWindow: { duration: '30d', type: 'rolling' },
+      budgetingMethod: 'occurrences',
+      objective: { target: 0.995 },
+      settings: { syncDelay: 1, frequency: 1, preventInitialBackfill: false },
+      tags: ['api'],
+      extraField: 'should be preserved',
+    };
+
+    const result = normalizeSloDefinition(aiGenerated);
+
+    expect(result.name).toBe('API Availability');
+    expect(result.tags).toEqual(['api', 'auto-discovered']);
+    expect(result.groupBy).toBe('*');
+
+    const settings = result.settings as Record<string, unknown>;
+    expect(settings.syncDelay).toBe('1m');
+    expect(settings.frequency).toBe('1m');
+    expect(settings.preventInitialBackfill).toBe(false);
+
+    const indicator = result.indicator as { params: Record<string, unknown> };
+    expect(indicator.params.index).toBe('metrics-apm*');
+    expect(indicator.params.transactionName).toBe('*');
+    expect(indicator.params.transactionType).toBe('request');
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/ai/normalize_slo_definition.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/ai/normalize_slo_definition.ts
@@ -93,10 +93,7 @@ export function normalizeSloDefinition(
 
   if (!normalized.tags) {
     normalized.tags = ['auto-discovered'];
-  } else if (
-    Array.isArray(normalized.tags) &&
-    !normalized.tags.includes('auto-discovered')
-  ) {
+  } else if (Array.isArray(normalized.tags) && !normalized.tags.includes('auto-discovered')) {
     (normalized.tags as string[]).push('auto-discovered');
   }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/ai/normalize_slo_definition.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/ai/normalize_slo_definition.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Default Elasticsearch index patterns for each SLO indicator type.
+ * These are injected when the LLM omits the required `index` field.
+ */
+export const DEFAULT_INDEX_BY_INDICATOR_TYPE: Record<string, string> = {
+  'sli.apm.transactionDuration': 'metrics-apm*',
+  'sli.apm.transactionErrorRate': 'metrics-apm*',
+  'sli.kql.custom': 'logs-*',
+  'sli.metric.custom': 'metrics-*',
+  'sli.metric.timeslice': 'metrics-*',
+  'sli.histogram.custom': 'metrics-*',
+  'sli.synthetics.availability': 'synthetics-*',
+};
+
+/**
+ * Converts a value to a valid SLO duration string (e.g. "1m", "5m").
+ * The LLM may return numbers instead of duration strings.
+ */
+export function toDurationString(value: unknown, defaultValue: string): string {
+  if (typeof value === 'string' && /^\d+[smhdwMy]$/.test(value)) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return `${value}m`;
+  }
+  return defaultValue;
+}
+
+/**
+ * Ensures the indicator.params.index field is always set.
+ * The schema requires it for all indicator types, but the LLM often omits it.
+ * Also fills in required APM-specific fields with safe defaults.
+ */
+export function normalizeIndicatorIndex(normalized: Record<string, unknown>): void {
+  const indicator = normalized.indicator as
+    | { type?: string; params?: Record<string, unknown> }
+    | undefined;
+
+  if (!indicator?.params || !indicator.type) return;
+
+  if (!indicator.params.index) {
+    const defaultIndex = DEFAULT_INDEX_BY_INDICATOR_TYPE[indicator.type];
+    if (defaultIndex) {
+      indicator.params.index = defaultIndex;
+    }
+  }
+
+  if (
+    indicator.type === 'sli.apm.transactionErrorRate' ||
+    indicator.type === 'sli.apm.transactionDuration'
+  ) {
+    if (!indicator.params.transactionName) {
+      indicator.params.transactionName = '*';
+    }
+    if (!indicator.params.environment) {
+      indicator.params.environment = '*';
+    }
+    if (!indicator.params.transactionType) {
+      indicator.params.transactionType = 'request';
+    }
+    if (!indicator.params.service) {
+      indicator.params.service = '*';
+    }
+  }
+
+  if (indicator.type === 'sli.kql.custom') {
+    if (!indicator.params.timestampField) {
+      indicator.params.timestampField = '@timestamp';
+    }
+  }
+}
+
+/**
+ * Normalizes an AI-generated SLO definition to comply with the SLO schema.
+ *
+ * This handles common LLM output issues:
+ * - Missing `auto-discovered` tag
+ * - Missing `groupBy` default
+ * - Numeric values where duration strings are expected
+ * - Missing indicator index and required APM fields
+ */
+export function normalizeSloDefinition(
+  definition: Record<string, unknown>
+): Record<string, unknown> {
+  const normalized = { ...definition };
+
+  if (!normalized.tags) {
+    normalized.tags = ['auto-discovered'];
+  } else if (
+    Array.isArray(normalized.tags) &&
+    !normalized.tags.includes('auto-discovered')
+  ) {
+    (normalized.tags as string[]).push('auto-discovered');
+  }
+
+  if (!normalized.groupBy) {
+    normalized.groupBy = '*';
+  }
+
+  if (normalized.settings && typeof normalized.settings === 'object') {
+    const settings = normalized.settings as Record<string, unknown>;
+    normalized.settings = {
+      ...(settings.preventInitialBackfill !== undefined
+        ? { preventInitialBackfill: settings.preventInitialBackfill }
+        : {}),
+      ...(settings.syncDelay !== undefined
+        ? { syncDelay: toDurationString(settings.syncDelay, '1m') }
+        : {}),
+      ...(settings.frequency !== undefined
+        ? { frequency: toDurationString(settings.frequency, '1m') }
+        : {}),
+      ...(settings.syncField !== undefined ? { syncField: settings.syncField } : {}),
+    };
+  }
+
+  normalizeIndicatorIndex(normalized);
+
+  return normalized;
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/ai/slo_generation_prompt.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/ai/slo_generation_prompt.ts
@@ -1,0 +1,425 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolSchema } from '@kbn/inference-common';
+
+export const SLO_GENERATION_SYSTEM_PROMPT = `You are an expert SRE assistant specializing in Service Level Objectives (SLOs) within Elastic Observability.
+Your task is to generate a structured SLO definition from a natural language description.
+
+## SLO Indicator Types
+
+Choose the most appropriate indicator type based on the user's description:
+
+1. **sli.kql.custom** — Custom KQL: Define good and total events using KQL filter queries against any index.
+   - Use when the user describes good/bad events using log or event data with query conditions.
+   - Requires: index, good (KQL filter for good events), total (KQL filter for all events), timestampField.
+   - Optional: filter (additional KQL filter applied to both good and total).
+
+2. **sli.apm.transactionDuration** — APM Latency: Measures the percentage of APM transactions completing within a latency threshold.
+   - Use when the user mentions response time, latency, or transaction duration for a service.
+   - Requires: service, environment, transactionType, transactionName, threshold (in ms), index.
+   - The index MUST always be set. Use "metrics-apm*" as the default for APM indicators.
+   - Optional: filter.
+
+3. **sli.apm.transactionErrorRate** — APM Availability: Measures the percentage of successful (non-error) APM transactions.
+   - Use when the user mentions error rate, availability, or success rate for a service.
+   - Requires: service, environment, transactionType, transactionName, index.
+   - The index MUST always be set. Use "metrics-apm*" as the default for APM indicators.
+   - Optional: filter.
+
+4. **sli.metric.custom** — Custom Metric: Define good and total using metric aggregations (sum, doc_count).
+   - Use when the user describes metrics with aggregation functions against numeric fields.
+   - Requires: index, timestampField, good.metrics (array of {name, aggregation, field}), good.equation, total.metrics, total.equation.
+   - Optional: filter.
+
+5. **sli.metric.timeslice** — Timeslice Metric: Evaluate a metric equation per timeslice against a threshold.
+   - Use when the user wants to measure a metric value per time interval (e.g., avg CPU < 80%).
+   - Requires: index, timestampField, metric.metrics (array of {name, aggregation, field}), metric.equation, metric.comparator (GT, GTE, LT, LTE), metric.threshold.
+   - Optional: filter.
+
+6. **sli.histogram.custom** — Custom Histogram: Define good and total via range or value_count on histogram fields.
+   - Use for histogram-based metrics with range filters.
+   - Requires: index, timestampField, good.field, good.aggregation, total.field, total.aggregation.
+   - Optional: filter, good.from, good.to, total.from, total.to.
+
+7. **sli.synthetics.availability** — Synthetics Availability: Uptime for synthetic monitors.
+   - Use when the user mentions synthetic monitors, uptime checks, or ping tests.
+   - Requires: monitorIds (array), tags (array), projects (array).
+
+## Time Windows
+- **Rolling**: duration must be "7d", "30d", or "90d". Type is "rolling".
+- **Calendar-aligned**: duration must be "1w" or "1M". Type is "calendarAligned".
+- Default to 30d rolling if not specified.
+
+## Budgeting Methods
+- **occurrences**: Ratio of good events to total events over the time window. This is the default.
+- **timeslices**: Percentage of time slices that meet the threshold. Requires timesliceTarget (0-1) and timesliceWindow (e.g., "5m", "1h").
+
+## Objectives
+- target: A percentage value between 0 and 100 (e.g., 99 for 99%, 99.9 for 99.9%). Common targets: 95, 99, 99.5, 99.9, 99.99.
+- Default to 99 if not specified.
+
+## Settings Defaults
+- frequency: "1m" (duration string format: number + unit, e.g. "1m", "5m", "1h")
+- syncDelay: "1m" (duration string format: number + unit)
+- preventInitialBackfill: false
+- syncField: null
+- IMPORTANT: syncDelay and frequency MUST be duration strings like "1m", NOT numbers like 1.
+
+## Guidelines
+- Choose the simplest indicator type that matches the user's intent.
+- For APM services, prefer APM-specific indicators over custom KQL.
+- For latency SLOs, use sli.apm.transactionDuration with a reasonable threshold (e.g., 250ms, 500ms, 1000ms).
+- For availability SLOs on services, use sli.apm.transactionErrorRate.
+- For custom queries on logs or events, use sli.kql.custom.
+- For infrastructure metrics (CPU, memory, disk), use sli.metric.timeslice.
+- Generate a meaningful name and description for the SLO.
+- If the user mentions grouping by host, service, environment, etc., set groupBy to the appropriate field name(s).
+- If the user doesn't specify an index, use a sensible default based on the indicator type (e.g., "logs-*" for log-based, "metrics-*" for metric-based).
+- For KQL indicators, the timestampField is typically "@timestamp".
+- Always provide an explanation of the choices made and why the indicator type was selected.`;
+
+export const SLO_GENERATION_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    sloDefinition: {
+      type: 'object',
+      description: 'The structured SLO definition matching the CreateSLOForm schema.',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'A concise, descriptive name for the SLO.',
+        },
+        description: {
+          type: 'string',
+          description: 'A human-readable description explaining what this SLO measures.',
+        },
+        indicator: {
+          type: 'object',
+          description:
+            'The SLI indicator configuration. The "type" field determines which params are required.',
+          properties: {
+            type: {
+              type: 'string',
+              enum: [
+                'sli.kql.custom',
+                'sli.apm.transactionDuration',
+                'sli.apm.transactionErrorRate',
+                'sli.metric.custom',
+                'sli.metric.timeslice',
+                'sli.histogram.custom',
+                'sli.synthetics.availability',
+              ],
+              description: 'The indicator type.',
+            },
+            params: {
+              type: 'object',
+              description:
+                'Indicator-specific parameters. Structure depends on the indicator type.',
+            },
+          },
+          required: ['type', 'params'],
+        },
+        timeWindow: {
+          type: 'object',
+          properties: {
+            duration: {
+              type: 'string',
+              description:
+                'Time window duration. Rolling: "7d", "30d", or "90d". Calendar: "1w" or "1M".',
+            },
+            type: {
+              type: 'string',
+              enum: ['rolling', 'calendarAligned'],
+              description: 'Time window type.',
+            },
+          },
+          required: ['duration', 'type'],
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tags for categorizing the SLO.',
+        },
+        budgetingMethod: {
+          type: 'string',
+          enum: ['occurrences', 'timeslices'],
+          description: 'The budgeting method.',
+        },
+        objective: {
+          type: 'object',
+          properties: {
+            target: {
+              type: 'number',
+              description: 'The SLO target percentage (e.g., 99 for 99%).',
+            },
+            timesliceTarget: {
+              type: 'number',
+              description:
+                'Required when budgetingMethod is "timeslices". Value between 0 and 1 (e.g., 0.95).',
+            },
+            timesliceWindow: {
+              type: 'string',
+              description:
+                'Required when budgetingMethod is "timeslices". E.g., "5m", "10m", "1h".',
+            },
+          },
+          required: ['target'],
+        },
+        groupBy: {
+          description: 'Field(s) to group the SLO by, or "*" for no grouping.',
+        },
+        settings: {
+          type: 'object',
+          properties: {
+            preventInitialBackfill: { type: 'boolean' },
+            syncDelay: {
+              type: 'string',
+              description: 'Sync delay as a duration string, e.g. "1m", "5m".',
+            },
+            frequency: {
+              type: 'string',
+              description: 'Evaluation frequency as a duration string, e.g. "1m", "5m".',
+            },
+            syncField: {
+              description: 'Custom timestamp field for sync, or null.',
+            },
+          },
+        },
+      },
+      required: [
+        'name',
+        'description',
+        'indicator',
+        'timeWindow',
+        'budgetingMethod',
+        'objective',
+      ],
+    },
+    explanation: {
+      type: 'string',
+      description:
+        'A brief explanation of the choices made: why this indicator type was chosen, what the queries measure, and any assumptions made.',
+    },
+  },
+  required: ['sloDefinition', 'explanation'],
+} satisfies ToolSchema;
+
+export const SLO_DISCOVER_SYSTEM_PROMPT = `You are an expert SRE assistant specializing in Service Level Objectives (SLOs) within Elastic Observability.
+Your task is to analyze a user's cluster data and propose user-centric SLOs and SLIs based on the available data sources.
+
+## Your Goal
+Given a summary of available data (APM services, synthetics monitors, log data streams, metric indices),
+propose concrete, actionable SLOs that follow SRE best practices. Focus on user-facing reliability —
+availability, latency, and correctness — not internal infrastructure metrics.
+
+## SLO Indicator Types You Can Use
+
+1. **sli.apm.transactionErrorRate** — APM Availability: Percentage of successful (non-error) transactions.
+   - Best for: service availability SLOs.
+   - Requires: service, environment, transactionType, transactionName, index.
+   - The index field is REQUIRED. Use "metrics-apm*" as the default.
+
+2. **sli.apm.transactionDuration** — APM Latency: Percentage of transactions completing within a threshold.
+   - Best for: service latency/performance SLOs.
+   - Requires: service, environment, transactionType, transactionName, threshold (in ms), index.
+   - The index field is REQUIRED. Use "metrics-apm*" as the default.
+
+3. **sli.synthetics.availability** — Synthetics Availability: Uptime for synthetic monitors.
+   - Best for: endpoint/URL uptime SLOs.
+   - Requires: monitorIds (array), tags (array), projects (array).
+
+4. **sli.kql.custom** — Custom KQL: Good/total events from any index via KQL queries.
+   - Best for: log-based error rate, custom event SLOs.
+   - Requires: index, good (KQL), total (KQL), timestampField.
+
+5. **sli.metric.timeslice** — Timeslice Metric: Metric equation per timeslice vs threshold.
+   - Best for: infrastructure metrics like CPU, memory, disk usage.
+   - Requires: index, timestampField, metric.metrics, metric.equation, metric.comparator, metric.threshold.
+
+## Prioritization Rules
+1. **User-facing availability first**: For every APM service, always propose an availability SLO (error rate).
+2. **Latency second**: For key services (especially "request" transaction types), propose a latency SLO.
+3. **Synthetics monitors**: If monitors exist, propose availability SLOs for them.
+4. **Error logs**: If log data exists, propose error-rate SLOs for high-volume log streams.
+5. **Infrastructure**: Only propose infrastructure SLOs if they clearly support user-facing reliability.
+
+## Guidelines
+- Generate between 1 and 15 SLOs depending on what data is available.
+- Use sensible default targets: 99% for availability, 99% for latency (250ms for web, 1000ms for APIs).
+- Default time window: 30d rolling.
+- Default budgeting method: occurrences.
+- Use groupBy when it makes sense (e.g., service.environment for multi-environment services).
+- Each SLO must have a meaningful name, clear description, and appropriate tags.
+- For APM services, set transactionType to "request" for web services and the appropriate type for others.
+- Provide a brief rationale for each proposed SLO.
+- Tag each SLO with "auto-discovered" plus relevant domain tags.
+- IMPORTANT: All duration values (syncDelay, frequency, timesliceWindow, timeWindow.duration) MUST be strings in the format "<number><unit>" e.g. "1m", "5m", "30d", "7d". Never use bare numbers.
+- Do NOT include a "settings" field unless you need to override the defaults. If omitted, defaults will be applied automatically.`;
+
+export const SLO_DISCOVER_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    proposedSlos: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          sloDefinition: {
+            type: 'object',
+            description: 'The structured SLO definition matching the CreateSLOForm schema.',
+            properties: {
+              name: { type: 'string', description: 'A concise, descriptive name for the SLO.' },
+              description: {
+                type: 'string',
+                description: 'A human-readable description explaining what this SLO measures.',
+              },
+              indicator: {
+                type: 'object',
+                properties: {
+                  type: {
+                    type: 'string',
+                    enum: [
+                      'sli.kql.custom',
+                      'sli.apm.transactionDuration',
+                      'sli.apm.transactionErrorRate',
+                      'sli.metric.custom',
+                      'sli.metric.timeslice',
+                      'sli.histogram.custom',
+                      'sli.synthetics.availability',
+                    ],
+                  },
+                  params: { type: 'object' },
+                },
+                required: ['type', 'params'],
+              },
+              timeWindow: {
+                type: 'object',
+                properties: {
+                  duration: { type: 'string' },
+                  type: { type: 'string', enum: ['rolling', 'calendarAligned'] },
+                },
+                required: ['duration', 'type'],
+              },
+              tags: { type: 'array', items: { type: 'string' } },
+              budgetingMethod: {
+                type: 'string',
+                enum: ['occurrences', 'timeslices'],
+              },
+              objective: {
+                type: 'object',
+                properties: {
+                  target: { type: 'number' },
+                  timesliceTarget: { type: 'number' },
+                  timesliceWindow: { type: 'string' },
+                },
+                required: ['target'],
+              },
+              groupBy: { description: 'Field(s) to group the SLO by, or "*" for no grouping.' },
+              settings: {
+                type: 'object',
+                properties: {
+                  preventInitialBackfill: { type: 'boolean' },
+                  syncDelay: {
+                    type: 'string',
+                    description: 'Duration string, e.g. "1m".',
+                  },
+                  frequency: {
+                    type: 'string',
+                    description: 'Duration string, e.g. "1m".',
+                  },
+                  syncField: { description: 'Custom timestamp field or null.' },
+                },
+              },
+            },
+            required: [
+              'name',
+              'description',
+              'indicator',
+              'timeWindow',
+              'budgetingMethod',
+              'objective',
+            ],
+          },
+          rationale: {
+            type: 'string',
+            description:
+              'Brief explanation of why this SLO was proposed and what user-facing impact it monitors.',
+          },
+          category: {
+            type: 'string',
+            enum: ['availability', 'latency', 'correctness', 'uptime', 'throughput'],
+            description: 'The category of reliability this SLO measures.',
+          },
+          priority: {
+            type: 'string',
+            enum: ['critical', 'high', 'medium', 'low'],
+            description:
+              'How important this SLO is for user-facing reliability. Critical = directly impacts users.',
+          },
+        },
+        required: ['sloDefinition', 'rationale', 'category', 'priority'],
+      },
+      description: 'Array of proposed SLO definitions with rationale.',
+    },
+    summary: {
+      type: 'string',
+      description:
+        'A brief overview of the cluster data analyzed and the reasoning behind the proposed SLOs.',
+    },
+  },
+  required: ['proposedSlos', 'summary'],
+} satisfies ToolSchema;
+
+export const SLO_SUGGEST_SYSTEM_PROMPT = `You are an expert SRE assistant specializing in Service Level Objectives (SLOs).
+Your task is to analyze an SLO definition and suggest improvements or enhancements.
+
+Consider the following when making suggestions:
+- Is the objective target appropriate for the use case? Common targets are 99%, 99.5%, 99.9%.
+- Would a different time window better suit the use case?
+- Could groupBy be used to create per-service or per-host SLOs?
+- Would timeslice budgeting be more appropriate than occurrences for this type of metric?
+- Are the KQL queries or metric definitions optimal?
+- Are there missing tags that would help organize this SLO?
+- Could the SLO description be more informative?
+- Is the indicator type the best fit for what the user is trying to measure?
+
+Provide actionable, specific suggestions. Each suggestion should explain WHY the change would improve the SLO.`;
+
+export const SLO_SUGGEST_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    suggestions: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'A short title for the suggestion.',
+          },
+          description: {
+            type: 'string',
+            description:
+              'A detailed explanation of the suggestion and why it would improve the SLO.',
+          },
+          field: {
+            type: 'string',
+            description:
+              'The SLO field this suggestion applies to (e.g., "objective.target", "groupBy", "budgetingMethod").',
+          },
+          suggestedValue: {
+            description: 'The suggested new value for the field, if applicable.',
+          },
+        },
+        required: ['title', 'description'],
+      },
+      description: 'Array of improvement suggestions for the SLO definition.',
+    },
+  },
+  required: ['suggestions'],
+} satisfies ToolSchema;

--- a/x-pack/solutions/observability/plugins/slo/server/services/ai/slo_generation_prompt.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/ai/slo_generation_prompt.ts
@@ -191,14 +191,7 @@ export const SLO_GENERATION_OUTPUT_SCHEMA = {
           },
         },
       },
-      required: [
-        'name',
-        'description',
-        'indicator',
-        'timeWindow',
-        'budgetingMethod',
-        'objective',
-      ],
+      required: ['name', 'description', 'indicator', 'timeWindow', 'budgetingMethod', 'objective'],
     },
     explanation: {
       type: 'string',

--- a/x-pack/solutions/observability/plugins/slo/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/slo/tsconfig.json
@@ -117,6 +117,9 @@
     "@kbn/react-query",
     "@kbn/deeplinks-management",
     "@kbn/deeplinks-observability",
-    "@kbn/observability-get-padded-alert-time-range-util"
+    "@kbn/observability-get-padded-alert-time-range-util",
+    "@kbn/inference-plugin",
+    "@kbn/management-settings-ids",
+    "@kbn/inference-common"
   ]
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_bulk_create_slos.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_bulk_create_slos.ts
@@ -96,9 +96,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       expect(response.summary.total).to.be(2);
       expect(response.results).to.have.length(2);
 
-      const validResult = response.results.find(
-        (r: { name: string }) => r.name === 'Valid SLO'
-      );
+      const validResult = response.results.find((r: { name: string }) => r.name === 'Valid SLO');
       expect(validResult?.success).to.be(true);
     });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_bulk_create_slos.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_bulk_create_slos.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cleanup, generate } from '@kbn/data-forge';
+import expect from '@kbn/expect';
+import type { RoleCredentials } from '@kbn/ftr-common-functional-services';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import { DEFAULT_SLO } from './fixtures/slo';
+import { DATA_FORGE_CONFIG } from './helpers/dataforge';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const esClient = getService('es');
+  const sloApi = getService('sloApi');
+  const logger = getService('log');
+  const samlAuth = getService('samlAuth');
+  const dataViewApi = getService('dataViewApi');
+
+  const DATA_VIEW = 'kbn-data-forge-fake_hosts.fake_hosts-*';
+  const DATA_VIEW_ID = 'data-view-id';
+
+  let adminRoleAuthc: RoleCredentials;
+
+  describe('AI Bulk Create SLOs', function () {
+    before(async () => {
+      adminRoleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
+
+      await generate({ client: esClient, config: DATA_FORGE_CONFIG, logger });
+
+      await dataViewApi.create({
+        roleAuthc: adminRoleAuthc,
+        name: DATA_VIEW,
+        id: DATA_VIEW_ID,
+        title: DATA_VIEW,
+      });
+
+      await sloApi.deleteAllSLOs(adminRoleAuthc);
+    });
+
+    after(async () => {
+      await dataViewApi.delete({ roleAuthc: adminRoleAuthc, id: DATA_VIEW_ID });
+      await cleanup({ client: esClient, config: DATA_FORGE_CONFIG, logger });
+      await sloApi.deleteAllSLOs(adminRoleAuthc);
+      await samlAuth.invalidateM2mApiKeyWithRoleScope(adminRoleAuthc);
+    });
+
+    it('successfully creates multiple SLOs in bulk', async () => {
+      const slos = [
+        { ...DEFAULT_SLO, name: 'Bulk SLO 1' },
+        { ...DEFAULT_SLO, name: 'Bulk SLO 2' },
+        { ...DEFAULT_SLO, name: 'Bulk SLO 3' },
+      ];
+
+      const response = await sloApi.aiBulkCreate(slos, adminRoleAuthc);
+
+      expect(response).to.have.property('results');
+      expect(response).to.have.property('summary');
+      expect(response.summary.total).to.be(3);
+      expect(response.summary.success).to.be(3);
+      expect(response.summary.failure).to.be(0);
+      expect(response.results).to.have.length(3);
+
+      for (const result of response.results) {
+        expect(result.success).to.be(true);
+        expect(result).to.have.property('id');
+        expect(result).to.have.property('name');
+      }
+    });
+
+    it('returns individual errors for invalid SLO definitions', async () => {
+      const slos = [
+        { ...DEFAULT_SLO, name: 'Valid SLO' },
+        {
+          ...DEFAULT_SLO,
+          name: 'Invalid SLO',
+          indicator: {
+            type: 'sli.kql.custom',
+            params: {
+              index: 'nonexistent-index-that-should-not-exist-*',
+              filter: '',
+              good: 'status: 200',
+              total: '*',
+              timestampField: '@timestamp',
+            },
+          },
+        },
+      ];
+
+      const response = await sloApi.aiBulkCreate(slos, adminRoleAuthc);
+
+      expect(response).to.have.property('results');
+      expect(response).to.have.property('summary');
+      expect(response.summary.total).to.be(2);
+      expect(response.results).to.have.length(2);
+
+      const validResult = response.results.find(
+        (r: { name: string }) => r.name === 'Valid SLO'
+      );
+      expect(validResult?.success).to.be(true);
+    });
+
+    it('returns results with correct structure', async () => {
+      const slos = [{ ...DEFAULT_SLO, name: 'Structure Test SLO' }];
+
+      const response = await sloApi.aiBulkCreate(slos, adminRoleAuthc);
+
+      expect(response.results[0]).to.have.property('success');
+      expect(response.results[0]).to.have.property('name');
+      expect(response.results[0].success).to.be(true);
+      expect(response.results[0].name).to.be('Structure Test SLO');
+      expect(response.results[0]).to.have.property('id');
+
+      expect(response.summary).to.have.property('total');
+      expect(response.summary).to.have.property('success');
+      expect(response.summary).to.have.property('failure');
+    });
+
+    it('creates SLOs that are retrievable via the standard API', async () => {
+      const slos = [{ ...DEFAULT_SLO, name: 'Retrievable Bulk SLO' }];
+
+      const response = await sloApi.aiBulkCreate(slos, adminRoleAuthc);
+      expect(response.summary.success).to.be(1);
+
+      const createdId = response.results[0].id;
+      const getSloResponse = await sloApi.get(createdId, adminRoleAuthc);
+
+      expect(getSloResponse.name).to.be('Retrievable Bulk SLO');
+      expect(getSloResponse).to.have.property('id');
+      expect(getSloResponse.id).to.be(createdId);
+    });
+
+    it('handles empty array gracefully', async () => {
+      const response = await sloApi.aiBulkCreate([], adminRoleAuthc);
+
+      expect(response.summary.total).to.be(0);
+      expect(response.summary.success).to.be(0);
+      expect(response.summary.failure).to.be(0);
+      expect(response.results).to.have.length(0);
+    });
+
+    it('rejects requests with invalid body schema', async () => {
+      const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+      await supertestWithoutAuth
+        .post(`/internal/slo/ai/bulk-create`)
+        .set(adminRoleAuthc.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send({ invalid: 'body' })
+        .expect(400);
+    });
+  });
+}

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_discover_slos.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_discover_slos.ts
@@ -45,10 +45,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     it('rejects unauthenticated requests', async () => {
       const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-      await supertestWithoutAuth
-        .post(`/internal/slo/ai/discover`)
-        .send()
-        .expect(401);
+      await supertestWithoutAuth.post(`/internal/slo/ai/discover`).send().expect(401);
     });
   });
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_discover_slos.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ai_discover_slos.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { RoleCredentials } from '@kbn/ftr-common-functional-services';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const sloApi = getService('sloApi');
+  const samlAuth = getService('samlAuth');
+
+  let adminRoleAuthc: RoleCredentials;
+
+  describe('AI Discover SLOs', function () {
+    before(async () => {
+      adminRoleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
+    });
+
+    after(async () => {
+      await samlAuth.invalidateM2mApiKeyWithRoleScope(adminRoleAuthc);
+    });
+
+    it('returns an error when inference plugin is not configured', async () => {
+      // The discover endpoint requires the inference plugin with a configured AI connector.
+      // Without it, it should return a 400 indicating the feature is unavailable.
+      const response = await sloApi.aiDiscover(adminRoleAuthc, undefined, 400);
+
+      expect(response).to.have.property('message');
+    });
+
+    it('returns an error when a non-existent connector ID is provided', async () => {
+      const response = await sloApi.aiDiscover(
+        adminRoleAuthc,
+        { connectorId: 'non-existent-connector-id' },
+        400
+      );
+
+      expect(response).to.have.property('message');
+    });
+
+    it('rejects unauthenticated requests', async () => {
+      const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+      await supertestWithoutAuth
+        .post(`/internal/slo/ai/discover`)
+        .send()
+        .expect(401);
+    });
+  });
+}

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/index.ts
@@ -26,5 +26,7 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./health_scan'));
     loadTestFile(require.resolve('./search_slo_definitions'));
     loadTestFile(require.resolve('./get_slo_grouped_stats'));
+    loadTestFile(require.resolve('./ai_bulk_create_slos'));
+    loadTestFile(require.resolve('./ai_discover_slos'));
   });
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts
@@ -427,5 +427,40 @@ export function SloApiProvider({ getService }: DeploymentAgnosticFtrProviderCont
 
       return body;
     },
+
+    async aiBulkCreate(
+      slos: CreateSLOInput[],
+      roleAuthc: RoleCredentials,
+      expectedStatus: number = 200
+    ) {
+      const { body } = await supertestWithoutAuth
+        .post(`/internal/slo/ai/bulk-create`)
+        .set(roleAuthc.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send({ slos })
+        .expect(expectedStatus);
+
+      return body;
+    },
+
+    async aiDiscover(
+      roleAuthc: RoleCredentials,
+      params?: { connectorId?: string },
+      expectedStatus: number = 200
+    ) {
+      const req = supertestWithoutAuth
+        .post(`/internal/slo/ai/discover`)
+        .set(roleAuthc.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader());
+
+      if (params?.connectorId) {
+        req.send({ connectorId: params.connectorId });
+      } else {
+        req.send();
+      }
+
+      const { body } = await req.expect(expectedStatus);
+      return body;
+    },
   };
 }


### PR DESCRIPTION
## Summary

Adds a new **Auto-discover** creation mode to the SLO creation page that scans the user's cluster data and uses AI to propose user-centric SLOs following SRE best practices.

- **Cluster data discovery**: Scans APM services, synthetics monitors, log streams, and metric indices to build a summary of available data sources
- **AI-powered SLO proposals**: Sends the cluster summary to an LLM via the inference plugin with a specialized prompt that prioritizes user-facing reliability (availability > latency > uptime > error logs)
- **Bulk SLO creation**: One-click creation of all selected SLOs with per-SLO success/failure reporting

### New API endpoints

| Endpoint | Description |
|----------|-------------|
| `POST /internal/slo/ai/discover` | Scans cluster data and proposes SLOs via AI |
| `POST /internal/slo/ai/bulk-create` | Creates multiple SLOs at once |
| `POST /internal/slo/ai/generate` | Converts NL prompt to structured SLO definition |
| `POST /internal/slo/ai/suggest` | Suggests improvements for an SLO definition |

### User flow

1. Navigate to **Create new SLO** (`/app/slos/create`)
2. Click the **Auto-discover** toggle (alongside Manual and AI-assisted)
3. Click **Scan cluster & discover SLOs**
4. AI analyzes cluster data and proposes SLOs (Critical/High priority pre-selected)
5. Review proposals — each card shows indicator type, target, time window, service, priority badge, category badge, and AI rationale
6. Toggle selections as needed (select all / deselect all available)
7. Click **Create N SLOs** to bulk-create all selected
8. Redirected to SLO list with success notification

### Files changed

**18 files changed** (~2,970 lines added)

**Server (6 new files):**
- `server/services/ai/slo_generation_prompt.ts` — System prompts and output schemas for generate, suggest, and discover
- `server/services/ai/get_default_connector.ts` — Default AI connector resolution (UI settings → inference plugin EIS fallback)
- `server/routes/slo/ai_discover_slos.ts` — Discovery route with cluster scanning + LLM proposals
- `server/routes/slo/ai_bulk_create_slos.ts` — Bulk create route using createSLOParamsSchema
- `server/routes/slo/ai_generate_slo.ts` — NL generation route
- `server/routes/slo/ai_suggest_slo.ts` — Suggestion route

**Client (10 new files, 2 modified):**
- `public/hooks/use_discover_slos.ts` — React Query mutation for discovery
- `public/hooks/use_bulk_create_slos.ts` — React Query mutation for bulk create
- `public/hooks/use_generate_slo.ts` — React Query mutation for NL generation
- `public/hooks/use_suggest_slo.ts` — React Query mutation for suggestions
- `public/pages/slo_edit/components/nl_slo/creation_mode_toggle.tsx` — Three-way toggle
- `public/pages/slo_edit/components/nl_slo/slo_discover_form.tsx` — Main auto-discover UI
- `public/pages/slo_edit/components/nl_slo/discovered_slo_card.tsx` — Individual proposal card
- `public/pages/slo_edit/components/nl_slo/nl_slo_form.tsx` — NL generation form
- `public/pages/slo_edit/components/nl_slo/slo_preview.tsx` — SLO definition preview
- `public/pages/slo_edit/components/nl_slo/slo_suggestions.tsx` — AI suggestions display
- `public/pages/slo_edit/slo_edit.tsx` — Integrated all creation modes
- `server/routes/slo/route.ts` — Registered all AI routes

### Dependencies

- Requires the `inference` plugin (optional dependency)
- Uses the default AI connector (EIS preferred, falls back to OpenAI/first available)

## Test plan

- [ ] Navigate to `/app/slos/create` and verify the three-way toggle appears
- [ ] Click "Auto-discover" and verify the scan prompt appears
- [ ] Click "Scan cluster & discover SLOs" with APM data in the cluster
- [ ] Verify proposals appear with priority badges, category badges, and rationale
- [ ] Test select all / deselect all controls
- [ ] Click "Create N SLOs" and verify SLOs are created successfully
- [ ] Verify navigation to SLO list after creation
- [ ] Test with no data in cluster — should show "No SLOs discovered" warning
- [ ] Test "AI-assisted" mode — verify NL generation and refinement work
- [ ] Verify error handling when no AI connector is configured

Made with [Cursor](https://cursor.com)