### PR TITLE
Add CPS/UIAM support to serverless test infrastructure

### DIFF
--- a/src/core/test-helpers/kbn-server/src/create_serverless_root.ts
+++ b/src/core/test-helpers/kbn-server/src/create_serverless_root.ts
@@ -16,8 +16,9 @@ import { REPO_ROOT } from '@kbn/repo-info';
 import { ToolingLog } from '@kbn/tooling-log';
 import { esTestConfig } from '@kbn/test';
 import type { CliArgs } from '@kbn/config';
-import { kibanaDevServiceAccount } from '@kbn/dev-utils';
+import { kibanaDevServiceAccount, CA_CERT_PATH } from '@kbn/dev-utils';
 import { systemIndicesSuperuser } from '@kbn/test';
+import { set } from '@kbn/safer-lodash-set';
 import { createRoot, type TestElasticsearchUtils, type TestKibanaUtils } from './create_root';
 
 export type TestServerlessESUtils = Pick<TestElasticsearchUtils, 'stop' | 'es'> & {
@@ -31,7 +32,8 @@ export interface TestServerlessUtils {
 }
 
 const ES_BASE_PATH_DIR = Path.join(REPO_ROOT, '.es/es_test_serverless');
-const projectType: ServerlessProjectType = 'es';
+const DEFAULT_PROJECT_TYPE: ServerlessProjectType = 'es';
+const DEFAULT_KIBANA_URL = 'http://localhost:5601/';
 
 /**
  * See docs in {@link TestUtils}. This function provides the same utilities but
@@ -42,16 +44,83 @@ const projectType: ServerlessProjectType = 'es';
 export function createTestServerlessInstances({
   adjustTimeout,
   kibana = {},
+  enableCPS = false,
+  esArgs = [],
+  projectType = DEFAULT_PROJECT_TYPE,
+  kibanaUrl = DEFAULT_KIBANA_URL,
 }: {
   kibana?: {
     settings?: {};
     cliArgs?: Partial<CliArgs>;
   };
   adjustTimeout?: (timeout: number) => void;
+  /**
+   * Enable Cross-Project Search (CPS) mode on the serverless ES instance.
+   * When true, starts ES with UIAM support and the required CPS settings:
+   *  - `serverless.cross_project.enabled=true`
+   *  - `remote_cluster_server.enabled=true`
+   *
+   * Equivalent to running:
+   *  `yarn es serverless --projectType observability --uiam --kill --clean \
+   *    --kibanaUrl http://localhost:5601/ \
+   *    -E serverless.cross_project.enabled=true -E remote_cluster_server.enabled=true`
+   *
+   * @default false
+   */
+  enableCPS?: boolean;
+  /**
+   * Additional Elasticsearch arguments to pass when starting the cluster.
+   * These will be appended to the default esArgs when enableCPS is true.
+   *
+   * @default []
+   */
+  esArgs?: string[];
+  /**
+   * The serverless project type to run (`yarn es serverless --projectType`).
+   *
+   * Defaults to `es` for existing tests.
+   */
+  projectType?: ServerlessProjectType;
+  /**
+   * Passed through to the `@kbn/es` serverless docker runner as `--kibanaUrl`.
+   *
+   * This is important for UIAM mode: the serverless runner only applies the
+   * UIAM-related ES args (including project metadata) when `kibanaUrl` is set.
+   *
+   * See `resolveEsArgs()` in `src/platform/packages/shared/kbn-es/src/utils/docker.ts`.
+   */
+  kibanaUrl?: string;
 } = {}): TestServerlessUtils {
   adjustTimeout?.(150_000);
 
-  const esUtils = createServerlessES();
+  const esUtils = createServerlessES({
+    enableCPS,
+    esArgs,
+    projectType,
+    kibanaUrl: enableCPS ? kibanaUrl : undefined,
+  });
+
+  if (enableCPS) {
+    if (!kibana.settings) kibana.settings = {};
+    set(kibana.settings, 'cps.cpsEnabled', true);
+    const existingEsSettings = (kibana.settings as any).elasticsearch ?? {};
+    set(kibana.settings, 'elasticsearch.hosts', [`https://localhost:${esTestConfig.getPort()}`]);
+    set(kibana.settings, 'elasticsearch.ssl.certificateAuthorities', CA_CERT_PATH);
+    if (
+      (existingEsSettings.username || existingEsSettings.password) &&
+      existingEsSettings.serviceAccountToken
+    ) {
+      delete (kibana.settings as any).elasticsearch.serviceAccountToken;
+    }
+    if (
+      !existingEsSettings.serviceAccountToken &&
+      !existingEsSettings.username &&
+      !existingEsSettings.password
+    ) {
+      set(kibana.settings, 'elasticsearch.serviceAccountToken', kibanaDevServiceAccount.token);
+    }
+    kibana.cliArgs = { ...kibana.cliArgs, uiam: true, serverless: true };
+  }
   const kbUtils = createServerlessKibana(kibana.settings, kibana.cliArgs);
 
   return {
@@ -78,7 +147,17 @@ export function createTestServerlessInstances({
   };
 }
 
-function createServerlessES() {
+function createServerlessES({
+  enableCPS = false,
+  esArgs = [],
+  projectType = DEFAULT_PROJECT_TYPE,
+  kibanaUrl,
+}: {
+  enableCPS?: boolean;
+  esArgs?: string[];
+  projectType?: ServerlessProjectType;
+  kibanaUrl?: string;
+} = {}) {
   const log = new ToolingLog({
     level: 'info',
     writeTo: process.stdout,
@@ -88,6 +167,10 @@ function createServerlessES() {
   const esServerlessImageParams = parseEsServerlessImageOverride(
     esTestConfig.getESServerlessImage()
   );
+  const baseArgs = enableCPS
+    ? ['serverless.cross_project.enabled=true', 'remote_cluster_server.enabled=true']
+    : [];
+
   return {
     es,
     start: async () => {
@@ -99,9 +182,17 @@ function createServerlessES() {
         clean: true,
         kill: true,
         waitForReady: true,
+        ...(kibanaUrl ? { kibanaUrl } : {}),
         ...esServerlessImageParams,
+        ...(enableCPS
+          ? {
+              ssl: true,
+              uiam: true,
+              esArgs: [...baseArgs, ...esArgs],
+            }
+          : {}),
       });
-      const client = getServerlessESClient({ port: esPort });
+      const client = getServerlessESClient({ port: esPort, ssl: enableCPS });
 
       return {
         getClient: () => client,
@@ -113,12 +204,13 @@ function createServerlessES() {
   };
 }
 
-const getServerlessESClient = ({ port }: { port: number }) => {
+const getServerlessESClient = ({ port, ssl = false }: { port: number; ssl?: boolean }) => {
   return new Client({
-    node: `http://localhost:${port}`,
+    node: `${ssl ? 'https' : 'http'}://localhost:${port}`,
     Connection: HttpConnection,
     requestTimeout: 30_000,
     auth: { ...systemIndicesSuperuser },
+    ...(ssl ? { tls: { rejectUnauthorized: false } } : {}),
   });
 };
 
@@ -163,7 +255,13 @@ const getServerlessDefault = () => {
 };
 
 export function createServerlessKibana(settings = {}, cliArgs: Partial<CliArgs> = {}) {
-  return createRoot(defaultsDeep(settings, getServerlessDefault()), {
+  const defaults = getServerlessDefault();
+  const esOverrides = (settings as any)?.elasticsearch;
+  if (esOverrides?.username || esOverrides?.password) {
+    delete (defaults as any).elasticsearch.serviceAccountToken;
+  }
+
+  return createRoot(defaultsDeep(settings, defaults), {
     ...cliArgs,
     serverless: true,
   });

--- a/src/platform/packages/shared/kbn-config/src/env.ts
+++ b/src/platform/packages/shared/kbn-config/src/env.ts
@@ -36,6 +36,7 @@ export interface CliArgs {
   cache: boolean;
   dist: boolean;
   serverless?: boolean;
+  uiam?: boolean;
   retrictInternalApis?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Extends the serverless test infrastructure (`createTestServerlessInstances`) to support CPS and UIAM testing scenarios:

- New options: `enableCPS`, `esArgs`, `projectType`, `kibanaUrl` for configuring serverless ES with CPS mode
- When CPS is enabled, automatically configures SSL, UIAM, and the required ES settings (`serverless.cross_project.enabled`, `remote_cluster_server.enabled`)
- Adds `uiam` to the `CliArgs` interface to allow Kibana to boot with UIAM support in tests
- Handles credential precedence (username/password vs serviceAccountToken) when merging settings

Extracted from #253316 to ease review.

Made with [Cursor](https://cursor.com)