### PR TITLE
[Search] Add permissions and API routes needed for data preview

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/helpers/http_requests.ts
@@ -241,13 +241,32 @@ const registerHttpRequestMockHelpers = (
 
   const setInferenceModels = (response?: HttpResponse, error?: ResponseError) =>
     mockResponse('GET', `${API_BASE_PATH}/inference/all`, response, error);
+
   const setUserStartPrivilegesResponse = (
     indexName: string,
     response?: HttpResponse,
     error?: ResponseError
   ) => {
-    mockResponse('GET', `${API_BASE_PATH}/start_privileges/${indexName}`, response, error);
+    mockResponse(
+      'GET',
+      `${API_BASE_PATH}/start_privileges/${encodeURIComponent(indexName)}`,
+      response,
+      error
+    );
   };
+
+  const setLoadIndexDocumentsSampleResponse = (
+    indexName: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) =>
+    mockResponse(
+      'GET',
+      `${INTERNAL_API_BASE_PATH}/indices/${encodeURIComponent(indexName)}/sample`,
+      response,
+      error
+    );
+
   return {
     setLoadTemplatesResponse,
     setLoadIndicesStatsResponse,
@@ -281,6 +300,7 @@ const registerHttpRequestMockHelpers = (
     setInferenceModels,
     setGetMatchingDataStreams,
     setUserStartPrivilegesResponse,
+    setLoadIndexDocumentsSampleResponse,
   };
 };
 

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/helpers/http_requests.ts
@@ -267,6 +267,21 @@ const registerHttpRequestMockHelpers = (
       error
     );
 
+  const setDeleteDocumentResponse = (
+    indexName: string,
+    id: string,
+    response?: HttpResponse,
+    error?: ResponseError
+  ) =>
+    mockResponse(
+      'DELETE',
+      `${INTERNAL_API_BASE_PATH}/indices/${encodeURIComponent(
+        indexName
+      )}/documents/${encodeURIComponent(id)}`,
+      response,
+      error
+    );
+
   return {
     setLoadTemplatesResponse,
     setLoadIndicesStatsResponse,
@@ -301,6 +316,7 @@ const registerHttpRequestMockHelpers = (
     setGetMatchingDataStreams,
     setUserStartPrivilegesResponse,
     setLoadIndexDocumentsSampleResponse,
+    setDeleteDocumentResponse,
   };
 };
 

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/mocks.ts
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/mocks.ts
@@ -123,3 +123,12 @@ export const testUserStartPrivilegesResponse = {
     canManageIndex: true,
   },
 };
+
+export const testIndexDocumentsSampleResponse = {
+  results: [
+    {
+      _id: '1',
+      _source: { field: 'value' },
+    },
+  ],
+};

--- a/x-pack/platform/plugins/shared/index_management/moon.yml
+++ b/x-pack/platform/plugins/shared/index_management/moon.yml
@@ -77,6 +77,7 @@ dependsOn:
   - '@kbn/test-eui-helpers'
   - '@kbn/core-elasticsearch-server'
   - '@kbn/cloud'
+  - '@kbn/search-index-documents'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/index_management/public/application/services/api.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/services/api.ts
@@ -7,7 +7,7 @@
 
 import { METRIC_TYPE } from '@kbn/analytics';
 import type { SerializedEnrichPolicy } from '@kbn/index-management-shared-types';
-import type { IndicesStatsResponse } from '@elastic/elasticsearch/lib/api/types';
+import type { IndicesStatsResponse, SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 import type { ReindexService } from '@kbn/reindex-service-plugin/public';
@@ -557,6 +557,13 @@ export function createIndex(indexName: string, indexMode: string) {
       indexName,
       indexMode,
     }),
+  });
+}
+
+export function useLoadIndexDocumentsSample(indexName: string) {
+  return useRequest<{ results: SearchHit[] }>({
+    path: `${INTERNAL_API_BASE_PATH}/indices/${encodeURIComponent(indexName)}/sample`,
+    method: 'get',
   });
 }
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/services/api.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/services/api.ts
@@ -567,6 +567,15 @@ export function useLoadIndexDocumentsSample(indexName: string) {
   });
 }
 
