### PR TITLE
[ResponseOps] Code Scanning Alerts for @elastic/response-ops in elastic/kibana

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule_template/methods/find/schema.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule_template/methods/find/schema.ts
@@ -15,5 +15,5 @@ export const findRuleTemplatesParamsSchema = schema.object({
   sortField: schema.maybe(schema.string()),
   sortOrder: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
   ruleTypeId: schema.maybe(schema.string()),
-  tags: schema.maybe(schema.arrayOf(schema.string())),
+  tags: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
 });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/2508

## Summary

- fixed the `Unbounded array in schema validation` error by adding the limit of **10** tags



