### PR TITLE
[content-list] Add tags filtering and display

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_tags_features.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_tags_features.stories.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { ContentListProvider } from '@kbn/content-list-provider';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import { ContentListTable } from '@kbn/content-list-table';
+import { ContentListFooter } from '@kbn/content-list-footer';
+import { ContentListToolbar } from '@kbn/content-list-toolbar';
+import { createStoryFindItems, mockTagsService, StateDiagnosticPanel } from './stories_helpers';
+
+// =============================================================================
+// Storybook Meta
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Content List/Tags Features',
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '20px', maxWidth: '1200px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+// =============================================================================
+// Tags Features Story (MS2)
+// =============================================================================
+
+const { Column, Action } = ContentListTable;
+const { Filters } = ContentListToolbar;
+
+/**
+ * Wrapper component for the MS2 Tags story.
+ *
+ * MS2 (Maps migration) requires Core + Tags. This story shows the full
+ * tag filtering flow: tag badges in the Name column, the Tags filter
+ * popover (include/exclude), and search bar query sync (`tag:(Production)`).
+ *
+ * Current state of MS2 features:
+ * - [x] Tags filter popover — include/exclude, Cmd/Ctrl+click (PR 9)
+ * - [x] Tag badges in Name column — click to filter (PR 9)
+ * - [x] Search bar ↔ filter sync — `tag:name` parsed to `filters.tag` (PR 9)
+ */
+const TagsFeaturesWrapper = () => {
+  const labels = useMemo(
+    () => ({
+      entity: 'map',
+      entityPlural: 'maps',
+    }),
+    []
+  );
+
+  const dataSource = useMemo(() => {
+    const findItems = createStoryFindItems({ totalItems: 30 });
+    return { findItems };
+  }, []);
+
+  const features = useMemo(
+    () => ({
+      sorting: {
+        initialSort: { field: 'title', direction: 'asc' as const },
+        fields: [
+          { field: 'title', name: 'Name' },
+          {
+            field: 'updatedAt',
+            name: 'Last updated',
+            ascLabel: 'Old-Recent',
+            descLabel: 'Recent-Old',
+          },
+        ],
+      },
+      pagination: { initialPageSize: 20 },
+      tags: true as const,
+    }),
+    []
+  );
+
+  const itemConfig = useMemo(
+    () => ({
+      getHref: (item: ContentListItem) => `#/maps/${item.id}`,
+      onDelete: async (_items: ContentListItem[]) => {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      },
+    }),
+    []
+  );
+
+  const tableChildren = useMemo(
+    () => (
+      <>
+        <Column.Name showDescription showTags />
+        <Column.UpdatedAt />
+        <Column.Actions>
+          <Action.Delete />
+        </Column.Actions>
+      </>
+    ),
+    []
+  );
+
+  const displayElement = useMemo(
+    () => (
+      <ContentListProvider
+        id="tags-features"
+        labels={labels}
+        dataSource={dataSource}
+        features={features}
+        item={itemConfig}
+        services={{ tags: mockTagsService }}
+      >
+        <ContentListToolbar>
+          <Filters>
+            <Filters.Tags />
+            <Filters.Sort />
+          </Filters>
+        </ContentListToolbar>
+        <ContentListTable title="maps table">{tableChildren}</ContentListTable>
+        <ContentListFooter />
+      </ContentListProvider>
+    ),
+    [labels, dataSource, features, itemConfig, tableChildren]
+  );
+
+  return (
+    <ContentListProvider
+      id="tags-features"
+      labels={labels}
+      dataSource={dataSource}
+      features={features}
+      item={itemConfig}
+      services={{ tags: mockTagsService }}
+    >
+      <EuiTitle size="s">
+        <h2>Tags Features</h2>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        <p>
+          Core + Tags — the feature set required to migrate Maps to Content List. Demonstrates the
+          Tags filter popover (include/exclude via Cmd/Ctrl+click), tag badges in the Name column
+          (click to filter), and search bar query sync (<code>tag:(name)</code> ↔{' '}
+          <code>filters.tag</code>).
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem>
+          <ContentListToolbar>
+            <Filters>
+              <Filters.Tags />
+              <Filters.Sort />
+            </Filters>
+          </ContentListToolbar>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ContentListTable title="maps table">{tableChildren}</ContentListTable>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ContentListFooter />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <StateDiagnosticPanel defaultOpen element={displayElement} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </ContentListProvider>
+  );
+};
+
+/**
+ * The "Tags" feature set: Core + tag filtering and display.
+ *
+ * Required by the Maps migration (MS2). Adds:
+ * - `services.tags` on the provider wires the tag service.
+ * - `features.tags: true` enables tag state and the `Filters.Tags` preset.
+ * - `Column.Name showTags` renders clickable tag badges beneath each title.
+ * - `Filters.Tags` in the toolbar renders an include/exclude popover.
+ * - Typing `tag:name` in the search bar syncs to `filters.tag` via the
+ *   tag query parser pipeline.
+ *
+ * **Try:** Click a tag badge in the table to toggle it as a filter. Hold
+ * Cmd (Mac) or Ctrl (Windows/Linux) while clicking to exclude instead.
+ * Type `tag:Production` directly in the search bar to see query sync.
+ */
+export const TagsFeatures: StoryObj = {
+  name: 'Tags Features',
+  render: () => <TagsFeaturesWrapper />,
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
@@ -29,7 +29,7 @@ import { ContentListTable } from '@kbn/content-list-table';
 import { ContentListToolbar } from '@kbn/content-list-toolbar';
 import { ContentListFooter } from '@kbn/content-list-footer';
 
-import { createStoryFindItems, toJsx } from '../stories_helpers';
+import { createStoryFindItems, mockTagsService, toJsx } from '../stories_helpers';
 import { BuilderPanel } from './builder_panel';
 import type { PlaygroundState } from './playground_state';
 import { INITIAL_STATE, playgroundReducer } from './playground_state';
@@ -120,6 +120,8 @@ const usePreview = (state: PlaygroundState) => {
 
   const sortFields = useMemo(() => buildSortFields(state.table.columns), [state.table.columns]);
 
+  const hasTagsFilter = toolbar.filters.some((f) => f.type === 'tags');
+
   const providerFeatures = useMemo(
     () => ({
       sorting: features.sorting
@@ -129,8 +131,16 @@ const usePreview = (state: PlaygroundState) => {
         ? { initialPageSize: features.initialPageSize }
         : (false as const),
       search: features.search ? {} : (false as const),
+      tags: hasTagsFilter ? true : (false as const),
     }),
-    [features.sorting, features.pagination, features.initialPageSize, features.search, sortFields]
+    [
+      features.sorting,
+      features.pagination,
+      features.initialPageSize,
+      features.search,
+      sortFields,
+      hasTagsFilter,
+    ]
   );
 
   const providerItemConfig = useMemo(() => {
@@ -219,7 +229,18 @@ const usePreview = (state: PlaygroundState) => {
         <Filters>
           {toolbar.filters.map((f) => {
             if (f.type === 'sort') {
-              return <Filters.Sort key={f.instanceId} />;
+              return (
+                <React.Fragment key={f.instanceId}>
+                  <Filters.Sort />
+                </React.Fragment>
+              );
+            }
+            if (f.type === 'tags') {
+              return (
+                <React.Fragment key={f.instanceId}>
+                  <Filters.Tags />
+                </React.Fragment>
+              );
             }
             return null;
           })}
@@ -237,8 +258,9 @@ const usePreview = (state: PlaygroundState) => {
       features: providerFeatures,
       isReadOnly: provider.isReadOnly,
       item: providerItemConfig,
+      ...(hasTagsFilter && { services: { tags: mockTagsService } }),
     }),
-    [labels, dataSource, providerFeatures, provider.isReadOnly, providerItemConfig]
+    [labels, dataSource, providerFeatures, provider.isReadOnly, providerItemConfig, hasTagsFilter]
   );
 
   const consumerJsx = useMemo(
@@ -305,6 +327,16 @@ export const PlaygroundBuilder = () => {
   const tabs = useMemo<EuiTabbedContentTab[]>(
     () => [
       {
+        id: 'about',
+        name: 'About',
+        content: (
+          <>
+            <EuiSpacer size="m" />
+            <EuiMarkdownFormat textSize="s">{INSTRUCTIONS_MD}</EuiMarkdownFormat>
+          </>
+        ),
+      },
+      {
         id: 'preview',
         name: 'Preview',
         content: (
@@ -325,16 +357,6 @@ export const PlaygroundBuilder = () => {
             <EuiCodeBlock language="tsx" fontSize="s" paddingSize="s" overflowHeight={300}>
               {jsx}
             </EuiCodeBlock>
-          </>
-        ),
-      },
-      {
-        id: 'about',
-        name: 'About',
-        content: (
-          <>
-            <EuiSpacer size="m" />
-            <EuiMarkdownFormat textSize="s">{INSTRUCTIONS_MD}</EuiMarkdownFormat>
           </>
         ),
       },

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
@@ -28,7 +28,7 @@ export interface ActiveAction {
   type: ActionType;
 }
 
-export type FilterType = 'sort';
+export type FilterType = 'sort' | 'tags';
 
 export interface ActiveFilter {
   instanceId: string;
@@ -134,6 +134,7 @@ export const COLUMN_DEFINITIONS: ColumnDefinition[] = [
 
 export const FILTER_DEFINITIONS: { type: FilterType; label: string }[] = [
   { type: 'sort', label: 'Filters.Sort' },
+  { type: 'tags', label: 'Filters.Tags' },
 ];
 
 export const ACTION_DEFINITIONS: { type: ActionType; label: string }[] = [

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
@@ -93,9 +93,10 @@ export const COLUMN_DEFINITIONS: ColumnDefinition[] = [
     type: 'name',
     label: 'Column.Name',
     allowMultiple: false,
-    defaultProps: { showDescription: true },
+    defaultProps: { showDescription: true, showTags: false },
     configurableProps: [
       { name: 'showDescription', label: 'showDescription', type: 'boolean', defaultValue: true },
+      { name: 'showTags', label: 'showTags', type: 'boolean', defaultValue: false },
       { name: 'width', label: 'width', type: 'string', defaultValue: '' },
       { name: 'columnTitle', label: 'columnTitle', type: 'string', defaultValue: '' },
     ],

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
@@ -29,7 +29,14 @@ import {
   useContentListConfig,
 } from '@kbn/content-list-provider';
 import type { FindItemsParams, FindItemsResult } from '@kbn/content-list-provider';
-import { MOCK_DASHBOARDS, createMockFindItems } from '@kbn/content-list-mock-data';
+import {
+  MOCK_DASHBOARDS,
+  createMockFindItems,
+  extractTagIds,
+  mockTagsService,
+} from '@kbn/content-list-mock-data';
+
+export { mockTagsService };
 
 // =============================================================================
 // Mock Data
@@ -85,7 +92,7 @@ export const createStoryFindItems = (options?: {
 
     const result = await mockFindItems({
       searchQuery: params.searchQuery,
-      filters: {},
+      filters: params.filters,
       sort: params.sort ?? { field: 'title', direction: 'asc' },
       page: params.page,
     });
@@ -97,8 +104,10 @@ export const createStoryFindItems = (options?: {
         description: item.attributes.description,
         type: item.type,
         updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
+        tags: extractTagIds(item.references),
       })),
       total: result.total,
+      counts: result.counts,
     };
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/moon.yml
@@ -19,6 +19,7 @@ project:
     sourceRoot: src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data
 dependsOn:
   - '@kbn/content-management-table-list-view-common'
+  - '@kbn/content-management-tags'
   - '@kbn/user-profile-components'
 tags:
   - shared-browser

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
@@ -15,6 +15,27 @@ import { MOCK_VISUALIZATIONS, type VisualizationMockItem } from './visualization
 import { MOCK_USER_PROFILES } from './user_profiles';
 import { mockFavoritesClient } from './services';
 
+/** Shape compatible with `ActiveFilters` from `@kbn/content-list-provider`. Defined locally to avoid circular dependency. */
+interface MockFindItemsFilters {
+  search?: string;
+  tag?: { include?: string[]; exclude?: string[] };
+  favoritesOnly?: boolean;
+  users?: string[];
+}
+
+/**
+ * Extracts tag IDs from a `UserContentCommonSchema` item's `references` array.
+ *
+ * Mock items store tags as `{ type: 'tag', id: 'tag-id' }` references. This
+ * helper converts them into a flat `string[]` suitable for `ContentListItem.tags`.
+ */
+export const extractTagIds = (
+  references: UserContentCommonSchema['references']
+): string[] | undefined => {
+  const tagIds = references?.filter((ref) => ref.type === 'tag').map((ref) => ref.id);
+  return tagIds && tagIds.length > 0 ? tagIds : undefined;
+};
+
 /**
  * Generic mock item type
  */
@@ -51,7 +72,7 @@ export function createMockFindItems<T extends UserContentCommonSchema>(
     page,
   }: {
     searchQuery?: string;
-    filters: { tags?: { include?: string[]; exclude?: string[] }; favoritesOnly?: boolean };
+    filters: MockFindItemsFilters;
     sort: { field: string; direction: 'asc' | 'desc' };
     page: { index: number; size: number };
   }) => {
@@ -73,7 +94,8 @@ export function createMockFindItems<T extends UserContentCommonSchema>(
     }
 
     // Apply tag include filters
-    const includeTags = filters.tags?.include;
+    const tagFilter = filters.tag;
+    const includeTags = tagFilter?.include;
     if (includeTags && includeTags.length > 0) {
       items = items.filter((item) =>
         includeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
@@ -81,15 +103,15 @@ export function createMockFindItems<T extends UserContentCommonSchema>(
     }
 
     // Apply tag exclude filters
-    const excludeTags = filters.tags?.exclude;
+    const excludeTags = tagFilter?.exclude;
     if (excludeTags && excludeTags.length > 0) {
       items = items.filter(
         (item) => !excludeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
       );
     }
 
-    // Apply favorites filter
-    if (filters.favoritesOnly) {
+    // Apply favorites filter (mock extension, not in ActiveFilters)
+    if ((filters as { favoritesOnly?: boolean }).favoritesOnly) {
       const favorites = await mockFavoritesClient.getFavorites();
       items = items.filter((item) => favorites.favoriteIds.includes(item.id));
     }
@@ -122,7 +144,19 @@ export function createMockFindItems<T extends UserContentCommonSchema>(
       return sort.direction === 'asc' ? comparison : -comparison;
     });
 
-    // Apply pagination
+    // Compute per-tag item counts from the full (pre-paginated) result set.
+    // Key by id (or name) to match TagFilterRenderer lookup.
+    const tagCounts: Record<string, number> = {};
+    items.forEach((item) => {
+      item.references?.forEach((ref) => {
+        if (ref.type === 'tag') {
+          const key = ref.id ?? ref.name;
+          tagCounts[key] = (tagCounts[key] || 0) + 1;
+        }
+      });
+    });
+
+    // Apply pagination.
     const total = items.length;
     const start = page.index * page.size;
     const end = start + page.size;
@@ -131,6 +165,7 @@ export function createMockFindItems<T extends UserContentCommonSchema>(
     return {
       items: paginatedItems,
       total,
+      counts: { tag: tagCounts },
     };
   };
 }
@@ -389,11 +424,7 @@ export const createSimpleMockFindItems = (delay: number = 0) => {
     page,
   }: {
     searchQuery?: string;
-    filters: {
-      tags?: { include?: string[]; exclude?: string[] };
-      users?: string[];
-      favoritesOnly?: boolean;
-    };
+    filters: MockFindItemsFilters;
     sort: { field: string; direction: 'asc' | 'desc' };
     page: { index: number; size: number };
   }) => {
@@ -416,7 +447,8 @@ export const createSimpleMockFindItems = (delay: number = 0) => {
     }
 
     // Apply tag include filters
-    const includeTags = filters.tags?.include;
+    const tagFilter = filters.tag;
+    const includeTags = tagFilter?.include;
     if (includeTags && includeTags.length > 0) {
       items = items.filter((item) =>
         includeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
@@ -424,7 +456,7 @@ export const createSimpleMockFindItems = (delay: number = 0) => {
     }
 
     // Apply tag exclude filters
-    const excludeTags = filters.tags?.exclude;
+    const excludeTags = tagFilter?.exclude;
     if (excludeTags && excludeTags.length > 0) {
       items = items.filter(
         (item) => !excludeTags.some((tag) => item.references?.some((ref) => ref.id === tag))
@@ -432,8 +464,9 @@ export const createSimpleMockFindItems = (delay: number = 0) => {
     }
 
     // Apply user filters (createdBy) - supports both email and uid filter values
-    if (filters.users && filters.users.length > 0) {
-      items = items.filter((item) => matchesUserFilter(item.createdBy, filters.users!));
+    const usersFilter = (filters as { users?: string[] }).users;
+    if (usersFilter && usersFilter.length > 0) {
+      items = items.filter((item) => matchesUserFilter(item.createdBy, usersFilter));
     }
 
     // Apply favorites filter
@@ -465,7 +498,19 @@ export const createSimpleMockFindItems = (delay: number = 0) => {
       return sort.direction === 'asc' ? comparison : -comparison;
     });
 
-    // Apply pagination
+    // Compute per-tag item counts from the full (pre-paginated) result set.
+    // Key by id (or name) to match TagFilterRenderer lookup.
+    const tagCounts: Record<string, number> = {};
+    items.forEach((item) => {
+      item.references?.forEach((ref) => {
+        if (ref.type === 'tag') {
+          const key = ref.id ?? ref.name;
+          tagCounts[key] = (tagCounts[key] || 0) + 1;
+        }
+      });
+    });
+
+    // Apply pagination.
     const total = items.length;
     const start = page.index * page.size;
     const end = start + page.size;
@@ -474,6 +519,7 @@ export const createSimpleMockFindItems = (delay: number = 0) => {
     return {
       items: paginatedItems,
       total,
+      counts: { tag: tagCounts },
     };
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/index.ts
@@ -36,6 +36,7 @@ export {
   type ItemWithStatus,
   createMockFindItems,
   createSimpleMockFindItems,
+  extractTagIds,
   mockFindDashboards,
   mockFindMaps,
   mockFindFiles,
@@ -51,4 +52,4 @@ export {
 } from './user_profiles';
 
 // Services
-export { mockFavoritesClient } from './services';
+export { mockFavoritesClient, mockTagsService } from './services';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/services.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/services.ts
@@ -25,14 +25,16 @@ export const mockFavoritesClient = {
 // Mock Tags Service
 // =============================================================================
 
-const resolveTagNamesToIds = (tagNames: string[], tags: Tag[]): string[] =>
-  tagNames.reduce<string[]>((ids, name) => {
+const resolveTagNamesToIds = (tagNames: string[], tags: Tag[]): string[] => {
+  const ids: string[] = [];
+  tagNames.forEach((name) => {
     const tag = tags.find((t) => t.name === name);
     if (tag?.id) {
       ids.push(tag.id);
     }
-    return ids;
-  }, []);
+  });
+  return ids;
+};
 
 /**
  * Parses EUI query syntax to extract `tag:Name` and `-tag:Name` clauses,
@@ -87,7 +89,7 @@ const parseSearchQuery = (searchQuery: string): ParsedQuery => {
   }
 
   return {
-    searchQuery: query.removeOrFieldClauses('tag').text,
+    searchQuery: query.removeOrFieldClauses('tag').removeSimpleFieldClauses('tag').text,
     tagIds: unique.length > 0 ? unique : undefined,
     tagIdsToExclude: uniqueExclude.length > 0 ? uniqueExclude : undefined,
   };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/services.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/services.ts
@@ -7,6 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Query } from '@elastic/eui';
+import type { ContentManagementTagsServices, ParsedQuery, Tag } from '@kbn/content-management-tags';
+import { MOCK_TAGS } from './tags';
+
 /**
  * Mock favorites client for testing favorites filtering in stories.
  * Returns a static set of favorited item IDs.
@@ -15,4 +19,87 @@ export const mockFavoritesClient = {
   getFavorites: async () => ({
     favoriteIds: ['dashboard-001', 'dashboard-003', 'vis-001', 'map-001'],
   }),
+};
+
+// =============================================================================
+// Mock Tags Service
+// =============================================================================
+
+const resolveTagNamesToIds = (tagNames: string[], tags: Tag[]): string[] =>
+  tagNames.reduce<string[]>((ids, name) => {
+    const tag = tags.find((t) => t.name === name);
+    if (tag?.id) {
+      ids.push(tag.id);
+    }
+    return ids;
+  }, []);
+
+/**
+ * Parses EUI query syntax to extract `tag:Name` and `-tag:Name` clauses,
+ * resolving tag names against {@link MOCK_TAGS}.
+ *
+ * **Approximation only.** This mirrors the real `parseSearchQueryCore` from
+ * `@kbn/content-management-tags` closely enough for Storybook demos, but it
+ * reimplements the parsing logic and may diverge on edge cases (e.g. quoting,
+ * partial matches, case sensitivity). Production behavior should always be
+ * verified against the real implementation.
+ */
+const parseSearchQuery = (searchQuery: string): ParsedQuery => {
+  const tags = MOCK_TAGS;
+  const query = Query.parse(searchQuery, {
+    schema: { strict: false, fields: { tag: { type: 'string' } } },
+  });
+
+  const tagIds: string[] = [];
+  const tagIdsToExclude: string[] = [];
+
+  const tagClauses = query.ast.getFieldClauses('tag');
+  if (tagClauses) {
+    tagClauses.forEach((clause) => {
+      const names = Array.isArray(clause.value) ? clause.value : [clause.value];
+      const resolved = resolveTagNamesToIds(names as string[], tags);
+      if (clause.match === 'must') {
+        tagIds.push(...resolved);
+      } else if (clause.match === 'must_not') {
+        tagIdsToExclude.push(...resolved);
+      }
+    });
+  }
+
+  const includeOr = query.ast.getOrFieldClause('tag', undefined, true, 'eq');
+  if (includeOr) {
+    const names = Array.isArray(includeOr.value) ? includeOr.value : [includeOr.value];
+    tagIds.push(...resolveTagNamesToIds(names as string[], tags));
+  }
+
+  const excludeOr = query.ast.getOrFieldClause('tag', undefined, false, 'eq');
+  if (excludeOr) {
+    const names = Array.isArray(excludeOr.value) ? excludeOr.value : [excludeOr.value];
+    tagIdsToExclude.push(...resolveTagNamesToIds(names as string[], tags));
+  }
+
+  const unique = [...new Set(tagIds)];
+  const uniqueExclude = [...new Set(tagIdsToExclude)];
+  const hasResolved = unique.length > 0 || uniqueExclude.length > 0;
+
+  if (!hasResolved) {
+    return { searchQuery, tagIds: undefined, tagIdsToExclude: undefined };
+  }
+
+  return {
+    searchQuery: query.removeOrFieldClauses('tag').text,
+    tagIds: unique.length > 0 ? unique : undefined,
+    tagIdsToExclude: uniqueExclude.length > 0 ? uniqueExclude : undefined,
+  };
+};
+
+/**
+ * Pre-configured mock tags service backed by {@link MOCK_TAGS}.
+ *
+ * Provides `getTagList` and `parseSearchQuery` ready for use as
+ * `services.tags` on `ContentListProvider`.
+ */
+export const mockTagsService: ContentManagementTagsServices = {
+  getTagList: () => MOCK_TAGS,
+  parseSearchQuery,
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/tsconfig.json
@@ -18,6 +18,7 @@
   ],
   "kbn_references": [
     "@kbn/content-management-table-list-view-common",
+    "@kbn/content-management-tags",
     "@kbn/user-profile-components"
   ],
   "exclude": [

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -21,14 +21,21 @@ export type {
   ContentListLabels,
   ContentListCoreConfig,
   ContentListConfig,
+  ContentListServices,
 } from './src/context';
 
 // Hooks.
 export { useContentListItems, useContentListState } from './src/state';
 export type { ContentListQueryData } from './src/state';
-export { useContentListSort, useContentListSearch, useContentListSelection } from './src/features';
-export { useContentListPagination } from './src/features';
 export {
+  useContentListSort,
+  useContentListSearch,
+  useContentListPagination,
+  useContentListSelection,
+  useFilterDisplay,
+  useContentListFilters,
+  useTagFilterToggle,
+  TAG_FILTER_ID,
   DeleteConfirmationModal,
   DeleteConfirmationComponent,
   useDeleteConfirmation,
@@ -52,6 +59,8 @@ export type {
   SearchConfig,
   UseContentListSearchReturn,
   UseContentListSelectionReturn,
+  FilterDisplayState,
+  UseContentListFiltersReturn,
   DeleteConfirmationModalProps,
   DeleteConfirmationComponentProps,
   UseDeleteConfirmationOptions,
@@ -59,6 +68,8 @@ export type {
 } from './src/features';
 export type {
   ActiveFilters,
+  IncludeExcludeFilter,
+  FilterCounts,
   FindItemsFn,
   FindItemsParams,
   FindItemsResult,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/moon.yml
@@ -21,6 +21,7 @@ dependsOn:
   - '@kbn/react-query'
   - '@kbn/content-list-mock-data'
   - '@kbn/i18n'
+  - '@kbn/content-management-tags'
   - '@kbn/i18n'
 tags:
   - shared-browser

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.test.tsx
@@ -13,6 +13,7 @@ import { ContentListProvider, useContentListConfig } from './provider';
 import type { ContentListProviderProps } from './provider';
 import type { FindItemsResult, FindItemsParams } from '../datasource';
 import type { ContentListItem } from '../item';
+import type { ContentManagementTagsServices } from '@kbn/content-management-tags';
 
 describe('ContentListProvider', () => {
   const mockFindItems = jest.fn(
@@ -176,6 +177,60 @@ describe('ContentListProvider', () => {
       });
 
       expect(result.current.supports.search).toBe(true);
+    });
+
+    describe('tags support', () => {
+      const mockTagsService: ContentManagementTagsServices = {
+        getTagList: () => [
+          { id: 'tag-1', name: 'Production', description: '', color: '#FF0000', managed: false },
+        ],
+      };
+
+      it('disables tags by default when no tags service is provided', () => {
+        const { result } = renderHook(() => useContentListConfig(), {
+          wrapper: createWrapper(),
+        });
+
+        expect(result.current.supports.tags).toBe(false);
+      });
+
+      it('enables tags when tags service is provided', () => {
+        const { result } = renderHook(() => useContentListConfig(), {
+          wrapper: createWrapper({ services: { tags: mockTagsService } }),
+        });
+
+        expect(result.current.supports.tags).toBe(true);
+      });
+
+      it('disables tags when `features.tags` is false even with tags service', () => {
+        const { result } = renderHook(() => useContentListConfig(), {
+          wrapper: createWrapper({
+            features: { tags: false },
+            services: { tags: mockTagsService },
+          }),
+        });
+
+        expect(result.current.supports.tags).toBe(false);
+      });
+
+      it('enables tags when `features.tags` is true and service is provided', () => {
+        const { result } = renderHook(() => useContentListConfig(), {
+          wrapper: createWrapper({
+            features: { tags: true },
+            services: { tags: mockTagsService },
+          }),
+        });
+
+        expect(result.current.supports.tags).toBe(true);
+      });
+
+      it('disables tags when `features.tags` is true but no service is provided', () => {
+        const { result } = renderHook(() => useContentListConfig(), {
+          wrapper: createWrapper({ features: { tags: true } }),
+        });
+
+        expect(result.current.supports.tags).toBe(false);
+      });
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/types.ts
@@ -76,19 +76,5 @@ export type ContentListConfig = ContentListCoreConfig & {
   dataSource: DataSourceConfig;
 };
 
-/**
- * Services provided to the content list provider to enable additional capabilities.
- *
- * @internal This interface is a placeholder for future service integrations.
- * @remarks
- * Planned services include:
- * - Tagging service for tag-based filtering.
- * - Favorites service for user favorites.
- * - Permissions service for access control.
- *
- * This interface is not yet used and may change without notice.
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ContentListServices {
-  // Future services will be added here.
-}
+// Re-export `ContentListServices` from the services module.
+export type { ContentListServices } from '../services';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
@@ -10,12 +10,47 @@
 import type { ContentListItem } from '../item';
 
 /**
+ * Include/exclude filter shape used by tag, type, lastResponse, and other filter dimensions.
+ */
+export interface IncludeExcludeFilter {
+  /** Values that items must match (include filter). */
+  include?: string[];
+  /** Values that items must not match (exclude filter). */
+  exclude?: string[];
+}
+
+/** Filter dimension key for tag-based filtering. Matches the `fieldName` used in tag filter popovers. */
+export const TAG_FILTER_ID = 'tag';
+
+/**
  * Active filters applied to the content list.
+ *
+ * Filter dimensions (e.g. `tag`, `type`, `lastResponse`) are keyed by their
+ * `fieldName` and hold an {@link IncludeExcludeFilter}. The index signature is
+ * required to allow arbitrary filter dimensions, but note:
+ *
+ * - The `search` key is always `string | undefined` — access it directly.
+ * - All other keys return `IncludeExcludeFilter | string | undefined`; use
+ *   {@link getIncludeExcludeFilter} to safely narrow them to `IncludeExcludeFilter`.
  */
 export interface ActiveFilters {
   /** Search text extracted from the search bar, without filter syntax. */
   search?: string;
+  [filterId: string]: IncludeExcludeFilter | string | undefined;
 }
+
+/**
+ * Returns the filter value as `IncludeExcludeFilter` if it is an object; otherwise `undefined`.
+ * Use when accessing `include`/`exclude` on a filter dimension, since the index signature allows `string`.
+ */
+export const getIncludeExcludeFilter = (
+  value: IncludeExcludeFilter | string | undefined
+): IncludeExcludeFilter | undefined => (value && typeof value === 'object' ? value : undefined);
+
+/**
+ * Per-value counts for a single filter dimension.
+ */
+export type FilterCounts = Record<string, number>;
 
 /**
  * Parameters for the `findItems` function.
@@ -66,6 +101,19 @@ export interface FindItemsResult {
 
   /** Total matching items for pagination. */
   total: number;
+
+  /**
+   * Optional per-filter counts, indexed by filter identifier.
+   *
+   * Each key (e.g. `tag`, `type`, `lastResponse`) maps to a `Record<string, number>` of
+   * value → count for the full result set (not just the current page). When present for a
+   * filter, the corresponding filter popover displays counts next to each option.
+   *
+   * Client-side data sources that iterate the full item set before paginating can compute
+   * this cheaply. Server-side data sources should omit entries unless they can retrieve
+   * counts via an aggregation query.
+   */
+  counts?: Record<string, FilterCounts>;
 }
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/index.ts
@@ -7,13 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  IncludeExcludeFilter,
-  FilterCounts,
-  ActiveFilters,
-  FindItemsParams,
-  FindItemsResult,
-  FindItemsFn,
-  DataSourceConfig,
-} from './types';
-export { getIncludeExcludeFilter, TAG_FILTER_ID } from './types';
+export type { FilterDisplayState, UseContentListFiltersReturn } from './types';
+export { useFilterDisplay } from './use_filter_display';
+export { useContentListFilters } from './use_content_list_filters';
+export { useTagFilterToggle } from './use_tag_filter_toggle';
+export { TAG_FILTER_ID } from '../../datasource';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/types.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActiveFilters } from '../../datasource';
+
+/**
+ * State returned by `useFilterDisplay` indicating which filter UI elements should be rendered.
+ */
+export interface FilterDisplayState {
+  /** Whether any filter popover buttons should be shown (sorting or tags). Search is separate. */
+  hasFilters: boolean;
+  /** Whether sorting is enabled. */
+  hasSorting: boolean;
+  /** Whether search is enabled. */
+  hasSearch: boolean;
+  /** Whether tags filtering should be shown. */
+  hasTags: boolean;
+}
+
+/**
+ * Return type for the {@link useContentListFilters} hook.
+ */
+export interface UseContentListFiltersReturn {
+  /** Currently active filters (derived from query text and state). */
+  filters: ActiveFilters;
+  /** Clear all filters and search text. */
+  clearFilters: () => void;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_content_list_filters.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_content_list_filters.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ContentListProvider } from '../../context';
+import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import { useContentListFilters } from './use_content_list_filters';
+import { useContentListSearch } from '../search/use_content_list_search';
+
+describe('useContentListFilters', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: [],
+      total: 0,
+    })
+  );
+
+  const createWrapper =
+    () =>
+    ({ children }: { children: React.ReactNode }) =>
+      (
+        <ContentListProvider
+          id="test-list"
+          labels={{ entity: 'item', entityPlural: 'items' }}
+          dataSource={{ findItems: mockFindItems }}
+        >
+          {children}
+        </ContentListProvider>
+      );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('returns default filters', () => {
+      const { result } = renderHook(() => useContentListFilters(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.filters).toEqual({
+        search: undefined,
+      });
+    });
+  });
+
+  describe('clearFilters', () => {
+    it('resets filters to defaults', () => {
+      const { result } = renderHook(
+        () => ({ filters: useContentListFilters(), search: useContentListSearch() }),
+        { wrapper: createWrapper() }
+      );
+
+      act(() => {
+        result.current.search.setSearch('query', {
+          search: 'query',
+          tag: { include: ['tag-1'] },
+        });
+      });
+
+      act(() => {
+        result.current.filters.clearFilters();
+      });
+
+      expect(result.current.filters.filters).toEqual({
+        search: undefined,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws when used outside provider', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useContentListFilters());
+      }).toThrow(
+        'ContentListStateContext is missing. Ensure your component is wrapped with ContentListProvider.'
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_content_list_filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_content_list_filters.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import { useContentListState } from '../../state/use_content_list_state';
+import { CONTENT_LIST_ACTIONS } from '../../state/types';
+import type { UseContentListFiltersReturn } from './types';
+
+/**
+ * Hook to read the current filter state and clear all filters.
+ *
+ * Reads the current `filters` from provider state. Filters are always updated
+ * atomically with the search bar query text via `SET_SEARCH` — use
+ * {@link useContentListSearch}'s `setSearch` to change filters programmatically,
+ * or {@link useTagFilterToggle} to toggle a single tag.
+ *
+ * @returns A {@link UseContentListFiltersReturn} object.
+ *
+ * @example
+ * ```tsx
+ * const { filters, clearFilters } = useContentListFilters();
+ *
+ * // Read current filters.
+ * const { search, tag, type, ...otherFilters } = filters;
+ *
+ * // Clear all filters and search text.
+ * clearFilters();
+ * ```
+ */
+export const useContentListFilters = (): UseContentListFiltersReturn => {
+  const { state, dispatch } = useContentListState();
+
+  const clearFilters = useCallback(() => {
+    dispatch({ type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS });
+  }, [dispatch]);
+
+  return {
+    filters: state.filters,
+    clearFilters,
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_filter_display.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_filter_display.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { ContentListProvider } from '../../context';
+import type { ContentListProviderProps } from '../../context';
+import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import type { ContentManagementTagsServices } from '@kbn/content-management-tags';
+import { useFilterDisplay } from './use_filter_display';
+
+describe('useFilterDisplay', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: [],
+      total: 0,
+    })
+  );
+
+  const mockTagsService: ContentManagementTagsServices = {
+    getTagList: () => [
+      { id: 'tag-1', name: 'Production', description: '', color: '#FF0000', managed: false },
+    ],
+  };
+
+  const createWrapper = (props?: Partial<ContentListProviderProps>) => {
+    const defaultProps: ContentListProviderProps = {
+      id: 'test-list',
+      labels: { entity: 'item', entityPlural: 'items' },
+      dataSource: { findItems: mockFindItems },
+      children: null,
+      ...props,
+    };
+
+    return ({ children }: { children: React.ReactNode }) => (
+      <ContentListProvider {...defaultProps}>{children}</ContentListProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('hasSorting', () => {
+    it('returns true when sorting is supported (default)', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.hasSorting).toBe(true);
+    });
+
+    it('returns false when sorting is disabled', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper({ features: { sorting: false } }),
+      });
+
+      expect(result.current.hasSorting).toBe(false);
+    });
+  });
+
+  describe('hasSearch', () => {
+    it('returns true when search is supported (default)', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.hasSearch).toBe(true);
+    });
+
+    it('returns false when search is disabled', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper({ features: { search: false } }),
+      });
+
+      expect(result.current.hasSearch).toBe(false);
+    });
+  });
+
+  describe('hasTags', () => {
+    it('returns true when tags service is provided', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper({ services: { tags: mockTagsService } }),
+      });
+
+      expect(result.current.hasTags).toBe(true);
+    });
+
+    it('returns false when no tags service is provided', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.hasTags).toBe(false);
+    });
+
+    it('returns false when tags are explicitly disabled even with service', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper({
+          features: { tags: false },
+          services: { tags: mockTagsService },
+        }),
+      });
+
+      expect(result.current.hasTags).toBe(false);
+    });
+  });
+
+  describe('hasFilters', () => {
+    it('returns true when sorting is available', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.hasFilters).toBe(true);
+    });
+
+    it('returns true when tags are available', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper({
+          features: { sorting: false },
+          services: { tags: mockTagsService },
+        }),
+      });
+
+      expect(result.current.hasFilters).toBe(true);
+    });
+
+    it('returns false when neither sorting nor tags are available', () => {
+      const { result } = renderHook(() => useFilterDisplay(), {
+        wrapper: createWrapper({ features: { sorting: false } }),
+      });
+
+      expect(result.current.hasFilters).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws when used outside provider', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useFilterDisplay());
+      }).toThrow(
+        'ContentListContext is missing. Ensure your component is wrapped with ContentListProvider.'
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_filter_display.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_filter_display.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useContentListConfig } from '../../context';
+import type { FilterDisplayState } from './types';
+
+/**
+ * Hook to determine which filters should be displayed based on provider configuration
+ * and service availability.
+ *
+ * This hook centralizes the logic for determining filter visibility using both
+ * the `supports` flags (which reflect service availability) and feature config.
+ *
+ * @returns A {@link FilterDisplayState} object indicating which filters are available.
+ *
+ * @example
+ * ```tsx
+ * const { hasTags, hasSorting } = useFilterDisplay();
+ *
+ * return (
+ *   <>
+ *     {hasTags && <TagsFilter />}
+ *     {hasSorting && <SortFilter />}
+ *   </>
+ * );
+ * ```
+ */
+export const useFilterDisplay = (): FilterDisplayState => {
+  const { supports } = useContentListConfig();
+
+  const hasSorting = supports.sorting;
+  const hasSearch = supports.search;
+  const hasTags = supports.tags;
+
+  return {
+    hasSorting,
+    hasSearch,
+    hasTags,
+    hasFilters: hasSorting || hasTags,
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_tag_filter_toggle.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_tag_filter_toggle.test.tsx
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ContentListProvider } from '../../context';
+import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import { getIncludeExcludeFilter } from '../../datasource';
+import { useContentListFilters } from './use_content_list_filters';
+import { useContentListSearch } from '../search/use_content_list_search';
+import { useTagFilterToggle } from './use_tag_filter_toggle';
+
+describe('useTagFilterToggle', () => {
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: [],
+      total: 0,
+    })
+  );
+
+  const createWrapper =
+    () =>
+    ({ children }: { children: React.ReactNode }) =>
+      (
+        <ContentListProvider
+          id="test-list"
+          labels={{ entity: 'item', entityPlural: 'items' }}
+          dataSource={{ findItems: mockFindItems }}
+        >
+          {children}
+        </ContentListProvider>
+      );
+
+  const useToggleState = () => ({
+    toggle: useTagFilterToggle(),
+    filters: useContentListFilters(),
+    search: useContentListSearch(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('include (withModifierKey: false)', () => {
+    it('adds a tag to include filters', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.filters.filters.tag).toEqual({
+        include: ['tag-1'],
+        exclude: [],
+      });
+    });
+
+    it('removes a tag from include on second call (toggle off)', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.filters.filters.tag).toBeUndefined();
+    });
+
+    it('removes the tag from exclude when adding to include', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      // First exclude the tag.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', true);
+      });
+
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.exclude).toContain(
+        'tag-1'
+      );
+
+      // Now include it — should move from exclude to include.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.include).toContain(
+        'tag-1'
+      );
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.exclude).not.toContain(
+        'tag-1'
+      );
+    });
+
+    it('accumulates multiple include tags', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      act(() => {
+        result.current.toggle('tag-2', 'Development', false);
+      });
+
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.include).toEqual([
+        'tag-1',
+        'tag-2',
+      ]);
+    });
+  });
+
+  describe('exclude (withModifierKey: true)', () => {
+    it('adds a tag to exclude filters', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', true);
+      });
+
+      expect(result.current.filters.filters.tag).toEqual({
+        include: [],
+        exclude: ['tag-1'],
+      });
+    });
+
+    it('removes a tag from exclude on second modifier call (toggle off)', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', true);
+      });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', true);
+      });
+
+      expect(result.current.filters.filters.tag).toBeUndefined();
+    });
+
+    it('removes the tag from include when adding to exclude', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      // First include the tag.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.include).toContain(
+        'tag-1'
+      );
+
+      // Now exclude it — should move from include to exclude.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', true);
+      });
+
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.include).not.toContain(
+        'tag-1'
+      );
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.exclude).toContain(
+        'tag-1'
+      );
+    });
+  });
+
+  describe('query text synchronization', () => {
+    it('updates query text with tag syntax when including a tag', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.search.search).toContain('Production');
+    });
+
+    it('removes tag syntax from query text when toggling off', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.search.search).toContain('Production');
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.search.search).not.toContain('Production');
+    });
+
+    it('preserves existing free-text search when toggling a tag', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      // Set search text first.
+      act(() => {
+        result.current.search.setSearch('dashboard', { search: 'dashboard' });
+      });
+
+      // Toggle a tag — free text should be preserved.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.search.search).toContain('dashboard');
+      expect(result.current.search.search).toContain('Production');
+    });
+  });
+
+  describe('error resilience', () => {
+    it('preserves query text and still updates filters when `Query.parse` throws', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      // Set query text to something unparseable by EUI's strict parser.
+      act(() => {
+        result.current.search.setSearch('title:(', { search: 'title:(' });
+      });
+
+      // Toggle a tag — filters should still update even though query text can't be parsed.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.include).toContain(
+        'tag-1'
+      );
+      // Query text should be preserved unchanged since parsing failed.
+      expect(result.current.search.search).toContain('title:(');
+    });
+  });
+
+  describe('normalization', () => {
+    it('returns `undefined` tags when both include and exclude become empty', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      // Add then remove — should normalize back to `undefined`.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.filters.filters.tag).toBeDefined();
+
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.filters.filters.tag).toBeUndefined();
+    });
+
+    it('preserves existing search filter when toggling tags', () => {
+      const { result } = renderHook(useToggleState, { wrapper: createWrapper() });
+
+      // Set a search filter first via SET_SEARCH.
+      act(() => {
+        result.current.search.setSearch('dashboard', { search: 'dashboard' });
+      });
+
+      // Toggle a tag — search filter should be preserved.
+      act(() => {
+        result.current.toggle('tag-1', 'Production', false);
+      });
+
+      expect(result.current.filters.filters.search).toBe('dashboard');
+      expect(getIncludeExcludeFilter(result.current.filters.filters.tag)?.include).toContain(
+        'tag-1'
+      );
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_tag_filter_toggle.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/use_tag_filter_toggle.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import { TAG_FILTER_ID } from '../../datasource';
+import { useContentListState } from '../../state/use_content_list_state';
+import { CONTENT_LIST_ACTIONS } from '../../state/types';
+
+/**
+ * Hook that returns a stable callback for toggling a tag in the content list filters.
+ *
+ * - Regular call: toggles the tag as an **include** filter.
+ * - `withModifierKey: true`: toggles the tag as an **exclude** filter.
+ *
+ * When a tag is added to include it is removed from exclude (and vice versa).
+ * Dispatches `TOGGLE_FILTER`; the reducer handles all EUI `Query` manipulation
+ * and atomically updates `filters` and `search.queryText`.
+ *
+ * @example
+ * ```tsx
+ * const toggleTag = useTagFilterToggle();
+ * <TagBadge tag={tag} onClick={(t, mod) => toggleTag(t.id!, t.name, mod)} />
+ * ```
+ */
+export const useTagFilterToggle = () => {
+  const { dispatch } = useContentListState();
+
+  return useCallback(
+    (tagId: string, tagName: string, withModifierKey: boolean) => {
+      dispatch({
+        type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+        payload: { filterId: TAG_FILTER_ID, valueId: tagId, valueName: tagName, withModifierKey },
+      });
+    },
+    [dispatch]
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
@@ -27,6 +27,15 @@ export { useContentListSearch } from './search';
 export type { UseContentListSelectionReturn } from './selection';
 export { useContentListSelection } from './selection';
 
+// Filtering feature.
+export type { FilterDisplayState, UseContentListFiltersReturn } from './filtering';
+export {
+  useFilterDisplay,
+  useContentListFilters,
+  useTagFilterToggle,
+  TAG_FILTER_ID,
+} from './filtering';
+
 // Delete feature.
 export type {
   DeleteConfirmationModalProps,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/search/use_content_list_search.ts
@@ -39,6 +39,13 @@ export interface UseContentListSearchReturn {
  * used for data fetching. When search is disabled via `features.search: false`,
  * `setSearch` becomes a no-op and `isSupported` returns `false`.
  *
+ * When tag services are available, the toolbar parses tag filter syntax
+ * (e.g., `tag:production`) from the query text and passes the full
+ * {@link ActiveFilters} object to `setSearch`. To toggle a tag without
+ * going through the search bar (e.g., a tag badge click), use
+ * {@link useTagFilterToggle} — it rebuilds the query text via EUI's `Query`
+ * API so the toolbar stays in sync.
+ *
  * @throws Error if used outside `ContentListProvider`.
  * @returns Object containing `search` text, `setSearch` function, and `isSupported` flag.
  *

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
@@ -28,17 +28,24 @@ export interface ContentListFeatures {
    * Selection is automatically disabled when `isReadOnly` is `true`.
    */
   selection?: boolean;
+  /**
+   * Tags feature configuration.
+   *
+   * - `true` or `undefined`: Auto-enabled when `services.tags` is provided.
+   * - `false`: Explicitly disables tags even if `services.tags` is present.
+   */
+  tags?: boolean;
 }
 
 /**
- * Type guard to check if sorting config is a `SortingConfig` object (not boolean).
+ * Type guard to check if sorting config is a {@link SortingConfig} object (not boolean).
  */
 export const isSortingConfig = (sorting?: SortingConfig | boolean): sorting is SortingConfig => {
   return typeof sorting === 'object' && sorting !== null;
 };
 
 /**
- * Type guard to check if pagination config is a `PaginationConfig` object (not boolean).
+ * Type guard to check if pagination config is a {@link PaginationConfig} object (not boolean).
  */
 export const isPaginationConfig = (
   pagination?: PaginationConfig | boolean
@@ -47,7 +54,7 @@ export const isPaginationConfig = (
 };
 
 /**
- * Type guard to check if search config is a `SearchConfig` object (not boolean).
+ * Type guard to check if search config is a {@link SearchConfig} object (not boolean).
  */
 export const isSearchConfig = (search: ContentListFeatures['search']): search is SearchConfig => {
   return typeof search === 'object' && search !== null;
@@ -72,6 +79,7 @@ export const isSearchConfig = (search: ContentListFeatures['search']): search is
  * return (
  *   <div>
  *     {supports.sorting && <SortDropdown />}
+ *     {supports.tags && <TagFilter />}
  *   </div>
  * );
  * ```
@@ -85,4 +93,6 @@ export interface ContentListSupports {
   search: boolean;
   /** Whether item selection and bulk actions are supported. */
   selection: boolean;
+  /** Whether tags filtering and display is supported. */
+  tags: boolean;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
@@ -27,6 +27,8 @@ export type ContentListItem<T = Record<string, unknown>> = T & {
   type?: string;
   /** Last update timestamp. */
   updatedAt?: Date;
+  /** Optional array of tag IDs associated with this item. */
+  tags?: string[];
 };
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query/use_content_list_items_query.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query/use_content_list_items_query.ts
@@ -28,7 +28,7 @@ const DEFAULT_PAGE = { index: 0, size: 20 };
  * Note: Items are expected to already be in `ContentListItem` format.
  * Transformation should happen in the `findItems` implementation.
  *
- * @param clientState - Client-controlled state (filters, sort).
+ * @param clientState - Client-controlled state (search, filters, sort).
  * @returns Query data and refetch function.
  */
 export const useContentListItemsQuery = (
@@ -87,6 +87,7 @@ export const useContentListItemsQuery = (
   return {
     items: query.data?.items ?? [],
     totalItems: query.data?.total ?? 0,
+    counts: query.data?.counts,
     isLoading: query.isLoading,
     isFetching: query.isFetching,
     error,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/index.ts
@@ -7,9 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/**
- * Services module for content list provider.
- */
-
-// Placeholder - services will be exported here.
-export {};
+export type { ContentListServices } from './types';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/types.ts
@@ -7,12 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/**
- * Services skeleton for content list provider.
- *
- * This file establishes the pattern for service adapters that will
- * integrate Kibana services with the content list provider.
- */
+import type { ContentManagementTagsServices } from '@kbn/content-management-tags';
 
-// Placeholder export to establish the module.
-export {};
+/**
+ * Services provided to the content list provider to enable additional capabilities.
+ *
+ * Each service follows a pattern where providing the service enables the corresponding
+ * feature by default. Features can be explicitly disabled via the `features` prop
+ * even when the service is present.
+ */
+export interface ContentListServices {
+  /**
+   * Tags service for tag-based filtering and display.
+   *
+   * Uses the standard `ContentManagementTagsServices` interface from `@kbn/content-management-tags`.
+   * Provides `getTagList` for listing available tags and optionally `parseSearchQuery`
+   * for extracting tag filters from the search bar query text.
+   */
+  tags?: ContentManagementTagsServices;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
@@ -106,6 +106,7 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
   const {
     items,
     totalItems,
+    counts,
     isLoading,
     isFetching,
     error,
@@ -122,6 +123,7 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
         ...clientState,
         items,
         totalItems,
+        counts,
         isLoading,
         isFetching,
         error,
@@ -129,7 +131,7 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
       dispatch,
       refetch,
     }),
-    [clientState, items, totalItems, isLoading, isFetching, error, dispatch, refetch]
+    [clientState, items, totalItems, counts, isLoading, isFetching, error, dispatch, refetch]
   );
 
   return (

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Query } from '@elastic/eui';
 import { reducer, DEFAULT_SELECTION } from './state_reducer';
 import { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
 import type { ContentListClientState, ContentListAction } from './types';
@@ -56,8 +57,9 @@ describe('state_reducer', () => {
       expect(newState.sort).toEqual({ field: 'updatedAt', direction: 'desc' });
     });
 
-    it('preserves filters when setting sort', () => {
+    it('preserves filters and search when setting sort', () => {
       const initialState = createInitialState({
+        search: { queryText: 'my query' },
         filters: { search: 'test query' },
       });
       const action: ContentListAction = {
@@ -68,6 +70,7 @@ describe('state_reducer', () => {
       const newState = reducer(initialState, action);
 
       expect(newState.filters).toEqual({ search: 'test query' });
+      expect(newState.search.queryText).toBe('my query');
     });
 
     it('clears selection when sort changes', () => {
@@ -443,6 +446,312 @@ describe('state_reducer', () => {
 
       expect(newState.page.index).toBe(0);
       expect(newState.page.size).toBe(20);
+    });
+  });
+
+  describe('TOGGLE_FILTER', () => {
+    describe('include toggle (no modifier key)', () => {
+      it('adds a value to the include filter when not already included', () => {
+        const initialState = createInitialState();
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+      });
+
+      it('removes a value from the include filter when already included', () => {
+        const initialState = createInitialState({
+          filters: { tag: { include: ['tag-1'], exclude: [] } },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.tag).toBeUndefined();
+      });
+
+      it('moves a value from exclude to include', () => {
+        const initialState = createInitialState({
+          filters: { tag: { include: [], exclude: ['tag-1'] } },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+      });
+
+      it('works for non-tag filter dimensions', () => {
+        const initialState = createInitialState();
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'type',
+            valueId: 'dashboard',
+            valueName: 'Dashboard',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.type).toEqual({ include: ['dashboard'], exclude: [] });
+        expect(newState.filters.tag).toBeUndefined();
+      });
+    });
+
+    describe('exclude toggle (with modifier key)', () => {
+      it('adds a value to the exclude filter when not already excluded', () => {
+        const initialState = createInitialState();
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: true,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.tag).toEqual({ include: [], exclude: ['tag-1'] });
+      });
+
+      it('removes a value from the exclude filter when already excluded', () => {
+        const initialState = createInitialState({
+          filters: { tag: { include: [], exclude: ['tag-1'] } },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: true,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.tag).toBeUndefined();
+      });
+
+      it('moves a value from include to exclude', () => {
+        const initialState = createInitialState({
+          filters: { tag: { include: ['tag-1'], exclude: [] } },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: true,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.tag).toEqual({ include: [], exclude: ['tag-1'] });
+      });
+    });
+
+    describe('query text synchronization', () => {
+      it('adds value to query text when including', () => {
+        const initialState = createInitialState({ search: { queryText: 'my search' } });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.search.queryText).toContain('production');
+      });
+
+      it('removes value from query text when de-selecting', () => {
+        const afterAdd = reducer(createInitialState(), {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        });
+        expect(afterAdd.search.queryText).toContain('production');
+
+        const afterRemove = reducer(afterAdd, {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        });
+
+        expect(afterRemove.search.queryText).not.toContain('production');
+        expect(afterRemove.filters.tag).toBeUndefined();
+      });
+
+      it('parses existing queryText and appends new filter values', () => {
+        const initialState = createInitialState({
+          filters: { tag: { include: ['tag-1'], exclude: [] } },
+          search: { queryText: 'tag:production' },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-2',
+            valueName: 'staging',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.search.queryText).toContain('production');
+        expect(newState.search.queryText).toContain('staging');
+      });
+    });
+
+    describe('side effects', () => {
+      it('resets page index to 0', () => {
+        const initialState = createInitialState({ page: { index: 3, size: 20 } });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.page.index).toBe(0);
+        expect(newState.page.size).toBe(20);
+      });
+
+      it('clears selection', () => {
+        const initialState = createInitialState({
+          selection: { selectedIds: ['item-1', 'item-2'] },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.selection.selectedIds).toEqual([]);
+      });
+
+      it('preserves sort', () => {
+        const initialState = createInitialState({
+          sort: { field: 'title', direction: 'asc' },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+      });
+
+      it('preserves other filter dimensions', () => {
+        const initialState = createInitialState({
+          filters: { search: 'my query', type: { include: ['dashboard'], exclude: [] } },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.search).toBe('my query');
+        expect(newState.filters.type).toEqual({ include: ['dashboard'], exclude: [] });
+      });
+    });
+
+    describe('parse failure fallback', () => {
+      it('still updates filters and preserves query text on parse error', () => {
+        const parseSpy = jest.spyOn(Query, 'parse').mockImplementation(() => {
+          throw new Error('parse error');
+        });
+
+        const initialState = createInitialState({
+          search: { queryText: 'some query' },
+        });
+        const action: ContentListAction = {
+          type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
+          payload: {
+            filterId: 'tag',
+            valueId: 'tag-1',
+            valueName: 'production',
+            withModifierKey: false,
+          },
+        };
+
+        const newState = reducer(initialState, action);
+
+        expect(newState.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+        expect(newState.search.queryText).toBe('some query');
+
+        parseSpy.mockRestore();
+      });
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
@@ -7,8 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Query } from '@elastic/eui';
+import type { IncludeExcludeFilter, ActiveFilters } from '../datasource';
+import { getIncludeExcludeFilter } from '../datasource';
 import type { ContentListClientState, ContentListAction } from './types';
 import { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
+
+/** Returns `undefined` when both arrays are empty, matching the default empty-filter state. */
+const normalizeIncludeExclude = (
+  include: string[],
+  exclude: string[]
+): IncludeExcludeFilter | undefined =>
+  include.length === 0 && exclude.length === 0 ? undefined : { include, exclude };
 
 /**
  * Default selection state.
@@ -43,6 +53,63 @@ export const reducer = (
         page: { ...state.page, index: 0 },
         selection: { ...DEFAULT_SELECTION },
       };
+
+    case CONTENT_LIST_ACTIONS.TOGGLE_FILTER: {
+      const { filterId, valueId, valueName, withModifierKey } = action.payload;
+      const { filters, search } = state;
+      const existingFilter = getIncludeExcludeFilter(filters[filterId]);
+      const currentInclude = existingFilter?.include ?? [];
+      const currentExclude = existingFilter?.exclude ?? [];
+
+      let nextInclude: string[];
+      let nextExclude: string[];
+
+      if (withModifierKey) {
+        const isExcluded = currentExclude.includes(valueId);
+        nextInclude = currentInclude.filter((id) => id !== valueId);
+        nextExclude = isExcluded
+          ? currentExclude.filter((id) => id !== valueId)
+          : [...currentExclude, valueId];
+      } else {
+        const isIncluded = currentInclude.includes(valueId);
+        nextInclude = isIncluded
+          ? currentInclude.filter((id) => id !== valueId)
+          : [...currentInclude, valueId];
+        nextExclude = currentExclude.filter((id) => id !== valueId);
+      }
+
+      const nextFilterValue = normalizeIncludeExclude(nextInclude, nextExclude);
+      const { [filterId]: _, ...rest } = filters;
+      const nextFilters: ActiveFilters = nextFilterValue
+        ? { ...rest, [filterId]: nextFilterValue }
+        : rest;
+
+      let nextQueryText = search.queryText;
+      try {
+        let nextQuery = search.queryText ? Query.parse(search.queryText) : Query.parse('');
+        nextQuery = nextQuery.removeOrFieldValue(filterId, valueName);
+        if (withModifierKey) {
+          if (!currentExclude.includes(valueId)) {
+            nextQuery = nextQuery.addOrFieldValue(filterId, valueName, false, 'eq');
+          }
+        } else {
+          if (!currentInclude.includes(valueId)) {
+            nextQuery = nextQuery.addOrFieldValue(filterId, valueName, true, 'eq');
+          }
+        }
+        nextQueryText = nextQuery.text;
+      } catch {
+        // Preserve query text on parse failure; filters will still be correct.
+      }
+
+      return {
+        ...state,
+        filters: nextFilters,
+        search: { queryText: nextQueryText },
+        page: { ...state.page, index: 0 },
+        selection: { ...DEFAULT_SELECTION },
+      };
+    }
 
     case CONTENT_LIST_ACTIONS.CLEAR_FILTERS:
       return {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
@@ -19,6 +19,8 @@ export const CONTENT_LIST_ACTIONS = {
   SET_SEARCH: 'SET_SEARCH',
   /** Clear all filters and reset query text. */
   CLEAR_FILTERS: 'CLEAR_FILTERS',
+  /** Toggle a value's include/exclude state for any filter dimension, updating filters and query text atomically. */
+  TOGGLE_FILTER: 'TOGGLE_FILTER',
   /** Set sort field and direction. */
   SET_SORT: 'SET_SORT',
   /** Set page index. */
@@ -54,10 +56,10 @@ export interface ContentListClientState {
   /**
    * Parsed filter state used to drive data fetching.
    *
-   * Updated atomically with `search.queryText` via `SET_SEARCH`.
+   * Always updated atomically with `search.queryText` via `SET_SEARCH`.
    * When no tag service is configured, `filters.search` equals `search.queryText`.
    * When tag parsing is available, `filters.search` contains only the free-text
-   * portion and `filters.tags` holds the structured tag filters.
+   * portion and `filters.tag`, `filters.type`, etc. hold structured filters.
    */
   filters: ActiveFilters;
   /** Sort state. */
@@ -92,6 +94,10 @@ export interface ContentListQueryData {
   /** Total number of items matching the current query (for pagination). */
   totalItems: number;
   /**
+   * Per-filter counts from the full result set. See {@link FindItemsResult.counts}.
+   */
+  counts?: Record<string, Record<string, number>>;
+  /**
    * Whether the initial data load is in progress (no data available yet).
    *
    * This is `true` only on the first fetch before any data has been received.
@@ -121,7 +127,7 @@ export interface ContentListQueryData {
  */
 export type ContentListState = ContentListClientState & ContentListQueryData;
 
-/** Atomically update both the query text and the parsed filters. */
+/** Atomically update both the query text and parsed filters. */
 interface SetSearchAction {
   type: typeof CONTENT_LIST_ACTIONS.SET_SEARCH;
   payload: { queryText: string; filters: ActiveFilters };
@@ -130,6 +136,20 @@ interface SetSearchAction {
 /** Clear all filters and search text. */
 interface ClearFiltersAction {
   type: typeof CONTENT_LIST_ACTIONS.CLEAR_FILTERS;
+}
+
+/**
+ * Toggle a value's include/exclude state for any filter dimension.
+ *
+ * Regular call (`withModifierKey: false`): toggles `valueId` in the **include** list.
+ * Modifier call (`withModifierKey: true`): toggles `valueId` in the **exclude** list.
+ * In both cases the opposite list drops `valueId` if present.
+ * The reducer updates `filters` and `search.queryText` atomically
+ * using `valueName` as the EUI `Query` field value (the display label in query text).
+ */
+interface ToggleFilterAction {
+  type: typeof CONTENT_LIST_ACTIONS.TOGGLE_FILTER;
+  payload: { filterId: string; valueId: string; valueName: string; withModifierKey: boolean };
 }
 
 /** Set sort field and direction. */
@@ -146,6 +166,7 @@ interface SetSortAction {
 export type ContentListAction =
   | SetSearchAction
   | ClearFiltersAction
+  | ToggleFilterAction
   | SetSortAction
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_INDEX; payload: { index: number } }
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_SIZE; payload: { size: number } }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Dispatch } from 'react';
-import type { ActiveFilters } from '../datasource';
+import type { ActiveFilters, FilterCounts } from '../datasource';
 import type { ContentListItem } from '../item';
 
 /**
@@ -96,7 +96,7 @@ export interface ContentListQueryData {
   /**
    * Per-filter counts from the full result set. See {@link FindItemsResult.counts}.
    */
-  counts?: Record<string, Record<string, number>>;
+  counts?: Record<string, FilterCounts>;
   /**
    * Whether the initial data load is in progress (no data available yet).
    *

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.test.tsx
@@ -8,59 +8,169 @@
  */
 
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { ContentListProvider } from '../context';
 import type { ContentListProviderProps } from '../context';
-import type { FindItemsResult, FindItemsParams, DataSourceConfig } from '../datasource';
+import type { FindItemsResult, FindItemsParams } from '../datasource';
 import type { ContentListItem } from '../item';
 import { useContentListItems } from './use_content_list_items';
+import { useContentListSearch } from '../features/search/use_content_list_search';
 
-const mockItems: ContentListItem[] = [
+const sampleItems: ContentListItem[] = [
   { id: '1', title: 'Dashboard A', description: 'First dashboard' },
   { id: '2', title: 'Dashboard B', description: 'Second dashboard' },
-  { id: '3', title: 'Dashboard C' },
+  { id: '3', title: 'Dashboard C', tags: ['tag-1'] },
 ];
 
 describe('useContentListItems', () => {
-  const createMockFindItems = (
-    result: FindItemsResult = { items: mockItems, total: mockItems.length }
-  ) => jest.fn(async (_params: FindItemsParams): Promise<FindItemsResult> => result);
+  const mockFindItems = jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items: sampleItems,
+      total: sampleItems.length,
+    })
+  );
 
-  const createWrapper = (
-    dataSource: DataSourceConfig,
-    overrides?: Partial<ContentListProviderProps>
-  ) => {
+  const createWrapper = (props?: Partial<ContentListProviderProps>) => {
+    const defaultProps: ContentListProviderProps = {
+      id: 'test-list',
+      labels: { entity: 'item', entityPlural: 'items' },
+      dataSource: { findItems: mockFindItems },
+      children: null,
+      ...props,
+    };
+
     return ({ children }: { children: React.ReactNode }) => (
-      <ContentListProvider
-        id={overrides?.id ?? 'test-items'}
-        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
-        dataSource={dataSource}
-        {...overrides}
-      >
-        {children}
-      </ContentListProvider>
+      <ContentListProvider {...defaultProps}>{children}</ContentListProvider>
     );
   };
 
-  describe('successful fetch', () => {
-    it('returns items from the data source', async () => {
-      const findItems = createMockFindItems();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('error handling', () => {
+    it('throws when used outside provider', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useContentListItems());
+      }).toThrow(
+        'ContentListStateContext is missing. Ensure your component is wrapped with ContentListProvider.'
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('return shape', () => {
+    it('returns items, totalItems, isLoading, error, and refetch', () => {
       const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }),
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current).toHaveProperty('items');
+      expect(result.current).toHaveProperty('totalItems');
+      expect(result.current).toHaveProperty('isLoading');
+      expect(result.current).toHaveProperty('error');
+      expect(result.current).toHaveProperty('refetch');
+      expect(typeof result.current.refetch).toBe('function');
+    });
+  });
+
+  describe('data fetching', () => {
+    it('calls `findItems` on mount and returns the items', async () => {
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper(),
       });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      expect(result.current.items).toEqual(mockItems);
+      expect(mockFindItems).toHaveBeenCalled();
+      expect(result.current.items).toEqual(sampleItems);
       expect(result.current.totalItems).toBe(3);
     });
 
-    it('returns empty items when data source returns no results', async () => {
-      const findItems = createMockFindItems({ items: [], total: 0 });
+    it('passes default sort params to `findItems`', async () => {
       const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }, { id: 'empty-items' }),
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockFindItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort: { field: 'title', direction: 'asc' },
+        })
+      );
+    });
+
+    it('passes custom initial sort from features', async () => {
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({
+          features: {
+            sorting: { initialSort: { field: 'updatedAt', direction: 'desc' } },
+          },
+        }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockFindItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort: { field: 'updatedAt', direction: 'desc' },
+        })
+      );
+    });
+
+    it('omits sort when sorting is disabled', async () => {
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({ features: { sorting: false } }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockFindItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort: undefined,
+        })
+      );
+    });
+
+    it('passes initial search text to `findItems`', async () => {
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({
+          features: { search: { initialSearch: 'hello' } },
+        }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockFindItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchQuery: 'hello',
+          filters: expect.objectContaining({ search: 'hello' }),
+        })
+      );
+    });
+
+    it('returns empty items when `findItems` returns no results', async () => {
+      const emptyFindItems = jest.fn(async () => ({ items: [] as ContentListItem[], total: 0 }));
+
+      const { result } = renderHook(() => useContentListItems(), {
+        wrapper: createWrapper({
+          id: 'empty-list',
+          dataSource: { findItems: emptyFindItems },
+        }),
       });
 
       await waitFor(() => {
@@ -70,58 +180,42 @@ describe('useContentListItems', () => {
       expect(result.current.items).toEqual([]);
       expect(result.current.totalItems).toBe(0);
     });
-  });
 
-  describe('loading states', () => {
-    it('starts with isLoading true', () => {
-      const findItems = jest.fn(
-        () => new Promise<FindItemsResult>(() => {}) // Never resolves.
-      );
-      const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }, { id: 'loading-items' }),
-      });
-
-      expect(result.current.isLoading).toBe(true);
-      expect(result.current.isFetching).toBe(true);
-    });
-
-    it('sets isLoading to false after fetch completes', async () => {
-      const findItems = createMockFindItems();
-      const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }, { id: 'loaded-items' }),
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.isFetching).toBe(false);
-    });
-  });
-
-  describe('error handling', () => {
-    it('returns error when fetch fails with Error', async () => {
-      const findItems = jest.fn(async () => {
+    it('provides an error when `findItems` rejects', async () => {
+      const failingFindItems = jest.fn(async () => {
         throw new Error('Network failure');
       });
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
       const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }, { id: 'error-items' }),
+        wrapper: createWrapper({
+          id: 'error-list',
+          dataSource: { findItems: failingFindItems },
+        }),
       });
 
       await waitFor(() => {
         expect(result.current.error).toBeDefined();
       });
 
-      expect(result.current.error).toBeInstanceOf(Error);
       expect(result.current.error?.message).toBe('Network failure');
+
+      consoleSpy.mockRestore();
     });
 
-    it('normalizes non-Error thrown values to Error instances', async () => {
-      const findItems = jest.fn(async () => {
+    it('normalizes non-Error rejections into an `Error` instance', async () => {
+      const failingFindItems = jest.fn(async () => {
         throw 'string error'; // eslint-disable-line no-throw-literal
       });
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
       const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }, { id: 'string-error-items' }),
+        wrapper: createWrapper({
+          id: 'string-error-list',
+          dataSource: { findItems: failingFindItems },
+        }),
       });
 
       await waitFor(() => {
@@ -130,54 +224,50 @@ describe('useContentListItems', () => {
 
       expect(result.current.error).toBeInstanceOf(Error);
       expect(result.current.error?.message).toBe('string error');
-    });
 
-    it('returns no error on successful fetch', async () => {
-      const findItems = createMockFindItems();
-      const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }, { id: 'no-error-items' }),
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.error).toBeUndefined();
+      consoleSpy.mockRestore();
     });
   });
 
   describe('onFetchSuccess callback', () => {
-    it('calls onFetchSuccess after successful fetch', async () => {
-      const fetchResult = { items: mockItems, total: mockItems.length };
-      const findItems = createMockFindItems(fetchResult);
+    it('invokes `onFetchSuccess` after a successful fetch', async () => {
       const onFetchSuccess = jest.fn();
 
       const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems, onFetchSuccess }, { id: 'success-callback-items' }),
+        wrapper: createWrapper({
+          dataSource: { findItems: mockFindItems, onFetchSuccess },
+        }),
       });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      expect(onFetchSuccess).toHaveBeenCalledWith(fetchResult);
+      expect(onFetchSuccess).toHaveBeenCalledWith({
+        items: sampleItems,
+        total: sampleItems.length,
+      });
     });
 
-    it('logs warning when onFetchSuccess throws', async () => {
+    it('logs a warning if `onFetchSuccess` throws, without breaking the query', async () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      const findItems = createMockFindItems();
       const onFetchSuccess = jest.fn(() => {
         throw new Error('callback error');
       });
 
       const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems, onFetchSuccess }, { id: 'callback-error-items' }),
+        wrapper: createWrapper({
+          dataSource: { findItems: mockFindItems, onFetchSuccess },
+        }),
       });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
       });
 
+      // The query should still succeed despite the callback error.
+      expect(result.current.items).toEqual(sampleItems);
+      expect(result.current.error).toBeUndefined();
       expect(consoleSpy).toHaveBeenCalledWith(
         '[ContentListProvider] onFetchSuccess callback error:',
         expect.any(Error)
@@ -187,18 +277,90 @@ describe('useContentListItems', () => {
     });
   });
 
+  describe('filter integration', () => {
+    it('re-fetches when tag filters are updated via `setSearch`', async () => {
+      const { result } = renderHook(
+        () => ({
+          items: useContentListItems(),
+          search: useContentListSearch(),
+        }),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(() => {
+        expect(result.current.items.isLoading).toBe(false);
+      });
+
+      mockFindItems.mockClear();
+
+      act(() => {
+        result.current.search.setSearch('tag:production', {
+          search: undefined,
+          tag: { include: ['production'] },
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockFindItems).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filters: expect.objectContaining({
+              tag: { include: ['production'] },
+            }),
+          })
+        );
+      });
+    });
+  });
+
+  describe('search integration', () => {
+    it('re-fetches when search is updated via `setSearch`', async () => {
+      const { result } = renderHook(
+        () => ({
+          items: useContentListItems(),
+          search: useContentListSearch(),
+        }),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(() => {
+        expect(result.current.items.isLoading).toBe(false);
+      });
+
+      mockFindItems.mockClear();
+
+      act(() => {
+        result.current.search.setSearch('my query', { search: 'my query' });
+      });
+
+      await waitFor(() => {
+        expect(mockFindItems).toHaveBeenCalledWith(
+          expect.objectContaining({
+            searchQuery: 'my query',
+          })
+        );
+      });
+    });
+  });
+
   describe('refetch', () => {
-    it('provides a refetch function', async () => {
-      const findItems = createMockFindItems();
+    it('can manually trigger a refetch', async () => {
       const { result } = renderHook(() => useContentListItems(), {
-        wrapper: createWrapper({ findItems }, { id: 'refetch-items' }),
+        wrapper: createWrapper(),
       });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      expect(result.current.refetch).toBeInstanceOf(Function);
+      const callCount = mockFindItems.mock.calls.length;
+
+      await act(async () => {
+        result.current.refetch();
+      });
+
+      await waitFor(() => {
+        expect(mockFindItems.mock.calls.length).toBeGreaterThan(callCount);
+      });
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.ts
@@ -39,6 +39,7 @@ export const useContentListItems = () => {
   return {
     items: state.items,
     totalItems: state.totalItems,
+    counts: state.counts,
     isLoading: state.isLoading,
     isFetching: state.isFetching,
     error: state.error,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_state.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_state.test.tsx
@@ -50,25 +50,32 @@ describe('useContentListState', () => {
     consoleSpy.mockRestore();
   });
 
-  it('returns state, dispatch, and refetch', () => {
+  it('returns state, dispatch, and refetch when inside provider', () => {
     const { result } = renderHook(() => useContentListState(), {
       wrapper: createWrapper(),
     });
 
-    expect(result.current.state).toBeDefined();
-    expect(result.current.dispatch).toBeInstanceOf(Function);
-    expect(result.current.refetch).toBeInstanceOf(Function);
+    expect(result.current).toHaveProperty('state');
+    expect(result.current).toHaveProperty('dispatch');
+    expect(result.current).toHaveProperty('refetch');
   });
 
-  it('provides state with expected shape', () => {
+  it('returns state with the expected shape', () => {
     const { result } = renderHook(() => useContentListState(), {
       wrapper: createWrapper(),
     });
 
     const { state } = result.current;
+
+    // Client state.
     expect(state).toHaveProperty('search');
+    expect(state.search).toHaveProperty('queryText');
     expect(state).toHaveProperty('filters');
     expect(state).toHaveProperty('sort');
+    expect(state.sort).toHaveProperty('field');
+    expect(state.sort).toHaveProperty('direction');
+
+    // Query data.
     expect(state).toHaveProperty('items');
     expect(state).toHaveProperty('totalItems');
     expect(state).toHaveProperty('isLoading');
@@ -89,5 +96,21 @@ describe('useContentListState', () => {
 
     expect(result.current.state.search.queryText).toBe('test query');
     expect(result.current.state.filters).toEqual({ search: 'test query' });
+  });
+
+  it('provides dispatch as a function', () => {
+    const { result } = renderHook(() => useContentListState(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(typeof result.current.dispatch).toBe('function');
+  });
+
+  it('provides refetch as a function', () => {
+    const { result } = renderHook(() => useContentListState(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(typeof result.current.refetch).toBe('function');
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/stories/content_list_provider.stories.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   EuiPanel,
@@ -22,18 +22,34 @@ import {
   EuiIcon,
   EuiCallOut,
 } from '@elastic/eui';
-import { MOCK_DASHBOARDS, createMockFindItems } from '@kbn/content-list-mock-data/storybook';
+import {
+  MOCK_DASHBOARDS,
+  MOCK_TAGS,
+  createMockFindItems,
+  extractTagIds,
+  mockTagsService,
+} from '@kbn/content-list-mock-data/storybook';
+import { TagBadge, TagListComponent } from '@kbn/content-management-tags';
+import type { Tag } from '@kbn/content-management-tags';
 import { ContentListProvider, useContentListConfig } from '../context';
+import type { ContentListServices } from '../context';
 import { useContentListItems } from '../state';
 import { useContentListSort } from '../features/sorting';
 import { useContentListPagination } from '../features/pagination';
+import { useContentListFilters, useTagFilterToggle } from '../features/filtering';
 import type { FindItemsParams, FindItemsResult } from '../datasource';
+import { getIncludeExcludeFilter } from '../datasource';
+
+// =============================================================================
+// Story Args
+// =============================================================================
 
 interface StoryArgs {
   entityName: string;
   entityNamePlural: string;
-  enableSorting: boolean;
-  enablePagination: boolean;
+  hasSorting: boolean;
+  hasPagination: boolean;
+  hasTags: boolean;
   initialSortField: 'title' | 'updatedAt';
   initialSortDirection: 'asc' | 'desc';
   numberOfItems: number;
@@ -41,30 +57,120 @@ interface StoryArgs {
 }
 
 /**
- * Demo component that displays the config context.
+ * Demo component that displays the config context and active filters.
  */
 const ConfigDisplay = () => {
   const config = useContentListConfig();
+  const { filters } = useContentListFilters();
 
   return (
-    <EuiPanel hasBorder paddingSize="s">
-      <EuiText size="xs">
-        <strong>Config Context:</strong>
-        <pre style={{ fontSize: '11px', margin: '8px 0 0' }}>
-          {JSON.stringify(
-            {
-              id: config.id,
-              labels: config.labels,
-              queryKeyScope: config.queryKeyScope,
-              features: config.features,
-              supports: config.supports,
-            },
-            null,
-            2
-          )}
-        </pre>
-      </EuiText>
-    </EuiPanel>
+    <EuiFlexGroup gutterSize="s">
+      <EuiFlexItem>
+        <EuiPanel hasBorder paddingSize="s">
+          <EuiText size="xs">
+            <strong>Config Context:</strong>
+            <pre style={{ fontSize: '11px', margin: '8px 0 0' }}>
+              {JSON.stringify(
+                {
+                  id: config.id,
+                  labels: config.labels,
+                  queryKeyScope: config.queryKeyScope,
+                  features: config.features,
+                  supports: config.supports,
+                },
+                null,
+                2
+              )}
+            </pre>
+          </EuiText>
+        </EuiPanel>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false} style={{ minWidth: 250 }}>
+        <EuiPanel hasBorder paddingSize="s">
+          <EuiText size="xs">
+            <strong>Active Filters:</strong>
+            <pre style={{ fontSize: '11px', margin: '8px 0 0' }}>
+              {JSON.stringify(filters, null, 2)}
+            </pre>
+          </EuiText>
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+/**
+ * Lookup map from tag ID to {@link Tag} object for resolving tag badges.
+ */
+const TAG_MAP = new Map<string, Tag>(MOCK_TAGS.filter((t) => t.id).map((t) => [t.id!, t]));
+
+/**
+ * Resolves an array of tag IDs to their {@link Tag} objects.
+ */
+const resolveTagObjects = (tagIds?: string[]): Tag[] =>
+  tagIds?.reduce<Tag[]>((acc, id) => {
+    const tag = TAG_MAP.get(id);
+    if (tag) {
+      acc.push(tag);
+    }
+    return acc;
+  }, []) ?? [];
+
+/**
+ * Demo component for filtering by tags using `useTagFilterToggle`.
+ *
+ * Renders clickable tag badges that toggle include filters. Active tags
+ * are visually distinguished. A clear button resets all filters.
+ */
+const TagControls = () => {
+  const { supports } = useContentListConfig();
+  const { filters, clearFilters } = useContentListFilters();
+  const toggleTag = useTagFilterToggle();
+
+  if (!supports.tags) {
+    return (
+      <EuiCallOut announceOnMount size="s" color="warning">
+        Tags are disabled
+      </EuiCallOut>
+    );
+  }
+
+  const activeIncludes = new Set(getIncludeExcludeFilter(filters.tag)?.include ?? []);
+
+  const handleTagClick = (tag: Tag) => {
+    if (!tag.id) {
+      return;
+    }
+    toggleTag(tag.id, tag.name, false);
+  };
+
+  return (
+    <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
+      <EuiFlexItem grow={false}>
+        <EuiIcon type="tag" aria-label="Tags" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="s">Filter by tag:</EuiText>
+      </EuiFlexItem>
+      {MOCK_TAGS.filter((t) => !t.managed && t.id).map((tag) => (
+        <EuiFlexItem key={tag.id} grow={false}>
+          <TagBadge
+            tag={{
+              ...tag,
+              color: activeIncludes.has(tag.id as string) ? tag.color : '#D3DAE6',
+            }}
+            onClick={() => handleTagClick(tag)}
+          />
+        </EuiFlexItem>
+      ))}
+      {activeIncludes.size > 0 && (
+        <EuiFlexItem grow={false}>
+          <EuiButton size="s" iconType="cross" onClick={clearFilters}>
+            Clear
+          </EuiButton>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
   );
 };
 
@@ -73,7 +179,18 @@ const ConfigDisplay = () => {
  */
 const ItemsList = () => {
   const { items, totalItems, refetch } = useContentListItems();
+  const { supports } = useContentListConfig();
+  const toggleTag = useTagFilterToggle();
   const pagination = useContentListPagination();
+
+  const handleTagClick = useCallback(
+    (tag: Tag, withModifierKey: boolean) => {
+      if (tag.id) {
+        toggleTag(tag.id, tag.name, withModifierKey);
+      }
+    },
+    [toggleTag]
+  );
 
   return (
     <div>
@@ -135,6 +252,17 @@ const ItemsList = () => {
         columns={[
           { field: 'title', name: 'Title', render: (title: string) => <strong>{title}</strong> },
           { field: 'description', name: 'Description' },
+          ...(supports.tags
+            ? [
+                {
+                  field: 'tags' as const,
+                  name: 'Tags',
+                  render: (tagIds: string[] | undefined) => (
+                    <TagListComponent tags={resolveTagObjects(tagIds)} onClick={handleTagClick} />
+                  ),
+                },
+              ]
+            : []),
           {
             field: 'updatedAt',
             name: 'Updated',
@@ -198,8 +326,12 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     entityName: { control: 'text', description: 'Singular entity name' },
     entityNamePlural: { control: 'text', description: 'Plural entity name' },
-    enableSorting: { control: 'boolean', description: 'Enable sorting feature' },
-    enablePagination: { control: 'boolean', description: 'Enable pagination feature' },
+    hasSorting: { control: 'boolean', description: 'Enable sorting feature.' },
+    hasPagination: { control: 'boolean', description: 'Enable pagination feature.' },
+    hasTags: {
+      control: 'boolean',
+      description: 'Enable tag filtering. Provides a mock tags service with 8 tags.',
+    },
     initialSortField: {
       control: 'select',
       options: ['title', 'updatedAt'],
@@ -232,7 +364,6 @@ const ProviderStory = ({ args }: { args: StoryArgs }) => {
     [args.entityName, args.entityNamePlural]
   );
 
-  // Memoize dataSource to maintain stable reference.
   const dataSource = useMemo(() => {
     const mockFindItems = createMockFindItems({
       items: MOCK_DASHBOARDS.slice(0, args.numberOfItems),
@@ -241,7 +372,7 @@ const ProviderStory = ({ args }: { args: StoryArgs }) => {
     const findItems = async (params: FindItemsParams): Promise<FindItemsResult> => {
       const result = await mockFindItems({
         searchQuery: params.searchQuery,
-        filters: {},
+        filters: params.filters,
         sort: params.sort ?? { field: 'title', direction: 'asc' },
         page: params.page,
       });
@@ -252,29 +383,41 @@ const ProviderStory = ({ args }: { args: StoryArgs }) => {
           description: item.attributes.description,
           type: item.type,
           updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
+          tags: extractTagIds(item.references),
         })),
         total: result.total,
+        counts: result.counts,
       };
     };
 
     return { findItems };
   }, [args.numberOfItems]);
 
-  // Memoize features to maintain stable reference.
   const features = useMemo(
     () => ({
-      sorting: args.enableSorting
+      sorting: args.hasSorting
         ? {
             initialSort: { field: args.initialSortField, direction: args.initialSortDirection },
           }
         : (false as const),
-      pagination: args.enablePagination ? { initialPageSize: 5 } : (false as const),
+      pagination: args.hasPagination ? { initialPageSize: 5 } : (false as const),
+      tags: args.hasTags,
     }),
-    [args.enableSorting, args.enablePagination, args.initialSortField, args.initialSortDirection]
+    [
+      args.hasSorting,
+      args.hasPagination,
+      args.hasTags,
+      args.initialSortField,
+      args.initialSortDirection,
+    ]
   );
 
-  // Key forces re-mount when configuration changes.
-  const key = `${args.enableSorting}-${args.enablePagination}-${args.initialSortField}-${args.initialSortDirection}-${args.numberOfItems}`;
+  const services: ContentListServices | undefined = useMemo(
+    () => (args.hasTags ? { tags: mockTagsService } : undefined),
+    [args.hasTags]
+  );
+
+  const key = `${args.hasSorting}-${args.hasPagination}-${args.hasTags}-${args.initialSortField}-${args.initialSortDirection}-${args.numberOfItems}`;
 
   return (
     <ContentListProvider
@@ -283,6 +426,7 @@ const ProviderStory = ({ args }: { args: StoryArgs }) => {
       labels={labels}
       dataSource={dataSource}
       features={features}
+      services={services}
     >
       {args.showConfig && (
         <>
@@ -291,6 +435,8 @@ const ProviderStory = ({ args }: { args: StoryArgs }) => {
         </>
       )}
       <SortControls />
+      <EuiSpacer size="s" />
+      <TagControls />
       <EuiSpacer size="m" />
       <ItemsList />
     </ContentListProvider>
@@ -301,8 +447,9 @@ export const Provider: Story = {
   args: {
     entityName: 'dashboard',
     entityNamePlural: 'dashboards',
-    enableSorting: true,
-    enablePagination: true,
+    hasSorting: true,
+    hasPagination: true,
+    hasTags: true,
     initialSortField: 'title',
     initialSortDirection: 'asc',
     numberOfItems: 8,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/tsconfig.json
@@ -13,6 +13,7 @@
   "kbn_references": [
     "@kbn/react-query",
     "@kbn/content-list-mock-data",
-    "@kbn/i18n"
+    "@kbn/i18n",
+    "@kbn/content-management-tags"
   ]
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
@@ -23,7 +23,14 @@ export {
 } from './src/content_list_table';
 
 // Column components.
-export { NameColumn, NameCell, type NameColumnProps, type NameCellProps } from './src/column';
+export {
+  NameColumn,
+  NameCell,
+  NameCellTags,
+  type NameColumnProps,
+  type NameCellProps,
+  type NameCellTagsProps,
+} from './src/column';
 export {
   ActionsColumn,
   type ActionsColumnProps,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
@@ -21,6 +21,7 @@ dependsOn:
   - '@kbn/content-list-assembly'
   - '@kbn/content-list-provider'
   - '@kbn/content-list-mock-data'
+  - '@kbn/content-management-tags'
   - '@kbn/i18n'
   - '@kbn/i18n-react'
   - '@kbn/content-list-toolbar'

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
@@ -21,7 +21,7 @@ const defaultContext: ActionBuilderContext = {
   },
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true, selection: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true, tags: false },
   actions: { onDelete },
 };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
@@ -17,7 +17,7 @@ const defaultContext: ActionBuilderContext = {
   },
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true, selection: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true, tags: false },
 };
 
 describe('edit action builder', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
@@ -26,7 +26,7 @@ const defaultContext: ColumnBuilderContext = {
   },
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true, selection: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true, tags: false },
 };
 
 describe('actions column builder', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/index.ts
@@ -9,7 +9,14 @@
 
 // Declarative components and props.
 export { Column, type ColumnProps } from './part';
-export { NameColumn, type NameColumnProps, NameCell, type NameCellProps } from './name';
+export {
+  NameColumn,
+  type NameColumnProps,
+  NameCell,
+  type NameCellProps,
+  NameCellTags,
+  type NameCellTagsProps,
+} from './name';
 export { ActionsColumn, type ActionsColumnProps } from './actions';
 export {
   UpdatedAtColumn,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_tags.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_tags.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EuiProvider } from '@elastic/eui';
+import {
+  ContentListProvider,
+  useContentListFilters,
+  type FindItemsResult,
+  type FindItemsParams,
+} from '@kbn/content-list-provider';
+import type { ContentManagementTagsServices } from '@kbn/content-management-tags';
+import { NameCellTags } from './cell_tags';
+
+const mockFindItems = jest.fn(
+  async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+    items: [],
+    total: 0,
+  })
+);
+
+const mockTags = [
+  { id: 'tag-1', name: 'Production', description: '', color: '#FF0000', managed: false },
+  { id: 'tag-2', name: 'Development', description: '', color: '#00FF00', managed: false },
+  { id: 'tag-3', name: 'Staging', description: '', color: '#0000FF', managed: false },
+];
+
+const mockTagsService: ContentManagementTagsServices = {
+  getTagList: () => mockTags,
+};
+
+const FilterState = () => {
+  const { filters } = useContentListFilters();
+  return <pre data-test-subj="filter-state">{JSON.stringify(filters)}</pre>;
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <EuiProvider>
+    <ContentListProvider
+      id="test-list"
+      labels={{ entity: 'item', entityPlural: 'items' }}
+      dataSource={{ findItems: mockFindItems }}
+      services={{ tags: mockTagsService }}
+    >
+      <FilterState />
+      {children}
+    </ContentListProvider>
+  </EuiProvider>
+);
+
+describe('NameCellTags', () => {
+  it('renders nothing when `tagIds` is empty', () => {
+    const { container } = render(
+      <Wrapper>
+        <NameCellTags tagIds={[]} />
+      </Wrapper>
+    );
+
+    expect(container.querySelector('[data-test-subj^="tag-"]')).not.toBeInTheDocument();
+  });
+
+  it('renders tag badges for given IDs', () => {
+    render(
+      <Wrapper>
+        <NameCellTags tagIds={['tag-1', 'tag-2']} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('tag-tag-1')).toBeInTheDocument();
+    expect(screen.getByTestId('tag-tag-2')).toBeInTheDocument();
+    expect(screen.getByText('Production')).toBeInTheDocument();
+    expect(screen.getByText('Development')).toBeInTheDocument();
+  });
+
+  it('adds an include filter on regular click', () => {
+    render(
+      <Wrapper>
+        <NameCellTags tagIds={['tag-1']} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByText('Production'));
+
+    const state = JSON.parse(screen.getByTestId('filter-state').textContent!);
+    expect(state.tag?.include).toContain('tag-1');
+  });
+
+  it('toggles off an include filter on second click', () => {
+    render(
+      <Wrapper>
+        <NameCellTags tagIds={['tag-1']} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByText('Production'));
+    fireEvent.click(screen.getByText('Production'));
+
+    const state = JSON.parse(screen.getByTestId('filter-state').textContent!);
+    expect(state.tag?.include ?? []).not.toContain('tag-1');
+  });
+
+  it('adds an exclude filter on modifier+click', () => {
+    render(
+      <Wrapper>
+        <NameCellTags tagIds={['tag-1']} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByText('Production'), { ctrlKey: true });
+
+    const state = JSON.parse(screen.getByTestId('filter-state').textContent!);
+    expect(state.tag?.exclude).toContain('tag-1');
+  });
+
+  it('toggles off an exclude filter on second modifier+click', () => {
+    render(
+      <Wrapper>
+        <NameCellTags tagIds={['tag-1']} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByText('Production'), { ctrlKey: true });
+    fireEvent.click(screen.getByText('Production'), { ctrlKey: true });
+
+    const state = JSON.parse(screen.getByTestId('filter-state').textContent!);
+    expect(state.tag?.exclude ?? []).not.toContain('tag-1');
+  });
+
+  it('calls custom `onTagClick` when provided', () => {
+    const handleClick = jest.fn();
+
+    render(
+      <Wrapper>
+        <NameCellTags tagIds={['tag-1']} onTagClick={handleClick} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByText('Production'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'tag-1', name: 'Production' }),
+      expect.any(Boolean)
+    );
+
+    const state = JSON.parse(screen.getByTestId('filter-state').textContent!);
+    expect(state.tag).toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_tags.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_tags.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { memo, useCallback } from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { TagList, type Tag } from '@kbn/content-management-tags';
+import { useTagFilterToggle } from '@kbn/content-list-provider';
+
+export interface NameCellTagsProps {
+  /** Tag IDs to render. */
+  tagIds: string[];
+  /**
+   * Optional override for the tag click handler.
+   * When omitted, the built-in handler toggles include/exclude
+   * filters via {@link useTagFilterToggle}.
+   */
+  onTagClick?: (tag: Tag, withModifierKey: boolean) => void;
+}
+
+/**
+ * Renders tag badges below the title/description in the name cell.
+ *
+ * Provides a built-in click handler that toggles tag filters on the
+ * content list state:
+ * - **Click**: toggles the tag as an include filter.
+ * - **Modifier+click** (Cmd on macOS, Ctrl on Windows/Linux): toggles
+ *   the tag as an exclude filter.
+ *
+ * Consumers can override this behavior via the `onTagClick` prop.
+ */
+export const NameCellTags = memo(function NameCellTags({ tagIds, onTagClick }: NameCellTagsProps) {
+  const toggleTag = useTagFilterToggle();
+
+  const handleTagClick = useCallback(
+    (tag: Tag, withModifierKey: boolean) => {
+      if (onTagClick) {
+        onTagClick(tag, withModifierKey);
+        return;
+      }
+
+      if (tag.id) {
+        toggleTag(tag.id, tag.name, withModifierKey);
+      }
+    },
+    [toggleTag, onTagClick]
+  );
+
+  if (tagIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiSpacer size="xs" />
+      <TagList tagIds={tagIds} onClick={handleTagClick} />
+    </>
+  );
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/index.ts
@@ -9,3 +9,4 @@
 
 export { NameColumn, buildNameColumn, type NameColumnProps } from './name_builder';
 export { NameCell, type NameCellProps } from './name_cell';
+export { NameCellTags, type NameCellTagsProps } from './cell_tags';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
@@ -20,7 +20,7 @@ const defaultContext: ColumnBuilderContext = {
   itemConfig: undefined,
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: false, selection: true },
+  supports: { sorting: true, pagination: true, search: false, selection: true, tags: false },
 };
 
 describe('name column builder', () => {
@@ -65,12 +65,7 @@ describe('name column builder', () => {
     it('forces sortable false when sorting is unsupported', () => {
       const context: ColumnBuilderContext = {
         ...defaultContext,
-        supports: {
-          sorting: false,
-          pagination: true,
-          search: false,
-          selection: true,
-        },
+        supports: { sorting: false, pagination: true, search: false, selection: true, tags: false },
       };
 
       const result = buildNameColumn({}, context);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.tsx
@@ -14,7 +14,7 @@ import { i18n } from '@kbn/i18n';
 import type { ContentListItem } from '@kbn/content-list-provider';
 import type { ColumnBuilderContext } from '../types';
 import { column } from '../part';
-import { NameCell } from './name_cell';
+import { NameCell, type NameCellProps } from './name_cell';
 
 /** Default i18n-translated column title for the name column. */
 const DEFAULT_NAME_COLUMN_TITLE = i18n.translate(
@@ -45,6 +45,21 @@ export interface NameColumnProps {
    * @default true
    */
   showDescription?: boolean;
+  /**
+   * Whether to show tags below the title/description.
+   * Requires `item.tags` to contain tag IDs and a tags service
+   * to be configured on the `ContentListProvider`.
+   *
+   * @default false
+   */
+  showTags?: boolean;
+  /**
+   * Optional click handler for tag badges.
+   * Called with the tag and a boolean indicating whether a modifier key
+   * (Cmd on Mac, Ctrl on Windows/Linux) was held during the click.
+   * Only effective when `showTags` is `true`.
+   */
+  onTagClick?: NameCellProps['onTagClick'];
   /** Custom render function (overrides default rendering). */
   render?: (item: ContentListItem) => ReactNode;
 }
@@ -65,6 +80,8 @@ export const buildNameColumn = (
     width,
     sortable: sortableProp,
     showDescription = true,
+    showTags = false,
+    onTagClick,
     render: customRender,
   } = attributes;
 
@@ -84,7 +101,7 @@ export const buildNameColumn = (
         return customRender(item);
       }
 
-      return <NameCell item={item} showDescription={showDescription} />;
+      return <NameCell {...{ item, showDescription, showTags, onTagClick }} />;
     },
   };
 };
@@ -111,6 +128,7 @@ export const buildNameColumn = (
  * <ContentListTable>
  *   <Column.Name
  *     showDescription={false}
+ *     showTags
  *     width="50%"
  *   />
  * </ContentListTable>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
@@ -13,6 +13,7 @@ import type { ContentListItem } from '@kbn/content-list-provider';
 
 import { NameCellTitle as Title } from './cell_title';
 import { NameCellDescription as Description } from './cell_description';
+import { NameCellTags as Tags, type NameCellTagsProps } from './cell_tags';
 
 export interface NameCellProps {
   item: ContentListItem;
@@ -22,22 +23,47 @@ export interface NameCellProps {
    * @default true
    */
   showDescription?: boolean;
+  /**
+   * Whether to show tags below the title/description.
+   * Requires `item.tags` to contain tag IDs and a tags service
+   * to be configured on the `ContentListProvider`.
+   *
+   * @default false
+   */
+  showTags?: boolean;
+  /**
+   * Optional click handler for tag badges.
+   * When omitted, the built-in handler in {@link NameCellTags} toggles
+   * include/exclude filters via `useContentListFilters`.
+   */
+  onTagClick?: NameCellTagsProps['onTagClick'];
 }
 
 /**
  * Default rich renderer for the name column that includes:
  * - Clickable title (with href or onClick).
- * - Description (if available and showDescription is true).
+ * - Description (if available and `showDescription` is true).
+ * - Tag badges (if available and `showTags` is true).
+ *
+ * When `showTags` is true, clicking a tag badge toggles a filter on the
+ * content list (include on click, exclude on modifier+click). Provide
+ * `onTagClick` to override this behavior.
  *
  * Memoized to prevent unnecessary re-renders when parent table re-renders.
  */
-export const NameCell = memo(({ item, showDescription = true }: NameCellProps) => {
-  return (
-    <div>
-      <Title item={item} />
-      {showDescription && <Description item={item} />}
-    </div>
-  );
-});
+export const NameCell = memo(
+  ({ item, showDescription = true, showTags = false, onTagClick }: NameCellProps) => {
+    const { tags: tagIds } = item;
+    const hasTags = showTags && tagIds && tagIds.length > 0;
+
+    return (
+      <div>
+        <Title item={item} />
+        {showDescription && <Description item={item} />}
+        {hasTags && <Tags tagIds={tagIds} onTagClick={onTagClick} />}
+      </div>
+    );
+  }
+);
 
 NameCell.displayName = 'NameCell';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
@@ -22,7 +22,7 @@ const defaultContext: ColumnBuilderContext = {
   itemConfig: undefined,
   isReadOnly: false,
   entityName: 'dashboard',
-  supports: { sorting: true, pagination: true, search: true, selection: true },
+  supports: { sorting: true, pagination: true, search: true, selection: true, tags: false },
 };
 
 describe('updated at column builder', () => {
@@ -67,12 +67,7 @@ describe('updated at column builder', () => {
     it('forces sortable false when sorting is unsupported', () => {
       const context: ColumnBuilderContext = {
         ...defaultContext,
-        supports: {
-          sorting: false,
-          pagination: true,
-          search: true,
-          selection: true,
-        },
+        supports: { sorting: false, pagination: true, search: true, selection: true, tags: false },
       };
 
       const result = buildUpdatedAtColumn({}, context);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
@@ -30,17 +30,24 @@ import {
   useContentListSort,
   useContentListSearch,
   useContentListPagination,
+  useContentListFilters,
   useContentListConfig,
   useContentListSelection,
 } from '@kbn/content-list-provider';
 import type {
   ContentListItem,
   ContentListItemConfig,
+  ContentListServices,
   FindItemsParams,
   FindItemsResult,
 } from '@kbn/content-list-provider';
 import { ContentListToolbar } from '@kbn/content-list-toolbar';
-import { MOCK_DASHBOARDS, createMockFindItems } from '@kbn/content-list-mock-data/storybook';
+import {
+  MOCK_DASHBOARDS,
+  createMockFindItems,
+  extractTagIds,
+  mockTagsService,
+} from '@kbn/content-list-mock-data/storybook';
 import { ContentListTable } from './content_list_table';
 
 // =============================================================================
@@ -75,16 +82,14 @@ const createStoryFindItems = (options?: {
       return { items: [], total: 0 };
     }
 
-    // Use mock findItems for sorting logic.
     const mockFindItems = createMockFindItems({ items: availableItems });
     const result = await mockFindItems({
       searchQuery: params.searchQuery,
-      filters: {},
+      filters: params.filters,
       sort: params.sort ?? { field: 'title', direction: 'asc' },
       page: params.page,
     });
 
-    // Transform to ContentListItem format.
     return {
       items: result.items.map((item) => ({
         id: item.id,
@@ -92,8 +97,10 @@ const createStoryFindItems = (options?: {
         description: item.attributes.description,
         type: item.type,
         updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
+        tags: extractTagIds(item.references),
       })),
       total: result.total,
+      counts: result.counts,
     };
   };
 };
@@ -189,6 +196,7 @@ const StateDiagnosticPanel = ({
   const { items, totalItems, isLoading, isFetching, error } = useContentListItems();
   const { field: sortField, direction: sortDirection } = useContentListSort();
   const { search } = useContentListSearch();
+  const { filters } = useContentListFilters();
   const pagination = useContentListPagination();
   const { selectedIds, selectedCount } = useContentListSelection();
   const config = useContentListConfig();
@@ -284,6 +292,14 @@ const StateDiagnosticPanel = ({
                   {JSON.stringify({ search, isFetching }, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
+              <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                <EuiTitle size="xxs">
+                  <h3>Filters</h3>
+                </EuiTitle>
+                <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                  {JSON.stringify(filters, null, 2)}
+                </EuiCodeBlock>
+              </EuiFlexItem>
               {pagination.isSupported && (
                 <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
                   <EuiTitle size="xxs">
@@ -372,9 +388,11 @@ interface PlaygroundArgs {
   isLoading: boolean;
   isReadOnly: boolean;
   hasPagination: boolean;
+  hasTags: boolean;
   compressed: boolean;
   tableLayout: 'auto' | 'fixed';
   showDescription: boolean;
+  showTags: boolean;
   showTypeColumn: boolean;
   showActions: boolean;
   showCustomActions: boolean;
@@ -469,7 +487,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
         compressed={args.compressed}
         tableLayout={args.tableLayout}
       >
-        <Column.Name showDescription={args.showDescription} />
+        <Column.Name showDescription={args.showDescription} showTags={args.showTags} />
         <Column.UpdatedAt />
         {args.showTypeColumn && (
           <Column
@@ -479,6 +497,32 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
             render={(item) => <EuiBadge color="hollow">{item.type ?? 'unknown'}</EuiBadge>}
           />
         )}
+        {args.showActions && (
+          <Column.Actions>
+            <Action.Edit />
+            {args.showCustomActions && (
+              <>
+                <Action
+                  id="share"
+                  name="Share"
+                  description="Share with team"
+                  icon="share"
+                  type="icon"
+                  onClick={handleShare}
+                />
+                <Action
+                  id="archive"
+                  name="Archive"
+                  description="Move to archive"
+                  icon="folderClosed"
+                  type="icon"
+                  onClick={handleArchive}
+                />
+              </>
+            )}
+            <Action.Delete />
+          </Column.Actions>
+        )}
       </ContentListTable>
     ),
     [
@@ -486,12 +530,22 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
       args.compressed,
       args.tableLayout,
       args.showDescription,
+      args.showTags,
       args.showTypeColumn,
+      args.showActions,
+      args.showCustomActions,
+      handleShare,
+      handleArchive,
     ]
   );
 
+  const services: ContentListServices | undefined = useMemo(
+    () => (args.hasTags ? { tags: mockTagsService } : undefined),
+    [args.hasTags]
+  );
+
   // Key forces re-mount when configuration changes.
-  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}-${args.hasPagination}-${args.showActions}-${args.showSelection}`;
+  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}-${args.hasPagination}-${args.hasTags}-${args.showActions}-${args.showSelection}`;
 
   return (
     <>
@@ -508,7 +562,9 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
           },
           pagination: args.hasPagination ? { initialPageSize: 10 } : (false as const),
           selection: args.showSelection,
+          tags: args.hasTags,
         }}
+        services={services}
       >
         <EuiPanel paddingSize="xl">
           <ContentListToolbar />
@@ -518,7 +574,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
             compressed={args.compressed}
             tableLayout={args.tableLayout}
           >
-            <Column.Name showDescription={args.showDescription} />
+            <Column.Name showDescription={args.showDescription} showTags={args.showTags} />
             <Column.UpdatedAt />
             {args.showTypeColumn && (
               <Column
@@ -579,12 +635,14 @@ export const Table: PlaygroundStory = {
     isLoading: false,
     isReadOnly: false,
     hasPagination: true,
+    hasTags: true,
     showTypeColumn: false,
     showActions: true,
     showCustomActions: false,
     showSelection: true,
     hasClickableRows: true,
     showDescription: true,
+    showTags: true,
     entityName: 'dashboard',
     entityNamePlural: 'dashboards',
     compressed: false,
@@ -622,6 +680,11 @@ export const Table: PlaygroundStory = {
       description: 'Enable pagination in provider config.',
       table: { category: 'Features' },
     },
+    hasTags: {
+      control: 'boolean',
+      description: 'Enable tag filtering. Provides a mock tags service.',
+      table: { category: 'Features' },
+    },
     compressed: {
       control: 'boolean',
       description: 'Use compact table style.',
@@ -637,6 +700,12 @@ export const Table: PlaygroundStory = {
       control: 'boolean',
       description: 'Show description in Name column.',
       table: { category: 'Columns' },
+    },
+    showTags: {
+      control: 'boolean',
+      description: 'Show tag badges in Name column. Clicking a tag toggles a filter.',
+      table: { category: 'Columns' },
+      if: { arg: 'hasTags' },
     },
     showTypeColumn: {
       control: 'boolean',

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
@@ -22,6 +22,7 @@
     "@kbn/content-list-assembly",
     "@kbn/content-list-provider",
     "@kbn/content-list-mock-data",
+    "@kbn/content-management-tags",
     "@kbn/i18n",
     "@kbn/i18n-react",
     "@kbn/content-list-toolbar",

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/README.md
@@ -24,10 +24,11 @@ Container for filter presets. Accepts children to control order; auto-renders de
 | Preset | Component | Status | Description |
 |--------|-----------|--------|-------------|
 | `sort` | `Filters.Sort` | Available | Sort dropdown populated from the provider's sorting config. |
+| `tags` | `Filters.Tags` | Available | Tag include/exclude popover. Requires `services.tags` on the provider. |
 
 #### Default filter order
 
-Use the `Filters` component with no children to control where in the Toolbar the default filters will appear.
+Use the `Filters` component with no children to control where in the toolbar the default filters appear.
 
 ```tsx
 const { Filters } = ContentListToolbar;
@@ -46,7 +47,225 @@ const { Filters } = ContentListToolbar;
 
 <ContentListToolbar>
   <Filters>
+    <Filters.Tags />
     <Filters.Sort />
   </Filters>
 </ContentListToolbar>
 ```
+
+---
+
+## Adding a new filter type
+
+Adding a filter involves two independent concerns:
+
+1. **Popover UI** — what appears when the user clicks the filter button.
+2. **Query parser** — how typed filter syntax (e.g. `createdBy:alice`) is extracted from the search bar and mapped to `ActiveFilters`.
+
+The two concerns are implemented separately and composed in the toolbar.
+
+---
+
+### Step 1 — Implement the popover renderer
+
+A filter renderer is a React component that renders the popover UI. Use `SelectableFilterPopover` from this package for include/exclude-style filters.
+
+```tsx
+// kbn-content-list-toolbar/src/filters/users/user_filter_renderer.tsx
+
+import React, { useMemo } from 'react';
+import { Query } from '@elastic/eui';
+import { SelectableFilterPopover, useFieldQueryFilter } from '@kbn/content-list-toolbar';
+import { useUserProfileService } from '@kbn/content-management-user-profiles';
+
+export const UserFilterRenderer = ({
+  query,
+  onChange,
+}: {
+  query?: Query;
+  onChange?: (query: Query) => void;
+}) => {
+  const userService = useUserProfileService();
+  const { selection, toggle, clearAll, activeCount } = useFieldQueryFilter({
+    fieldName: 'createdBy',
+    query,
+    onChange,
+  });
+
+  const options = useMemo(
+    () =>
+      (userService?.getUserList() ?? []).map((user) => ({
+        key: user.uid,
+        label: user.displayName,
+        value: user.username,
+      })),
+    [userService]
+  );
+
+  if (!userService) return null;
+
+  return (
+    <SelectableFilterPopover
+      title="Created by"
+      options={options}
+      selection={selection}
+      onToggle={toggle}
+      onClearAll={clearAll}
+      activeCount={activeCount}
+    />
+  );
+};
+```
+
+Then declare it as a `Filters` preset so consumers can include it declaratively:
+
+```ts
+// kbn-content-list-toolbar/src/filters/users/user_filter.ts
+
+import { filter } from '../part';
+import { UserFilterRenderer } from './user_filter_renderer';
+
+export const UserFilter = filter.createPreset({
+  name: 'users',
+  resolve: (_attributes, { hasUsers }) => {
+    if (!hasUsers) return undefined;
+    return { type: 'custom_component', component: UserFilterRenderer };
+  },
+});
+```
+
+Wire it into the auto-render defaults in `use_filters.ts` so it appears without any declarative configuration.
+
+---
+
+### Step 2 — Implement a `QueryParser`
+
+When a user types `createdBy:alice` directly into the search bar, the toolbar must extract that clause, resolve `alice` to a user ID, and merge it into `ActiveFilters.createdBy`. This is the job of a `QueryParser`.
+
+A `QueryParser` receives the raw `EuiSearchBar` query text (already cleaned by any preceding parsers in the chain) and returns:
+
+- `searchQuery` — the text with its field clauses removed (passed to the next parser and ultimately to `findItems`).
+- `filters` — a partial `ActiveFilters` object. Return an empty object `{}` when no clauses are found — this clears the filter dimension, which is correct since the search bar is the authoritative source of truth.
+
+```ts
+// kbn-content-list-toolbar/src/filters/users/use_user_query_parser.ts
+
+import { useMemo } from 'react';
+import { useUserProfileService } from '@kbn/content-management-user-profiles';
+import type { QueryParser, QueryParserResult } from '@kbn/content-list-toolbar';
+
+export const useUserQueryParser = (): QueryParser | null => {
+  const userService = useUserProfileService();
+
+  return useMemo((): QueryParser | null => {
+    if (!userService?.parseSearchQuery) return null;
+
+    const { parseSearchQuery } = userService;
+
+    return {
+      parse(queryText: string): QueryParserResult {
+        const { searchQuery, userIds } = parseSearchQuery(queryText);
+        return {
+          searchQuery,
+          filters: userIds?.length ? { createdBy: { include: userIds } } : {},
+        };
+      },
+    };
+  }, [userService]);
+};
+```
+
+> The `QueryParser` interface and `parseFiltersFromQuery` pipeline are exported from `@kbn/content-list-toolbar`. Import them to implement or test a parser outside this package.
+
+---
+
+### Step 3 — Register the parser in the toolbar
+
+Open [`content_list_toolbar.tsx`](src/content_list_toolbar.tsx) and add the new parser to the `queryParsers` array. This is the **only file that needs to change** when adding a new filter type.
+
+```ts
+// content_list_toolbar.tsx
+
+const tagParser = useTagQueryParser();
+const userParser = useUserQueryParser();          // ← add this
+
+const queryParsers = useMemo(
+  (): ReadonlyArray<QueryParser> =>
+    [tagParser, userParser].filter((p): p is QueryParser => p !== null),   // ← add userParser
+  [tagParser, userParser]
+);
+```
+
+Parsers run in the order listed. Each receives the cleaned text from the previous. Order matters when field names might overlap — but for disjoint field names, order is irrelevant.
+
+---
+
+### How the pipeline works
+
+`parseFiltersFromQuery(queryText, parsers)` reduces over the parsers array:
+
+```
+queryText = "my query tag:(Production) createdBy:alice"
+
+tag parser:
+  → extracts tag:(Production), resolves to tag-1
+  → searchQuery = "my query createdBy:alice"
+  → filters = { tag: { include: ['tag-1'] } }
+
+user parser:
+  → extracts createdBy:alice, resolves to uid-42
+  → searchQuery = "my query"
+  → filters = { createdBy: { include: ['uid-42'] } }
+
+result:
+  → setSearch(queryText, { search: 'my query', tag: { include: ['tag-1'] }, createdBy: { include: ['uid-42'] } })
+```
+
+Each parser only removes its own field syntax. The final `searchQuery` is sent to `findItems` as plain text.
+
+---
+
+### Testing a `QueryParser`
+
+`parseFiltersFromQuery` is a pure function — test it directly without React or a toolbar:
+
+```ts
+import { parseFiltersFromQuery } from '@kbn/content-list-toolbar';
+
+describe('useCreatedByQueryParser', () => {
+  it('extracts createdBy clauses and resolves to IDs', () => {
+    const parser = {
+      parse: (queryText: string) => {
+        // minimal inline implementation for the test
+        const match = queryText.match(/createdBy:(\S+)/);
+        return {
+          searchQuery: queryText.replace(/createdBy:\S+\s*/g, '').trim(),
+          filters: match ? { createdBy: { include: [`uid-${match[1]}`] } } : {},
+        };
+      },
+    };
+
+    const result = parseFiltersFromQuery('my query createdBy:alice', [parser]);
+
+    expect(result.searchQuery).toBe('my query');
+    expect(result.filters).toEqual({ createdBy: { include: ['uid-alice'] } });
+  });
+
+  it('clears createdBy filter when no clause is present', () => {
+    const parser = { parse: (q: string) => ({ searchQuery: q, filters: {} }) };
+    const result = parseFiltersFromQuery('plain search', [parser]);
+    expect(result.filters).toEqual({});
+  });
+});
+```
+
+---
+
+### Checklist for a new filter
+
+- [ ] Renderer component using `SelectableFilterPopover` + `useFieldQueryFilter`.
+- [ ] Preset declared with `filter.createPreset` and wired into the auto-render defaults.
+- [ ] `useXxxQueryParser` hook implementing `QueryParser`, calling the service's own `parseSearchQuery`.
+- [ ] Parser added to the `queryParsers` array in `content_list_toolbar.tsx`.
+- [ ] `filterDisplay` flag (`hasUsers`, `hasStarred`, etc.) added to `useFilterDisplay`.
+- [ ] `findItems` updated in the consumer (or mock datasource) to act on the new filter dimension.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
@@ -17,7 +17,37 @@
 export { ContentListToolbar, type ContentListToolbarProps } from './src/content_list_toolbar';
 
 // Filter declarative components for direct imports.
-export { Filters, SortFilter, type FiltersProps, type SortFilterProps } from './src/filters';
+export {
+  Filters,
+  SortFilter,
+  TagFilter,
+  type FiltersProps,
+  type SortFilterProps,
+  type TagFilterProps,
+} from './src/filters';
 
 // Selection bar component for direct imports.
 export { SelectionBar, type SelectionBarProps } from './src/selection_bar';
+
+// Reusable filter popover components.
+export {
+  FilterPopover,
+  FilterPopoverHeader,
+  SelectableFilterPopover,
+  StandardFilterOption,
+  useFilterPopover,
+  type FilterPopoverProps,
+  type FilterPopoverHeaderProps,
+  type SelectableFilterPopoverProps,
+  type SelectableFilterOption,
+} from './src/filters';
+
+// Filter utilities.
+export {
+  useFieldQueryFilter,
+  isExcludeModifier,
+  getCheckedState,
+  ModifierKeyTip,
+  FilterCountBadge,
+  type FilterType,
+} from './src/filters';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
@@ -51,3 +51,11 @@ export {
   FilterCountBadge,
   type FilterType,
 } from './src/filters';
+
+// Query parser pipeline — implement `QueryParser` to add a new filter type.
+export {
+  parseFiltersFromQuery,
+  useTagQueryParser,
+  type QueryParser,
+  type QueryParserResult,
+} from './src/filters';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/moon.yml
@@ -21,7 +21,9 @@ dependsOn:
   - '@kbn/content-list-assembly'
   - '@kbn/content-list-provider'
   - '@kbn/content-list-mock-data'
+  - '@kbn/content-management-tags'
   - '@kbn/i18n'
+  - '@kbn/shared-ux-utility'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
@@ -27,10 +27,20 @@ import {
   useContentListSort,
   useContentListSearch,
   useContentListPagination,
+  useContentListFilters,
   useContentListConfig,
 } from '@kbn/content-list-provider';
-import type { FindItemsParams, FindItemsResult } from '@kbn/content-list-provider';
-import { MOCK_DASHBOARDS, createMockFindItems } from '@kbn/content-list-mock-data/storybook';
+import type {
+  FindItemsParams,
+  FindItemsResult,
+  ContentListServices,
+} from '@kbn/content-list-provider';
+import {
+  MOCK_DASHBOARDS,
+  createMockFindItems,
+  extractTagIds,
+  mockTagsService,
+} from '@kbn/content-list-mock-data/storybook';
 import { ContentListToolbar } from './content_list_toolbar';
 
 // =============================================================================
@@ -40,29 +50,24 @@ import { ContentListToolbar } from './content_list_toolbar';
 /**
  * Creates a mock `findItems` function with configurable behavior.
  *
- * Supports:
- * - Sorting (locale-aware for strings).
- * - Configurable delay for loading states.
+ * Supports sorting, search, tag filtering, and configurable delay.
  */
 const createStoryFindItems = (options?: { delay?: number }) => {
   const { delay = 0 } = options ?? {};
 
   return async (params: FindItemsParams): Promise<FindItemsResult> => {
-    // Simulate network delay.
     if (delay > 0) {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
-    // Use mock findItems for sorting logic.
     const mockFindItems = createMockFindItems({ items: MOCK_DASHBOARDS });
     const result = await mockFindItems({
       searchQuery: params.searchQuery,
-      filters: {},
+      filters: params.filters,
       sort: params.sort ?? { field: 'title', direction: 'asc' },
       page: params.page,
     });
 
-    // Transform to ContentListItem format.
     return {
       items: result.items.map((item) => ({
         id: item.id,
@@ -70,8 +75,10 @@ const createStoryFindItems = (options?: { delay?: number }) => {
         description: item.attributes.description,
         type: item.type,
         updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
+        tags: extractTagIds(item.references),
       })),
       total: result.total,
+      counts: result.counts,
     };
   };
 };
@@ -98,14 +105,15 @@ const StateDiagnosticPanel = ({
   const { items, totalItems, isLoading, isFetching } = useContentListItems();
   const { field: sortField, direction: sortDirection } = useContentListSort();
   const { search } = useContentListSearch();
+  const { filters } = useContentListFilters();
   const pagination = useContentListPagination();
   const config = useContentListConfig();
 
-  // Generate JSX code based on current configuration.
   const toolbarJsx = useMemo(() => {
     if (useDeclarativeConfig) {
       return `<ContentListToolbar>
   <ContentListToolbar.Filters>
+    <ContentListToolbar.Filters.Tags />
     <ContentListToolbar.Filters.Sort />
   </ContentListToolbar.Filters>
 </ContentListToolbar>`;
@@ -178,6 +186,14 @@ const StateDiagnosticPanel = ({
                 </EuiTitle>
                 <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
                   {JSON.stringify({ search, isFetching }, null, 2)}
+                </EuiCodeBlock>
+              </EuiFlexItem>
+              <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                <EuiTitle size="xxs">
+                  <h3>Filters</h3>
+                </EuiTitle>
+                <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                  {JSON.stringify(filters, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
               {pagination.isSupported && (
@@ -266,6 +282,7 @@ interface PlaygroundArgs {
   searchPlaceholder: string;
   hasSorting: boolean;
   hasPagination: boolean;
+  hasTags: boolean;
   useDeclarativeConfig: boolean;
   showDiagnostics: boolean;
 }
@@ -304,14 +321,18 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
           }
         : (false as const),
       pagination: args.hasPagination ? { initialPageSize: 10 } : (false as const),
+      tags: args.hasTags,
     }),
-    [args.hasSorting, args.hasPagination]
+    [args.hasSorting, args.hasPagination, args.hasTags]
   );
 
-  // Key forces re-mount when configuration changes.
-  const key = `${args.hasSorting}-${args.hasPagination}-${args.useDeclarativeConfig}`;
+  const services: ContentListServices | undefined = useMemo(
+    () => (args.hasTags ? { tags: mockTagsService } : undefined),
+    [args.hasTags]
+  );
 
-  // Destructure Filters from ContentListToolbar for compound component usage.
+  const key = `${args.hasSorting}-${args.hasPagination}-${args.hasTags}-${args.useDeclarativeConfig}`;
+
   const { Filters } = ContentListToolbar;
 
   return (
@@ -321,6 +342,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
       labels={labels}
       dataSource={dataSource}
       features={features}
+      services={services}
     >
       <EuiTitle size="s">
         <h2>ContentListToolbar</h2>
@@ -344,6 +366,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
           <EuiSpacer size="m" />
           <ContentListToolbar>
             <Filters>
+              <Filters.Tags />
               <Filters.Sort />
             </Filters>
           </ContentListToolbar>
@@ -386,6 +409,7 @@ export const Toolbar: PlaygroundStory = {
     useDeclarativeConfig: false,
     hasSorting: true,
     hasPagination: true,
+    hasTags: true,
     showDiagnostics: true,
     entityName: 'dashboard',
     entityNamePlural: 'dashboards',
@@ -420,6 +444,11 @@ export const Toolbar: PlaygroundStory = {
     hasPagination: {
       control: 'boolean',
       description: 'Enable pagination in provider config.',
+      table: { category: 'Features' },
+    },
+    hasTags: {
+      control: 'boolean',
+      description: 'Enable tag filtering. Provides a mock tags service with 8 tags.',
       table: { category: 'Features' },
     },
     showDiagnostics: {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.test.tsx
@@ -28,21 +28,28 @@ const mockFindItems = jest.fn(
 const mockTags = [
   { id: 'tag-1', name: 'Production', description: '', color: '#FF0000', managed: false },
   { id: 'tag-2', name: 'Development', description: '', color: '#00FF00', managed: false },
+  { id: 'tag-3', name: 'New World', description: '', color: '#0000FF', managed: false },
 ];
 
 const mockParseSearchQuery = jest.fn((queryText: string) => {
-  // Simple mock: extract `tag:Name` patterns and return the rest as `searchQuery`.
-  const tagPattern = /tag:(\S+)/g;
-  const tagNames: string[] = [];
+  // Simple mock: extract `tag:Name` and `tag:"Multi Word"` patterns, resolve names
+  // to IDs via `mockTags`, and return the remaining text as `searchQuery`.
+  // This mirrors the real `parseSearchQueryCore` which resolves names to IDs.
+  const tagPattern = /tag:(?:"([^"]+)"|(\S+))/g;
+  const resolvedIds: string[] = [];
   let match = tagPattern.exec(queryText);
   while (match) {
-    tagNames.push(match[1]);
+    const name = match[1] ?? match[2];
+    const tag = mockTags.find((t) => t.name === name);
+    if (tag) {
+      resolvedIds.push(tag.id);
+    }
     match = tagPattern.exec(queryText);
   }
-  const searchQuery = queryText.replace(/tag:\S+\s*/g, '').trim();
+  const searchQuery = queryText.replace(/tag:(?:"[^"]+?"|\S+)\s*/g, '').trim();
   return {
     searchQuery,
-    tagIds: tagNames.length > 0 ? tagNames : undefined,
+    tagIds: resolvedIds.length > 0 ? resolvedIds : undefined,
     tagIdsToExclude: undefined,
   };
 });
@@ -333,7 +340,7 @@ describe('ContentListToolbar', () => {
         const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
         expect(lastCall[0].searchQuery).toBe('my query');
         expect(lastCall[0].filters.tag).toEqual({
-          include: ['Production'],
+          include: ['tag-1'],
           exclude: [],
         });
       });
@@ -373,6 +380,67 @@ describe('ContentListToolbar', () => {
         const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
         expect(lastCall[0].searchQuery).toContain('tag:Production my query');
         expect(lastCall[0].filters.tag).toBeUndefined();
+      });
+    });
+
+    it('parses quoted multi-word tag names and resolves them to IDs', async () => {
+      const Wrapper = createWrapper({ tagsService: mockTagsService });
+      render(
+        <Wrapper>
+          <ContentListToolbar />
+        </Wrapper>
+      );
+
+      const searchBox = screen.getByTestId('contentListToolbar-searchBox');
+      await userEvent.type(searchBox, 'tag:"New World" my query');
+
+      await waitFor(() => {
+        expect(mockParseSearchQuery).toHaveBeenCalledWith('tag:"New World" my query');
+      });
+
+      await waitFor(() => {
+        const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
+        expect(lastCall[0].searchQuery).toBe('my query');
+        expect(lastCall[0].filters.tag).toEqual({
+          include: ['tag-3'],
+          exclude: [],
+        });
+      });
+    });
+
+    it('preserves existing filters when parseSearchQuery throws', async () => {
+      // First render with a working parser so we can establish a known filter state.
+      const Wrapper = createWrapper({ tagsService: mockTagsService });
+      render(
+        <Wrapper>
+          <ContentListToolbar />
+        </Wrapper>
+      );
+
+      const searchBox = screen.getByTestId('contentListToolbar-searchBox');
+
+      // Set up initial state: type a valid tag query to populate filters.
+      await userEvent.type(searchBox, 'tag:Production');
+      await waitFor(() => {
+        expect(mockFindItems.mock.calls.length).toBeGreaterThan(0);
+        const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
+        expect(lastCall[0].filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+      });
+
+      // Now make the parser throw on the next keystroke.
+      mockParseSearchQuery.mockImplementationOnce(() => {
+        throw new Error('parse failure');
+      });
+
+      // Type another character to trigger a new change event.
+      await userEvent.type(searchBox, ' x');
+
+      // The existing tag filter should be preserved; the raw queryText must not
+      // become the `search` value (which would leak tag syntax to findItems).
+      await waitFor(() => {
+        const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
+        expect(lastCall[0].filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+        expect(lastCall[0].searchQuery).not.toContain('tag:');
       });
     });
   });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.test.tsx
@@ -15,6 +15,7 @@ import {
   type FindItemsResult,
   type FindItemsParams,
 } from '@kbn/content-list-provider';
+import type { ContentManagementTagsServices } from '@kbn/content-management-tags';
 import { ContentListToolbar } from './content_list_toolbar';
 
 const mockFindItems = jest.fn(
@@ -24,17 +25,45 @@ const mockFindItems = jest.fn(
   })
 );
 
+const mockTags = [
+  { id: 'tag-1', name: 'Production', description: '', color: '#FF0000', managed: false },
+  { id: 'tag-2', name: 'Development', description: '', color: '#00FF00', managed: false },
+];
+
+const mockParseSearchQuery = jest.fn((queryText: string) => {
+  // Simple mock: extract `tag:Name` patterns and return the rest as `searchQuery`.
+  const tagPattern = /tag:(\S+)/g;
+  const tagNames: string[] = [];
+  let match = tagPattern.exec(queryText);
+  while (match) {
+    tagNames.push(match[1]);
+    match = tagPattern.exec(queryText);
+  }
+  const searchQuery = queryText.replace(/tag:\S+\s*/g, '').trim();
+  return {
+    searchQuery,
+    tagIds: tagNames.length > 0 ? tagNames : undefined,
+    tagIdsToExclude: undefined,
+  };
+});
+
+const mockTagsService: ContentManagementTagsServices = {
+  getTagList: () => mockTags,
+  parseSearchQuery: mockParseSearchQuery,
+};
+
 interface CreateWrapperOptions {
   sortingDisabled?: boolean;
   searchDisabled?: boolean;
   searchPlaceholder?: string;
   sortFields?: Array<{ field: string; name: string }>;
+  tagsService?: ContentManagementTagsServices;
 }
 
 const createWrapper =
   (options: CreateWrapperOptions = {}) =>
   ({ children }: { children: React.ReactNode }) => {
-    const { sortingDisabled, searchDisabled, searchPlaceholder, sortFields } = options;
+    const { sortingDisabled, searchDisabled, searchPlaceholder, sortFields, tagsService } = options;
 
     const features = {
       sorting: sortingDisabled ? (false as const) : sortFields ? { fields: sortFields } : true,
@@ -51,6 +80,7 @@ const createWrapper =
         }}
         dataSource={{ findItems: mockFindItems }}
         features={features}
+        services={tagsService ? { tags: tagsService } : undefined}
       >
         {children}
       </ContentListProvider>
@@ -279,6 +309,71 @@ describe('ContentListToolbar', () => {
       );
 
       expect(screen.getByTestId('contentListSortRenderer')).toBeInTheDocument();
+    });
+  });
+
+  describe('tag filter integration with parseSearchQuery', () => {
+    it('calls parseSearchQuery and passes parsed tags to findItems', async () => {
+      const Wrapper = createWrapper({ tagsService: mockTagsService });
+      render(
+        <Wrapper>
+          <ContentListToolbar />
+        </Wrapper>
+      );
+
+      const searchBox = screen.getByTestId('contentListToolbar-searchBox');
+      await userEvent.type(searchBox, 'tag:Production my query');
+
+      await waitFor(() => {
+        expect(mockParseSearchQuery).toHaveBeenCalledWith('tag:Production my query');
+      });
+
+      // Verify that `findItems` receives the parsed search query and tag filters.
+      await waitFor(() => {
+        const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
+        expect(lastCall[0].searchQuery).toBe('my query');
+        expect(lastCall[0].filters.tag).toEqual({
+          include: ['Production'],
+          exclude: [],
+        });
+      });
+    });
+
+    it('passes search text without tags when no tag syntax is used', async () => {
+      const Wrapper = createWrapper({ tagsService: mockTagsService });
+      render(
+        <Wrapper>
+          <ContentListToolbar />
+        </Wrapper>
+      );
+
+      const searchBox = screen.getByTestId('contentListToolbar-searchBox');
+      await userEvent.type(searchBox, 'plain search');
+
+      await waitFor(() => {
+        const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
+        expect(lastCall[0].searchQuery).toBe('plain search');
+        expect(lastCall[0].filters.tag).toBeUndefined();
+      });
+    });
+
+    it('falls back to simple search when no tags service is provided', async () => {
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <ContentListToolbar />
+        </Wrapper>
+      );
+
+      const searchBox = screen.getByTestId('contentListToolbar-searchBox');
+      await userEvent.type(searchBox, 'tag:Production my query');
+
+      // Without tags service, the entire text is treated as the search query.
+      await waitFor(() => {
+        const lastCall = mockFindItems.mock.calls[mockFindItems.mock.calls.length - 1];
+        expect(lastCall[0].searchQuery).toContain('tag:Production my query');
+        expect(lastCall[0].filters.tag).toBeUndefined();
+      });
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
@@ -7,11 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { EuiSearchBar } from '@elastic/eui';
 import type { EuiSearchBarOnChangeArgs } from '@elastic/eui';
-import { useContentListConfig, useContentListSearch } from '@kbn/content-list-provider';
+import {
+  useContentListConfig,
+  useContentListSearch,
+  useContentListFilters,
+} from '@kbn/content-list-provider';
+import { useTagServices } from '@kbn/content-management-tags';
 import { i18n } from '@kbn/i18n';
 import { Filters } from './filters';
 import { useFilters } from './hooks';
@@ -36,7 +41,11 @@ const defaultPlaceholder = i18n.translate(
  * `ContentListToolbar` component.
  *
  * Provides a toolbar with search and filter controls for content lists using `EuiSearchBar`.
- * Currently supports search and the Sort filter; additional filters will be added in subsequent PRs.
+ * Uses the atomic `setSearch(queryText, filters)` call to update both the displayed query
+ * text and the parsed filters in a single dispatch.
+ *
+ * When tag services are available, the toolbar parses tag filter syntax
+ * (e.g., `tag:production`) from the query text using `parseSearchQuery`.
  *
  * When items are selected in the table, a "Delete N entities" button appears in the
  * toolbar's left tools area (via `EuiSearchBar`'s `toolsLeft`), matching the existing
@@ -61,6 +70,7 @@ const defaultPlaceholder = i18n.translate(
  * // Custom filter order.
  * <ContentListToolbar>
  *   <Filters>
+ *     <Filters.Tags />
  *     <Filters.Sort />
  *   </Filters>
  * </ContentListToolbar>
@@ -72,18 +82,57 @@ const ContentListToolbarComponent = ({
 }: ContentListToolbarProps) => {
   const { labels, supports } = useContentListConfig();
   const { search, setSearch, isSupported: searchIsSupported } = useContentListSearch();
+  const { filters: currentFilters } = useContentListFilters();
+  const tagServices = useTagServices();
   const filters = useFilters(children);
+
+  // Keep a ref so the error-recovery branch of handleSearchChange can read the
+  // latest filters without making them a useCallback dependency (which would
+  // cause the callback to re-create on every tag toggle).
+  const currentFiltersRef = useRef(currentFilters);
+  currentFiltersRef.current = currentFilters;
 
   const handleSearchChange = useCallback(
     ({ queryText, error }: EuiSearchBarOnChangeArgs) => {
       if (error) {
         return;
       }
-      // `queryText` preserves the raw input (including whitespace) for display fidelity.
-      // `filters.search` is trimmed so data fetching ignores leading/trailing spaces.
-      setSearch(queryText, { search: queryText.trim() || undefined });
+
+      if (tagServices?.parseSearchQuery) {
+        try {
+          const { searchQuery, tagIds, tagIdsToExclude } = tagServices.parseSearchQuery(queryText);
+          const hasTags =
+            (tagIds && tagIds.length > 0) || (tagIdsToExclude && tagIdsToExclude.length > 0);
+
+          setSearch(queryText, {
+            search: searchQuery?.trim() || undefined,
+            ...(hasTags && {
+              tag: { include: tagIds ?? [], exclude: tagIdsToExclude ?? [] },
+            }),
+          });
+        } catch (e) {
+          // Preserve existing filters on parse failure so structured
+          // filters aren't silently dropped while the search bar still
+          // displays filter syntax.
+          if (process.env.NODE_ENV !== 'production') {
+            // eslint-disable-next-line no-console
+            console.warn(
+              '[ContentListToolbar] parseSearchQuery failed, preserving existing filters',
+              e
+            );
+          }
+          setSearch(queryText, {
+            ...currentFiltersRef.current,
+            search: queryText?.trim() || undefined,
+          });
+        }
+      } else {
+        // `queryText` preserves the raw input (including whitespace) for display fidelity.
+        // `filters.search` is trimmed so data fetching ignores leading/trailing spaces.
+        setSearch(queryText, { search: queryText.trim() || undefined });
+      }
     },
-    [setSearch]
+    [setSearch, tagServices]
   );
 
   // Only include the selection bar when selection is supported to avoid

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
@@ -16,9 +16,11 @@ import {
   useContentListSearch,
   useContentListFilters,
 } from '@kbn/content-list-provider';
-import { useTagServices } from '@kbn/content-management-tags';
 import { i18n } from '@kbn/i18n';
 import { Filters } from './filters';
+import { parseFiltersFromQuery } from './filters/query_parser';
+import type { QueryParser } from './filters/query_parser';
+import { useTagQueryParser } from './filters/tags/use_tag_query_parser';
 import { useFilters } from './hooks';
 import { SelectionBar } from './selection_bar';
 
@@ -83,14 +85,23 @@ const ContentListToolbarComponent = ({
   const { labels, supports } = useContentListConfig();
   const { search, setSearch, isSupported: searchIsSupported } = useContentListSearch();
   const { filters: currentFilters } = useContentListFilters();
-  const tagServices = useTagServices();
   const filters = useFilters(children);
 
   // Keep a ref so the error-recovery branch of handleSearchChange can read the
   // latest filters without making them a useCallback dependency (which would
-  // cause the callback to re-create on every tag toggle).
+  // cause the callback to re-create on every filter toggle).
   const currentFiltersRef = useRef(currentFilters);
   currentFiltersRef.current = currentFilters;
+
+  // Assemble the query parser pipeline. Each filter type contributes a parser that
+  // extracts its field syntax (e.g. `tag:name`, `createdBy:user`) from the query
+  // text and maps it to `ActiveFilters`. Add new parsers here as filter PRs land —
+  // `handleSearchChange` itself never needs to change.
+  const tagParser = useTagQueryParser();
+  const queryParsers = useMemo(
+    (): ReadonlyArray<QueryParser> => [tagParser].filter((p): p is QueryParser => p !== null),
+    [tagParser]
+  );
 
   const handleSearchChange = useCallback(
     ({ queryText, error }: EuiSearchBarOnChangeArgs) => {
@@ -98,41 +109,35 @@ const ContentListToolbarComponent = ({
         return;
       }
 
-      if (tagServices?.parseSearchQuery) {
+      if (queryParsers.length > 0) {
         try {
-          const { searchQuery, tagIds, tagIdsToExclude } = tagServices.parseSearchQuery(queryText);
-          const hasTags =
-            (tagIds && tagIds.length > 0) || (tagIdsToExclude && tagIdsToExclude.length > 0);
-
-          setSearch(queryText, {
-            search: searchQuery?.trim() || undefined,
-            ...(hasTags && {
-              tag: { include: tagIds ?? [], exclude: tagIdsToExclude ?? [] },
-            }),
-          });
+          const { searchQuery, filters: parsedFilters } = parseFiltersFromQuery(
+            queryText,
+            queryParsers
+          );
+          setSearch(queryText, { search: searchQuery.trim() || undefined, ...parsedFilters });
         } catch (e) {
-          // Preserve existing filters on parse failure so structured
-          // filters aren't silently dropped while the search bar still
-          // displays filter syntax.
+          // Preserve existing filters on parse failure so structured filters aren't silently
+          // dropped while the search bar still displays filter syntax. In particular, keep
+          // the existing `search` value rather than using `queryText` directly — doing so
+          // would leak raw filter syntax (e.g. `tag:foo`) into the text search sent to `findItems`.
           if (process.env.NODE_ENV !== 'production') {
             // eslint-disable-next-line no-console
             console.warn(
-              '[ContentListToolbar] parseSearchQuery failed, preserving existing filters',
+              '[ContentListToolbar] query parser failed, preserving existing filters',
               e
             );
           }
-          setSearch(queryText, {
-            ...currentFiltersRef.current,
-            search: queryText?.trim() || undefined,
-          });
+          setSearch(queryText, { ...currentFiltersRef.current });
         }
       } else {
+        // No parsers registered — treat the entire query as plain text search.
         // `queryText` preserves the raw input (including whitespace) for display fidelity.
         // `filters.search` is trimmed so data fetching ignores leading/trailing spaces.
         setSearch(queryText, { search: queryText.trim() || undefined });
       }
     },
-    [setSearch, tagServices]
+    [setSearch, queryParsers]
   );
 
   // Only include the selection bar when selection is supported to avoid

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_popover.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_popover.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import {
   EuiPopover,
   EuiPopoverTitle,
@@ -108,15 +108,16 @@ export const FilterPopover = ({
 
   const hasActiveFilters = activeCount > 0;
 
-  // Build panel CSS from width props. Intentionally not memoized—the object
-  // construction is trivial and `EuiPopover` does not rely on referential equality.
-  const panelCSS =
-    panelWidth || panelMinWidth
-      ? {
-          ...(panelWidth && { width: panelWidth }),
-          ...(panelMinWidth && { minWidth: panelMinWidth }),
-        }
-      : undefined;
+  // Build panel CSS from width props.
+  const panelCSS = useMemo(() => {
+    if (!panelWidth && !panelMinWidth) {
+      return undefined;
+    }
+    return {
+      ...(panelWidth && { width: panelWidth }),
+      ...(panelMinWidth && { minWidth: panelMinWidth }),
+    };
+  }, [panelWidth, panelMinWidth]);
 
   return (
     <EuiPopover

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_popover_header.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_popover_header.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiPanel } from '@elastic/eui';
+import { FilterSelectionHeader } from './filter_selection_header';
+
+/**
+ * Props for the {@link FilterPopoverHeader} component.
+ */
+export interface FilterPopoverHeaderProps {
+  /** Search element from `EuiSelectable`. */
+  search?: React.ReactNode;
+  /** Number of active filter selections. */
+  activeCount: number;
+  /** Callback to clear all selections. */
+  onClear: () => void;
+  /** `data-test-subj` attribute for the clear button. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Header section for filter popovers with search and selection controls.
+ *
+ * Includes:
+ * - Optional search box (from `EuiSelectable`).
+ * - "X selected" count.
+ * - "Clear filter" button.
+ *
+ * @example
+ * ```tsx
+ * <EuiSelectable searchable>
+ *   {(list, search) => (
+ *     <>
+ *       <FilterPopoverHeader
+ *         search={search}
+ *         activeCount={selectedCount}
+ *         onClear={clearAll}
+ *       />
+ *       <EuiHorizontalRule margin="none" />
+ *       {list}
+ *     </>
+ *   )}
+ * </EuiSelectable>
+ * ```
+ */
+export const FilterPopoverHeader = ({
+  search,
+  activeCount,
+  onClear,
+  'data-test-subj': dataTestSubj,
+}: FilterPopoverHeaderProps) => {
+  return (
+    <EuiPanel hasShadow={false} paddingSize="s">
+      {search}
+      <FilterSelectionHeader
+        activeCount={activeCount}
+        onClear={onClear}
+        data-test-subj={dataTestSubj}
+      />
+    </EuiPanel>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_resolve.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_resolve.test.ts
@@ -10,11 +10,17 @@
 import type { ParsedPart } from '@kbn/content-list-assembly';
 import { filter, type FilterContext } from './part';
 import { SortRenderer } from './sort';
+import { TagFilterRenderer } from './tags';
 
-// Ensure the sort preset's resolve callback is registered.
+// Ensure preset resolve callbacks are registered.
 import './sort/sort';
+import './tags/tag_filter';
 
-const createContext = (hasSorting: boolean): FilterContext => ({ hasSorting });
+const createContext = (overrides: Partial<FilterContext> = {}): FilterContext => ({
+  hasSorting: false,
+  hasTags: false,
+  ...overrides,
+});
 
 const createSortPart = (): ParsedPart => ({
   type: 'part',
@@ -24,21 +30,45 @@ const createSortPart = (): ParsedPart => ({
   attributes: {},
 });
 
-describe('filter.resolve', () => {
-  it('returns a `SearchFilterConfig` for the sort preset when sorting is available.', () => {
-    const result = filter.resolve(createSortPart(), createContext(true));
+const createTagsPart = (): ParsedPart => ({
+  type: 'part',
+  part: 'filter',
+  preset: 'tags',
+  instanceId: 'tags',
+  attributes: {},
+});
 
-    expect(result).toBeDefined();
-    expect(result).toMatchObject({
-      type: 'custom_component',
+describe('filter.resolve', () => {
+  describe('sort preset', () => {
+    it('returns a `SearchFilterConfig` for the sort preset when sorting is available.', () => {
+      const result = filter.resolve(createSortPart(), createContext({ hasSorting: true }));
+
+      expect(result).toBeDefined();
+      expect(result).toMatchObject({ type: 'custom_component' });
+      expect((result as { component: unknown }).component).toBe(SortRenderer);
     });
-    expect((result as { component: unknown }).component).toBe(SortRenderer);
+
+    it('returns `undefined` for the sort preset when sorting is unavailable.', () => {
+      const result = filter.resolve(createSortPart(), createContext({ hasSorting: false }));
+
+      expect(result).toBeUndefined();
+    });
   });
 
-  it('returns `undefined` for the sort preset when sorting is unavailable.', () => {
-    const result = filter.resolve(createSortPart(), createContext(false));
+  describe('tags preset', () => {
+    it('returns a `SearchFilterConfig` for the tags preset when tags are available.', () => {
+      const result = filter.resolve(createTagsPart(), createContext({ hasTags: true }));
 
-    expect(result).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result).toMatchObject({ type: 'custom_component' });
+      expect((result as { component: unknown }).component).toBe(TagFilterRenderer);
+    });
+
+    it('returns `undefined` for the tags preset when tags are unavailable.', () => {
+      const result = filter.resolve(createTagsPart(), createContext({ hasTags: false }));
+
+      expect(result).toBeUndefined();
+    });
   });
 
   it('returns `undefined` for an unknown preset.', () => {
@@ -49,7 +79,7 @@ describe('filter.resolve', () => {
       instanceId: 'unknown-filter',
       attributes: {},
     };
-    const result = filter.resolve(unknownPart, createContext(true));
+    const result = filter.resolve(unknownPart, createContext({ hasSorting: true }));
 
     expect(result).toBeUndefined();
   });
@@ -62,7 +92,7 @@ describe('filter.resolve', () => {
       instanceId: 'custom',
       attributes: {},
     };
-    const result = filter.resolve(noPresetPart, createContext(true));
+    const result = filter.resolve(noPresetPart, createContext({ hasSorting: true }));
 
     expect(result).toBeUndefined();
   });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_selection_header.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_selection_header.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiButtonEmpty, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+
+/**
+ * Props for the {@link FilterSelectionHeader} component.
+ */
+export interface FilterSelectionHeaderProps {
+  /** Number of active filter selections. */
+  activeCount: number;
+  /** Callback to clear all selections. */
+  onClear: () => void;
+  /** `data-test-subj` attribute for the clear button. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Displays the selection count and clear filter button.
+ * Used in multi-select filter popovers.
+ */
+export const FilterSelectionHeader = ({
+  activeCount,
+  onClear,
+  'data-test-subj': dataTestSubj,
+}: FilterSelectionHeaderProps) => {
+  const { euiTheme } = useEuiTheme();
+  const hasActiveFilters = activeCount > 0;
+
+  return (
+    <EuiFlexGroup
+      alignItems="center"
+      justifyContent="spaceBetween"
+      gutterSize="s"
+      responsive={false}
+      css={css`
+        margin-top: ${euiTheme.size.s};
+      `}
+    >
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs" color="subdued">
+          {i18n.translate('contentManagement.contentList.filter.selectedCount', {
+            defaultMessage: '{count, plural, =0 {0 selected} other {# selected}}',
+            values: { count: activeCount },
+          })}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        {hasActiveFilters && (
+          <EuiButtonEmpty size="xs" flush="right" onClick={onClear} data-test-subj={dataTestSubj}>
+            {i18n.translate('contentManagement.contentList.filter.clearFilter', {
+              defaultMessage: 'Clear filter',
+            })}
+          </EuiButtonEmpty>
+        )}
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
@@ -117,14 +117,7 @@ export const useFieldQueryFilter = ({
   onChange,
   singleSelection = false,
 }: UseFieldQueryFilterOptions): UseFieldQueryFilterResult => {
-  // When the caller already has a parsed `Query` object (e.g. from `EuiSearchBar`), use
-  // it directly. Only fall back to `Query.parse(text)` when the raw text is all we have.
-  const { parsedQuery, hasParseError } = useMemo(() => {
-    if (query) {
-      return { parsedQuery: query, hasParseError: false };
-    }
-    return { parsedQuery: null, hasParseError: false };
-  }, [query]);
+  const parsedQuery = query ?? null;
 
   const selection = useMemo((): FilterSelection => {
     if (!parsedQuery) {
@@ -133,17 +126,35 @@ export const useFieldQueryFilter = ({
 
     const result: FilterSelection = {};
 
-    const includeClause = parsedQuery.ast.getOrFieldClause(fieldName, undefined, true, 'eq');
-    if (includeClause) {
-      toArray(includeClause.value).forEach((v) => {
+    // Read OR-field clauses (`field:(A or B)`) — the primary format written by the UI.
+    const includeOrClause = parsedQuery.ast.getOrFieldClause(fieldName, undefined, true, 'eq');
+    if (includeOrClause) {
+      toArray(includeOrClause.value).forEach((v) => {
         result[String(v)] = 'include';
       });
     }
 
-    const excludeClause = parsedQuery.ast.getOrFieldClause(fieldName, undefined, false, 'eq');
-    if (excludeClause) {
-      toArray(excludeClause.value).forEach((v) => {
+    const excludeOrClause = parsedQuery.ast.getOrFieldClause(fieldName, undefined, false, 'eq');
+    if (excludeOrClause) {
+      toArray(excludeOrClause.value).forEach((v) => {
         result[String(v)] = 'exclude';
+      });
+    }
+
+    // Also read simple field clauses (`field:value` or `-field:value`) so that
+    // values typed manually by the user are reflected as active in the popover.
+    // Only write if the key isn't already captured by an OR-field clause above —
+    // OR-clauses are the primary format written by the UI and take precedence.
+    const simpleClauses = parsedQuery.ast.getFieldClauses(fieldName);
+    if (simpleClauses) {
+      simpleClauses.forEach((clause) => {
+        const type: FilterType = clause.match === 'must' ? 'include' : 'exclude';
+        toArray(clause.value).forEach((v) => {
+          const key = String(v);
+          if (!result[key]) {
+            result[key] = type;
+          }
+        });
       });
     }
 
@@ -157,27 +168,25 @@ export const useFieldQueryFilter = ({
 
   const toggle = useCallback(
     (value: string, targetType: FilterType) => {
-      // Don't modify when query has parse error — preserve the user's in-progress text.
-      if (hasParseError) {
-        return;
-      }
-
       // Use existing parsed query or create empty one.
       let q = parsedQuery ?? Query.parse('');
       const currentState = getState(value);
 
       // In single selection mode, clear all existing selections first.
       if (singleSelection) {
-        q = q.removeOrFieldClauses(fieldName);
+        // Remove both OR-field and simple field clauses so no stale values remain.
+        q = q.removeOrFieldClauses(fieldName).removeSimpleFieldClauses(fieldName);
         // If clicking the already-selected value, just clear it (toggle off).
         if (currentState === targetType) {
           onChange?.(q);
           return;
         }
       } else {
-        // Multi-select: just remove the current value if it's already set.
+        // Multi-select: remove the current value if it's already set.
+        // Chain both removal methods to handle values written by the UI (OR-field)
+        // and values typed manually by the user (simple field clause).
         if (currentState) {
-          q = q.removeOrFieldValue(fieldName, value);
+          q = q.removeOrFieldValue(fieldName, value).removeSimpleFieldValue(fieldName, value);
         }
       }
 
@@ -187,16 +196,16 @@ export const useFieldQueryFilter = ({
 
       onChange?.(q);
     },
-    [hasParseError, parsedQuery, getState, fieldName, onChange, singleSelection]
+    [parsedQuery, getState, fieldName, onChange, singleSelection]
   );
 
   const clearAll = useCallback(() => {
-    // Don't modify when query has parse error — preserve the user's in-progress text.
-    if (hasParseError || !parsedQuery) {
+    if (!parsedQuery) {
       return;
     }
-    onChange?.(parsedQuery.removeOrFieldClauses(fieldName));
-  }, [hasParseError, parsedQuery, fieldName, onChange]);
+    // Remove both OR-field clauses and simple field clauses (e.g. `field:value` typed manually).
+    onChange?.(parsedQuery.removeOrFieldClauses(fieldName).removeSimpleFieldClauses(fieldName));
+  }, [parsedQuery, fieldName, onChange]);
 
   return {
     selection,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_utils.tsx
@@ -1,0 +1,267 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo, useCallback } from 'react';
+import {
+  EuiPopoverFooter,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiTextColor,
+  EuiBadge,
+  Query,
+} from '@elastic/eui';
+import { isMac } from '@kbn/shared-ux-utility';
+import { i18n } from '@kbn/i18n';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Platform detection for modifier keys.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const modifierKeyPrefix = isMac ? '⌘' : '^';
+
+/**
+ * Checks if the exclude modifier key is pressed (Cmd on Mac, Ctrl on Windows/Linux).
+ *
+ * @param e - An event object containing `metaKey` and `ctrlKey` properties.
+ * @returns `true` if the exclude modifier is pressed.
+ */
+export const isExcludeModifier = (e: { metaKey: boolean; ctrlKey: boolean }): boolean => {
+  return (isMac && e.metaKey) || (!isMac && e.ctrlKey);
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter types and utilities.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type FilterType = 'include' | 'exclude';
+export type FilterSelection = Record<string, FilterType>;
+
+/**
+ * Converts a value to an array (handles single values and arrays).
+ */
+const toArray = (item: unknown): unknown[] => (Array.isArray(item) ? item : [item]);
+
+/**
+ * Maps filter state to `EuiSelectable` checked state.
+ *
+ * - `'include'` → `'on'` (green checkmark).
+ * - `'exclude'` → `'off'` (red X).
+ * - `undefined` → `undefined` (no indicator).
+ */
+export const getCheckedState = (state: FilterType | null | undefined): 'on' | 'off' | undefined => {
+  if (state === 'include') {
+    return 'on';
+  }
+  if (state === 'exclude') {
+    return 'off';
+  }
+  return undefined;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `useFieldQueryFilter` hook.
+// Generic hook for managing include/exclude filter state via `EuiSearchBar` query.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Options for the {@link useFieldQueryFilter} hook.
+ */
+export interface UseFieldQueryFilterOptions {
+  /** The field name in the query (e.g., `'tag'`, `'createdBy'`). */
+  fieldName: string;
+  /** Query object from `EuiSearchBar`. */
+  query?: Query;
+  /** Callback when filter changes. */
+  onChange?: (query: Query) => void;
+  /**
+   * Single selection mode — only one value can be selected at a time.
+   * When `true`, selecting a new value clears any previous selection.
+   *
+   * @default false
+   */
+  singleSelection?: boolean;
+}
+
+/**
+ * Result object returned by the {@link useFieldQueryFilter} hook.
+ */
+export interface UseFieldQueryFilterResult {
+  /** Map of value to {@link FilterType} (`'include'` or `'exclude'`). */
+  selection: FilterSelection;
+  /** Number of active filters. */
+  activeCount: number;
+  /** Gets the current state of a value. */
+  getState: (value: string) => FilterType | null;
+  /** Toggles a value's filter state. */
+  toggle: (value: string, targetType: FilterType) => void;
+  /** Clears all filters for this field. */
+  clearAll: () => void;
+}
+
+/**
+ * Generic hook for managing include/exclude filter state.
+ *
+ * Works with `EuiSearchBar`'s `query`/`onChange` pattern to sync filter state
+ * with the search query text.
+ */
+export const useFieldQueryFilter = ({
+  fieldName,
+  query,
+  onChange,
+  singleSelection = false,
+}: UseFieldQueryFilterOptions): UseFieldQueryFilterResult => {
+  // When the caller already has a parsed `Query` object (e.g. from `EuiSearchBar`), use
+  // it directly. Only fall back to `Query.parse(text)` when the raw text is all we have.
+  const { parsedQuery, hasParseError } = useMemo(() => {
+    if (query) {
+      return { parsedQuery: query, hasParseError: false };
+    }
+    return { parsedQuery: null, hasParseError: false };
+  }, [query]);
+
+  const selection = useMemo((): FilterSelection => {
+    if (!parsedQuery) {
+      return {};
+    }
+
+    const result: FilterSelection = {};
+
+    const includeClause = parsedQuery.ast.getOrFieldClause(fieldName, undefined, true, 'eq');
+    if (includeClause) {
+      toArray(includeClause.value).forEach((v) => {
+        result[String(v)] = 'include';
+      });
+    }
+
+    const excludeClause = parsedQuery.ast.getOrFieldClause(fieldName, undefined, false, 'eq');
+    if (excludeClause) {
+      toArray(excludeClause.value).forEach((v) => {
+        result[String(v)] = 'exclude';
+      });
+    }
+
+    return result;
+  }, [parsedQuery, fieldName]);
+
+  const getState = useCallback(
+    (value: string): FilterType | null => selection[value] ?? null,
+    [selection]
+  );
+
+  const toggle = useCallback(
+    (value: string, targetType: FilterType) => {
+      // Don't modify when query has parse error — preserve the user's in-progress text.
+      if (hasParseError) {
+        return;
+      }
+
+      // Use existing parsed query or create empty one.
+      let q = parsedQuery ?? Query.parse('');
+      const currentState = getState(value);
+
+      // In single selection mode, clear all existing selections first.
+      if (singleSelection) {
+        q = q.removeOrFieldClauses(fieldName);
+        // If clicking the already-selected value, just clear it (toggle off).
+        if (currentState === targetType) {
+          onChange?.(q);
+          return;
+        }
+      } else {
+        // Multi-select: just remove the current value if it's already set.
+        if (currentState) {
+          q = q.removeOrFieldValue(fieldName, value);
+        }
+      }
+
+      if (currentState !== targetType) {
+        q = q.addOrFieldValue(fieldName, value, targetType === 'include', 'eq');
+      }
+
+      onChange?.(q);
+    },
+    [hasParseError, parsedQuery, getState, fieldName, onChange, singleSelection]
+  );
+
+  const clearAll = useCallback(() => {
+    // Don't modify when query has parse error — preserve the user's in-progress text.
+    if (hasParseError || !parsedQuery) {
+      return;
+    }
+    onChange?.(parsedQuery.removeOrFieldClauses(fieldName));
+  }, [hasParseError, parsedQuery, fieldName, onChange]);
+
+  return {
+    selection,
+    activeCount: Object.keys(selection).length,
+    getState,
+    toggle,
+    clearAll,
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `ModifierKeyTip` component.
+// Footer component showing the keyboard shortcut for exclude.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Props for the {@link ModifierKeyTip} component.
+ */
+export interface ModifierKeyTipProps {
+  /** Optional additional content to display below the tip. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Footer component that displays the modifier key shortcut for exclude.
+ */
+export const ModifierKeyTip = ({ children }: ModifierKeyTipProps) => {
+  return (
+    <EuiPopoverFooter paddingSize="m">
+      <EuiFlexGroup direction="column" alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem>
+          <EuiText size="xs">
+            <EuiTextColor color="subdued">
+              {i18n.translate('contentManagement.contentList.filter.modifierKeyHelpText', {
+                defaultMessage: '{modifierKeyPrefix} + click exclude',
+                values: { modifierKeyPrefix },
+              })}
+            </EuiTextColor>
+          </EuiText>
+        </EuiFlexItem>
+        {children}
+      </EuiFlexGroup>
+    </EuiPopoverFooter>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `FilterCountBadge` component.
+// Badge showing item count, changes color when filter is active.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Props for the {@link FilterCountBadge} component.
+ */
+export interface FilterCountBadgeProps {
+  /** Number of items matching this filter option. */
+  count: number;
+  /** Whether this filter option is currently active (included or excluded). */
+  isActive: boolean;
+}
+
+/**
+ * Badge that displays item counts in filter options.
+ * Shows accent color when the filter is active, hollow when inactive.
+ */
+export const FilterCountBadge = ({ count, isActive }: FilterCountBadgeProps) => {
+  return <EuiBadge color={isActive ? 'accent' : 'hollow'}>{count}</EuiBadge>;
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filters.ts
@@ -10,6 +10,7 @@
 import type { ReactNode } from 'react';
 import { filtersPart } from './part';
 import { SortFilter } from './sort';
+import { TagFilter } from './tags';
 
 /**
  * Props for the {@link Filters} container component.
@@ -36,6 +37,7 @@ export interface FiltersProps {
  *
  * <ContentListToolbar>
  *   <Filters>
+ *     <Filters.Tags />
  *     <Filters.Sort />
  *   </Filters>
  * </ContentListToolbar>
@@ -46,4 +48,5 @@ const FiltersComponent = filtersPart.createComponent<FiltersProps>();
 // Attach sub-components via Object.assign for compound component pattern.
 export const Filters = Object.assign(FiltersComponent, {
   Sort: SortFilter,
+  Tags: TagFilter,
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/index.ts
@@ -10,6 +10,39 @@
 // Filter container and declarative components.
 export { Filters, type FiltersProps } from './filters';
 export { SortFilter, type SortFilterProps, SortRenderer, type SortRendererProps } from './sort';
+export {
+  TagFilter,
+  type TagFilterProps,
+  TagFilterRenderer,
+  type TagFilterRendererProps,
+} from './tags';
+
+// Common popover components.
+export { FilterPopover, useFilterPopover, type FilterPopoverProps } from './filter_popover';
+export { FilterPopoverHeader, type FilterPopoverHeaderProps } from './filter_popover_header';
+export { FilterSelectionHeader, type FilterSelectionHeaderProps } from './filter_selection_header';
+export {
+  SelectableFilterPopover,
+  StandardFilterOption,
+  type SelectableFilterPopoverProps,
+  type SelectableFilterOption,
+  type StandardOptionRenderProps,
+} from './selectable_filter_popover';
+
+// Filter utilities.
+export {
+  useFieldQueryFilter,
+  isExcludeModifier,
+  getCheckedState,
+  ModifierKeyTip,
+  FilterCountBadge,
+  type FilterType,
+  type FilterSelection,
+  type UseFieldQueryFilterOptions,
+  type UseFieldQueryFilterResult,
+  type ModifierKeyTipProps,
+  type FilterCountBadgeProps,
+} from './filter_utils';
 
 // Part factory and context (used by `useFilters` hook).
 export { filter, type FilterPresets, type FilterContext } from './part';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/index.ts
@@ -15,6 +15,7 @@ export {
   type TagFilterProps,
   TagFilterRenderer,
   type TagFilterRendererProps,
+  useTagQueryParser,
 } from './tags';
 
 // Common popover components.
@@ -43,6 +44,9 @@ export {
   type ModifierKeyTipProps,
   type FilterCountBadgeProps,
 } from './filter_utils';
+
+// Query parser pipeline — implement `QueryParser` to add a new filter type.
+export { parseFiltersFromQuery, type QueryParser, type QueryParserResult } from './query_parser';
 
 // Part factory and context (used by `useFilters` hook).
 export { filter, type FilterPresets, type FilterContext } from './part';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/part.ts
@@ -19,23 +19,31 @@ import { toolbar } from '../assembly';
  * forwarded to the underlying {@link SortRenderer}. Extend this interface
  * only with props the `resolve` callback can act on directly.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SortFilterProps {}
+export type SortFilterProps = Record<string, never>;
+
+/**
+ * Props for the {@link TagFilter} declarative component.
+ *
+ * Note: `TagFilter` is a non-rendering declarative component whose props are
+ * parsed as attributes during filter resolution. Because `EuiSearchBar`
+ * instantiates `custom_component` filters itself, attributes cannot be
+ * forwarded to the underlying {@link TagFilterRenderer}. Extend this interface
+ * only with props the `resolve` callback can act on directly.
+ */
+export type TagFilterProps = Record<string, never>;
 
 /** Preset-to-props mapping for toolbar filters. */
 export interface FilterPresets {
   sort: SortFilterProps;
+  tags: TagFilterProps;
 }
 
-/**
- * Runtime context passed to filter `resolve` callbacks.
- *
- * Assembled from hooks in `useFilters` and forwarded to each
- * preset's resolver so it can decide whether to render.
- */
+/** Context passed to filter `resolve` callbacks. */
 export interface FilterContext {
   /** Whether sorting is available from the provider. */
   hasSorting: boolean;
+  /** Whether tags filtering is available from the provider. */
+  hasTags: boolean;
 }
 
 /** Part factory for toolbar filters. */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/query_parser.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/query_parser.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActiveFilters } from '@kbn/content-list-provider';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// QueryParser — generic interface for extracting filter values from EUI search
+// query text and returning cleaned text + parsed filter state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Result returned by a {@link QueryParser}.
+ */
+export interface QueryParserResult {
+  /**
+   * Query text with this parser's field syntax removed.
+   *
+   * Passed to the next parser in the chain so each parser operates on
+   * progressively cleaner text. The final value is used as `filters.search`.
+   */
+  searchQuery: string;
+  /**
+   * Filter values extracted by this parser, keyed by filter ID.
+   *
+   * Merged into the accumulated {@link ActiveFilters} for the current query.
+   * Return an empty object when no clauses for this filter type are present —
+   * this clears the filter dimension, which is correct since the search bar
+   * is the source of truth.
+   */
+  filters: Partial<ActiveFilters>;
+}
+
+/**
+ * A parser that extracts one filter dimension from an EUI search bar query string.
+ *
+ * Parsers are chained by {@link parseFiltersFromQuery} — each receives the
+ * cleaned query text produced by the previous parser (with earlier filter
+ * syntax already removed), and returns cleaned text + its own parsed filters.
+ *
+ * @example Implementing a `createdBy` filter parser:
+ * ```ts
+ * const useCreatedByQueryParser = (): QueryParser | null => {
+ *   const userService = useUserProfileService();
+ *   return useMemo(() => {
+ *     if (!userService) return null;
+ *     return {
+ *       parse(queryText) {
+ *         const { searchQuery, userIds } = userService.parseSearchQuery(queryText);
+ *         return {
+ *           searchQuery,
+ *           filters: userIds?.length ? { createdBy: { include: userIds } } : {},
+ *         };
+ *       },
+ *     };
+ *   }, [userService]);
+ * };
+ * ```
+ */
+export interface QueryParser {
+  parse(queryText: string): QueryParserResult;
+}
+
+/**
+ * Chains multiple query parsers, passing cleaned text from each to the next.
+ *
+ * Each parser receives the `searchQuery` produced by the previous parser (with
+ * its filter syntax already stripped), and contributes its own filter values to
+ * the accumulated result. The pipeline is pure — it does not touch React state.
+ *
+ * @param queryText - Raw query text from `EuiSearchBar`.
+ * @param parsers - Ordered array of parsers to run. Typically one parser per
+ *   filter type (tags, users, starred, etc.).
+ * @returns The final cleaned `searchQuery` and merged `filters` ready to pass
+ *   to `setSearch`.
+ *
+ * @example
+ * ```ts
+ * const { searchQuery, filters } = parseFiltersFromQuery(queryText, [tagParser, userParser]);
+ * setSearch(queryText, { search: searchQuery.trim() || undefined, ...filters });
+ * ```
+ */
+export const parseFiltersFromQuery = (
+  queryText: string,
+  parsers: ReadonlyArray<QueryParser>
+): QueryParserResult =>
+  parsers.reduce<QueryParserResult>(
+    (acc, parser) => {
+      const result = parser.parse(acc.searchQuery);
+      return {
+        searchQuery: result.searchQuery,
+        filters: { ...acc.filters, ...result.filters },
+      };
+    },
+    { searchQuery: queryText, filters: {} }
+  );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
@@ -1,0 +1,342 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo, useRef } from 'react';
+import {
+  EuiSelectable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPanel,
+  type Query,
+} from '@elastic/eui';
+import { useFilterPopover, FilterPopover } from './filter_popover';
+import { FilterPopoverHeader } from './filter_popover_header';
+import {
+  useFieldQueryFilter,
+  isExcludeModifier,
+  getCheckedState,
+  ModifierKeyTip,
+  FilterCountBadge,
+  type FilterType,
+} from './filter_utils';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for a selectable filter option.
+ */
+export interface SelectableFilterOption<T extends object = Record<string, unknown>> {
+  /** Unique key for the option. */
+  key: string;
+  /** Display label. */
+  label: string;
+  /** Value to store in the query (defaults to `key` if not provided). */
+  value?: string;
+  /** Item count for this option. */
+  count?: number;
+  /** Custom data associated with this option. */
+  data?: T;
+}
+
+/**
+ * Props for the {@link SelectableFilterPopover} component.
+ */
+export interface SelectableFilterPopoverProps<T extends object = Record<string, unknown>> {
+  /** Field name in the query (e.g., `'tag'`, `'createdBy'`). */
+  fieldName: string;
+  /** Title displayed in the popover header and button. */
+  title: string;
+  /** Query object from `EuiSearchBar`. */
+  query?: Query;
+  /** Callback when filter changes. */
+  onChange?: (query: Query) => void;
+  /** Options to display. See {@link SelectableFilterOption}. */
+  options: Array<SelectableFilterOption<T>>;
+  /** Render function for option content. */
+  renderOption: (
+    option: SelectableFilterOption<T>,
+    state: {
+      checked: 'on' | 'off' | undefined;
+      isActive: boolean;
+    }
+  ) => React.ReactNode;
+  /**
+   * Single selection mode — only one value can be selected at a time.
+   * Also hides the modifier key tip since exclude is not supported.
+   *
+   * @default false
+   */
+  singleSelection?: boolean;
+  /** Whether the options are loading. */
+  isLoading?: boolean;
+  /** Empty state message to display. */
+  emptyMessage?: string;
+  /** No matches message to display. */
+  noMatchesMessage?: string;
+  /** Width of the popover panel. */
+  panelWidth?: number;
+  /** Minimum width of the popover panel. */
+  panelMinWidth?: number;
+  /** Optional footer content (rendered below {@link ModifierKeyTip}). */
+  footerContent?: React.ReactNode;
+  /** `data-test-subj` attribute for testing. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Internal interface for selectable options used within the popover.
+ */
+interface InternalSelectableOption<T extends object> {
+  key: string;
+  label: string;
+  value: string;
+  checked?: 'on' | 'off' | undefined;
+  data?: T;
+  count: number;
+  view: React.ReactNode;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `SelectableFilterPopover` component.
+ *
+ * A reusable multi-select filter popover with include/exclude support.
+ *
+ * Provides:
+ * - `EuiSelectable` with search.
+ * - Include/exclude via modifier key (Cmd/Ctrl + click).
+ * - Filter counts with active state badges.
+ * - Standard header with selection count and clear button.
+ * - Standard footer with modifier key tip.
+ *
+ * @example
+ * ```tsx
+ * <SelectableFilterPopover
+ *   fieldName="tag"
+ *   title="Tags"
+ *   query={query}
+ *   onChange={onChange}
+ *   options={tags.map(tag => ({
+ *     key: tag.id,
+ *     label: tag.name,
+ *     count: tagCounts[tag.name] ?? 0,
+ *     data: tag,
+ *   }))}
+ *   renderOption={(option, { isActive }) => (
+ *     <StandardFilterOption count={option.count ?? 0} isActive={isActive}>
+ *       <EuiHealth color={option.data.color}>{option.label}</EuiHealth>
+ *     </StandardFilterOption>
+ *   )}
+ * />
+ * ```
+ */
+export const SelectableFilterPopover = <T extends object = Record<string, unknown>>({
+  fieldName,
+  title,
+  query,
+  onChange,
+  options,
+  renderOption,
+  singleSelection = false,
+  isLoading,
+  emptyMessage,
+  noMatchesMessage,
+  panelWidth,
+  panelMinWidth,
+  footerContent,
+  'data-test-subj': dataTestSubj = 'selectableFilterPopover',
+}: SelectableFilterPopoverProps<T>) => {
+  const { isOpen, toggle, close } = useFilterPopover();
+  const {
+    selection,
+    toggle: toggleValue,
+    clearAll,
+  } = useFieldQueryFilter({
+    fieldName,
+    query,
+    onChange,
+    singleSelection,
+  });
+
+  // Track the modifier key state from the most recent user interaction so
+  // `handleSelectChange` can distinguish include from exclude. Capture-phase
+  // handlers fire before `EuiSelectable` processes the event, guaranteeing
+  // the ref is set before `onChange` runs.
+  const lastModifierRef = useRef(false);
+  const handleInteractionCapture = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
+    lastModifierRef.current = isExcludeModifier(e);
+  }, []);
+
+  // Only count values that match an available option so the badge doesn't
+  // reflect unresolved or stale query clauses (e.g. `tag:NonExistent`).
+  const validOptionValues = useMemo(() => new Set(options.map((o) => o.value ?? o.key)), [options]);
+  const activeCount = useMemo(
+    () => Object.keys(selection).filter((value) => validOptionValues.has(value)).length,
+    [selection, validOptionValues]
+  );
+
+  // Build selectable options with view rendering.
+  const selectableOptions = useMemo((): Array<InternalSelectableOption<T>> => {
+    return options.map((option) => {
+      const value = option.value ?? option.key;
+      const state: FilterType | undefined = selection[value];
+      const checked = getCheckedState(state);
+      const isActive = checked !== undefined;
+      const count = option.count ?? 0;
+
+      return {
+        key: option.key,
+        label: option.label,
+        value,
+        checked,
+        data: option.data,
+        count,
+        view: renderOption(option, { checked, isActive }),
+      };
+    });
+  }, [options, selection, renderOption]);
+
+  // Build a lookup from key → checked state for stable comparison that
+  // doesn't rely on index alignment (safe if `EuiSelectable` reorders options).
+  const prevCheckedByKey = useMemo(() => {
+    const map = new Map<string, 'on' | 'off' | undefined>();
+    selectableOptions.forEach((opt) => map.set(opt.key, opt.checked));
+    return map;
+  }, [selectableOptions]);
+
+  // Handle `EuiSelectable` change — reads modifier key state from
+  // `lastModifierRef` to support Cmd/Ctrl+click for exclude.
+  const handleSelectChange = useCallback(
+    (updatedOptions: Array<InternalSelectableOption<T>>) => {
+      const filterType: FilterType = lastModifierRef.current ? 'exclude' : 'include';
+
+      if (singleSelection) {
+        const newlyChecked = updatedOptions.find(
+          (item) => item.checked === 'on' && prevCheckedByKey.get(item.key) !== 'on'
+        );
+        if (newlyChecked) {
+          toggleValue(newlyChecked.value, filterType);
+        } else {
+          const unchecked = updatedOptions.find(
+            (item) => item.checked !== 'on' && prevCheckedByKey.get(item.key) === 'on'
+          );
+          if (unchecked) {
+            toggleValue(unchecked.value, filterType);
+          }
+        }
+      } else {
+        const changed = updatedOptions.find(
+          (item) => item.checked !== prevCheckedByKey.get(item.key)
+        );
+        if (changed) {
+          toggleValue(changed.value, filterType);
+        }
+      }
+    },
+    [prevCheckedByKey, toggleValue, singleSelection]
+  );
+
+  // Don't show count badge on button for single-select (only one value can be selected).
+  const displayActiveCount = singleSelection ? 0 : activeCount;
+
+  return (
+    <FilterPopover
+      title={title}
+      activeCount={displayActiveCount}
+      isOpen={isOpen}
+      onToggle={toggle}
+      onClose={close}
+      panelWidth={panelWidth}
+      panelMinWidth={panelMinWidth}
+      data-test-subj={dataTestSubj}
+    >
+      <div
+        onMouseDownCapture={handleInteractionCapture}
+        onKeyDownCapture={handleInteractionCapture}
+      >
+        <EuiSelectable<InternalSelectableOption<T>>
+          singleSelection={singleSelection}
+          options={selectableOptions}
+          renderOption={(option) => option.view}
+          isLoading={isLoading}
+          emptyMessage={emptyMessage}
+          noMatchesMessage={noMatchesMessage}
+          onChange={handleSelectChange}
+          searchable
+          searchProps={{ compressed: true }}
+          data-test-subj={`${dataTestSubj}-list`}
+          aria-label={title}
+        >
+          {(list, search) => (
+            <>
+              {singleSelection ? (
+                <EuiPanel hasShadow={false} paddingSize="s">
+                  {search}
+                </EuiPanel>
+              ) : (
+                <FilterPopoverHeader
+                  search={search}
+                  activeCount={activeCount}
+                  onClear={clearAll}
+                  data-test-subj={`${dataTestSubj}-clear`}
+                />
+              )}
+              <EuiHorizontalRule margin="none" />
+              {list}
+            </>
+          )}
+        </EuiSelectable>
+      </div>
+      {/* Only show modifier key tip for multi-select (exclude not supported in single-select). */}
+      {!singleSelection && <ModifierKeyTip>{footerContent}</ModifierKeyTip>}
+      {singleSelection && footerContent}
+    </FilterPopover>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper: Standard option renderer with count badge.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Props for the {@link StandardFilterOption} component.
+ */
+export interface StandardOptionRenderProps {
+  /** Primary content (e.g., name with icon/avatar). */
+  children: React.ReactNode;
+  /** Item count. When `undefined`, the count badge is hidden entirely. */
+  count?: number;
+  /** Whether the filter is active. */
+  isActive: boolean;
+}
+
+/**
+ * Standard option layout with content and optional count badge.
+ *
+ * Include/exclude is handled by `SelectableFilterPopover`'s modifier key
+ * tracking — no click handler is needed on individual options.
+ */
+export const StandardFilterOption = ({ children, count, isActive }: StandardOptionRenderProps) => {
+  return (
+    <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">
+      <EuiFlexItem grow={false}>{children}</EuiFlexItem>
+      {count !== undefined && (
+        <EuiFlexItem grow={false}>
+          <FilterCountBadge count={count} isActive={isActive} />
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/index.ts
@@ -9,3 +9,4 @@
 
 export { TagFilter, type TagFilterProps } from './tag_filter';
 export { TagFilterRenderer, type TagFilterRendererProps } from './tag_filter_renderer';
+export { useTagQueryParser } from './use_tag_query_parser';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { TagFilter, type TagFilterProps } from './tag_filter';
+export { TagFilterRenderer, type TagFilterRendererProps } from './tag_filter_renderer';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { filter } from '../part';
+import { TagFilterRenderer } from './tag_filter_renderer';
+
+// Re-export the props type for consumers.
+export type { TagFilterProps } from '../part';
+
+/**
+ * `TagFilter` declarative component (non-rendering).
+ *
+ * This is a declarative component that doesn't render anything.
+ * It specifies that a tag filter dropdown should appear in the toolbar filters.
+ * The `resolve` callback checks whether tags are available and returns
+ * a `SearchFilterConfig` wrapping {@link TagFilterRenderer}, or `undefined`
+ * to skip the filter entirely.
+ *
+ * Tags must be enabled via the provider's `services.tags` configuration.
+ *
+ * @returns `null` - this component does not render anything.
+ *
+ * @example
+ * ```tsx
+ * <Filters>
+ *   <Filters.Tags />
+ *   <Filters.Sort />
+ * </Filters>
+ * ```
+ */
+export const TagFilter = filter.createPreset({
+  name: 'tags',
+  resolve: (_attributes, { hasTags }) => {
+    if (!hasTags) {
+      return undefined;
+    }
+    return { type: 'custom_component', component: TagFilterRenderer };
+  },
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.test.tsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Query } from '@elastic/eui';
+import {
+  ContentListProvider,
+  type FindItemsResult,
+  type FindItemsParams,
+} from '@kbn/content-list-provider';
+import type { ContentManagementTagsServices } from '@kbn/content-management-tags';
+import { TagFilterRenderer } from './tag_filter_renderer';
+
+const mockTags = [
+  {
+    id: 'tag-1',
+    name: 'Production',
+    description: 'Production items',
+    color: '#FF0000',
+    managed: false,
+  },
+  { id: 'tag-2', name: 'Development', description: 'Dev items', color: '#00FF00', managed: false },
+  {
+    id: 'tag-3',
+    name: 'Archived',
+    description: 'Archived items',
+    color: '#808080',
+    managed: false,
+  },
+];
+
+const mockFindItems = jest.fn(
+  async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+    items: [
+      { id: 'item-1', title: 'Item 1', tags: ['tag-1', 'tag-2'] },
+      { id: 'item-2', title: 'Item 2', tags: ['tag-1'] },
+      { id: 'item-3', title: 'Item 3', tags: ['tag-3'] },
+    ],
+    total: 3,
+  })
+);
+
+const mockTagsService: ContentManagementTagsServices = {
+  getTagList: () => mockTags,
+};
+
+const createWrapper = (options?: { tagsService?: ContentManagementTagsServices }) => {
+  const { tagsService } = options ?? {};
+  return ({ children }: { children: React.ReactNode }) => (
+    <ContentListProvider
+      id="test-list"
+      labels={{ entity: 'item', entityPlural: 'items' }}
+      dataSource={{ findItems: mockFindItems }}
+      services={tagsService ? { tags: tagsService } : undefined}
+    >
+      {children}
+    </ContentListProvider>
+  );
+};
+
+describe('TagFilterRenderer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the tag filter button', () => {
+    render(<TagFilterRenderer query={Query.parse('')} />, {
+      wrapper: createWrapper({ tagsService: mockTagsService }),
+    });
+
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+  });
+
+  it('renders nothing when tags service is not available', () => {
+    const { container } = render(<TagFilterRenderer query={Query.parse('')} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows tag options when popover is opened', () => {
+    render(<TagFilterRenderer query={Query.parse('')} />, {
+      wrapper: createWrapper({ tagsService: mockTagsService }),
+    });
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    expect(screen.getByText('Production')).toBeInTheDocument();
+    expect(screen.getByText('Development')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+  });
+
+  it('shows modifier hint text in the footer', () => {
+    render(<TagFilterRenderer query={Query.parse('')} />, {
+      wrapper: createWrapper({ tagsService: mockTagsService }),
+    });
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    expect(screen.getByText(/\+ click exclude/)).toBeInTheDocument();
+  });
+
+  it('calls `onChange` when a tag option is clicked', () => {
+    const onChange = jest.fn();
+
+    render(<TagFilterRenderer query={Query.parse('')} onChange={onChange} />, {
+      wrapper: createWrapper({ tagsService: mockTagsService }),
+    });
+
+    fireEvent.click(screen.getByText('Tags'));
+    fireEvent.click(screen.getByText('Production'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updatedQuery: Query = onChange.mock.calls[0][0];
+    expect(updatedQuery.text).toContain('Production');
+  });
+
+  it('reflects include state from query prop', () => {
+    const query = Query.parse('').addOrFieldValue('tag', 'Production', true, 'eq');
+
+    render(<TagFilterRenderer query={query} />, {
+      wrapper: createWrapper({ tagsService: mockTagsService }),
+    });
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    const productionOption = screen.getByTestId('tag-searchbar-option-tag-1');
+    expect(productionOption).toBeInTheDocument();
+  });
+
+  it('renders tag options with health indicator colors', () => {
+    render(<TagFilterRenderer query={Query.parse('')} />, {
+      wrapper: createWrapper({ tagsService: mockTagsService }),
+    });
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    expect(screen.getByTestId('tag-searchbar-option-tag-1')).toBeInTheDocument();
+    expect(screen.getByTestId('tag-searchbar-option-tag-2')).toBeInTheDocument();
+    expect(screen.getByTestId('tag-searchbar-option-tag-3')).toBeInTheDocument();
+  });
+
+  it('removes a tag from the query when clicking an already-included tag', () => {
+    const query = Query.parse('').addOrFieldValue('tag', 'Production', true, 'eq');
+    const onChange = jest.fn();
+
+    render(<TagFilterRenderer query={query} onChange={onChange} />, {
+      wrapper: createWrapper({ tagsService: mockTagsService }),
+    });
+
+    fireEvent.click(screen.getByText('Tags'));
+    fireEvent.click(screen.getByText('Production'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updatedQuery: Query = onChange.mock.calls[0][0];
+    expect(updatedQuery.text).not.toContain('Production');
+  });
+
+  describe('tag counts from FindItemsResult', () => {
+    it('displays counts keyed by tag ID', async () => {
+      // Return counts.tag keyed by tag ID.
+      const mockFindItemsWithCounts = jest.fn(
+        async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+          items: [
+            { id: 'item-1', title: 'Item 1', tags: ['tag-1', 'tag-2'] },
+            { id: 'item-2', title: 'Item 2', tags: ['tag-1'] },
+          ],
+          total: 2,
+          counts: { tag: { 'tag-1': 2, 'tag-2': 1 } },
+        })
+      );
+
+      const WrapperWithCounts = ({ children }: { children: React.ReactNode }) => (
+        <ContentListProvider
+          id="test-with-counts"
+          labels={{ entity: 'item', entityPlural: 'items' }}
+          dataSource={{ findItems: mockFindItemsWithCounts }}
+          services={{ tags: mockTagsService }}
+        >
+          {children}
+        </ContentListProvider>
+      );
+
+      render(<TagFilterRenderer query={Query.parse('')} />, { wrapper: WrapperWithCounts });
+
+      fireEvent.click(screen.getByText('Tags'));
+
+      // Counts render as badge text next to each tag name. Wait for query to resolve.
+      // tag-1 → 'Production' should show count 2, tag-2 → 'Development' should show count 1.
+      await waitFor(() => {
+        expect(screen.getByText('2')).toBeInTheDocument();
+        expect(screen.getByText('1')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.tsx
@@ -85,7 +85,11 @@ export const TagFilterRenderer = ({
     }
     try {
       return tagServices.getTagList();
-    } catch {
+    } catch (e) {
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('[TagFilterRenderer] getTagList failed', e);
+      }
       return [];
     }
   }, [tagServices]);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/tag_filter_renderer.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiHealth,
+  useEuiTheme,
+  type Query,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useContentListItems, useFilterDisplay, TAG_FILTER_ID } from '@kbn/content-list-provider';
+import { useTagServices, type Tag } from '@kbn/content-management-tags';
+import {
+  SelectableFilterPopover,
+  StandardFilterOption,
+  type SelectableFilterOption,
+} from '../selectable_filter_popover';
+
+/**
+ * Props for the {@link TagFilterRenderer} component.
+ *
+ * When used with `EuiSearchBar` `custom_component` filters, the search bar passes
+ * `query` and `onChange` props. The tag filter uses these to sync include/exclude
+ * state directly with the search bar query text.
+ */
+export interface TagFilterRendererProps {
+  /** Query object from `EuiSearchBar`. */
+  query?: Query;
+  /** `onChange` callback from `EuiSearchBar`. */
+  onChange?: (query: Query) => void;
+  /** Optional `data-test-subj` attribute for testing. */
+  'data-test-subj'?: string;
+}
+
+const i18nText = {
+  title: i18n.translate('contentManagement.contentList.tagsRenderer.tagsLabel', {
+    defaultMessage: 'Tags',
+  }),
+  emptyMessage: i18n.translate('contentManagement.contentList.tagsRenderer.emptyMessage', {
+    defaultMessage: "There aren't any tags",
+  }),
+  noMatchesMessage: i18n.translate('contentManagement.contentList.tagsRenderer.noMatchesMessage', {
+    defaultMessage: 'No tag matches the search',
+  }),
+};
+
+/**
+ * `TagFilterRenderer` component for `EuiSearchBar` `custom_component` filter.
+ *
+ * This is a thin wrapper around {@link SelectableFilterPopover} that provides
+ * tag-specific data: options with colors, per-tag item counts, and dynamic
+ * panel sizing.
+ *
+ * Features:
+ * - Multi-select with include/exclude support (Cmd+click to exclude).
+ * - Tag counts per option.
+ * - Search within the popover.
+ * - Colored tag badges.
+ *
+ * Requires `ContentManagementTagsProvider` in the component tree (automatically
+ * provided when `services.tags` is configured on the `ContentListProvider`).
+ */
+export const TagFilterRenderer = ({
+  query,
+  onChange,
+  'data-test-subj': dataTestSubj = 'contentListTagsRenderer',
+}: TagFilterRendererProps) => {
+  const { euiTheme } = useEuiTheme();
+  const { hasTags } = useFilterDisplay();
+  const tagServices = useTagServices();
+  const { counts } = useContentListItems();
+
+  const availableTags = useMemo(() => {
+    if (!tagServices?.getTagList) {
+      return [];
+    }
+    try {
+      return tagServices.getTagList();
+    } catch {
+      return [];
+    }
+  }, [tagServices]);
+
+  // Build options for `SelectableFilterPopover`. Counts are only included
+  // when the data source provides full-set counts — per-page counts would
+  // be misleading with pagination. Counts are keyed by filter id in
+  // `FindItemsResult.counts`; for tags, use `counts[TAG_FILTER_ID]` keyed by tag ID
+  // (or name for tags without an ID).
+  const tagCounts = counts?.[TAG_FILTER_ID];
+  const options = useMemo((): Array<SelectableFilterOption<Tag>> => {
+    return availableTags.map((tag) => ({
+      key: tag.id ?? tag.name,
+      label: tag.name,
+      value: tag.name,
+      count: tagCounts?.[tag.id ?? tag.name],
+      data: tag,
+    }));
+  }, [availableTags, tagCounts]);
+
+  // Minimum panel width derived from the EUI base unit so the popover
+  // doesn't collapse on short tag names. The panel grows naturally beyond
+  // this minimum when tags have longer names.
+  const panelMinWidth = euiTheme.base * 24;
+
+  const renderOption = useCallback(
+    (option: SelectableFilterOption<Tag>, state: { isActive: boolean }) => (
+      <StandardFilterOption count={option.count} isActive={state.isActive}>
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiHealth
+              color={option.data?.color}
+              data-test-subj={`tag-searchbar-option-${option.key}`}
+            >
+              <EuiText size="s">{option.label}</EuiText>
+            </EuiHealth>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </StandardFilterOption>
+    ),
+    []
+  );
+
+  if (!hasTags || availableTags.length === 0) {
+    return null;
+  }
+
+  return (
+    <SelectableFilterPopover<Tag>
+      fieldName={TAG_FILTER_ID}
+      title={i18nText.title}
+      query={query}
+      onChange={onChange}
+      options={options}
+      renderOption={renderOption}
+      emptyMessage={i18nText.emptyMessage}
+      noMatchesMessage={i18nText.noMatchesMessage}
+      panelMinWidth={panelMinWidth}
+      data-test-subj={dataTestSubj}
+    />
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/use_tag_query_parser.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/tags/use_tag_query_parser.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo } from 'react';
+import { useTagServices } from '@kbn/content-management-tags';
+import type { QueryParser, QueryParserResult } from '../query_parser';
+
+/**
+ * Returns a {@link QueryParser} that extracts `tag:name` and `-tag:name` clauses
+ * from the search bar query text and maps them to `filters.tag` include/exclude lists.
+ *
+ * Returns `null` when no tag service is registered — the toolbar skips this
+ * parser and the query text is passed through unchanged.
+ *
+ * Used by {@link ContentListToolbar}'s `handleSearchChange` pipeline. Register
+ * additional parsers alongside this one (e.g. `useUserQueryParser`) to support
+ * more filter types without modifying `handleSearchChange`.
+ */
+export const useTagQueryParser = (): QueryParser | null => {
+  const tagServices = useTagServices();
+
+  return useMemo((): QueryParser | null => {
+    if (!tagServices?.parseSearchQuery) {
+      return null;
+    }
+
+    const { parseSearchQuery } = tagServices;
+
+    return {
+      parse(queryText: string): QueryParserResult {
+        const { searchQuery, tagIds, tagIdsToExclude } = parseSearchQuery(queryText);
+        const hasTags =
+          (tagIds && tagIds.length > 0) || (tagIdsToExclude && tagIdsToExclude.length > 0);
+
+        return {
+          searchQuery,
+          // Return an empty object when no tag clauses are present — this correctly
+          // clears any existing tag filter, since the search bar is the source of truth.
+          filters: hasTags
+            ? { tag: { include: tagIds ?? [], exclude: tagIdsToExclude ?? [] } }
+            : {},
+        };
+      },
+    };
+  }, [tagServices]);
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
@@ -11,13 +11,14 @@ import { Children, Fragment, isValidElement, useMemo } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import type { SearchFilterConfig } from '@elastic/eui';
 import type { ParsedPart } from '@kbn/content-list-assembly';
-import { useContentListSort } from '@kbn/content-list-provider';
+import { useContentListSort, useFilterDisplay } from '@kbn/content-list-provider';
 import { filter } from '../filters/part';
 import { Filters, type FiltersProps } from '../filters/filters';
 import type { FilterContext } from '../filters/part';
 
-/** Default filter when no children are provided. */
+/** Default filters when no children are provided. */
 const DEFAULT_PARTS: ParsedPart[] = [
+  { type: 'part', part: 'filter', preset: 'tags', instanceId: 'tags', attributes: {} },
   { type: 'part', part: 'filter', preset: 'sort', instanceId: 'sort', attributes: {} },
 ];
 
@@ -56,7 +57,9 @@ const extractFilterChildren = (children: ReactNode): ReactNode[] => {
  */
 const parseFilterParts = (children: ReactNode): ParsedPart[] => {
   const filterChildren = extractFilterChildren(children);
-  if (filterChildren.length === 0) return DEFAULT_PARTS;
+  if (filterChildren.length === 0) {
+    return DEFAULT_PARTS;
+  }
 
   const parts = filterChildren.flatMap((child) => filter.parseChildren(child));
   return parts.length > 0 ? parts : DEFAULT_PARTS;
@@ -69,13 +72,14 @@ const parseFilterParts = (children: ReactNode): ParsedPart[] => {
  * 1. Extract `<Filters>` children from the toolbar's children.
  * 2. Parse declarative `Filter` presets via `filter.parseChildren`.
  * 3. Resolve `SearchFilterConfig` objects via `filter.resolve`.
- * 4. Fall back to default sort filter if none are found.
+ * 4. Fall back to default filters (tags + sort) if none are found.
  *
  * @param children - React children from the toolbar component.
  * @returns Array of EUI search filter configs ready for `EuiSearchBar`.
  */
 export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
   const { isSupported: hasSorting } = useContentListSort();
+  const { hasTags } = useFilterDisplay();
 
   // Note: `children` is used as a memo dependency. React children are often
   // unstable references (new JSX objects each render), so this memo may
@@ -84,10 +88,10 @@ export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
   // consider keying on a more stable signal.
   return useMemo(() => {
     const parts = parseFilterParts(children);
-    const context: FilterContext = { hasSorting };
+    const context: FilterContext = { hasSorting, hasTags };
 
     return parts
       .map((part) => filter.resolve(part, context))
       .filter((f): f is SearchFilterConfig => f !== undefined);
-  }, [children, hasSorting]);
+  }, [children, hasSorting, hasTags]);
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/tsconfig.json
@@ -25,6 +25,8 @@
     "@kbn/content-list-assembly",
     "@kbn/content-list-provider",
     "@kbn/content-list-mock-data",
+    "@kbn/content-management-tags",
     "@kbn/i18n",
+    "@kbn/shared-ux-utility",
   ]
 }

--- a/src/platform/packages/shared/content-management/kbn-content-management-tags/src/services.tsx
+++ b/src/platform/packages/shared/content-management/kbn-content-management-tags/src/services.tsx
@@ -82,17 +82,6 @@ export interface ContentManagementTagsKibanaDependencies {
 const ContentManagementTagsContext = createContext<Services | null>(null);
 
 /**
- * Pure parsing logic for extracting tag filters from a search query.
- *
- * This function is intentionally defined outside the component to avoid
- * recreation on each render. It contains no dependencies on React state
- * or callbacks.
- *
- * @param searchQuery - The raw search query string to parse.
- * @param tags - The list of available tags to resolve names against.
- * @returns Parsed query with extracted tag IDs and cleaned search text.
- */
-/**
  * Resolves tag names to tag IDs using the provided tag list.
  *
  * @param tagNames - Array of tag names to resolve.
@@ -171,7 +160,9 @@ const parseSearchQueryCore = (searchQuery: string, tags: Tag[]): ParsedQuery => 
   const uniqueTagIdsToExclude = [...new Set(tagIdsToExclude)];
 
   // Remove tag clauses from search query to get clean search term.
-  const cleanQuery = query.removeOrFieldClauses('tag');
+  // Both OR-field clauses (`tag:(A or B)`) and simple field clauses (`tag:A`) must be
+  // stripped, otherwise simple clauses leak into the text search sent to `findItems`.
+  const cleanQuery = query.removeOrFieldClauses('tag').removeSimpleFieldClauses('tag');
   const hasResolvedTags = uniqueTagIds.length > 0 || uniqueTagIdsToExclude.length > 0;
 
   if (!hasResolvedTags) {

--- a/src/platform/packages/shared/content-management/kbn-content-management-tags/src/tags_query.test.ts
+++ b/src/platform/packages/shared/content-management/kbn-content-management-tags/src/tags_query.test.ts
@@ -29,6 +29,14 @@ describe('useTags', () => {
     managed: false,
   };
 
+  const mockTagMultiWord: Tag = {
+    id: 'tag-multi',
+    name: 'New York',
+    description: 'Multi-word tag name',
+    color: '#0000FF',
+    managed: false,
+  };
+
   const mockItems = [
     {
       id: 'item-1',
@@ -407,6 +415,122 @@ describe('useTags', () => {
       });
 
       expect(updateQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('multi-word tag names', () => {
+    it('adds a multi-word tag to include filter with quoted syntax', () => {
+      const updateQuery = jest.fn();
+      const { result } = renderHook(() =>
+        useTags({
+          query: Query.parse(''),
+          updateQuery,
+          items: mockItems,
+        })
+      );
+
+      act(() => {
+        result.current.toggleIncludeTagFilter(mockTagMultiWord);
+      });
+
+      expect(updateQuery).toHaveBeenCalledTimes(1);
+      const calledQuery = updateQuery.mock.calls[0][0];
+      expect(calledQuery.text).toContain('New York');
+    });
+
+    it('removes a multi-word tag from include filter', () => {
+      const updateQuery = jest.fn();
+      const { result } = renderHook(() =>
+        useTags({
+          query: Query.parse('tag:("New York")'),
+          updateQuery,
+          items: mockItems,
+        })
+      );
+
+      act(() => {
+        result.current.toggleIncludeTagFilter(mockTagMultiWord);
+      });
+
+      expect(updateQuery).toHaveBeenCalledTimes(1);
+      const calledQuery = updateQuery.mock.calls[0][0];
+      expect(calledQuery.text).not.toContain('New York');
+    });
+
+    it('combines multi-word and single-word tags in an OR clause', () => {
+      const updateQuery = jest.fn();
+      const { result } = renderHook(() =>
+        useTags({
+          query: Query.parse('tag:(Important)'),
+          updateQuery,
+          items: mockItems,
+        })
+      );
+
+      act(() => {
+        result.current.toggleIncludeTagFilter(mockTagMultiWord);
+      });
+
+      const calledQuery = updateQuery.mock.calls[0][0];
+      expect(calledQuery.text).toContain('Important');
+      expect(calledQuery.text).toContain('New York');
+    });
+
+    it('adds a multi-word tag to exclude filter', () => {
+      const updateQuery = jest.fn();
+      const { result } = renderHook(() =>
+        useTags({
+          query: Query.parse(''),
+          updateQuery,
+          items: mockItems,
+        })
+      );
+
+      act(() => {
+        result.current.toggleExcludeTagFilter(mockTagMultiWord);
+      });
+
+      expect(updateQuery).toHaveBeenCalledTimes(1);
+      const calledQuery = updateQuery.mock.calls[0][0];
+      expect(calledQuery.text).toContain('New York');
+      expect(calledQuery.text).toContain('-tag:');
+    });
+
+    it('moves a multi-word tag from include to exclude', () => {
+      const updateQuery = jest.fn();
+      const { result } = renderHook(() =>
+        useTags({
+          query: Query.parse('tag:("New York")'),
+          updateQuery,
+          items: mockItems,
+        })
+      );
+
+      act(() => {
+        result.current.toggleExcludeTagFilter(mockTagMultiWord);
+      });
+
+      expect(updateQuery).toHaveBeenCalledTimes(1);
+      const calledQuery = updateQuery.mock.calls[0][0];
+      expect(calledQuery.text).toBe('-tag:("New York")');
+    });
+
+    it('clears multi-word tags along with single-word tags', () => {
+      const updateQuery = jest.fn();
+      const { result } = renderHook(() =>
+        useTags({
+          query: Query.parse('tag:(Important or "New York") -tag:("New York")'),
+          updateQuery,
+          items: mockItems,
+        })
+      );
+
+      act(() => {
+        result.current.clearTagSelection();
+      });
+
+      const calledQuery = updateQuery.mock.calls[0][0];
+      expect(calledQuery.text).toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds tag filtering and tag display to the Content List system — include/exclude tag filters in the toolbar and clickable tag badges on the Name column.

> [!NOTE]
> This is PR 9 of the Content List implementation plan derived from #247778.

### What changed

**`@kbn/content-list-provider`**

- `ContentListServices.tags` backed by `ContentManagementTagsServices` from `@kbn/content-management-tags`.
- `features.tags` (`boolean`) and `supports.tags` flag — auto-enabled when `services.tags` is provided, overridable with `features.tags: false`.
- `filters: ActiveFilters` in client state, with a `tag: { include, exclude }` dimension keyed by `TAG_FILTER_ID = 'tag'`.
- `useTagFilterToggle` hook — toggles include/exclude tag filters from any component. Regular click = include; modifier+click (Cmd/Ctrl) = exclude. Normalizes to `undefined` when both arrays are empty.
- `useFilterDisplay`, `useContentListFilters` hooks for reading filter and display state.
- When `services.tags` is provided, wraps children in `ContentManagementTagsProvider`.

**`@kbn/content-list-table`**

- `Column.Name` gains `showTags` and `onTagClick` props.
- `NameCellTags` renders tag badges beneath the title/description and wires to `useTagFilterToggle` by default.

**`@kbn/content-list-toolbar`**

- `EuiSearchBar` in controlled mode; `onChange` dispatches both query text and structured filters via `tagServices.parseSearchQuery`.
- `SelectableFilterPopover` — reusable multi-select filter popover with include/exclude support via modifier key.
- `TagFilter` / `TagFilterRenderer` — declarative filter preset for tags.
- Shared utilities: `useFieldQueryFilter`, `ModifierKeyTip`, `FilterCountBadge`, `StandardFilterOption`.

**`@kbn/content-list-mock-data`**

- `mockTagsService` with `getTagList` and `parseSearchQuery` backed by `MOCK_TAGS`.
- `extractTagIds` helper for converting `references` to `ContentListItem.tags`.

## Test plan

> [!TIP]
> The **Playground** story (Content List → Playground in Storybook) is the easiest way to exercise tags. Enable the Tags filter via the builder panel, then use the Preview tab.

1. Run Storybook: `yarn storybook content_management`
2. **Playground → enable Tags filter:**
   - Select a tag in the popover — results narrow and other tag counts update.
   - Cmd/Ctrl+click a tag — it's excluded (red X); second Cmd/Ctrl+click removes it.
   - Click a tag badge in the Name column — toggles an include filter; Cmd/Ctrl+click toggles exclude.
   - Type `tag:foo` directly in the search bar — filter state updates to match.
3. **Unit tests:** all pass
   - `yarn jest src/platform/packages/shared/content-management/content_list/kbn-content-list-provider`
   - `yarn jest src/platform/packages/shared/content-management/content_list/kbn-content-list-table`
   - `yarn jest src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar`