### PR TITLE
Streams rally track: Set up streams through Kibana

### DIFF
--- a/x-pack/platform/plugins/shared/streams/common/config.ts
+++ b/x-pack/platform/plugins/shared/streams/common/config.ts
@@ -5,10 +5,23 @@
  * 2.0.
  */
 
+import type {
+  IngestPutPipelineRequest,
+  IndicesPutIndexTemplateRequest,
+  ClusterPutComponentTemplateRequest,
+} from '@elastic/elasticsearch/lib/api/types';
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 
-export const configSchema = schema.object({});
+export const configSchema = schema.object({
+  component_templates: schema.arrayOf<ClusterPutComponentTemplateRequest>(schema.any(), {
+    defaultValue: [],
+  }),
+  index_templates: schema.arrayOf<IndicesPutIndexTemplateRequest>(schema.any(), {
+    defaultValue: [],
+  }),
+  pipelines: schema.arrayOf<IngestPutPipelineRequest>(schema.any(), { defaultValue: [] }),
+});
 
 export type StreamsConfig = TypeOf<typeof configSchema>;
 

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -269,8 +269,41 @@ export class StreamsPlugin
 
     this.processorSuggestionsService.setConsoleStart(plugins.console);
 
+    this.createFromConfig(core);
+
     return {};
   }
 
   public stop() {}
+
+  private async createFromConfig(core: CoreStart): Promise<void> {
+    const esClient = core.elasticsearch.client.asInternalUser;
+
+    for (const componentTemplate of this.config.component_templates) {
+      try {
+        await esClient.cluster.putComponentTemplate(componentTemplate);
+        this.logger.info(`Successfully created component template ${componentTemplate.name}`);
+      } catch (error) {
+        this.logger.error(`Error creating component template ${componentTemplate.name}: ${error}`);
+      }
+    }
+
+    for (const indexTemplate of this.config.index_templates) {
+      try {
+        await esClient.indices.putIndexTemplate(indexTemplate);
+        this.logger.info(`Successfully created index template ${indexTemplate.name}`);
+      } catch (error) {
+        this.logger.error(`Error creating index template ${indexTemplate.name}: ${error}`);
+      }
+    }
+
+    for (const pipeline of this.config.pipelines) {
+      try {
+        await esClient.ingest.putPipeline(pipeline);
+        this.logger.info(`Successfully created ingest pipeline ${pipeline.id}`);
+      } catch (error) {
+        this.logger.error(`Error creating ingest pipeline ${pipeline.id}: ${error}`);
+      }
+    }
+  }
 }

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -269,7 +269,7 @@ export class StreamsPlugin
 
     this.processorSuggestionsService.setConsoleStart(plugins.console);
 
-    this.createFromConfig(core);
+    void this.createFromConfig(core);
 
     return {};
   }


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/streams-program/issues/402

This PR allows configuring index templates, component templates, and ingest pipelines via kibana config and applying them at startup.

**Component templates:**
```
xpack.streams:
  component_templates:
    - name: component_template1
      template:
        mappings:
          dynamic: false
          properties:
            '@timestamp':
              type: date
            host:
              type: keyword
```
**Index templates:**
```
xpack.streams:
  index_templates:
    - name: index_template1
      index_patterns:
        - logs
      template:
        settings:
          index:
            default_pipeline: pipeline1
            number_of_shards: 1
        mappings:
          properties:
            stream_name:
              type: constant_keyword
              value: example_stream
      composed_of:
        - component_template1
      priority: 100
      version: 1
      _meta:
        managed: true
        description: Example index template
```
**Ingest pipelines:**
```
xpack.streams:
  pipelines:
    - id: pipeline1
      description: Simple example pipeline
      processors:
        - set:
            description: Set timestamp if missing
            field: '@timestamp'
            override: false
            copy_from: _ingest.timestamp
```