### PR TITLE
[Agent Builder] Update telemetry - track total hits for conversation metrics

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.ts
@@ -208,6 +208,7 @@ export class QueryUtils {
       const response = await this.esClient.search({
         index: conversationIndexName,
         size: 0,
+        track_total_hits: true,
         aggs: {
           rounds_distribution: {
             terms: {


### PR DESCRIPTION
https://www.elastic.co/docs/solutions/search/the-search-api#track-total-hits according to this documentation, Elastic Search queries using the `search` API are capped at 10k, unless `track_total_hits` is set to `true`. This comes at a performance cost of course, however, given that it's unlikely we have many users with >10k conversations, it's acceptable to turn it on.

Context: We are seeing a user in our dashboards with 10000 conversations. However, it's highly likely they have >10k conversations, and we can't see the true number unless we actually track the total correctly.