### PR TITLE
[One Workflows] Show IF step evaluation result in Outputs

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_if_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_if_node_impl.ts
@@ -52,7 +52,12 @@ export class EnterIfNodeImpl implements NodeImplementation {
       this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(thenNode.condition);
     const evaluatedConditionResult = this.evaluateCondition(renderedCondition);
     this.stepExecutionRuntime.setInput({
+      rawCondition: thenNode.condition as string,
       condition: renderedCondition,
+      conditionResult: evaluatedConditionResult,
+    });
+    // set the condition result to the step state so that it can be used in the exit node
+    this.stepExecutionRuntime.setCurrentStepState({
       conditionResult: evaluatedConditionResult,
     });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_if_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_if_node_impl.ts
@@ -18,7 +18,10 @@ export class ExitIfNodeImpl implements NodeImplementation {
   ) {}
 
   public run(): void {
-    this.stepExecutionRuntime.finishStep();
+    const stepState = this.stepExecutionRuntime.getCurrentStepState();
+    const conditionResult = stepState?.conditionResult;
+    this.stepExecutionRuntime.setCurrentStepState(undefined);
+    this.stepExecutionRuntime.finishStep(conditionResult ? { conditionResult } : {});
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/tests/enter_if_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/tests/enter_if_node_impl.test.ts
@@ -40,6 +40,7 @@ describe('EnterIfNodeImpl', () => {
       contextManager: mockContextManager,
       startStep: jest.fn().mockResolvedValue(undefined),
       setInput: jest.fn(),
+      setCurrentStepState: jest.fn(),
     } as any;
 
     node = {
@@ -100,7 +101,37 @@ describe('EnterIfNodeImpl', () => {
       'event.type: alert'
     );
     expect(mockStepExecutionRuntime.setInput).toHaveBeenCalledWith({
+      rawCondition: 'event.type: alert',
       condition: 'event.type: foo',
+      conditionResult: false,
+    });
+    expect(mockStepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
+      conditionResult: false,
+    });
+  });
+
+  it('should store true conditionResult in step state when condition matches', async () => {
+    await impl.run();
+    expect(mockStepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
+      conditionResult: true,
+    });
+  });
+
+  it('should store false conditionResult in step state when condition does not match', async () => {
+    workflowGraph.getDirectSuccessors = jest.fn().mockReturnValueOnce([
+      {
+        id: 'thenNode',
+        type: 'enter-then-branch',
+        condition: 'event.type:rule',
+      } as EnterConditionBranchNode,
+      {
+        id: 'elseNode',
+        type: 'enter-else-branch',
+      } as EnterConditionBranchNode,
+    ]);
+
+    await impl.run();
+    expect(mockStepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
       conditionResult: false,
     });
   });

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_output_schema_for_step_type.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_output_schema_for_step_type.test.ts
@@ -138,6 +138,68 @@ describe('getOutputSchemaForStepType', () => {
     );
   });
 
