### PR TITLE
Extend mappings for ES|QL rule

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/field_map.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/field_map.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { alertFieldMap } from '@kbn/alerts-as-data-utils';
+import type { FieldMap } from '@kbn/alerts-as-data-utils';
+
+type WellKnownFieldEntry = { path: string } & FieldMap[string];
+
+/**
+ * Well-known fields under `original_source` that should be mapped so they are
+ * indexed and queryable/sortable/filterable. Add a new entry here to extend
+ * the ES|QL rule alert mappings.
+ */
+const WELL_KNOWN_FIELDS: WellKnownFieldEntry[] = [
+  { path: 'host.hostname', type: 'keyword', required: false },
+  { path: 'service.name', type: 'keyword', required: false },
+];
+
+function buildWellKnownFieldsMap(): FieldMap {
+  const fieldMap: FieldMap = {};
+  for (const { path, ...fieldDef } of WELL_KNOWN_FIELDS) {
+    fieldMap[`original_source.${path}`] = fieldDef;
+  }
+  return fieldMap;
+}
+
+export const esqlRuleFieldMap: FieldMap = {
+  ...alertFieldMap,
+  ...buildWellKnownFieldsMap(),
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/register.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/register.ts
@@ -6,7 +6,6 @@
  */
 
 import type { AlertInstanceContext, RuleTypeState } from '@kbn/alerting-plugin/server';
-import { alertFieldMap } from '@kbn/alerts-as-data-utils';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import type { LicenseType } from '@kbn/licensing-types';
 import { STREAMS_ESQL_RULE_TYPE_ID } from '@kbn/rule-data-utils';
@@ -15,6 +14,7 @@ import { STREAMS_PRODUCER, STREAMS_RULE_REGISTRATION_CONTEXT } from '../../../..
 import { getRuleExecutor } from './executor';
 import type { EsqlRuleParams } from './types';
 import { esqlRuleParams } from './types';
+import { esqlRuleFieldMap } from './field_map';
 
 export function esqlRuleType(): PersistenceAlertType<
   EsqlRuleParams,
@@ -52,7 +52,7 @@ export function esqlRuleType(): PersistenceAlertType<
     autoRecoverAlerts: false,
     alerts: {
       context: STREAMS_RULE_REGISTRATION_CONTEXT,
-      mappings: { dynamic: false, fieldMap: { ...alertFieldMap } },
+      mappings: { dynamic: false, fieldMap: esqlRuleFieldMap },
       shouldWrite: false,
       isSpaceAware: false,
       dangerouslyCreateAlertsInAllSpaces: true,


### PR DESCRIPTION
### Summary

This PR extends the mappings for the Streams internal ES|QL rule with well known fields that could be used for clustering.

### TODO

- Extend the initial list with common ECS and SemConv fields that would be good for grouping events
- Add semantic_text field that combines the fields (how to handle missing field values?)
- Check how to migrate existing indices