### PR TITLE
Inject per-space project_routing into CPS-sensitive ES requests

### DIFF
--- a/src/core/packages/elasticsearch/client-server-internal/index.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/index.ts
@@ -28,3 +28,4 @@ export {
   type OnRequestHandler,
   type OnRequestContext,
 } from './src/create_transport';
+export { isCpsSensitivePath } from './src/cps_utils';

--- a/src/core/packages/elasticsearch/client-server-internal/src/cps_utils.test.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/cps_utils.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isCpsSensitivePath } from './cps_utils';
+
+describe('isCpsSensitivePath', () => {
+  describe('suffix-matched endpoints', () => {
+    it.each([
+      ['/_search', '/_search'],
+      ['/my-index/_search', '/_search with index prefix'],
+      ['/_async_search', '/_async_search'],
+      ['/my-index/_async_search', '/_async_search with index prefix'],
+      ['/_msearch', '/_msearch'],
+      ['/my-index/_msearch', '/_msearch with index prefix'],
+      ['/_query', '/_query (ES|QL)'],
+      ['/_field_caps', '/_field_caps'],
+      ['/my-index/_field_caps', '/_field_caps with index prefix'],
+      ['/_search/template', '/_search/template'],
+      ['/my-index/_search/template', '/_search/template with index prefix'],
+      ['/_msearch/template', '/_msearch/template'],
+      ['/my-index/_msearch/template', '/_msearch/template with index prefix'],
+      ['/_eql/search', '/_eql/search'],
+      ['/my-index/_eql/search', '/_eql/search with index prefix'],
+      ['/_sql', '/_sql'],
+      ['/my-index/_pit', '/_pit with index prefix'],
+      ['/_count', '/_count'],
+      ['/my-index/_count', '/_count with index prefix'],
+    ])('should match %s (%s)', (path) => {
+      expect(isCpsSensitivePath(path)).toBe(true);
+    });
+  });
+
+  describe('segment-matched endpoints', () => {
+    it.each([
+      ['/_query/async', '/_query/async (ES|QL async)'],
+      ['/_resolve/index/my-index', '/_resolve/index with name'],
+      ['/_resolve/index/*', '/_resolve/index with wildcard'],
+      ['/my-index/_mvt/field/0/0/0', '/_mvt with index and tile coords'],
+      ['/_cat/count', '/_cat/count'],
+      ['/_cat/count/my-index', '/_cat/count with index'],
+    ])('should match %s (%s)', (path) => {
+      expect(isCpsSensitivePath(path)).toBe(true);
+    });
+  });
+
+  describe('non-CPS paths', () => {
+    it.each([
+      '/_bulk',
+      '/my-index/_doc/1',
+      '/_cluster/health',
+      '/_nodes',
+      '/_aliases',
+      '/_index_template/my-template',
+      '/my-index/_mapping',
+      '/_refresh',
+      '/',
+    ])('should not match %s', (path) => {
+      expect(isCpsSensitivePath(path)).toBe(false);
+    });
+  });
+});

--- a/src/core/packages/elasticsearch/client-server-internal/src/cps_utils.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/cps_utils.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const CPS_SENSITIVE_SUFFIXES = [
+  '/_search',
+  '/_async_search',
+  '/_msearch',
+  '/_query',
+  '/_field_caps',
+  '/_search/template',
+  '/_msearch/template',
+  '/_eql/search',
+  '/_sql',
+  '/_pit',
+  '/_count',
+];
+
+const CPS_SENSITIVE_SEGMENTS = ['/_query/async', '/_resolve/index/', '/_mvt/', '/_cat/count'];
+
+/**
+ * Determines whether the given ES request path targets a CPS-sensitive endpoint
+ * that should have `project_routing` injected when cross-project search is enabled.
+ */
+export const isCpsSensitivePath = (path: string): boolean => {
+  return (
+    CPS_SENSITIVE_SUFFIXES.some((suffix) => path.endsWith(suffix)) ||
+    CPS_SENSITIVE_SEGMENTS.some((segment) => path.includes(segment))
+  );
+};

--- a/src/core/packages/elasticsearch/client-server-internal/src/create_transport.test.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/create_transport.test.ts
@@ -759,6 +759,26 @@ describe('createTransport', () => {
       );
     });
 
