### PR TITLE
[ResponseOps][Connectors] PagerDuty action fails with "Expected object, received string" for customDetails field

### DIFF
--- a/src/platform/packages/shared/kbn-connector-schemas/pagerduty/schemas/v1.test.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/pagerduty/schemas/v1.test.ts
@@ -211,5 +211,13 @@ describe('PagerDuty Schema', () => {
         })
       ).toThrow();
     });
+
+    it('validates customDetails as a JSON string and coerces to object', () => {
+      const customDetailsObject = { key: 'value' };
+      const result = ParamsSchema.parse({
+        customDetails: JSON.stringify(customDetailsObject),
+      });
+      expect(result.customDetails).toEqual(customDetailsObject);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-connector-schemas/pagerduty/schemas/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/pagerduty/schemas/v1.ts
@@ -9,7 +9,8 @@
 import { i18n } from '@kbn/i18n';
 import { z } from '@kbn/zod';
 import moment from 'moment';
-import { convertTimestamp } from '../../common/utils';
+import { convertTimestamp, Coerced } from '../../common/utils';
+
 import {
   EVENT_ACTIONS_WITH_REQUIRED_DEDUPKEY,
   EVENT_ACTION_ACKNOWLEDGE,
@@ -36,7 +37,7 @@ const EventActionSchema = z.enum([
 
 const PayloadSeveritySchema = z.enum(['critical', 'error', 'warning', 'info']);
 const LinksSchema = z.array(z.object({ href: z.string(), text: z.string() }).strict());
-const customDetailsSchema = z.record(z.string(), z.any());
+const customDetailsSchema = Coerced(z.record(z.string(), z.any()));
 
 export const ParamsSchema = z
   .object({


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/253665

## Summary

- The customDetails field was saved as a JSON string by the UI, but the backend schema expected an object, causing validation failures at rule execution time.
- Wrap customDetailsSchema with `Coerced()` to automatically parse JSON strings into objects before validation.

## Release notes
Fix a bug with PagerDuty where setting the Custom details field will cause rules to fail.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->