### PR TITLE
[9.2] Disable lmdb/ci-stats in Codex sandbox (#250652)

### DIFF
--- a/src/platform/packages/private/kbn-ci-stats-reporter/src/ci_stats_reporter.ts
+++ b/src/platform/packages/private/kbn-ci-stats-reporter/src/ci_stats_reporter.ts
@@ -133,6 +133,11 @@ export class CiStatsReporter {
    * for builds use #hasBuildConfig().
    */
   isEnabled() {
+    if (process.env.CODEX_SANDBOX) {
+      // Codex sandbox blocks outbound network access, so disable ci-stats there.
+      return false;
+    }
+
     return process.env.CI_STATS_DISABLED !== 'true';
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Disable lmdb/ci-stats in Codex sandbox (#250652)](https://github.com/elastic/kibana/pull/250652)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-01-28T03:23:39Z","message":"Disable lmdb/ci-stats in Codex sandbox (#250652)\n\nLMDB cache and ci-stats reporting don't work in the Codex sandbox, so\nguard both with CODEX_SANDBOX.","sha":"62017728cb8ac7b35b0f29b2a20a739eb04bfd78","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0"],"title":"Disable lmdb/ci-stats in Codex sandbox","number":250652,"url":"https://github.com/elastic/kibana/pull/250652","mergeCommit":{"message":"Disable lmdb/ci-stats in Codex sandbox (#250652)\n\nLMDB cache and ci-stats reporting don't work in the Codex sandbox, so\nguard both with CODEX_SANDBOX.","sha":"62017728cb8ac7b35b0f29b2a20a739eb04bfd78"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250652","number":250652,"mergeCommit":{"message":"Disable lmdb/ci-stats in Codex sandbox (#250652)\n\nLMDB cache and ci-stats reporting don't work in the Codex sandbox, so\nguard both with CODEX_SANDBOX.","sha":"62017728cb8ac7b35b0f29b2a20a739eb04bfd78"}}]}] BACKPORT-->