### PR TITLE
[8.19] [Stack Connectors] Add `region` implementation to Bedrock Connector (#252960)

### DIFF
--- a/docs/management/connectors/action-types/bedrock.asciidoc
+++ b/docs/management/connectors/action-types/bedrock.asciidoc
@@ -29,6 +29,7 @@ image::management/connectors/images/bedrock-connector.png[{bedrock} connector]
 
 Name::      The name of the connector.
 API URL::   The {bedrock} request URL.
+Region::   (Optional) The AWS region used for request signing. Required when using a custom endpoint URL that does not include the region in the hostname (for example, +us-east-1+).
 Default model:: The GAI model for {bedrock} to use. Current support is for the Anthropic Claude models, defaulting to Claude 2. The model can be set on a per request basis by including a "model" parameter alongside the request body.
 Access Key::   The AWS access key for authentication.
 Secret::   The secret for authentication.

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -71924,6 +71924,10 @@ components:
         apiUrl:
           type: string
           description: The Amazon Bedrock request URL.
+        region:
+          type: string
+          description: |
+            Optional AWS region for request signing. Required when using a custom endpoint URL that does not include the region in the hostname (for example, `us-west-1`).
         defaultModel:
           type: string
           description: |

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -56607,6 +56607,10 @@ components:
         apiUrl:
           type: string
           description: The Amazon Bedrock request URL.
+        region:
+          type: string
+          description: |
+            Optional AWS region for request signing. Required when using a custom endpoint URL that does not include the region in the hostname (for example, `us-west-1`).
         defaultModel:
           type: string
           description: |

--- a/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/bedrock_config.yaml
+++ b/x-pack/platform/plugins/shared/actions/docs/openapi/components/schemas/bedrock_config.yaml
@@ -7,6 +7,11 @@ properties:
   apiUrl:
     type: string
     description: The Amazon Bedrock request URL.
+  region:
+    type: string
+    description: >
+      Optional AWS region for request signing. Required when using a custom endpoint URL that does not
+      include the region in the hostname (for example, `us-west-1`).
   defaultModel:
     type: string
     description: >

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/connector.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/connector.test.tsx
@@ -64,6 +64,8 @@ describe('BedrockConnectorFields renders', () => {
 
     expect(getAllByTestId('config.apiUrl-input')[0]).toBeInTheDocument();
     expect(getAllByTestId('config.apiUrl-input')[0]).toHaveValue(bedrockConnector.config.apiUrl);
+    expect(getAllByTestId('config.region-input')[0]).toBeInTheDocument();
+    expect(getAllByTestId('config.region-input')[0]).toHaveValue('');
     expect(getAllByTestId('config.defaultModel-input')[0]).toBeInTheDocument();
     expect(getAllByTestId('config.defaultModel-input')[0]).toHaveValue(
       bedrockConnector.config.defaultModel

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/constants.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/constants.tsx
@@ -14,6 +14,7 @@ import {
   DEFAULT_BEDROCK_URL,
   DEFAULT_TOKEN_LIMIT,
 } from '../../../common/bedrock/constants';
+import { OptionalFieldLabel } from '../../common/optional_field_label';
 import * as i18n from './translations';
 
 const human = '\n\nHuman:';
@@ -46,6 +47,18 @@ export const bedrockConfig: ConfigFieldSchema[] = [
             </EuiLink>
           ),
         }}
+      />
+    ),
+  },
+  {
+    id: 'region',
+    label: i18n.REGION_LABEL,
+    isRequired: false,
+    labelAppend: OptionalFieldLabel,
+    helpText: (
+      <FormattedMessage
+        defaultMessage="Optional AWS region for request signing. Required when using a custom endpoint URL that does not include the region in the hostname (for example, `us-west-1`)."
+        id="xpack.stackConnectors.components.bedrock.regionHelpText"
       />
     ),
   },

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/translations.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/translations.ts
@@ -27,6 +27,10 @@ export const DEFAULT_MODEL_LABEL = i18n.translate(
   }
 );
 
