### PR TITLE
Fix flaky reindex task timeout in serverless migration actions test

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1008,7 +1008,7 @@ export const runActionTestSuite = ({
         excludeOnUpgradeQuery: { match_all: {} },
         batchSize: 1000,
       })()) as Either.Right<ReindexResponse>;
-      const task = waitForReindexTask({ client, taskId: reindexTaskId, timeout: '10s' });
+      const task = waitForReindexTask({ client, taskId: reindexTaskId, timeout: '60s' });
 
       await expect(task()).resolves.toMatchInlineSnapshot(`
         Object {
@@ -1049,7 +1049,7 @@ export const runActionTestSuite = ({
         excludeOnUpgradeQuery: { match_all: {} },
         batchSize: 1000,
       })()) as Either.Right<ReindexResponse>;
-      const task = waitForReindexTask({ client, taskId: reindexTaskId, timeout: '10s' });
+      const task = waitForReindexTask({ client, taskId: reindexTaskId, timeout: '60s' });
 
       await expect(task()).resolves.toMatchInlineSnapshot(`
         Object {


### PR DESCRIPTION
## Summary

Increases `waitForReindexTask` timeout from `10s` to `60s` for the `incompatible_mapping_exception` integration tests (`strict_dynamic_mapping_exception` and `mapper_parsing_exception`). The 10s timeout was too tight for serverless environments, causing intermittent `timeout_exception` instead of the expected mapping error.

Closes #167274
Close https://github.com/elastic/kibana/issues/167275

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

### Identify risks

No risks. This only increases a wait timeout upper bound in a test — it does not change production code or test semantics.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->