### PR TITLE
[Fleet] Display incompatible agent versions warning for package policy operations

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/agent_policy.ts
@@ -105,6 +105,7 @@ export interface AgentPolicy extends Omit<NewAgentPolicy, 'id'> {
   agents?: number;
   unprivileged_agents?: number;
   fips_agents?: number;
+  agents_per_version?: Array<{ version: string; count: number }>;
   is_protected: boolean;
   version?: string;
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.test.ts
@@ -23,64 +23,64 @@ const createPackageInfo = (agentVersionCondition?: string): PackageInfo =>
   } as unknown as PackageInfo);
 
 describe('getIncompatibleAgentVersionStatus', () => {
-  it('returns NONE when packageInfo is undefined', () => {
+  it('returns { status: NONE } when packageInfo is undefined', () => {
     const result = getIncompatibleAgentVersionStatus(undefined, []);
-    expect(result).toBe('NONE');
+    expect(result).toEqual({ status: 'NONE' });
   });
 
-  it('returns NONE when no agent version condition is set', () => {
+  it('returns { status: NONE } when no agent version condition is set', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo(), []);
-    expect(result).toBe('NONE');
+    expect(result).toEqual({ status: 'NONE' });
   });
 
-  it('returns NONE when agentPolicies is undefined', () => {
+  it('returns { status: NONE } when agentPolicies is undefined', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), undefined);
-    expect(result).toBe('NONE');
+    expect(result).toEqual({ status: 'NONE' });
   });
 
-  it('returns NONE when agentPolicies is empty', () => {
+  it('returns { status: NONE } when agentPolicies is empty', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), []);
-    expect(result).toBe('NONE');
+    expect(result).toEqual({ status: 'NONE' });
   });
 
-  it('returns NONE when agent policy has no agents_per_version', () => {
+  it('returns { status: NONE } when agent policy has no agents_per_version', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
       createAgentPolicy(undefined),
     ]);
-    expect(result).toBe('NONE');
+    expect(result).toEqual({ status: 'NONE' });
   });
 
-  it('returns NONE when all agents satisfy the version condition', () => {
+  it('returns { status: NONE } when all agents satisfy the version condition', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
       createAgentPolicy([
         { version: '8.1.0', count: 3 },
         { version: '8.2.0', count: 5 },
       ]),
     ]);
-    expect(result).toBe('NONE');
+    expect(result).toEqual({ status: 'NONE' });
   });
 
-  it('returns SOME when some agents are incompatible and some are compatible', () => {
+  it('returns { status: SOME } with versionCondition when some agents are incompatible', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
       createAgentPolicy([
         { version: '7.17.0', count: 2 },
         { version: '8.1.0', count: 5 },
       ]),
     ]);
-    expect(result).toBe('SOME');
+    expect(result).toEqual({ status: 'SOME', versionCondition: '>=8.0.0' });
   });
 
-  it('returns ALL when all agents are incompatible', () => {
+  it('returns { status: ALL } with versionCondition when all agents are incompatible', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
       createAgentPolicy([
         { version: '7.16.0', count: 2 },
         { version: '7.17.0', count: 3 },
       ]),
     ]);
-    expect(result).toBe('ALL');
+    expect(result).toEqual({ status: 'ALL', versionCondition: '>=8.0.0' });
   });
 
