### PR TITLE
[9.3] [Lens] Fix layer editor scrolling in full lens editor (#253247)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/editor/constants.ts
+++ b/src/platform/packages/shared/kbn-lens-common/editor/constants.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Width of the drag-drop extra targets (e.g., "Alt/Option to duplicate" tooltip).
+ * This is used to override the default max-width from @kbn/dom-drag-drop.
+ */
+export const DRAG_DROP_EXTRA_TARGETS_WIDTH = 280;
+
+/**
+ * Total padding needed to accommodate drag-drop extra targets.
+ * Calculated as: DRAG_DROP_EXTRA_TARGETS_WIDTH + 8px gap + 8px buffer = 296px
+ */
+export const DRAG_DROP_EXTRA_TARGETS_PADDING = 296;

--- a/src/platform/packages/shared/kbn-lens-common/index.ts
+++ b/src/platform/packages/shared/kbn-lens-common/index.ts
@@ -382,3 +382,4 @@ export {
   getLensLayerTypeTabDisplayName,
   lensLayerTypeTabDisplayNames,
 } from './visualizations/layer_type_tab_display_name';
+export { DRAG_DROP_EXTRA_TARGETS_WIDTH, DRAG_DROP_EXTRA_TARGETS_PADDING } from './editor/constants';

--- a/src/platform/packages/shared/kbn-visualization-ui-components/components/dimension_buttons/dimension_button.tsx
+++ b/src/platform/packages/shared/kbn-visualization-ui-components/components/dimension_buttons/dimension_button.tsx
@@ -62,7 +62,6 @@ function DimensionButtonImpl({
         border-radius: ${euiTheme.border.radius};
         position: relative;
         line-height: 1;
-        overflow: hidden;
         display: flex;
         align-items: center;
         gap: ${euiTheme.size.s};

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
@@ -26,6 +26,7 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { DRAG_DROP_EXTRA_TARGETS_WIDTH, DRAG_DROP_EXTRA_TARGETS_PADDING } from '@kbn/lens-common';
 import type { FlyoutWrapperProps } from './types';
 
 const applyAndCloseLabel = i18n.translate('xpack.lens.config.applyFlyoutLabel', {
@@ -160,9 +161,14 @@ export const FlyoutWrapper = ({
         css={css`
           // styles needed to display extra drop targets that are outside of the config panel main area
           overflow-y: auto;
-          padding-left: ${euiTheme.components.forms.maxWidth};
-          margin-left: -${euiTheme.components.forms.maxWidth};
+          padding-left: ${DRAG_DROP_EXTRA_TARGETS_PADDING}px;
+          margin-left: -${DRAG_DROP_EXTRA_TARGETS_PADDING}px;
           pointer-events: none;
+          // Override the default max-width of drag-drop extra targets to reduce
+          // horizontal overflow space requirements
+          .domDroppable__extraTargets {
+            width: ${DRAG_DROP_EXTRA_TARGETS_WIDTH}px;
+          }
           .euiFlyoutBody__overflow {
             transform: initial;
             -webkit-mask-image: none;

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -482,26 +482,26 @@ export function LensEditConfigurationFlyout({
         toolbar={toolbar}
         layerTabs={layerTabs}
       >
-          {/* Flex container for the flyout content layout.
+        {/* Flex container for the flyout content layout.
               Enables proper scroll behavior where accordion headers stay fixed
               and only the accordion content areas scroll independently. */}
         <EuiFlexGroup
           css={css`
             block-size: 100%;
-              /* Reset min-block-size to allow flex items to shrink below content size */
+            /* Reset min-block-size to allow flex items to shrink below content size */
             .euiFlexItem,
             .euiAccordion,
             .euiAccordion__triggerWrapper,
             .euiAccordion__childWrapper {
               min-block-size: 0;
             }
-              /* Make accordions flex containers to enable content scrolling */
+            /* Make accordions flex containers to enable content scrolling */
             .euiAccordion {
               display: flex;
               flex: 1;
               flex-direction: column;
             }
-              /* When accordion is open, its content area takes remaining space */
+            /* When accordion is open, its content area takes remaining space */
             .euiAccordion-isOpen {
               .euiAccordion__childWrapper {
                 // Override euiAccordion__childWrapper blockSize only when ES|QL mode is enabled
@@ -509,7 +509,7 @@ export function LensEditConfigurationFlyout({
                 flex: 1;
               }
             }
-              /* Scrollable accordion content area with custom scrollbar styling.
+            /* Scrollable accordion content area with custom scrollbar styling.
                  pointer-events handling allows drag-drop to work outside content bounds. */
             .euiAccordion__childWrapper {
               ${euiScrollBarStyles(euiTheme)}
@@ -522,7 +522,7 @@ export function LensEditConfigurationFlyout({
                 pointer-events: auto;
               }
             }
-              /* Advanced options nested accordion should not scroll independently */
+            /* Advanced options nested accordion should not scroll independently */
             .lnsIndexPatternDimensionEditor-advancedOptions {
               .euiAccordion__childWrapper {
                 flex: none;
@@ -533,7 +533,7 @@ export function LensEditConfigurationFlyout({
           direction="column"
           gutterSize="none"
         >
-            {/* Container for ES|QL editor - fixed height, doesn't grow */}
+          {/* Container for ES|QL editor - fixed height, doesn't grow */}
           <EuiFlexItem grow={false}>
             <EuiFlexGroup
               css={css`
@@ -609,7 +609,7 @@ export function LensEditConfigurationFlyout({
             </EuiAccordion>
           </EuiFlexItem>
 
-            {/* Visualization parameters accordion - grows when open to fill available space */}
+          {/* Visualization parameters accordion - grows when open to fill available space */}
           <EuiFlexItem
             grow={isSuggestionsAccordionOpen ? 1 : false}
             data-test-subj="InlineEditingSuggestions"

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -482,20 +482,26 @@ export function LensEditConfigurationFlyout({
         toolbar={toolbar}
         layerTabs={layerTabs}
       >
+          {/* Flex container for the flyout content layout.
+              Enables proper scroll behavior where accordion headers stay fixed
+              and only the accordion content areas scroll independently. */}
         <EuiFlexGroup
           css={css`
             block-size: 100%;
+              /* Reset min-block-size to allow flex items to shrink below content size */
             .euiFlexItem,
             .euiAccordion,
             .euiAccordion__triggerWrapper,
             .euiAccordion__childWrapper {
               min-block-size: 0;
             }
+              /* Make accordions flex containers to enable content scrolling */
             .euiAccordion {
               display: flex;
               flex: 1;
               flex-direction: column;
             }
+              /* When accordion is open, its content area takes remaining space */
             .euiAccordion-isOpen {
               .euiAccordion__childWrapper {
                 // Override euiAccordion__childWrapper blockSize only when ES|QL mode is enabled
@@ -503,6 +509,8 @@ export function LensEditConfigurationFlyout({
                 flex: 1;
               }
             }
+              /* Scrollable accordion content area with custom scrollbar styling.
+                 pointer-events handling allows drag-drop to work outside content bounds. */
             .euiAccordion__childWrapper {
               ${euiScrollBarStyles(euiTheme)}
               overflow-y: auto !important;
@@ -514,6 +522,7 @@ export function LensEditConfigurationFlyout({
                 pointer-events: auto;
               }
             }
+              /* Advanced options nested accordion should not scroll independently */
             .lnsIndexPatternDimensionEditor-advancedOptions {
               .euiAccordion__childWrapper {
                 flex: none;
@@ -524,6 +533,7 @@ export function LensEditConfigurationFlyout({
           direction="column"
           gutterSize="none"
         >
+            {/* Container for ES|QL editor - fixed height, doesn't grow */}
           <EuiFlexItem grow={false}>
             <EuiFlexGroup
               css={css`
@@ -599,6 +609,7 @@ export function LensEditConfigurationFlyout({
             </EuiAccordion>
           </EuiFlexItem>
 
+            {/* Visualization parameters accordion - grows when open to fill available space */}
           <EuiFlexItem
             grow={isSuggestionsAccordionOpen ? 1 : false}
             data-test-subj="InlineEditingSuggestions"

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useMemo, memo, useCallback } from 'react';
-import { EuiForm, euiBreakpoint, useEuiTheme, useEuiOverflowScroll } from '@elastic/eui';
+import { EuiForm, euiBreakpoint, useEuiTheme } from '@elastic/eui';
 import type { ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import {
   UPDATE_FILTER_REFERENCES_ACTION,
@@ -16,6 +16,7 @@ import {
 import type { DragDropIdentifier, DropType } from '@kbn/dom-drag-drop';
 import { css } from '@emotion/react';
 import type { AddLayerFunction, DragDropOperation, Visualization } from '@kbn/lens-common';
+import { DRAG_DROP_EXTRA_TARGETS_WIDTH, DRAG_DROP_EXTRA_TARGETS_PADDING } from '@kbn/lens-common';
 import {
   changeIndexPattern,
   onDropToDimension,
@@ -317,21 +318,35 @@ export function ConfigPanel(
     };
   }, [activeVisualization, props.framePublicAPI, selectedLayerId, visualization.state]);
 
-  const euiOverflowScroll = useEuiOverflowScroll('y');
-
   if (layerConfig?.config.hidden || !selectedLayerId || !layerConfig) return null;
 
   return (
     <EuiForm
       css={css`
         .lnsApp & {
+          /* Add left padding and negative margin to create space for drag-drop extra targets
+             (e.g., "Alt/Option to duplicate" tooltip) that are positioned to the left of drop zones. */
           padding: ${euiTheme.size.base} ${euiTheme.size.base} ${euiTheme.size.xl}
-            calc(400px + ${euiTheme.size.base});
-          margin-left: -400px;
-          ${euiOverflowScroll}
+            calc(${DRAG_DROP_EXTRA_TARGETS_PADDING}px + ${euiTheme.size.base});
+          margin-left: -${DRAG_DROP_EXTRA_TARGETS_PADDING}px;
+          /* Background gradient: transparent in the extended left area (for tooltips),
+             solid color for the visible content area */
+          background: linear-gradient(
+            to right,
+            transparent 0,
+            transparent ${DRAG_DROP_EXTRA_TARGETS_PADDING}px,
+            ${euiTheme.colors.emptyShade} ${DRAG_DROP_EXTRA_TARGETS_PADDING}px
+          );
+          /* Override the default max-width of drag-drop extra targets to reduce
+             horizontal overflow space requirements */
+          .domDroppable__extraTargets {
+            width: ${DRAG_DROP_EXTRA_TARGETS_WIDTH}px;
+          }
+          /* Note: overflow scrolling is handled by the parent lnsConfigPanelScrollContainer */
           ${euiBreakpoint(euiThemeContext, ['xs', 's', 'm'])} {
             padding-left: ${euiTheme.size.base};
             margin-left: 0;
+            background: ${euiTheme.colors.emptyShade};
           }
         }
       `}

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/frame_layout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/frame_layout.tsx
@@ -65,7 +65,10 @@ export function FrameLayout(props: FrameLayoutProps) {
             left: 0;
             right: 0;
             bottom: 0;
-            overflow: hidden;
+            /* Use 'clip' for y-axis to constrain layout, 'visible' for x-axis to allow
+               drag-drop extra targets in the config panel to overflow horizontally. */
+            overflow-y: clip;
+            overflow-x: visible;
             flex-direction: column;
             ${euiBreakpoint(euiThemeContext, ['xs', 's', 'm'])} {
               position: static;
@@ -77,7 +80,10 @@ export function FrameLayout(props: FrameLayoutProps) {
             className="lnsFrameLayout__pageContent"
             aria-labelledby="lns_ChartTitle"
             css={css`
-              overflow: hidden;
+              /* Use 'clip' for y-axis to constrain layout, 'visible' for x-axis to allow
+                 drag-drop extra targets in the config panel to overflow horizontally. */
+              overflow-y: clip;
+              overflow-x: visible;
               flex-grow: 1;
               flex-direction: row;
               ${euiBreakpoint(euiThemeContext, ['xs', 's', 'm'])} {
@@ -155,6 +161,11 @@ export function FrameLayout(props: FrameLayoutProps) {
                   min-width: 358px;
                   max-width: 440px;
                   max-height: 100%;
+                  /* Use 'clip' for y-axis to constrain flex children for scrolling,
+                     and 'visible' for x-axis to allow drag-drop extra targets to overflow.
+                     Unlike 'hidden'/'auto', 'clip' can be combined with 'visible' on the other axis. */
+                  overflow-y: clip;
+                  overflow-x: visible;
                   ${euiBreakpoint(euiThemeContext, ['xs', 's', 'm'])} {
                     max-width: 100%;
                   }

--- a/x-pack/platform/test/functional/apps/lens/group2/config_panel_scroll.ts
+++ b/x-pack/platform/test/functional/apps/lens/group2/config_panel_scroll.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const { visualize, lens } = getPageObjects(['visualize', 'lens']);
+  const browser = getService('browser');
+  const testSubjects = getService('testSubjects');
+  const log = getService('log');
+
+  describe('lens config panel scroll', () => {
+    // Use a small window height to force the config panel content to overflow
+    const SMALL_WINDOW_HEIGHT = 600;
+    let originalWindowSize: { height: number; width: number };
+
+    before(async () => {
+      // Store original window size to restore later
+      originalWindowSize = await browser.getWindowSize();
+    });
+
+    after(async () => {
+      // Restore original window size
+      await browser.setWindowSize(originalWindowSize.width, originalWindowSize.height);
+    });
+
+    /**
+     * Helper to verify the config panel is scrollable by using scrollIntoView
+     * on a bottom element and checking that its position changes.
+     * This tests actual user-facing scroll behavior.
+     */
+    async function assertConfigPanelIsScrollable(bottomElementTestSubj: string) {
+      const bottomElement = await testSubjects.find(bottomElementTestSubj);
+
+      // Get initial position of the bottom element
+      // Note: browser.execute receives the raw DOM element, not WebElementWrapper
+      const initialTop = await browser.execute(
+        (el) => (el as unknown as Element).getBoundingClientRect().top,
+        bottomElement
+      );
+      log.debug(`Initial top position of ${bottomElementTestSubj}: ${initialTop}`);
+
+      // Scroll the element into view
+      await browser.execute((el) => {
+        (el as unknown as Element).scrollIntoView({ block: 'center', behavior: 'instant' });
+      }, bottomElement);
+
+      // Small delay for scroll to complete
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Get new position after scrolling
+      const newTop = await browser.execute(
+        (el) => (el as unknown as Element).getBoundingClientRect().top,
+        bottomElement
+      );
+      log.debug(`New top position of ${bottomElementTestSubj}: ${newTop}`);
+
+      // If scrolling works, the element's position should have changed
+      // (it should have moved up on the screen)
+      expect(newTop).to.be.lessThan(
+        initialTop,
+        `Element "${bottomElementTestSubj}" should move up when scrolled into view. ` +
+          `Initial top: ${initialTop}, new top: ${newTop}`
+      );
+    }
+
+    it('should allow scrolling the config panel with a single layer (no tabs)', async () => {
+      // Use a smaller window height to force the config panel to overflow
+      log.debug(`Resizing browser to ${originalWindowSize.width}x${SMALL_WINDOW_HEIGHT}`);
+      await browser.setWindowSize(originalWindowSize.width, SMALL_WINDOW_HEIGHT);
+
+      await visualize.navigateToNewVisualization();
+      await visualize.clickVisType('lens');
+
+      // Switch to Table visualization which has multiple dimension groups
+      // (Rows, Columns, Metrics, Split metrics by) to generate enough content
+      await lens.switchToVisualization('lnsDatatable');
+
+      // Add dimensions to create enough content to overflow the config panel
+      await lens.configureDimension({
+        dimension: 'lnsDatatable_rows > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await lens.configureDimension({
+        dimension: 'lnsDatatable_rows > lns-empty-dimension',
+        operation: 'terms',
+        field: 'ip',
+      });
+
+      await lens.configureDimension({
+        dimension: 'lnsDatatable_rows > lns-empty-dimension',
+        operation: 'terms',
+        field: 'geo.src',
+      });
+
+      await lens.configureDimension({
+        dimension: 'lnsDatatable_metrics > lns-empty-dimension',
+        operation: 'average',
+        field: 'bytes',
+      });
+
+      await lens.configureDimension({
+        dimension: 'lnsDatatable_metrics > lns-empty-dimension',
+        operation: 'count',
+      });
+
+      // Verify single layer - no tabs should be visible
+      await lens.assertLayerCount(1);
+
+      // Verify the config panel is scrollable by scrolling a bottom element into view
+      await assertConfigPanelIsScrollable('lnsDatatable_metrics > lns-empty-dimension');
+    });
+
+    it('should allow scrolling the config panel with multiple layers (with tabs)', async () => {
+      // Use a smaller window height to force the config panel to overflow
+      log.debug(`Resizing browser to ${originalWindowSize.width}x${SMALL_WINDOW_HEIGHT}`);
+      await browser.setWindowSize(originalWindowSize.width, SMALL_WINDOW_HEIGHT);
+
+      await visualize.navigateToNewVisualization();
+      await visualize.clickVisType('lens');
+
+      // Use XY chart which supports multiple layers
+      await lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await lens.configureDimension({
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
+        operation: 'average',
+        field: 'bytes',
+      });
+
+      await lens.configureDimension({
+        dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
+        operation: 'terms',
+        field: 'ip',
+      });
+
+      // Add a second layer to trigger tabs
+      await lens.createLayer('data');
+
+      // Verify multiple layers - tabs should be visible
+      await lens.assertLayerCount(2);
+
+      // Configure second layer to add more content
+      await lens.configureDimension({
+        dimension: 'lns-layerPanel-1 > lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await lens.configureDimension({
+        dimension: 'lns-layerPanel-1 > lnsXY_yDimensionPanel > lns-empty-dimension',
+        operation: 'count',
+      });
+
+      // Switch back to first layer and verify scrolling works
+      await lens.ensureLayerTabIsActive(0);
+
+      // Verify the config panel is scrollable by scrolling a bottom element into view
+      await assertConfigPanelIsScrollable('lnsXY_splitDimensionPanel > lns-dimensionTrigger');
+    });
+  });
+}

--- a/x-pack/platform/test/functional/apps/lens/group2/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group2/index.ts
@@ -62,5 +62,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
     loadTestFile(require.resolve('./layer_actions')); // 1m 45s
     loadTestFile(require.resolve('./field_formatters')); // 1m 30s
     loadTestFile(require.resolve('./color_mapping_runtime_migrations'));
+    loadTestFile(require.resolve('./config_panel_scroll'));
   });
 };

--- a/x-pack/platform/test/functional/page_objects/lens_page.ts
+++ b/x-pack/platform/test/functional/page_objects/lens_page.ts
@@ -1708,8 +1708,52 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           return;
         }
 
-        // Click to make it active
-        await tabs[index].click();
+        // Scroll tabs into view by clicking scroll buttons if needed.
+        // The tab may be hidden behind the scroll navigation buttons.
+        // Note: scroll buttons only exist when there are enough tabs to overflow.
+        // We try scrolling right first for higher indices, left for lower indices.
+        let scrollAttempts = 0;
+        const maxScrollAttempts = 10;
+
+        await retry.try(async () => {
+          // Try clicking the tab - if it fails due to scroll button overlap, scroll and retry
+          try {
+            await tabs[index].click();
+          } catch (e) {
+            if (e instanceof Error && e.message.includes('element click intercepted')) {
+              scrollAttempts++;
+              if (scrollAttempts > maxScrollAttempts) {
+                throw e; // Give up after max attempts
+              }
+
+              // Determine scroll direction based on tab index
+              // Lower indices are on the left, higher indices are on the right
+              const scrollRightBtnExists = await testSubjects.exists(
+                'unifiedTabs_tabsBar_scrollRightBtn',
+                { timeout: 500 }
+              );
+              const scrollLeftBtnExists = await testSubjects.exists(
+                'unifiedTabs_tabsBar_scrollLeftBtn',
+                { timeout: 500 }
+              );
+
+              // Try scrolling in the appropriate direction
+              if (index >= tabs.length / 2 && scrollRightBtnExists) {
+                // Tab is in the right half, try scrolling right
+                await testSubjects.click('unifiedTabs_tabsBar_scrollRightBtn');
+              } else if (scrollLeftBtnExists) {
+                // Tab is in the left half, try scrolling left
+                await testSubjects.click('unifiedTabs_tabsBar_scrollLeftBtn');
+              } else if (scrollRightBtnExists) {
+                // Fallback to scrolling right if left isn't available
+                await testSubjects.click('unifiedTabs_tabsBar_scrollRightBtn');
+              }
+
+              throw e; // Rethrow to retry
+            }
+            throw e;
+          }
+        });
 
         // Wait for the layer panel to render
         await retry.waitFor('layer panel to be visible', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Lens] Fix layer editor scrolling in full lens editor (#253247)](https://github.com/elastic/kibana/pull/253247)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Walter M. Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2026-02-17T10:15:35Z","message":"[Lens] Fix layer editor scrolling in full lens editor (#253247)\n\n## Summary\n\nFixes #244198 (flaky layer config tests). Fixes #253050 (layer config\nnot scrollable in full lens editor).\n\n- Restructured the config panel layout in `editor_frame.tsx` to use a\nflex container with overflow handling\n- Extracted inline CSS into `componentStyles` object in\n`editor_frame.tsx` for consistency across the file\n- Fixed flaky layer_actions FTR test by improving the logic to make\nlayer tabs visible\n\n### How to test\n\n- Open full lens editor and reduce the height of the browser window\n- Add some dimension configs so the config panel grows beyond the\nvisible area\n- Check the config panel is scrollable so you can reach the bottom\nelement like the breakdown form\n- Check it works for single layer charts (no tabs) and multi layer\ncharts (visible tabs)\n\n### FTR tests\n\n- Server: `node scripts/functional_tests_server --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts`\n- Runner (layer config no longer flaky): `node\nscripts/functional_test_runner --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts --grep \"lens\nlayer actions tests\"`\n- Runner (scroll test): `node scripts/functional_test_runner --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts --grep \"lens\nconfig panel scroll\"`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Release notes\n\nFixes config panel scrolling in the Lens editor. Previously, when the\nconfig panel content exceeded the available height (e.g., with multiple\ndimensions or small viewport), users could not scroll to access all\nconfiguration options.","sha":"1fd818b36c9f0dc132e3b32f6c43546640c6ba78","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:version","v9.4.0","v9.3.1"],"title":"[Lens] Fix layer editor scrolling in full lens editor","number":253247,"url":"https://github.com/elastic/kibana/pull/253247","mergeCommit":{"message":"[Lens] Fix layer editor scrolling in full lens editor (#253247)\n\n## Summary\n\nFixes #244198 (flaky layer config tests). Fixes #253050 (layer config\nnot scrollable in full lens editor).\n\n- Restructured the config panel layout in `editor_frame.tsx` to use a\nflex container with overflow handling\n- Extracted inline CSS into `componentStyles` object in\n`editor_frame.tsx` for consistency across the file\n- Fixed flaky layer_actions FTR test by improving the logic to make\nlayer tabs visible\n\n### How to test\n\n- Open full lens editor and reduce the height of the browser window\n- Add some dimension configs so the config panel grows beyond the\nvisible area\n- Check the config panel is scrollable so you can reach the bottom\nelement like the breakdown form\n- Check it works for single layer charts (no tabs) and multi layer\ncharts (visible tabs)\n\n### FTR tests\n\n- Server: `node scripts/functional_tests_server --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts`\n- Runner (layer config no longer flaky): `node\nscripts/functional_test_runner --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts --grep \"lens\nlayer actions tests\"`\n- Runner (scroll test): `node scripts/functional_test_runner --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts --grep \"lens\nconfig panel scroll\"`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Release notes\n\nFixes config panel scrolling in the Lens editor. Previously, when the\nconfig panel content exceeded the available height (e.g., with multiple\ndimensions or small viewport), users could not scroll to access all\nconfiguration options.","sha":"1fd818b36c9f0dc132e3b32f6c43546640c6ba78"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253247","number":253247,"mergeCommit":{"message":"[Lens] Fix layer editor scrolling in full lens editor (#253247)\n\n## Summary\n\nFixes #244198 (flaky layer config tests). Fixes #253050 (layer config\nnot scrollable in full lens editor).\n\n- Restructured the config panel layout in `editor_frame.tsx` to use a\nflex container with overflow handling\n- Extracted inline CSS into `componentStyles` object in\n`editor_frame.tsx` for consistency across the file\n- Fixed flaky layer_actions FTR test by improving the logic to make\nlayer tabs visible\n\n### How to test\n\n- Open full lens editor and reduce the height of the browser window\n- Add some dimension configs so the config panel grows beyond the\nvisible area\n- Check the config panel is scrollable so you can reach the bottom\nelement like the breakdown form\n- Check it works for single layer charts (no tabs) and multi layer\ncharts (visible tabs)\n\n### FTR tests\n\n- Server: `node scripts/functional_tests_server --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts`\n- Runner (layer config no longer flaky): `node\nscripts/functional_test_runner --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts --grep \"lens\nlayer actions tests\"`\n- Runner (scroll test): `node scripts/functional_test_runner --config\nx-pack/platform/test/functional/apps/lens/group2/config.ts --grep \"lens\nconfig panel scroll\"`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Release notes\n\nFixes config panel scrolling in the Lens editor. Previously, when the\nconfig panel content exceeded the available height (e.g., with multiple\ndimensions or small viewport), users could not scroll to access all\nconfiguration options.","sha":"1fd818b36c9f0dc132e3b32f6c43546640c6ba78"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->