### PR TITLE
fix precommit hook for local use

### DIFF
--- a/src/dev/precommit_hook/casing_check_config.js
+++ b/src/dev/precommit_hook/casing_check_config.js
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import minimatch from 'minimatch';
+
 export const IGNORE_PATTERNS = [
   // the gitignore: true option makes sure that we don't
   // include files from node_modules in the result, but it still
@@ -71,3 +73,22 @@ export const IGNORE_PATTERNS = [
 ];
 
 export const KEBAB_CASE_PATTERNS = ['docs/**/*'];
+
+/**
+ * Contains the logic that decides what is the expected casing for each Kibana resource (folders, files)
+ * @param relativePath string the relative path to the resource
+ * @param packageRootDirs set of relative paths that represent the root of Kibana packages (not plugins)
+ * @returns the expected casing (kebab-case | snake_case) for the given resource
+ */
+export function getExpectedCasing(relativePath, packageRootDirs) {
+  if (packageRootDirs.has(relativePath)) {
+    // it is a Kibana module of type package (not a plugin)
+    return 'kebab-case';
+  } else if (KEBAB_CASE_PATTERNS.some((pattern) => minimatch(relativePath, pattern))) {
+    // the resource matches one of the KEBAB_CASE_PATTERNS from the config
+    return 'kebab-case';
+  } else {
+    // everything else is snake_case by default
+    return 'snake_case';
+  }
+}

--- a/src/dev/precommit_hook/check_file_casing.js
+++ b/src/dev/precommit_hook/check_file_casing.js
@@ -63,7 +63,7 @@ function getSegmentPaths(relativePath) {
 }
 
 export async function checkFileCasing(log, paths, getExpectedCasing, options = {}) {
-  const { exceptions = [], generateExceptions = false } = options;
+  const { exceptions = [], generateExceptions = false, packageRootDirs } = options;
 
   const violations = [];
 
@@ -77,7 +77,7 @@ export async function checkFileCasing(log, paths, getExpectedCasing, options = {
 
   pathsToValidate.forEach((path) => {
     const resourceName = basename(path);
-    const expectedCasing = getExpectedCasing(path);
+    const expectedCasing = getExpectedCasing(path, packageRootDirs);
 
     switch (expectedCasing) {
       case 'kebab-case':

--- a/src/dev/precommit_hook/check_file_casing.js
+++ b/src/dev/precommit_hook/check_file_casing.js
@@ -69,7 +69,7 @@ export async function checkFileCasing(log, paths, getExpectedCasing, options = {
 
   const pathsToValidate = uniq(
     paths
-      .map((path) => new File(path))
+      .map((path) => (path instanceof File ? path : new File(path)))
       .map((file) => normalizePath(file.getRelativePath()))
       .flatMap((path) => getSegmentPaths(path))
       .filter((path) => generateExceptions || !exceptions.includes(path))

--- a/src/dev/run_check_file_casing.ts
+++ b/src/dev/run_check_file_casing.ts
@@ -11,13 +11,12 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import globby from 'globby';
-import minimatch from 'minimatch';
 
 import { REPO_ROOT } from '@kbn/repo-info';
 import { run } from '@kbn/dev-cli-runner';
 import { getPackages } from '@kbn/repo-packages';
 import { checkFileCasing } from './precommit_hook/check_file_casing';
-import { IGNORE_PATTERNS, KEBAB_CASE_PATTERNS } from './precommit_hook/casing_check_config';
+import { IGNORE_PATTERNS, getExpectedCasing } from './precommit_hook/casing_check_config';
 
 const RELATIVE_EXCEPTIONS_PATH = 'src/dev/precommit_hook/exceptions.json';
 const EXCEPTIONS_JSON_PATH = join(REPO_ROOT, RELATIVE_EXCEPTIONS_PATH);
@@ -46,24 +45,6 @@ run(
     const exceptions: string[] = Object.values(rawExceptions).flatMap((teamObject) =>
       Object.keys(teamObject)
     );
-
-    /**
-     * Contains the logic that decides what is the expected casing for each Kibana resource (folders, files)
-     * @param relativePath string the relative path to the resource
-     * @returns expected casing (kebab-case | snake_case) for the given resource
-     */
-    const getExpectedCasing = function (relativePath: string) {
-      if (packageRootDirs.has(relativePath)) {
-        // it is a Kibana module of type package (not a plugin)
-        return 'kebab-case';
-      } else if (KEBAB_CASE_PATTERNS.some((pattern) => minimatch(relativePath, pattern))) {
-        // the resource matches one of the KEBAB_CASE_PATTERNS from the config
-        return 'kebab-case';
-      } else {
-        // everything else is snake_case by default
-        return 'snake_case';
-      }
-    };
 
     await checkFileCasing(log, paths, getExpectedCasing, {
       packageRootDirs,

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -22,8 +22,7 @@ import { getFilesForCommit, checkFileCasing } from './precommit_hook';
 import { checkSemverRanges } from './no_pkg_semver_ranges';
 import { load as yamlLoad } from 'js-yaml';
 import { readFile } from 'fs/promises';
-import { KEBAB_CASE_PATTERNS } from './precommit_hook/casing_check_config';
-import minimatch from 'minimatch';
+import { getExpectedCasing } from './precommit_hook/casing_check_config';
 
 const EXCEPTIONS_JSON_PATH = join(REPO_ROOT, 'src/dev/precommit_hook/exceptions.json');
 
@@ -89,24 +88,6 @@ class FileCasingCheck extends PrecommitCheck {
     const exceptions = Object.values(rawExceptions).flatMap((teamObject) =>
       Object.keys(teamObject)
     );
-
-    /**
-     * Contains the logic that decides what is the expected casing for each Kibana resource (folders, files)
-     * @param relativePath string the relative path to the resource
-     * @returns expected casing (kebab-case | snake_case) for the given resource
-     */
-    const getExpectedCasing = function (relativePath) {
-      if (packageRootDirs.has(relativePath)) {
-        // it is a Kibana module of type package (not a plugin)
-        return 'kebab-case';
-      } else if (KEBAB_CASE_PATTERNS.some((pattern) => minimatch(relativePath, pattern))) {
-        // the resource matches one of the KEBAB_CASE_PATTERNS from the config
-        return 'kebab-case';
-      } else {
-        // everything else is snake_case by default
-        return 'snake_case';
-      }
-    };
 
     await checkFileCasing(log, files, getExpectedCasing, {
       packageRootDirs,

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -22,6 +22,8 @@ import { getFilesForCommit, checkFileCasing } from './precommit_hook';
 import { checkSemverRanges } from './no_pkg_semver_ranges';
 import { load as yamlLoad } from 'js-yaml';
 import { readFile } from 'fs/promises';
+import { KEBAB_CASE_PATTERNS } from './precommit_hook/casing_check_config';
+import minimatch from 'minimatch';
 
 const EXCEPTIONS_JSON_PATH = join(REPO_ROOT, 'src/dev/precommit_hook/exceptions.json');
 
@@ -87,7 +89,26 @@ class FileCasingCheck extends PrecommitCheck {
     const exceptions = Object.values(rawExceptions).flatMap((teamObject) =>
       Object.keys(teamObject)
     );
-    await checkFileCasing(log, files, {
+
+    /**
+     * Contains the logic that decides what is the expected casing for each Kibana resource (folders, files)
+     * @param relativePath string the relative path to the resource
+     * @returns expected casing (kebab-case | snake_case) for the given resource
+     */
+    const getExpectedCasing = function (relativePath) {
+      if (packageRootDirs.has(relativePath)) {
+        // it is a Kibana module of type package (not a plugin)
+        return 'kebab-case';
+      } else if (KEBAB_CASE_PATTERNS.some((pattern) => minimatch(relativePath, pattern))) {
+        // the resource matches one of the KEBAB_CASE_PATTERNS from the config
+        return 'kebab-case';
+      } else {
+        // everything else is snake_case by default
+        return 'snake_case';
+      }
+    };
+
+    await checkFileCasing(log, files, getExpectedCasing, {
       packageRootDirs,
       exceptions,
     });


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/213696 updated the calculation for file name casing, but it broke the interaction with the local run of precommit hooks. 
This PR fixes it by extracting the function `getExpectedCasing` and reusing it in both callsites to the shared casing logic.