### PR TITLE
[8.19] Disable lmdb/ci-stats in Codex sandbox (#250652)

### DIFF
--- a/src/platform/packages/private/kbn-ci-stats-reporter/src/ci_stats_reporter.ts
+++ b/src/platform/packages/private/kbn-ci-stats-reporter/src/ci_stats_reporter.ts
@@ -131,6 +131,11 @@ export class CiStatsReporter {
    * for builds use #hasBuildConfig().
    */
   isEnabled() {
+    if (process.env.CODEX_SANDBOX) {
+      // Codex sandbox blocks outbound network access, so disable ci-stats there.
+      return false;
+    }
+
     return process.env.CI_STATS_DISABLED !== 'true';
   }
 

--- a/src/platform/packages/shared/kbn-babel-register/cache/index.js
+++ b/src/platform/packages/shared/kbn-babel-register/cache/index.js
@@ -37,13 +37,38 @@ function determineCachePrefix() {
   return Crypto.createHash('sha256').update(json).digest('hex').slice(0, 10);
 }
 
+/** @type {boolean} */
+let lmdbDisabledLogged = false;
+/** @type {string | undefined} */
+let lmdbDisabledReason;
+
 function lmdbAvailable() {
   try {
+    if (process.env.CODEX_SANDBOX) {
+      // Codex sandbox disallows LMDB-backed caches, so skip them entirely here.
+      lmdbDisabledReason = 'CODEX_SANDBOX is set';
+      return false;
+    }
+
     require('lmdb');
     return true;
-  } catch (error) {
+  } catch {
+    lmdbDisabledReason = 'LMDB module unavailable';
     return false;
   }
+}
+
+/**
+ * @param {string | undefined} reason
+ */
+function logLmdbDisabledOnce(reason) {
+  if (lmdbDisabledLogged) {
+    return;
+  }
+
+  lmdbDisabledLogged = true;
+  const detail = reason ? ` (${reason})` : '';
+  console.warn(`LMDB cache disabled for @kbn/babel-register${detail}`);
 }
 
 /**
@@ -69,7 +94,7 @@ function getCache() {
   }
 
   log?.end('lmdb is unavailable, disabling cache\n');
-  console.error('unable to load LMDB in this env, disabling babel/register cache');
+  logLmdbDisabledOnce(lmdbDisabledReason);
   return new (require('./no_cache_cache').NoCacheCache)();
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Disable lmdb/ci-stats in Codex sandbox (#250652)](https://github.com/elastic/kibana/pull/250652)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-01-28T03:23:39Z","message":"Disable lmdb/ci-stats in Codex sandbox (#250652)\n\nLMDB cache and ci-stats reporting don't work in the Codex sandbox, so\nguard both with CODEX_SANDBOX.","sha":"62017728cb8ac7b35b0f29b2a20a739eb04bfd78","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0"],"title":"Disable lmdb/ci-stats in Codex sandbox","number":250652,"url":"https://github.com/elastic/kibana/pull/250652","mergeCommit":{"message":"Disable lmdb/ci-stats in Codex sandbox (#250652)\n\nLMDB cache and ci-stats reporting don't work in the Codex sandbox, so\nguard both with CODEX_SANDBOX.","sha":"62017728cb8ac7b35b0f29b2a20a739eb04bfd78"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250652","number":250652,"mergeCommit":{"message":"Disable lmdb/ci-stats in Codex sandbox (#250652)\n\nLMDB cache and ci-stats reporting don't work in the Codex sandbox, so\nguard both with CODEX_SANDBOX.","sha":"62017728cb8ac7b35b0f29b2a20a739eb04bfd78"}}]}] BACKPORT-->