### PR TITLE
feat(NA): add support for p75 durations on pick test group bin packing from ci-stats

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/client.ts
+++ b/.buildkite/pipeline-utils/ci-stats/client.ts
@@ -164,6 +164,7 @@ export class CiStatsClient {
           jobName: string;
         }
     >;
+    durationPercentile?: number;
     groups: Array<{
       type: string;
       queue?: string;

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -222,6 +222,7 @@ export async function pickTestGroupRunOrder() {
   const prNumber = process.env.GITHUB_PR_NUMBER as string | undefined;
 
   const { sources, types } = await ciStats.pickTestGroupRunOrder({
+    durationPercentile: 75,
     sources: [
       // try to get times from a recent successful job on this PR
       ...(prNumber


### PR DESCRIPTION
Depends on https://github.com/elastic/kibana-ci-stats/pull/1009

This PR adds durationPercentile: 75 to the ci stats pickTestGroupRunOrder request. This tells ci stats to use the p75 of the last 5 runs (instead of the single most-recent run) when estimating config durations for bin-packing. Requires the corresponding ci-stats server change to be deployed first. If no param is provided, legacy continues to be used.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->