### PR TITLE
[ES|QL] Improves the responsiveness of the editor with controls

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -897,15 +897,14 @@ export const QueryBarTopRow = React.memo(
     }
 
     function renderEsqlMenuPopover() {
-      if (!Boolean(isQueryLangSelected)) {
-        return null;
-      }
-
       return (
         <EuiFlexItem
           grow={false}
           css={css`
             margin-left: auto;
+            @media (min-width: ${euiTheme.breakpoint.xl}px) {
+              order: 1;
+            }
           `}
         >
           <ESQLMenu onESQLDocsFlyoutVisibilityChanged={props.onESQLDocsFlyoutVisibilityChanged} />
@@ -1047,7 +1046,14 @@ export const QueryBarTopRow = React.memo(
                 {renderDatePickerWithUpdateBtn()}
                 {/* Optional wrapper for the ES|QL controls elements */}
                 {Boolean(props.esqlVariablesConfig?.controlsWrapper) && (
-                  <EuiFlexItem grow={false}>
+                  <EuiFlexItem
+                    grow={false}
+                    css={css`
+                      @media (max-width: ${euiTheme.breakpoint.xl}px) {
+                        order: 1;
+                      }
+                    `}
+                  >
                     {props.esqlVariablesConfig?.controlsWrapper}
                   </EuiFlexItem>
                 )}


### PR DESCRIPTION
## Summary

 Part of https://github.com/elastic/kibana/issues/235616

With the new and old design the responsiveness of the editor when you have multiple controls was not great.

<img width="1948" height="830" alt="image" src="https://github.com/user-attachments/assets/c4d602a2-ad84-494f-9c14-d3e2de69dcfe" />

This PR is making it a bit better without introducing many changes

<img width="435" height="187" alt="image" src="https://github.com/user-attachments/assets/cf22ec88-9115-44d6-9e97-f4903ce56b7b" />


