### PR TITLE
fix(streams): resolve no-explicit-any lint in stream_detail_lifecycle DSL flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/edit_dsl_steps_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/edit_dsl_steps_flyout.test.tsx
@@ -40,7 +40,7 @@ const renderFlyout = (
       dsl: {
         data_retention: '30d',
       },
-    } as any);
+    } as IngestStreamLifecycleDSL);
 
   const setSelectedStepIndexRef: { current: ((index: number | undefined) => void) | null } = {
     current: null,
@@ -204,7 +204,7 @@ describe('EditDslStepsFlyout', () => {
         initialSteps: {
           dsl: {
             data_retention: '30d',
-          } as any,
+          },
         },
       });
 
@@ -223,18 +223,24 @@ describe('EditDslStepsFlyout', () => {
 
   describe('save and cancel', () => {
     it('calls onSave with the current serialized lifecycle when valid', async () => {
+      type LifecycleWithPreservedFields = IngestStreamLifecycleDSL & {
+        dsl: IngestStreamLifecycleDSL['dsl'] & {
+          enabled?: boolean;
+          downsampling_method?: string;
+        };
+      };
       const { onSave, initialSteps } = renderFlyout({
         initialSteps: {
           dsl: {
             data_retention: '30d',
             enabled: true,
-            downsampling_method: 'something' as any,
+            downsampling_method: 'something',
             downsample: [
               { after: '30d', fixed_interval: '1h' },
               { after: '40d', fixed_interval: '5d' },
             ],
-          } as any,
-        },
+          },
+        } as LifecycleWithPreservedFields,
       });
 
       await tick();

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/form/validations.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/form/validations.test.ts
@@ -23,7 +23,7 @@ const createArg = ({
   path: string;
   value: unknown;
   formData?: FlatFormData;
-}): ValidationFuncArg<any, any> =>
+}): ValidationFuncArg<FlatFormData, unknown> =>
   ({
     path,
     value,
@@ -37,7 +37,7 @@ const createArg = ({
       provider: async () => undefined,
       value: undefined,
     },
-  } as unknown as ValidationFuncArg<any, any>);
+  } as unknown as ValidationFuncArg<FlatFormData, unknown>);
 
 describe('streams DSL steps flyout validations', () => {
   it('returns undefined for non-step paths', () => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/form/validations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/form/validations.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { ValidationFunc } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import type { FormData, ValidationFunc } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 
 import type { DslStepMetaFields, PreservedTimeUnit } from './types';
@@ -16,10 +16,10 @@ const { emptyField, isInteger } = fieldValidators;
 
 /**
  * `hook-form-lib` validators receive a *flattened* `formData` object (keys like
- * `_meta.downsampleSteps[0].afterValue`). We keep access centralized to reduce `any`/casts.
+ * `_meta.downsampleSteps[0].afterValue`). We keep access centralized to reduce casts.
  */
 type StreamsDslFlatFormData = Record<string, unknown>;
-type DslValidationFunc<V = unknown> = ValidationFunc<any, string, V>;
+type DslValidationFunc<V = unknown> = ValidationFunc<FormData, string, V>;
 type DslValidationArg<V = unknown> = Parameters<DslValidationFunc<V>>[0];
 
 type DslStepField = keyof DslStepMetaFields;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
@@ -22,10 +22,19 @@ import type { FormArrayField } from '@kbn/es-ui-shared-plugin/static/forms/hook_
 import {
   MAX_DOWNSAMPLE_STEPS,
   type DslStepMetaFields,
+  type DslStepsFlyoutFormInternal,
   type PreservedTimeUnit,
   toMilliseconds,
 } from '../form';
 import { TIME_UNIT_OPTIONS } from '../constants';
+
+/** Partial form update including internal __dslStepsFlyout flag for updateFieldValues */
+type DslStepsFlyoutFormFieldUpdate = Partial<DslStepsFlyoutFormInternal> & {
+  _meta?: Partial<DslStepsFlyoutFormInternal['_meta']> & {
+    __dslStepsFlyout?: boolean;
+    downsampleSteps: DslStepMetaFields[];
+  };
+};
 import { useStyles } from '../use_styles';
 import { StepPanel } from './step_panel';
 import { StepTabsRow } from './step_tabs_row';
@@ -143,10 +152,10 @@ export const DslStepsFlyoutArrayView = ({
         nextSteps.push(createNextStepFromPrevious(nextSteps[nextSteps.length - 1]));
       }
 
-      form.updateFieldValues(
-        { _meta: { __dslStepsFlyout: true, downsampleSteps: nextSteps } } as any,
-        { runDeserializer: false }
-      );
+      const payload: DslStepsFlyoutFormFieldUpdate = {
+        _meta: { __dslStepsFlyout: true, downsampleSteps: nextSteps },
+      };
+      form.updateFieldValues(payload, { runDeserializer: false });
     },
     [
       clampStepIndex,
@@ -243,10 +252,10 @@ export const DslStepsFlyoutArrayView = ({
     const nextStep = createNextStepFromPrevious(previousStep);
 
     const nextSteps: DslStepMetaFields[] = [...currentSteps, nextStep];
-    form.updateFieldValues(
-      { _meta: { __dslStepsFlyout: true, downsampleSteps: nextSteps } } as any,
-      { runDeserializer: false }
-    );
+    const payload: DslStepsFlyoutFormFieldUpdate = {
+      _meta: { __dslStepsFlyout: true, downsampleSteps: nextSteps },
+    };
+    form.updateFieldValues(payload, { runDeserializer: false });
     setSelectedStepIndex(nextIndex);
   }, [createNextStepFromPrevious, form, getCurrentSteps, items.length, setSelectedStepIndex]);
 
@@ -255,10 +264,10 @@ export const DslStepsFlyoutArrayView = ({
       const oldLength = items.length;
 
       const nextSteps = getCurrentSteps().filter((_, index) => index !== stepIndex);
-      form.updateFieldValues(
-        { _meta: { __dslStepsFlyout: true, downsampleSteps: nextSteps } } as any,
-        { runDeserializer: false }
-      );
+      const payload: DslStepsFlyoutFormFieldUpdate = {
+        _meta: { __dslStepsFlyout: true, downsampleSteps: nextSteps },
+      };
+      form.updateFieldValues(payload, { runDeserializer: false });
 
       if (selectedStepIndex === undefined) return;
       const newLength = oldLength - 1;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
@@ -27,6 +27,9 @@ import {
   toMilliseconds,
 } from '../form';
 import { TIME_UNIT_OPTIONS } from '../constants';
+import { useStyles } from '../use_styles';
+import { StepPanel } from './step_panel';
+import { StepTabsRow } from './step_tabs_row';
 
 /** Partial form update including internal __dslStepsFlyout flag for updateFieldValues */
 type DslStepsFlyoutFormFieldUpdate = Partial<DslStepsFlyoutFormInternal> & {
@@ -35,9 +38,6 @@ type DslStepsFlyoutFormFieldUpdate = Partial<DslStepsFlyoutFormInternal> & {
     downsampleSteps: DslStepMetaFields[];
   };
 };
-import { useStyles } from '../use_styles';
-import { StepPanel } from './step_panel';
-import { StepTabsRow } from './step_tabs_row';
 
 export interface DslStepsFlyoutArrayViewProps {
   arrayField: FormArrayField;


### PR DESCRIPTION
## Summary
Fixes lint errors in streams:

- validations.ts: use FormData from hook_form_lib for ValidationFunc
- validations.test.ts: type createArg as ValidationFuncArg<FlatFormData, unknown>
- edit_dsl_steps_flyout.test.tsx: use IngestStreamLifecycleDSL and LifecycleWithPreserved
- deserializer_and_serializer.test.ts: add LifecycleWithPreserved and DownsampleStepWithExtras
- dsl_steps_flyout_array_view.tsx: add DslStepsFlyoutFormFieldUpdate for updateFieldValues