### PR TITLE
[Streams] Adjust affected resource text

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
@@ -166,7 +166,9 @@ export function EditPolicyModal({
                       data-test-subj={`editPolicyModal-affectedResourcesList-${resource.name}`}
                     >
                       <EuiText size="s">{resource.name}</EuiText>
-                      <EuiText size="s">{affectedResourceTypeLabelMap[resource.type]}</EuiText>
+                      <EuiText size="xs" color="subdued">
+                        {affectedResourceTypeLabelMap[resource.type]}
+                      </EuiText>
                     </EuiFlexGroup>
                   </EuiFlexItem>
                 ))}


### PR DESCRIPTION
## Summary

Small change in the `edit_policy_modal`to better match the mocks. The affected resource column now is displayed with font-size 12px (xs) and color subdued.

### How to test

View and test the component in Storybook:

```bash
yarn storybook streams_app
```

### Mocks
<img width="740" height="494" alt="Screenshot 2026-02-18 at 09 19 47" src="https://github.com/user-attachments/assets/88fbb924-abfe-42f9-b096-8168707084d2" />

### Implementation


#### Before
<img width="621" height="407" alt="Screenshot 2026-02-18 at 09 16 22" src="https://github.com/user-attachments/assets/ff9f77bf-8697-4721-8de0-242657d7e785" />

#### After

<img width="651" height="412" alt="Screenshot 2026-02-18 at 09 15 58" src="https://github.com/user-attachments/assets/69ea3a41-731b-4830-8e4b-9564895a0a6f" />