### PR TITLE
[SharedUX] Fix doclinks key for deprecated hideAnnouncements setting

### DIFF
--- a/src/core/packages/ui-settings/server-internal/src/settings/announcements.ts
+++ b/src/core/packages/ui-settings/server-internal/src/settings/announcements.ts
@@ -26,7 +26,7 @@ export const getAnnouncementsSettings = (): Record<string, UiSettingsParams> => 
           defaultMessage:
             'This setting is deprecated and will be removed in Kibana 10.0. Use the global setting "Hide announcements" instead.',
         }),
-        docLinksKey: 'uiSettings',
+        docLinksKey: 'generalSettings',
       },
       schema: schema.boolean(),
     },


### PR DESCRIPTION
## Summary

This PR fixes the doclinks key for deprecated hideAnnouncements setting "deprecated" badge which was leading nowhere since it was using a non-existing key (I never realized the badge was clickable):

<img width="989" height="198" alt="Screenshot 2026-02-19 at 09 59 07" src="https://github.com/user-attachments/assets/8468398b-8f73-4f8a-a09e-0f467f02af73" />

### Testing

Tested that instead of opening a blank page, deprecated badge now leads to: 

https://www.elastic.co/docs/reference/kibana/advanced-settings#kibana-general-settings