### PR TITLE
fix(NA): fixing failures on typechecking and lint with types step for ci

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.test.ts
@@ -54,11 +54,11 @@ describe('createAutomaticTroubleshootingSkill', () => {
     });
   });
 
-  describe('getAllowedTools', () => {
+  describe('getRegistryTools', () => {
     it('returns the correct platform core tools', () => {
       const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
 
-      const allowedTools = skill.getAllowedTools?.();
+      const allowedTools = skill.getRegistryTools?.();
 
       expect(allowedTools).toBeDefined();
       expect(allowedTools).toHaveLength(3);

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.ts
@@ -74,7 +74,7 @@ Reference './available_indices' for the list of indices available for troublesho
         content: JSON.stringify(AVAILABLE_INDICES, null, 2),
       },
     ],
-    getAllowedTools: () => [
+    getRegistryTools: () => [
       platformCoreTools.search,
       platformCoreTools.getDocumentById,
       platformCoreTools.integrationKnowledge,

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -22,7 +22,7 @@ export const registerSkills = async (
 ): Promise<void> => {
   // await agentBuilder.skill.registerSkill(alertAnalysisSampleSkill);
   if (experimentalFeatures.automaticTroubleshootingSkill) {
-    agentBuilder.skills.register(
+    await agentBuilder.skills.register(
       createAutomaticTroubleshootingSkill(options.endpointAppContextService)
     );
   }


### PR DESCRIPTION
This PR fixes the failures introduced after the merge of https://buildkite.com/elastic/kibana-on-merge/builds/88554