### PR TITLE
[Entity Store v2] Add helpers required for ID based risk scoring

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.test.ts
@@ -5,48 +5,25 @@
  * 2.0.
  */
 
-import type { EntityType } from '../definitions/entity_schema';
+import { EntityType } from '../definitions/entity_schema';
 import { getIdentitySourceFields } from './identity_fields';
 
 describe('getIdentitySourceFields', () => {
-  it('returns requiresOneOf and identitySourceFields for host', () => {
-    const result = getIdentitySourceFields('host' as EntityType);
-    expect(result.requiresOneOf).toEqual([
-      'host.entity.id',
-      'host.id',
-      'host.name',
-      'host.hostname',
-    ]);
-    expect(result.identitySourceFields).toEqual([
-      'host.entity.id',
-      'host.id',
-      'host.name',
-      'host.domain',
-      'host.hostname',
-    ]);
-  });
+  it('returns expected host identity invariants deduplicated', () => {
+    const result = getIdentitySourceFields(EntityType.Values.host);
 
-  it('returns requiresOneOf and identitySourceFields for user', () => {
-    const result = getIdentitySourceFields('user' as EntityType);
-    expect(result.requiresOneOf).toContain('user.entity.id');
-    expect(result.requiresOneOf).toContain('user.name');
-    expect(result.identitySourceFields).toContain('user.name');
-    expect(result.identitySourceFields).toContain('user.email');
-    expect(result.identitySourceFields).toContain('host.entity.id');
-  });
-
-  it('returns requiresOneOf and identitySourceFields for service', () => {
-    const result = getIdentitySourceFields('service' as EntityType);
-    expect(result.requiresOneOf).toEqual(['service.entity.id', 'service.name']);
-    expect(result.identitySourceFields).toEqual(['service.entity.id', 'service.name']);
-  });
-
-  it('deduplicates identity source fields in definition order', () => {
-    const result = getIdentitySourceFields('host' as EntityType);
-    const seen = new Set<string>();
-    for (const f of result.identitySourceFields) {
-      expect(seen.has(f)).toBe(false);
-      seen.add(f);
-    }
+    expect(result.requiresOneOf).toEqual(
+      expect.arrayContaining(['host.entity.id', 'host.id', 'host.name', 'host.hostname'])
+    );
+    expect(result.identitySourceFields).toHaveLength(new Set(result.identitySourceFields).size);
+    expect(result.identitySourceFields).toEqual(
+      expect.arrayContaining([
+        'host.entity.id',
+        'host.id',
+        'host.name',
+        'host.domain',
+        'host.hostname',
+      ])
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityType } from '../definitions/entity_schema';
+import { getIdentitySourceFields } from './identity_fields';
+
+describe('getIdentitySourceFields', () => {
+  it('returns requiresOneOf and identitySourceFields for host', () => {
+    const result = getIdentitySourceFields('host' as EntityType);
+    expect(result.requiresOneOf).toEqual([
+      'host.entity.id',
+      'host.id',
+      'host.name',
+      'host.hostname',
+    ]);
+    expect(result.identitySourceFields).toEqual([
+      'host.entity.id',
+      'host.id',
+      'host.name',
+      'host.domain',
+      'host.hostname',
+    ]);
+  });
+
+  it('returns requiresOneOf and identitySourceFields for user', () => {
+    const result = getIdentitySourceFields('user' as EntityType);
+    expect(result.requiresOneOf).toContain('user.entity.id');
+    expect(result.requiresOneOf).toContain('user.name');
+    expect(result.identitySourceFields).toContain('user.name');
+    expect(result.identitySourceFields).toContain('user.email');
+    expect(result.identitySourceFields).toContain('host.entity.id');
+  });
+
+  it('returns requiresOneOf and identitySourceFields for service', () => {
+    const result = getIdentitySourceFields('service' as EntityType);
+    expect(result.requiresOneOf).toEqual(['service.entity.id', 'service.name']);
+    expect(result.identitySourceFields).toEqual(['service.entity.id', 'service.name']);
+  });
+
+  it('deduplicates identity source fields in definition order', () => {
+    const result = getIdentitySourceFields('host' as EntityType);
+    const seen = new Set<string>();
+    for (const f of result.identitySourceFields) {
+      expect(seen.has(f)).toBe(false);
+      seen.add(f);
+    }
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.test.ts
@@ -6,11 +6,11 @@
  */
 
 import { EntityType } from '../definitions/entity_schema';
-import { getIdentitySourceFields } from './identity_fields';
+import { getEuidSourceFields } from './identity_fields';
 
-describe('getIdentitySourceFields', () => {
+describe('getEuidSourceFields', () => {
   it('returns expected host identity invariants deduplicated', () => {
-    const result = getIdentitySourceFields(EntityType.Values.host);
+    const result = getEuidSourceFields(EntityType.Values.host);
 
     expect(result.requiresOneOf).toEqual(
       expect.arrayContaining(['host.entity.id', 'host.id', 'host.name', 'host.hostname'])

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityType } from '../definitions/entity_schema';
+import { getEntityDefinitionWithoutId } from '../definitions/registry';
+import { isEuidField } from './commons';
+
+export interface IdentitySourceFields {
+  /** Fields of which at least one must be present for identity to be valid. */
+  requiresOneOf: string[];
+  /** All field names used in EUID composition, deduplicated in definition order. */
+  identitySourceFields: string[];
+}
+
+/**
+ * Returns the identity source field names for a given entity type.
+ * Used when projecting or persisting identity data (e.g. risk-score ESQL or entity store updates).
+ *
+ * @param entityType - The entity type (e.g. 'host', 'user', 'service')
+ * @returns requiresOneOf and deduplicated identitySourceFields from the entity definition
+ */
+export function getIdentitySourceFields(entityType: EntityType): IdentitySourceFields {
+  const { identityField } = getEntityDefinitionWithoutId(entityType);
+  const seen = new Set<string>();
+  const identitySourceFields: string[] = [];
+  for (const composedField of identityField.euidFields) {
+    for (const attr of composedField) {
+      if (isEuidField(attr) && !seen.has(attr.field)) {
+        seen.add(attr.field);
+        identitySourceFields.push(attr.field);
+      }
+    }
+  }
+  return {
+    requiresOneOf: [...identityField.requiresOneOfFields],
+    identitySourceFields,
+  };
+}

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.ts
@@ -27,7 +27,7 @@ export interface IdentitySourceFields {
  * @param entityType - The entity type (e.g. 'host', 'user', 'service')
  * @returns requiresOneOf and identitySourceFields from the entity definition
  */
-export function getIdentitySourceFields(entityType: EntityType): IdentitySourceFields {
+export function getEuidSourceFields(entityType: EntityType): IdentitySourceFields {
   const {
     identityField: { requiresOneOfFields, euidFields },
   } = getEntityDefinitionWithoutId(entityType);

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/identity_fields.ts
@@ -7,6 +7,7 @@
 
 import type { EntityType } from '../definitions/entity_schema';
 import { getEntityDefinitionWithoutId } from '../definitions/registry';
+import { isEuidField } from './commons';
 
 export interface IdentitySourceFields {
   /** At least one must be present for identity to be valid.
@@ -33,7 +34,11 @@ export function getIdentitySourceFields(entityType: EntityType): IdentitySourceF
   return {
     requiresOneOf: requiresOneOfFields,
     identitySourceFields: Array.from(
-      new Set(euidFields.flatMap((composedField) => composedField.map((attr) => attr.field)))
+      new Set(
+        euidFields.flatMap((composedField) =>
+          composedField.filter(isEuidField).map((attr) => attr.field)
+        )
+      )
     ),
   };
 }

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
@@ -13,4 +13,4 @@ export {
   getEuidEsqlEvaluation,
   getEuidEsqlFilterBasedOnDocument,
 } from './esql';
-export { getIdentitySourceFields, type IdentitySourceFields } from './identity_fields';
+export { getEuidSourceFields, type IdentitySourceFields } from './identity_fields';

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
@@ -6,10 +6,11 @@
  */
 
 export { getEuidFromObject } from './memory';
-export { getEuidPainlessEvaluation } from './painless';
+export { getEuidPainlessEvaluation, getEuidPainlessRuntimeMapping } from './painless';
 export { getEuidDslFilterBasedOnDocument } from './dsl';
 export {
   getEuidEsqlDocumentsContainsIdFilter,
   getEuidEsqlEvaluation,
   getEuidEsqlFilterBasedOnDocument,
 } from './esql';
+export { getIdentitySourceFields, type IdentitySourceFields } from './identity_fields';

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/painless.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/painless.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { EntityType } from '../definitions/entity_schema';
-import { getEuidPainlessEvaluation } from './painless';
+import { getEuidPainlessEvaluation, getEuidPainlessRuntimeMapping } from './painless';
 
 describe('getEuidPainlessEvaluation', () => {
   describe('snapshots per entity type', () => {
@@ -15,6 +15,20 @@ describe('getEuidPainlessEvaluation', () => {
         const script = getEuidPainlessEvaluation(entityType);
         expect(script).toMatchSnapshot();
       });
+    });
+  });
+});
+
+describe('getEuidPainlessRuntimeMapping', () => {
+  Object.values(EntityType.Values).forEach((entityType) => {
+    it(`returns a keyword runtime mapping that wraps getEuidPainlessEvaluation for ${entityType}`, () => {
+      const returnScript = getEuidPainlessEvaluation(entityType);
+      const mapping = getEuidPainlessRuntimeMapping(entityType);
+
+      expect(mapping.type).toBe('keyword');
+      expect(mapping.script).toBeDefined();
+      expect(mapping.script.source).toContain('emit(result)');
+      expect(mapping.script.source).toContain(returnScript);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -30,7 +30,7 @@ export const euid = {
   getEuidEsqlDocumentsContainsIdFilter: euidModule.getEuidEsqlDocumentsContainsIdFilter,
   getEuidEsqlEvaluation: euidModule.getEuidEsqlEvaluation,
   getEuidEsqlFilterBasedOnDocument: euidModule.getEuidEsqlFilterBasedOnDocument,
-  getIdentitySourceFields: euidModule.getIdentitySourceFields,
+  getEuidSourceFields: euidModule.getEuidSourceFields,
 };
 
 export type { EntityType } from './domain/definitions/entity_schema';

--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -25,13 +25,16 @@ export const FF_ENABLE_ENTITY_STORE_V2 = 'securitySolution:entityStoreEnableV2';
 export const euid = {
   getEuidFromObject: euidModule.getEuidFromObject,
   getEuidPainlessEvaluation: euidModule.getEuidPainlessEvaluation,
+  getEuidPainlessRuntimeMapping: euidModule.getEuidPainlessRuntimeMapping,
   getEuidDslFilterBasedOnDocument: euidModule.getEuidDslFilterBasedOnDocument,
   getEuidEsqlDocumentsContainsIdFilter: euidModule.getEuidEsqlDocumentsContainsIdFilter,
   getEuidEsqlEvaluation: euidModule.getEuidEsqlEvaluation,
   getEuidEsqlFilterBasedOnDocument: euidModule.getEuidEsqlFilterBasedOnDocument,
+  getIdentitySourceFields: euidModule.getIdentitySourceFields,
 };
 
 export type { EntityType } from './domain/definitions/entity_schema';
+export type { IdentitySourceFields } from './domain/euid';
 
 export type EntityStoreStatus = z.infer<typeof EntityStoreStatus>;
 export const EntityStoreStatus = z.enum([


### PR DESCRIPTION
## Summary

These are the utils I added as part of developing ID based risk scoring (the PR for that is not ready yet).

- Added `getEuidPainlessRuntimeMapping(entityType)` for a ready-to-use runtime_mappings field
- Added `getEuidSourceFields(entityType)` to expose:
    - `requiresOneOf` - minimum EUID field requirements to allow filtering down docs to just those with the right ID fields
    - deduped `identitySourceFields` used to build EUIDs - allows maintainers to bring back the ID fields needed to upsert an entity

- Updated unit tests & the Scout API painless translation test to use the new runtime mapping helper directly
