### PR TITLE
[Entity Store] Filter out CCS indices

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
@@ -36,6 +36,7 @@ import type {
 } from './definitions/saved_objects';
 import { ENGINE_STATUS } from './constants';
 import { parseDurationToMs } from '../infra/time';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 
 interface LogsExtractionOptions {
   specificWindow?: {
@@ -319,7 +320,7 @@ export class LogsExtractionClient {
       const cleanIndices = secSolDataView
         .getIndexPattern()
         .split(',')
-        .filter((index) => index !== alertsIndex);
+        .filter((index) => index !== alertsIndex && !isCCSRemoteIndexName(index));
       indexPatterns.push(...cleanIndices);
     } catch (error) {
       this.logger.warn(

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
@@ -9,6 +9,7 @@ import type { Logger } from '@kbn/logging';
 import moment from 'moment';
 import { SavedObjectsErrorHelpers, type ElasticsearchClient } from '@kbn/core/server';
 import type { DataViewsService } from '@kbn/data-views-plugin/common';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import type {
   EntityType,
   ManagedEntityDefinition,
@@ -36,7 +37,6 @@ import type {
 } from './definitions/saved_objects';
 import { ENGINE_STATUS } from './constants';
 import { parseDurationToMs } from '../infra/time';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
 
 interface LogsExtractionOptions {
   specificWindow?: {


### PR DESCRIPTION
for the time being, we remove CCS indices from the security solution data view as there's some [issues](https://github.com/elastic/kibana/issues/253380) with how it works with our ESQL query


closes https://github.com/elastic/kibana/issues/252567