### PR TITLE
[9.3] Don’t block User & Host flyouts while observed data loading (#252657)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/components/observed_data_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/components/observed_data_section.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiAccordion,
+  EuiLoadingSpinner,
+  EuiTitle,
+  useEuiFontSize,
+  useEuiTheme,
+} from '@elastic/eui';
+
+import React, { memo, useMemo } from 'react';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { hostToCriteria } from '../../../../common/components/ml/criteria/host_to_criteria';
+import { useGlobalTime } from '../../../../common/containers/use_global_time';
+import { useInstalledSecurityJobNameById } from '../../../../common/components/ml/hooks/use_installed_security_jobs';
+import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
+import { ONE_WEEK_IN_HOURS } from '../../shared/constants';
+import { ObservedEntity } from '../../shared/components/observed_entity';
+import { useObservedHostFields } from '../hooks/use_observed_host_fields';
+import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
+import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
+import type { HostItem } from '../../../../../common/search_strategy';
+import { useAnomaliesTableData } from '../../../../common/components/ml/anomaly/use_anomalies_table_data';
+
+type ObservedHostData = Omit<ObservedEntityData<HostItem>, 'anomalies'>;
+
+export const ObservedDataSection = memo(
+  ({
+    hostName,
+    observedHost,
+    contextID,
+    scopeId,
+    queryId,
+  }: {
+    hostName: string;
+    observedHost: ObservedHostData;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+  }) => {
+    const { euiTheme } = useEuiTheme();
+    const xsFontSize = useEuiFontSize('xxs').fontSize;
+
+    const buttonContent = (
+      <EuiTitle size="xs">
+        <h3>
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.entityDetails.observedDataTitle"
+            defaultMessage="Observed data"
+          />
+        </h3>
+      </EuiTitle>
+    );
+
+    const extraAction = (
+      <>
+        <span
+          css={css`
+            margin-right: ${euiTheme.size.s};
+          `}
+        >
+          <InspectButton
+            queryId={queryId}
+            title={
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.entityDetails.observedDataInspectTitle"
+                defaultMessage="Observed data"
+              />
+            }
+          />
+        </span>
+        {observedHost.lastSeen.date && (
+          <span
+            css={css`
+              font-size: ${xsFontSize};
+            `}
+          >
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.entityDetails.observedEntityUpdatedTime"
+              defaultMessage="Updated {time}"
+              values={{
+                time: (
+                  <FormattedRelativePreferenceDate
+                    value={observedHost.lastSeen.date}
+                    dateFormat="MMM D, YYYY"
+                    relativeThresholdInHrs={ONE_WEEK_IN_HOURS}
+                  />
+                ),
+              }}
+            />
+          </span>
+        )}
+      </>
+    );
+
+    return (
+      <InspectButtonContainer>
+        <EuiAccordion
+          initialIsOpen={true}
+          id="observedEntity-accordion"
+          data-test-subj="observedEntity-accordion"
+          buttonProps={{
+            'data-test-subj': 'observedEntity-accordion-button',
+            css: css`
+              color: ${euiTheme.colors.primary};
+            `,
+          }}
+          buttonContent={buttonContent}
+          extraAction={extraAction}
+          css={css`
+            .euiAccordion__optionalAction {
+              margin-left: auto;
+            }
+          `}
+        >
+          {observedHost.isLoading ? (
+            <EuiLoadingSpinner data-test-subj="observedDataSectionLoadingSpinner" />
+          ) : (
+            <ObservedDataSectionContent
+              hostName={hostName}
+              observedHost={observedHost}
+              contextID={contextID}
+              scopeId={scopeId}
+              queryId={queryId}
+            />
+          )}
+        </EuiAccordion>
+      </InspectButtonContainer>
+    );
+  }
+);
+ObservedDataSection.displayName = 'ObservedDataSection';
+
+const ObservedDataSectionContent = memo(
+  ({
+    hostName,
+    observedHost,
+    contextID,
+    scopeId,
+    queryId,
+  }: {
+    hostName: string;
+    observedHost: ObservedHostData;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+  }) => {
+    const { to, from, isInitializing } = useGlobalTime();
+
+    const { jobNameById } = useInstalledSecurityJobNameById();
+    const jobIds = useMemo(() => Object.keys(jobNameById), [jobNameById]);
+    const [isLoadingAnomaliesData, anomaliesData] = useAnomaliesTableData({
+      criteriaFields: hostToCriteria(observedHost.details),
+      startDate: from,
+      endDate: to,
+      skip: isInitializing,
+      jobIds,
+      aggregationInterval: 'auto',
+    });
+
+    const observedHostWithAnomalies = useMemo(
+      (): ObservedEntityData<HostItem> => ({
+        ...observedHost,
+        anomalies: {
+          isLoading: isLoadingAnomaliesData,
+          anomalies: anomaliesData,
+          jobNameById,
+        },
+      }),
+      [observedHost, isLoadingAnomaliesData, anomaliesData, jobNameById]
+    );
+    const observedFields = useObservedHostFields(observedHostWithAnomalies);
+
+    return (
+      <ObservedEntity
+        observedData={observedHostWithAnomalies}
+        contextID={contextID}
+        scopeId={scopeId}
+        observedFields={observedFields}
+      />
+    );
+  }
+);
+ObservedDataSectionContent.displayName = 'ObservedDataSectionContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.stories.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.stories.tsx
@@ -64,7 +64,6 @@ export const NoObservedData = {
           isLoading: false,
           date: undefined,
         },
-        anomalies: { isLoading: false, anomalies: null, jobNameById: {} },
       }}
       riskScoreState={riskScoreData}
       contextID={'test-host-details'}
