### PR TITLE
[Agent Builder] Disable AB smoke tests on pull requests

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -143,10 +143,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       /^x-pack\/platform\/plugins\/shared\/stack_connectors\/server\/connector_types\/openai/,
       /^x-pack\/platform\/plugins\/shared\/stack_connectors\/server\/connector_types\/inference/,
     ];
-    const agentBuilderPaths = [
-      /^x-pack\/platform\/plugins\/shared\/agent_builder/,
-      /^x-pack\/platform\/packages\/shared\/agent_builder/,
-    ];
+    // const agentBuilderPaths = [
+    //   /^x-pack\/platform\/plugins\/shared\/agent_builder/,
+    //   /^x-pack\/platform\/packages\/shared\/agent_builder/,
+    // ];
 
     if (
       (await doAnyChangesMatch([...aiInfraPaths, ...aiConnectorPaths])) ||
@@ -156,8 +156,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml'));
     }
 
+    // Temporarily disable auto-trigger on file changes - smoke tests still run daily
     if (
-      (await doAnyChangesMatch([...aiInfraPaths, ...aiConnectorPaths, ...agentBuilderPaths])) ||
+      // (await doAnyChangesMatch([...aiInfraPaths, ...aiConnectorPaths, ...agentBuilderPaths])) ||
       GITHUB_PR_LABELS.includes('agent-builder:run-smoke-tests') ||
       GITHUB_PR_LABELS.includes('ci:all-gen-ai-suites') ||
       ALL_UI_TEST_SUITES


### PR DESCRIPTION
We have had to temporarily block QA access for OpenRouter-based models. This means you will get service errors if you try to access any EIS model via QA.  Agent Builder smoke tests do this dynamically as part of FTR tests that run on pull requests that touch `agent_builder` or `stack_connectors` related code. This means that all PRs touching this code would fail in CI whilst the smoke-tests are enabled as the QA API key has temporarily been removed. 

This PR temporarily disables the smoke-tests from running on pull requests.