### PR TITLE
[Saved Objects] Stabilize index-pattern relationships API test ordering

### DIFF
--- a/src/platform/test/api_integration/apis/saved_objects_management/relationships.ts
+++ b/src/platform/test/api_integration/apis/saved_objects_management/relationships.ts
@@ -71,6 +71,12 @@ export default function ({ getService }: FtrProviderContext) {
       const typesQuery = types.map((t) => `savedObjectTypes=${t}`).join('&');
       return `${baseApiUrl}/${type}/${id}?${typesQuery}`;
     };
+    const sortRelations = <TRelation extends { relationship: string; type: string; id: string }>(
+      relations: TRelation[]
+    ) =>
+      [...relations].sort((a, b) =>
+        `${a.relationship}:${a.type}:${a.id}`.localeCompare(`${b.relationship}:${b.type}:${b.id}`)
+      );
 
     describe('searches', () => {
       it('should validate search response schema', async () => {
@@ -462,7 +468,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
           .expect(200);
 
-        expect(resp.body.relations).to.eql([
+        const expectedRelations = [
           {
             id: '960372e0-3224-11e8-a572-ffca06da1357',
             type: 'search',
@@ -509,7 +515,9 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ];
+
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations(expectedRelations));
       });
 
       it('should filter based on savedObjectTypes', async () => {


### PR DESCRIPTION
## Summary
- Stabilizes the saved objects management relationships API test for index patterns by sorting relations before asserting equality.
- Prevents flaky failures caused by non-deterministic relation ordering in API responses.
- Closes https://github.com/elastic/kibana/issues/244751

## Test plan
- [x] Run `node scripts/functional_test_runner --config src/platform/test/api_integration/config.ts --include-tag saved_objects_management` (or equivalent targeted API integration run)

Made with [Cursor](https://cursor.com)