-  it('returns SOME across multiple agent policies with mixed compatibility', () => {
+  it('returns { status: SOME } across multiple agent policies with mixed compatibility', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
       createAgentPolicy([{ version: '8.1.0', count: 5 }]),
       createAgentPolicy([
@@ -88,14 +88,14 @@ describe('getIncompatibleAgentVersionStatus', () => {
         { version: '8.1.0', count: 3 },
       ]),
     ]);
-    expect(result).toBe('SOME');
+    expect(result).toEqual({ status: 'SOME', versionCondition: '>=8.0.0' });
   });
 
-  it('returns ALL when all agents across all policies are incompatible', () => {
+  it('returns { status: ALL } when all agents across all policies are incompatible', () => {
     const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
       createAgentPolicy([{ version: '7.16.0', count: 2 }]),
       createAgentPolicy([{ version: '7.17.0', count: 3 }]),
     ]);
-    expect(result).toBe('ALL');
+    expect(result).toEqual({ status: 'ALL', versionCondition: '>=8.0.0' });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentPolicy } from '../types';
+import type { PackageInfo } from '../../../../common/types';
+
+import { getIncompatibleAgentVersionStatus } from './use_has_incompatible_agent_version';
+
+const createAgentPolicy = (
+  versions: Array<{ version: string; count: number }> | undefined
+): AgentPolicy =>
+  ({
+    agents_per_version: versions,
+  } as unknown as AgentPolicy);
+
+const createPackageInfo = (agentVersionCondition?: string): PackageInfo =>
+  ({
+    conditions: agentVersionCondition
+      ? { agent: { version: agentVersionCondition } }
+      : undefined,
+  } as unknown as PackageInfo);
+
+describe('getIncompatibleAgentVersionStatus', () => {
+  it('returns NONE when packageInfo is undefined', () => {
+    const result = getIncompatibleAgentVersionStatus(undefined, []);
+    expect(result).toBe('NONE');
+  });
+
+  it('returns NONE when no agent version condition is set', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo(), []);
+    expect(result).toBe('NONE');
+  });
+
+  it('returns NONE when agentPolicies is undefined', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), undefined);
+    expect(result).toBe('NONE');
+  });
+
+  it('returns NONE when agentPolicies is empty', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), []);
+    expect(result).toBe('NONE');
+  });
+
+  it('returns NONE when agent policy has no agents_per_version', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
+      createAgentPolicy(undefined),
+    ]);
+    expect(result).toBe('NONE');
+  });
+
+  it('returns NONE when all agents satisfy the version condition', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
+      createAgentPolicy([
+        { version: '8.1.0', count: 3 },
+        { version: '8.2.0', count: 5 },
+      ]),
+    ]);
+    expect(result).toBe('NONE');
+  });
+
+  it('returns SOME when some agents are incompatible and some are compatible', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
+      createAgentPolicy([
+        { version: '7.17.0', count: 2 },
+        { version: '8.1.0', count: 5 },
+      ]),
+    ]);
+    expect(result).toBe('SOME');
+  });
+
+  it('returns ALL when all agents are incompatible', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
+      createAgentPolicy([
+        { version: '7.16.0', count: 2 },
+        { version: '7.17.0', count: 3 },
+      ]),
+    ]);
+    expect(result).toBe('ALL');
+  });
+
+  it('returns SOME across multiple agent policies with mixed compatibility', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
+      createAgentPolicy([{ version: '8.1.0', count: 5 }]),
+      createAgentPolicy([
+        { version: '7.17.0', count: 2 },
+        { version: '8.1.0', count: 3 },
+      ]),
+    ]);
+    expect(result).toBe('SOME');
+  });
+
+  it('returns ALL when all agents across all policies are incompatible', () => {
+    const result = getIncompatibleAgentVersionStatus(createPackageInfo('>=8.0.0'), [
+      createAgentPolicy([{ version: '7.16.0', count: 2 }]),
+      createAgentPolicy([{ version: '7.17.0', count: 3 }]),
+    ]);
+    expect(result).toBe('ALL');
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.test.ts
@@ -19,9 +19,7 @@ const createAgentPolicy = (
 
 const createPackageInfo = (agentVersionCondition?: string): PackageInfo =>
   ({
-    conditions: agentVersionCondition
-      ? { agent: { version: agentVersionCondition } }
-      : undefined,
+    conditions: agentVersionCondition ? { agent: { version: agentVersionCondition } } : undefined,
   } as unknown as PackageInfo);
 
 describe('getIncompatibleAgentVersionStatus', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.ts
@@ -12,12 +12,14 @@ import satisfies from 'semver/functions/satisfies';
 import type { AgentPolicy } from '../types';
 import type { PackageInfo } from '../../../../common/types';
 
-export type IncompatibleAgentVersionStatus = 'NONE' | 'SOME' | 'ALL';
+export type IncompatibleAgentVersionResult =
+  | { status: 'NONE' }
+  | { status: 'SOME' | 'ALL'; versionCondition: string };
 
 export const useHasIncompatibleAgentVersion = (
   packageInfo: PackageInfo | undefined,
   agentPolicies: AgentPolicy[] | undefined
-): IncompatibleAgentVersionStatus => {
+): IncompatibleAgentVersionResult => {
   return useMemo(() => {
     return getIncompatibleAgentVersionStatus(packageInfo, agentPolicies);
   }, [packageInfo, agentPolicies]);
@@ -26,12 +28,12 @@ export const useHasIncompatibleAgentVersion = (
 export const getIncompatibleAgentVersionStatus = (
   packageInfo: PackageInfo | undefined,
   agentPolicies: AgentPolicy[] | undefined
-): IncompatibleAgentVersionStatus => {
+): IncompatibleAgentVersionResult => {
   const versionCondition = packageInfo?.conditions?.agent?.version;
   if (!versionCondition) {
-    return 'NONE';
+    return { status: 'NONE' };
   }
-  return (agentPolicies ?? []).reduce<IncompatibleAgentVersionStatus>((acc, agentPolicy) => {
+  const status = (agentPolicies ?? []).reduce<'NONE' | 'SOME' | 'ALL'>((acc, agentPolicy) => {
     if (acc === 'SOME') return acc;
     const { agents_per_version: agentPerVersion } = agentPolicy;
     if (!agentPerVersion) {
@@ -45,4 +47,9 @@ export const getIncompatibleAgentVersionStatus = (
     );
     return hasAllIncompatible ? 'ALL' : hasSomeIncompatible ? 'SOME' : acc;
   }, 'NONE');
+
+  if (status === 'NONE') {
+    return { status: 'NONE' };
+  }
+  return { status, versionCondition };
 };

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_has_incompatible_agent_version.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+
+import satisfies from 'semver/functions/satisfies';
+
+import type { AgentPolicy } from '../types';
+import type { PackageInfo } from '../../../../common/types';
+
+export type IncompatibleAgentVersionStatus = 'NONE' | 'SOME' | 'ALL';
+
+export const useHasIncompatibleAgentVersion = (
+  packageInfo: PackageInfo | undefined,
+  agentPolicies: AgentPolicy[] | undefined
+): IncompatibleAgentVersionStatus => {
+  return useMemo(() => {
+    return getIncompatibleAgentVersionStatus(packageInfo, agentPolicies);
+  }, [packageInfo, agentPolicies]);
+};
+
+export const getIncompatibleAgentVersionStatus = (
+  packageInfo: PackageInfo | undefined,
+  agentPolicies: AgentPolicy[] | undefined
+): IncompatibleAgentVersionStatus => {
+  const versionCondition = packageInfo?.conditions?.agent?.version;
+  if (!versionCondition) {
+    return 'NONE';
+  }
+  return (agentPolicies ?? []).reduce<IncompatibleAgentVersionStatus>((acc, agentPolicy) => {
+    if (acc === 'SOME') return acc;
+    const { agents_per_version: agentPerVersion } = agentPolicy;
+    if (!agentPerVersion) {
+      return acc;
+    }
+    const hasAllIncompatible = agentPerVersion.every(
+      (entry) => !satisfies(entry.version, versionCondition)
+    );
+    const hasSomeIncompatible = agentPerVersion.some(
+      (entry) => !satisfies(entry.version, versionCondition)
+    );
+    return hasAllIncompatible ? 'ALL' : hasSomeIncompatible ? 'SOME' : acc;
+  }, 'NONE');
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_incompatible_agent_version_status.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_incompatible_agent_version_status.test.ts
@@ -8,7 +8,7 @@
 import type { AgentPolicy } from '../types';
 import type { PackageInfo } from '../../../../common/types';
 
-import { getIncompatibleAgentVersionStatus } from './use_has_incompatible_agent_version';
+import { getIncompatibleAgentVersionStatus } from './use_incompatible_agent_version_status';
 
 const createAgentPolicy = (
   versions: Array<{ version: string; count: number }> | undefined

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_incompatible_agent_version_status.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/hooks/use_incompatible_agent_version_status.ts
@@ -16,7 +16,7 @@ export type IncompatibleAgentVersionResult =
   | { status: 'NONE' }
   | { status: 'SOME' | 'ALL'; versionCondition: string };
 
-export const useHasIncompatibleAgentVersion = (
+export const useIncompatibleAgentVersionStatus = (
   packageInfo: PackageInfo | undefined,
   agentPolicies: AgentPolicy[] | undefined
 ): IncompatibleAgentVersionResult => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
@@ -11,7 +11,8 @@ import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 
 export const IncompatibleAgentVersionCallout: React.FC<{
   incompatibility: 'SOME' | 'ALL';
-}> = ({ incompatibility }) => {
+  versionCondition?: string;
+}> = ({ incompatibility, versionCondition }) => {
   return (
     <>
       <EuiCallOut
@@ -27,12 +28,14 @@ export const IncompatibleAgentVersionCallout: React.FC<{
         {incompatibility === 'SOME' ? (
           <FormattedMessage
             id="xpack.fleet.createPackagePolicy.StepSelectPolicy.someIncompatibleAgentVersionWarning"
-            defaultMessage="Some agents using the selected agent policy are running on a version that is not compatible with this integration."
+            defaultMessage="Some agents using the selected agent policy are running on a version that is not compatible with this integration. This integration requires agents on version {versionCondition}."
+            values={{ versionCondition }}
           />
         ) : (
           <FormattedMessage
             id="xpack.fleet.createPackagePolicy.StepSelectPolicy.allIncompatibleAgentVersionWarning"
-            defaultMessage="None of the agents using the selected agent policy are compatible with this integration."
+            defaultMessage="None of the agents using the selected agent policy are compatible with this integration. This integration requires agents on version {versionCondition}."
+            values={{ versionCondition }}
           />
         )}
       </EuiCallOut>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
@@ -32,7 +32,7 @@ export const IncompatibleAgentVersionCallout: React.FC<{
         ) : (
           <FormattedMessage
             id="xpack.fleet.createPackagePolicy.StepSelectPolicy.allIncompatibleAgentVersionWarning"
-            defaultMessage="The selected agent policies have no agents in a version compatible with the integration."
+            defaultMessage="None of the agents using the selected agent policy are compatible with this integration."
           />
         )}
       </EuiCallOut>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
@@ -27,7 +27,7 @@ export const IncompatibleAgentVersionCallout: React.FC<{
         {incompatibility === 'SOME' ? (
           <FormattedMessage
             id="xpack.fleet.createPackagePolicy.StepSelectPolicy.someIncompatibleAgentVersionWarning"
-            defaultMessage="The selected agent policies have some agent in a version non compatible with the integration."
+            defaultMessage="Some agents using the selected agent policy are running on a version that is not compatible with this integration."
           />
         ) : (
           <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/incompatible_agent_version_callout.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+
+export const IncompatibleAgentVersionCallout: React.FC<{
+  incompatibility: 'SOME' | 'ALL';
+}> = ({ incompatibility }) => {
+  return (
+    <>
+      <EuiCallOut
+        announceOnMount
+        title={
+          <FormattedMessage
+            id="xpack.fleet.createPackagePolicy.StepSelectPolicy.incompatibleAgentVersionTitle"
+            defaultMessage="Incompatible agent version"
+          />
+        }
+        color="warning"
+      >
+        {incompatibility === 'SOME' ? (
+          <FormattedMessage
+            id="xpack.fleet.createPackagePolicy.StepSelectPolicy.someIncompatibleAgentVersionWarning"
+            defaultMessage="The selected agent policies have some agent in a version non compatible with the integration."
+          />
+        ) : (
+          <FormattedMessage
+            id="xpack.fleet.createPackagePolicy.StepSelectPolicy.allIncompatibleAgentVersionWarning"
+            defaultMessage="The selected agent policies have no agents in a version compatible with the integration."
+          />
+        )}
+      </EuiCallOut>
+
+      <EuiSpacer size="m" />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/index.ts
@@ -17,3 +17,4 @@ export { AgentPolicyActionMenu } from './actions_menu';
 export { AgentPolicyIntegrationForm } from './agent_policy_integration';
 export { agentPolicyFormValidation } from './agent_policy_validation';
 export { AgentPolicyCreateInlineForm } from './agent_policy_create_inline';
+export { IncompatibleAgentVersionCallout } from './incompatible_agent_version_callout';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -264,7 +264,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                 ) : someNewAgentPoliciesHaveAllAgentIncompatible ? (
                   <FormattedMessage
                     id="xpack.fleet.createPackagePolicy.StepSelectPolicy.cannotAddIncompatibleAgentVersionError"
-                    defaultMessage="The selected agent policies have all agents in a version non compatible with the integration."
+                    defaultMessage="None of the agents using the selected agent policies are compatible with this integration."
                   />
                 ) : null
               }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -172,11 +172,11 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
     (policy) => !initialSelectedAgentPolicyIds.find((id) => policy.id === id)
   );
 
-  const hasIncompatibleAgentVersion = useHasIncompatibleAgentVersion(
+  const incompatibleAgentVersion = useHasIncompatibleAgentVersion(
     packageInfo,
     newlySelectedAgentPolicies
   );
-  const someNewAgentPoliciesHaveAllAgentIncompatible = hasIncompatibleAgentVersion === 'ALL';
+  const someNewAgentPoliciesHaveAllAgentIncompatible = incompatibleAgentVersion.status === 'ALL';
 
   // Display agent policies list error if there is one
   if (agentPoliciesError) {
@@ -264,7 +264,10 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                 ) : someNewAgentPoliciesHaveAllAgentIncompatible ? (
                   <FormattedMessage
                     id="xpack.fleet.createPackagePolicy.StepSelectPolicy.cannotAddIncompatibleAgentVersionError"
-                    defaultMessage="None of the agents using the selected agent policies are compatible with this integration."
+                    defaultMessage="None of the agents using the selected agent policies are compatible with this integration. This integration requires agents on version {versionCondition}."
+                    values={{
+                      versionCondition: incompatibleAgentVersion.versionCondition,
+                    }}
                   />
                 ) : null
               }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -24,7 +24,7 @@ import { Error } from '../../../../../components';
 import type { AgentPolicy, PackageInfo } from '../../../../../types';
 import { isPackageLimited, doesAgentPolicyAlreadyIncludePackage } from '../../../../../services';
 import { useFleetStatus, sendBulkGetAgentPolicies } from '../../../../../hooks';
-import { useHasIncompatibleAgentVersion } from '../../../../../hooks/use_has_incompatible_agent_version';
+import { useIncompatibleAgentVersionStatus } from '../../../../../hooks/use_incompatible_agent_version_status';
 import { useMultipleAgentPolicies } from '../../../../../hooks';
 
 import { AgentPolicyMultiSelect } from './components/agent_policy_multi_select';
@@ -172,7 +172,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
     (policy) => !initialSelectedAgentPolicyIds.find((id) => policy.id === id)
   );
 
-  const incompatibleAgentVersion = useHasIncompatibleAgentVersion(
+  const incompatibleAgentVersion = useIncompatibleAgentVersionStatus(
     packageInfo,
     newlySelectedAgentPolicies
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -24,7 +24,7 @@ import { Error } from '../../../../../components';
 import type { AgentPolicy, PackageInfo } from '../../../../../types';
 import { isPackageLimited, doesAgentPolicyAlreadyIncludePackage } from '../../../../../services';
 import { useFleetStatus, sendBulkGetAgentPolicies } from '../../../../../hooks';
-
+import { useHasIncompatibleAgentVersion } from '../../../../../hooks/use_has_incompatible_agent_version';
 import { useMultipleAgentPolicies } from '../../../../../hooks';
 
 import { AgentPolicyMultiSelect } from './components/agent_policy_multi_select';
@@ -168,6 +168,16 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
     []
   );
 
+  const newlySelectedAgentPolicies = selectedAgentPolicies.filter(
+    (policy) => !initialSelectedAgentPolicyIds.find((id) => policy.id === id)
+  );
+
+  const hasIncompatibleAgentVersion = useHasIncompatibleAgentVersion(
+    packageInfo,
+    newlySelectedAgentPolicies
+  );
+  const someNewAgentPoliciesHaveAllAgentIncompatible = hasIncompatibleAgentVersion === 'ALL';
+
   // Display agent policies list error if there is one
   if (agentPoliciesError) {
     return (
@@ -185,11 +195,9 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
 
   const someNewAgentPoliciesHaveLimitedPackage =
     !packageInfo ||
-    selectedAgentPolicies
-      .filter((policy) => !initialSelectedAgentPolicyIds.find((id) => policy.id === id))
-      .some((selectedAgentPolicy) =>
-        doesAgentPolicyHaveLimitedPackage(selectedAgentPolicy, packageInfo)
-      );
+    newlySelectedAgentPolicies.some((selectedAgentPolicy) =>
+      doesAgentPolicyHaveLimitedPackage(selectedAgentPolicy, packageInfo)
+    );
 
   return (
     <>
@@ -243,12 +251,20 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                   />
                 ) : null
               }
-              isInvalid={Boolean(someNewAgentPoliciesHaveLimitedPackage)}
+              isInvalid={Boolean(
+                someNewAgentPoliciesHaveLimitedPackage ||
+                  someNewAgentPoliciesHaveAllAgentIncompatible
+              )}
               error={
                 someNewAgentPoliciesHaveLimitedPackage ? (
                   <FormattedMessage
                     id="xpack.fleet.createPackagePolicy.StepSelectPolicy.cannotAddLimitedIntegrationError"
                     defaultMessage="This integration can only be added once per agent policy."
+                  />
+                ) : someNewAgentPoliciesHaveAllAgentIncompatible ? (
+                  <FormattedMessage
+                    id="xpack.fleet.createPackagePolicy.StepSelectPolicy.cannotAddIncompatibleAgentVersionError"
+                    defaultMessage="The selected agent policies have all agents in a version non compatible with the integration."
                   />
                 ) : null
               }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -323,7 +323,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     return agentPolicyData.items.reduce((acc, item) => (acc += item.fips_agents || 0), 0);
   }, [agentPolicyData?.items]);
 
-  const hasIncompatibleAgentVersion = useHasIncompatibleAgentVersion(
+  const incompatibleAgentVersion = useHasIncompatibleAgentVersion(
     packageInfo,
     agentPolicyData?.items
   );
@@ -684,8 +684,11 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         </>
       )}
 
-      {hasIncompatibleAgentVersion !== 'NONE' && (
-        <IncompatibleAgentVersionCallout incompatibility={hasIncompatibleAgentVersion} />
+      {incompatibleAgentVersion.status !== 'NONE' && (
+        <IncompatibleAgentVersionCallout
+          incompatibility={incompatibleAgentVersion.status}
+          versionCondition={incompatibleAgentVersion.versionCondition}
+        />
       )}
 
       {showSecretsDisabledCallout && (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -52,7 +52,7 @@ import {
   useAuthz,
   useBulkGetAgentPoliciesQuery,
 } from '../../../../hooks';
-import { useHasIncompatibleAgentVersion } from '../../../../hooks/use_has_incompatible_agent_version';
+import { useIncompatibleAgentVersionStatus } from '../../../../hooks/use_incompatible_agent_version_status';
 import {
   DevtoolsRequestFlyoutButton,
   Error as ErrorComponent,
@@ -323,7 +323,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     return agentPolicyData.items.reduce((acc, item) => (acc += item.fips_agents || 0), 0);
   }, [agentPolicyData?.items]);
 
-  const incompatibleAgentVersion = useHasIncompatibleAgentVersion(
+  const incompatibleAgentVersion = useIncompatibleAgentVersionStatus(
     packageInfo,
     agentPolicyData?.items
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -60,7 +60,11 @@ import {
   Loading,
 } from '../../../../components';
 
-import { agentPolicyFormValidation, ConfirmDeployAgentPolicyModal } from '../../components';
+import {
+  agentPolicyFormValidation,
+  ConfirmDeployAgentPolicyModal,
+  IncompatibleAgentVersionCallout,
+} from '../../components';
 import { pkgKeyFromPackageInfo } from '../../../../services';
 
 import type { CreatePackagePolicyParams } from '../types';
@@ -680,33 +684,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         </>
       )}
 
-      {(hasIncompatibleAgentVersion === 'SOME' || hasIncompatibleAgentVersion === 'ALL') && (
-        <>
-          <EuiCallOut
-            announceOnMount
-            title={
-              <FormattedMessage
-                id="xpack.fleet.createPackagePolicy.StepSelectPolicy.incompatibleAgentVersionTitle"
-                defaultMessage="Incompatible agent version"
-              />
-            }
-            color="warning"
-          >
-            {hasIncompatibleAgentVersion === 'SOME' ? (
-              <FormattedMessage
-                id="xpack.fleet.createPackagePolicy.StepSelectPolicy.someIncompatibleAgentVersionWarning"
-                defaultMessage="The selected agent policies have some agent in a version non compatible with the integration."
-              />
-            ) : (
-              <FormattedMessage
-                id="xpack.fleet.createPackagePolicy.StepSelectPolicy.allIncompatibleAgentVersionWarning"
-                defaultMessage="The selected agent policies have no agents in a version compatible with the integration."
-              />
-            )}
-          </EuiCallOut>
-
-          <EuiSpacer size="m" />
-        </>
+      {hasIncompatibleAgentVersion !== 'NONE' && (
+        <IncompatibleAgentVersionCallout incompatibility={hasIncompatibleAgentVersion} />
       )}
 
       {showSecretsDisabledCallout && (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -52,6 +52,7 @@ import {
   useAuthz,
   useBulkGetAgentPoliciesQuery,
 } from '../../../../hooks';
+import { useHasIncompatibleAgentVersion } from '../../../../hooks/use_has_incompatible_agent_version';
 import {
   DevtoolsRequestFlyoutButton,
   Error as ErrorComponent,
@@ -317,6 +318,11 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
 
     return agentPolicyData.items.reduce((acc, item) => (acc += item.fips_agents || 0), 0);
   }, [agentPolicyData?.items]);
+
+  const hasIncompatibleAgentVersion = useHasIncompatibleAgentVersion(
+    packageInfo,
+    agentPolicyData?.items
+  );
 
   useEffect(() => {
     if (
@@ -673,6 +679,36 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
           <EuiSpacer size="m" />
         </>
       )}
+
+      {(hasIncompatibleAgentVersion === 'SOME' || hasIncompatibleAgentVersion === 'ALL') && (
+        <>
+          <EuiCallOut
+            announceOnMount
+            title={
+              <FormattedMessage
+                id="xpack.fleet.createPackagePolicy.StepSelectPolicy.incompatibleAgentVersionTitle"
+                defaultMessage="Incompatible agent version"
+              />
+            }
+            color="warning"
+          >
+            {hasIncompatibleAgentVersion === 'SOME' ? (
+              <FormattedMessage
+                id="xpack.fleet.createPackagePolicy.StepSelectPolicy.someIncompatibleAgentVersionWarning"
+                defaultMessage="The selected agent policies have some agent in a version non compatible with the integration."
+              />
+            ) : (
+              <FormattedMessage
+                id="xpack.fleet.createPackagePolicy.StepSelectPolicy.allIncompatibleAgentVersionWarning"
+                defaultMessage="The selected agent policies have no agents in a version compatible with the integration."
+              />
+            )}
+          </EuiCallOut>
+
+          <EuiSpacer size="m" />
+        </>
+      )}
+
       {showSecretsDisabledCallout && (
         <>
           <EuiCallOut

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -71,7 +71,7 @@ import { UpgradeStatusCallout } from './components';
 import { usePackagePolicyWithRelatedData, useHistoryBlock } from './hooks';
 import { getNewSecrets } from './utils';
 import { usePackagePolicySteps } from './hooks';
-import { useHasIncompatibleAgentVersion } from '../../../hooks/use_has_incompatible_agent_version';
+import { useIncompatibleAgentVersionStatus } from '../../../hooks/use_incompatible_agent_version_status';
 
 export const EditPackagePolicyPage = memo(() => {
   const {
@@ -218,7 +218,7 @@ export const EditPackagePolicyForm = memo<{
       agentPolicies.find((policy) => policy.id === existingPolicy.id)
     );
   }, [agentPolicies, existingAgentPolicies]);
-  const incompatibleAgentVersion = useHasIncompatibleAgentVersion(
+  const incompatibleAgentVersion = useIncompatibleAgentVersionStatus(
     packageInfo,
     selectedExistingPolicies
   );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -218,12 +218,10 @@ export const EditPackagePolicyForm = memo<{
       agentPolicies.find((policy) => policy.id === existingPolicy.id)
     );
   }, [agentPolicies, existingAgentPolicies]);
-  const hasIncompatibleAgentVersion = useHasIncompatibleAgentVersion(
+  const incompatibleAgentVersion = useHasIncompatibleAgentVersion(
     packageInfo,
     selectedExistingPolicies
   );
-  console.log('TEST', selectedExistingPolicies);
-
   // Retrieve agent count
   const [agentCount, setAgentCount] = useState<number>(0);
   const [impactedAgentCount, setImpactedAgentCount] = useState<number>(0);
@@ -604,9 +602,12 @@ export const EditPackagePolicyForm = memo<{
                 <EuiSpacer size="m" />
               </>
             ) : null}
-            {hasIncompatibleAgentVersion !== 'NONE' && (
+            {incompatibleAgentVersion.status !== 'NONE' && (
               <>
-                <IncompatibleAgentVersionCallout incompatibility={hasIncompatibleAgentVersion} />
+                <IncompatibleAgentVersionCallout
+                  incompatibility={incompatibleAgentVersion.status}
+                  versionCondition={incompatibleAgentVersion.versionCondition}
+                />
                 <EuiSpacer size="m" />
               </>
             )}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -40,7 +40,7 @@ import {
   EuiButtonWithTooltip,
   DevtoolsRequestFlyoutButton,
 } from '../../../components';
-import { ConfirmDeployAgentPolicyModal } from '../components';
+import { ConfirmDeployAgentPolicyModal, IncompatibleAgentVersionCallout } from '../components';
 import { CreatePackagePolicySinglePageLayout } from '../create_package_policy_page/single_page_layout/components';
 import type { EditPackagePolicyFrom } from '../create_package_policy_page/types';
 import {
@@ -71,6 +71,7 @@ import { UpgradeStatusCallout } from './components';
 import { usePackagePolicyWithRelatedData, useHistoryBlock } from './hooks';
 import { getNewSecrets } from './utils';
 import { usePackagePolicySteps } from './hooks';
+import { useHasIncompatibleAgentVersion } from '../../../hooks/use_has_incompatible_agent_version';
 
 export const EditPackagePolicyPage = memo(() => {
   const {
@@ -211,6 +212,17 @@ export const EditPackagePolicyForm = memo<{
     () => agentPoliciesToRemove.map((policy) => policy.name),
     [agentPoliciesToRemove]
   );
+
+  const selectedExistingPolicies = useMemo(() => {
+    return existingAgentPolicies.filter((existingPolicy) =>
+      agentPolicies.find((policy) => policy.id === existingPolicy.id)
+    );
+  }, [agentPolicies, existingAgentPolicies]);
+  const hasIncompatibleAgentVersion = useHasIncompatibleAgentVersion(
+    packageInfo,
+    selectedExistingPolicies
+  );
+  console.log('TEST', selectedExistingPolicies);
 
   // Retrieve agent count
   const [agentCount, setAgentCount] = useState<number>(0);
@@ -592,6 +604,12 @@ export const EditPackagePolicyForm = memo<{
                 <EuiSpacer size="m" />
               </>
             ) : null}
+            {hasIncompatibleAgentVersion !== 'NONE' && (
+              <>
+                <IncompatibleAgentVersionCallout incompatibility={hasIncompatibleAgentVersion} />
+                <EuiSpacer size="m" />
+              </>
+            )}
             {isUpgrade && upgradeDryRunData && (
               <>
                 <UpgradeStatusCallout dryRunData={upgradeDryRunData} newSecrets={newSecrets} />

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -124,7 +124,32 @@ export async function populateAssignedAgentsCount(
           kuery: `${policyKuery} and ${FIPS_AGENT_KUERY}`,
         })
         .then(({ total }) => (agentPolicy.fips_agents = total));
-      return Promise.all([totalAgents, unprivilegedAgents, fipsAgents]);
+
+      const perVersionAgents = agentClient
+        .listAgents({
+          showInactive: true,
+          perPage: 0,
+          page: 1,
+          aggregations: {
+            versions: {
+              terms: {
+                field: 'agent.version',
+                size: 1000,
+              },
+            },
+          },
+          kuery: policyKuery,
+        })
+        .then(({ aggregations }) => {
+          const versions = (aggregations?.versions as any)?.buckets ?? [];
+          agentPolicy.agents_per_version = versions.map(
+            (version: { key: string; doc_count: number }) => ({
+              version: version.key,
+              count: version.doc_count,
+            })
+          );
+        });
+      return Promise.all([totalAgents, unprivilegedAgents, fipsAgents, perVersionAgents]);
     },
     { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_10 }
   );

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
@@ -328,6 +328,15 @@ export const AgentPolicyResponseSchema = AgentPolicySchema.extends({
   agents: schema.maybe(schema.number()),
   unprivileged_agents: schema.maybe(schema.number()),
   fips_agents: schema.maybe(schema.number()),
+  agents_per_version: schema.maybe(
+    schema.arrayOf(
+      schema.object({
+        version: schema.string(),
+        count: schema.number(),
+      }),
+      { maxSize: 1000 }
+    )
+  ),
   is_protected: schema.boolean({
     meta: {
       description:

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
@@ -45,6 +45,7 @@ Object {
 exports[`Agent policies fleet_agent_policies POST /api/fleet/agent_policies/_bulk_get should populate package_policies if called with ?full=true 1`] = `
 Object {
   "agents": 0,
+  "agents_per_version": Array [],
   "fips_agents": 0,
   "inactivity_timeout": 1209600,
   "is_managed": false,
@@ -81,6 +82,7 @@ Object {
 exports[`Agent policies fleet_agent_policies POST /api/fleet/agent_policies/_bulk_get should populate package_policies if called with ?full=true 1`] = `
 Object {
   "agents": 0,
+  "agents_per_version": Array [],
   "fips_agents": 0,
   "inactivity_timeout": 1209600,
   "is_managed": false,

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
@@ -3,6 +3,7 @@
 exports[`Agent policies fleet_agent_policies GET /api/fleet/agent_policies should get a list of agent policies by kuery 1`] = `
 Object {
   "agents": 0,
+  "agents_per_version": Array [],
   "fips_agents": 0,
   "inactivity_timeout": 1209600,
   "is_managed": false,
@@ -23,6 +24,7 @@ Object {
 exports[`Agent policies fleet_agent_policies GET /api/fleet/agent_policies should get a list of agent policies by kuery 1`] = `
 Object {
   "agents": 0,
+  "agents_per_version": Array [],
   "fips_agents": 0,
   "inactivity_timeout": 1209600,
   "is_managed": false,

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -2540,5 +2540,77 @@ export default function (providerContext: FtrProviderContext) {
           .expect(404);
       });
     });
+
+    describe('GET /api/fleet/agent_policies agents_per_version', () => {
+      let policyId: string;
+      const agentId1 = `agent-per-version-1-${Date.now()}`;
+      const agentId2 = `agent-per-version-2-${Date.now()}`;
+      const agentId3 = `agent-per-version-3-${Date.now()}`;
+
+      before(async () => {
+        await esArchiver.load('x-pack/platform/test/fixtures/es_archives/fleet/empty_fleet_server');
+        await kibanaServer.savedObjects.cleanStandardList();
+        await fleetAndAgents.setup();
+
+        const { body: agentPolicyResponse } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Test agents_per_version policy',
+            namespace: 'default',
+            force: true,
+          })
+          .expect(200);
+        policyId = agentPolicyResponse.item.id;
+
+        await fleetAndAgents.generateAgent('online', agentId1, policyId, '8.15.0');
+        await fleetAndAgents.generateAgent('online', agentId2, policyId, '8.16.0');
+        await fleetAndAgents.generateAgent('online', agentId3, policyId, '8.16.0');
+      });
+
+      after(async () => {
+        for (const agentId of [agentId1, agentId2, agentId3]) {
+          await es.delete({ index: '.fleet-agents', id: agentId, refresh: true });
+        }
+        await supertest
+          .post(`/api/fleet/agent_policies/delete`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({ agentPolicyId: policyId })
+          .expect(200);
+      });
+
+      it('should return agents_per_version when getting a single agent policy', async () => {
+        const { body } = await supertest.get(`/api/fleet/agent_policies/${policyId}`).expect(200);
+
+        const agentsPerVersion = body.item.agents_per_version;
+        expect(agentsPerVersion).to.be.an('array');
+        expect(agentsPerVersion.length).to.eql(2);
+
+        const sorted = [...agentsPerVersion].sort((a: any, b: any) =>
+          a.version.localeCompare(b.version)
+        );
+        expect(sorted[0]).to.eql({ version: '8.15.0', count: 1 });
+        expect(sorted[1]).to.eql({ version: '8.16.0', count: 2 });
+      });
+
+      it('should return agents_per_version when listing agent policies with withAgentCount', async () => {
+        const { body } = await supertest
+          .get(`/api/fleet/agent_policies?withAgentCount=true&perPage=100`)
+          .expect(200);
+
+        const policy = body.items.find((p: { id: string }) => p.id === policyId);
+        expect(policy).to.be.ok();
+
+        const agentsPerVersion = policy.agents_per_version;
+        expect(agentsPerVersion).to.be.an('array');
+        expect(agentsPerVersion.length).to.eql(2);
+
+        const sorted = [...agentsPerVersion].sort((a: any, b: any) =>
+          a.version.localeCompare(b.version)
+        );
+        expect(sorted[0]).to.eql({ version: '8.15.0', count: 1 });
+        expect(sorted[1]).to.eql({ version: '8.16.0', count: 2 });
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/ingest-dev/issues/6587 

Show incompatible message when a agent policy contains agent in incompatible versions 

@elastic/ingest-docs I would love to have your thoughts/suggestions on the new callouts messages.

## API changes

Agent policy apis return the count of agent per version

## UI Changes

#### On creation|edit when adding to a policy with all incompatible agents

<img width="600" height="314" alt="Screenshot 2026-02-18 at 1 48 30 PM" src="https://github.com/user-attachments/assets/cb22d072-fea1-41fc-b8e7-aa112d1c0d0f" />

####  On creation|edit when adding to a policy with some incompatible agents (similar to what is done for FIPS incompatible integration)

<img width="600" height="391" alt="Screenshot 2026-02-18 at 1 48 39 PM" src="https://github.com/user-attachments/assets/415b0a85-d49d-471c-b066-b29486d5a223" />

####  On upgrade

<img width="900" height="628" alt="Screenshot 2026-02-18 at 1 47 48 PM" src="https://github.com/user-attachments/assets/0abcaf80-4d80-4ea6-b9aa-22c093b7297c" />


## Test 

This can be tested with the following auth0 package 
[auth0-1.27.0.zip](https://github.com/user-attachments/files/25398378/auth0-1.27.0.zip)



