### PR TITLE
[Core] Fix failing elasticsearch config serverless defaults test

### DIFF
--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.test.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.test.ts
@@ -73,8 +73,7 @@ test.skip('set correct defaults', () => {
   `);
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/253373
-test.skip('set correct defaults (serverless)', () => {
+test('set correct defaults (serverless)', () => {
   const configValue = new ElasticsearchConfig(config.schema.validate({}, { serverless: true }));
   expect(configValue).toMatchInlineSnapshot(`
     ElasticsearchConfig {
@@ -84,6 +83,7 @@ test.skip('set correct defaults (serverless)', () => {
       "customHeaders": Object {},
       "dnsCacheTtl": "P0D",
       "healthCheckDelay": "PT2.5S",
+      "healthCheckFailureInterval": undefined,
       "healthCheckRetry": 3,
       "healthCheckStartupDelay": "PT0.5S",
       "hosts": Array [


### PR DESCRIPTION
## Summary

Fix the failing `set correct defaults (serverless)` jest test in the Elasticsearch config by updating the inline snapshot to include the new `healthCheckFailureInterval` property and re-enabling the skipped test.

### Issue resolution

The test was failing because the `ElasticsearchConfig` gained a new `healthCheckFailureInterval` property that wasn't reflected in the inline snapshot. The snapshot has been updated to match the current config shape and the `test.skip` has been reverted back to `test`.

Closes https://github.com/elastic/kibana/issues/253373
Closes https://github.com/elastic/kibana/issues/253372

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

None.