### PR TITLE
fix(NA): openapi:build task for cases plugin

### DIFF
--- a/x-pack/platform/plugins/shared/cases/package.json
+++ b/x-pack/platform/plugins/shared/cases/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "generate:cases": "node scripts/generate_cases.js",
     "openapi": "yarn openapi:build && yarn openapi:generate",
-    "openapi:build": "npx @redocly/cli bundle docs/openapi/entrypoint.yaml --output docs/openapi/bundled-types.schema.yaml --ext yaml",
+    "openapi:build": "npx --no-install redocly bundle docs/openapi/entrypoint.yaml --output docs/openapi/bundled-types.schema.yaml --ext yaml",
     "openapi:generate": "node scripts/openapi_generate.js"
   }
 }


### PR DESCRIPTION
This PR fixes the openapi:build task into the cases plugin which is now failing ci.