@@ -94,7 +93,6 @@ export const Loading = {
           isLoading: true,
           date: undefined,
         },
-        anomalies: { isLoading: true, anomalies: null, jobNameById: {} },
       }}
       riskScoreState={riskScoreData}
       contextID={'test-host-details'}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { EuiHorizontalRule } from '@elastic/eui';
+import { ObservedDataSection } from './components/observed_data_section';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { EntityHighlightsAccordion } from '../../../entity_analytics/components/entity_details_flyout/components/entity_highlights';
 import { FlyoutBody } from '../../shared/components/flyout_body';
@@ -15,20 +16,20 @@ import { AssetCriticalityAccordion } from '../../../entity_analytics/components/
 import { FlyoutRiskSummary } from '../../../entity_analytics/components/risk_summary_flyout/risk_summary';
 import type { RiskScoreState } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { EntityIdentifierFields, EntityType } from '../../../../common/entity_analytics/types';
-import type { HostItem } from '../../../../common/search_strategy';
-import { ObservedEntity } from '../shared/components/observed_entity';
 import { HOST_PANEL_OBSERVED_HOST_QUERY_ID, HOST_PANEL_RISK_SCORE_QUERY_ID } from '.';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
-import { useObservedHostFields } from './hooks/use_observed_host_fields';
 import type { EntityDetailsPath } from '../shared/components/left_panel/left_panel_header';
