### PR TITLE
[9.2] [Vega] Fix `data[].url.body.runtime_mappings` param (#253560)

### DIFF
--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
@@ -25,18 +25,17 @@ export const extendSearchParamsWithRuntimeFields = async (
   indexPatternString?: string
 ) => {
   if (indexPatternString) {
-    let runtimeMappings = requestParams.runtime_mappings;
-
-    if (!runtimeMappings) {
-      const indexPattern = (await indexPatterns.find(indexPatternString, 1)).find(
-        (index) => index.title === indexPatternString
-      );
-      runtimeMappings = indexPattern?.getRuntimeMappings();
+    if (requestParams.runtime_mappings) {
+      return requestParams;
     }
+
+    const indexPattern = (await indexPatterns.find(indexPatternString, 1)).find(
+      (index) => index.title === indexPatternString
+    );
 
     return {
       ...requestParams,
-      runtime_mappings: runtimeMappings,
+      runtime_mappings: indexPattern?.getRuntimeMappings(),
     };
   }
 
@@ -64,11 +63,17 @@ export class SearchAPI {
 
     return combineLatest(
       searchRequests.map((request) => {
-        const { name: requestId, ...restRequest } = request;
+        const { name: requestId, body, ...restRequest } = request;
 
-        const requestParams = getSearchParamsFromRequest(restRequest, {
-          getConfig: this.dependencies.uiSettings.get.bind(this.dependencies.uiSettings),
-        });
+        const requestParams = getSearchParamsFromRequest(
+          {
+            ...body,
+            ...restRequest,
+          },
+          {
+            getConfig: this.dependencies.uiSettings.get.bind(this.dependencies.uiSettings),
+          }
+        );
 
         return from(
           extendSearchParamsWithRuntimeFields(indexPatterns, requestParams, `${request.index}`)

--- a/src/platform/plugins/shared/data/common/search/search_source/fetch/get_search_params.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/fetch/get_search_params.ts
@@ -35,7 +35,7 @@ export function getSearchParamsFromRequest(
   const searchParams = { preference: getEsPreference(getConfig) };
   const dataView = typeof searchRequest.index !== 'string' ? searchRequest.index : undefined;
   const index = dataView?.title ?? `${searchRequest.index}`;
-  const trackTotalHits = searchRequest.track_total_hits ?? searchRequest.body.track_total_hits;
+  const trackTotalHits = searchRequest.track_total_hits ?? searchRequest.body?.track_total_hits;
 
   // @ts-expect-error elasticsearch@9.0.0 `query` types don't match (it seems like it's been wrong here for a while)
   return {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Vega] Fix `data[].url.body.runtime_mappings` param (#253560)](https://github.com/elastic/kibana/pull/253560)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2026-02-18T08:14:54Z","message":"[Vega] Fix `data[].url.body.runtime_mappings` param (#253560)\n\n## Summary\n\nFixes a breaking change caused by upgrading the elasticsearch js client\nto `9.x` where we started to ignore the\n`data[].url.body.runtime_mappings` in favor of\n`data[].url.runtime_mappings`.\n\nFixes #253545\n\n## Details\n\nIn #208776 when upgrading to the `9.x` ES client, we changed the code to\npoint at the request `params` instead of `params.body`. Specifically\n[here](https://github.com/elastic/kibana/pull/208776/changes#diff-fca94e46395fddbb9ba787d8d4eadd9bb236856081a09e02fdc7a8b4217a2be5R31).\n\n```diff\n// src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts\n-    let runtimeMappings = requestParams.body.runtime_mappings;\n+    let runtimeMappings = requestParams.runtime_mappings;\n```\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Notes\n\nFixes a bug where `runtime_mappings` where ignored or overridden in a\nVega spec when defined in `data[].url.body`. Note, the `data[].url.body`\nproperty was deprecated in `kibana@v8.0` and properties moved to\n`data[].url`.\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"6234793cfc55be88686e28d015a76300b579c29a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","v9.4.0"],"title":"[Vega] Fix `data[].url.body.runtime_mappings` param","number":253560,"url":"https://github.com/elastic/kibana/pull/253560","mergeCommit":{"message":"[Vega] Fix `data[].url.body.runtime_mappings` param (#253560)\n\n## Summary\n\nFixes a breaking change caused by upgrading the elasticsearch js client\nto `9.x` where we started to ignore the\n`data[].url.body.runtime_mappings` in favor of\n`data[].url.runtime_mappings`.\n\nFixes #253545\n\n## Details\n\nIn #208776 when upgrading to the `9.x` ES client, we changed the code to\npoint at the request `params` instead of `params.body`. Specifically\n[here](https://github.com/elastic/kibana/pull/208776/changes#diff-fca94e46395fddbb9ba787d8d4eadd9bb236856081a09e02fdc7a8b4217a2be5R31).\n\n```diff\n// src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts\n-    let runtimeMappings = requestParams.body.runtime_mappings;\n+    let runtimeMappings = requestParams.runtime_mappings;\n```\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Notes\n\nFixes a bug where `runtime_mappings` where ignored or overridden in a\nVega spec when defined in `data[].url.body`. Note, the `data[].url.body`\nproperty was deprecated in `kibana@v8.0` and properties moved to\n`data[].url`.\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"6234793cfc55be88686e28d015a76300b579c29a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253560","number":253560,"mergeCommit":{"message":"[Vega] Fix `data[].url.body.runtime_mappings` param (#253560)\n\n## Summary\n\nFixes a breaking change caused by upgrading the elasticsearch js client\nto `9.x` where we started to ignore the\n`data[].url.body.runtime_mappings` in favor of\n`data[].url.runtime_mappings`.\n\nFixes #253545\n\n## Details\n\nIn #208776 when upgrading to the `9.x` ES client, we changed the code to\npoint at the request `params` instead of `params.body`. Specifically\n[here](https://github.com/elastic/kibana/pull/208776/changes#diff-fca94e46395fddbb9ba787d8d4eadd9bb236856081a09e02fdc7a8b4217a2be5R31).\n\n```diff\n// src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts\n-    let runtimeMappings = requestParams.body.runtime_mappings;\n+    let runtimeMappings = requestParams.runtime_mappings;\n```\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Notes\n\nFixes a bug where `runtime_mappings` where ignored or overridden in a\nVega spec when defined in `data[].url.body`. Note, the `data[].url.body`\nproperty was deprecated in `kibana@v8.0` and properties moved to\n`data[].url`.\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"6234793cfc55be88686e28d015a76300b579c29a"}}]}] BACKPORT-->