### PR TITLE
[Streams] Add stream relationships API and storage

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -167,6 +167,16 @@ export {
 export { type System, systemSchema, isSystem } from './src/system';
 
 export {
+  type Relationship,
+  type RelationshipDirection,
+  type RelationshipSource,
+  relationshipSchema,
+  relationshipDirectionSchema,
+  relationshipSourceSchema,
+  isRelationship,
+} from './src/relationship';
+
+export {
   type BaseSimulationError,
   type SimulationError,
   type DocSimulationStatus,

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/relationship.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/relationship.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+
+/**
+ * Direction of the relationship between streams.
+ * - directional: from_stream -> to_stream (one-way relationship)
+ * - bidirectional: from_stream <-> to_stream (two-way relationship)
+ */
+export type RelationshipDirection = 'directional' | 'bidirectional';
+
+/**
+ * Source of how the relationship was created.
+ * - manual: User explicitly created the relationship
+ * - auto_detected: System detected the relationship based on shared fields
+ */
+export type RelationshipSource = 'manual' | 'auto_detected';
+
+/**
+ * A relationship between two streams.
+ * This represents a semantic connection between streams that don't have a parent-child
+ * relationship but are related (e.g., application logs and proxy logs for the same service).
+ */
+export interface Relationship {
+  from_stream: string;
+  to_stream: string;
+  description: string;
+  direction: RelationshipDirection;
+  source: RelationshipSource;
+  confidence?: number; // Only for auto_detected relationships (0-1)
+}
+
+export const relationshipDirectionSchema = z.enum(['directional', 'bidirectional']);
+
+export const relationshipSourceSchema = z.enum(['manual', 'auto_detected']);
+
+export const relationshipSchema: z.Schema<Relationship> = z.object({
+  from_stream: z.string(),
+  to_stream: z.string(),
+  description: z.string(),
+  direction: relationshipDirectionSchema,
+  source: relationshipSourceSchema,
+  confidence: z.number().min(0).max(1).optional(),
+});
+
+export function isRelationship(value: unknown): value is Relationship {
+  return relationshipSchema.safeParse(value).success;
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -39,6 +39,7 @@ import type { StreamsStorageClient } from './storage/streams_storage_client';
 import { checkAccess, checkAccessBulk } from './stream_crud';
 import type { SystemClient } from './system/system_client';
 import type { FeatureClient } from './feature';
+import type { RelationshipClient } from './relationships/relationship_client';
 
 interface AcknowledgeResponse<TResult extends Result> {
   acknowledged: true;
@@ -76,6 +77,7 @@ export class StreamsClient {
       queryClient: QueryClient;
       systemClient: SystemClient;
       featureClient: FeatureClient;
+      relationshipClient: RelationshipClient;
       storageClient: StreamsStorageClient;
       logger: Logger;
       request: KibanaRequest;

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/relationship_not_found_error.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/relationship_not_found_error.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StatusError } from './status_error';
+
+export class RelationshipNotFoundError extends StatusError {
+  constructor(message: string) {
+    super(message, 404);
+    this.name = 'RelationshipNotFoundError';
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/fields.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/fields.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const RELATIONSHIP_UUID = 'relationship.uuid';
+export const FROM_STREAM = 'relationship.from_stream';
+export const TO_STREAM = 'relationship.to_stream';
+export const RELATIONSHIP_DESCRIPTION = 'relationship.description';
+export const RELATIONSHIP_DIRECTION = 'relationship.direction';
+export const RELATIONSHIP_SOURCE = 'relationship.source';
+export const RELATIONSHIP_CONFIDENCE = 'relationship.confidence';
+export const RELATIONSHIP_UPDATED_AT = 'relationship.updated_at';

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { RelationshipClient } from './relationship_client';
+export { RelationshipService } from './relationship_service';
+export { relationshipStorageSettings } from './storage_settings';
+export type { RelationshipStorageSettings } from './storage_settings';
+export type { StoredRelationship } from './stored_relationship';
+export { storedRelationshipSchema } from './stored_relationship';
+export * from './fields';

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/relationship_client.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/relationship_client.test.ts
@@ -1,0 +1,363 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Relationship } from '@kbn/streams-schema';
+import type { IStorageClient } from '@kbn/storage-adapter';
+import { RelationshipClient } from './relationship_client';
+import { RelationshipNotFoundError } from '../errors/relationship_not_found_error';
+import type { RelationshipStorageSettings } from './storage_settings';
+import type { StoredRelationship } from './stored_relationship';
+import {
+  FROM_STREAM,
+  TO_STREAM,
+  RELATIONSHIP_DESCRIPTION,
+  RELATIONSHIP_DIRECTION,
+  RELATIONSHIP_SOURCE,
+  RELATIONSHIP_CONFIDENCE,
+  RELATIONSHIP_UUID,
+  RELATIONSHIP_UPDATED_AT,
+} from './fields';
+
+describe('RelationshipClient', () => {
+  let mockStorageClient: jest.Mocked<
+    IStorageClient<RelationshipStorageSettings, StoredRelationship>
+  >;
+  let relationshipClient: RelationshipClient;
+
+  const createMockStorageClient = (): jest.Mocked<
+    IStorageClient<RelationshipStorageSettings, StoredRelationship>
+  > => {
+    return {
+      index: jest.fn(),
+      delete: jest.fn(),
+      get: jest.fn(),
+      search: jest.fn(),
+      bulk: jest.fn(),
+      clean: jest.fn(),
+    } as unknown as jest.Mocked<IStorageClient<RelationshipStorageSettings, StoredRelationship>>;
+  };
+
+  beforeEach(() => {
+    mockStorageClient = createMockStorageClient();
+    relationshipClient = new RelationshipClient({
+      storageClient: mockStorageClient,
+    });
+  });
+
+  describe('linkRelationship', () => {
+    it('should create a relationship with proper storage format', async () => {
+      const relationship: Relationship = {
+        from_stream: 'stream-a',
+        to_stream: 'stream-b',
+        description: 'Test relationship',
+        direction: 'bidirectional',
+        source: 'manual',
+      };
+
+      mockStorageClient.index.mockResolvedValue({
+        _id: 'some-id',
+        _index: '.kibana_streams_relationships',
+        result: 'created',
+        _version: 1,
+        _seq_no: 1,
+        _primary_term: 1,
+        _shards: { total: 1, successful: 1, failed: 0 },
+      });
+
+      await relationshipClient.linkRelationship(relationship);
+
+      expect(mockStorageClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            [FROM_STREAM]: 'stream-a',
+            [TO_STREAM]: 'stream-b',
+            [RELATIONSHIP_DESCRIPTION]: 'Test relationship',
+            [RELATIONSHIP_DIRECTION]: 'bidirectional',
+            [RELATIONSHIP_SOURCE]: 'manual',
+          }),
+        })
+      );
+    });
+
+    it('should include confidence score for auto-detected relationships', async () => {
+      const relationship: Relationship = {
+        from_stream: 'stream-a',
+        to_stream: 'stream-b',
+        description: 'Auto-detected relationship',
+        direction: 'bidirectional',
+        source: 'auto_detected',
+        confidence: 0.85,
+      };
+
+      mockStorageClient.index.mockResolvedValue({
+        _id: 'some-id',
+        _index: '.kibana_streams_relationships',
+        result: 'created',
+        _version: 1,
+        _seq_no: 1,
+        _primary_term: 1,
+        _shards: { total: 1, successful: 1, failed: 0 },
+      });
+
+      await relationshipClient.linkRelationship(relationship);
+
+      expect(mockStorageClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            [RELATIONSHIP_CONFIDENCE]: 0.85,
+          }),
+        })
+      );
+    });
+
+    it('should sort stream names for bidirectional relationships', async () => {
+      const relationship1: Relationship = {
+        from_stream: 'z-stream',
+        to_stream: 'a-stream',
+        description: 'Test',
+        direction: 'bidirectional',
+        source: 'manual',
+      };
+
+      const relationship2: Relationship = {
+        from_stream: 'a-stream',
+        to_stream: 'z-stream',
+        description: 'Test',
+        direction: 'bidirectional',
+        source: 'manual',
+      };
+
+      mockStorageClient.index.mockResolvedValue({
+        _id: 'some-id',
+        _index: '.kibana_streams_relationships',
+        result: 'created',
+        _version: 1,
+        _seq_no: 1,
+        _primary_term: 1,
+        _shards: { total: 1, successful: 1, failed: 0 },
+      });
+
+      await relationshipClient.linkRelationship(relationship1);
+      const id1 = mockStorageClient.index.mock.calls[0][0].id;
+
+      await relationshipClient.linkRelationship(relationship2);
+      const id2 = mockStorageClient.index.mock.calls[1][0].id;
+
+      // Both should have the same UUID since they're bidirectional
+      expect(id1).toBe(id2);
+    });
+
+    it('should not sort stream names for directional relationships', async () => {
+      const relationship1: Relationship = {
+        from_stream: 'z-stream',
+        to_stream: 'a-stream',
+        description: 'Test',
+        direction: 'directional',
+        source: 'manual',
+      };
+
+      const relationship2: Relationship = {
+        from_stream: 'a-stream',
+        to_stream: 'z-stream',
+        description: 'Test',
+        direction: 'directional',
+        source: 'manual',
+      };
+
+      mockStorageClient.index.mockResolvedValue({
+        _id: 'some-id',
+        _index: '.kibana_streams_relationships',
+        result: 'created',
+        _version: 1,
+        _seq_no: 1,
+        _primary_term: 1,
+        _shards: { total: 1, successful: 1, failed: 0 },
+      });
+
+      await relationshipClient.linkRelationship(relationship1);
+      const id1 = mockStorageClient.index.mock.calls[0][0].id;
+
+      await relationshipClient.linkRelationship(relationship2);
+      const id2 = mockStorageClient.index.mock.calls[1][0].id;
+
+      // Should have different UUIDs since they're directional
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('unlinkRelationship', () => {
+    it('should delete a relationship successfully', async () => {
+      mockStorageClient.delete.mockResolvedValue({
+        acknowledged: true,
+        result: 'deleted',
+      });
+
+      await relationshipClient.unlinkRelationship('stream-a', 'stream-b', 'bidirectional');
+
+      expect(mockStorageClient.delete).toHaveBeenCalled();
+    });
+
+    it('should throw RelationshipNotFoundError when relationship does not exist', async () => {
+      mockStorageClient.delete.mockResolvedValue({
+        acknowledged: true,
+        result: 'not_found',
+      });
+
+      await expect(
+        relationshipClient.unlinkRelationship('stream-a', 'stream-b', 'bidirectional')
+      ).rejects.toThrow(RelationshipNotFoundError);
+    });
+  });
+
+  describe('getRelationships', () => {
+    it('should return relationships for a stream as source or target', async () => {
+      const mockHits = [
+        {
+          _source: {
+            [RELATIONSHIP_UUID]: 'uuid-1',
+            [FROM_STREAM]: 'stream-a',
+            [TO_STREAM]: 'stream-b',
+            [RELATIONSHIP_DESCRIPTION]: 'Test 1',
+            [RELATIONSHIP_DIRECTION]: 'bidirectional',
+            [RELATIONSHIP_SOURCE]: 'manual',
+            [RELATIONSHIP_UPDATED_AT]: '2024-01-01T00:00:00Z',
+          },
+        },
+        {
+          _source: {
+            [RELATIONSHIP_UUID]: 'uuid-2',
+            [FROM_STREAM]: 'stream-c',
+            [TO_STREAM]: 'stream-a',
+            [RELATIONSHIP_DESCRIPTION]: 'Test 2',
+            [RELATIONSHIP_DIRECTION]: 'directional',
+            [RELATIONSHIP_SOURCE]: 'auto_detected',
+            [RELATIONSHIP_CONFIDENCE]: 0.9,
+            [RELATIONSHIP_UPDATED_AT]: '2024-01-02T00:00:00Z',
+          },
+        },
+      ];
+
+      mockStorageClient.search.mockResolvedValue({
+        hits: {
+          hits: mockHits,
+          total: { value: 2, relation: 'eq' },
+        },
+      } as any);
+
+      const result = await relationshipClient.getRelationships('stream-a');
+
+      expect(result.relationships).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.relationships[0]).toEqual({
+        from_stream: 'stream-a',
+        to_stream: 'stream-b',
+        description: 'Test 1',
+        direction: 'bidirectional',
+        source: 'manual',
+      });
+      expect(result.relationships[1]).toEqual({
+        from_stream: 'stream-c',
+        to_stream: 'stream-a',
+        description: 'Test 2',
+        direction: 'directional',
+        source: 'auto_detected',
+        confidence: 0.9,
+      });
+    });
+
+    it('should return empty array when no relationships exist', async () => {
+      mockStorageClient.search.mockResolvedValue({
+        hits: {
+          hits: [],
+          total: { value: 0, relation: 'eq' },
+        },
+      } as any);
+
+      const result = await relationshipClient.getRelationships('stream-x');
+
+      expect(result.relationships).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('deleteRelationshipsForStream', () => {
+    it('should delete all relationships for a stream', async () => {
+      const mockHits = [
+        {
+          _source: {
+            [RELATIONSHIP_UUID]: 'uuid-1',
+            [FROM_STREAM]: 'stream-a',
+            [TO_STREAM]: 'stream-b',
+            [RELATIONSHIP_DESCRIPTION]: 'Test 1',
+            [RELATIONSHIP_DIRECTION]: 'bidirectional',
+            [RELATIONSHIP_SOURCE]: 'manual',
+            [RELATIONSHIP_UPDATED_AT]: '2024-01-01T00:00:00Z',
+          },
+        },
+        {
+          _source: {
+            [RELATIONSHIP_UUID]: 'uuid-2',
+            [FROM_STREAM]: 'stream-c',
+            [TO_STREAM]: 'stream-a',
+            [RELATIONSHIP_DESCRIPTION]: 'Test 2',
+            [RELATIONSHIP_DIRECTION]: 'directional',
+            [RELATIONSHIP_SOURCE]: 'manual',
+            [RELATIONSHIP_UPDATED_AT]: '2024-01-02T00:00:00Z',
+          },
+        },
+      ];
+
+      mockStorageClient.search.mockResolvedValue({
+        hits: {
+          hits: mockHits,
+          total: { value: 2, relation: 'eq' },
+        },
+      } as any);
+
+      mockStorageClient.bulk.mockResolvedValue({
+        errors: false,
+        items: [],
+        took: 1,
+      });
+
+      const result = await relationshipClient.deleteRelationshipsForStream('stream-a');
+
+      expect(result.deleted).toBe(2);
+      expect(mockStorageClient.bulk).toHaveBeenCalledWith({
+        operations: expect.arrayContaining([
+          expect.objectContaining({ delete: expect.any(Object) }),
+          expect.objectContaining({ delete: expect.any(Object) }),
+        ]),
+        throwOnFail: true,
+      });
+    });
+
+    it('should return 0 deleted when stream has no relationships', async () => {
+      mockStorageClient.search.mockResolvedValue({
+        hits: {
+          hits: [],
+          total: { value: 0, relation: 'eq' },
+        },
+      } as any);
+
+      const result = await relationshipClient.deleteRelationshipsForStream('stream-x');
+
+      expect(result.deleted).toBe(0);
+      expect(mockStorageClient.bulk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clean', () => {
+    it('should clean the relationships index', async () => {
+      mockStorageClient.clean.mockResolvedValue({ acknowledged: true, result: 'deleted' });
+
+      await relationshipClient.clean();
+
+      expect(mockStorageClient.clean).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/relationship_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/relationship_client.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import objectHash from 'object-hash';
+import { termQuery } from '@kbn/es-query';
+import type {
+  IStorageClient,
+  StorageClientDeleteResponse,
+  StorageClientIndexResponse,
+} from '@kbn/storage-adapter';
+import type { Relationship } from '@kbn/streams-schema';
+import {
+  RELATIONSHIP_UUID,
+  FROM_STREAM,
+  TO_STREAM,
+  RELATIONSHIP_DESCRIPTION,
+  RELATIONSHIP_DIRECTION,
+  RELATIONSHIP_SOURCE,
+  RELATIONSHIP_CONFIDENCE,
+  RELATIONSHIP_UPDATED_AT,
+} from './fields';
+import type { RelationshipStorageSettings } from './storage_settings';
+import type { StoredRelationship } from './stored_relationship';
+import { RelationshipNotFoundError } from '../errors/relationship_not_found_error';
+
+export class RelationshipClient {
+  constructor(
+    private readonly clients: {
+      storageClient: IStorageClient<RelationshipStorageSettings, StoredRelationship>;
+    }
+  ) {}
+
+  /**
+   * Generate a deterministic UUID for a relationship based on stream names.
+   * For bidirectional relationships, we sort stream names to ensure
+   * the same relationship isn't stored twice with different UUIDs.
+   */
+  private getRelationshipUuid(
+    fromStream: string,
+    toStream: string,
+    direction: Relationship['direction']
+  ): string {
+    if (direction === 'bidirectional') {
+      // Sort stream names for bidirectional relationships
+      const [streamA, streamB] = [fromStream, toStream].sort();
+      return objectHash({
+        [FROM_STREAM]: streamA,
+        [TO_STREAM]: streamB,
+      });
+    }
+    return objectHash({
+      [FROM_STREAM]: fromStream,
+      [TO_STREAM]: toStream,
+    });
+  }
+
+  private fromStorage(stored: StoredRelationship): Relationship {
+    const relationship: Relationship = {
+      from_stream: stored[FROM_STREAM],
+      to_stream: stored[TO_STREAM],
+      description: stored[RELATIONSHIP_DESCRIPTION],
+      direction: stored[RELATIONSHIP_DIRECTION],
+      source: stored[RELATIONSHIP_SOURCE],
+    };
+
+    if (stored[RELATIONSHIP_CONFIDENCE] !== undefined) {
+      relationship.confidence = stored[RELATIONSHIP_CONFIDENCE];
+    }
+
+    return relationship;
+  }
+
+  private toStorage(relationship: Relationship): StoredRelationship {
+    const uuid = this.getRelationshipUuid(
+      relationship.from_stream,
+      relationship.to_stream,
+      relationship.direction
+    );
+
+    const stored: StoredRelationship = {
+      [RELATIONSHIP_UUID]: uuid,
+      [FROM_STREAM]: relationship.from_stream,
+      [TO_STREAM]: relationship.to_stream,
+      [RELATIONSHIP_DESCRIPTION]: relationship.description,
+      [RELATIONSHIP_DIRECTION]: relationship.direction,
+      [RELATIONSHIP_SOURCE]: relationship.source,
+      [RELATIONSHIP_UPDATED_AT]: new Date().toISOString(),
+    };
+
+    if (relationship.confidence !== undefined) {
+      stored[RELATIONSHIP_CONFIDENCE] = relationship.confidence;
+    }
+
+    return stored;
+  }
+
+  /**
+   * Link a relationship between two streams.
+   */
+  async linkRelationship(relationship: Relationship): Promise<StorageClientIndexResponse> {
+    const document = this.toStorage(relationship);
+    return await this.clients.storageClient.index({
+      id: document[RELATIONSHIP_UUID],
+      document,
+    });
+  }
+
+  /**
+   * Unlink a relationship between two streams.
+   */
+  async unlinkRelationship(
+    fromStream: string,
+    toStream: string,
+    direction: Relationship['direction']
+  ): Promise<StorageClientDeleteResponse> {
+    const id = this.getRelationshipUuid(fromStream, toStream, direction);
+    const result = await this.clients.storageClient.delete({ id });
+    if (result.result === 'not_found') {
+      throw new RelationshipNotFoundError(
+        `Relationship between ${fromStream} and ${toStream} not found`
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Get all relationships for a given stream (as either from_stream or to_stream).
+   */
+  async getRelationships(streamName: string): Promise<{
+    relationships: Relationship[];
+    total: number;
+  }> {
+    const response = await this.clients.storageClient.search({
+      size: 10_000,
+      track_total_hits: true,
+      query: {
+        bool: {
+          should: [...termQuery(FROM_STREAM, streamName), ...termQuery(TO_STREAM, streamName)],
+          minimum_should_match: 1,
+        },
+      },
+    });
+
+    return {
+      relationships: response.hits.hits.map((hit) => this.fromStorage(hit._source)),
+      total: response.hits.total.value,
+    };
+  }
+
+  /**
+   * Get a specific relationship between two streams.
+   */
+  async getRelationship(
+    fromStream: string,
+    toStream: string,
+    direction: Relationship['direction']
+  ): Promise<Relationship> {
+    const id = this.getRelationshipUuid(fromStream, toStream, direction);
+    const hit = await this.clients.storageClient.get({ id });
+    return this.fromStorage(hit._source!);
+  }
+
+  /**
+   * Delete all relationships for a given stream.
+   * Used when a stream is deleted to clean up all its relationships.
+   */
+  async deleteRelationshipsForStream(streamName: string): Promise<{ deleted: number }> {
+    const { relationships } = await this.getRelationships(streamName);
+
+    if (relationships.length === 0) {
+      return { deleted: 0 };
+    }
+
+    const operations = relationships.map((rel) => ({
+      delete: {
+        _id: this.getRelationshipUuid(rel.from_stream, rel.to_stream, rel.direction),
+      },
+    }));
+
+    await this.clients.storageClient.bulk({
+      operations,
+      throwOnFail: true,
+    });
+
+    return { deleted: relationships.length };
+  }
+
+  /**
+   * Clean the entire relationships index.
+   */
+  async clean(): Promise<void> {
+    await this.clients.storageClient.clean();
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/relationship_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/relationship_service.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, KibanaRequest, Logger } from '@kbn/core/server';
+import { StorageIndexAdapter } from '@kbn/storage-adapter';
+import type { StreamsPluginStartDependencies } from '../../../types';
+import type { RelationshipStorageSettings } from './storage_settings';
+import { relationshipStorageSettings } from './storage_settings';
+import { RelationshipClient } from './relationship_client';
+import type { StoredRelationship } from './stored_relationship';
+import { storedRelationshipSchema } from './stored_relationship';
+
+export class RelationshipService {
+  constructor(
+    private readonly coreSetup: CoreSetup<StreamsPluginStartDependencies>,
+    private readonly logger: Logger
+  ) {}
+
+  async getClientWithRequest({ request }: { request: KibanaRequest }): Promise<RelationshipClient> {
+    const [coreStart] = await this.coreSetup.getStartServices();
+
+    const adapter = new StorageIndexAdapter<RelationshipStorageSettings, StoredRelationship>(
+      coreStart.elasticsearch.client.asInternalUser,
+      this.logger.get('relationships'),
+      relationshipStorageSettings,
+      {
+        migrateSource: (relationship: Record<string, unknown>) => {
+          // Validate that stored documents match the expected schema
+          const parsed = storedRelationshipSchema.parse(relationship);
+          return parsed;
+        },
+      }
+    );
+
+    return new RelationshipClient({ storageClient: adapter.getClient() });
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/storage_settings.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/storage_settings.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IndexStorageSettings } from '@kbn/storage-adapter';
+import { types } from '@kbn/storage-adapter';
+import {
+  RELATIONSHIP_UUID,
+  FROM_STREAM,
+  TO_STREAM,
+  RELATIONSHIP_DESCRIPTION,
+  RELATIONSHIP_DIRECTION,
+  RELATIONSHIP_SOURCE,
+  RELATIONSHIP_CONFIDENCE,
+  RELATIONSHIP_UPDATED_AT,
+} from './fields';
+
+export const relationshipStorageSettings = {
+  name: '.kibana_streams_relationships',
+  schema: {
+    properties: {
+      [RELATIONSHIP_UUID]: types.keyword(),
+      [FROM_STREAM]: types.keyword(),
+      [TO_STREAM]: types.keyword(),
+      [RELATIONSHIP_DESCRIPTION]: types.text(),
+      [RELATIONSHIP_DIRECTION]: types.keyword(),
+      [RELATIONSHIP_SOURCE]: types.keyword(),
+      [RELATIONSHIP_CONFIDENCE]: types.float(),
+      [RELATIONSHIP_UPDATED_AT]: types.date(),
+    },
+  },
+} satisfies IndexStorageSettings;
+
+export type RelationshipStorageSettings = typeof relationshipStorageSettings;

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/stored_relationship.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/stored_relationship.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import {
+  relationshipDirectionSchema,
+  relationshipSourceSchema,
+  type RelationshipDirection,
+  type RelationshipSource,
+} from '@kbn/streams-schema';
+import {
+  RELATIONSHIP_UUID,
+  FROM_STREAM,
+  TO_STREAM,
+  RELATIONSHIP_DESCRIPTION,
+  RELATIONSHIP_DIRECTION,
+  RELATIONSHIP_SOURCE,
+  RELATIONSHIP_CONFIDENCE,
+  RELATIONSHIP_UPDATED_AT,
+} from './fields';
+
+export interface StoredRelationship {
+  [RELATIONSHIP_UUID]: string;
+  [FROM_STREAM]: string;
+  [TO_STREAM]: string;
+  [RELATIONSHIP_DESCRIPTION]: string;
+  [RELATIONSHIP_DIRECTION]: RelationshipDirection;
+  [RELATIONSHIP_SOURCE]: RelationshipSource;
+  [RELATIONSHIP_CONFIDENCE]?: number;
+  [RELATIONSHIP_UPDATED_AT]: string;
+}
+
+export const storedRelationshipSchema: z.Schema<StoredRelationship> = z.object({
+  [RELATIONSHIP_UUID]: z.string(),
+  [FROM_STREAM]: z.string(),
+  [TO_STREAM]: z.string(),
+  [RELATIONSHIP_DESCRIPTION]: z.string(),
+  [RELATIONSHIP_DIRECTION]: relationshipDirectionSchema,
+  [RELATIONSHIP_SOURCE]: relationshipSourceSchema,
+  [RELATIONSHIP_CONFIDENCE]: z.number().min(0).max(1).optional(),
+  [RELATIONSHIP_UPDATED_AT]: z.string(),
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
@@ -14,6 +14,7 @@ import { StreamsClient } from './client';
 import type { AttachmentClient } from './attachments/attachment_client';
 import type { SystemClient } from './system/system_client';
 import type { FeatureClient } from './feature';
+import type { RelationshipClient } from './relationships/relationship_client';
 
 export class StreamsService {
   constructor(
@@ -28,12 +29,14 @@ export class StreamsService {
     queryClient,
     systemClient,
     featureClient,
+    relationshipClient,
   }: {
     request: KibanaRequest;
     attachmentClient: AttachmentClient;
     queryClient: QueryClient;
     systemClient: SystemClient;
     featureClient: FeatureClient;
+    relationshipClient: RelationshipClient;
   }): Promise<StreamsClient> {
     const [coreStart] = await this.coreSetup.getStartServices();
 
@@ -48,6 +51,7 @@ export class StreamsService {
       logger,
       systemClient,
       featureClient,
+      relationshipClient,
       scopedClusterClient,
       lockManager: new LockManagerService(this.coreSetup, logger),
       storageClient: createStreamsStorageClient(scopedClusterClient.asInternalUser, logger),

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
@@ -56,6 +56,7 @@ import type {
   UpdateDefaultIngestPipelineAction,
   UnlinkAssetsAction,
   UnlinkSystemsAction,
+  UnlinkRelationshipsAction,
   UpdateIngestSettingsAction,
   UpdateFailureStoreAction,
   UnlinkFeaturesAction,
@@ -96,6 +97,7 @@ export class ExecutionPlan {
       unlink_assets: [],
       unlink_systems: [],
       unlink_features: [],
+      unlink_relationships: [],
       update_ingest_settings: [],
       upsert_esql_view: [],
       delete_esql_view: [],
@@ -190,6 +192,7 @@ export class ExecutionPlan {
         unlink_assets,
         unlink_systems,
         unlink_features,
+        unlink_relationships,
         update_ingest_settings,
         upsert_esql_view,
         delete_esql_view,
@@ -235,6 +238,7 @@ export class ExecutionPlan {
         this.unlinkAssets(unlink_assets),
         this.unlinkSystems(unlink_systems),
         this.unlinkFeatures(unlink_features),
+        this.unlinkRelationships(unlink_relationships),
         this.deleteEsqlViews(delete_esql_view),
       ]);
 
@@ -294,6 +298,18 @@ export class ExecutionPlan {
 
     return Promise.all(
       actions.map((action) => this.dependencies.featureClient.deleteFeatures(action.request.name))
+    );
+  }
+
+  private async unlinkRelationships(actions: UnlinkRelationshipsAction[]) {
+    if (actions.length === 0) {
+      return;
+    }
+
+    return Promise.all(
+      actions.map((action) =>
+        this.dependencies.relationshipClient.deleteRelationshipsForStream(action.request.name)
+      )
     );
   }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/required_permissions.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/required_permissions.ts
@@ -75,6 +75,7 @@ export function getRequiredPermissionsForActions({
     unlink_assets,
     unlink_systems,
     unlink_features,
+    unlink_relationships,
     update_failure_store,
     upsert_esql_view,
     delete_esql_view,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/translate_classic_stream_pipeline_actions.test.ts
@@ -1048,6 +1048,7 @@ function emptyActionsByType(): ActionsByType {
     unlink_assets: [],
     unlink_systems: [],
     unlink_features: [],
+    unlink_relationships: [],
     update_ingest_settings: [],
     update_failure_store: [],
     upsert_esql_view: [],

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/types.ts
@@ -163,6 +163,13 @@ export interface UnlinkFeaturesAction {
   };
 }
 
+export interface UnlinkRelationshipsAction {
+  type: 'unlink_relationships';
+  request: {
+    name: string;
+  };
+}
+
 export interface UpdateIngestSettingsAction {
   type: 'update_ingest_settings';
   request: {
@@ -211,6 +218,7 @@ export type ElasticsearchAction =
   | UnlinkAssetsAction
   | UnlinkSystemsAction
   | UnlinkFeaturesAction
+  | UnlinkRelationshipsAction
   | UpdateFailureStoreAction
   | UpdateIngestSettingsAction
   | UpsertEsqlViewAction
@@ -237,6 +245,7 @@ export interface ActionsByType {
   unlink_assets: UnlinkAssetsAction[];
   unlink_systems: UnlinkSystemsAction[];
   unlink_features: UnlinkFeaturesAction[];
+  unlink_relationships: UnlinkRelationshipsAction[];
   update_failure_store: UpdateFailureStoreAction[];
   update_ingest_settings: UpdateIngestSettingsAction[];
   upsert_esql_view: UpsertEsqlViewAction[];

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
@@ -570,6 +570,12 @@ export class ClassicStream extends StreamActiveRecord<Streams.ClassicStream.Defi
           name: this._definition.name,
         },
       },
+      {
+        type: 'unlink_relationships',
+        request: {
+          name: this._definition.name,
+        },
+      },
     ];
 
     if (this._definition.ingest.processing.steps.length > 0) {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/query_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/query_stream.ts
@@ -475,6 +475,12 @@ export class QueryStream extends StreamActiveRecord<Streams.QueryStream.Definiti
         },
       },
       {
+        type: 'unlink_relationships',
+        request: {
+          name: this._definition.name,
+        },
+      },
+      {
         type: 'delete_esql_view',
         request: {
           name: getEsqlViewName(this._definition.name),

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -1003,6 +1003,12 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
           name: this._definition.name,
         },
       },
+      {
+        type: 'unlink_relationships',
+        request: {
+          name: this._definition.name,
+        },
+      },
     ];
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/types.ts
@@ -14,6 +14,7 @@ import type { QueryClient } from '../assets/query/query_client';
 import type { AttachmentClient } from '../attachments/attachment_client';
 import type { SystemClient } from '../system/system_client';
 import type { FeatureClient } from '../feature/feature_client';
+import type { RelationshipClient } from '../relationships/relationship_client';
 
 interface StreamUpsertChange {
   type: 'upsert';
@@ -37,6 +38,7 @@ export interface StateDependencies {
   attachmentClient: AttachmentClient;
   queryClient: QueryClient;
   featureClient: FeatureClient;
+  relationshipClient: RelationshipClient;
   isServerless: boolean;
   isDev: boolean;
 }

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -47,6 +47,7 @@ import { ProcessorSuggestionsService } from './lib/streams/ingest_pipelines/proc
 import { registerStreamsSavedObjects } from './lib/saved_objects/register_saved_objects';
 import { TaskService } from './lib/tasks/task_service';
 import { SystemService } from './lib/streams/system/system_service';
+import { RelationshipService } from './lib/streams/relationships/relationship_service';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
@@ -110,6 +111,7 @@ export class StreamsPlugin
     const streamsService = new StreamsService(core, this.logger, this.isDev);
     const featureService = new FeatureService(core, this.logger);
     const systemService = new SystemService(core, this.logger);
+    const relationshipService = new RelationshipService(core, this.logger);
     const contentService = new ContentService(core, this.logger);
     const queryService = new QueryService(core, this.logger);
     const taskService = new TaskService(plugins.taskManager);
@@ -124,6 +126,7 @@ export class StreamsPlugin
         attachmentClient,
         featureClient,
         systemClient,
+        relationshipClient,
         contentClient,
         queryClient,
       ] = await Promise.all([
@@ -131,6 +134,7 @@ export class StreamsPlugin
         attachmentService.getClientWithRequest({ request }),
         featureService.getClientWithRequest({ request }),
         systemService.getClientWithRequest({ request }),
+        relationshipService.getClientWithRequest({ request }),
         contentService.getClient(),
         queryService.getClientWithRequest({ request }),
       ]);
@@ -156,6 +160,7 @@ export class StreamsPlugin
         queryClient,
         systemClient,
         featureClient,
+        relationshipClient,
       });
 
       return {
@@ -165,6 +170,7 @@ export class StreamsPlugin
         streamsClient,
         featureClient,
         systemClient,
+        relationshipClient,
         inferenceClient,
         contentClient,
         queryClient,

--- a/x-pack/platform/plugins/shared/streams/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/index.ts
@@ -17,6 +17,7 @@ import { contentRoutes } from './content/route';
 import { internalCrudRoutes } from './internal/streams/crud/route';
 import { internalManagementRoutes } from './internal/streams/management/route';
 import { systemRoutes as internalSystemsRoutes } from './internal/streams/systems/route';
+import { relationshipRoutes as internalRelationshipRoutes } from './internal/streams/relationships/route';
 import { internalPromptsRoutes } from './internal/streams/prompts/route';
 import { internalSignificantEventsRoutes } from './internal/streams/significant_events/route';
 import { significantEventsRoutes } from './streams/significant_events/route';
@@ -43,6 +44,7 @@ export const streamsRouteRepository = {
   ...internalProcessingRoutes,
   ...failureStoreRoutes,
   ...internalSystemsRoutes,
+  ...internalRelationshipRoutes,
   ...internalPromptsRoutes,
   ...internalSignificantEventsRoutes,
   ...internalIngestRoutes,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/relationships/route.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/relationships/route.test.ts
@@ -1,0 +1,472 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FieldMetadataPlain } from '@kbn/fields-metadata-plugin/common';
+import type { Streams } from '@kbn/streams-schema';
+
+// We need to re-export the utility functions for testing
+// For now, we'll test the logic by creating test utilities that mirror the implementation
+
+/**
+ * Fields that are strong correlation signals for stream relationships.
+ */
+const CORRELATION_FIELD_WEIGHTS: Record<string, number> = {
+  'trace.id': 1.0,
+  'span.id': 0.95,
+  'service.name': 0.85,
+  'container.id': 0.85,
+  'kubernetes.pod.uid': 0.85,
+  'host.id': 0.8,
+  'session.id': 0.8,
+  'user.id': 0.75,
+};
+
+/**
+ * Extract field names and types from a stream definition
+ */
+function extractFieldsFromStream(stream: Streams.all.Definition): Map<string, string> {
+  const fields = new Map<string, string>();
+
+  if ('ingest' in stream && stream.ingest && 'wired' in stream.ingest) {
+    const wiredStream = stream as Streams.WiredStream.Definition;
+    for (const [fieldName, config] of Object.entries(wiredStream.ingest.wired.fields)) {
+      if (config.type !== 'system') {
+        fields.set(fieldName, config.type);
+      }
+    }
+  } else if ('ingest' in stream && stream.ingest && 'classic' in stream.ingest) {
+    const classicStream = stream as Streams.ClassicStream.Definition;
+    const overrides = classicStream.ingest.classic.field_overrides;
+    if (overrides) {
+      for (const [fieldName, config] of Object.entries(overrides)) {
+        if (config.type !== 'system') {
+          fields.set(fieldName, config.type);
+        }
+      }
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Check if two field types are compatible for correlation purposes
+ */
+function areTypesCompatible(type1: string, type2: string): boolean {
+  if (type1 === type2) return true;
+
+  const numericTypes = new Set([
+    'long',
+    'integer',
+    'short',
+    'byte',
+    'double',
+    'float',
+    'half_float',
+    'unsigned_long',
+  ]);
+  if (numericTypes.has(type1) && numericTypes.has(type2)) return true;
+
+  const textTypes = new Set(['keyword', 'text', 'match_only_text', 'wildcard']);
+  if (textTypes.has(type1) && textTypes.has(type2)) return true;
+
+  return false;
+}
+
+interface SharedField {
+  name: string;
+  type: string;
+  otherType: string;
+  isCorrelationField: boolean;
+  correlationWeight: number;
+  metadata?: FieldMetadataPlain;
+}
+
+/**
+ * Compute shared fields between two streams
+ */
+function computeSharedFields(
+  sourceFields: Map<string, string>,
+  targetFields: Map<string, string>,
+  fieldMetadata: Record<string, FieldMetadataPlain>
+): SharedField[] {
+  const sharedFields: SharedField[] = [];
+
+  for (const [fieldName, sourceType] of sourceFields) {
+    const targetType = targetFields.get(fieldName);
+    if (targetType && areTypesCompatible(sourceType, targetType)) {
+      const correlationWeight = CORRELATION_FIELD_WEIGHTS[fieldName] ?? 0;
+      sharedFields.push({
+        name: fieldName,
+        type: sourceType,
+        otherType: targetType,
+        isCorrelationField: correlationWeight > 0,
+        correlationWeight,
+        metadata: fieldMetadata[fieldName],
+      });
+    }
+  }
+
+  return sharedFields;
+}
+
+/**
+ * Calculate confidence score for a relationship based on shared fields
+ */
+function calculateConfidence(sharedFields: SharedField[]): number {
+  if (sharedFields.length === 0) return 0;
+
+  const fieldCountScore = Math.min(sharedFields.length / 10, 0.3);
+
+  const correlationFields = sharedFields.filter((f) => f.isCorrelationField);
+  const correlationScore = correlationFields.reduce((sum, f) => sum + f.correlationWeight * 0.5, 0);
+  const normalizedCorrelationScore = Math.min(correlationScore, 0.6);
+
+  const metadataFields = sharedFields.filter(
+    (f) => f.metadata?.source === 'ecs' || f.metadata?.source === 'otel'
+  );
+  const metadataScore = Math.min(metadataFields.length * 0.02, 0.1);
+
+  const totalScore = fieldCountScore + normalizedCorrelationScore + metadataScore;
+  return Math.min(Math.round(totalScore * 100) / 100, 1.0);
+}
+
+/**
+ * Generate a description for the suggested relationship
+ */
+function generateDescription(sharedFields: SharedField[]): string {
+  const correlationFields = sharedFields
+    .filter((f) => f.isCorrelationField)
+    .sort((a, b) => b.correlationWeight - a.correlationWeight)
+    .slice(0, 3);
+
+  if (correlationFields.length > 0) {
+    const fieldNames = correlationFields.map((f) => f.name).join(', ');
+    return `Streams share correlation fields: ${fieldNames}`;
+  }
+
+  const topFields = sharedFields
+    .slice(0, 3)
+    .map((f) => f.name)
+    .join(', ');
+  return `Streams share ${sharedFields.length} field(s): ${topFields}${sharedFields.length > 3 ? '...' : ''}`;
+}
+
+describe('relationship suggestions', () => {
+  describe('extractFieldsFromStream', () => {
+    it('extracts fields from a wired stream', () => {
+      const stream: Streams.WiredStream.Definition = {
+        name: 'logs.test',
+        description: '',
+        updated_at: '2024-01-01T00:00:00Z',
+        query_streams: [],
+        ingest: {
+          lifecycle: { inherit: {} },
+          processing: { steps: [], updated_at: '2024-01-01T00:00:00Z' },
+          settings: {},
+          failure_store: { inherit: {} },
+          wired: {
+            fields: {
+              'service.name': { type: 'keyword' },
+              'trace.id': { type: 'keyword' },
+              '@timestamp': { type: 'system' },
+            },
+            routing: [],
+          },
+        },
+      };
+
+      const fields = extractFieldsFromStream(stream);
+      expect(fields.size).toBe(2);
+      expect(fields.get('service.name')).toBe('keyword');
+      expect(fields.get('trace.id')).toBe('keyword');
+      expect(fields.has('@timestamp')).toBe(false);
+    });
+
+    it('extracts fields from a classic stream', () => {
+      const stream: Streams.ClassicStream.Definition = {
+        name: 'my-data-stream',
+        description: '',
+        updated_at: '2024-01-01T00:00:00Z',
+        ingest: {
+          lifecycle: { inherit: {} },
+          processing: { steps: [], updated_at: '2024-01-01T00:00:00Z' },
+          settings: {},
+          failure_store: { inherit: {} },
+          classic: {
+            field_overrides: {
+              'host.name': { type: 'keyword' },
+              response_code: { type: 'long' },
+            },
+          },
+        },
+      };
+
+      const fields = extractFieldsFromStream(stream);
+      expect(fields.size).toBe(2);
+      expect(fields.get('host.name')).toBe('keyword');
+      expect(fields.get('response_code')).toBe('long');
+    });
+
+    it('returns empty map for query stream', () => {
+      const stream: Streams.QueryStream.Definition = {
+        name: 'my-query-stream',
+        description: '',
+        updated_at: '2024-01-01T00:00:00Z',
+        query_streams: [],
+        query: {
+          kql: { query: 'service.name: "test"' },
+        },
+      };
+
+      const fields = extractFieldsFromStream(stream);
+      expect(fields.size).toBe(0);
+    });
+  });
+
+  describe('areTypesCompatible', () => {
+    it('returns true for exact type matches', () => {
+      expect(areTypesCompatible('keyword', 'keyword')).toBe(true);
+      expect(areTypesCompatible('long', 'long')).toBe(true);
+    });
+
+    it('returns true for compatible numeric types', () => {
+      expect(areTypesCompatible('long', 'integer')).toBe(true);
+      expect(areTypesCompatible('double', 'float')).toBe(true);
+      expect(areTypesCompatible('short', 'byte')).toBe(true);
+    });
+
+    it('returns true for compatible text types', () => {
+      expect(areTypesCompatible('keyword', 'text')).toBe(true);
+      expect(areTypesCompatible('match_only_text', 'wildcard')).toBe(true);
+    });
+
+    it('returns false for incompatible types', () => {
+      expect(areTypesCompatible('keyword', 'long')).toBe(false);
+      expect(areTypesCompatible('boolean', 'keyword')).toBe(false);
+      expect(areTypesCompatible('ip', 'keyword')).toBe(false);
+    });
+  });
+
+  describe('computeSharedFields', () => {
+    it('finds shared fields with compatible types', () => {
+      const sourceFields = new Map([
+        ['service.name', 'keyword'],
+        ['trace.id', 'keyword'],
+        ['count', 'long'],
+      ]);
+      const targetFields = new Map([
+        ['service.name', 'keyword'],
+        ['trace.id', 'text'],
+        ['other_field', 'keyword'],
+      ]);
+
+      const shared = computeSharedFields(sourceFields, targetFields, {});
+      expect(shared.length).toBe(2);
+      expect(shared.find((f) => f.name === 'service.name')).toBeDefined();
+      expect(shared.find((f) => f.name === 'trace.id')).toBeDefined();
+    });
+
+    it('marks correlation fields correctly', () => {
+      const sourceFields = new Map([
+        ['trace.id', 'keyword'],
+        ['custom_field', 'keyword'],
+      ]);
+      const targetFields = new Map([
+        ['trace.id', 'keyword'],
+        ['custom_field', 'keyword'],
+      ]);
+
+      const shared = computeSharedFields(sourceFields, targetFields, {});
+      const traceField = shared.find((f) => f.name === 'trace.id');
+      const customField = shared.find((f) => f.name === 'custom_field');
+
+      expect(traceField?.isCorrelationField).toBe(true);
+      expect(traceField?.correlationWeight).toBe(1.0);
+      expect(customField?.isCorrelationField).toBe(false);
+      expect(customField?.correlationWeight).toBe(0);
+    });
+
+    it('includes field metadata when available', () => {
+      const sourceFields = new Map([['service.name', 'keyword']]);
+      const targetFields = new Map([['service.name', 'keyword']]);
+      const metadata: Record<string, FieldMetadataPlain> = {
+        'service.name': {
+          name: 'service.name',
+          source: 'ecs',
+          type: 'keyword',
+          description: 'Name of the service',
+        },
+      };
+
+      const shared = computeSharedFields(sourceFields, targetFields, metadata);
+      expect(shared[0].metadata?.source).toBe('ecs');
+    });
+  });
+
+  describe('calculateConfidence', () => {
+    it('returns 0 for no shared fields', () => {
+      expect(calculateConfidence([])).toBe(0);
+    });
+
+    it('returns low confidence for generic fields only', () => {
+      const sharedFields: SharedField[] = [
+        {
+          name: 'custom_field_1',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: false,
+          correlationWeight: 0,
+        },
+        {
+          name: 'custom_field_2',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: false,
+          correlationWeight: 0,
+        },
+      ];
+
+      const confidence = calculateConfidence(sharedFields);
+      // Should be around 0.2 (field count score only)
+      expect(confidence).toBeGreaterThan(0);
+      expect(confidence).toBeLessThan(0.3);
+    });
+
+    it('returns high confidence for correlation fields', () => {
+      const sharedFields: SharedField[] = [
+        {
+          name: 'trace.id',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: true,
+          correlationWeight: 1.0,
+        },
+        {
+          name: 'service.name',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: true,
+          correlationWeight: 0.85,
+        },
+      ];
+
+      const confidence = calculateConfidence(sharedFields);
+      expect(confidence).toBeGreaterThan(0.7);
+    });
+
+    it('caps confidence at 1.0', () => {
+      const sharedFields: SharedField[] = Array.from({ length: 20 }, (_, i) => ({
+        name: `field_${i}`,
+        type: 'keyword',
+        otherType: 'keyword',
+        isCorrelationField: true,
+        correlationWeight: 1.0,
+        metadata: { name: `field_${i}`, source: 'ecs' as const },
+      }));
+
+      const confidence = calculateConfidence(sharedFields);
+      expect(confidence).toBe(1.0);
+    });
+
+    it('adds bonus for ECS metadata-backed fields', () => {
+      const withoutMetadata: SharedField[] = [
+        {
+          name: 'service.name',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: true,
+          correlationWeight: 0.85,
+        },
+      ];
+
+      const withMetadata: SharedField[] = [
+        {
+          name: 'service.name',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: true,
+          correlationWeight: 0.85,
+          metadata: { name: 'service.name', source: 'ecs' as const },
+        },
+      ];
+
+      const confidenceWithout = calculateConfidence(withoutMetadata);
+      const confidenceWith = calculateConfidence(withMetadata);
+      expect(confidenceWith).toBeGreaterThan(confidenceWithout);
+    });
+  });
+
+  describe('generateDescription', () => {
+    it('prioritizes correlation fields in description', () => {
+      const sharedFields: SharedField[] = [
+        {
+          name: 'custom_field',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: false,
+          correlationWeight: 0,
+        },
+        {
+          name: 'trace.id',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: true,
+          correlationWeight: 1.0,
+        },
+        {
+          name: 'service.name',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: true,
+          correlationWeight: 0.85,
+        },
+      ];
+
+      const description = generateDescription(sharedFields);
+      expect(description).toContain('correlation fields');
+      expect(description).toContain('trace.id');
+      expect(description).toContain('service.name');
+    });
+
+    it('falls back to generic description for non-correlation fields', () => {
+      const sharedFields: SharedField[] = [
+        {
+          name: 'custom_field_1',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: false,
+          correlationWeight: 0,
+        },
+        {
+          name: 'custom_field_2',
+          type: 'keyword',
+          otherType: 'keyword',
+          isCorrelationField: false,
+          correlationWeight: 0,
+        },
+      ];
+
+      const description = generateDescription(sharedFields);
+      expect(description).toContain('share 2 field(s)');
+      expect(description).toContain('custom_field_1');
+    });
+
+    it('truncates long field lists with ellipsis', () => {
+      const sharedFields: SharedField[] = Array.from({ length: 10 }, (_, i) => ({
+        name: `field_${i}`,
+        type: 'keyword',
+        otherType: 'keyword',
+        isCorrelationField: false,
+        correlationWeight: 0,
+      }));
+
+      const description = generateDescription(sharedFields);
+      expect(description).toContain('...');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/relationships/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/relationships/route.ts
@@ -1,0 +1,487 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { Relationship } from '@kbn/streams-schema';
+import { relationshipSchema, Streams } from '@kbn/streams-schema';
+import type {
+  StorageClientDeleteResponse,
+  StorageClientIndexResponse,
+} from '@kbn/storage-adapter';
+import type { FieldMetadataPlain } from '@kbn/fields-metadata-plugin/common';
+import type { IFieldsMetadataClient } from '@kbn/fields-metadata-plugin/server/services/fields_metadata/types';
+import { createServerRoute } from '../../../create_server_route';
+import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
+import { RelationshipNotFoundError } from '../../../../lib/streams/errors/relationship_not_found_error';
+import type { StreamsClient } from '../../../../lib/streams/client';
+
+export const listRelationshipsRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/{name}/relationships',
+  options: {
+    access: 'internal',
+    summary: 'List relationships for a stream',
+    description: 'Fetches all relationships where the stream is either the source or target',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  params: z.object({
+    path: z.object({
+      name: z.string(),
+    }),
+  }),
+  handler: async ({
+    params,
+    request,
+    getScopedClients,
+  }): Promise<{ relationships: Relationship[]; total: number }> => {
+    const { relationshipClient, streamsClient } = await getScopedClients({
+      request,
+    });
+
+    const { name } = params.path;
+    await streamsClient.ensureStream(name);
+
+    return await relationshipClient.getRelationships(name);
+  },
+});
+
+export const upsertRelationshipRoute = createServerRoute({
+  endpoint: 'PUT /internal/streams/{name}/relationships',
+  options: {
+    access: 'internal',
+    summary: 'Create or update a relationship for a stream',
+    description: 'Creates or updates a relationship between two streams',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.manage],
+    },
+  },
+  params: z.object({
+    path: z.object({
+      name: z.string(),
+    }),
+    body: relationshipSchema,
+  }),
+  handler: async ({
+    params,
+    request,
+    getScopedClients,
+  }): Promise<StorageClientIndexResponse> => {
+    const { relationshipClient, streamsClient } = await getScopedClients({
+      request,
+    });
+
+    const { name } = params.path;
+    const { body: relationship } = params;
+
+    // Ensure both streams in the relationship exist
+    await streamsClient.ensureStream(name);
+    await streamsClient.ensureStream(relationship.to_stream);
+
+    // Validate that from_stream matches the stream name in the path
+    if (relationship.from_stream !== name) {
+      throw new Error(
+        `from_stream (${relationship.from_stream}) must match the stream name in the path (${name})`
+      );
+    }
+
+    return await relationshipClient.linkRelationship(relationship);
+  },
+});
+
+export const deleteRelationshipRoute = createServerRoute({
+  endpoint: 'DELETE /internal/streams/{name}/relationships/{targetStream}',
+  options: {
+    access: 'internal',
+    summary: 'Delete a relationship between two streams',
+    description: 'Removes a relationship between two streams',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.manage],
+    },
+  },
+  params: z.object({
+    path: z.object({
+      name: z.string(),
+      targetStream: z.string(),
+    }),
+    query: z.object({
+      direction: z.enum(['directional', 'bidirectional']).default('bidirectional'),
+    }),
+  }),
+  handler: async ({
+    params,
+    request,
+    getScopedClients,
+  }): Promise<StorageClientDeleteResponse> => {
+    const { relationshipClient, streamsClient } = await getScopedClients({
+      request,
+    });
+
+    const { name, targetStream } = params.path;
+    const { direction } = params.query;
+
+    await streamsClient.ensureStream(name);
+
+    try {
+      return await relationshipClient.unlinkRelationship(name, targetStream, direction);
+    } catch (error) {
+      if (error instanceof RelationshipNotFoundError) {
+        throw error;
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Fields that are strong correlation signals for stream relationships.
+ * These are ECS/OTel fields commonly used to correlate data across different sources.
+ * Higher weight = stronger relationship signal.
+ */
+const CORRELATION_FIELD_WEIGHTS: Record<string, number> = {
+  // Tracing/APM fields - strongest correlation signals
+  'trace.id': 1.0,
+  'span.id': 0.95,
+  'transaction.id': 0.95,
+  'parent.id': 0.9,
+
+  // Service identification
+  'service.name': 0.85,
+  'service.namespace': 0.75,
+  'service.environment': 0.7,
+  'service.version': 0.6,
+
+  // Container/infrastructure correlation
+  'container.id': 0.85,
+  'container.name': 0.75,
+  'kubernetes.pod.uid': 0.85,
+  'kubernetes.pod.name': 0.8,
+  'kubernetes.namespace': 0.75,
+  'kubernetes.node.name': 0.7,
+  'kubernetes.deployment.name': 0.75,
+
+  // Host identification
+  'host.id': 0.8,
+  'host.name': 0.75,
+  'host.hostname': 0.75,
+
+  // Cloud correlation
+  'cloud.instance.id': 0.75,
+  'cloud.account.id': 0.7,
+
+  // Session/user correlation
+  'session.id': 0.8,
+  'user.id': 0.75,
+  'user.name': 0.7,
+
+  // Request correlation
+  'http.request.id': 0.8,
+  'event.id': 0.7,
+
+  // OTel equivalents (prefixed versions)
+  'resource.attributes.service.name': 0.85,
+  'resource.attributes.service.namespace': 0.75,
+  'attributes.service.name': 0.85,
+  'resource.attributes.container.id': 0.85,
+  'resource.attributes.host.name': 0.75,
+  'resource.attributes.k8s.pod.uid': 0.85,
+  'resource.attributes.k8s.namespace.name': 0.75,
+};
+
+/**
+ * Extract field names and types from a stream definition
+ */
+function extractFieldsFromStream(
+  stream: Streams.all.Definition
+): Map<string, string> {
+  const fields = new Map<string, string>();
+
+  if (Streams.WiredStream.Definition.is(stream)) {
+    for (const [fieldName, config] of Object.entries(stream.ingest.wired.fields)) {
+      if (config.type !== 'system') {
+        fields.set(fieldName, config.type);
+      }
+    }
+  } else if (Streams.ClassicStream.Definition.is(stream)) {
+    const overrides = stream.ingest.classic.field_overrides;
+    if (overrides) {
+      for (const [fieldName, config] of Object.entries(overrides)) {
+        if (config.type !== 'system') {
+          fields.set(fieldName, config.type);
+        }
+      }
+    }
+  }
+  // QueryStream doesn't have its own fields - it references other streams
+
+  return fields;
+}
+
+/**
+ * Check if two field types are compatible for correlation purposes
+ */
+function areTypesCompatible(type1: string, type2: string): boolean {
+  // Exact match
+  if (type1 === type2) return true;
+
+  // Numeric types are compatible with each other
+  const numericTypes = new Set(['long', 'integer', 'short', 'byte', 'double', 'float', 'half_float', 'unsigned_long']);
+  if (numericTypes.has(type1) && numericTypes.has(type2)) return true;
+
+  // Text types are compatible with each other
+  const textTypes = new Set(['keyword', 'text', 'match_only_text', 'wildcard']);
+  if (textTypes.has(type1) && textTypes.has(type2)) return true;
+
+  return false;
+}
+
+/**
+ * Shared field information between two streams
+ */
+interface SharedField {
+  name: string;
+  type: string;
+  otherType: string;
+  isCorrelationField: boolean;
+  correlationWeight: number;
+  metadata?: FieldMetadataPlain;
+}
+
+/**
+ * A suggested relationship between two streams
+ */
+export interface RelationshipSuggestion {
+  from_stream: string;
+  to_stream: string;
+  confidence: number;
+  shared_fields: SharedField[];
+  description: string;
+}
+
+/**
+ * Compute shared fields between two streams
+ */
+function computeSharedFields(
+  sourceFields: Map<string, string>,
+  targetFields: Map<string, string>,
+  fieldMetadata: Record<string, FieldMetadataPlain>
+): SharedField[] {
+  const sharedFields: SharedField[] = [];
+
+  for (const [fieldName, sourceType] of sourceFields) {
+    const targetType = targetFields.get(fieldName);
+    if (targetType && areTypesCompatible(sourceType, targetType)) {
+      const correlationWeight = CORRELATION_FIELD_WEIGHTS[fieldName] ?? 0;
+      sharedFields.push({
+        name: fieldName,
+        type: sourceType,
+        otherType: targetType,
+        isCorrelationField: correlationWeight > 0,
+        correlationWeight,
+        metadata: fieldMetadata[fieldName],
+      });
+    }
+  }
+
+  return sharedFields;
+}
+
+/**
+ * Calculate confidence score for a relationship based on shared fields
+ */
+function calculateConfidence(sharedFields: SharedField[]): number {
+  if (sharedFields.length === 0) return 0;
+
+  // Base confidence from having shared fields
+  const fieldCountScore = Math.min(sharedFields.length / 10, 0.3);
+
+  // Score from correlation fields (weighted)
+  const correlationFields = sharedFields.filter((f) => f.isCorrelationField);
+  const correlationScore = correlationFields.reduce(
+    (sum, f) => sum + f.correlationWeight * 0.5,
+    0
+  );
+  const normalizedCorrelationScore = Math.min(correlationScore, 0.6);
+
+  // Bonus for ECS/OTel metadata-backed fields
+  const metadataFields = sharedFields.filter((f) => f.metadata?.source === 'ecs' || f.metadata?.source === 'otel');
+  const metadataScore = Math.min(metadataFields.length * 0.02, 0.1);
+
+  const totalScore = fieldCountScore + normalizedCorrelationScore + metadataScore;
+  return Math.min(Math.round(totalScore * 100) / 100, 1.0);
+}
+
+/**
+ * Generate a description for the suggested relationship
+ */
+function generateDescription(sharedFields: SharedField[]): string {
+  const correlationFields = sharedFields
+    .filter((f) => f.isCorrelationField)
+    .sort((a, b) => b.correlationWeight - a.correlationWeight)
+    .slice(0, 3);
+
+  if (correlationFields.length > 0) {
+    const fieldNames = correlationFields.map((f) => f.name).join(', ');
+    return `Streams share correlation fields: ${fieldNames}`;
+  }
+
+  const topFields = sharedFields.slice(0, 3).map((f) => f.name).join(', ');
+  return `Streams share ${sharedFields.length} field(s): ${topFields}${sharedFields.length > 3 ? '...' : ''}`;
+}
+
+/**
+ * Get fields from all streams and return a map of stream name to fields
+ */
+async function getAllStreamFields(
+  streamsClient: StreamsClient
+): Promise<Map<string, Map<string, string>>> {
+  const streams = await streamsClient.listStreams();
+  const streamFieldsMap = new Map<string, Map<string, string>>();
+
+  for (const stream of streams) {
+    const fields = extractFieldsFromStream(stream);
+    if (fields.size > 0) {
+      streamFieldsMap.set(stream.name, fields);
+    }
+  }
+
+  return streamFieldsMap;
+}
+
+/**
+ * Fetch metadata for all unique field names across streams
+ */
+async function fetchFieldMetadataForStreams(
+  fieldsMetadataClient: IFieldsMetadataClient,
+  streamFieldsMap: Map<string, Map<string, string>>
+): Promise<Record<string, FieldMetadataPlain>> {
+  const allFieldNames = new Set<string>();
+  for (const fields of streamFieldsMap.values()) {
+    for (const fieldName of fields.keys()) {
+      allFieldNames.add(fieldName);
+    }
+  }
+
+  if (allFieldNames.size === 0) {
+    return {};
+  }
+
+  try {
+    const dictionary = await fieldsMetadataClient.find({
+      fieldNames: Array.from(allFieldNames),
+    });
+    return dictionary.toPlain();
+  } catch {
+    // Gracefully handle metadata service failures
+    return {};
+  }
+}
+
+export const suggestRelationshipsRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/{name}/relationships/_suggestions',
+  options: {
+    access: 'internal',
+    summary: 'Get relationship suggestions for a stream',
+    description: 'Returns suggested relationships based on shared fields with other streams',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  params: z.object({
+    path: z.object({
+      name: z.string(),
+    }),
+    query: z.object({
+      min_confidence: z.coerce.number().min(0).max(1).default(0.1),
+      max_suggestions: z.coerce.number().min(1).max(100).default(10),
+    }),
+  }),
+  handler: async ({
+    params,
+    request,
+    getScopedClients,
+  }): Promise<{ suggestions: RelationshipSuggestion[] }> => {
+    const { streamsClient, fieldsMetadataClient, relationshipClient } = await getScopedClients({
+      request,
+    });
+
+    const { name } = params.path;
+    const { min_confidence: minConfidence, max_suggestions: maxSuggestions } = params.query;
+
+    // Ensure the source stream exists
+    await streamsClient.ensureStream(name);
+
+    // Get all stream fields
+    const streamFieldsMap = await getAllStreamFields(streamsClient);
+
+    const sourceFields = streamFieldsMap.get(name);
+    if (!sourceFields || sourceFields.size === 0) {
+      return { suggestions: [] };
+    }
+
+    // Fetch field metadata for enrichment
+    const fieldMetadata = await fetchFieldMetadataForStreams(fieldsMetadataClient, streamFieldsMap);
+
+    // Get existing relationships to exclude from suggestions
+    const { relationships: existingRelationships } = await relationshipClient.getRelationships(name);
+    const existingRelatedStreams = new Set(
+      existingRelationships.flatMap((r) => [r.from_stream, r.to_stream])
+    );
+
+    // Calculate suggestions for all other streams
+    const suggestions: RelationshipSuggestion[] = [];
+
+    for (const [targetStreamName, targetFields] of streamFieldsMap) {
+      // Skip self and already related streams
+      if (targetStreamName === name || existingRelatedStreams.has(targetStreamName)) {
+        continue;
+      }
+
+      // Skip parent-child relationships (they already have structural relationships)
+      if (targetStreamName.startsWith(name + '.') || name.startsWith(targetStreamName + '.')) {
+        continue;
+      }
+
+      const sharedFields = computeSharedFields(sourceFields, targetFields, fieldMetadata);
+      if (sharedFields.length === 0) {
+        continue;
+      }
+
+      const confidence = calculateConfidence(sharedFields);
+      if (confidence < minConfidence) {
+        continue;
+      }
+
+      suggestions.push({
+        from_stream: name,
+        to_stream: targetStreamName,
+        confidence,
+        shared_fields: sharedFields.sort((a, b) => b.correlationWeight - a.correlationWeight),
+        description: generateDescription(sharedFields),
+      });
+    }
+
+    // Sort by confidence and limit results
+    suggestions.sort((a, b) => b.confidence - a.confidence);
+    return { suggestions: suggestions.slice(0, maxSuggestions) };
+  },
+});
+
+export const relationshipRoutes = {
+  ...listRelationshipsRoute,
+  ...upsertRelationshipRoute,
+  ...deleteRelationshipRoute,
+  ...suggestRelationshipsRoute,
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/types.ts
@@ -24,6 +24,7 @@ import type { ProcessorSuggestionsService } from '../lib/streams/ingest_pipeline
 import type { TaskClient } from '../lib/tasks/task_client';
 import type { StreamsTaskType } from '../lib/tasks/task_definitions';
 import type { SystemClient } from '../lib/streams/system/system_client';
+import type { RelationshipClient } from '../lib/streams/relationships/relationship_client';
 
 export type GetScopedClients = ({
   request,
@@ -38,6 +39,7 @@ export interface RouteHandlerScopedClients {
   streamsClient: StreamsClient;
   featureClient: FeatureClient;
   systemClient: SystemClient;
+  relationshipClient: RelationshipClient;
   inferenceClient: InferenceClient;
   contentClient: ContentClient;
   queryClient: QueryClient;


### PR DESCRIPTION
## Summary

Adds infrastructure for managing cross-hierarchy relationships between streams. This enables connecting streams that share semantic connections (e.g., application logs and proxy logs for the same service) but don't have parent-child relationships.

**Changes:**
- New `.kibana_streams_relationships` satellite storage index with `RelationshipClient` (follows `SystemClient` pattern)
- API routes for CRUD operations: `GET/PUT/DELETE /internal/streams/{name}/relationships`
- Auto-cleanup of relationships when streams are deleted via `unlink_relationships` action in execution plan
- Shared-field auto-detection endpoint (`GET /internal/streams/{name}/relationships/_suggestions`) that suggests relationships based on common fields, enriched with ECS/OTel metadata

## Test plan

- [ ] Unit tests pass: `yarn test:jest x-pack/platform/plugins/shared/streams/server/lib/streams/relationships/`
- [ ] Suggestion route tests pass: `yarn test:jest x-pack/platform/plugins/shared/streams/server/routes/internal/streams/relationships/`
- [ ] Verify relationship CRUD via API (create, list, delete)
- [ ] Verify deleting a stream removes associated relationships
- [ ] Verify suggestion endpoint returns reasonable matches for streams with shared fields

Refs: elastic/observability-dev#405

Made with [Cursor](https://cursor.com)