### PR TITLE
Fix some Waterfall Trace Items don't load at all

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -211,6 +211,40 @@ describe('waterfall_helpers', () => {
       expect(waterfall.errorItems.length).toBe(0);
       expect(waterfall.getErrorCount('myTransactionId2')).toEqual(0);
     });
+
+    it('should fallback to root transaction when entry is missing from trace docs', () => {
+      const apiResp = {
+        traceItems: {
+          traceDocs: hits.filter(
+            (item) =>
+              item.processor?.event === 'transaction' && item.transaction?.id === 'myTransactionId2'
+          ),
+          errorDocs,
+          exceedsMax: false,
+          spanLinksCountById: {},
+          traceDocsTotal: hits.length,
+          maxTraceItems: 5000,
+        },
+        entryTransaction: {
+          processor: { event: 'transaction' },
+          trace: { id: 'myTraceId' },
+          service: { name: 'opbeans-node' },
+          transaction: {
+            duration: { us: 49660 },
+            name: 'GET /api',
+            id: 'myTransactionId1',
+          },
+          timestamp: { us: 1549324795784006 },
+        } as Transaction,
+      };
+
+      const waterfall = getWaterfall(apiResp);
+
+      expect(waterfall.items.length).toBe(1);
+      expect(waterfall.items[0].id).toBe('myTransactionId2');
+      expect(waterfall.errorItems.length).toBe(0);
+    });
+
     it('should reparent spans', () => {
       const traceItems = [
         {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -519,7 +519,7 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
     traceItems.spanLinksCountById
   );
 
-  const entryWaterfallTransaction = getEntryWaterfallTransaction(
+  let entryWaterfallTransaction: IWaterfallTransaction | undefined = getEntryWaterfallTransaction(
     entryTransaction.transaction.id,
     waterfallItems
   );
@@ -529,10 +529,14 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
     reparentOrphanItems(orphanItemsIds, reparentSpans(waterfallItems), entryWaterfallTransaction)
   );
 
+  const rootWaterfallTransaction = getRootWaterfallTransaction(childrenByParentId);
+
+  if (!entryWaterfallTransaction && rootWaterfallTransaction) {
+    entryWaterfallTransaction = rootWaterfallTransaction;
+  }
+
   const items = getOrderedWaterfallItems(childrenByParentId, entryWaterfallTransaction);
   const errorItems = getWaterfallErrors(traceItems.errorDocs, items, entryWaterfallTransaction);
-
-  const rootWaterfallTransaction = getRootWaterfallTransaction(childrenByParentId);
 
   const duration = getWaterfallDuration(items);
   const { legends, colorBy } = generateLegendsAndAssignColorsToWaterfall(items);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/253318
## Summary
- If no `entryWaterfallTransaction` is found and we find a `rootWaterfallTransaction`, then the `entryWaterfallTransaction` is the same as `rootWaterfallTransaction`


### Images

#### Before

<img width="1611" height="224" alt="image" src="https://github.com/user-attachments/assets/2283fc8f-602b-4fe4-84ee-ed9a4f425cb2" />


#### After

<img width="1607" height="859" alt="image" src="https://github.com/user-attachments/assets/6bc5ffcb-1e02-4538-95f8-d19bd0438314" />


### Unit tests

`yarn test:jest x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts`

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- [ ] We need to validate this somehow in a large number of different traces, both complex and simple examples to see if nothing breaks.




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->