+import type { ObservedEntityData } from '../shared/components/observed_entity/types';
+import type { HostItem } from '../../../../common/search_strategy';
+
+type ObservedHostData = Omit<ObservedEntityData<HostItem>, 'anomalies'>;
 
 interface HostPanelContentProps {
-  observedHost: ObservedEntityData<HostItem>;
+  hostName: string;
+  observedHost: ObservedHostData;
   riskScoreState: RiskScoreState<EntityType.host>;
   contextID: string;
   scopeId: string;
   openDetailsPanel: (path: EntityDetailsPath) => void;
-  hostName: string;
   onAssetCriticalityChange: () => void;
   recalculatingScore: boolean;
   isPreviewMode: boolean;
@@ -45,8 +46,6 @@ export const HostPanelContent = ({
   onAssetCriticalityChange,
   isPreviewMode,
 }: HostPanelContentProps) => {
-  const observedFields = useObservedHostFields(observedHost);
-
   const isEntityDetailsHighlightsAIEnabled = useIsExperimentalFeatureEnabled(
     'entityDetailsHighlightsEnabled'
   );
@@ -79,11 +78,11 @@ export const HostPanelContent = ({
         isPreviewMode={isPreviewMode}
         openDetailsPanel={openDetailsPanel}
       />
-      <ObservedEntity
-        observedData={observedHost}
+      <ObservedDataSection
+        hostName={hostName}
+        observedHost={observedHost}
         contextID={contextID}
         scopeId={scopeId}
-        observedFields={observedFields}
         queryId={HOST_PANEL_OBSERVED_HOST_QUERY_ID}
       />
     </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.test.tsx
@@ -9,11 +9,16 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../common/mock';
 import { HostPanelHeader } from './header';
-import { mockObservedHostData } from '../mocks';
+
+const defaultLastSeen = {
+  date: '2023-02-23T20:03:17.489Z',
+  isLoading: false,
+};
 
 const mockProps = {
   hostName: 'test',
-  observedHost: mockObservedHostData,
+  scopeId: 'test-scope-id',
+  lastSeen: defaultLastSeen,
 };
 
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable');
@@ -33,18 +38,7 @@ describe('HostPanelHeader', () => {
     const futureDay = '2989-03-07T20:00:00.000Z';
     const { getByTestId } = render(
       <TestProviders>
-        <HostPanelHeader
-          {...{
-            ...mockProps,
-            observedHost: {
-              ...mockObservedHostData,
-              lastSeen: {
-                isLoading: false,
-                date: futureDay,
-              },
-            },
-          }}
-        />
+        <HostPanelHeader {...mockProps} lastSeen={{ date: futureDay, isLoading: false }} />
       </TestProviders>
     );
 
@@ -64,21 +58,22 @@ describe('HostPanelHeader', () => {
   it('does not render observed badge when lastSeen date is undefined', () => {
     const { queryByTestId } = render(
       <TestProviders>
-        <HostPanelHeader
-          {...{
-            ...mockProps,
-            observedHost: {
-              ...mockObservedHostData,
-              lastSeen: {
-                isLoading: false,
-                date: undefined,
-              },
-            },
-          }}
-        />
+        <HostPanelHeader {...mockProps} lastSeen={{ date: undefined, isLoading: false }} />
       </TestProviders>
     );
 
+    expect(queryByTestId('host-panel-header-observed-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders skeleton when loading', () => {
+    const { getByTestId, queryByTestId } = render(
+      <TestProviders>
+        <HostPanelHeader {...mockProps} lastSeen={{ date: undefined, isLoading: true }} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('host-panel-header-lastSeen-loading')).toBeInTheDocument();
+    expect(getByTestId('host-panel-header-observed-badge-loading')).toBeInTheDocument();
     expect(queryByTestId('host-panel-header-observed-badge')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.tsx
@@ -5,37 +5,54 @@
  * 2.0.
  */
 
-import { EuiSpacer, EuiBadge, EuiText, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSkeletonText,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useMemo } from 'react';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import type { HostItem } from '../../../../common/search_strategy';
 import { getHostDetailsUrl } from '../../../common/components/link_to';
 import { SecuritySolutionLinkAnchor } from '../../../common/components/links';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
 import { FlyoutHeader } from '../../shared/components/flyout_header';
 import { FlyoutTitle } from '../../shared/components/flyout_title';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
+import type { FirstLastSeenData } from '../shared/components/observed_entity/types';
 
 interface HostPanelHeaderProps {
   hostName: string;
-  observedHost: ObservedEntityData<HostItem>;
+  lastSeen: FirstLastSeenData;
 }
 
 const linkTitleCSS = { width: 'fit-content' };
 
-export const HostPanelHeader = ({ hostName, observedHost }: HostPanelHeaderProps) => {
-  const lastSeenDate = useMemo(
-    () => observedHost.lastSeen.date && new Date(observedHost.lastSeen.date),
-    [observedHost.lastSeen.date]
-  );
+const urlParamOverride = { timeline: { isOpen: false } };
 
+export const HostPanelHeader = ({ hostName, lastSeen }: HostPanelHeaderProps) => {
+  const lastSeenDate = lastSeen?.date;
+  const isLoading = lastSeen?.isLoading ?? false;
+  const lastSeenDateFormatted = useMemo(
+    () => lastSeenDate && new Date(lastSeenDate),
+    [lastSeenDate]
+  );
   return (
     <FlyoutHeader data-test-subj="host-panel-header">
       <EuiFlexGroup gutterSize="s" responsive={false} direction="column">
         <EuiFlexItem grow={false}>
           <EuiText size="xs" data-test-subj={'host-panel-header-lastSeen'}>
-            {lastSeenDate && <PreferenceFormattedDate value={lastSeenDate} />}
+            {isLoading ? (
+              <EuiSkeletonText
+                lines={1}
+                size="xs"
+                data-test-subj="host-panel-header-lastSeen-loading"
+              />
+            ) : (
+              lastSeenDateFormatted && <PreferenceFormattedDate value={lastSeenDateFormatted} />
+            )}
             <EuiSpacer size="xs" />
           </EuiText>
         </EuiFlexItem>
@@ -50,20 +67,30 @@ export const HostPanelHeader = ({ hostName, observedHost }: HostPanelHeaderProps
             <FlyoutTitle title={hostName} iconType={'storage'} isLink />
           </SecuritySolutionLinkAnchor>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            <EuiFlexItem grow={false}>
-              {observedHost.lastSeen.date && (
-                <EuiBadge data-test-subj="host-panel-header-observed-badge" color="hollow">
-                  <FormattedMessage
-                    id="xpack.securitySolution.flyout.entityDetails.host.observedBadge"
-                    defaultMessage="Observed"
-                  />
-                </EuiBadge>
-              )}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+        {isLoading ? (
+          <EuiFlexItem grow={true}>
+            <EuiSkeletonText
+              lines={1}
+              size="xs"
+              data-test-subj="host-panel-header-observed-badge-loading"
+            />
+          </EuiFlexItem>
+        ) : (
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                {lastSeenDateFormatted && (
+                  <EuiBadge data-test-subj="host-panel-header-observed-badge" color="hollow">
+                    <FormattedMessage
+                      id="xpack.securitySolution.flyout.entityDetails.host.observedBadge"
+                      defaultMessage="Observed"
+                    />
+                  </EuiBadge>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     </FlyoutHeader>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/header.tsx
@@ -30,8 +30,6 @@ interface HostPanelHeaderProps {
 
 const linkTitleCSS = { width: 'fit-content' };
 
-const urlParamOverride = { timeline: { isOpen: false } };
-
 export const HostPanelHeader = ({ hostName, lastSeen }: HostPanelHeaderProps) => {
   const lastSeenDate = lastSeen?.date;
   const isLoading = lastSeen?.isLoading ?? false;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.test.tsx
@@ -83,13 +83,14 @@ describe('HostPanel', () => {
       isLoading: true,
     });
 
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <TestProviders>
         <HostPanel {...mockProps} />
       </TestProviders>
     );
 
-    expect(getByTestId('securitySolutionFlyoutLoading')).toBeInTheDocument();
+    expect(queryByTestId('securitySolutionFlyoutLoading')).not.toBeInTheDocument();
+    expect(getByTestId('observedDataSectionLoadingSpinner')).toBeInTheDocument();
   });
 
   it('renders preview panel', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -16,23 +16,18 @@ import { useRefetchQueryById } from '../../../entity_analytics/api/hooks/use_ref
 import { RISK_INPUTS_TAB_QUERY_ID } from '../../../entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab';
 import type { Refetch } from '../../../common/types';
 import { useCalculateEntityRiskScore } from '../../../entity_analytics/api/hooks/use_calculate_entity_risk_score';
-import { hostToCriteria } from '../../../common/components/ml/criteria/host_to_criteria';
 import { useRiskScore } from '../../../entity_analytics/api/hooks/use_risk_score';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
-import type { HostItem } from '../../../../common/search_strategy';
 import { buildHostNamesFilter } from '../../../../common/search_strategy';
-import { FlyoutLoading } from '../../shared/components/flyout_loading';
 import { FlyoutNavigation } from '../../shared/components/flyout_navigation';
 import { HostPanelFooter } from './footer';
 import { HostPanelContent } from './content';
 import { HostPanelHeader } from './header';
-import { AnomalyTableProvider } from '../../../common/components/ml/anomaly/anomaly_table_provider';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
-import { useObservedHost } from './hooks/use_observed_host';
 import { EntityDetailsLeftPanelTab } from '../shared/components/left_panel/left_panel_header';
 import { HostPreviewPanelFooter } from '../host_preview/footer';
 import { useNavigateToHostDetails } from './hooks/use_navigate_to_host_details';
+import { useObservedHost } from './hooks/use_observed_host';
 import { EntityIdentifierFields, EntityType } from '../../../../common/entity_analytics/types';
 import { useKibana } from '../../../common/lib/kibana';
 import { ENABLE_ASSET_INVENTORY_SETTING } from '../../../../common/constants';
@@ -67,7 +62,7 @@ export const HostPanel = ({
   const { uiSettings } = useKibana().services;
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
 
-  const { to, from, isInitializing, setQuery, deleteQuery } = useGlobalTime();
+  const { to, from, setQuery, deleteQuery } = useGlobalTime();
   const hostNameFilterQuery = useMemo(
     () => (hostName ? buildHostNamesFilter([hostName]) : undefined),
     [hostName]
@@ -140,60 +135,36 @@ export const HostPanel = ({
 
   const observedHost = useObservedHost(hostName, scopeId);
 
-  if (observedHost.isLoading) {
-    return <FlyoutLoading />;
-  }
-
   return (
-    <AnomalyTableProvider
-      criteriaFields={hostToCriteria(observedHost.details)}
-      startDate={from}
-      endDate={to}
-      skip={isInitializing}
-    >
-      {({ isLoadingAnomaliesData, anomaliesData, jobNameById }) => {
-        const observedHostWithAnomalies: ObservedEntityData<HostItem> = {
-          ...observedHost,
-          anomalies: {
-            isLoading: isLoadingAnomaliesData,
-            anomalies: anomaliesData,
-            jobNameById,
-          },
-        };
-
-        return (
-          <>
-            <FlyoutNavigation
-              flyoutIsExpandable={
-                isRiskScoreExist ||
-                hasMisconfigurationFindings ||
-                hasVulnerabilitiesFindings ||
-                hasNonClosedAlerts
-              }
-              expandDetails={openDefaultPanel}
-              isPreviewMode={isPreviewMode}
-              isRulePreview={scopeId === TableId.rulePreview}
-            />
-            <HostPanelHeader hostName={hostName} observedHost={observedHostWithAnomalies} />
-            <HostPanelContent
-              hostName={hostName}
-              observedHost={observedHostWithAnomalies}
-              riskScoreState={riskScoreState}
-              contextID={contextID}
-              scopeId={scopeId}
-              openDetailsPanel={openDetailsPanel}
-              recalculatingScore={recalculatingScore}
-              onAssetCriticalityChange={calculateEntityRiskScore}
-              isPreviewMode={isPreviewMode}
-            />
-            {isPreviewMode && (
-              <HostPreviewPanelFooter hostName={hostName} contextID={contextID} scopeId={scopeId} />
-            )}
-            {!isPreviewMode && assetInventoryEnabled && <HostPanelFooter hostName={hostName} />}
-          </>
-        );
-      }}
-    </AnomalyTableProvider>
+    <>
+      <FlyoutNavigation
+        flyoutIsExpandable={
+          isRiskScoreExist ||
+          hasMisconfigurationFindings ||
+          hasVulnerabilitiesFindings ||
+          hasNonClosedAlerts
+        }
+        expandDetails={openDefaultPanel}
+        isPreviewMode={isPreviewMode}
+        isRulePreview={scopeId === TableId.rulePreview}
+      />
+      <HostPanelHeader hostName={hostName} lastSeen={observedHost.lastSeen} />
+      <HostPanelContent
+        hostName={hostName}
+        observedHost={observedHost}
+        riskScoreState={riskScoreState}
+        contextID={contextID}
+        scopeId={scopeId}
+        openDetailsPanel={openDetailsPanel}
+        recalculatingScore={recalculatingScore}
+        onAssetCriticalityChange={calculateEntityRiskScore}
+        isPreviewMode={isPreviewMode}
+      />
+      {isPreviewMode && (
+        <HostPreviewPanelFooter hostName={hostName} contextID={contextID} scopeId={scopeId} />
+      )}
+      {!isPreviewMode && assetInventoryEnabled && <HostPanelFooter hostName={hostName} />}
+    </>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
@@ -68,7 +68,6 @@ export const ServicePanelContent = ({
         contextID={contextID}
         scopeId={scopeId}
         observedFields={observedFields}
-        queryId={OBSERVED_SERVICE_QUERY_ID}
       />
       <EuiHorizontalRule margin="m" />
     </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/observed_entity/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/observed_entity/index.test.tsx
@@ -11,32 +11,32 @@ import { ObservedEntity } from '.';
 import { TestProviders } from '../../../../../common/mock';
 import { mockObservedHostData } from '../../../mocks';
 
-describe('ObservedHost', () => {
+describe('ObservedEntity', () => {
   const mockProps = {
     observedData: mockObservedHostData,
     contextID: '',
     scopeId: '',
-    queryId: 'TEST_QUERY_ID',
     observedFields: [],
   };
 
-  it('renders', () => {
+  it('renders the entity table', () => {
     const { getByTestId } = render(
       <TestProviders>
         <ObservedEntity {...mockProps} />
       </TestProviders>
     );
 
-    expect(getByTestId('observedEntity-accordion')).toBeInTheDocument();
+    expect(getByTestId('entity-table')).toBeInTheDocument();
   });
 
-  it('renders the formatted date', () => {
-    const { getByTestId } = render(
+  it('renders table column headers', () => {
+    const { getByText } = render(
       <TestProviders>
         <ObservedEntity {...mockProps} />
       </TestProviders>
     );
 
-    expect(getByTestId('observedEntity-accordion')).toHaveTextContent('Updated Feb 23, 2023');
+    expect(getByText('Field')).toBeInTheDocument();
+    expect(getByText('Values')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/observed_entity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/observed_entity/index.tsx
@@ -5,16 +5,12 @@
  * 2.0.
  */
 
-import { EuiAccordion, EuiSpacer, EuiTitle, useEuiFontSize, useEuiTheme } from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
 
 import React from 'react';
-import { css } from '@emotion/react';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { EntityTable } from '../entity_table';
-import { FormattedRelativePreferenceDate } from '../../../../../common/components/formatted_date';
-import { InspectButton, InspectButtonContainer } from '../../../../../common/components/inspect';
+import { InspectButtonContainer } from '../../../../../common/components/inspect';
 import type { EntityTableRows } from '../entity_table/types';
-import { ONE_WEEK_IN_HOURS } from '../../constants';
 import type { ObservedEntityData } from './types';
 
 export const ObservedEntity = <T,>({
@@ -22,96 +18,21 @@ export const ObservedEntity = <T,>({
   contextID,
   scopeId,
   observedFields,
-  queryId,
 }: {
   observedData: ObservedEntityData<T>;
   contextID: string;
   scopeId: string;
   observedFields: EntityTableRows<ObservedEntityData<T>>;
-  queryId: string;
 }) => {
-  const { euiTheme } = useEuiTheme();
-  const xsFontSize = useEuiFontSize('xxs').fontSize;
-
   return (
-    <>
-      <InspectButtonContainer>
-        <EuiAccordion
-          initialIsOpen={true}
-          isLoading={observedData.isLoading}
-          id="observedEntity-accordion"
-          data-test-subj="observedEntity-accordion"
-          buttonProps={{
-            'data-test-subj': 'observedEntity-accordion-button',
-            css: css`
-              color: ${euiTheme.colors.primary};
-            `,
-          }}
-          buttonContent={
-            <EuiTitle size="xs">
-              <h3>
-                <FormattedMessage
-                  id="xpack.securitySolution.flyout.entityDetails.observedDataTitle"
-                  defaultMessage="Observed data"
-                />
-              </h3>
-            </EuiTitle>
-          }
-          extraAction={
-            <>
-              <span
-                css={css`
-                  margin-right: ${euiTheme.size.s};
-                `}
-              >
-                <InspectButton
-                  queryId={queryId}
-                  title={
-                    <FormattedMessage
-                      id="xpack.securitySolution.flyout.entityDetails.observedDataInspectTitle"
-                      defaultMessage="Observed data"
-                    />
-                  }
-                />
-              </span>
-              {observedData.lastSeen.date && (
-                <span
-                  css={css`
-                    font-size: ${xsFontSize};
-                  `}
-                >
-                  <FormattedMessage
-                    id="xpack.securitySolution.flyout.entityDetails.observedEntityUpdatedTime"
-                    defaultMessage="Updated {time}"
-                    values={{
-                      time: (
-                        <FormattedRelativePreferenceDate
-                          value={observedData.lastSeen.date}
-                          dateFormat="MMM D, YYYY"
-                          relativeThresholdInHrs={ONE_WEEK_IN_HOURS}
-                        />
-                      ),
-                    }}
-                  />
-                </span>
-              )}
-            </>
-          }
-          css={css`
-            .euiAccordion__optionalAction {
-              margin-left: auto;
-            }
-          `}
-        >
-          <EuiSpacer size="m" />
-          <EntityTable
-            contextID={contextID}
-            scopeId={scopeId}
-            data={observedData}
-            entityFields={observedFields}
-          />
-        </EuiAccordion>
-      </InspectButtonContainer>
-    </>
+    <InspectButtonContainer>
+      <EuiSpacer size="m" />
+      <EntityTable
+        contextID={contextID}
+        scopeId={scopeId}
+        data={observedData}
+        entityFields={observedFields}
+      />
+    </InspectButtonContainer>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/observed_data_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/components/observed_data_section.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiAccordion,
+  EuiLoadingSpinner,
+  EuiTitle,
+  useEuiFontSize,
+  useEuiTheme,
+} from '@elastic/eui';
+
+import React, { memo, useMemo } from 'react';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useInstalledSecurityJobNameById } from '../../../../common/components/ml/hooks/use_installed_security_jobs';
+import { ONE_WEEK_IN_HOURS } from '../../shared/constants';
+import { ObservedEntity } from '../../shared/components/observed_entity';
+import { useObservedUserItems } from '../hooks/use_observed_user_items';
+import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
+import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
+import { useAnomaliesTableData } from '../../../../common/components/ml/anomaly/use_anomalies_table_data';
+import { useGlobalTime } from '../../../../common/containers/use_global_time';
+import { getCriteriaFromUsersType } from '../../../../common/components/ml/criteria/get_criteria_from_users_type';
+import { UsersType } from '../../../../explore/users/store/model';
+import type { ObservedUserData } from '../content';
+
+export const ObservedDataSection = memo(
+  ({
+    userName,
+    observedUser,
+    contextID,
+    scopeId,
+    queryId,
+  }: {
+    userName: string;
+    observedUser: ObservedUserData;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+  }) => {
+    const { euiTheme } = useEuiTheme();
+    const xsFontSize = useEuiFontSize('xxs').fontSize;
+
+    const buttonContent = (
+      <EuiTitle size="xs">
+        <h3>
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.entityDetails.observedDataTitle"
+            defaultMessage="Observed data"
+          />
+        </h3>
+      </EuiTitle>
+    );
+
+    const extraAction = (
+      <>
+        <span
+          css={css`
+            margin-right: ${euiTheme.size.s};
+          `}
+        >
+          <InspectButton
+            queryId={queryId}
+            title={
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.entityDetails.observedDataInspectTitle"
+                defaultMessage="Observed data"
+              />
+            }
+          />
+        </span>
+        {observedUser.lastSeen.date && (
+          <span
+            css={css`
+              font-size: ${xsFontSize};
+            `}
+          >
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.entityDetails.observedEntityUpdatedTime"
+              defaultMessage="Updated {time}"
+              values={{
+                time: (
+                  <FormattedRelativePreferenceDate
+                    value={observedUser.lastSeen.date}
+                    dateFormat="MMM D, YYYY"
+                    relativeThresholdInHrs={ONE_WEEK_IN_HOURS}
+                  />
+                ),
+              }}
+            />
+          </span>
+        )}
+      </>
+    );
+
+    return (
+      <InspectButtonContainer>
+        <EuiAccordion
+          initialIsOpen={true}
+          id="observedEntity-accordion"
+          data-test-subj="observedEntity-accordion"
+          buttonProps={{
+            'data-test-subj': 'observedEntity-accordion-button',
+            css: css`
+              color: ${euiTheme.colors.primary};
+            `,
+          }}
+          buttonContent={buttonContent}
+          extraAction={extraAction}
+          css={css`
+            .euiAccordion__optionalAction {
+              margin-left: auto;
+            }
+          `}
+        >
+          {observedUser.isLoading ? (
+            <EuiLoadingSpinner data-test-subj="observedDataSectionLoadingSpinner" />
+          ) : (
+            <ObservedDataSectionContent
+              userName={userName}
+              observedUser={observedUser}
+              contextID={contextID}
+              scopeId={scopeId}
+              queryId={queryId}
+            />
+          )}
+        </EuiAccordion>
+      </InspectButtonContainer>
+    );
+  }
+);
+ObservedDataSection.displayName = 'ObservedDataSection';
+
+const ObservedDataSectionContent = memo(
+  ({
+    userName,
+    observedUser,
+    contextID,
+    scopeId,
+    queryId,
+  }: {
+    userName: string;
+    observedUser: ObservedUserData;
+    contextID: string;
+    scopeId: string;
+    queryId: string;
+  }) => {
+    const { to, from, isInitializing } = useGlobalTime();
+
+    const { jobNameById } = useInstalledSecurityJobNameById();
+    const jobIds = useMemo(() => Object.keys(jobNameById), [jobNameById]);
+    const [isLoadingAnomaliesData, anomaliesData] = useAnomaliesTableData({
+      criteriaFields: getCriteriaFromUsersType(UsersType.details, userName),
+      startDate: from,
+      endDate: to,
+      skip: isInitializing,
+      jobIds,
+      aggregationInterval: 'auto',
+    });
+
+    const observedUserWithAnomalies = useMemo(
+      () => ({
+        ...observedUser,
+        anomalies: {
+          isLoading: isLoadingAnomaliesData,
+          anomalies: anomaliesData,
+          jobNameById,
+        },
+      }),
+      [observedUser, isLoadingAnomaliesData, anomaliesData, jobNameById]
+    );
+    const observedFields = useObservedUserItems(observedUserWithAnomalies);
+
+    return (
+      <ObservedEntity
+        observedData={observedUserWithAnomalies}
+        contextID={contextID}
+        scopeId={scopeId}
+        observedFields={observedFields}
+      />
+    );
+  }
+);
+ObservedDataSectionContent.displayName = 'ObservedDataSectionContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.stories.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.stories.tsx
@@ -112,7 +112,6 @@ export const NoObservedData = {
           isLoading: false,
           date: undefined,
         },
-        anomalies: { isLoading: false, anomalies: null, jobNameById: {} },
       }}
       riskScoreState={riskScoreData}
       contextID={'test-user-details'}
@@ -154,7 +153,6 @@ export const Loading = {
           isLoading: true,
           date: undefined,
         },
-        anomalies: { isLoading: true, anomalies: null, jobNameById: {} },
       }}
       riskScoreState={riskScoreData}
       contextID={'test-user-details'}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -7,9 +7,9 @@
 
 import { EuiHorizontalRule } from '@elastic/eui';
 import React from 'react';
+import { ObservedDataSection } from './components/observed_data_section';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { EntityHighlightsAccordion } from '../../../entity_analytics/components/entity_details_flyout/components/entity_highlights';
-import type { UserItem } from '../../../../common/search_strategy';
 import { AssetCriticalityAccordion } from '../../../entity_analytics/components/asset_criticality/asset_criticality_selector';
 import { OBSERVED_USER_QUERY_ID } from '../../../explore/users/containers/users/observed_details';
 import { FlyoutRiskSummary } from '../../../entity_analytics/components/risk_summary_flyout/risk_summary';
@@ -17,15 +17,16 @@ import type { RiskScoreState } from '../../../entity_analytics/api/hooks/use_ris
 import { EntityIdentifierFields, EntityType } from '../../../../common/entity_analytics/types';
 import { USER_PANEL_RISK_SCORE_QUERY_ID } from '.';
 import { FlyoutBody } from '../../shared/components/flyout_body';
-import { ObservedEntity } from '../shared/components/observed_entity';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
-import { useObservedUserItems } from './hooks/use_observed_user_items';
 import type { EntityDetailsPath } from '../shared/components/left_panel/left_panel_header';
 import { EntityInsight } from '../../../cloud_security_posture/components/entity_insight';
+import type { ObservedEntityData } from '../shared/components/observed_entity/types';
+import type { UserItem } from '../../../../common/search_strategy';
+
+export type ObservedUserData = Omit<ObservedEntityData<UserItem>, 'anomalies'>;
 
 interface UserPanelContentProps {
   userName: string;
-  observedUser: ObservedEntityData<UserItem>;
+  observedUser: ObservedUserData;
   riskScoreState: RiskScoreState<EntityType.user>;
   recalculatingScore: boolean;
   contextID: string;
@@ -46,8 +47,6 @@ export const UserPanelContent = ({
   onAssetCriticalityChange,
   isPreviewMode,
 }: UserPanelContentProps) => {
-  const observedFields = useObservedUserItems(observedUser);
-
   const isEntityDetailsHighlightsAIEnabled = useIsExperimentalFeatureEnabled(
     'entityDetailsHighlightsEnabled'
   );
@@ -80,11 +79,11 @@ export const UserPanelContent = ({
         isPreviewMode={isPreviewMode}
         openDetailsPanel={openDetailsPanel}
       />
-      <ObservedEntity
-        observedData={observedUser}
+      <ObservedDataSection
+        userName={userName}
+        observedUser={observedUser}
         contextID={contextID}
         scopeId={scopeId}
-        observedFields={observedFields}
         queryId={OBSERVED_USER_QUERY_ID}
       />
       <EuiHorizontalRule margin="m" />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/header.tsx
@@ -5,30 +5,41 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSkeletonText,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useMemo } from 'react';
 import { max } from 'lodash/fp';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import type { ManagedUserData } from '../shared/hooks/use_managed_user';
-import type { UserItem } from '../../../../common/search_strategy';
 import { ManagedUserDatasetKey } from '../../../../common/search_strategy/security_solution/users/managed_details';
 import { getUsersDetailsUrl } from '../../../common/components/link_to/redirect_to_users';
 import { SecuritySolutionLinkAnchor } from '../../../common/components/links';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
 import { FlyoutHeader } from '../../shared/components/flyout_header';
 import { FlyoutTitle } from '../../shared/components/flyout_title';
-import type { ObservedEntityData } from '../shared/components/observed_entity/types';
+import type { FirstLastSeenData } from '../shared/components/observed_entity/types';
+import type { ManagedUserData } from '../shared/hooks/use_managed_user';
 
 interface UserPanelHeaderProps {
   userName: string;
-  observedUser: ObservedEntityData<UserItem>;
   managedUser: ManagedUserData;
+  lastSeen: FirstLastSeenData;
 }
 
 const linkTitleCSS = { width: 'fit-content' };
 
-export const UserPanelHeader = ({ userName, observedUser, managedUser }: UserPanelHeaderProps) => {
+const urlParamOverride = { timeline: { isOpen: false } };
+
+export const UserPanelHeader = ({ userName, managedUser, lastSeen }: UserPanelHeaderProps) => {
+  const observedUserLastSeenDate = lastSeen?.date;
+  const isLoading = lastSeen?.isLoading ?? false;
+
   const oktaTimestamp = managedUser.data?.[ManagedUserDatasetKey.OKTA]?.fields?.[
     '@timestamp'
   ][0] as string | undefined;
@@ -40,9 +51,9 @@ export const UserPanelHeader = ({ userName, observedUser, managedUser }: UserPan
   const lastSeenDate = useMemo(
     () =>
       max(
-        [observedUser.lastSeen.date, entraTimestamp, oktaTimestamp].map((el) => el && new Date(el))
+        [observedUserLastSeenDate, entraTimestamp, oktaTimestamp].map((el) => el && new Date(el))
       ),
-    [oktaTimestamp, entraTimestamp, observedUser.lastSeen]
+    [oktaTimestamp, entraTimestamp, observedUserLastSeenDate]
   );
 
   return (
@@ -50,7 +61,15 @@ export const UserPanelHeader = ({ userName, observedUser, managedUser }: UserPan
       <EuiFlexGroup gutterSize="s" responsive={false} direction="column">
         <EuiFlexItem grow={false}>
           <EuiText size="xs" data-test-subj={'user-panel-header-lastSeen'}>
-            {lastSeenDate && <PreferenceFormattedDate value={lastSeenDate} />}
+            {isLoading ? (
+              <EuiSkeletonText
+                lines={1}
+                size="xs"
+                data-test-subj="user-panel-header-lastSeen-loading"
+              />
+            ) : (
+              lastSeenDate && <PreferenceFormattedDate value={lastSeenDate} />
+            )}
             <EuiSpacer size="xs" />
           </EuiText>
         </EuiFlexItem>
@@ -65,30 +84,40 @@ export const UserPanelHeader = ({ userName, observedUser, managedUser }: UserPan
             <FlyoutTitle title={userName} iconType={'user'} isLink />
           </SecuritySolutionLinkAnchor>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            <EuiFlexItem grow={false}>
-              {observedUser.lastSeen.date && (
-                <EuiBadge data-test-subj="user-panel-header-observed-badge" color="hollow">
-                  <FormattedMessage
-                    id="xpack.securitySolution.flyout.entityDetails.user.observedBadge"
-                    defaultMessage="Observed"
-                  />
-                </EuiBadge>
-              )}
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              {isManaged && (
-                <EuiBadge data-test-subj="user-panel-header-managed-badge" color="hollow">
-                  <FormattedMessage
-                    id="xpack.securitySolution.flyout.entityDetails.user.managedBadge"
-                    defaultMessage="Managed"
-                  />
-                </EuiBadge>
-              )}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+        {isLoading ? (
+          <EuiFlexItem grow={true}>
+            <EuiSkeletonText
+              lines={1}
+              size="xs"
+              data-test-subj="user-panel-header-observed-badge-loading"
+            />
+          </EuiFlexItem>
+        ) : (
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                {observedUserLastSeenDate && (
+                  <EuiBadge data-test-subj="user-panel-header-observed-badge" color="hollow">
+                    <FormattedMessage
+                      id="xpack.securitySolution.flyout.entityDetails.user.observedBadge"
+                      defaultMessage="Observed"
+                    />
+                  </EuiBadge>
+                )}
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                {isManaged && (
+                  <EuiBadge data-test-subj="user-panel-header-managed-badge" color="hollow">
+                    <FormattedMessage
+                      id="xpack.securitySolution.flyout.entityDetails.user.managedBadge"
+                      defaultMessage="Managed"
+                    />
+                  </EuiBadge>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     </FlyoutHeader>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/header.tsx
@@ -34,8 +34,6 @@ interface UserPanelHeaderProps {
 
 const linkTitleCSS = { width: 'fit-content' };
 
-const urlParamOverride = { timeline: { isOpen: false } };
-
 export const UserPanelHeader = ({ userName, managedUser, lastSeen }: UserPanelHeaderProps) => {
   const observedUserLastSeenDate = lastSeen?.date;
   const isLoading = lastSeen?.isLoading ?? false;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.test.tsx
@@ -89,12 +89,13 @@ describe('UserPanel', () => {
       isLoading: true,
     });
 
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <TestProviders>
         <UserPanel {...mockProps} />
       </TestProviders>
     );
 
-    expect(getByTestId('securitySolutionFlyoutLoading')).toBeInTheDocument();
+    expect(queryByTestId('securitySolutionFlyoutLoading')).not.toBeInTheDocument();
+    expect(getByTestId('observedDataSectionLoadingSpinner')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Don’t block User & Host flyouts while observed data loading (#252657)](https://github.com/elastic/kibana/pull/252657)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mark Hopkin","email":"mark.hopkin@elastic.co"},"sourceCommit":{"committedDate":"2026-02-11T17:53:24Z","message":"Don’t block User & Host flyouts while observed data loading (#252657)\n\n# Summary\n\nDon’t block the entity flyout while observed data is loading. The host\nand user entity detail flyouts open immediately and show their layout\nwith EuiSkeleton elements while loading. This allows customers to see\nrisk data etc while the observed data is loading.\n\nI have kept @PhilippeOberti's changes of moving the observed data to its\nown component I think thats neater.\n\n## Before\nWhole flyout has a loading spinner while observed data loading:\n\n\n\nhttps://github.com/user-attachments/assets/cff38c80-4b45-4f3c-b4f5-3d080224cdaf\n\n\n\n\n## After\nlabels and timestamps in the header show skeletons, and observed data\nsection have independent loading state.\n\nThere is more UI jitter as sections load, we can try and make this\nbetter but there is an element of urgency so I am thinking we do that in\nslower time:\n\n\n\nhttps://github.com/user-attachments/assets/68106f2d-0f8b-4461-9db4-7a6c1f85286b\n\n---------\n\nCo-authored-by: PhilippeOberti <philippe.oberti@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3756a47b35b19fa1f83739fc0f10ba29a036a79d","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport missing","ci:project-deploy-security","Team:Entity Analytics","backport:version","v9.3.0","v9.4.0","v9.3.1"],"title":"Don’t block User & Host flyouts while observed data loading","number":252657,"url":"https://github.com/elastic/kibana/pull/252657","mergeCommit":{"message":"Don’t block User & Host flyouts while observed data loading (#252657)\n\n# Summary\n\nDon’t block the entity flyout while observed data is loading. The host\nand user entity detail flyouts open immediately and show their layout\nwith EuiSkeleton elements while loading. This allows customers to see\nrisk data etc while the observed data is loading.\n\nI have kept @PhilippeOberti's changes of moving the observed data to its\nown component I think thats neater.\n\n## Before\nWhole flyout has a loading spinner while observed data loading:\n\n\n\nhttps://github.com/user-attachments/assets/cff38c80-4b45-4f3c-b4f5-3d080224cdaf\n\n\n\n\n## After\nlabels and timestamps in the header show skeletons, and observed data\nsection have independent loading state.\n\nThere is more UI jitter as sections load, we can try and make this\nbetter but there is an element of urgency so I am thinking we do that in\nslower time:\n\n\n\nhttps://github.com/user-attachments/assets/68106f2d-0f8b-4461-9db4-7a6c1f85286b\n\n---------\n\nCo-authored-by: PhilippeOberti <philippe.oberti@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3756a47b35b19fa1f83739fc0f10ba29a036a79d"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252657","number":252657,"mergeCommit":{"message":"Don’t block User & Host flyouts while observed data loading (#252657)\n\n# Summary\n\nDon’t block the entity flyout while observed data is loading. The host\nand user entity detail flyouts open immediately and show their layout\nwith EuiSkeleton elements while loading. This allows customers to see\nrisk data etc while the observed data is loading.\n\nI have kept @PhilippeOberti's changes of moving the observed data to its\nown component I think thats neater.\n\n## Before\nWhole flyout has a loading spinner while observed data loading:\n\n\n\nhttps://github.com/user-attachments/assets/cff38c80-4b45-4f3c-b4f5-3d080224cdaf\n\n\n\n\n## After\nlabels and timestamps in the header show skeletons, and observed data\nsection have independent loading state.\n\nThere is more UI jitter as sections load, we can try and make this\nbetter but there is an element of urgency so I am thinking we do that in\nslower time:\n\n\n\nhttps://github.com/user-attachments/assets/68106f2d-0f8b-4461-9db4-7a6c1f85286b\n\n---------\n\nCo-authored-by: PhilippeOberti <philippe.oberti@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3756a47b35b19fa1f83739fc0f10ba29a036a79d"}}]}] BACKPORT-->