### PR TITLE
[9.2] [Security Solution] Add rule details overview tab and set to default link from installed rules table (#251662)

### DIFF
--- a/src/platform/packages/shared/kbn-cypress-test-helper/src/services/alerting_services.ts
+++ b/src/platform/packages/shared/kbn-cypress-test-helper/src/services/alerting_services.ts
@@ -9,8 +9,7 @@
 
 import 'cypress-network-idle';
 
-const GLOBAL_KQL_WRAPPER = '[data-test-subj="filters-global-container"]';
-const REFRESH_BUTTON = `${GLOBAL_KQL_WRAPPER} [data-test-subj="querySubmitButton"]`;
+const REFRESH_BUTTON = `[data-test-subj="kbnQueryBar"] [data-test-subj="querySubmitButton"]`;
 const DATAGRID_CHANGES_IN_PROGRESS = '[data-test-subj="body-data-grid"] .euiProgress';
 const EVENT_CONTAINER_TABLE_LOADING = '[data-test-subj="internalAlertsPageLoading"]';
 const LOADING_INDICATOR = '[data-test-subj="globalLoadingIndicator"]';

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/alert_test.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/alert_test.cy.ts
@@ -8,7 +8,7 @@
 import { waitForAlertsToPopulate } from '@kbn/cypress-test-helper/src/services/alerting_services';
 import { disableNewFeaturesTours } from '../../tasks/navigation';
 import { initializeDataViews } from '../../tasks/login';
-import { checkResults, clickRuleName, submitQuery } from '../../tasks/live_query';
+import { checkResults, clickRuleName, goToAlertsTab, submitQuery } from '../../tasks/live_query';
 import { loadRule, cleanupRule } from '../../tasks/api_fixtures';
 import { ServerlessRoleName } from '../../support/roles';
 
@@ -32,6 +32,7 @@ describe('Alert Test', { tags: ['@ess'] }, () => {
         onBeforeLoad: (win) => disableNewFeaturesTours(win),
       });
       clickRuleName(ruleName);
+      goToAlertsTab();
       waitForAlertsToPopulate();
       cy.getBySel('expand-event').first().click();
       cy.getBySel('securitySolutionFlyoutInvestigationGuideButton').click();

--- a/x-pack/platform/plugins/shared/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/tasks/live_query.ts
@@ -17,6 +17,7 @@ import { ServerlessRoleName } from '../support/roles';
 
 export const DEFAULT_QUERY = 'select * from processes;';
 export const BIG_QUERY = 'select * from processes, users limit 110;';
+export const ALERTS_TAB = '[data-test-subj="navigation-alerts"]';
 
 export const selectAllAgents = () => {
   cy.getBySel('globalLoadingIndicator').should('not.exist');
@@ -127,6 +128,7 @@ export const navigateToRule = (ruleName: string) => {
     onBeforeLoad: (win) => disableNewFeaturesTours(win),
   });
   clickRuleName(ruleName);
+  goToAlertsTab();
   waitForAlertsToPopulate();
 };
 
