### PR TITLE
[Synthetics] Rename title and description of private location sync task

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -14,13 +14,6 @@ import { replaceVarsWithParams } from './lightweight_param_formatter';
 import variableParser from './variable_parser';
 import { hasNoParams } from './param_utils';
 
-export {
-  hasNoParams,
-  extractParamReferences,
-  valueContainsParams,
-  monitorUsesGlobalParams,
-} from './param_utils';
-
 export type FormatterFn = (
   fields: Partial<MonitorFields>,
   key: ConfigKey

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -93,9 +93,9 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       task.registerTaskDefinition(mockTaskManager as any);
       expect(mockTaskManager.registerTaskDefinitions).toHaveBeenCalledWith({
         'Synthetics:Sync-Private-Location-Monitors': expect.objectContaining({
-          title: 'Synthetics Sync Global Params Task',
+          title: 'Synthetics Sync Private Location Monitors Task',
           description:
-            'This task is executed so that we can sync private location monitors for example when global params are updated',
+            'This task syncs private location monitor package policies, handling maintenance window changes and cleaning up duplicate policies',
           timeout: '10m',
           maxAttempts: 1,
           createTaskRunner: expect.any(Function),

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -59,9 +59,9 @@ export class SyncPrivateLocationMonitorsTask {
   registerTaskDefinition(taskManager: TaskManagerSetupContract) {
     taskManager.registerTaskDefinitions({
       [TASK_TYPE]: {
-        title: 'Synthetics Sync Global Params Task',
+        title: 'Synthetics Sync Private Location Monitors Task',
         description:
-          'This task is executed so that we can sync private location monitors for example when global params are updated',
+          'This task syncs private location monitor package policies, handling maintenance window changes and cleaning up duplicate policies',
         timeout: '10m',
         maxAttempts: 1,
         createTaskRunner: ({ taskInstance }) => {


### PR DESCRIPTION
Renames title and description of `Synthetics:Sync-Private-Location-Monitors` task and removes unused exports