### PR TITLE
[8.19] [Dashboard] Update Scout API tests to use non-admin privileged role and deployment agnostic tags (#253413)

### DIFF
--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/create_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/create_dashboard.spec.ts
@@ -19,11 +19,12 @@ import {
   TEST_DASHBOARD_ID,
 } from '../fixtures';
 
-apiTest.describe('dashboards - create', { tag: tags.stateful.classic }, () => {
+apiTest.describe('dashboards - create', { tag: tags.deploymentAgnostic }, () => {
   let editorCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ kbnClient, requestAuth }) => {
-    editorCredentials = await requestAuth.getApiKey('editor');
+    // returns editor role in most deployment project and deployment types
+    editorCredentials = await requestAuth.getApiKeyForPrivilegedUser();
     await kbnClient.importExport.load(KBN_ARCHIVES.BASIC);
     await kbnClient.importExport.load(KBN_ARCHIVES.TAGS);
   });

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/delete_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/delete_dashboard.spec.ts
@@ -18,11 +18,12 @@ import {
   TEST_DASHBOARD_ID,
 } from '../fixtures';
 
-apiTest.describe('dashboards - delete', { tag: tags.stateful.classic }, () => {
+apiTest.describe('dashboards - delete', { tag: tags.deploymentAgnostic }, () => {
   let editorCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ kbnClient, requestAuth }) => {
-    editorCredentials = await requestAuth.getApiKey('editor');
+    // returns editor role in most deployment project and deployment types
+    editorCredentials = await requestAuth.getApiKeyForPrivilegedUser();
     await kbnClient.importExport.load(KBN_ARCHIVES.BASIC);
   });
 

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/update_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/update_dashboard.spec.ts
@@ -44,11 +44,12 @@ const updatedDashboard = {
   ],
 };
 
-apiTest.describe('dashboards - update', { tag: tags.stateful.classic }, () => {
+apiTest.describe('dashboards - update', { tag: tags.deploymentAgnostic }, () => {
   let editorCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ kbnClient, requestAuth }) => {
-    editorCredentials = await requestAuth.getApiKey('editor');
+    // returns editor role in most deployment project and deployment types
+    editorCredentials = await requestAuth.getApiKeyForPrivilegedUser();
     await kbnClient.importExport.load(KBN_ARCHIVES.BASIC);
     await kbnClient.importExport.load(KBN_ARCHIVES.TAGS);
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Dashboard] Update Scout API tests to use non-admin privileged role and deployment agnostic tags (#253413)](https://github.com/elastic/kibana/pull/253413)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2026-02-17T13:25:22Z","message":"[Dashboard] Update Scout API tests to use non-admin privileged role and deployment agnostic tags (#253413)\n\nWe introduced the `requestAuth.getApiKeyForPrivilegedUser()` API-key\nbased authentication method via\nhttps://github.com/elastic/kibana/pull/252095. We now update some of the\ntest suites introduced via https://github.com/elastic/kibana/pull/251163\nto use the new method. We update the tags so that these tests are marked\nto run in more testing environments, not just stateful.","sha":"6636fb6ae49adb46eae25b2baebe7e50c8417fc5","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0"],"title":"[Dashboard] Update Scout API tests to use non-admin privileged role and deployment agnostic tags","number":253413,"url":"https://github.com/elastic/kibana/pull/253413","mergeCommit":{"message":"[Dashboard] Update Scout API tests to use non-admin privileged role and deployment agnostic tags (#253413)\n\nWe introduced the `requestAuth.getApiKeyForPrivilegedUser()` API-key\nbased authentication method via\nhttps://github.com/elastic/kibana/pull/252095. We now update some of the\ntest suites introduced via https://github.com/elastic/kibana/pull/251163\nto use the new method. We update the tags so that these tests are marked\nto run in more testing environments, not just stateful.","sha":"6636fb6ae49adb46eae25b2baebe7e50c8417fc5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253413","number":253413,"mergeCommit":{"message":"[Dashboard] Update Scout API tests to use non-admin privileged role and deployment agnostic tags (#253413)\n\nWe introduced the `requestAuth.getApiKeyForPrivilegedUser()` API-key\nbased authentication method via\nhttps://github.com/elastic/kibana/pull/252095. We now update some of the\ntest suites introduced via https://github.com/elastic/kibana/pull/251163\nto use the new method. We update the tags so that these tests are marked\nto run in more testing environments, not just stateful.","sha":"6636fb6ae49adb46eae25b2baebe7e50c8417fc5"}},{"url":"https://github.com/elastic/kibana/pull/253447","number":253447,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->