### PR TITLE
[Streams] Make feature extraction descriptions more extensive

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
@@ -7,7 +7,7 @@ Every feature you output MUST include ALL required fields:
 - `subtype` (string): categorization within the type (e.g. `service`, `database`, `cloud_deployment`, `programming_language`, `service_dependency`)
 - `id` (string): unique concise identifier for deduplication across runs (e.g. "order-service", "postgresql-db", "aws-deployment", "log4j-2.14.1")
 - `title` (string): very short human-readable title for UI display (e.g. "Order Service", "PostgreSQL", "AWS", "api-service → user-service"). Keep it to a few words.
-- `description` (string): a short summary of what the feature represents
+- `description` (string): a summary of what the feature represents—include role, context, dependencies and how it fits in the system; one to four sentences so the description is informative and useful on its own
 - `properties` (object): stable, low-cardinality key facts for deduplication (**MUST NOT be empty**; if you cannot provide at least one stable identifying property, do not emit the feature)
 - `confidence` (number): 0–100
 - `evidence` (array of strings): supporting evidence from logs (2–5 items)


### PR DESCRIPTION
Eventually we want to semantically index the description. This adds slighty more information to the description so it will be available in the semantic index when we get there.

- Update description field to request extensive 1-3 sentence summaries
- Add Output Quality requirement for informative, context-rich descriptions