+export async function deleteDocuments(indexName: string, id: string) {
+  return sendRequest({
+    path: `${INTERNAL_API_BASE_PATH}/indices/${encodeURIComponent(
+      indexName
+    )}/documents/${encodeURIComponent(id)}`,
+    method: 'delete',
+  });
+}
+
 export function updateIndexMappings(indexName: string, newFields: Fields) {
   return sendRequest({
     path: `${API_BASE_PATH}/mapping/${encodeURIComponent(indexName)}`,

--- a/x-pack/platform/plugins/shared/index_management/server/lib/fetch_indices_status.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/lib/fetch_indices_status.ts
@@ -17,7 +17,7 @@ export async function fetchUserStartPrivileges(
     index: [
       {
         names: [indexName],
-        privileges: ['manage'],
+        privileges: ['manage', 'delete'],
       },
     ],
   });

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_delete_document_route.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_delete_document_route.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { registerDeleteDocumentRoute } from './register_delete_document_route';
+import { addInternalBasePath } from '..';
+import type { RequestMock } from '../../../test/helpers';
+import { RouterMock, routeDependencies, withStubbedHandleEsError } from '../../../test/helpers';
+
+const router = new RouterMock();
+const deleteMock = router.getMockESApiFn('delete');
+
+const mockRequest: RequestMock = {
+  method: 'delete',
+  path: addInternalBasePath('/indices/{indexName}/documents/{id}'),
+  params: { indexName: 'my-index', id: 'doc-1' },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  registerDeleteDocumentRoute({
+    ...routeDependencies,
+    router,
+  });
+});
+
+describe('Delete document API', () => {
+  describe('DELETE /internal/index_management/indices/{indexName}/documents/{id}', () => {
+    it('should call the ES delete API with the correct parameters', async () => {
+      deleteMock.mockResolvedValue({});
+
+      await router.runRequest(mockRequest);
+
+      expect(deleteMock).toHaveBeenCalledWith({ index: 'my-index', id: 'doc-1' });
+    });
+
+    it('should return ok on success', async () => {
+      deleteMock.mockResolvedValue({});
+
+      const res = await router.runRequest(mockRequest);
+
+      expect(res).toEqual({ status: 200, options: {} });
+    });
+
+    it('should handle errors via handleEsError', async () => {
+      const restore = withStubbedHandleEsError(routeDependencies);
+      registerDeleteDocumentRoute({ ...routeDependencies, router });
+
+      deleteMock.mockRejectedValue(new Error('Internal Server Error'));
+
+      const res = await router.runRequest(mockRequest);
+      expect(res).toEqual({ status: 500, options: {} });
+
+      restore();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_delete_document_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_delete_document_route.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import type { RouteDependencies } from '../../../types';
+import { addInternalBasePath } from '..';
+
+export function registerDeleteDocumentRoute({ router, lib: { handleEsError } }: RouteDependencies) {
+  router.delete(
+    {
+      path: addInternalBasePath('/indices/{indexName}/documents/{id}'),
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Relies on es client for authorization',
+        },
+      },
+      validate: {
+        params: schema.object({
+          indexName: schema.string(),
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = (await context.core).elasticsearch.client.asCurrentUser;
+      const { indexName, id } = request.params;
+
+      try {
+        await client.delete({ index: indexName, id });
+        return response.ok();
+      } catch (error) {
+        return handleEsError({ error, response });
+      }
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { registerDocumentsSampleRoute } from './register_documents_sample_route';
+import { addInternalBasePath } from '..';
+import type { RequestMock } from '../../../test/helpers';
+import { RouterMock, routeDependencies, withStubbedHandleEsError } from '../../../test/helpers';
+import { DEFAULT_DOCS_PER_PAGE } from '@kbn/search-index-documents';
+
+const router = new RouterMock();
+const searchMock = router.getMockESApiFn('search');
+
+const mockRequest: RequestMock = {
+  method: 'get',
+  path: addInternalBasePath('/indices/{indexName}/sample'),
+  params: { indexName: 'my-index' },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  registerDocumentsSampleRoute({
+    ...routeDependencies,
+    router,
+  });
+});
+
+describe('Documents sample API', () => {
+  describe('GET /internal/index_management/indices/{indexName}/sample', () => {
+    it('should return search results', async () => {
+      searchMock.mockResolvedValue({
+        hits: {
+          hits: [{ _id: '1', _source: { field: 'value' } }],
+        },
+      });
+
+      const res = await router.runRequest(mockRequest);
+
+      expect(searchMock).toHaveBeenCalledWith({
+        index: 'my-index',
+        size: DEFAULT_DOCS_PER_PAGE,
+      });
+
+      expect(res).toEqual({
+        body: {
+          results: [{ _id: '1', _source: { field: 'value' } }],
+        },
+      });
+    });
+
+    it('should handle errors via handleEsError', async () => {
+      const restore = withStubbedHandleEsError(routeDependencies);
+      registerDocumentsSampleRoute({ ...routeDependencies, router });
+
+      searchMock.mockRejectedValue(new Error('Internal Server Error'));
+
+      const res = await router.runRequest(mockRequest);
+      expect(res).toEqual({ status: 500, options: {} });
+
+      restore();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { DEFAULT_DOCS_PER_PAGE } from '@kbn/search-index-documents';
+
+import type { RouteDependencies } from '../../../types';
+import { addInternalBasePath } from '..';
+
+export function registerDocumentsSampleRoute({
+  router,
+  lib: { handleEsError },
+}: RouteDependencies) {
+  router.get(
+    {
+      path: addInternalBasePath('/indices/{indexName}/sample'),
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Relies on es client for authorization',
+        },
+      },
+      validate: {
+        params: schema.object({
+          indexName: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = (await context.core).elasticsearch.client.asCurrentUser;
+      const { indexName } = request.params;
+
+      try {
+        const searchResults = await client.search({
+          index: indexName,
+          size: DEFAULT_DOCS_PER_PAGE,
+        });
+
+        return response.ok({
+          body: {
+            results: searchResults.hits.hits,
+          },
+        });
+      } catch (error) {
+        return handleEsError({ error, response });
+      }
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_indices_routes.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_indices_routes.ts
@@ -20,6 +20,7 @@ import { registerGetRoute } from './register_get_route';
 import { registerCreateRoute } from './register_create_route';
 import { registerPostIndexDocCountRoute } from './register_post_index_doc_count';
 import { registerDocumentsSampleRoute } from './register_documents_sample_route';
+import { registerDeleteDocumentRoute } from './register_delete_document_route';
 
 import { registerIndicesGet } from './indices_get';
 import { registerIndicesStats } from './indices_stats';
@@ -41,5 +42,6 @@ export function registerIndicesRoutes(dependencies: RouteDependencies) {
   registerIndicesGet(dependencies);
   registerIndicesStats(dependencies);
   registerDocumentsSampleRoute(dependencies);
+  registerDeleteDocumentRoute(dependencies);
   registerUserStatusPrivilegeRoutes(dependencies);
 }

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_indices_routes.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_indices_routes.ts
@@ -23,6 +23,7 @@ import { registerDocumentsSampleRoute } from './register_documents_sample_route'
 
 import { registerIndicesGet } from './indices_get';
 import { registerIndicesStats } from './indices_stats';
+import { registerUserStatusPrivilegeRoutes } from './register_user_status_route';
 
 export function registerIndicesRoutes(dependencies: RouteDependencies) {
   registerClearCacheRoute(dependencies);
@@ -40,4 +41,5 @@ export function registerIndicesRoutes(dependencies: RouteDependencies) {
   registerIndicesGet(dependencies);
   registerIndicesStats(dependencies);
   registerDocumentsSampleRoute(dependencies);
+  registerUserStatusPrivilegeRoutes(dependencies);
 }

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_indices_routes.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_indices_routes.ts
@@ -19,6 +19,7 @@ import { registerDeleteRoute } from './register_delete_route';
 import { registerGetRoute } from './register_get_route';
 import { registerCreateRoute } from './register_create_route';
 import { registerPostIndexDocCountRoute } from './register_post_index_doc_count';
+import { registerDocumentsSampleRoute } from './register_documents_sample_route';
 
 import { registerIndicesGet } from './indices_get';
 import { registerIndicesStats } from './indices_stats';
@@ -38,4 +39,5 @@ export function registerIndicesRoutes(dependencies: RouteDependencies) {
   registerPostIndexDocCountRoute(dependencies);
   registerIndicesGet(dependencies);
   registerIndicesStats(dependencies);
+  registerDocumentsSampleRoute(dependencies);
 }

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_user_status_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_user_status_route.ts
@@ -42,6 +42,7 @@ export function registerUserStatusPrivilegeRoutes({
           body: {
             privileges: {
               canManageIndex: securityCheck?.index?.[indexName]?.manage ?? false,
+              canDeleteDocuments: securityCheck?.index?.[indexName]?.delete ?? false,
             },
           },
           headers: { 'content-type': 'application/json' },

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/mapping/register_index_mapping_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/mapping/register_index_mapping_route.ts
@@ -8,10 +8,8 @@
 import type { RouteDependencies } from '../../../types';
 import { registerGetMappingRoute } from './register_mapping_route';
 import { registerUpdateMappingRoute } from './register_update_mapping_route';
-import { registerUserStatusPrivilegeRoutes } from './register_user_status_route';
 
 export function registerIndexMappingRoutes(dependencies: RouteDependencies) {
   registerGetMappingRoute(dependencies);
   registerUpdateMappingRoute(dependencies);
-  registerUserStatusPrivilegeRoutes(dependencies);
 }

--- a/x-pack/platform/plugins/shared/index_management/tsconfig.json
+++ b/x-pack/platform/plugins/shared/index_management/tsconfig.json
@@ -71,7 +71,8 @@
     "@kbn/deeplinks-management",
     "@kbn/test-eui-helpers",
     "@kbn/core-elasticsearch-server",
-    "@kbn/cloud"
+    "@kbn/cloud",
+    "@kbn/search-index-documents"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This PR introduces two new server routes in the Index Management plugin and extends the permissions check in `registerPrivilegesRoute` to maintain 1:1 parity with the Data Preview section of the Search Index Details page.

#### New routes

- `registerDocumentsSampleRoute` - Performs a document search against a specified index, enabling retrieval of a sample set of documents for display in the Data Preview section.
- `registerDeleteDocumentRoute` - Enables deletion of a specified document from within the Data Preview section.

#### Permissions update

Delete privilege checks have been added to `fetchUserStartPrivileges` and `registerPrivilegesRoute`. This allows us to determine whether a user has the `canDeleteDocuments` permission ahead of introducing document deletion functionality in the UI.

The UI for the Data Preview section will be implemented in a follow-up PR.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~


