### PR TITLE
[9.2] ci: Fix chromium path file test resolving to wrong directory (#252207)

### DIFF
--- a/.buildkite/scripts/pipelines/chromium_linux_build/issue_feedback/transform_path_file.test.ts
+++ b/.buildkite/scripts/pipelines/chromium_linux_build/issue_feedback/transform_path_file.test.ts
@@ -16,7 +16,7 @@ import pathFileTransform from './transform_path_file';
 
 // read contents of the path file our transform is built to update
 const pathFileContents = readFileSync(
-  resolve(process.cwd(), '../src/platform/packages/private/kbn-screenshotting-server/src/paths.ts'),
+  resolve(process.cwd(), 'src/platform/packages/private/kbn-screenshotting-server/src/paths.ts'),
   'utf8'
 );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [ci: Fix chromium path file test resolving to wrong directory (#252207)](https://github.com/elastic/kibana/pull/252207)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-02-10T00:10:44Z","message":"ci: Fix chromium path file test resolving to wrong directory (#252207)\n\nThe test reads kbn-screenshotting-server/src/paths.ts using a path\nrelative to process.cwd(). The '../' prefix assumed cwd would be\n.buildkite/, but jest runs from the repo root, so the path resolved one\nlevel above the repo. Remove the unnecessary '../' prefix.","sha":"5205d483321207ee101d50ff70d1db4847ce6c86","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0"],"title":"ci: Fix chromium path file test resolving to wrong directory","number":252207,"url":"https://github.com/elastic/kibana/pull/252207","mergeCommit":{"message":"ci: Fix chromium path file test resolving to wrong directory (#252207)\n\nThe test reads kbn-screenshotting-server/src/paths.ts using a path\nrelative to process.cwd(). The '../' prefix assumed cwd would be\n.buildkite/, but jest runs from the repo root, so the path resolved one\nlevel above the repo. Remove the unnecessary '../' prefix.","sha":"5205d483321207ee101d50ff70d1db4847ce6c86"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252207","number":252207,"mergeCommit":{"message":"ci: Fix chromium path file test resolving to wrong directory (#252207)\n\nThe test reads kbn-screenshotting-server/src/paths.ts using a path\nrelative to process.cwd(). The '../' prefix assumed cwd would be\n.buildkite/, but jest runs from the repo root, so the path resolved one\nlevel above the repo. Remove the unnecessary '../' prefix.","sha":"5205d483321207ee101d50ff70d1db4847ce6c86"}}]}] BACKPORT-->