### PR TITLE
[9.3] [APM] Service Map message queue grouping fix (#252713)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/service_map/group_resource_nodes.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/service_map/group_resource_nodes.ts
@@ -58,25 +58,45 @@ function groupConnections({
   return Array.from(groups.values()).filter(({ targets }) => targets.length >= MINIMUM_GROUP_SIZE);
 }
 
+function getGroupedNodeIds(groupedConnections: ReturnType<typeof groupConnections>): Set<string> {
+  const groupedNodeIds = new Set<string>();
+  for (const { targets } of groupedConnections) {
+    for (const target of targets) {
+      groupedNodeIds.add(target);
+    }
+  }
+  return groupedNodeIds;
+}
+
 function getUngroupedNodesAndEdges({
   nodesMap,
   edgesMap,
   groupedConnections,
+  groupedNodeIds,
 }: {
   nodesMap: Map<string, { data: ConnectionNode }>;
   edgesMap: Map<string, { data: ConnectionEdge }>;
   groupedConnections: ReturnType<typeof groupConnections>;
+  groupedNodeIds: Set<string>;
 }) {
   const ungroupedEdges = new Map(edgesMap);
   const ungroupedNodes = new Map(nodesMap);
 
+  const groupedEdgeIds = new Set<string>();
+
   for (const { sources, targets } of groupedConnections) {
-    targets.forEach((target) => {
+    for (const target of targets) {
       ungroupedNodes.delete(target);
-      sources.forEach((source) => {
-        ungroupedEdges.delete(getEdgeId(source, target));
-      });
-    });
+      for (const source of sources) {
+        groupedEdgeIds.add(getEdgeId(source, target));
+      }
+    }
+  }
+
+  for (const [edgeId, { data }] of ungroupedEdges) {
+    if (groupedEdgeIds.has(edgeId) || groupedNodeIds.has(data.source)) {
+      ungroupedEdges.delete(edgeId);
+    }
   }
 
   return {
@@ -126,10 +146,18 @@ function groupNodes({
 
 function groupEdges({
   groupedConnections,
+  edgesMap,
+  groupedNodeIds,
 }: {
   groupedConnections: ReturnType<typeof groupConnections>;
+  edgesMap: Map<string, { data: ConnectionEdge }>;
+  groupedNodeIds: Set<string>;
 }) {
-  return groupedConnections.flatMap(({ id, sources }) =>
+  const nodeToGroup = new Map<string, string>();
+  const outgoingEdgeKeys = new Set<string>();
+  const outgoingEdges: GroupedEdge[] = [];
+
+  const incomingEdges = groupedConnections.flatMap(({ id, sources }) =>
     sources.map(
       (source): GroupedEdge => ({
         data: {
@@ -140,6 +168,33 @@ function groupEdges({
       })
     )
   );
+
+  for (const { id: groupId, targets } of groupedConnections) {
+    for (const target of targets) {
+      nodeToGroup.set(target, groupId);
+    }
+  }
+
+  for (const [, { data }] of edgesMap) {
+    const groupId = nodeToGroup.get(data.source);
+
+    if (groupId && !groupedNodeIds.has(data.target)) {
+      const edgeKey = `${groupId}~>${data.target}`;
+
+      if (!outgoingEdgeKeys.has(edgeKey)) {
+        outgoingEdgeKeys.add(edgeKey);
+        outgoingEdges.push({
+          data: {
+            id: edgeKey,
+            source: groupId,
+            target: data.target,
+          },
+        });
+      }
+    }
+  }
+
+  return [...incomingEdges, ...outgoingEdges];
 }
 
 export function groupResourceNodes({
@@ -156,14 +211,17 @@ export function groupResourceNodes({
   );
 
   const groupedConnections = groupConnections({ edgesMap, groupableNodeIds });
+  const groupedNodeIds = getGroupedNodeIds(groupedConnections);
+
   const { ungroupedEdges, ungroupedNodes } = getUngroupedNodesAndEdges({
     nodesMap,
     edgesMap,
     groupedConnections,
+    groupedNodeIds,
   });
 
   const groupedNodes = groupNodes({ nodesMap, groupedConnections });
-  const groupedEdges = groupEdges({ groupedConnections });
+  const groupedEdges = groupEdges({ groupedConnections, edgesMap, groupedNodeIds });
 
   return {
     elements: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[APM] Service Map message queue grouping fix (#252713)](https://github.com/elastic/kibana/pull/252713)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-16T12:34:13Z","message":"[APM] Service Map message queue grouping fix (#252713)\n\n## Summary\n\nThis PR fixes a bug with grouping messaging spans, which caused outgoing\nspans to become orphans. This caused the service map to crash\n\n| Before | After |\n|-------|------|\n|<img width=\"1708\" height=\"854\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/012aaa2b-bcda-4800-9f9f-95a2a12507d1\"\n/>|<img width=\"930\" height=\"438\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4fb26376-a446-41ad-8822-dd6681e64b59\"\n/>|\n\nreact flow version:\n\n<img width=\"1476\" height=\"776\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/14281961-f270-4cd3-b752-ab0ea1e5dbb8\"\n/>\n\n\n\n_tested with a synthtrace scenario not included in the PR_\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e851bf584eac857a6cab483e37dfe8ca2d579191","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0","Team:obs-presentation"],"title":"[APM] Service Map message queue grouping fix","number":252713,"url":"https://github.com/elastic/kibana/pull/252713","mergeCommit":{"message":"[APM] Service Map message queue grouping fix (#252713)\n\n## Summary\n\nThis PR fixes a bug with grouping messaging spans, which caused outgoing\nspans to become orphans. This caused the service map to crash\n\n| Before | After |\n|-------|------|\n|<img width=\"1708\" height=\"854\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/012aaa2b-bcda-4800-9f9f-95a2a12507d1\"\n/>|<img width=\"930\" height=\"438\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4fb26376-a446-41ad-8822-dd6681e64b59\"\n/>|\n\nreact flow version:\n\n<img width=\"1476\" height=\"776\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/14281961-f270-4cd3-b752-ab0ea1e5dbb8\"\n/>\n\n\n\n_tested with a synthtrace scenario not included in the PR_\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e851bf584eac857a6cab483e37dfe8ca2d579191"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252713","number":252713,"mergeCommit":{"message":"[APM] Service Map message queue grouping fix (#252713)\n\n## Summary\n\nThis PR fixes a bug with grouping messaging spans, which caused outgoing\nspans to become orphans. This caused the service map to crash\n\n| Before | After |\n|-------|------|\n|<img width=\"1708\" height=\"854\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/012aaa2b-bcda-4800-9f9f-95a2a12507d1\"\n/>|<img width=\"930\" height=\"438\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4fb26376-a446-41ad-8822-dd6681e64b59\"\n/>|\n\nreact flow version:\n\n<img width=\"1476\" height=\"776\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/14281961-f270-4cd3-b752-ab0ea1e5dbb8\"\n/>\n\n\n\n_tested with a synthtrace scenario not included in the PR_\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e851bf584eac857a6cab483e37dfe8ca2d579191"}}]}] BACKPORT-->