### PR TITLE
[Unified Doc Viewer] Fix DocViewerTable test timeouts

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.test.tsx
@@ -112,8 +112,7 @@ describe('DocViewerTable', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/253440
-  describe.skip('search', () => {
+  describe('search', () => {
     beforeEach(() => {
       storage.clear();
     });
@@ -125,7 +124,8 @@ describe('DocViewerTable', () => {
       expect(screen.getByText('bytes')).toBeInTheDocument();
       expect(screen.getByText('extension.keyword')).toBeInTheDocument();
 
-      await user.type(screen.getByTestId('unifiedDocViewerFieldsSearchInput'), 'bytes');
+      await user.click(screen.getByTestId('unifiedDocViewerFieldsSearchInput'));
+      await user.paste('bytes');
 
       expect(screen.queryByText('@timestamp')).toBeNull();
       expect(screen.queryByText('bytes')).toBeInTheDocument();
@@ -139,10 +139,8 @@ describe('DocViewerTable', () => {
       expect(screen.getByText('bytes')).toBeInTheDocument();
       expect(screen.getByText('extension.keyword')).toBeInTheDocument();
 
-      await user.type(
-        screen.getByTestId('unifiedDocViewerFieldsSearchInput'),
-        String(hit.flattened['extension.keyword'])
-      );
+      await user.click(screen.getByTestId('unifiedDocViewerFieldsSearchInput'));
+      await user.paste(String(hit.flattened['extension.keyword']));
 
       expect(screen.queryByText('@timestamp')).toBeNull();
       expect(screen.queryByText('bytes')).toBeNull();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/253440

`userEvent.type` is a surprisingly slow action because of all the things that it's doing under the hood (https://github.com/testing-library/user-event/discussions/977#discussioncomment-3038558) - but it's possible to get a similar behaviour with a pretty good performance improvement by doing focus + paste, or in other words clicking the input and pasting in it.

Speed comparison - AVG/MAX/MIN 10 runs of 'should find by field value'

| | Type | Focus + Paste |
|-|------|---------------|
| All runs | 743,728,716,706,699,715,723,709,733,701 | 250,235,234,239,245,257,232,255,238,239 |
| Avg | 717.3 | 242.4 |
| Max | 743 | 257 |
| Min | 699 | 232 |





### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


