### PR TITLE
[Streams] Add schema as LLM-inferred feature type for ECS/OTel detection

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/features_identification_datasets.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/features_identification_datasets.ts
@@ -12,6 +12,7 @@ export const VALID_FEATURE_TYPES = [
   'infrastructure',
   'technology',
   'dependency',
+  'schema',
 ] as const;
 export type ValidFeatureType = (typeof VALID_FEATURE_TYPES)[number];
 

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/system_prompt.text
@@ -3,7 +3,7 @@ You are extracting **features** from log data. Features are stable facts about r
 The primary goal is to identify **entities** (what distinct components exist in the system) and **dependencies** (how they are connected). Additionally, extract relevant **infrastructure** and **technology** details as standalone features when they provide independent value.
 
 Every feature you output MUST include ALL required fields:
-- `type` (string): one of `entity`, `infrastructure`, `technology`, `dependency`
+- `type` (string): one of `entity`, `infrastructure`, `technology`, `dependency`, `schema`
 - `subtype` (string): categorization within the type (e.g. `service`, `database`, `cloud_deployment`, `programming_language`, `service_dependency`)
 - `id` (string): unique concise identifier for deduplication across runs (e.g. "order-service", "postgresql-db", "aws-deployment", "log4j-2.14.1")
 - `title` (string): very short human-readable title for UI display (e.g. "Order Service", "PostgreSQL", "AWS", "api-service → user-service"). Keep it to a few words.
@@ -16,7 +16,7 @@ Every feature you output MUST include ALL required fields:
 
 ## Feature Types
 
-Extract features in four categories:
+Extract features in five categories:
 
 ### Entity (Primary Focus)
 
@@ -44,6 +44,15 @@ Technology features describe **languages, frameworks, libraries, and tools** det
 Dependency features describe **explicit relationships between components** (service-to-service calls, database connections, API integrations).
 
 - Example subtypes: `service_dependency`, `database_connection`, `api_integration`
+
+### Schema
+
+Schema features describe the **log schema family** evident from field names and structure in the sample documents. Emit when you can infer ECS, OTel, or other conventions from the data.
+
+- Example subtypes: `ecs`, `otel`, `custom` (align with `properties.schema_family`)
+- **Evidence**: Field names and log structure (e.g. ECS: `@timestamp`, `ecs.version`, `event.*`, `log.*`, `service.name`; OTel: `resource.attributes.*`, `severity_text`, `body.text`). Use only evidence from sample_documents.
+- **Short properties**: For `type: "schema"`, `properties` must be minimal: include `schema_family` (`"ecs"` | `"otel"` | `"custom"`) and optionally `ecs_version` when ECS is detected and version is evident. Do not list all fields or paste long analysis.
+- **Multiple schemas**: If evidence supports more than one schema family (e.g. ECS and OTel both present), emit one schema feature per detected family; list all of them. Each feature keeps short `properties`.
 
 ## Entity Extraction Guidelines
 
@@ -317,6 +326,7 @@ Version formatting rules (important for vulnerability analysis):
 - Sort features by descending `confidence` (and within ties, stable alphabetical order by `type`, then `subtype`).
 - Dependency anti-spam: only emit a dependency feature when logs contain explicit evidence of a relationship; aggregate endpoints in `meta.endpoints` and cap the list.
 - Entity threshold: only create entity features when there is clear evidence of a distinct, named system component. When in doubt, omit the entity.
+- Schema: when multiple schema families are evident (e.g. ECS and OTel), emit one schema feature per family; keep each schema feature's `properties` short (`schema_family`, optional `ecs_version` only).
 
 Extract all features that meet the confidence threshold and have supporting evidence.
 Build one complete, deduplicated feature list internally, then call **finalize_features** exactly once.

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/task_description.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/task_description.text
@@ -4,7 +4,7 @@ Task: Create a system prompt for an LLM to extract "features" from log data.
 Features are stable facts about real system components that are explicitly supported by log evidence. The primary focus is on identifying **entities** (what distinct components exist) and **dependencies** (how they are connected), supplemented by standalone **infrastructure** and **technology** features.
 
 **Required BaseFeature schema fields** (ALL must be present in every feature):
-- `type` (string): "entity", "infrastructure", "technology", or "dependency"
+- `type` (string): "entity", "infrastructure", "technology", "dependency", or "schema"
 - `subtype` (string): categorization within the type (e.g. `service`, `database`, `cloud_deployment`, `programming_language`)
 - `id` (string): unique concise identifier for deduplication
 - `title` (string): very short human-readable title for UI display