+export const REGION_LABEL = i18n.translate('xpack.stackConnectors.components.bedrock.region', {
+  defaultMessage: 'Region',
+});
+
 export const SECRET = i18n.translate('xpack.stackConnectors.components.bedrock.secret', {
   defaultMessage: 'Secret',
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/types.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/types.ts
@@ -16,6 +16,7 @@ export interface BedrockActionParams {
 
 export interface Config {
   apiUrl: string;
+  region?: string;
   defaultModel: string;
 }
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
@@ -166,11 +166,11 @@ describe('BedrockConnector', () => {
         mockSigner.mockClear();
         const customConnector = new BedrockConnector({
           configurationUtilities: actionsConfigMock.create(),
-          connector: { id: '1', type: CONNECTOR_ID },
+          connector: { id: '1', type: BEDROCK_CONNECTOR_ID },
           config: {
             apiUrl: 'https://custom.endpoint.example',
             region: 'us-west-1',
-            defaultModel: DEFAULT_MODEL,
+            defaultModel: DEFAULT_BEDROCK_MODEL,
           },
           secrets: { accessKey: '123', secret: 'secret' },
           logger,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
@@ -154,9 +154,39 @@ describe('BedrockConnector', () => {
               'Content-Type': 'application/json',
             },
             host: 'bedrock-runtime.us-east-1.amazonaws.com',
+            region: 'us-east-1',
             path: `/model/${encodedModel}/invoke`,
             service: 'bedrock',
           },
+          { accessKeyId: '123', secretAccessKey: 'secret' }
+        );
+      });
+
+      it('passes an explicit region to the signer for custom endpoints', async () => {
+        mockSigner.mockClear();
+        const customConnector = new BedrockConnector({
+          configurationUtilities: actionsConfigMock.create(),
+          connector: { id: '1', type: CONNECTOR_ID },
+          config: {
+            apiUrl: 'https://custom.endpoint.example',
+            region: 'us-west-1',
+            defaultModel: DEFAULT_MODEL,
+          },
+          secrets: { accessKey: '123', secret: 'secret' },
+          logger,
+          services: actionsMock.createServices(),
+        });
+        // @ts-ignore
+        customConnector.request = mockRequest;
+
+        await customConnector.runApi({ body: DEFAULT_BODY }, connectorUsageCollector);
+
+        expect(mockSigner).toHaveBeenCalledWith(
+          expect.objectContaining({
+            host: 'custom.endpoint.example',
+            region: 'us-west-1',
+            service: 'bedrock',
+          }),
           { accessKeyId: '123', secretAccessKey: 'secret' }
         );
       });
@@ -255,6 +285,7 @@ describe('BedrockConnector', () => {
               'x-amzn-bedrock-accept': '*/*',
             },
             host: 'bedrock-runtime.us-east-1.amazonaws.com',
+            region: 'us-east-1',
             path: `/model/${encodedModel}/invoke-with-response-stream`,
             service: 'bedrock',
           },
@@ -973,6 +1004,7 @@ describe('BedrockConnector', () => {
               'x-amzn-bedrock-accept': '*/*',
             },
             host: 'bedrock-runtime.us-east-1.amazonaws.com',
+            region: 'us-east-1',
             path: `/model/${encodedModel}/converse-stream`,
             service: 'bedrock',
           },

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -76,12 +76,14 @@ export class BedrockConnector extends SubActionConnector<Config, Secrets> {
   private url;
   private model;
   private bedrockClient;
+  private region;
 
   constructor(params: ServiceParams<Config, Secrets>) {
     super(params);
 
     this.url = this.config.apiUrl;
     this.model = this.config.defaultModel;
+    this.region = this.config.region ?? extractRegionId(this.config.apiUrl) ?? 'us-east-1';
     const { httpAgent, httpsAgent } = getCustomAgents(
       this.configurationUtilities,
       this.logger,
@@ -89,7 +91,7 @@ export class BedrockConnector extends SubActionConnector<Config, Secrets> {
     );
     const isHttps = this.url.toLowerCase().startsWith('https');
     this.bedrockClient = new BedrockRuntimeClient({
-      region: extractRegionId(this.config.apiUrl),
+      region: this.region,
       credentials: {
         accessKeyId: this.secrets.accessKey,
         secretAccessKey: this.secrets.secret,
@@ -188,6 +190,7 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
     return aws.sign(
       {
         host,
+        region: this.region,
         headers: stream
           ? {
               accept: 'application/vnd.amazon.eventstream',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Stack Connectors] Add `region` implementation to Bedrock Connector (#252960)](https://github.com/elastic/kibana/pull/252960)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Garrett Spong","email":"spong@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-17T16:21:06Z","message":"[Stack Connectors] Add `region` implementation to Bedrock Connector (#252960)\n\n## Summary\n\nFollow-up PR to https://github.com/elastic/kibana/pull/252956 that adds\n`region` to the Bedrock Connector schema.\n\nThis PR adds support for an **optional `region`** field on the Amazon\nBedrock connector to support **custom Bedrock endpoint domains** (e.g.\nenvironments that do not use `amazonaws.com`, such as `us-west-1`).\n\nWithout an explicit region, region inference fails for custom domains\nand **SigV4 request signing** can scope credentials to the wrong region,\nresulting in errors like:\n- `403 Forbidden - Credential should be scoped to a valid region.`\n\n## Changes\n\n- **Server**\n- Resolve Bedrock region as: `config.region ?? extractRegionId(apiUrl)\n?? 'us-east-1'`\n  - Pass resolved region into:\n    - `aws4.sign({ region, service: 'bedrock', ... })`\n    - `new BedrockRuntimeClient({ region, ... })`\n- **UI**\n- Add optional **Region** field to the Bedrock connector config form\n(with help text for custom endpoints)\n- Add i18n label and update connector config typing to include `region?:\nstring`\n- **OpenAPI**\n  - Add `region` to `bedrock_config.yaml`\n- **Tests**\n- Update existing Bedrock connector unit tests to assert `aws.sign`\nreceives `region`\n- Add a unit test ensuring explicit region is passed for custom endpoint\ndomains\n  - Update UI rendering test to assert `config.region-input` renders\n\n## Why\n\nSome AWS environments use custom Bedrock endpoint URLs that do not match\n`*.amazonaws.com`, preventing reliable region inference. Providing an\noptional `region` allows correct SigV4 signing and SDK client\nconfiguration, enabling Bedrock connectors to work in these\nenvironments.\n\n## Test plan\n\n- `yarn test:jest\nx-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts`\n- `yarn test:jest\nx-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/connector.test.tsx`\n\n(If needed) type check:\n- `yarn test:type_check --project\nx-pack/platform/plugins/shared/stack_connectors/tsconfig.json`\n\n## Notes\n\nThis branch includes the Bedrock connector schema update (`region` added\nto config schema). Once the schema-only PR merges, this PR can be\nrebased and the duplicate schema commit dropped.\n\n## Testing\n\nCreate a new Bedrock connector with and without the `region` field and\nconfirm the connector connection is successful for the expected region\n(using what was specified, or if not, what was extracted from the\nprovided URL).\n\n<p align=\"center\">\n<img width=\"500\"\nsrc=\"https://github.com/user-attachments/assets/0548b8de-1595-40e4-badd-9570d9d68c02\"\n/>\n</p> \n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n_PR developed with cursor-cli + GPT 5.2-high_\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e545ec82a0cd6ffcd5d443c43e14b3809cd19fb3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team: SecuritySolution","Feature:Actions/ConnectorTypes","backport:version","v9.4.0","v9.3.1","v9.2.6","v8.19.12"],"title":"[Stack Connectors] Add `region` implementation to Bedrock Connector","number":252960,"url":"https://github.com/elastic/kibana/pull/252960","mergeCommit":{"message":"[Stack Connectors] Add `region` implementation to Bedrock Connector (#252960)\n\n## Summary\n\nFollow-up PR to https://github.com/elastic/kibana/pull/252956 that adds\n`region` to the Bedrock Connector schema.\n\nThis PR adds support for an **optional `region`** field on the Amazon\nBedrock connector to support **custom Bedrock endpoint domains** (e.g.\nenvironments that do not use `amazonaws.com`, such as `us-west-1`).\n\nWithout an explicit region, region inference fails for custom domains\nand **SigV4 request signing** can scope credentials to the wrong region,\nresulting in errors like:\n- `403 Forbidden - Credential should be scoped to a valid region.`\n\n## Changes\n\n- **Server**\n- Resolve Bedrock region as: `config.region ?? extractRegionId(apiUrl)\n?? 'us-east-1'`\n  - Pass resolved region into:\n    - `aws4.sign({ region, service: 'bedrock', ... })`\n    - `new BedrockRuntimeClient({ region, ... })`\n- **UI**\n- Add optional **Region** field to the Bedrock connector config form\n(with help text for custom endpoints)\n- Add i18n label and update connector config typing to include `region?:\nstring`\n- **OpenAPI**\n  - Add `region` to `bedrock_config.yaml`\n- **Tests**\n- Update existing Bedrock connector unit tests to assert `aws.sign`\nreceives `region`\n- Add a unit test ensuring explicit region is passed for custom endpoint\ndomains\n  - Update UI rendering test to assert `config.region-input` renders\n\n## Why\n\nSome AWS environments use custom Bedrock endpoint URLs that do not match\n`*.amazonaws.com`, preventing reliable region inference. Providing an\noptional `region` allows correct SigV4 signing and SDK client\nconfiguration, enabling Bedrock connectors to work in these\nenvironments.\n\n## Test plan\n\n- `yarn test:jest\nx-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts`\n- `yarn test:jest\nx-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/connector.test.tsx`\n\n(If needed) type check:\n- `yarn test:type_check --project\nx-pack/platform/plugins/shared/stack_connectors/tsconfig.json`\n\n## Notes\n\nThis branch includes the Bedrock connector schema update (`region` added\nto config schema). Once the schema-only PR merges, this PR can be\nrebased and the duplicate schema commit dropped.\n\n## Testing\n\nCreate a new Bedrock connector with and without the `region` field and\nconfirm the connector connection is successful for the expected region\n(using what was specified, or if not, what was extracted from the\nprovided URL).\n\n<p align=\"center\">\n<img width=\"500\"\nsrc=\"https://github.com/user-attachments/assets/0548b8de-1595-40e4-badd-9570d9d68c02\"\n/>\n</p> \n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n_PR developed with cursor-cli + GPT 5.2-high_\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e545ec82a0cd6ffcd5d443c43e14b3809cd19fb3"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252960","number":252960,"mergeCommit":{"message":"[Stack Connectors] Add `region` implementation to Bedrock Connector (#252960)\n\n## Summary\n\nFollow-up PR to https://github.com/elastic/kibana/pull/252956 that adds\n`region` to the Bedrock Connector schema.\n\nThis PR adds support for an **optional `region`** field on the Amazon\nBedrock connector to support **custom Bedrock endpoint domains** (e.g.\nenvironments that do not use `amazonaws.com`, such as `us-west-1`).\n\nWithout an explicit region, region inference fails for custom domains\nand **SigV4 request signing** can scope credentials to the wrong region,\nresulting in errors like:\n- `403 Forbidden - Credential should be scoped to a valid region.`\n\n## Changes\n\n- **Server**\n- Resolve Bedrock region as: `config.region ?? extractRegionId(apiUrl)\n?? 'us-east-1'`\n  - Pass resolved region into:\n    - `aws4.sign({ region, service: 'bedrock', ... })`\n    - `new BedrockRuntimeClient({ region, ... })`\n- **UI**\n- Add optional **Region** field to the Bedrock connector config form\n(with help text for custom endpoints)\n- Add i18n label and update connector config typing to include `region?:\nstring`\n- **OpenAPI**\n  - Add `region` to `bedrock_config.yaml`\n- **Tests**\n- Update existing Bedrock connector unit tests to assert `aws.sign`\nreceives `region`\n- Add a unit test ensuring explicit region is passed for custom endpoint\ndomains\n  - Update UI rendering test to assert `config.region-input` renders\n\n## Why\n\nSome AWS environments use custom Bedrock endpoint URLs that do not match\n`*.amazonaws.com`, preventing reliable region inference. Providing an\noptional `region` allows correct SigV4 signing and SDK client\nconfiguration, enabling Bedrock connectors to work in these\nenvironments.\n\n## Test plan\n\n- `yarn test:jest\nx-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts`\n- `yarn test:jest\nx-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock/connector.test.tsx`\n\n(If needed) type check:\n- `yarn test:type_check --project\nx-pack/platform/plugins/shared/stack_connectors/tsconfig.json`\n\n## Notes\n\nThis branch includes the Bedrock connector schema update (`region` added\nto config schema). Once the schema-only PR merges, this PR can be\nrebased and the duplicate schema commit dropped.\n\n## Testing\n\nCreate a new Bedrock connector with and without the `region` field and\nconfirm the connector connection is successful for the expected region\n(using what was specified, or if not, what was extracted from the\nprovided URL).\n\n<p align=\"center\">\n<img width=\"500\"\nsrc=\"https://github.com/user-attachments/assets/0548b8de-1595-40e4-badd-9570d9d68c02\"\n/>\n</p> \n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n_PR developed with cursor-cli + GPT 5.2-high_\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e545ec82a0cd6ffcd5d443c43e14b3809cd19fb3"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/253511","number":253511,"state":"OPEN"},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.12","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->