+  describe('structural step nodes', () => {
+    it('should return conditionResult schema for enter-if node', () => {
+      const mockNode = {
+        id: 'test-id',
+        stepId: 'test-step-id',
+        stepType: 'if',
+        type: 'enter-if' as const,
+        exitNodeId: 'exit-id',
+        configuration: {},
+      };
+
+      const result = getOutputSchemaForStepType(mockNode as any);
+      const parsed = result.safeParse({ conditionResult: true });
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual({ conditionResult: true });
+    });
+
+    it('should return conditionResult schema for exit-if node', () => {
+      const mockNode = {
+        id: 'test-id',
+        stepId: 'test-step-id',
+        stepType: 'if',
+        type: 'exit-if' as const,
+        startNodeId: 'enter-id',
+      };
+
+      const result = getOutputSchemaForStepType(mockNode as any);
+      const parsed = result.safeParse({ conditionResult: false });
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual({ conditionResult: false });
+    });
+
+    it('should resolve structural schema by stepType regardless of node type', () => {
+      const mockNode = {
+        id: 'test-id',
+        stepId: 'test-step-id',
+        stepType: 'if',
+        type: 'exit-then-branch' as const,
+      };
+
+      const result = getOutputSchemaForStepType(mockNode as any);
+      const parsed = result.safeParse({ conditionResult: true });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    it('should fall through to z.unknown() for structural nodes without a registered schema', () => {
+      const mockNode = {
+        id: 'test-id',
+        stepId: 'test-step-id',
+        stepType: 'retry',
+        type: 'enter-retry' as const,
+      };
+
+      const result = getOutputSchemaForStepType(mockNode as any);
+
+      expect(result.def.type).toBe('unknown');
+    });
+  });
+
   describe('fallback behavior', () => {
     it('should return z.unknown() for unknown step types', () => {
       // Map is empty, connector not found

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_output_schema_for_step_type.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_output_schema_for_step_type.ts
@@ -10,6 +10,7 @@
 import type { GraphNodeUnion } from '@kbn/workflows/graph';
 import { isAtomic } from '@kbn/workflows/graph';
 import { z } from '@kbn/zod/v4';
+import { structuralStepOutputSchemas } from './structural_step_output_schemas';
 import { stepSchemas } from '../../../../common/step_schemas';
 
 export const getOutputSchemaForStepType = (node: GraphNodeUnion): z.ZodSchema => {
@@ -44,6 +45,11 @@ export const getOutputSchemaForStepType = (node: GraphNodeUnion): z.ZodSchema =>
       return z.unknown();
     }
     return connector.outputSchema;
+  }
+
+  const structuralSchema = structuralStepOutputSchemas[node.stepType];
+  if (structuralSchema) {
+    return structuralSchema;
   }
 
   // Fallback to unknown if not found

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts
@@ -47,24 +47,26 @@ export function getStepsCollectionSchema(
 
   let stepsSchema = z.object({});
   for (const node of predecessors) {
+    // Excluding triggers from the context for now. Maybe they should be included under 'triggers' key?
     if (node.type === 'trigger') {
       // eslint-disable-next-line no-continue
       continue;
     }
 
-    if (isEnterForeach(node)) {
-      stepsSchema = stepsSchema.extend({
-        [node.stepId]: getForeachStateSchema(
-          stepContextSchema.merge(z.object({ steps: stepsSchema })),
-          node.configuration
-        ),
-      });
-    } else {
+    if (!isEnterForeach(node)) {
       stepsSchema = stepsSchema.extend({
         [node.stepId]: z.object({
           output: getOutputSchemaForStepType(node).optional(),
           error: z.any().optional(),
         }),
+      });
+    } else {
+      // if the step is a foreach, add the foreach schema to the step state schema
+      stepsSchema = stepsSchema.extend({
+        [node.stepId]: getForeachStateSchema(
+          stepContextSchema.merge(z.object({ steps: stepsSchema })),
+          node.configuration
+        ),
       });
     }
   }

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts
@@ -26,8 +26,20 @@ export function getStepsCollectionSchema(
   if (!stepNode) {
     throw new Error(`Step with id ${stepId} not found in the workflow graph.`);
   }
-  // reverse predecessors so the earliest steps are first and will be available when we reach the later ones
-  const predecessors = [...workflowExecutionGraph.getAllPredecessors(stepNode.id)].reverse();
+  // Reverse predecessors so the earliest steps are first and will be available when we reach the later ones.
+  // Deduplicate by stepId: structural nodes (enter-if/exit-if, enter-foreach/exit-foreach, etc.)
+  // share the same stepId, and processing both would cause the later one to overwrite the first.
+  // We keep the first occurrence per stepId since the earliest node (e.g. enter-foreach) carries
+  // the configuration needed for special schema handling (like getForeachStateSchema).
+  const allPredecessors = [...workflowExecutionGraph.getAllPredecessors(stepNode.id)].reverse();
+  const seenStepIds = new Set<string>();
+  const predecessors = allPredecessors.filter((node) => {
+    if (seenStepIds.has(node.stepId)) {
+      return false;
+    }
+    seenStepIds.add(node.stepId);
+    return true;
+  });
 
   if (predecessors.length === 0) {
     return z.object({});
@@ -35,26 +47,24 @@ export function getStepsCollectionSchema(
 
   let stepsSchema = z.object({});
   for (const node of predecessors) {
-    // Excluding triggers from the context for now. Maybe they should be included under 'triggers' key?
     if (node.type === 'trigger') {
       // eslint-disable-next-line no-continue
       continue;
     }
 
-    if (!isEnterForeach(node)) {
-      stepsSchema = stepsSchema.extend({
-        [node.stepId]: z.object({
-          output: getOutputSchemaForStepType(node).optional(),
-          error: z.any().optional(),
-        }),
-      });
-    } else {
-      // if the step is a foreach, add the foreach schema to the step state schema
+    if (isEnterForeach(node)) {
       stepsSchema = stepsSchema.extend({
         [node.stepId]: getForeachStateSchema(
           stepContextSchema.merge(z.object({ steps: stepsSchema })),
           node.configuration
         ),
+      });
+    } else {
+      stepsSchema = stepsSchema.extend({
+        [node.stepId]: z.object({
+          output: getOutputSchemaForStepType(node).optional(),
+          error: z.any().optional(),
+        }),
       });
     }
   }

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/structural_step_output_schemas.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/structural_step_output_schemas.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod/v4';
+
+/**
+ * Output schemas for built-in structural (control-flow) step types.
+ * Keyed by `stepType` (e.g. 'if', 'foreach', 'retry', 'wait').
+ *
+ * These are separate from the WorkflowsExtensions registry because structural
+ * steps don't have user-provided handlers — they are implemented as dedicated
+ * NodeImplementation classes in the execution engine.
+ */
+export const structuralStepOutputSchemas: Record<string, z.ZodSchema> = {
+  if: z.object({
+    conditionResult: z.boolean(),
+  }),
+};


### PR DESCRIPTION
## Summary

IF operator steps currently show an empty output in the execution detail view, which confuses users exploring workflow executions. The evaluated condition result (`conditionResult`) was only stored as an input, and outputs were left empty.

This PR moves `conditionResult` into the step output so that:
- **Inputs** show the condition expression (raw and rendered).
- **Outputs** show the evaluated boolean result (`true` / `false`).

### Changes

- Stores `conditionResult` in step output
- Stores `rawCondition` in step input

**Frontend autocompletion** (`workflows_management`):
- `structural_step_output_schemas.ts` (new): Introduces a dedicated schema map for structural step types so the YAML editor can provide autocompletion for `steps.<ifStepId>.output.conditionResult`.
- `get_output_schema_for_step_type.ts`: Looks up structural schemas from the new map.
- `get_steps_collection_schema.ts`: Fixes a predecessor dedup bug where structural nodes sharing the same `stepId` (e.g., `enter-foreach` / `exit-foreach`) would overwrite each other's schema.

## Acceptance criteria

- [x] Each IF step displays the condition expression under "Inputs"
- [x] Each IF step shows the boolean result (`true`/`false`) under "Outputs"
- [x] No IF step appears empty or shows "No output data"
- [x] `{{steps.<ifStepId>.output.conditionResult}}` autocompletion works in the YAML editor

<img width="769" height="285" alt="image" src="https://github.com/user-attachments/assets/b322732b-cf84-40ad-bd96-b0f4b2b1e5e2" />
<img width="1502" height="482" alt="image" src="https://github.com/user-attachments/assets/923d09ae-6b62-425e-9fe5-29db35f95d61" />
<img width="769" height="285" alt="image" src="https://github.com/user-attachments/assets/dfc596d7-140a-41a8-a9e2-0a7dbe1a7086" />
<img width="741" height="121" alt="image" src="https://github.com/user-attachments/assets/25821ec9-8235-4c28-ae38-1da29bae50d2" />
