### PR TITLE
Add developer docs for execution context

### DIFF
--- a/src/core/packages/execution-context/browser-internal/README.md
+++ b/src/core/packages/execution-context/browser-internal/README.md
@@ -2,16 +2,8 @@
 
 This package contains the internal types and implementation for Core's browser-side execution context service.
 
-## Implementation notes (for Core developers)
+## Pointers
 
-### How `x-kbn-context` is produced
-
-- **Where it’s injected**: Core HTTP attaches the header for each `core.http.fetch(...)` call in `src/core/packages/http/browser-internal/src/fetch.ts`.
-- **Header name**: `x-kbn-context`
-- **Header value**: `encodeURIComponent(JSON.stringify(context))`
-- **Length limit**: the value is truncated to align with the W3C baggage per-pair max (4096 bytes), conservatively using ~1024 characters. See:
-  - `src/core/packages/execution-context/browser-internal/src/execution_context_container.ts`
-
-### Per-request overrides
-
-`HttpFetchOptions.context` is merged with the current global context via `executionContext.withGlobalContext(...)` before serialization (also in `fetch.ts`).
+- `x-kbn-context` is attached to `core.http.fetch(...)` requests in `src/core/packages/http/browser-internal/src/fetch.ts`.
+- The header value is URI-encoded JSON produced by `src/core/packages/execution-context/browser-internal/src/execution_context_container.ts`.
+- `HttpFetchOptions.context` is merged with the current global context via `executionContext.withGlobalContext(...)` before serialization.

--- a/src/core/packages/execution-context/browser-internal/README.md
+++ b/src/core/packages/execution-context/browser-internal/README.md
@@ -1,3 +1,17 @@
 # @kbn/core-execution-context-browser-internal
 
 This package contains the internal types and implementation for Core's browser-side execution context service.
+
+## Implementation notes (for Core developers)
+
+### How `x-kbn-context` is produced
+
+- **Where it’s injected**: Core HTTP attaches the header for each `core.http.fetch(...)` call in `src/core/packages/http/browser-internal/src/fetch.ts`.
+- **Header name**: `x-kbn-context`
+- **Header value**: `encodeURIComponent(JSON.stringify(context))`
+- **Length limit**: the value is truncated to align with the W3C baggage per-pair max (4096 bytes), conservatively using ~1024 characters. See:
+  - `src/core/packages/execution-context/browser-internal/src/execution_context_container.ts`
+
+### Per-request overrides
+
+`HttpFetchOptions.context` is merged with the current global context via `executionContext.withGlobalContext(...)` before serialization (also in `fetch.ts`).

--- a/src/core/packages/execution-context/browser/README.md
+++ b/src/core/packages/execution-context/browser/README.md
@@ -1,16 +1,8 @@
 # @kbn/core-execution-context-browser
 
-Browser-side execution context helps Kibana associate **user interactions** and **HTTP requests** with a meaningful “where did this come from?” context (app/page/entity), so server-side work can be traced and correlated (APM, Elasticsearch `x-opaque-id`, logs).
+Browser-side execution context helps Kibana associate **HTTP requests** with a meaningful “where did this come from?” context (app/page/entity). Core includes this context in the `x-kbn-context` header on `core.http.fetch(...)` requests so the server can propagate it (for example into Elasticsearch `x-opaque-id` for slow log tracing).
 
 This package contains the **public contract types** for `core.executionContext` in the browser. The common data shape is `KibanaExecutionContext` from [`@kbn/core-execution-context-common`](../common).
-
-## When and why to set execution context
-
-- **App-level context**: set when your app mounts and update on route/page changes.
-- **Entity context**: set when the user is focused on a specific entity (dashboard id, visualization id, rule id, etc.).
-- **Embeddables/components**: use `child` to describe nested work initiated by a component inside a parent context.
-
-Core uses the current execution context to populate the `x-kbn-context` header on `core.http.fetch(...)` requests (including optional per-request overrides via `HttpFetchOptions.context`).
 
 ## How to set it (recommended)
 
