### PR TITLE
[Streams] Flush both in modal buttons

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/create_new_policy_modal/create_new_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/create_new_policy_modal/create_new_policy_modal.tsx
@@ -213,6 +213,7 @@ export function CreatePolicyModal({
               data-test-subj="createPolicyModal-backButton"
               onClick={onBack}
               disabled={isLoading}
+              flush="both"
             >
               {i18n.translate('xpack.streams.createPolicyModal.backButton', {
                 defaultMessage: 'Back',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
@@ -185,6 +185,7 @@ export function EditPolicyModal({
               data-test-subj="editPolicyModal-cancelButton"
               onClick={onCancel}
               disabled={isProcessing}
+              flush="both"
             >
               {i18n.translate('xpack.streams.editPolicyModal.cancelButton', {
                 defaultMessage: 'Cancel',


### PR DESCRIPTION
## Summary
Apply the flush="both" prop to the Save as new and Affected resources cancel/back buttons to make them align nicely with the text that precedes them

### Before
<img width="743" height="395" alt="Screenshot 2026-02-19 at 09 11 57" src="https://github.com/user-attachments/assets/06ffa48f-7577-4cb4-9a85-536b2cb79a74" />
<img width="668" height="331" alt="Screenshot 2026-02-19 at 09 11 54" src="https://github.com/user-attachments/assets/41141c65-c369-41cb-8e4b-5986d6d09fc8" />

### After


<img width="619" height="313" alt="Screenshot 2026-02-19 at 09 11 36" src="https://github.com/user-attachments/assets/10039522-0f69-4f91-a990-8867ba939e80" />
<img width="634" height="383" alt="Screenshot 2026-02-19 at 09 11 32" src="https://github.com/user-attachments/assets/c2d192dc-8043-46d3-8ef5-432fb4e14f36" />
