### PR TITLE
[ResponseOps][Reporting] Re generate api key when updating scheduled reports run schedule

### DIFF
--- a/x-pack/platform/plugins/private/reporting/server/services/scheduled_reports/scheduled_reports_service.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/services/scheduled_reports/scheduled_reports_service.test.ts
@@ -2379,7 +2379,7 @@ describe('ScheduledReportsService', () => {
       expect(taskManager.bulkUpdateSchedules).toHaveBeenCalledWith(
         [savedObjects[0].id],
         mockSchedule,
-        { request: fakeRawRequest }
+        { request: fakeRawRequest, regenerateApiKey: true }
       );
 
       expect(auditLogger.log).toHaveBeenCalledTimes(1);
@@ -2466,7 +2466,7 @@ describe('ScheduledReportsService', () => {
       expect(taskManager.bulkUpdateSchedules).toHaveBeenCalledWith(
         [savedObjects[0].id],
         mockSchedule,
-        { request: fakeRawRequest }
+        { request: fakeRawRequest, regenerateApiKey: true }
       );
 
       expect(auditLogger.log).toHaveBeenCalledTimes(1);

--- a/x-pack/platform/plugins/private/reporting/server/services/scheduled_reports/scheduled_reports_service.ts
+++ b/x-pack/platform/plugins/private/reporting/server/services/scheduled_reports/scheduled_reports_service.ts
@@ -493,7 +493,10 @@ export class ScheduledReportsService {
     schedule,
   }: { id: string } & UpdateScheduledReportParams) {
     if (schedule) {
-      await this.taskManager.bulkUpdateSchedules([id], schedule, { request: this.request });
+      await this.taskManager.bulkUpdateSchedules([id], schedule, {
+        request: this.request,
+        regenerateApiKey: true,
+      });
     }
   }
 


### PR DESCRIPTION
Closes #245086

## Summary

As a follow-up to the changes in #249109 I am updating the call to bulkUpdateSchedules to regenerate the API key.

I used https://github.com/elastic/kibana/issues/244918 as a reference where the description says:

> If a task with an API key is updated with a request, we **should** invalidate the old API key and create a new API key using the new request.

## Testing

1. Create a scheduled report which should run soon
2. Verify that created scheduled report ran successfully in the Reporting > Exports tab
3. Update the report to run soon again via Reporting > Schedules or via API
4. Confirm that the edited scheduled report ran successfully