@@ -70,6 +62,6 @@ await core.http.fetch('/api/my_plugin/do_something', {
 
 `KibanaExecutionContext.space` is the active space id. In the browser, the Spaces plugin keeps it in sync by calling `core.executionContext.set({ space })`, so most plugins shouldn’t need to set it themselves.
 
-## Size/encoding constraints
+## Keep it small
 
-The `x-kbn-context` header is URI-encoded JSON and is length-limited (truncated to approximately 1024 characters) to align with the W3C baggage header constraints. Keep context small and avoid sensitive values (especially in `description` and `meta`).
+The `x-kbn-context` header is URI-encoded JSON and is size-limited. Keep context values small and avoid sensitive data (especially in `description` and `meta`).

--- a/src/core/packages/execution-context/browser/README.md
+++ b/src/core/packages/execution-context/browser/README.md
@@ -1,3 +1,75 @@
 # @kbn/core-execution-context-browser
 
-This package contains the public types for Core's browser-side execution context service.
+Browser-side execution context helps Kibana associate **user interactions** and **HTTP requests** with a meaningful “where did this come from?” context (app/page/entity), so server-side work can be traced and correlated (APM, Elasticsearch `x-opaque-id`, logs).
+
+This package contains the **public contract types** for `core.executionContext` in the browser. The common data shape is `KibanaExecutionContext` from [`@kbn/core-execution-context-common`](../common).
+
+## When and why to set execution context
+
+- **App-level context**: set when your app mounts and update on route/page changes.
+- **Entity context**: set when the user is focused on a specific entity (dashboard id, visualization id, rule id, etc.).
+- **Embeddables/components**: use `child` to describe nested work initiated by a component inside a parent context.
+
+Core uses the current execution context to populate the `x-kbn-context` header on `core.http.fetch(...)` requests (including optional per-request overrides via `HttpFetchOptions.context`).
+
+## How to set it (recommended)
+
+Use the `useExecutionContext` hook from `@kbn/kibana-react-plugin/public` in your React components.
+
+```ts
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
+import { useExecutionContext } from '@kbn/kibana-react-plugin/public';
+
+const ctx: KibanaExecutionContext = {
+  type: 'application',
+  name: 'discover',
+  page: 'sessionView',
+  id: discoverSessionId,
+};
+
+useExecutionContext(core.executionContext, ctx);
+```
+
+Notes:
+- `page` should be a **stable logical unit** (don’t embed ids in `page`; use `id` for identifiers).
+- The hook clears on unmount; Core also clears the context when the current app changes.
+
+## Nested context with `child` (embeddables/components)
+
+If you already have a parent context (e.g. from an app), add a child context for a nested component:
+
+```ts
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
+
+const parent: KibanaExecutionContext = {
+  type: 'application',
+  name: 'dashboard',
+  page: 'view',
+  id: dashboardId,
+};
+
+const ctx: KibanaExecutionContext = {
+  ...parent,
+  child: { type: 'visualization', name: embeddableType, id: embeddableId },
+};
+```
+
+This pattern is used in e.g. ML embeddables: [`use_embeddable_execution_context.ts`](../../../../../x-pack/platform/plugins/shared/ml/public/embeddables/common/use_embeddable_execution_context.ts).
+
+## Per-request context (for a single `http.fetch`)
+
+You can attach a per-request context that will be merged with the current global context:
+
+```ts
+await core.http.fetch('/api/my_plugin/do_something', {
+  context: { type: 'myPlugin', name: 'doSomething', id: entityId },
+});
+```
+
+## Space id (`space`)
+
+`KibanaExecutionContext.space` is the active space id. In the browser, the Spaces plugin keeps it in sync by calling `core.executionContext.set({ space })`, so most plugins shouldn’t need to set it themselves.
+
+## Size/encoding constraints
+
+The `x-kbn-context` header is URI-encoded JSON and is length-limited (truncated to approximately 1024 characters) to align with the W3C baggage header constraints. Keep context small and avoid sensitive values (especially in `description` and `meta`).

--- a/src/core/packages/execution-context/common/README.md
+++ b/src/core/packages/execution-context/common/README.md
@@ -4,7 +4,7 @@ This package contains the common types for Core's execution context.
 
 ## `KibanaExecutionContext` (field reference)
 
-`KibanaExecutionContext` is a small object describing where work originates. It is used by the browser to populate the `x-kbn-context` header, and by the server to enrich APM labels and Elasticsearch `x-opaque-id`.
+`KibanaExecutionContext` is a small object describing where work originates. It is used by the browser to populate the `x-kbn-context` header, and by the server to enrich Elasticsearch `x-opaque-id`.
 
 - **`type`**: high-level category (e.g. `application`, `dashboard`, `visualization`, `task`).
 - **`name`**: public name of an app/feature/subsystem (e.g. `discover`, `lens`, `taskManager`).

--- a/src/core/packages/execution-context/common/README.md
+++ b/src/core/packages/execution-context/common/README.md
@@ -1,3 +1,17 @@
 # @kbn/core-execution-context-common
 
 This package contains the common types for Core's execution context.
+
+## `KibanaExecutionContext` (field reference)
+
+`KibanaExecutionContext` is a small object describing where work originates. It is used by the browser to populate the `x-kbn-context` header, and by the server to enrich APM labels and Elasticsearch `x-opaque-id`.
+
+- **`type`**: high-level category (e.g. `application`, `dashboard`, `visualization`, `task`).
+- **`name`**: public name of an app/feature/subsystem (e.g. `discover`, `lens`, `taskManager`).
+- **`space`**: current space id (when applicable).
+- **`page`**: stable logical unit like a page/tab/route segment (avoid embedding ids; put those in `id`).
+- **`id`**: identifier for the current entity (dashboard id, rule id, saved object id, etc.).
+- **`description`**: human-readable description (avoid large values and sensitive data).
+- **`url`**: browser URL or server endpoint/task URL (avoid unique identifiers if not needed).
+- **`meta`**: optional extra structured details (keep small; avoid sensitive data).
+- **`child`**: nested context spawned from the current one (embeddables/sub-operations); can be chained.

--- a/src/core/packages/execution-context/server-internal/README.md
+++ b/src/core/packages/execution-context/server-internal/README.md
@@ -2,3 +2,27 @@
 
 This package contains the internal types and implementation for Core's server-side execution context service.
 
+## Implementation notes (for Core developers)
+
+### How request context is installed
+
+Core HTTP parses the incoming `x-kbn-context` header at request start and calls `executionContext.set(...)` (see `src/core/packages/http/server-internal/src/http_server.ts`).
+
+The execution context service stores context using Node’s `AsyncLocalStorage` so it is available across async work spawned by a request.
+
+### Why `enterWith()` is used for `set()`
+
+Hapi’s lifecycle is event-based; wrapping only the request handler in `AsyncLocalStorage.run()` would lose context in other lifecycle hooks. For that reason, `ExecutionContextService.set()` uses `AsyncLocalStorage.enterWith()` (see `src/core/packages/execution-context/server-internal/src/execution_context_service.ts`).
+
+For cases where you *can* safely scope the context to a specific function, `withContext()` uses `AsyncLocalStorage.run()` and supports nested contexts (stacked via `child`).
+
+### Header parsing and propagation
+
+- **Incoming header**: `x-kbn-context` is parsed as `JSON.parse(decodeURIComponent(value))` in `src/core/packages/execution-context/server-internal/src/execution_context_container.ts`.
+- **Elasticsearch `x-opaque-id`**: Core builds an `x-opaque-id` value that combines a request id with a compact execution context chain (type/name/id, with nested children), prefixed with `kibana:`. See:
+  - `ExecutionContextService.getAsHeader()` in `src/core/packages/execution-context/server-internal/src/execution_context_service.ts`
+  - `ExecutionContextContainer.toString()` in `src/core/packages/execution-context/server-internal/src/execution_context_container.ts`
+
+### Config
+
+The service can be disabled with `execution_context.enabled` (default `true`). See `src/core/packages/execution-context/server-internal/src/execution_context_config.ts`.

--- a/src/core/packages/execution-context/server-internal/README.md
+++ b/src/core/packages/execution-context/server-internal/README.md
@@ -2,27 +2,9 @@
 
 This package contains the internal types and implementation for Core's server-side execution context service.
 
-## Implementation notes (for Core developers)
+## Pointers
 
-### How request context is installed
-
-Core HTTP parses the incoming `x-kbn-context` header at request start and calls `executionContext.set(...)` (see `src/core/packages/http/server-internal/src/http_server.ts`).
-
-The execution context service stores context using Node’s `AsyncLocalStorage` so it is available across async work spawned by a request.
-
-### Why `enterWith()` is used for `set()`
-
-Hapi’s lifecycle is event-based; wrapping only the request handler in `AsyncLocalStorage.run()` would lose context in other lifecycle hooks. For that reason, `ExecutionContextService.set()` uses `AsyncLocalStorage.enterWith()` (see `src/core/packages/execution-context/server-internal/src/execution_context_service.ts`).
-
-For cases where you *can* safely scope the context to a specific function, `withContext()` uses `AsyncLocalStorage.run()` and supports nested contexts (stacked via `child`).
-
-### Header parsing and propagation
-
-- **Incoming header**: `x-kbn-context` is parsed as `JSON.parse(decodeURIComponent(value))` in `src/core/packages/execution-context/server-internal/src/execution_context_container.ts`.
-- **Elasticsearch `x-opaque-id`**: Core builds an `x-opaque-id` value that combines a request id with a compact execution context chain (type/name/id, with nested children), prefixed with `kibana:`. See:
-  - `ExecutionContextService.getAsHeader()` in `src/core/packages/execution-context/server-internal/src/execution_context_service.ts`
-  - `ExecutionContextContainer.toString()` in `src/core/packages/execution-context/server-internal/src/execution_context_container.ts`
-
-### Config
-
-The service can be disabled with `execution_context.enabled` (default `true`). See `src/core/packages/execution-context/server-internal/src/execution_context_config.ts`.
+- Core HTTP installs request execution context from the `x-kbn-context` header in `src/core/packages/http/server-internal/src/http_server.ts`.
+- `AsyncLocalStorage` storage and the `withContext(...)` implementation live in `src/core/packages/execution-context/server-internal/src/execution_context_service.ts`.
+- `x-kbn-context` parsing and the compact context string used for Elasticsearch `x-opaque-id` live in `src/core/packages/execution-context/server-internal/src/execution_context_container.ts`.
+- Config: `execution_context.enabled` in `src/core/packages/execution-context/server-internal/src/execution_context_config.ts`.

--- a/src/core/packages/execution-context/server/README.md
+++ b/src/core/packages/execution-context/server/README.md
@@ -1,15 +1,14 @@
 # @kbn/core-execution-context-server
 
-Server-side execution context helps Kibana correlate **server work** with a meaningful “origin” (app/page/entity/background task). It is used to enrich:
-
-- **Elasticsearch `x-opaque-id`** (useful in slow logs/deprecation logs/tracing)
-- **APM labels** (Kibana server transactions)
+Server-side execution context helps Kibana correlate **server work** with a meaningful “origin” (app/page/entity/background task). Core uses it to enrich Elasticsearch `x-opaque-id`, which is useful for tracing expensive searches in Elasticsearch slow logs.
 
 This package contains the **public contract types** for `core.executionContext` on the server. The common data shape is `KibanaExecutionContext` from [`@kbn/core-execution-context-common`](../common).
 
 ## Request handling (typical case)
 
 For HTTP requests initiated from the browser, Core’s HTTP layer parses the incoming `x-kbn-context` header and installs it into request-scoped async context. In a normal route handler you generally **do not need to do anything**—Elasticsearch client calls will automatically include the derived `x-opaque-id`.
+
+For more context on how `x-opaque-id` is used to trace slow searches, see Elastic docs: [`Trace an Elasticsearch query in Kibana`](https://www.elastic.co/docs/troubleshoot/kibana/trace-elasticsearch-query-to-the-origin-in-kibana).
 
 ## Background/server-only work (use `withContext`)
 
@@ -32,16 +31,13 @@ return core.executionContext.withContext(ctx, async () => {
 });
 ```
 
-### Nesting / extending context (server-side child contexts)
+## Debugging
 
-Nested `withContext` calls stack contexts. When a parent context is present (from the request header or an outer `withContext`), the inner context becomes `child` of the current one. This is useful when you want to add a more specific “sub-operation” context around a particular call.
+To see stored execution context in Kibana logs, enable debug logging for the `execution_context` logger:
 
-## APM labels
-
-`core.executionContext.getAsLabels()` returns the subset of the current context that is used as APM labels. Today this includes **`name`**, **`id`**, and **`page`** (when present).
-
-## Notes / constraints
-
-- Execution context can be disabled via `execution_context.enabled` (default: `true`). When disabled, Core will not install/propagate execution context for server-side work.
-- Keep context values small and avoid sensitive data. The context may be propagated to Elasticsearch headers and observability tooling.
-
+```yml
+logging:
+  loggers:
+    - name: execution_context
+      level: debug
+```

--- a/src/core/packages/execution-context/server/README.md
+++ b/src/core/packages/execution-context/server/README.md
@@ -1,4 +1,47 @@
 # @kbn/core-execution-context-server
 
-This package contains the public types for Core's server-side execution context service.
+Server-side execution context helps Kibana correlate **server work** with a meaningful “origin” (app/page/entity/background task). It is used to enrich:
+
+- **Elasticsearch `x-opaque-id`** (useful in slow logs/deprecation logs/tracing)
+- **APM labels** (Kibana server transactions)
+
+This package contains the **public contract types** for `core.executionContext` on the server. The common data shape is `KibanaExecutionContext` from [`@kbn/core-execution-context-common`](../common).
+
+## Request handling (typical case)
+
+For HTTP requests initiated from the browser, Core’s HTTP layer parses the incoming `x-kbn-context` header and installs it into request-scoped async context. In a normal route handler you generally **do not need to do anything**—Elasticsearch client calls will automatically include the derived `x-opaque-id`.
+
+## Background/server-only work (use `withContext`)
+
+For work that doesn’t originate from an incoming browser request (task manager, background sync, scheduled jobs, etc.), wrap your work with `core.executionContext.withContext(...)`:
+
+```ts
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
+
+const ctx: KibanaExecutionContext = {
+  type: 'task',
+  name: 'myPlugin',
+  id: taskId,
+  page: 'run',
+  description: 'sync something',
+};
+
+return core.executionContext.withContext(ctx, async () => {
+  // Any Elasticsearch calls made from here will include the derived x-opaque-id
+  await esClient.asInternalUser.ping();
+});
+```
+
+### Nesting / extending context (server-side child contexts)
+
+Nested `withContext` calls stack contexts. When a parent context is present (from the request header or an outer `withContext`), the inner context becomes `child` of the current one. This is useful when you want to add a more specific “sub-operation” context around a particular call.
+
+## APM labels
+
+`core.executionContext.getAsLabels()` returns the subset of the current context that is used as APM labels. Today this includes **`name`**, **`id`**, and **`page`** (when present).
+
+## Notes / constraints
+
+- Execution context can be disabled via `execution_context.enabled` (default: `true`). When disabled, Core will not install/propagate execution context for server-side work.
+- Keep context values small and avoid sensitive data. The context may be propagated to Elasticsearch headers and observability tooling.
 


### PR DESCRIPTION
## Summary
- Add concise developer docs for Core execution context (browser + server), with usage examples and internal implementation notes.

## Related
Addresses #242415.

Note: This PR does not close the issue yet because the remaining public/customer documentation lives in a different repository. Will close the issue when update that.

## Test plan
- Docs-only change.

Made with [Cursor](https://cursor.com)