### PR TITLE
chore(NA): improves CI allocation for the current setup and targets

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -73,14 +73,14 @@ export async function pickTestGroupRunOrder() {
 
   const JEST_MAX_MINUTES = process.env.JEST_MAX_MINUTES
     ? parseFloat(process.env.JEST_MAX_MINUTES)
-    : 40;
+    : 35;
   if (Number.isNaN(JEST_MAX_MINUTES)) {
     throw new Error(`invalid JEST_MAX_MINUTES: ${process.env.JEST_MAX_MINUTES}`);
   }
 
   const FUNCTIONAL_MAX_MINUTES = process.env.FUNCTIONAL_MAX_MINUTES
     ? parseFloat(process.env.FUNCTIONAL_MAX_MINUTES)
-    : 37;
+    : 30;
   if (Number.isNaN(FUNCTIONAL_MAX_MINUTES)) {
     throw new Error(`invalid FUNCTIONAL_MAX_MINUTES: ${process.env.FUNCTIONAL_MAX_MINUTES}`);
   }

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -428,7 +428,7 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
     depends_on: *on_merge_gates
-    parallelism: 20
+    parallelism: 22
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -15,7 +15,7 @@ steps:
       - linting_with_types
       - check_types
     timeout_in_minutes: 60
-    parallelism: 20
+    parallelism: 22
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-operations/issues/446

This PR changes the max minute values both for FTR and JEST at pick test group time. Those new values are a better sweet spot for our current targets and setup having into account retries times after flakyness or failure. 

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->