### PR TITLE
[One Workflow] fix: inputs and consts autocomplete only when defined

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.test.ts
@@ -85,7 +85,7 @@ describe('getContextSchemaForPath', () => {
     expectZodSchemaEqual(
       context,
       DynamicStepContextSchema.extend({
-        inputs: z.object({}),
+        inputs: z.never(),
         consts: z.object({
           test: z.literal('test'),
         }),
@@ -105,7 +105,7 @@ describe('getContextSchemaForPath', () => {
     expectZodSchemaEqual(
       context,
       DynamicStepContextSchema.extend({
-        inputs: z.object({}),
+        inputs: z.never(),
         steps: z.object({
           'first-step': z.object({
             output: z.string().optional(),

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.test.ts
@@ -8,7 +8,8 @@
  */
 
 import type { WorkflowYaml } from '@kbn/workflows';
-import { getSchemaAtPath } from '@kbn/workflows/common/utils/zod';
+import { getSchemaAtPath, getShape } from '@kbn/workflows/common/utils/zod';
+import { z } from '@kbn/zod/v4';
 import {
   getWorkflowContextSchema,
   type WorkflowDefinitionForContext,
@@ -293,6 +294,98 @@ describe('getWorkflowContextSchema - Nested Objects', () => {
         const contextSchema = getWorkflowContextSchema(workflow);
         expect(contextSchema).toBeDefined();
       }).not.toThrow();
+    });
+  });
+
+  describe('inputs and consts conditional visibility', () => {
+    it('should use z.never() for inputs when no inputs are defined', () => {
+      const workflow: WorkflowYaml = {
+        version: '1',
+        name: 'Test Workflow',
+        description: undefined,
+        settings: undefined,
+        enabled: true,
+        tags: undefined,
+        triggers: [{ type: 'manual' }],
+        inputs: undefined,
+        consts: undefined,
+        steps: [{ name: 'step1', type: 'console' }],
+      };
+
+      const contextSchema = getWorkflowContextSchema(workflow);
+      const shape = getShape(contextSchema);
+      expect(shape.inputs).toBeInstanceOf(z.ZodNever);
+      expect(shape.consts).toBeInstanceOf(z.ZodNever);
+    });
+
+    it('should use z.never() for consts when no consts are defined', () => {
+      const workflow: WorkflowYaml = {
+        version: '1',
+        name: 'Test Workflow',
+        description: undefined,
+        settings: undefined,
+        enabled: true,
+        tags: undefined,
+        triggers: [{ type: 'manual' }],
+        inputs: {
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+        consts: undefined,
+        steps: [{ name: 'step1', type: 'console' }],
+      };
+
+      const contextSchema = getWorkflowContextSchema(workflow);
+      const shape = getShape(contextSchema);
+      expect(shape.inputs).toBeInstanceOf(z.ZodObject);
+      expect(shape.consts).toBeInstanceOf(z.ZodNever);
+    });
+
+    it('should use z.object for both inputs and consts when both are defined', () => {
+      const workflow: WorkflowYaml = {
+        version: '1',
+        name: 'Test Workflow',
+        description: undefined,
+        settings: undefined,
+        enabled: true,
+        tags: undefined,
+        triggers: [{ type: 'manual' }],
+        inputs: {
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+        consts: {
+          threshold: 100,
+        },
+        steps: [{ name: 'step1', type: 'console' }],
+      };
+
+      const contextSchema = getWorkflowContextSchema(workflow);
+      const shape = getShape(contextSchema);
+      expect(shape.inputs).toBeInstanceOf(z.ZodObject);
+      expect(shape.consts).toBeInstanceOf(z.ZodObject);
+    });
+
+    it('should use z.never() for inputs with empty consts object', () => {
+      const workflow: WorkflowYaml = {
+        version: '1',
+        name: 'Test Workflow',
+        description: undefined,
+        settings: undefined,
+        enabled: true,
+        tags: undefined,
+        triggers: [{ type: 'manual' }],
+        inputs: undefined,
+        consts: {},
+        steps: [{ name: 'step1', type: 'console' }],
+      };
+
+      const contextSchema = getWorkflowContextSchema(workflow);
+      const shape = getShape(contextSchema);
+      expect(shape.inputs).toBeInstanceOf(z.ZodNever);
+      expect(shape.consts).toBeInstanceOf(z.ZodNever);
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.ts
@@ -78,23 +78,26 @@ export function getWorkflowContextSchema(
     }
   }
 
+  const hasInputs = Object.keys(inputsObject).length > 0;
+  const constsEntries = Object.entries(definition.consts ?? {});
+  const hasConsts = constsEntries.length > 0;
+
   // Use DynamicWorkflowContextSchema instead of WorkflowContextSchema
   // This ensures compatibility with DynamicStepContextSchema.merge() in getContextSchemaForPath
   // The merge() method requires both schemas to have the same base structure
   return DynamicWorkflowContextSchema.extend({
-    // transform inputs properties to an object
-    // with the property name as the key and the Zod schema as the value
-    // Always create an object, even if empty, to ensure proper schema structure
-    inputs: Object.keys(inputsObject).length > 0 ? z.object(inputsObject) : z.object({}),
-    // transform an object of consts to an object
-    // with the const name as the key and inferred type as the value
-    consts: z.object({
-      ...Object.fromEntries(
-        Object.entries(definition.consts ?? {}).map(([key, value]) => [
-          key,
-          inferZodType(value, { isConst: true }),
-        ])
-      ),
-    }),
+    // Only include inputs in the schema when they are actually defined in the workflow.
+    // Using z.never() hides the key from autocomplete suggestions, avoiding confusion
+    // when the workflow doesn't declare any inputs.
+    inputs: hasInputs ? z.object(inputsObject) : z.never(),
+    // Only include consts in the schema when they are actually defined in the workflow.
+    // Same approach as inputs — z.never() prevents empty consts from appearing in autocomplete.
+    consts: hasConsts
+      ? z.object({
+          ...Object.fromEntries(
+            constsEntries.map(([key, value]) => [key, inferZodType(value, { isConst: true })])
+          ),
+        })
+      : z.never(),
   });
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/integration/variable.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/integration/variable.test.ts
@@ -54,8 +54,10 @@ steps:
 `.trim();
     const suggestions = await getSuggestions(yamlContent);
     expect(suggestions.map((s) => s.label)).toEqual(
-      expect.arrayContaining(['consts', 'event', 'now', 'workflow', 'steps', 'execution', 'inputs'])
+      expect.arrayContaining(['consts', 'event', 'now', 'workflow', 'steps', 'execution'])
     );
+    // inputs should NOT appear because no inputs are defined in this workflow
+    expect(suggestions.map((s) => s.label)).not.toContain('inputs');
   });
 
   it('should provide completions after @ and quote insertText automatically if cursor is in plain scalar', async () => {
@@ -71,18 +73,9 @@ steps:
       message: @|<-
 `.trim();
     const suggestions = await getSuggestions(yamlContent);
+    // inputs should NOT appear because no inputs are defined in this workflow
     expect(suggestions.map((s) => s.label).sort()).toEqual(
-      [
-        'consts',
-        'event',
-        'kibanaUrl',
-        'now',
-        'workflow',
-        'steps',
-        'execution',
-        'inputs',
-        'variables',
-      ].sort()
+      ['consts', 'event', 'kibanaUrl', 'now', 'workflow', 'steps', 'execution', 'variables'].sort()
     );
     expect(suggestions.map((s) => s.insertText).sort()).toEqual(
       [
@@ -90,7 +83,6 @@ steps:
         '"{{ execution$0 }}"',
         '"{{ kibanaUrl$0 }}"',
         '"{{ workflow$0 }}"',
-        '"{{ inputs$0 }}"',
         '"{{ consts$0 }}"',
         '"{{ now$0 }}"',
         '"{{ steps$0 }}"',
@@ -112,13 +104,13 @@ steps:
       message: hey, this is @|<-
 `.trim();
     const suggestions = await getSuggestions(yamlContent);
+    // inputs should NOT appear because no inputs are defined in this workflow
     expect(suggestions.map((s) => s.insertText).sort()).toEqual(
       [
         '{{ event$0 }}',
         '{{ execution$0 }}',
         '{{ kibanaUrl$0 }}',
         '{{ workflow$0 }}',
-        '{{ inputs$0 }}',
         '{{ consts$0 }}',
         '{{ now$0 }}',
         '{{ steps$0 }}',
@@ -141,9 +133,11 @@ steps:
 `.trim();
 
     const suggestions = await getSuggestions(yamlContent);
+    // inputs should NOT appear because no inputs are defined in this workflow
     expect(suggestions.map((s) => s.label)).toEqual(
-      expect.arrayContaining(['consts', 'event', 'now', 'workflow', 'steps', 'execution', 'inputs'])
+      expect.arrayContaining(['consts', 'event', 'now', 'workflow', 'steps', 'execution'])
     );
+    expect(suggestions.map((s) => s.label)).not.toContain('inputs');
     expect(suggestions.map((s) => s.insertText)).toEqual(
       expect.arrayContaining([expect.not.stringMatching(/^"[^"]*$/)])
     );
@@ -429,17 +423,11 @@ steps:
 `.trim();
       const suggestions = await getSuggestions(yamlContent);
       expect(suggestions.length).toBeGreaterThan(0);
+      // inputs should NOT appear because no inputs are defined in this workflow
       expect(suggestions.map((s) => s.label)).toEqual(
-        expect.arrayContaining([
-          'consts',
-          'event',
-          'now',
-          'workflow',
-          'steps',
-          'execution',
-          'inputs',
-        ])
+        expect.arrayContaining(['consts', 'event', 'now', 'workflow', 'steps', 'execution'])
       );
+      expect(suggestions.map((s) => s.label)).not.toContain('inputs');
       // Verify that suggestions include curly braces when not already inside braces
       const constsSuggestion = suggestions.find((s) => s.label === 'consts');
       expect(constsSuggestion?.insertText).toContain('{{');
@@ -460,17 +448,11 @@ steps:
 `.trim();
       const suggestions = await getSuggestions(yamlContent);
       expect(suggestions.length).toBeGreaterThan(0);
+      // inputs should NOT appear because no inputs are defined in this workflow
       expect(suggestions.map((s) => s.label)).toEqual(
-        expect.arrayContaining([
-          'consts',
-          'event',
-          'now',
-          'workflow',
-          'steps',
-          'execution',
-          'inputs',
-        ])
+        expect.arrayContaining(['consts', 'event', 'now', 'workflow', 'steps', 'execution'])
       );
+      expect(suggestions.map((s) => s.label)).not.toContain('inputs');
     });
   });
 
@@ -604,6 +586,105 @@ steps:
         (s) => s.label === 'threshold' || s.label === 'inputs'
       );
       expect(inputsSuggestions.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('inputs and consts conditional visibility', () => {
+    it('should NOT suggest inputs or consts when neither is defined', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{|<-}}"
+`.trim();
+      const suggestions = await getSuggestions(yamlContent);
+      expect(suggestions.map((s) => s.label)).not.toContain('inputs');
+      expect(suggestions.map((s) => s.label)).not.toContain('consts');
+      // Other context variables should still be present
+      expect(suggestions.map((s) => s.label)).toEqual(
+        expect.arrayContaining(['event', 'execution', 'workflow', 'steps', 'now'])
+      );
+    });
+
+    it('should suggest inputs when inputs are defined', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+inputs:
+  - name: alertName
+    type: string
+  - name: severity
+    type: string
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{|<-}}"
+`.trim();
+      const suggestions = await getSuggestions(yamlContent);
+      expect(suggestions.map((s) => s.label)).toContain('inputs');
+      expect(suggestions.map((s) => s.label)).not.toContain('consts');
+    });
+
+    it('should suggest consts when consts are defined', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+consts:
+  threshold: 100
+  region: us-east-1
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{|<-}}"
+`.trim();
+      const suggestions = await getSuggestions(yamlContent);
+      expect(suggestions.map((s) => s.label)).toContain('consts');
+      expect(suggestions.map((s) => s.label)).not.toContain('inputs');
+    });
+
+    it('should suggest both inputs and consts when both are defined', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+inputs:
+  - name: message
+    type: string
+consts:
+  apiUrl: "https://api.example.com"
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{|<-}}"
+`.trim();
+      const suggestions = await getSuggestions(yamlContent);
+      expect(suggestions.map((s) => s.label)).toContain('inputs');
+      expect(suggestions.map((s) => s.label)).toContain('consts');
+    });
+
+    it('should suggest specific input properties when navigating into inputs', async () => {
+      const yamlContent = `
+version: "1"
+name: "test"
+inputs:
+  - name: alertName
+    type: string
+  - name: severity
+    type: string
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{inputs.|<-}}"
+`.trim();
+      const suggestions = await getSuggestions(yamlContent);
+      expect(suggestions.map((s) => s.label)).toContain('alertName');
+      expect(suggestions.map((s) => s.label)).toContain('severity');
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.ts
@@ -9,6 +9,7 @@
 
 import type { monaco } from '@kbn/monaco';
 import { getShape } from '@kbn/workflows/common/utils/zod';
+import { z } from '@kbn/zod/v4';
 import { wrapAsMonacoSuggestion } from './wrap_as_monaco_suggestion';
 import { getDetailedTypeDescription } from '../../../../../../../common/lib/zod';
 import type { AutocompleteContext } from '../../context/autocomplete.types';
@@ -107,8 +108,10 @@ export function getVariableSuggestions(autocompleteContext: AutocompleteContext)
 
   const shape = getShape(contextSchema);
 
-  // Get all keys from the current schema
-  const keys = Object.keys(shape);
+  // Get all keys from the current schema, excluding ZodNever types.
+  // ZodNever is used to mark schema properties (e.g. inputs, consts) that are
+  // not defined in the current workflow, so they should not appear as suggestions.
+  const keys = Object.keys(shape).filter((key) => !(shape[key] instanceof z.ZodNever));
 
   if (keys.length === 0) {
     return [];

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
@@ -169,6 +169,65 @@ export class WorkflowEditorPage {
   }
 
   /**
+   * Trigger autocomplete at a specific text position using the Monaco API.
+   * Finds the first occurrence of `searchText` in the editor and places the cursor
+   * at the end of it, then triggers autocomplete via Ctrl+Space.
+   */
+  async triggerAutocompleteAfter(yamlContent: string, searchText: string) {
+    await this.setYamlEditorValue(yamlContent);
+
+    // Wait for the workflow definition to be parsed after setting the YAML.
+    // The autocomplete context schema depends on the parsed definition.
+    await this.page.waitForTimeout(1000);
+
+    // Use Monaco API to find the text and position cursor right after it
+    const uri = await this.yamlEditor.locator('.monaco-editor[data-uri]').getAttribute('data-uri');
+    if (!uri) {
+      throw new Error('Editor data-uri not found');
+    }
+    await this.page.evaluate(
+      ({ modelUri, text }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monaco environment is global
+        const monacoEnv = (window as any).MonacoEnvironment;
+        if (!monacoEnv?.monaco?.editor) {
+          throw new Error('MonacoEnvironment.monaco.editor is not available');
+        }
+        const model = monacoEnv.monaco.editor.getModel(modelUri);
+        if (!model) {
+          throw new Error('Editor model not found');
+        }
+
+        const content = model.getValue();
+        const offset = content.indexOf(text);
+        if (offset === -1) {
+          throw new Error(`Text "${text}" not found in editor`);
+        }
+
+        // Position cursor right after the search text
+        const endOffset = offset + text.length;
+        const position = model.getPositionAt(endOffset);
+
+        // Find the editor instance for this model by URI
+        const editors = monacoEnv.monaco.editor.getEditors();
+
+        const editorInstance = editors.find(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (e: any) => e.getModel()?.uri?.toString() === model.uri.toString()
+        );
+
+        if (editorInstance) {
+          editorInstance.setPosition(position);
+          editorInstance.focus();
+          editorInstance.trigger('autocomplete-test', 'editor.action.triggerSuggest', {});
+        } else {
+          throw new Error('No editor instance found for the YAML model');
+        }
+      },
+      { modelUri: uri, text: searchText }
+    );
+  }
+
+  /**
    * Save the workflow
    */
   async saveWorkflow() {

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/console_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/console_workflows.ts
@@ -184,3 +184,84 @@ triggers:
 steps:
   - name: hello_world_step
     type:`;
+
+/**
+ * Workflow with NO inputs and NO consts defined.
+ * Used for verifying that inputs/consts don't appear in autocomplete when undefined.
+ */
+export const getWorkflowWithoutInputsOrConstsYaml = (name: string) => `
+name: ${name}
+description: Simple workflow without inputs or consts
+enabled: true
+triggers:
+  - type: manual
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{ }}"`;
+
+/**
+ * Workflow with both inputs and consts defined.
+ * Used for verifying that inputs/consts appear in autocomplete only when defined.
+ */
+export const getWorkflowWithInputsAndConstsYaml = (name: string) => `
+name: ${name}
+description: Workflow with inputs and consts
+enabled: true
+triggers:
+  - type: manual
+inputs:
+  - name: alertName
+    type: string
+    default: "test alert"
+  - name: severity
+    type: string
+    default: "medium"
+consts:
+  threshold: 100
+  region: us-east-1
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{ }}"`;
+
+/**
+ * Workflow with only inputs defined (no consts).
+ * Used for verifying consts don't appear when not defined but inputs do.
+ */
+export const getWorkflowWithOnlyInputsYaml = (name: string) => `
+name: ${name}
+description: Workflow with only inputs
+enabled: true
+triggers:
+  - type: manual
+inputs:
+  - name: message
+    type: string
+    default: "hello"
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{ }}"`;
+
+/**
+ * Workflow with only consts defined (no inputs).
+ * Used for verifying inputs don't appear when not defined but consts do.
+ */
+export const getWorkflowWithOnlyConstsYaml = (name: string) => `
+name: ${name}
+description: Workflow with only consts
+enabled: true
+triggers:
+  - type: manual
+consts:
+  apiUrl: "https://api.example.com"
+  timeout: 30
+steps:
+  - name: step1
+    type: console
+    with:
+      message: "{{ }}"`;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
@@ -18,6 +18,10 @@ export {
   getDummyWorkflowYaml,
   getInvalidWorkflowYaml,
   getIncompleteStepTypeYaml,
+  getWorkflowWithoutInputsOrConstsYaml,
+  getWorkflowWithInputsAndConstsYaml,
+  getWorkflowWithOnlyInputsYaml,
+  getWorkflowWithOnlyConstsYaml,
 } from './console_workflows';
 export {
   TEST_ALERTS_INDEX,

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor_inputs_consts_autocomplete.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor_inputs_consts_autocomplete.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../fixtures';
+import { cleanupWorkflowsAndRules } from '../fixtures/cleanup';
+import {
+  getWorkflowWithInputsAndConstsYaml,
+  getWorkflowWithOnlyConstsYaml,
+  getWorkflowWithOnlyInputsYaml,
+  getWorkflowWithoutInputsOrConstsYaml,
+} from '../fixtures/workflows';
+
+test.describe(
+  'Inputs and consts autocomplete should only appear when defined',
+  {
+    tag: [
+      ...tags.stateful.classic,
+      ...tags.serverless.observability.complete,
+      ...tags.serverless.security.complete,
+    ],
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsPrivilegedUser();
+    });
+
+    test.afterAll(async ({ scoutSpace, apiServices }) => {
+      await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+    });
+
+    test('should NOT suggest inputs or consts when neither is defined', async ({ pageObjects }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+
+      // Use triggerAutocompleteAfter to reliably position cursor inside {{ }}
+      await pageObjects.workflowEditor.triggerAutocompleteAfter(
+        getWorkflowWithoutInputsOrConstsYaml('No Inputs No Consts'),
+        '{{ '
+      );
+
+      const suggestWidget = pageObjects.workflowEditor.getYamlEditorSuggestWidget();
+      await expect(suggestWidget).toBeVisible();
+
+      // inputs and consts should NOT be in the suggestions
+      await expect(suggestWidget.getByRole('option', { name: 'inputs' })).toBeHidden();
+      await expect(suggestWidget.getByRole('option', { name: 'consts' })).toBeHidden();
+
+      // But other context variables should still be available
+      await expect(suggestWidget.getByRole('option', { name: 'event' })).toBeVisible();
+      await expect(suggestWidget.getByRole('option', { name: 'execution' })).toBeVisible();
+    });
+
+    test('should suggest both inputs and consts when both are defined', async ({ pageObjects }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+
+      await pageObjects.workflowEditor.triggerAutocompleteAfter(
+        getWorkflowWithInputsAndConstsYaml('With Inputs And Consts'),
+        '{{ '
+      );
+
+      const suggestWidget = pageObjects.workflowEditor.getYamlEditorSuggestWidget();
+      await expect(suggestWidget).toBeVisible();
+
+      // Both inputs and consts should be suggested
+      await expect(suggestWidget.getByRole('option', { name: 'inputs' })).toBeVisible();
+      await expect(suggestWidget.getByRole('option', { name: 'consts' })).toBeVisible();
+    });
+
+    test('should suggest inputs but NOT consts when only inputs are defined', async ({
+      pageObjects,
+    }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+
+      await pageObjects.workflowEditor.triggerAutocompleteAfter(
+        getWorkflowWithOnlyInputsYaml('Only Inputs'),
+        '{{ '
+      );
+
+      const suggestWidget = pageObjects.workflowEditor.getYamlEditorSuggestWidget();
+      await expect(suggestWidget).toBeVisible();
+
+      // inputs should be suggested
+      await expect(suggestWidget.getByRole('option', { name: 'inputs' })).toBeVisible();
+      // consts should NOT be suggested
+      await expect(suggestWidget.getByRole('option', { name: 'consts' })).toBeHidden();
+    });
+
+    test('should suggest consts but NOT inputs when only consts are defined', async ({
+      pageObjects,
+    }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+
+      await pageObjects.workflowEditor.triggerAutocompleteAfter(
+        getWorkflowWithOnlyConstsYaml('Only Consts'),
+        '{{ '
+      );
+
+      const suggestWidget = pageObjects.workflowEditor.getYamlEditorSuggestWidget();
+      await expect(suggestWidget).toBeVisible();
+
+      // consts should be suggested
+      await expect(suggestWidget.getByRole('option', { name: 'consts' })).toBeVisible();
+      // inputs should NOT be suggested
+      await expect(suggestWidget.getByRole('option', { name: 'inputs' })).toBeHidden();
+    });
+  }
+);


### PR DESCRIPTION
## Summary

- **Inputs** and **consts** no longer appear in autocomplete suggestions when the workflow doesn't define them
- Uses `z.never()` in the context schema for undefined inputs/consts, and filters out `ZodNever` keys in `getVariableSuggestions`
- Follows the same dynamic schema pattern used for event properties in #253381

### Before
Autocomplete always showed `inputs` and `consts` even when not defined → users could reference undefined properties → runtime errors.

### After
- No inputs defined → `inputs` hidden from suggestions
- No consts defined → `consts` hidden from suggestions
- Inputs defined → shows only declared input properties
- Consts defined → shows only declared const keys

## Test Coverage

- **4 new unit tests** in `get_workflow_context_schema.test.ts` (z.never() for empty, z.object() when defined)
- **5 new integration tests** in `variable.test.ts` (conditional visibility of inputs/consts)
- **4 new E2E Scout tests** in `workflow_editor_inputs_consts_autocomplete.spec.ts`
- **Updated 8 existing tests** to match new behavior

## References

Closes elastic/security-team#15991

Made with [Cursor](https://cursor.com)