### PR TITLE
[ES|QL] Fixes wrong validation of TS

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/timeseries_check.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/timeseries_check.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ESQLAstCommand } from '../../../types';
+import { esqlCommandRegistry } from '../../registry';
+
+let _sourceCommandNames: Set<string> | undefined;
+let _timeseriesCommandNames: Set<string> | undefined;
+
+const initialize = () => {
+  if (!_sourceCommandNames) {
+    _sourceCommandNames = new Set(esqlCommandRegistry.getSourceCommandNames());
+    _timeseriesCommandNames = new Set(esqlCommandRegistry.getTimeseriesCommandNames());
+  }
+};
+
+const findSourceCommand = (ast: ESQLAstCommand[]) => {
+  initialize();
+  return ast.find((cmd) => _sourceCommandNames!.has(cmd.name));
+};
+
+/**
+ * Checks if the source command in the AST is a timeseries command (e.g. TS).
+ * Finds the source command dynamically rather than assuming it's at index 0.
+ */
+export const isTimeseriesSourceCommand = (ast: ESQLAstCommand[]): boolean => {
+  const sourceCommand = findSourceCommand(ast);
+  return sourceCommand ? _timeseriesCommandNames!.has(sourceCommand.name) : false;
+};

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/location.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/location.ts
@@ -12,6 +12,7 @@ import { within } from '../../ast/location';
 import type { ESQLAst, ESQLAstAllCommands, ESQLSingleAstItem } from '../../types';
 import { Walker } from '../../ast/walker';
 import { Location } from './types';
+import { isTimeseriesSourceCommand } from '../definitions/utils/timeseries_check';
 
 const commandOptionNameToLocation: Record<string, Location> = {
   eval: Location.EVAL,
@@ -67,7 +68,7 @@ export function getLocationInfo(
   ast: ESQLAst,
   withinAggFunction: boolean
 ): { id: Location; displayName: string } {
-  if (withinAggFunction && ast[0].name === 'ts') {
+  if (withinAggFunction && isTimeseriesSourceCommand(ast)) {
     return {
       id: Location.STATS_TIMESERIES,
       displayName: 'agg_function_in_timeseries_context',

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/registry.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/registry.ts
@@ -94,6 +94,7 @@ export interface ICommandMetadata {
   license?: LicenseType; // Optional property indicating the license for the command's availability
   observabilityTier?: string; // Optional property indicating the observability tier availability
   type?: 'source' | 'header' | 'processing'; // Optional property to classify the command type
+  isTimeseries?: boolean; // Optional property to indicate if the command is a timeseries source command
   subqueryRestrictions?: {
     hideInside: boolean; // Command is hidden inside subqueries
     hideOutside: boolean; // Command is hidden outside subqueries (at root level)
@@ -145,6 +146,12 @@ export interface ICommandRegistry {
   getProcessingCommandNames(): string[];
 
   /**
+   * Retrieves the names of timeseries source commands.
+   * @returns An array of timeseries command names.
+   */
+  getTimeseriesCommandNames(): string[];
+
+  /**
    * Retrieves a command by its name, including its methods and optional metadata.
    * @param commandName The name of the command to retrieve.
    * @returns The ICommand object if found, otherwise undefined.
@@ -174,6 +181,7 @@ export class CommandRegistry implements ICommandRegistry {
 
   private sourceCommandNames: string[] = [];
   private processingCommandNames: string[] = [];
+  private timeseriesCommandNames: string[] = [];
 
   constructor() {
     this.commands = new Map<
@@ -200,6 +208,10 @@ export class CommandRegistry implements ICommandRegistry {
         this.sourceCommandNames.push(command.name);
       } else if (!command.metadata.type) {
         this.processingCommandNames.push(command.name);
+      }
+
+      if (command.metadata.isTimeseries) {
+        this.timeseriesCommandNames.push(command.name);
       }
     }
   }
@@ -235,6 +247,14 @@ export class CommandRegistry implements ICommandRegistry {
    */
   public getProcessingCommandNames(): string[] {
     return this.processingCommandNames;
+  }
+
+  /**
+   * Retrieves the names of timeseries source commands.
+   * @returns An array of timeseries command names.
+   */
+  public getTimeseriesCommandNames(): string[] {
+    return this.timeseriesCommandNames;
   }
 
   /**

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/validate.test.ts
@@ -103,6 +103,10 @@ describe('STATS Validation', () => {
         ]);
       });
 
+      test('allows bare fields in STATS when source command is TS', () => {
+        statsExpectErrors('TS a_index | stats doubleField', []);
+      });
+
       test('various errors', () => {
         statsExpectErrors('from a_index | stats avg(doubleField) by wrongField', [
           'Unknown column "wrongField"',

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/index.ts
@@ -28,6 +28,7 @@ export const timeseriesCommand = {
     type: 'source' as const,
     hidden: false,
     preview: true,
+    isTimeseries: true,
     description: i18n.translate('kbn-esql-language.esql.definitions.metricsDoc', {
       defaultMessage:
         'A metrics-specific source command, use this command to load data from TSDB indices. ' +

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
@@ -804,6 +804,12 @@ describe('function validation', () => {
       await expectErrors('FROM a_index | STATS AGG_FUNCTION(TS_FUNCTION())', [
         'Function TS_FUNCTION not allowed in STATS',
       ]);
+
+      // TIME_SERIES_AGG functions are also allowed at the top level of STATS with TS source
+      await expectErrors('TS a_index | STATS TS_FUNCTION()', []);
+      await expectErrors('FROM a_index | STATS TS_FUNCTION()', [
+        'Function TS_FUNCTION not allowed in STATS',
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/251428

TS works a bit different than FROM. 

Bare fields are allowed, also functions that are used only nested in FROM. We were validating wrongly following FROM logic but we need to differentiate for TS

<img width="810" height="387" alt="image" src="https://github.com/user-attachments/assets/9fd9d8cd-562b-4586-801f-4514dfaa0a7b" />

<img width="808" height="409" alt="image" src="https://github.com/user-attachments/assets/12dfc89c-94ed-4932-b9b7-292b4619352e" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