+    it('does not override caller-provided project_routing', async () => {
+      getProjectRouting.mockResolvedValue('_alias:resolved');
+
+      const transportClass = createTransportWithProjectRouting();
+      const transport = new transportClass(baseConstructorParams);
+
+      await transport.request(
+        { method: 'POST', path: '/_search' },
+        { querystring: { project_routing: '_alias:caller' } }
+      );
+
+      expect(getProjectRouting).not.toHaveBeenCalled();
+      expect(transportRequestMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          querystring: { project_routing: '_alias:caller' },
+        })
+      );
+    });
+
     it('does not inject when getProjectRouting is not provided', async () => {
       const transportClass = createTransport({
         getUnauthorizedErrorHandler,

--- a/src/core/packages/elasticsearch/client-server-internal/src/create_transport.test.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/create_transport.test.ts
@@ -759,7 +759,7 @@ describe('createTransport', () => {
       );
     });
 
-    it('does not override caller-provided project_routing', async () => {
+    it('does not override caller-provided project_routing in options.querystring', async () => {
       getProjectRouting.mockResolvedValue('_alias:resolved');
 
       const transportClass = createTransportWithProjectRouting();
@@ -775,6 +775,26 @@ describe('createTransport', () => {
         expect.any(Object),
         expect.objectContaining({
           querystring: { project_routing: '_alias:caller' },
+        })
+      );
+    });
+
+    it('does not override caller-provided project_routing in params.querystring', async () => {
+      getProjectRouting.mockResolvedValue('_alias:resolved');
+
+      const transportClass = createTransportWithProjectRouting();
+      const transport = new transportClass(baseConstructorParams);
+
+      await transport.request(
+        { method: 'POST', path: '/_search', querystring: { project_routing: '_alias:caller' } },
+        {}
+      );
+
+      expect(getProjectRouting).not.toHaveBeenCalled();
+      expect(transportRequestMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.not.objectContaining({
+          querystring: expect.objectContaining({ project_routing: expect.anything() }),
         })
       );
     });

--- a/src/core/packages/elasticsearch/client-server-internal/src/create_transport.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/create_transport.ts
@@ -94,13 +94,16 @@ export const createTransport = ({
       // inject project_routing for CPS-sensitive endpoints
       // PIT-based searches are excluded: the PIT captures scope at open time, so
       // adding project_routing to a search that references a PIT would be incorrect.
-      if (getProjectRouting && isCpsSensitivePath(params.path) && !hasPitInBody(params.body)) {
+      const existingQs = opts.querystring as Record<string, string> | undefined;
+      if (
+        getProjectRouting &&
+        !existingQs?.project_routing &&
+        isCpsSensitivePath(params.path) &&
+        !hasPitInBody(params.body)
+      ) {
         const projectRouting = await getProjectRouting();
         if (projectRouting) {
-          opts.querystring = {
-            ...(opts.querystring as Record<string, string> | undefined),
-            project_routing: projectRouting,
-          };
+          opts.querystring = { ...existingQs, project_routing: projectRouting };
         }
       }
 

--- a/src/core/packages/elasticsearch/client-server-internal/src/create_transport.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/create_transport.ts
@@ -94,16 +94,18 @@ export const createTransport = ({
       // inject project_routing for CPS-sensitive endpoints
       // PIT-based searches are excluded: the PIT captures scope at open time, so
       // adding project_routing to a search that references a PIT would be incorrect.
-      const existingQs = opts.querystring as Record<string, string> | undefined;
+      const paramsQs = params.querystring as Record<string, string> | undefined;
+      const optsQs = opts.querystring as Record<string, string> | undefined;
       if (
         getProjectRouting &&
-        !existingQs?.project_routing &&
+        !paramsQs?.project_routing &&
+        !optsQs?.project_routing &&
         isCpsSensitivePath(params.path) &&
         !hasPitInBody(params.body)
       ) {
         const projectRouting = await getProjectRouting();
         if (projectRouting) {
-          opts.querystring = { ...existingQs, project_routing: projectRouting };
+          opts.querystring = { ...optsQs, project_routing: projectRouting };
         }
       }
 

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.test.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.test.ts
@@ -517,3 +517,32 @@ describe('#stop', () => {
     );
   });
 });
+
+describe('CPS project routing', () => {
+  it('passes a getProjectRoutingResolver that returns the registered resolver', async () => {
+    const resolver = jest.fn();
+    const setup = await elasticsearchService.setup(setupDeps);
+    setup.registerProjectRoutingResolver(resolver);
+
+    const { getProjectRoutingResolver } = MockClusterClient.mock.calls[0][0];
+    expect(getProjectRoutingResolver).toBeDefined();
+    expect(getProjectRoutingResolver()).toBe(resolver);
+  });
+
+  it('returns undefined from getProjectRoutingResolver when no resolver is registered', async () => {
+    await elasticsearchService.setup(setupDeps);
+
+    const { getProjectRoutingResolver } = MockClusterClient.mock.calls[0][0];
+    expect(getProjectRoutingResolver).toBeDefined();
+    expect(getProjectRoutingResolver()).toBeUndefined();
+  });
+
+  it('throws when registerProjectRoutingResolver is called more than once', async () => {
+    const setup = await elasticsearchService.setup(setupDeps);
+    setup.registerProjectRoutingResolver(jest.fn());
+
+    expect(() => setup.registerProjectRoutingResolver(jest.fn())).toThrow(
+      'registerProjectRoutingResolver can only be called once.'
+    );
+  });
+});

--- a/src/core/packages/elasticsearch/server-mocks/src/elasticsearch_service.mock.ts
+++ b/src/core/packages/elasticsearch/server-mocks/src/elasticsearch_service.mock.ts
@@ -65,7 +65,7 @@ const createPrebootContractMock = () => {
 const createSetupContractMock = () => {
   const setupContract: MockedElasticSearchServiceSetup = lazyObject({
     setUnauthorizedErrorHandler: jest.fn(),
-    setCpsFeatureFlag: jest.fn(),
+    registerProjectRoutingResolver: jest.fn(),
     legacy: {
       config$: new BehaviorSubject({} as ElasticsearchConfig),
     },

--- a/src/core/packages/elasticsearch/server/index.ts
+++ b/src/core/packages/elasticsearch/server/index.ts
@@ -33,6 +33,7 @@ export type {
   ElasticsearchServiceStart,
   ElasticsearchServiceSetup,
   ElasticsearchCapabilities,
+  ProjectRoutingResolver,
 } from './src/contracts';
 export type { IElasticsearchConfig, ElasticsearchSslConfig } from './src/elasticsearch_config';
 export type { ElasticsearchRequestHandlerContext } from './src/request_handler_context';

--- a/src/core/packages/plugins/server-internal/src/plugin_context.ts
+++ b/src/core/packages/plugins/server-internal/src/plugin_context.ts
@@ -221,7 +221,7 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>({
       legacy: deps.elasticsearch.legacy,
       publicBaseUrl: deps.elasticsearch.publicBaseUrl,
       setUnauthorizedErrorHandler: deps.elasticsearch.setUnauthorizedErrorHandler,
-      setCpsFeatureFlag: deps.elasticsearch.setCpsFeatureFlag,
+      registerProjectRoutingResolver: deps.elasticsearch.registerProjectRoutingResolver,
     },
     executionContext: {
       withContext: deps.executionContext.withContext,

--- a/src/core/server/integration_tests/elasticsearch/cps_project_routing.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/cps_project_routing.test.ts
@@ -1,0 +1,863 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * @jest-environment node
+ */
+
+import type {
+  TestServerlessESUtils,
+  TestServerlessKibanaUtils,
+} from '@kbn/core-test-helpers-kbn-server';
+import { createTestServerlessInstances } from '@kbn/core-test-helpers-kbn-server';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { systemIndicesSuperuser } from '@kbn/test';
+
+const TEST_INDEX = '.kibana_cps-routing-integration-test';
+const LOCAL_PROJECT_ROUTING = '_alias:_origin';
+
+// Test documents - defined at module scope so we can derive counts from them
+const TEST_DOCUMENTS = [
+  { title: 'First document', category: 'alpha', timestamp: '2024-01-01', count: 10 },
+  { title: 'Second document', category: 'beta', timestamp: '2024-01-02', count: 20 },
+  { title: 'Third document', category: 'alpha', timestamp: '2024-01-03', count: 30 },
+  { title: 'Fourth document', category: 'gamma', timestamp: '2024-01-04', count: 40 },
+  { title: 'Fifth document', category: 'beta', timestamp: '2024-01-05', count: 50 },
+] as const;
+
+const TOTAL_DOCS_COUNT = TEST_DOCUMENTS.length;
+const ALPHA_CATEGORY_DOCS_COUNT = TEST_DOCUMENTS.filter((d) => d.category === 'alpha').length;
+const BETA_CATEGORY_DOCS_COUNT = TEST_DOCUMENTS.filter((d) => d.category === 'beta').length;
+const FIRST_TITLE_DOCS_COUNT = TEST_DOCUMENTS.filter((d) => d.title === 'First document').length;
+const DOCS_WITH_DOCUMENT_IN_TITLE = TEST_DOCUMENTS.filter((d) =>
+  d.title.includes('document')
+).length;
+const SORTED_COUNTS_DESC = [...TEST_DOCUMENTS]
+  .sort((a, b) => b.count - a.count)
+  .map((d) => d.count);
+
+/**
+ * Integration tests for CPS (Cross-Project Search) project_routing parameter.
+ *
+ * It's important that we properly inject the `project_routing` parameter. Incorrect
+ * injection can cause 400 errors for requests that should otherwise pass, and risk
+ * of breaking requests to ES at a large scale. The integration tests send real requests
+ * to a real ES server to empirically verify that such errors do not happen.
+ *
+ * These tests start a serverless ES instance with CPS enabled (`enableCPS: true`).
+ *
+ * @see src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.ts
+ */
+describe('CPS project_routing on serverless ES', () => {
+  let serverlessES: TestServerlessESUtils;
+  let serverlessKibana: TestServerlessKibanaUtils;
+  let client: ElasticsearchClient;
+
+  beforeAll(async () => {
+    const { startES, startKibana } = createTestServerlessInstances({
+      adjustTimeout: (timeout: number) => jest.setTimeout(timeout),
+      enableCPS: true,
+      projectType: 'oblt',
+      kibanaUrl: 'http://localhost:5601/',
+      kibana: {
+        settings: {
+          elasticsearch: {
+            username: systemIndicesSuperuser.username,
+            password: systemIndicesSuperuser.password,
+          },
+        },
+      },
+    });
+    serverlessES = await startES();
+    serverlessKibana = await startKibana();
+    client = serverlessKibana.coreStart.elasticsearch.client.asInternalUser;
+
+    // Wait for ES/UIAM to fully initialize and establish project state
+    // The CPS team mentioned there's a brief window where ES returns errors after startup.
+    // We need to wait long enough for:
+    // 1. UIAM service to fully start and connect to CosmosDB
+    // 2. ES to sync project state from UIAM
+    // 3. Origin project state to be established
+    await new Promise((resolve) => setTimeout(resolve, 60000)); // Increased to 60 seconds
+
+    // Make an initial ping to establish connection
+    try {
+      await client.ping();
+    } catch (e) {
+      // Ignore ping errors
+    }
+
+    await client.indices.create({
+      index: TEST_INDEX,
+      settings: { hidden: true },
+      mappings: {
+        properties: {
+          title: { type: 'text' },
+          category: { type: 'keyword' },
+          timestamp: { type: 'date' },
+          count: { type: 'integer' },
+        },
+      },
+    });
+
+    for (const doc of TEST_DOCUMENTS) {
+      await client.index({ index: TEST_INDEX, document: doc });
+    }
+
+    await client.indices.refresh({ index: TEST_INDEX });
+  });
+
+  afterEach(async () => {
+    // Make mutations from tests deterministic (index/delete/update become visible).
+    await client?.indices.refresh({ index: TEST_INDEX }).catch(() => {});
+  });
+
+  afterAll(async () => {
+    await client?.indices.delete({ index: TEST_INDEX }).catch(() => {});
+    await serverlessKibana?.stop();
+    await serverlessES?.stop();
+  });
+
+  describe('baseline: requests without project_routing (no-op cases)', () => {
+    it('search works without project_routing', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('msearch works without project_routing', async () => {
+      const ndjson =
+        JSON.stringify({ index: TEST_INDEX }) +
+        '\n' +
+        JSON.stringify({ query: { match_all: {} } }) +
+        '\n' +
+        JSON.stringify({ index: TEST_INDEX }) +
+        '\n' +
+        JSON.stringify({ query: { term: { category: 'alpha' } } }) +
+        '\n';
+
+      const response: any = await client.transport.request(
+        {
+          method: 'POST',
+          path: '/_msearch',
+          body: ndjson,
+        },
+        {
+          headers: {
+            'content-type': 'application/x-ndjson',
+          },
+        }
+      );
+
+      expect(response.responses.length).toBe(2);
+      expect(response.responses[0].hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      expect(response.responses[1].hits.hits.length).toBe(ALPHA_CATEGORY_DOCS_COUNT);
+    });
+
+    it('count works without project_routing', async () => {
+      const response = await client.count({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+      });
+
+      expect(response.count).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('PIT operations work without project_routing (PIT has its own scope)', async () => {
+      const pitResponse = await client.openPointInTime({
+        index: TEST_INDEX,
+        keep_alive: '1m',
+      });
+
+      expect(pitResponse.id).toBeDefined();
+
+      const searchResponse = await client.search({
+        pit: { id: pitResponse.id, keep_alive: '1m' },
+        query: { match_all: {} },
+      });
+
+      expect(searchResponse.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+
+      await client.closePointInTime({ id: pitResponse.id });
+    });
+
+    it('index operations work without project_routing', async () => {
+      const indexResponse = await client.index({
+        index: TEST_INDEX,
+        document: { title: 'Temp doc', category: 'temp', timestamp: '2024-01-10', count: 100 },
+      });
+
+      expect(indexResponse._id).toBeDefined();
+
+      const getResponse = await client.get({
+        index: TEST_INDEX,
+        id: indexResponse._id,
+      });
+
+      expect(getResponse.found).toBe(true);
+
+      await client.delete({
+        index: TEST_INDEX,
+        id: indexResponse._id,
+      });
+    });
+
+    it('bulk operations work without project_routing', async () => {
+      const bulkResponse = await client.bulk({
+        operations: [
+          { index: { _index: TEST_INDEX } },
+          { title: 'Bulk doc 1', category: 'bulk', timestamp: '2024-01-11', count: 101 },
+          { index: { _index: TEST_INDEX } },
+          { title: 'Bulk doc 2', category: 'bulk', timestamp: '2024-01-12', count: 102 },
+        ],
+      });
+
+      expect(bulkResponse.errors).toBe(false);
+      expect(bulkResponse.items.length).toBe(2);
+
+      for (const item of bulkResponse.items) {
+        if (item.index?._id) {
+          await client.delete({ index: TEST_INDEX, id: item.index._id }).catch(() => {});
+        }
+      }
+    });
+
+    it('aggregations work without project_routing', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        size: 0,
+        aggs: {
+          categories: { terms: { field: 'category' } },
+          avg_count: { avg: { field: 'count' } },
+        },
+      });
+
+      expect(response.aggregations).toBeDefined();
+      expect(response.aggregations!.categories).toBeDefined();
+      expect(response.aggregations!.avg_count).toBeDefined();
+    });
+
+    it('scroll works without project_routing', async () => {
+      const scrollResponse = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        size: 2,
+        scroll: '1m',
+      });
+
+      expect(scrollResponse._scroll_id).toBeDefined();
+      expect(scrollResponse.hits.hits.length).toBe(2);
+
+      const scrollContinue = await client.scroll({
+        scroll_id: scrollResponse._scroll_id!,
+        scroll: '1m',
+      });
+
+      expect(scrollContinue.hits.hits.length).toBeGreaterThanOrEqual(0);
+
+      await client.clearScroll({ scroll_id: scrollResponse._scroll_id! });
+    });
+
+    it('cat APIs work without project_routing', async () => {
+      const response = await client.cat.indices({ format: 'json' });
+      expect(Array.isArray(response)).toBe(true);
+    });
+
+    it('cluster health works without project_routing', async () => {
+      const response = await client.cluster.health();
+      expect(response.cluster_name).toBeDefined();
+      expect(response.status).toBeDefined();
+    });
+  });
+
+  describe('APIs that do NOT support project_routing', () => {
+    it('cluster.health does not accept project_routing (baseline)', async () => {
+      const response = await client.cluster.health();
+      expect(response.cluster_name).toBeDefined();
+      expect(response.status).toBeDefined();
+    });
+
+    it('indices.create does not accept project_routing (baseline)', async () => {
+      const tempIndex = 'cps-test-temp-index';
+      try {
+        const response = await client.indices.create({ index: tempIndex });
+        expect(response.acknowledged).toBe(true);
+      } finally {
+        await client.indices.delete({ index: tempIndex }).catch(() => {});
+      }
+    });
+
+    it('indices.getMapping does not accept project_routing (baseline)', async () => {
+      const response = await client.indices.getMapping({ index: TEST_INDEX });
+      expect(response[TEST_INDEX]).toBeDefined();
+      expect(response[TEST_INDEX].mappings).toBeDefined();
+    });
+
+    it('cat.indices does not accept project_routing (baseline)', async () => {
+      const response = await client.cat.indices({ format: 'json' });
+      expect(Array.isArray(response)).toBe(true);
+    });
+
+    it('cat.shards does not accept project_routing (baseline)', async () => {
+      const response = await client.cat.shards({ format: 'json' });
+      expect(Array.isArray(response)).toBe(true);
+    });
+
+    it('index (PUT document) does not accept project_routing (baseline)', async () => {
+      const response = await client.index({
+        index: TEST_INDEX,
+        document: {
+          title: 'No routing test',
+          category: 'test',
+          timestamp: '2024-01-15',
+          count: 999,
+        },
+      });
+      expect(response._id).toBeDefined();
+
+      await client.delete({ index: TEST_INDEX, id: response._id }).catch(() => {});
+    });
+
+    it('bulk operations do not accept project_routing (baseline)', async () => {
+      const response = await client.bulk({
+        operations: [
+          { index: { _index: TEST_INDEX } },
+          { title: 'Bulk no routing', category: 'test', timestamp: '2024-01-16', count: 888 },
+        ],
+      });
+      expect(response.errors).toBe(false);
+
+      for (const item of response.items) {
+        if (item.index?._id) {
+          await client.delete({ index: TEST_INDEX, id: item.index._id }).catch(() => {});
+        }
+      }
+    });
+
+    it('delete does not accept project_routing (baseline)', async () => {
+      const indexResponse = await client.index({
+        index: TEST_INDEX,
+        document: { title: 'To delete', category: 'temp', timestamp: '2024-01-17', count: 1 },
+      });
+
+      const deleteResponse = await client.delete({
+        index: TEST_INDEX,
+        id: indexResponse._id,
+      });
+      expect(deleteResponse.result).toBe('deleted');
+    });
+
+    it('update does not accept project_routing (baseline)', async () => {
+      const indexResponse = await client.index({
+        index: TEST_INDEX,
+        document: { title: 'To update', category: 'temp', timestamp: '2024-01-18', count: 1 },
+      });
+
+      const updateResponse = await client.update({
+        index: TEST_INDEX,
+        id: indexResponse._id,
+        doc: { count: 2 },
+      });
+      expect(updateResponse.result).toBe('updated');
+
+      await client.delete({ index: TEST_INDEX, id: indexResponse._id }).catch(() => {});
+    });
+  });
+
+  describe('search API with project_routing', () => {
+    it('accepts project_routing parameter without error', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('works with match query', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match: { title: 'document' } },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(DOCS_WITH_DOCUMENT_IN_TITLE);
+    });
+
+    it('works with term query', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { term: { category: 'alpha' } },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(ALPHA_CATEGORY_DOCS_COUNT);
+    });
+
+    it('works with bool query', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: {
+          bool: {
+            must: [{ match: { title: 'document' } }],
+            filter: [{ term: { category: 'beta' } }],
+          },
+        },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(BETA_CATEGORY_DOCS_COUNT);
+    });
+
+    it('works with aggregations', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        size: 0,
+        aggs: {
+          categories: {
+            terms: { field: 'category' },
+          },
+          avg_count: {
+            avg: { field: 'count' },
+          },
+        },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.aggregations).toBeDefined();
+      expect(response.aggregations!.categories).toBeDefined();
+      expect(response.aggregations!.avg_count).toBeDefined();
+    });
+
+    it('works with sort', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        sort: [{ count: 'desc' }],
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      const counts = response.hits.hits.map((hit: any) => hit._source.count);
+      expect(counts).toEqual(SORTED_COUNTS_DESC);
+    });
+
+    it('works with pagination (from/size)', async () => {
+      const pageSize = 2;
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        from: 2,
+        size: pageSize,
+        sort: [{ count: 'asc' }],
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(pageSize);
+    });
+
+    it('works with _source filtering', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        _source: ['title', 'category'],
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      const firstHit = response.hits.hits[0]._source as any;
+      expect(firstHit.title).toBeDefined();
+      expect(firstHit.category).toBeDefined();
+      expect(firstHit.count).toBeUndefined();
+    });
+
+    it('works with highlight', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match: { title: 'First' } },
+        highlight: {
+          fields: { title: {} },
+        },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(FIRST_TITLE_DOCS_COUNT);
+      expect(response.hits.hits[0].highlight).toBeDefined();
+    });
+
+    it('works with wildcard index pattern', async () => {
+      const response = await client.search({
+        index: '.kibana_cps-routing-*',
+        query: { match_all: {} },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('works with non-existent index pattern (allow_no_indices)', async () => {
+      const response = await client.search({
+        index: 'nonexistent-index-*',
+        query: { match_all: {} },
+        allow_no_indices: true,
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits).toHaveLength(0);
+    });
+  });
+
+  describe('msearch API with project_routing', () => {
+    it('accepts project_routing parameter without error', async () => {
+      const ndjson =
+        JSON.stringify({ index: TEST_INDEX }) +
+        '\n' +
+        JSON.stringify({ query: { match_all: {} } }) +
+        '\n' +
+        JSON.stringify({ index: TEST_INDEX }) +
+        '\n' +
+        JSON.stringify({ query: { term: { category: 'alpha' } } }) +
+        '\n';
+
+      const response: any = await client.transport.request(
+        {
+          method: 'POST',
+          path: '/_msearch',
+          body: ndjson,
+          querystring: {
+            project_routing: LOCAL_PROJECT_ROUTING,
+          },
+        },
+        {
+          headers: {
+            'content-type': 'application/x-ndjson',
+          },
+        }
+      );
+
+      const expectedMsearchQueries = 2;
+      expect(response.responses.length).toBe(expectedMsearchQueries);
+      expect(response.responses[0].hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      expect((response.responses[1] as any).hits.hits.length).toBe(ALPHA_CATEGORY_DOCS_COUNT);
+    });
+  });
+
+  describe('count API with project_routing', () => {
+    it('accepts project_routing parameter without error', async () => {
+      const response = await client.count({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.count).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('works with filtered count', async () => {
+      const response = await client.count({
+        index: TEST_INDEX,
+        query: { term: { category: 'alpha' } },
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.count).toBe(ALPHA_CATEGORY_DOCS_COUNT);
+    });
+  });
+
+  describe('PIT (Point-In-Time) operations', () => {
+    it('can open PIT without project_routing (PIT establishes its own scope)', async () => {
+      const pitResponse = await client.openPointInTime({
+        index: TEST_INDEX,
+        keep_alive: '1m',
+      });
+
+      expect(pitResponse.id).toBeDefined();
+
+      const searchResponse = await client.search({
+        pit: { id: pitResponse.id, keep_alive: '1m' },
+        query: { match_all: {} },
+      });
+
+      expect(searchResponse.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+
+      await client.closePointInTime({ id: pitResponse.id });
+    });
+  });
+
+  describe('edge cases and error scenarios', () => {
+    it('handles empty query with project_routing', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('works with track_total_hits', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        track_total_hits: true,
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect((response.hits.total as any).value).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('works with explain', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match: { title: 'First' } },
+        explain: true,
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(FIRST_TITLE_DOCS_COUNT);
+      expect(response.hits.hits[0]._explanation).toBeDefined();
+    });
+
+    it('works with seq_no_primary_term', async () => {
+      const response = await client.search({
+        index: TEST_INDEX,
+        query: { match_all: {} },
+        seq_no_primary_term: true,
+        body: {
+          // @ts-expect-error - project_routing is a valid body parameter
+          project_routing: LOCAL_PROJECT_ROUTING,
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      expect(response.hits.hits[0]._seq_no).toBeDefined();
+      expect(response.hits.hits[0]._primary_term).toBeDefined();
+    });
+  });
+
+  describe('combined with other querystring params', () => {
+    it('works with pretty=true', async () => {
+      const response = await client.search(
+        {
+          index: TEST_INDEX,
+          query: { match_all: {} },
+          body: {
+            // @ts-expect-error - project_routing is a valid body parameter
+            project_routing: LOCAL_PROJECT_ROUTING,
+          },
+        },
+        {
+          querystring: {
+            pretty: true,
+          },
+        }
+      );
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('works with request_cache=false', async () => {
+      const response = await client.search(
+        {
+          index: TEST_INDEX,
+          query: { match_all: {} },
+          body: {
+            // @ts-expect-error - project_routing is a valid body parameter
+            project_routing: LOCAL_PROJECT_ROUTING,
+          },
+        },
+        {
+          querystring: {
+            request_cache: false,
+          },
+        }
+      );
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('works with timeout', async () => {
+      const response = await client.search(
+        {
+          index: TEST_INDEX,
+          query: { match_all: {} },
+          body: {
+            // @ts-expect-error - project_routing is a valid body parameter
+            project_routing: LOCAL_PROJECT_ROUTING,
+          },
+        },
+        {
+          querystring: {
+            timeout: '30s',
+          },
+        }
+      );
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+  });
+
+  /**
+   * Tests for project_routing with the Kibana service account.
+   * According to the CPS team, the Kibana service account can access the origin project
+   * without needing UIAM credentials. UIAM is only required for cross-project access.
+   */
+  describe('project_routing with origin project access', () => {
+    it('search works with project_routing to origin project', async () => {
+      const response: any = await client.transport.request({
+        method: 'POST',
+        path: `/${TEST_INDEX}/_search`,
+        body: {
+          project_routing: LOCAL_PROJECT_ROUTING,
+          query: { match_all: {} },
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('search with filters works with project_routing', async () => {
+      const response: any = await client.transport.request({
+        method: 'POST',
+        path: `/${TEST_INDEX}/_search`,
+        body: {
+          project_routing: LOCAL_PROJECT_ROUTING,
+          query: { term: { category: 'alpha' } },
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(ALPHA_CATEGORY_DOCS_COUNT);
+    });
+
+    it('count works with project_routing', async () => {
+      const response: any = await client.transport.request({
+        method: 'POST',
+        path: `/${TEST_INDEX}/_count`,
+        body: {
+          project_routing: LOCAL_PROJECT_ROUTING,
+          query: { match_all: {} },
+        },
+      });
+
+      expect(response.count).toBe(TOTAL_DOCS_COUNT);
+    });
+
+    it('msearch works with project_routing', async () => {
+      const ndjson =
+        JSON.stringify({ index: TEST_INDEX }) +
+        '\n' +
+        JSON.stringify({ query: { match_all: {} } }) +
+        '\n' +
+        JSON.stringify({ index: TEST_INDEX }) +
+        '\n' +
+        JSON.stringify({ query: { term: { category: 'beta' } } }) +
+        '\n';
+
+      const response: any = await client.transport.request(
+        {
+          method: 'POST',
+          path: '/_msearch',
+          body: ndjson,
+          querystring: {
+            project_routing: LOCAL_PROJECT_ROUTING,
+          },
+        },
+        {
+          headers: {
+            'content-type': 'application/x-ndjson',
+          },
+        }
+      );
+
+      expect(response.responses.length).toBe(2);
+      expect(response.responses[0].hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      expect(response.responses[1].hits.hits.length).toBe(BETA_CATEGORY_DOCS_COUNT);
+    });
+
+    it('search with match query works with project_routing', async () => {
+      const response: any = await client.transport.request({
+        method: 'POST',
+        path: `/${TEST_INDEX}/_search`,
+        body: {
+          project_routing: LOCAL_PROJECT_ROUTING,
+          query: { match: { title: 'document' } },
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(DOCS_WITH_DOCUMENT_IN_TITLE);
+    });
+
+    it('search with sort works with project_routing', async () => {
+      const response: any = await client.transport.request({
+        method: 'POST',
+        path: `/${TEST_INDEX}/_search`,
+        body: {
+          project_routing: LOCAL_PROJECT_ROUTING,
+          query: { match_all: {} },
+          sort: [{ count: { order: 'desc' } }],
+        },
+      });
+
+      expect(response.hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      const counts = response.hits.hits.map((hit: any) => hit._source.count);
+      expect(counts).toEqual(SORTED_COUNTS_DESC);
+    });
+  });
+});

--- a/src/core/server/integration_tests/elasticsearch/jest.integration.config.js
+++ b/src/core/server/integration_tests/elasticsearch/jest.integration.config.js
@@ -8,13 +8,12 @@
  */
 
 module.exports = {
-  // TODO replace the line below with
-  // preset: '@kbn/test/jest_integration_node
-  // to do so, we must fix all integration tests first
-  // see https://github.com/elastic/kibana/pull/130255/
-  preset: '@kbn/test/jest_integration',
+  preset: '@kbn/test/jest_integration_node',
   rootDir: '../../../../..',
   roots: ['<rootDir>/src/core/server/integration_tests/elasticsearch'],
   // must override to match all test given there is no `integration_tests` subfolder
   testMatch: ['**/*.test.{js,mjs,ts,tsx}'],
+  // Force exit after tests complete - necessary for Docker-based integration tests
+  // to avoid hanging on lingering async operations from Docker containers
+  forceExit: true,
 };

--- a/src/core/test-helpers/kbn-server/src/create_serverless_root.ts
+++ b/src/core/test-helpers/kbn-server/src/create_serverless_root.ts
@@ -16,8 +16,9 @@ import { REPO_ROOT } from '@kbn/repo-info';
 import { ToolingLog } from '@kbn/tooling-log';
 import { esTestConfig } from '@kbn/test';
 import type { CliArgs } from '@kbn/config';
-import { kibanaDevServiceAccount } from '@kbn/dev-utils';
+import { kibanaDevServiceAccount, CA_CERT_PATH } from '@kbn/dev-utils';
 import { systemIndicesSuperuser } from '@kbn/test';
+import { set } from '@kbn/safer-lodash-set';
 import { createRoot, type TestElasticsearchUtils, type TestKibanaUtils } from './create_root';
 
 export type TestServerlessESUtils = Pick<TestElasticsearchUtils, 'stop' | 'es'> & {
@@ -31,7 +32,8 @@ export interface TestServerlessUtils {
 }
 
 const ES_BASE_PATH_DIR = Path.join(REPO_ROOT, '.es/es_test_serverless');
-const projectType: ServerlessProjectType = 'es';
+const DEFAULT_PROJECT_TYPE: ServerlessProjectType = 'es';
+const DEFAULT_KIBANA_URL = 'http://localhost:5601/';
 
 /**
  * See docs in {@link TestUtils}. This function provides the same utilities but
@@ -42,16 +44,83 @@ const projectType: ServerlessProjectType = 'es';
 export function createTestServerlessInstances({
   adjustTimeout,
   kibana = {},
+  enableCPS = false,
+  esArgs = [],
+  projectType = DEFAULT_PROJECT_TYPE,
+  kibanaUrl = DEFAULT_KIBANA_URL,
 }: {
   kibana?: {
     settings?: {};
     cliArgs?: Partial<CliArgs>;
   };
   adjustTimeout?: (timeout: number) => void;
+  /**
+   * Enable Cross-Project Search (CPS) mode on the serverless ES instance.
+   * When true, starts ES with UIAM support and the required CPS settings:
+   *  - `serverless.cross_project.enabled=true`
+   *  - `remote_cluster_server.enabled=true`
+   *
+   * Equivalent to running:
+   *  `yarn es serverless --projectType observability --uiam --kill --clean \
+   *    --kibanaUrl http://localhost:5601/ \
+   *    -E serverless.cross_project.enabled=true -E remote_cluster_server.enabled=true`
+   *
+   * @default false
+   */
+  enableCPS?: boolean;
+  /**
+   * Additional Elasticsearch arguments to pass when starting the cluster.
+   * These will be appended to the default esArgs when enableCPS is true.
+   *
+   * @default []
+   */
+  esArgs?: string[];
+  /**
+   * The serverless project type to run (`yarn es serverless --projectType`).
+   *
+   * Defaults to `es` for existing tests.
+   */
+  projectType?: ServerlessProjectType;
+  /**
+   * Passed through to the `@kbn/es` serverless docker runner as `--kibanaUrl`.
+   *
+   * This is important for UIAM mode: the serverless runner only applies the
+   * UIAM-related ES args (including project metadata) when `kibanaUrl` is set.
+   *
+   * See `resolveEsArgs()` in `src/platform/packages/shared/kbn-es/src/utils/docker.ts`.
+   */
+  kibanaUrl?: string;
 } = {}): TestServerlessUtils {
   adjustTimeout?.(150_000);
 
-  const esUtils = createServerlessES();
+  const esUtils = createServerlessES({
+    enableCPS,
+    esArgs,
+    projectType,
+    kibanaUrl: enableCPS ? kibanaUrl : undefined,
+  });
+
+  if (enableCPS) {
+    if (!kibana.settings) kibana.settings = {};
+    set(kibana.settings, 'cps.cpsEnabled', true);
+    const existingEsSettings = (kibana.settings as any).elasticsearch ?? {};
+    set(kibana.settings, 'elasticsearch.hosts', [`https://localhost:${esTestConfig.getPort()}`]);
+    set(kibana.settings, 'elasticsearch.ssl.certificateAuthorities', CA_CERT_PATH);
+    if (
+      (existingEsSettings.username || existingEsSettings.password) &&
+      existingEsSettings.serviceAccountToken
+    ) {
+      delete (kibana.settings as any).elasticsearch.serviceAccountToken;
+    }
+    if (
+      !existingEsSettings.serviceAccountToken &&
+      !existingEsSettings.username &&
+      !existingEsSettings.password
+    ) {
+      set(kibana.settings, 'elasticsearch.serviceAccountToken', kibanaDevServiceAccount.token);
+    }
+    kibana.cliArgs = { ...kibana.cliArgs, uiam: true, serverless: true };
+  }
   const kbUtils = createServerlessKibana(kibana.settings, kibana.cliArgs);
 
   return {
@@ -78,7 +147,17 @@ export function createTestServerlessInstances({
   };
 }
 
-function createServerlessES() {
+function createServerlessES({
+  enableCPS = false,
+  esArgs = [],
+  projectType = DEFAULT_PROJECT_TYPE,
+  kibanaUrl,
+}: {
+  enableCPS?: boolean;
+  esArgs?: string[];
+  projectType?: ServerlessProjectType;
+  kibanaUrl?: string;
+} = {}) {
   const log = new ToolingLog({
     level: 'info',
     writeTo: process.stdout,
@@ -88,6 +167,10 @@ function createServerlessES() {
   const esServerlessImageParams = parseEsServerlessImageOverride(
     esTestConfig.getESServerlessImage()
   );
+  const baseArgs = enableCPS
+    ? ['serverless.cross_project.enabled=true', 'remote_cluster_server.enabled=true']
+    : [];
+
   return {
     es,
     start: async () => {
@@ -99,9 +182,17 @@ function createServerlessES() {
         clean: true,
         kill: true,
         waitForReady: true,
+        ...(kibanaUrl ? { kibanaUrl } : {}),
         ...esServerlessImageParams,
+        ...(enableCPS
+          ? {
+              ssl: true,
+              uiam: true,
+              esArgs: [...baseArgs, ...esArgs],
+            }
+          : {}),
       });
-      const client = getServerlessESClient({ port: esPort });
+      const client = getServerlessESClient({ port: esPort, ssl: enableCPS });
 
       return {
         getClient: () => client,
@@ -113,12 +204,13 @@ function createServerlessES() {
   };
 }
 
-const getServerlessESClient = ({ port }: { port: number }) => {
+const getServerlessESClient = ({ port, ssl = false }: { port: number; ssl?: boolean }) => {
   return new Client({
-    node: `http://localhost:${port}`,
+    node: `${ssl ? 'https' : 'http'}://localhost:${port}`,
     Connection: HttpConnection,
     requestTimeout: 30_000,
     auth: { ...systemIndicesSuperuser },
+    ...(ssl ? { tls: { rejectUnauthorized: false } } : {}),
   });
 };
 
@@ -163,7 +255,13 @@ const getServerlessDefault = () => {
 };
 
 export function createServerlessKibana(settings = {}, cliArgs: Partial<CliArgs> = {}) {
-  return createRoot(defaultsDeep(settings, getServerlessDefault()), {
+  const defaults = getServerlessDefault();
+  const esOverrides = (settings as any)?.elasticsearch;
+  if (esOverrides?.username || esOverrides?.password) {
+    delete (defaults as any).elasticsearch.serviceAccountToken;
+  }
+
+  return createRoot(defaultsDeep(settings, defaults), {
     ...cliArgs,
     serverless: true,
   });

--- a/src/platform/packages/shared/kbn-config/src/env.ts
+++ b/src/platform/packages/shared/kbn-config/src/env.ts
@@ -36,6 +36,7 @@ export interface CliArgs {
   cache: boolean;
   dist: boolean;
   serverless?: boolean;
+  uiam?: boolean;
   retrictInternalApis?: boolean;
 }
 

--- a/src/platform/plugins/shared/cps/kibana.jsonc
+++ b/src/platform/plugins/shared/cps/kibana.jsonc
@@ -14,7 +14,7 @@
     "configPath": [
       "cps"
     ],
-    "optionalPlugins": [],
+    "optionalPlugins": ["spaces"],
     "requiredPlugins": [],
     "requiredBundles": []
   }

--- a/src/platform/plugins/shared/cps/moon.yml
+++ b/src/platform/plugins/shared/cps/moon.yml
@@ -24,6 +24,8 @@ dependsOn:
   - '@kbn/cps-utils'
   - '@kbn/es-query'
   - '@kbn/i18n-react'
+  - '@kbn/core-elasticsearch-server'
+  - '@kbn/spaces-plugin'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/cps/server/plugin.test.ts
+++ b/src/platform/plugins/shared/cps/server/plugin.test.ts
@@ -8,7 +8,8 @@
  */
 
 import { CPSServerPlugin } from './plugin';
-import { coreMock } from '@kbn/core/server/mocks';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { ProjectRoutingResolver } from '@kbn/core-elasticsearch-server';
 import { registerRoutes } from './routes';
 
 jest.mock('./routes', () => ({
@@ -21,49 +22,88 @@ describe('CPSServerPlugin', () => {
   let mockCoreSetup: ReturnType<typeof coreMock.createSetup>;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     mockCoreSetup = coreMock.createSetup();
   });
 
   describe('when cpsEnabled is true', () => {
     beforeEach(() => {
-      mockInitContext = coreMock.createPluginInitializerContext({ cpsEnabled: true });
+      mockInitContext = coreMock.createPluginInitializerContext({
+        enabled: true,
+        cpsEnabled: true,
+      });
       (mockInitContext.env.packageInfo as any).buildFlavor = 'serverless';
       plugin = new CPSServerPlugin(mockInitContext);
     });
 
     it('should return true from getCpsEnabled', () => {
-      const setup = plugin.setup(mockCoreSetup);
+      const setup = plugin.setup(mockCoreSetup, {});
       expect(setup.getCpsEnabled()).toBe(true);
     });
 
     it('should register a projectRoutingResolver', () => {
-      plugin.setup(mockCoreSetup);
+      plugin.setup(mockCoreSetup, {});
       expect(mockCoreSetup.elasticsearch.registerProjectRoutingResolver).toHaveBeenCalledWith(
         expect.any(Function)
       );
+    });
+
+    it('should resolve to the NPRE name based on the space ID from the spaces plugin', async () => {
+      const mockGetSpaceId = jest.fn().mockReturnValue('my-space');
+      const spacesSetup = { spacesService: { getSpaceId: mockGetSpaceId } } as any;
+
+      plugin.setup(mockCoreSetup, { spaces: spacesSetup });
+
+      const resolver: ProjectRoutingResolver =
+        mockCoreSetup.elasticsearch.registerProjectRoutingResolver.mock.calls[0][0];
+      const request = httpServerMock.createKibanaRequest();
+      const result = await resolver(request);
+
+      expect(mockGetSpaceId).toHaveBeenCalledWith(request);
+      expect(result).toBe('kibana_space_my-space_default');
+    });
+
+    it('should fall back to the default space ID when spaces plugin is not available', async () => {
+      plugin.setup(mockCoreSetup, {});
+
+      const resolver: ProjectRoutingResolver =
+        mockCoreSetup.elasticsearch.registerProjectRoutingResolver.mock.calls[0][0];
+      const request = httpServerMock.createKibanaRequest();
+      const result = await resolver(request);
+
+      expect(result).toBe('kibana_space_default_default');
     });
   });
 
   describe('when cpsEnabled is false', () => {
     beforeEach(() => {
-      mockInitContext = coreMock.createPluginInitializerContext({ cpsEnabled: false });
+      mockInitContext = coreMock.createPluginInitializerContext({
+        enabled: true,
+        cpsEnabled: false,
+      });
       (mockInitContext.env.packageInfo as any).buildFlavor = 'serverless';
       plugin = new CPSServerPlugin(mockInitContext);
     });
 
     it('should return false from getCpsEnabled', () => {
-      const setup = plugin.setup(mockCoreSetup);
+      const setup = plugin.setup(mockCoreSetup, {});
       expect(setup.getCpsEnabled()).toBe(false);
     });
 
     it('should not register a projectRoutingResolver', () => {
-      plugin.setup(mockCoreSetup);
+      plugin.setup(mockCoreSetup, {});
       expect(mockCoreSetup.elasticsearch.registerProjectRoutingResolver).not.toHaveBeenCalled();
     });
   });
 
   it('should register routes in serverless mode', () => {
-    plugin.setup(mockCoreSetup);
+    mockInitContext = coreMock.createPluginInitializerContext({
+      enabled: true,
+      cpsEnabled: false,
+    });
+    (mockInitContext.env.packageInfo as any).buildFlavor = 'serverless';
+    plugin = new CPSServerPlugin(mockInitContext);
+    plugin.setup(mockCoreSetup, {});
     expect(registerRoutes).toHaveBeenCalled();
   });
 });

--- a/src/platform/plugins/shared/cps/server/plugin.test.ts
+++ b/src/platform/plugins/shared/cps/server/plugin.test.ts
@@ -36,9 +36,11 @@ describe('CPSServerPlugin', () => {
       expect(setup.getCpsEnabled()).toBe(true);
     });
 
-    it('should call setCpsFeatureFlag with true', () => {
+    it('should register a projectRoutingResolver', () => {
       plugin.setup(mockCoreSetup);
-      expect(mockCoreSetup.elasticsearch.setCpsFeatureFlag).toHaveBeenCalledWith(true);
+      expect(mockCoreSetup.elasticsearch.registerProjectRoutingResolver).toHaveBeenCalledWith(
+        expect.any(Function)
+      );
     });
   });
 
@@ -54,9 +56,9 @@ describe('CPSServerPlugin', () => {
       expect(setup.getCpsEnabled()).toBe(false);
     });
 
-    it('should call setCpsFeatureFlag with false', () => {
+    it('should not register a projectRoutingResolver', () => {
       plugin.setup(mockCoreSetup);
-      expect(mockCoreSetup.elasticsearch.setCpsFeatureFlag).toHaveBeenCalledWith(false);
+      expect(mockCoreSetup.elasticsearch.registerProjectRoutingResolver).not.toHaveBeenCalled();
     });
   });
 

--- a/src/platform/plugins/shared/cps/tsconfig.json
+++ b/src/platform/plugins/shared/cps/tsconfig.json
@@ -15,6 +15,8 @@
     "@kbn/cps-utils",
     "@kbn/es-query",
     "@kbn/i18n-react",
+    "@kbn/core-elasticsearch-server",
+    "@kbn/spaces-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Adds `project_routing` injection for Cross-Project Search (CPS) into the Elasticsearch transport layer.

- The CPS plugin conditionally registers a `ProjectRoutingResolver` with the Elasticsearch service (only when `cpsEnabled` is true). The resolver derives the routing value from the current Kibana space, using named project routing expressions of the form `kibana_space_<spaceId>_default`. Space ID is extracted via the optional `spaces` plugin dependency.
- `KibanaTransport` injects the resolved value as a `project_routing` querystring parameter on CPS-sensitive endpoints (`_search`, `_msearch`, `_count`, `_field_caps`, etc.). PIT-based searches are excluded since the PIT captures its own scope at open time.
- A `getProjectRoutingResolver` getter is used so the resolver is evaluated lazily at request time, after plugin setup has completed.
- Includes integration tests against a serverless ES instance with CPS/UIAM enabled, and the necessary test infrastructure updates (`create_serverless_root.ts`, jest config) to support that mode.

Made with [Cursor](https://cursor.com)