### PR TITLE
moon: guard jest src group inputs when file group is missing

### DIFF
--- a/packages/kbn-eslint-plugin-eslint/moon.yml
+++ b/packages/kbn-eslint-plugin-eslint/moon.yml
@@ -29,11 +29,7 @@ tasks:
     args:
       - '--config'
       - $projectRoot/jest.config.js
-    inputs:
-      - '@group(src)'
   jestCI:
     args:
       - '--config'
       - $projectRoot/jest.config.js
-    inputs:
-      - '@group(src)'

--- a/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
+++ b/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
@@ -232,15 +232,18 @@ function applyJestTaskConfig(projectConfig: MoonProjectConfig) {
       `Could not find jest config for ${projectConfig.id} @ ${projectConfig.project.metadata.sourceRoot}`
     );
   } else {
+    const hasSrcFileGroup = MOON_CONST.FILE_GROUP_SRC in (projectConfig.fileGroups ?? {});
+    const jestTaskInputs = hasSrcFileGroup ? ['@group(src)'] : undefined;
+
     projectConfig.tags = (projectConfig.tags || []).concat([MOON_CONST.TAG_JEST_UNIT]);
     projectConfig.tasks = projectConfig.tasks || {};
     projectConfig.tasks[MOON_CONST.TASK_NAME_JEST] = {
       args: ['--config', `$projectRoot/${jestConfigName}`],
-      inputs: ['@group(src)'],
+      ...(jestTaskInputs ? { inputs: jestTaskInputs } : {}),
     };
     projectConfig.tasks[MOON_CONST.TASK_NAME_JEST_CI] = {
       args: ['--config', `$projectRoot/${jestConfigName}`],
-      inputs: ['@group(src)'],
+      ...(jestTaskInputs ? { inputs: jestTaskInputs } : {}),
     };
   }
 }

--- a/src/platform/packages/private/kbn-dot-text-loader/moon.yml
+++ b/src/platform/packages/private/kbn-dot-text-loader/moon.yml
@@ -29,11 +29,7 @@ tasks:
     args:
       - '--config'
       - $projectRoot/jest.config.js
-    inputs:
-      - '@group(src)'
   jestCI:
     args:
       - '--config'
       - $projectRoot/jest.config.js
-    inputs:
-      - '@group(src)'


### PR DESCRIPTION
Some generated moon.yml files had jest task inputs referencing @group(src) even when fileGroups.src was absent (for projects without tsconfig.json). This caused Moon project queries to fail with project::unknown_file_group.

The generator now only sets jest inputs to @group(src) when the src file group exists. Regenerated affected project configs so Moon affected queries work again.