### PR TITLE
[9.1] [Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/src/field_value_wildcard/index.tsx
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/src/field_value_wildcard/index.tsx
@@ -133,14 +133,23 @@ export const AutocompleteFieldWildcardComponent: React.FC<AutocompleteFieldWildc
 
     const handleValuesChange = useCallback(
       (newOptions: EuiComboBoxOptionOption[]): void => {
-        const [newValue] = newOptions.map(({ label }) => optionsMemo[labels.indexOf(label)]);
-        handleError(undefined);
-        handleSpacesWarning(newValue);
-        setShowSpacesWarning(false);
+        const isCustomSearchQuery =
+          newOptions.length > 0 && searchQuery && searchQuery !== newOptions[0].label;
 
-        onChange(newValue ?? '');
+        handleError(undefined);
+        setShowSpacesWarning(false);
+        setSearchQuery('');
+
+        if (isCustomSearchQuery) {
+          handleSpacesWarning(searchQuery);
+          onChange(searchQuery);
+        } else {
+          const [newValue] = newOptions.map(({ label }) => optionsMemo[labels.indexOf(label)]);
+          handleSpacesWarning(newValue);
+          onChange(newValue ?? '');
+        }
       },
-      [handleError, handleSpacesWarning, labels, onChange, optionsMemo]
+      [handleError, handleSpacesWarning, labels, onChange, optionsMemo, searchQuery]
     );
 
     const handleSearchChange = useCallback(
@@ -150,7 +159,6 @@ export const AutocompleteFieldWildcardComponent: React.FC<AutocompleteFieldWildc
           handleError(err);
           handleWarning(warning);
           if (!err) handleSpacesWarning(searchVal);
-
           setSearchQuery(searchVal);
         }
       },

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/autocomplete_operators/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-utils/src/autocomplete_operators/index.ts
@@ -12,6 +12,11 @@ import {
 } from '@kbn/securitysolution-io-ts-list-types';
 import { OperatorOption } from '../types';
 
+/**
+ * The "is" operator (UI label) uses MATCH type in the code.
+ * This renders AutocompleteFieldMatchComponent in the UI.
+ * Note: The "matches" operator uses WILDCARD type (not MATCH) despite the similar name.
+ */
 export const isOperator: OperatorOption = {
   message: i18n.translate('lists.exceptions.isOperatorLabel', {
     defaultMessage: 'is',
@@ -21,6 +26,10 @@ export const isOperator: OperatorOption = {
   value: 'is',
 };
 
+/**
+ * The "is not" operator (UI label) uses MATCH type in the code.
+ * This renders AutocompleteFieldMatchComponent in the UI.
+ */
 export const isNotOperator: OperatorOption = {
   message: i18n.translate('lists.exceptions.isNotOperatorLabel', {
     defaultMessage: 'is not',
@@ -84,6 +93,12 @@ export const isNotInListOperator: OperatorOption = {
   value: 'is_not_in_list',
 };
 
+/**
+ * The "matches" operator (UI label) uses WILDCARD type in the code (not MATCH type).
+ * This is because "matches" supports wildcard patterns (*, ?) and renders
+ * AutocompleteFieldWildcardComponent in the UI.
+ * Note: The "is" operator uses MATCH type and renders AutocompleteFieldMatchComponent.
+ */
 export const matchesOperator: OperatorOption = {
   message: i18n.translate('lists.exceptions.matchesOperatorLabel', {
     defaultMessage: 'matches',
@@ -93,6 +108,10 @@ export const matchesOperator: OperatorOption = {
   value: 'matches',
 };
 
+/**
+ * The "does not match" operator supports wildcard patterns (*, ?) and uses WILDCARD type.
+ * This renders AutocompleteFieldWildcardComponent in the UI.
+ */
 export const doesNotMatchOperator: OperatorOption = {
   message: i18n.translate('lists.exceptions.doesNotMatchOperatorLabel', {
     defaultMessage: 'does not match',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117)](https://github.com/elastic/kibana/pull/250117)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Brooks","email":"hannah.brooks@elastic.co"},"sourceCommit":{"committedDate":"2026-02-03T16:49:18Z","message":"[Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117)\n\n## Summary\n\nWhen using the `AutocompleteFieldWildCardComponent`, if a user selected\na dropdown option and then edited the field, the component would go back\nto the originally selected option from the dropdown instead of creating\na new one. This is because the fuzzy matching would find the existing\noption and set that value as the selected.\n\nNow, if we see that the user's entry is different from the option that\nis currently selected, we add the updated value to the dropdown list of\nsuggestions and select it.\n\nThere are also some comments added explaining when `WILDCARD` is used\nvs. `MATCH`.","sha":"c3270c60105cc4bbd77955a7f8935260564f6042","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["review","release_note:fix","backport:all-open","Team:Detection Engine","v9.3.0","v9.4.0","v9.2.5","v8.19.11"],"title":"[Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value","number":250117,"url":"https://github.com/elastic/kibana/pull/250117","mergeCommit":{"message":"[Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117)\n\n## Summary\n\nWhen using the `AutocompleteFieldWildCardComponent`, if a user selected\na dropdown option and then edited the field, the component would go back\nto the originally selected option from the dropdown instead of creating\na new one. This is because the fuzzy matching would find the existing\noption and set that value as the selected.\n\nNow, if we see that the user's entry is different from the option that\nis currently selected, we add the updated value to the dropdown list of\nsuggestions and select it.\n\nThere are also some comments added explaining when `WILDCARD` is used\nvs. `MATCH`.","sha":"c3270c60105cc4bbd77955a7f8935260564f6042"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251510","number":251510,"state":"MERGED","mergeCommit":{"sha":"123c793fe404de3905c59d2a1bfae00de9db460e","message":"[9.3] [Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117) (#251510)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution][Detection Engine] Backslash Is Being Removed When\nTyped In Exception Field Value\n(#250117)](https://github.com/elastic/kibana/pull/250117)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Hannah Brooks <hannah.brooks@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250117","number":250117,"mergeCommit":{"message":"[Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117)\n\n## Summary\n\nWhen using the `AutocompleteFieldWildCardComponent`, if a user selected\na dropdown option and then edited the field, the component would go back\nto the originally selected option from the dropdown instead of creating\na new one. This is because the fuzzy matching would find the existing\noption and set that value as the selected.\n\nNow, if we see that the user's entry is different from the option that\nis currently selected, we add the updated value to the dropdown list of\nsuggestions and select it.\n\nThere are also some comments added explaining when `WILDCARD` is used\nvs. `MATCH`.","sha":"c3270c60105cc4bbd77955a7f8935260564f6042"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251508","number":251508,"state":"MERGED","mergeCommit":{"sha":"4a34e6c6bb9feba7f79ac4f8f7e45831ba3d7b37","message":"[9.2] [Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117) (#251508)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution][Detection Engine] Backslash Is Being Removed When\nTyped In Exception Field Value\n(#250117)](https://github.com/elastic/kibana/pull/250117)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Hannah Brooks <hannah.brooks@elastic.co>"}},{"branch":"8.19","label":"v8.19.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/251507","number":251507,"state":"MERGED","mergeCommit":{"sha":"b13db490157507584c5f164bfbd85c43425c8da4","message":"[8.19] [Security Solution][Detection Engine] Backslash Is Being Removed When Typed In Exception Field Value (#250117) (#251507)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution][Detection Engine] Backslash Is Being Removed When\nTyped In Exception Field Value\n(#250117)](https://github.com/elastic/kibana/pull/250117)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Hannah Brooks <hannah.brooks@elastic.co>"}}]}] BACKPORT-->