### PR TITLE
[ResponseOps][Connectors] Create connector does not work in Logs Essentials serverless

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.ts
@@ -79,7 +79,7 @@ const createConnectorTypeFromSpec = (
         spec.metadata.supportedFeatureIds[0] === WorkflowsConnectorFeatureId
       ) {
         // @ts-expect-error upgrade typescript v5.9.3
-        return !ref.uiSettings?.get<boolean>('workflows:ui:enabled') ?? false;
+        return !ref.uiSettings?.get<boolean>('workflows:ui:enabled', false) ?? false;
       }
       return false;
     },


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/253524

## Summary

- Fixes "Create connector" button error in Logs Essentials serverless by adding a default value to the `workflows:ui:enabled` UI setting call.
- The setting isn't registered in Logs Essentials, causing uiSettings.get() to throw when no default is provided.

