### PR TITLE
[Dashboard] Update Scout API tests to use non-admin privileged role and deployment agnostic tags

### DIFF
--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/create_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/create_dashboard.spec.ts
@@ -18,11 +18,12 @@ import {
   TEST_DASHBOARD_ID,
 } from '../fixtures';
 
-apiTest.describe('dashboards - create', { tag: tags.stateful.classic }, () => {
+apiTest.describe('dashboards - create', { tag: tags.deploymentAgnostic }, () => {
   let editorCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ kbnClient, requestAuth }) => {
-    editorCredentials = await requestAuth.getApiKey('editor');
+    // returns editor role in most deployment project and deployment types
+    editorCredentials = await requestAuth.getApiKeyForPrivilegedUser();
     await kbnClient.importExport.load(KBN_ARCHIVES.BASIC);
     await kbnClient.importExport.load(KBN_ARCHIVES.TAGS);
   });

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/delete_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/delete_dashboard.spec.ts
@@ -18,11 +18,12 @@ import {
   TEST_DASHBOARD_ID,
 } from '../fixtures';
 
-apiTest.describe('dashboards - delete', { tag: tags.stateful.classic }, () => {
+apiTest.describe('dashboards - delete', { tag: tags.deploymentAgnostic }, () => {
   let editorCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ kbnClient, requestAuth }) => {
-    editorCredentials = await requestAuth.getApiKey('editor');
+    // returns editor role in most deployment project and deployment types
+    editorCredentials = await requestAuth.getApiKeyForPrivilegedUser();
     await kbnClient.importExport.load(KBN_ARCHIVES.BASIC);
   });
 

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/update_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/update_dashboard.spec.ts
@@ -18,11 +18,12 @@ import {
   TEST_DASHBOARD_ID,
 } from '../fixtures';
 
-apiTest.describe('dashboards - update', { tag: tags.stateful.classic }, () => {
+apiTest.describe('dashboards - update', { tag: tags.deploymentAgnostic }, () => {
   let editorCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ kbnClient, requestAuth }) => {
-    editorCredentials = await requestAuth.getApiKey('editor');
+    // returns editor role in most deployment project and deployment types
+    editorCredentials = await requestAuth.getApiKeyForPrivilegedUser();
     await kbnClient.importExport.load(KBN_ARCHIVES.BASIC);
     await kbnClient.importExport.load(KBN_ARCHIVES.TAGS);
   });


### PR DESCRIPTION
We introduced the `requestAuth.getApiKeyForPrivilegedUser()` API-key based authentication method via https://github.com/elastic/kibana/pull/252095. We now update some of the test suites introduced via https://github.com/elastic/kibana/pull/251163 to use the new method. We update the tags so that these tests are marked to run in more testing environments, not just stateful.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->