@@ -24,6 +24,7 @@ Features are stable facts about real system components that are explicitly suppo
 - **infrastructure**: Cloud providers, container orchestration (Kubernetes, Docker), operating systems, networking, hardware
 - **technology**: Programming languages, web servers, databases, libraries, frameworks (e.g., nginx, postgresql, log4j, React)
 - **dependency**: Relationships between components (service-to-service calls, database connections, API integrations)
+- **schema**: Log schema family (ECS, OTel, or custom) inferred from field names and structure. Keep `properties` short (`schema_family`, optional `ecs_version`). When multiple schema families are evident, list all (one feature per family).
 
 ## Entity Extraction Guidelines
 - Identify high-level components (services, databases, queues, caches) — not individual instances
@@ -127,7 +128,7 @@ Return features following the BaseFeature schema structure using the finalize_fe
 ## Prompt Structure
 The prompt should follow this structure:
 1. Opening paragraph: Define features, state primary goal (entities + dependencies), list all required fields. No mention of specific downstream use cases.
-2. Feature Types section: List the four types (entity, infrastructure, technology, dependency) with example subtypes. Entity is primary focus.
+2. Feature Types section: List the five types (entity, infrastructure, technology, dependency, schema) with example subtypes. Entity is primary focus.
 3. Entity Extraction Guidelines section: High-level components, attach context, require evidence, keep rules generic.
 4. Consolidation Rules section: When to consolidate vs separate with examples.
 5. Naming Conventions section: Generic subtypes with good/bad examples.

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/significant_events/system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/significant_events/system_prompt.text
@@ -22,7 +22,7 @@ You will receive **Features**—structured facts about the environment extracted
 ### Feature Structure
 
 Each feature includes:
-- `type`: Identifies the kind of feature (e.g., `entity`, `infrastructure`, `technology`, `dependency`, `dataset_analysis`)
+- `type`: Identifies the kind of feature (e.g., `entity`, `infrastructure`, `technology`, `dependency`, `schema`, `dataset_analysis`)
 - `subtype`: Optional sub-classification within the type
 - `title`: Short display name
 - `description`: Summary of what the feature represents
@@ -45,7 +45,7 @@ The `dataset_analysis` input may be provided directly or as a computed feature:
 
 ### Inferred Feature Types
 
-Inferred Features fall into four categories. Each type contributes differently to query generation:
+Inferred Features fall into five categories. Each type contributes differently to query generation:
 
 #### Technology (`type: "technology"`)
 Technologies describe **languages, frameworks, libraries, and tools** detected in the logs. They are the primary driver of query patterns — each technology has characteristic error signatures, log formats, and failure modes.
@@ -77,6 +77,9 @@ Dependencies describe **explicit relationships between components** — service-
 *   **Database connections** → Connection pool exhaustion, authentication failures, or query timeouts targeting the specific database
 *   **External API integrations** → Monitor for failures in calls to external services or third-party APIs
 
+#### Schema (`type: "schema"`)
+Schema features indicate the **log schema family** (ecs, otel, or custom) detected in the data. Use them for field-name and query hints: e.g. prefer `body.text` vs `message`, or ECS field names like `service.name` and `log.level`, or OTel-style `resource.attributes.*` and `severity_text`, depending on the reported schema.
+
 ### Using Features to Generate Queries
 
 **Leverage features to create targeted queries beyond what's visible in the log samples:**
@@ -84,7 +87,8 @@ Dependencies describe **explicit relationships between components** — service-
 1.  **Start with entities** to understand the system's components. Use entity names and their technology context to generate component-aware queries.
 2.  **Use technology and infrastructure features** to determine the specific error patterns, log formats, and failure modes relevant to the stack.
 3.  **Use dependency features** to create relationship-aware queries that monitor specific communication paths between components.
-4.  **Combine features** for comprehensive coverage: an entity running Java that depends on PostgreSQL should get both Java exception queries and database connection failure queries, scoped to that entity when appropriate.
+4.  **Use schema features** (when present) to choose appropriate field names: e.g. ECS (`service.name`, `log.level`, `body.text`) vs OTel (`resource.attributes.*`, `severity_text`, `body.text`).
+5.  **Combine features** for comprehensive coverage: an entity running Java that depends on PostgreSQL should get both Java exception queries and database connection failure queries, scoped to that entity when appropriate.
 
 **Guidelines:**
 - Focus on features with confidence ≥ 70


### PR DESCRIPTION
- Add schema to feature identification system prompt (type list, Schema section, short properties rule, multiple schemas when evident)
- Add schema to task_description and significant_events prompts
- Add 'schema' to VALID_FEATURE_TYPES in evals
- Downstream: schema features indicate log schema family for field/query hints