@@ -192,4 +194,8 @@ export const takeOsqueryActionWithParams = () => {
 
 export const clickRuleName = (ruleName: string) => {
   cy.contains('a[data-test-subj="ruleName"]', ruleName).click({ force: true });
+};
+
+export const goToAlertsTab = () => {
+  cy.get(ALERTS_TAB).click();
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_about_rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/step_about_rule_details/index.tsx
@@ -115,9 +115,9 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
                 {(resizeRef) => (
                   <div ref={resizeRef} className={fullHeight}>
                     <VerticalOverflowContainer maxHeight={120}>
-                      <VerticalOverflowContent maxHeight={120}>
+                      <OverflowContent maxHeight={120}>
                         <RuleDescription description={stepDataDetails.description} />
-                      </VerticalOverflowContent>
+                      </OverflowContent>
                     </VerticalOverflowContainer>
                     <EuiSpacer size="m" />
                     <RuleAboutSection rule={rule} hideName hideDescription />
@@ -127,16 +127,16 @@ const StepAboutRuleToggleDetailsComponent: React.FC<StepPanelProps> = ({
             )}
             {selectedToggleOption === 'notes' && (
               <VerticalOverflowContainer maxHeight={aboutPanelHeight}>
-                <VerticalOverflowContent maxHeight={aboutPanelHeight}>
+                <OverflowContent maxHeight={aboutPanelHeight}>
                   <RuleInvestigationGuide note={stepDataDetails.note} />
-                </VerticalOverflowContent>
+                </OverflowContent>
               </VerticalOverflowContainer>
             )}
             {selectedToggleOption === 'setup' && (
               <VerticalOverflowContainer maxHeight={aboutPanelHeight}>
-                <VerticalOverflowContent maxHeight={aboutPanelHeight}>
+                <OverflowContent maxHeight={aboutPanelHeight}>
                   <RuleSetupGuide setup={stepDataDetails.setup} />
-                </VerticalOverflowContent>
+                </OverflowContent>
               </VerticalOverflowContainer>
             )}
           </EuiFlexItem>
@@ -169,17 +169,17 @@ function VerticalOverflowContainer({
   );
 }
 
-interface VerticalOverflowContentProps {
+interface OverflowContentProps {
   maxHeight: number;
 }
 
-function VerticalOverflowContent({
+function OverflowContent({
   maxHeight,
   children,
-}: PropsWithChildren<VerticalOverflowContentProps>): JSX.Element {
+}: PropsWithChildren<OverflowContentProps>): JSX.Element {
   return (
     <div
-      className={`eui-yScroll ${css`
+      className={`eui-yScroll eui-xScroll ${css`
         max-height: ${maxHeight}px;
       `}`}
     >

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -30,7 +30,6 @@ import styled from 'styled-components';
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 import type { Dispatch } from 'redux';
 import { isTab } from '@kbn/timelines-plugin/public';
-
 import {
   dataTableActions,
   dataTableSelectors,
@@ -59,7 +58,6 @@ import {
 } from '../../../../common/hooks/use_selector';
 import { useKibana } from '../../../../common/lib/kibana';
 import type { UpdateDateRange } from '../../../../common/components/charts/common';
-import { FiltersGlobal } from '../../../../common/components/filters_global';
 import {
   getDetectionEngineUrl,
   getRuleDetailsTabUrl,
@@ -111,7 +109,6 @@ import {
   hasUserCRUDPermission,
   isBoolean,
 } from '../../../../common/utils/privileges';
-
 import {
   RuleStatus,
   RuleStatusFailedCallOut,
@@ -183,6 +180,14 @@ const StyledMinHeightTabContainer = styled.div`
  */
 const RuleFieldsSectionWrapper = styled.div`
   overflow-wrap: anywhere;
+`;
+
+/**
+ * Styled EuiFlexItem component that occupies a predetermined percentage of the parent container.
+ */
+const StyledEuiFlexItem = styled(EuiFlexItem)`
+  min-width: 0px;
+  flex-basis: ${({ flexBasis }) => (flexBasis ? `${flexBasis}%` : 'auto')};
 `;
 
 const defaultGroupingOptions = [
@@ -477,14 +482,17 @@ export const RuleDetailsPage = connector(
           <EuiLoadingSpinner size="m" data-test-subj="rule-status-loader" />
         </EuiFlexItem>
       ) : (
-        <RuleStatusFailedCallOut
-          ruleNameForChat={rule?.name ?? ruleI18n.DETECTION_RULES_CONVERSATION_ID}
-          ruleName={rule?.immutable ? rule?.name : undefined}
-          dataSources={rule?.immutable ? ruleIndex : undefined}
-          status={lastExecutionStatus}
-          date={lastExecutionDate}
-          message={lastExecutionMessage}
-        />
+        <>
+          <EuiSpacer size="m" />
+          <RuleStatusFailedCallOut
+            ruleNameForChat={rule?.name ?? ruleI18n.DETECTION_RULES_CONVERSATION_ID}
+            ruleName={rule?.immutable ? rule?.name : undefined}
+            dataSources={rule?.immutable ? ruleIndex : undefined}
+            status={lastExecutionStatus}
+            date={lastExecutionDate}
+            message={lastExecutionMessage}
+          />
+        </>
       );
     }, [
       lastExecutionStatus,
@@ -641,15 +649,6 @@ export const RuleDetailsPage = connector(
         )}
         <StyledFullHeightContainer onKeyDown={onKeyDown} ref={containerElement}>
           <EuiWindowEvent event="resize" handler={noop} />
-          <FiltersGlobal>
-            <SiemSearchBar
-              id={InputsModelId.global}
-              pollForSignalIndex={pollForSignalIndex}
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataViewSpec
-              }
-            />
-          </FiltersGlobal>
           <RuleDetailsContextProvider>
             <RuleCustomizationsContextProvider rule={rule}>
               <SecuritySolutionPageWrapper noPadding={globalFullScreen}>
@@ -702,7 +701,6 @@ export const RuleDetailsPage = connector(
                           </EuiFlexGroup>
                         </EuiToolTip>
                       </EuiFlexItem>
-
                       <EuiFlexItem grow={false}>
                         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
                           <EuiFlexItem grow={false}>
@@ -742,63 +740,75 @@ export const RuleDetailsPage = connector(
                       </EuiFlexItem>
                     </EuiFlexGroup>
                   </HeaderPage>
+                  <TabNavigation navTabs={pageTabs} />
                   {ruleError}
                   <LegacyUrlConflictCallOut rule={rule} spacesApi={spacesApi} />
-                  <EuiSpacer />
-                  <RuleFieldsSectionWrapper>
-                    <EuiFlexGroup>
-                      <EuiFlexItem data-test-subj="aboutRule" component="section" grow={1}>
-                        {rule !== null && (
-                          <StepAboutRuleToggleDetails
-                            loading={isLoading}
-                            stepData={aboutRuleData}
-                            stepDataDetails={modifiedAboutRuleDetailsData}
-                            rule={rule}
-                          />
-                        )}
-                      </EuiFlexItem>
-
-                      <EuiFlexItem grow={1}>
-                        <EuiFlexGroup direction="column">
-                          <EuiFlexItem component="section" grow={1} data-test-subj="defineRule">
-                            <StepPanel loading={isLoading} title={ruleI18n.DEFINITION}>
-                              {rule !== null && !isStartingJobs && (
-                                <RuleDefinitionSection
-                                  rule={rule}
-                                  isInteractive
-                                  dataTestSubj="definitionRule"
-                                />
-                              )}
-                            </StepPanel>
-                          </EuiFlexItem>
-                          <EuiSpacer />
-                          <EuiFlexItem data-test-subj="schedule" component="section" grow={1}>
-                            <StepPanel loading={isLoading} title={ruleI18n.SCHEDULE}>
-                              {rule != null && <RuleScheduleSection rule={rule} />}
-                            </StepPanel>
-                          </EuiFlexItem>
-                          {hasActions && (
-                            <EuiFlexItem data-test-subj="actions" component="section" grow={1}>
-                              <StepPanel loading={isLoading} title={ruleI18n.ACTIONS}>
-                                <StepRuleActionsReadOnly
-                                  addPadding={false}
-                                  defaultValues={ruleActionsData}
-                                />
-                              </StepPanel>
-                            </EuiFlexItem>
-                          )}
-                        </EuiFlexGroup>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </RuleFieldsSectionWrapper>
-                  <EuiSpacer />
-                  <TabNavigation navTabs={pageTabs} />
                   <EuiSpacer />
                 </Display>
                 <StyledMinHeightTabContainer>
                   <Routes>
+                    <Route path={`/rules/id/:detailName/:tabName(${RuleDetailTabs.overview})`}>
+                      <RuleFieldsSectionWrapper>
+                        <EuiFlexGroup>
+                          <StyledEuiFlexItem
+                            data-test-subj="aboutRule"
+                            component="section"
+                            flexBasis={60}
+                          >
+                            {rule !== null && (
+                              <StepAboutRuleToggleDetails
+                                loading={isLoading}
+                                stepData={aboutRuleData}
+                                stepDataDetails={modifiedAboutRuleDetailsData}
+                                rule={rule}
+                              />
+                            )}
+                          </StyledEuiFlexItem>
+                          <StyledEuiFlexItem grow={1} component="section" flexBasis={40}>
+                            <EuiFlexGroup direction="column">
+                              <EuiFlexItem component="section" grow={1} data-test-subj="defineRule">
+                                <StepPanel loading={isLoading} title={ruleI18n.DEFINITION}>
+                                  {rule !== null && !isStartingJobs && (
+                                    <RuleDefinitionSection
+                                      rule={rule}
+                                      isInteractive
+                                      dataTestSubj="definitionRule"
+                                    />
+                                  )}
+                                </StepPanel>
+                              </EuiFlexItem>
+                              <EuiFlexItem data-test-subj="schedule" component="section" grow={1}>
+                                <StepPanel loading={isLoading} title={ruleI18n.SCHEDULE}>
+                                  {rule != null && <RuleScheduleSection rule={rule} />}
+                                </StepPanel>
+                              </EuiFlexItem>
+                              {hasActions && (
+                                <EuiFlexItem data-test-subj="actions" component="section" grow={1}>
+                                  <StepPanel loading={isLoading} title={ruleI18n.ACTIONS}>
+                                    <StepRuleActionsReadOnly
+                                      addPadding={false}
+                                      defaultValues={ruleActionsData}
+                                    />
+                                  </StepPanel>
+                                </EuiFlexItem>
+                              )}
+                            </EuiFlexGroup>
+                          </StyledEuiFlexItem>
+                        </EuiFlexGroup>
+                      </RuleFieldsSectionWrapper>
+                    </Route>
                     <Route path={`/rules/id/:detailName/:tabName(${RuleDetailTabs.alerts})`}>
                       <>
+                        <SiemSearchBar
+                          pollForSignalIndex={pollForSignalIndex}
+                          id={InputsModelId.global}
+                          sourcererDataView={
+                            newDataViewPickerEnabled
+                              ? experimentalDataView
+                              : oldSourcererDataViewSpec
+                          } // TODO remove when we remove the newDataViewPickerEnabled feature flag
+                        />
+                        <EuiSpacer />
                         <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
                           <EuiFlexItem grow={false}>
                             <AlertsTableFilterGroup

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/translations.ts
@@ -28,6 +28,13 @@ export const UNKNOWN = i18n.translate(
   }
 );
 
+export const OVERVIEW_TAB = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.overviewTab',
+  {
+    defaultMessage: 'Overview',
+  }
+);
+
 export const ALERTS_TAB = i18n.translate('xpack.securitySolution.detectionEngine.alertTitle', {
   defaultMessage: 'Alerts',
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/use_rule_details_tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/use_rule_details_tabs.tsx
@@ -15,6 +15,7 @@ import type { NavTab } from '../../../../common/components/navigation/types';
 import { useRuleExecutionSettings } from '../../../rule_monitoring';
 
 export enum RuleDetailTabs {
+  overview = 'overview',
   alerts = 'alerts',
   exceptions = 'rule_exceptions',
   endpointExceptions = 'endpoint_exceptions',
@@ -23,6 +24,7 @@ export enum RuleDetailTabs {
 }
 
 export const RULE_DETAILS_TAB_NAME: Record<string, string> = {
+  [RuleDetailTabs.overview]: i18n.OVERVIEW_TAB,
   [RuleDetailTabs.alerts]: i18n.ALERTS_TAB,
   [RuleDetailTabs.exceptions]: i18n.EXCEPTIONS_TAB,
   [RuleDetailTabs.endpointExceptions]: i18n.ENDPOINT_EXCEPTIONS_TAB,
@@ -45,6 +47,12 @@ export const useRuleDetailsTabs = ({
 }: UseRuleDetailsTabsProps) => {
   const ruleDetailTabs = useMemo(
     (): Record<RuleDetailTabs, NavTab> => ({
+      [RuleDetailTabs.overview]: {
+        id: RuleDetailTabs.overview,
+        name: RULE_DETAILS_TAB_NAME[RuleDetailTabs.overview],
+        disabled: rule == null,
+        href: `/rules/id/${ruleId}/${RuleDetailTabs.overview}`,
+      },
       [RuleDetailTabs.alerts]: {
         id: RuleDetailTabs.alerts,
         name: RULE_DETAILS_TAB_NAME[RuleDetailTabs.alerts],

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -131,7 +131,7 @@ export const RuleLink = ({ name, id }: Pick<Rule, 'id' | 'name'>) => {
       <SecuritySolutionLinkAnchor
         data-test-subj="ruleName"
         deepLinkId={SecurityPageName.rules}
-        path={getRuleDetailsTabUrl(id, RuleDetailTabs.alerts)}
+        path={getRuleDetailsTabUrl(id, RuleDetailTabs.overview)}
       >
         {name}
       </SecuritySolutionLinkAnchor>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/alerts.ts
@@ -199,7 +199,7 @@ export const getEndpointDetectionAlertsQueryForAgentId = (endpointAgentId: strin
 };
 
 export const changeAlertsFilter = (text: string) => {
-  cy.getByTestSubj('filters-global-container').within(() => {
+  cy.getByTestSubj('kbnQueryBar').within(() => {
     cy.getByTestSubj('queryInput').type(text);
     cy.getByTestSubj('querySubmitButton').click();
   });
@@ -214,10 +214,14 @@ export const DATAGRID_CHANGES_IN_PROGRESS = '[data-test-subj="body-data-grid"] .
 export const EVENT_CONTAINER_TABLE_LOADING = '[data-test-subj="internalAlertsPageLoading"]';
 export const LOADING_INDICATOR = '[data-test-subj="globalLoadingIndicator"]';
 export const ALERTS_URL = '/app/security/alerts';
-export const GLOBAL_KQL_WRAPPER = '[data-test-subj="filters-global-container"]';
-export const REFRESH_BUTTON = `${GLOBAL_KQL_WRAPPER} [data-test-subj="querySubmitButton"]`;
+export const REFRESH_BUTTON = `[data-test-subj="kbnQueryBar"] [data-test-subj="querySubmitButton"]`;
 export const EMPTY_ALERT_TABLE = '[data-test-subj="alertsTableEmptyState"]';
 export const ALERTS_TABLE_COUNT = `[data-test-subj="toolbar-alerts-count"]`;
+export const ALERTS_TAB = '[data-test-subj="navigation-alerts"]';
+
+export const goToAlertsTab = () => {
+  cy.get(ALERTS_TAB).click();
+};
 
 export const waitForPageFilters = () => {
   cy.log('Waiting for Page Filters');

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/isolate.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/isolate.ts
@@ -12,6 +12,7 @@ import { openAlertDetailsView } from '../screens/alerts';
 import type { ActionDetails } from '../../../../common/endpoint/types';
 import { loadPage } from './common';
 import { waitForActionToSucceed } from './response_actions';
+import { goToAlertsTab } from './alerts';
 
 const API_ENDPOINT_ACTION_PATH = '/api/endpoint/action/*';
 export const interceptActionRequests = (
@@ -73,6 +74,7 @@ export const waitForReleaseOption = (alertId: string): void => {
 export const visitRuleAlerts = (ruleName: string) => {
   loadPage('/app/security/rules');
   cy.contains(ruleName).click();
+  goToAlertsTab();
 };
 
 export const checkFlyoutEndpointIsolation = (): void => {

--- a/x-pack/solutions/security/plugins/security_solution/public/rules/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules/routes.tsx
@@ -56,7 +56,7 @@ const getRulesSubRoutes = (capabilities: Capabilities) => [
   ]) // some detection capability is enabled
     ? [
         {
-          path: `/rules/id/:detailName/:tabName(${RuleDetailTabs.alerts}|${RuleDetailTabs.exceptions}|${RuleDetailTabs.endpointExceptions}|${RuleDetailTabs.executionResults}|${RuleDetailTabs.executionEvents})`,
+          path: `/rules/id/:detailName/:tabName(${RuleDetailTabs.overview}|${RuleDetailTabs.alerts}|${RuleDetailTabs.exceptions}|${RuleDetailTabs.endpointExceptions}|${RuleDetailTabs.executionResults}|${RuleDetailTabs.executionEvents})`,
           main: RuleDetailsPage,
           exact: true,
         },
@@ -105,7 +105,7 @@ const RulesContainerComponent: React.FC = () => {
             <Redirect
               to={{
                 ...location,
-                pathname: `/rules/id/${detailName}/${RuleDetailTabs.alerts}`,
+                pathname: `/rules/id/${detailName}/${RuleDetailTabs.overview}`,
                 search: location.search,
               }}
             />

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/suppression_window_advanced_setting.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/suppression_window_advanced_setting.cy.ts
@@ -51,7 +51,7 @@ describe(
       }
       deleteAlertsAndRules();
       createRule(getCustomQueryRuleParams(params)).then((rule) =>
-        visitRuleDetailsPage(rule.body.id)
+        visitRuleDetailsPage(rule.body.id, { tab: 'alerts' })
       );
 
       waitForAlertsToPopulate();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/enrichments/alert_threat_enrichments.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/enrichments/alert_threat_enrichments.cy.ts
@@ -65,7 +65,7 @@ describe('Threat Match Enrichment', { tags: ['@ess', '@serverless', '@skipInServ
         threat_indicator_path: 'threat.indicator',
         enabled: true,
       })
-    ).then((response) => visitRuleDetailsPage(response.body.id));
+    ).then((response) => visitRuleDetailsPage(response.body.id, { tab: 'alerts' }));
   });
 
   after(() => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/status/alert_status.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/status/alert_status.cy.ts
@@ -41,7 +41,7 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
       login();
       deleteAlertsAndRules();
       createRule(getNewRule()).then((createdRule) => {
-        visit(ruleDetailsUrl(createdRule.body.id));
+        visit(ruleDetailsUrl(createdRule.body.id, 'alerts'));
       });
       waitForAlertsToPopulate();
       selectNumberOfAlerts(3);
@@ -119,7 +119,7 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
       login();
       deleteAlertsAndRules();
       createRule(getNewRule()).then((createdRule) => {
-        visit(ruleDetailsUrl(createdRule.body.id));
+        visit(ruleDetailsUrl(createdRule.body.id, 'alerts'));
       });
       waitForAlertsToPopulate();
     });
@@ -171,7 +171,7 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
       login();
       deleteAlertsAndRules();
       createRule(getNewRule()).then((createdRule) => {
-        visit(ruleDetailsUrl(createdRule.body.id));
+        visit(ruleDetailsUrl(createdRule.body.id, 'alerts'));
       });
       waitForAlertsToPopulate();
     });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/alerts_table_flow/endpoint_exceptions.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/alerts_table_flow/endpoint_exceptions.cy.ts
@@ -56,7 +56,9 @@ describe(
       deleteEndpointExceptionList();
 
       cy.task('esArchiverLoad', { archiveName: 'endpoint' });
-      createRule(getEndpointRule()).then((rule) => visitRuleDetailsPage(rule.body.id));
+      createRule(getEndpointRule()).then((rule) =>
+        visitRuleDetailsPage(rule.body.id, { tab: 'alerts' })
+      );
 
       waitForTheRuleToBeExecuted();
       waitForAlertsToPopulate();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/alerts_table_flow/rule_exceptions/auto_populate_with_alert_data.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/alerts_table_flow/rule_exceptions/auto_populate_with_alert_data.cy.ts
@@ -41,7 +41,9 @@ describe('Auto populate exception with Alert data', { tags: ['@ess', '@serverles
     cy.task('esArchiverUnload', { archiveName: 'endpoint_2' });
     cy.task('esArchiverLoad', { archiveName: 'endpoint_2' });
     login();
-    createRule(getEndpointRule()).then((rule) => visitRuleDetailsPage(rule.body.id));
+    createRule(getEndpointRule()).then((rule) =>
+      visitRuleDetailsPage(rule.body.id, { tab: 'alerts' })
+    );
 
     waitForAlertsToPopulate();
   });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/alerts_table_flow/rule_exceptions/closing_all_matching_alerts.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/alerts_table_flow/rule_exceptions/closing_all_matching_alerts.cy.ts
@@ -67,7 +67,7 @@ describe('Close matching Alerts ', { tags: ['@ess', '@serverless'] }, () => {
         interval: '1m',
         rule_id: 'rule_testing',
       })
-    ).then((rule) => visitRuleDetailsPage(rule.body.id));
+    ).then((rule) => visitRuleDetailsPage(rule.body.id, { tab: 'alerts' }));
 
     waitForAlertsToPopulate();
     // Disables enabled rule

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
@@ -74,7 +74,7 @@ describe(
           rule_id: 'rule_testing',
           enabled: true,
         })
-      ).then((rule) => visitRuleDetailsPage(rule.body.id));
+      ).then((rule) => visitRuleDetailsPage(rule.body.id, { tab: 'alerts' }));
       waitForAlertsToPopulate();
     });
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows.cy.ts
@@ -48,7 +48,7 @@ import {
 import { login } from '../../../../tasks/login';
 import { CREATE_RULE_URL } from '../../../../urls/navigation';
 import { visit } from '../../../../tasks/navigation';
-import { waitForTheRuleToBeExecuted } from '../../../../tasks/rule_details';
+import { goToAlertsTab, waitForTheRuleToBeExecuted } from '../../../../tasks/rule_details';
 import { ALERTS_COUNT, ALERT_GRID_CELL } from '../../../../screens/alerts';
 
 // This test is meant to test touching all the common various components in rule creation
@@ -115,6 +115,7 @@ describe('Common rule creation flows', { tags: ['@ess', '@serverless'] }, () => 
     cy.get(DESCRIPTION_SETUP_GUIDE_BUTTON).click();
     cy.get(DESCRIPTION_SETUP_GUIDE_CONTENT).should('contain', 'test setup markdown'); // Markdown formatting should be removed
 
+    goToAlertsTab();
     waitForTheRuleToBeExecuted();
     waitForAlertsToPopulate();
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/indicator_match_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/indicator_match_rule.cy.ts
@@ -106,6 +106,7 @@ import { visit } from '../../../../tasks/navigation';
 import {
   getDetails,
   goBackToRulesTable,
+  goToAlertsTab,
   visitRuleDetailsPage,
   waitForTheRuleToBeExecuted,
 } from '../../../../tasks/rule_details';
@@ -489,6 +490,7 @@ describe(
               .should('have.text', `${rule.interval}`);
           });
 
+          goToAlertsTab();
           waitForTheRuleToBeExecuted();
           waitForAlertsToPopulate();
 
@@ -501,7 +503,7 @@ describe(
         it('Investigate alert in timeline', () => {
           loadPrepackagedTimelineTemplates();
           createRule(getNewThreatIndicatorRule({ rule_id: 'rule_testing', enabled: true })).then(
-            (rule) => visitRuleDetailsPage(rule.body.id)
+            (rule) => visitRuleDetailsPage(rule.body.id, { tab: 'alerts' })
           );
 
           waitForAlertsToPopulate();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
@@ -41,6 +41,7 @@ import {
 import { fetchRuleAlerts } from '../../../../tasks/api_calls/alerts';
 import {
   clickEnableRuleSwitch,
+  goToAlertsTab,
   visitRuleDetailsPage,
   waitForPageToBeLoaded,
 } from '../../../../tasks/rule_details';
@@ -251,6 +252,7 @@ describe('Related integrations', { tags: ['@ess', '@serverless', '@skipInServerl
         createDocument(DATA_STREAM_NAME, generateEvent());
 
         clickEnableRuleSwitch();
+        goToAlertsTab();
         waitForAlertsToPopulate();
 
         fetchRuleAlerts({

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
@@ -51,7 +51,7 @@ describe(
     });
 
     it('should show backfill groups', function () {
-      visit(ruleDetailsUrl(this.ruleId));
+      visit(ruleDetailsUrl(this.ruleId, 'alerts'));
       waitForAlertsToPopulate();
       interceptFindBackfills();
       goToExecutionLogTab();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/gaps.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/gaps.cy.ts
@@ -11,13 +11,12 @@ import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { ruleDetailsUrl } from '../../../../urls/rule_details';
 import { createRule } from '../../../../tasks/api_calls/rules';
-import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 import { TOASTER } from '../../../../screens/alerts_detection_rules';
 import {
-  goToExecutionLogTab,
   getGapsTableRows,
   filterGapsByStatus,
   refreshGapsTable,
+  waitForPageToBeLoaded,
 } from '../../../../tasks/rule_details';
 import { getNewRule } from '../../../../objects/rule';
 import {
@@ -57,6 +56,7 @@ describe(
       deleteAlertsAndRules();
       createRule(getNewRule()).then((rule) => {
         cy.wrap(rule.body.id).as('ruleId');
+        cy.wrap(rule.body.name).as('ruleName');
       });
     });
 
@@ -66,9 +66,8 @@ describe(
       interceptFillGap();
 
       // Visit rule details and go to execution log tab
-      visit(ruleDetailsUrl(this.ruleId));
-      waitForAlertsToPopulate();
-      goToExecutionLogTab();
+      visit(ruleDetailsUrl(this.ruleId, 'execution_results'));
+      waitForPageToBeLoaded(this.ruleName);
       cy.wait('@getRuleGaps');
 
       // Check gaps table is displayed with metrics

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/security_header.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/security_header.ts
@@ -89,7 +89,7 @@ export const KQL_INPUT_TEXT_AREA = '[data-test-subj="queryInput"]';
 export const KQL_INPUT = (dataTestSubj: string = KQL_INPUT_TEXT_AREA) =>
   `${GLOBAL_KQL_WRAPPER} ${dataTestSubj}`;
 
-export const REFRESH_BUTTON = `${GLOBAL_KQL_WRAPPER} [data-test-subj="querySubmitButton"]`;
+export const REFRESH_BUTTON = `[data-test-subj="kbnQueryBar"] [data-test-subj="querySubmitButton"]`;
 
 export const LOADING_INDICATOR = '[data-test-subj="globalLoadingIndicator"]';
 export const LOADING_INDICATOR_HIDDEN = '[data-test-subj="globalLoadingIndicator-hidden"]';

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -158,10 +158,10 @@ import { TIMELINE } from '../screens/timelines';
 import { COMBO_BOX_INPUT, EUI_FILTER_SELECT_ITEM } from '../screens/common/controls';
 import { ruleFields } from '../data/detection_engine';
 import { waitForAlerts } from './alerts';
-import { refreshPage } from './security_header';
 import { COMBO_BOX_OPTION, TOOLTIP } from '../screens/common';
 import { EMPTY_ALERT_TABLE } from '../screens/alerts';
 import { fillComboBox } from './eui_form_interactions';
+import { refreshPage } from './security_header';
 
 export const createAndEnableRule = () => {
   cy.get(CREATE_AND_ENABLE_BTN).click();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security Solution] Add rule details overview tab and set to default link from installed rules table (#251662)](https://github.com/elastic/kibana/pull/251662)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alainna","email":"alainnahalliday+github@gmail.com"},"sourceCommit":{"committedDate":"2026-02-17T18:03:08Z","message":"[Security Solution] Add rule details overview tab and set to default link from installed rules table (#251662)\n\n## Summary\n**Resolves:\n[#7128](https://github.com/elastic/security-team/issues/7128)**\n(internal)\n**Resolves: #215133**\n**Partially addresses: #147367**  \n\nLifts the tab navigation on the rule details page to the top, and moves\nAbout/Definition/Schedule into a dedicated Overview tab to prevent\nloading Alerts on first navigation and allow navigation to Rule\nExceptions, Alerts, etc. without scrolling.\n\nOverview is now the default tab when navigating from the rules table,\nand when creating a new rule.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n<img width=\"1721\" height=\"838\" alt=\"Screenshot 2026-02-04 at 9 18 23 AM\"\nsrc=\"https://github.com/user-attachments/assets/5afb9911-6d14-4a37-b540-0822d13f05a5\"\n/>\n\n<img width=\"1725\" height=\"873\" alt=\"Screenshot 2026-02-04 at 9 18 37 AM\"\nsrc=\"https://github.com/user-attachments/assets/310ff705-c7ae-4da1-9862-5155b88612b3\"\n/>\n\n## Release note\n\nRule summary, definition, and schedule now have a dedicated tab and\nalerts, exceptions, results, and events are now accessible at the top of\nthe page.","sha":"d7f4ffb5b586800bca1a6b92c25a81aa5f5876e8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:enhancement","release_note:fix","enhancement","backport:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Rule Details","v9.4.0"],"title":"[Security Solution] Add rule details overview tab and set to default link from installed rules table","number":251662,"url":"https://github.com/elastic/kibana/pull/251662","mergeCommit":{"message":"[Security Solution] Add rule details overview tab and set to default link from installed rules table (#251662)\n\n## Summary\n**Resolves:\n[#7128](https://github.com/elastic/security-team/issues/7128)**\n(internal)\n**Resolves: #215133**\n**Partially addresses: #147367**  \n\nLifts the tab navigation on the rule details page to the top, and moves\nAbout/Definition/Schedule into a dedicated Overview tab to prevent\nloading Alerts on first navigation and allow navigation to Rule\nExceptions, Alerts, etc. without scrolling.\n\nOverview is now the default tab when navigating from the rules table,\nand when creating a new rule.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n<img width=\"1721\" height=\"838\" alt=\"Screenshot 2026-02-04 at 9 18 23 AM\"\nsrc=\"https://github.com/user-attachments/assets/5afb9911-6d14-4a37-b540-0822d13f05a5\"\n/>\n\n<img width=\"1725\" height=\"873\" alt=\"Screenshot 2026-02-04 at 9 18 37 AM\"\nsrc=\"https://github.com/user-attachments/assets/310ff705-c7ae-4da1-9862-5155b88612b3\"\n/>\n\n## Release note\n\nRule summary, definition, and schedule now have a dedicated tab and\nalerts, exceptions, results, and events are now accessible at the top of\nthe page.","sha":"d7f4ffb5b586800bca1a6b92c25a81aa5f5876e8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251662","number":251662,"mergeCommit":{"message":"[Security Solution] Add rule details overview tab and set to default link from installed rules table (#251662)\n\n## Summary\n**Resolves:\n[#7128](https://github.com/elastic/security-team/issues/7128)**\n(internal)\n**Resolves: #215133**\n**Partially addresses: #147367**  \n\nLifts the tab navigation on the rule details page to the top, and moves\nAbout/Definition/Schedule into a dedicated Overview tab to prevent\nloading Alerts on first navigation and allow navigation to Rule\nExceptions, Alerts, etc. without scrolling.\n\nOverview is now the default tab when navigating from the rules table,\nand when creating a new rule.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n<img width=\"1721\" height=\"838\" alt=\"Screenshot 2026-02-04 at 9 18 23 AM\"\nsrc=\"https://github.com/user-attachments/assets/5afb9911-6d14-4a37-b540-0822d13f05a5\"\n/>\n\n<img width=\"1725\" height=\"873\" alt=\"Screenshot 2026-02-04 at 9 18 37 AM\"\nsrc=\"https://github.com/user-attachments/assets/310ff705-c7ae-4da1-9862-5155b88612b3\"\n/>\n\n## Release note\n\nRule summary, definition, and schedule now have a dedicated tab and\nalerts, exceptions, results, and events are now accessible at the top of\nthe page.","sha":"d7f4ffb5b586800bca1a6b92c25a81aa5f5876e8"}}]}] BACKPORT-->