### PR TITLE
[agent builder] attachments default to readonly = false

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/attachment_state_manager.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/attachment_state_manager.ts
@@ -157,7 +157,7 @@ class AttachmentStateManagerImpl implements AttachmentStateManager {
 
   private getDefaultReadonly(type: string): boolean {
     const definition = this.options.getTypeDefinition(type);
-    return definition?.isReadonly ?? true;
+    return definition?.isReadonly ?? false;
   }
 
   private async validateAttachmentData(type: string, data: unknown): Promise<unknown> {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts
@@ -67,7 +67,7 @@ export interface AttachmentTypeDefinition<
    */
   getAgentDescription?: () => string;
   /**
-   * Whether attachments of this type are read-only. Defaults to true.
+   * Whether attachments of this type are read-only. Defaults to false.
    */
   isReadonly?: boolean;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/attachments_service.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/attachments_service.ts
@@ -17,6 +17,10 @@ export interface AttachmentsService {
    */
   getTypeDefinition(type: string): AttachmentTypeDefinition | undefined;
   /**
+   * Returns the IDs of all registered attachment types.
+   */
+  getRegisteredTypeIds(): string[];
+  /**
    * Convert an attachment-scoped tool to a generic executable tool
    */
   convertAttachmentTool(tool: AttachmentBoundedTool): ExecutableTool;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/prepare_conversation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/prepare_conversation.ts
@@ -232,7 +232,7 @@ export const prepareConversation = async ({
       }
 
       try {
-        const typeReadonly = definition.isReadonly ?? true;
+        const typeReadonly = definition.isReadonly ?? false;
         const isReadonly = typeReadonly || attachment.readonly === true;
         if (!isReadonly) {
           return undefined;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
@@ -42,6 +42,9 @@ export class AttachmentServiceImpl implements AttachmentService {
       getTypeDefinition: (attachment) => {
         return this.attachmentTypeRegistry.get(attachment);
       },
+      getRegisteredTypeIds: () => {
+        return this.attachmentTypeRegistry.list().map((def) => def.id);
+      },
     };
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
@@ -18,4 +18,5 @@ export interface AttachmentServiceStart {
     attachment: AttachmentInput<Type, Data>
   ): Promise<ValidateAttachmentResult<Type, Data>>;
   getTypeDefinition(type: string): AttachmentTypeDefinition | undefined;
+  getRegisteredTypeIds(): string[];
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/utils/attachments.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/utils/attachments.ts
@@ -44,6 +44,9 @@ export const createAttachmentsService = ({
     getTypeDefinition: (type) => {
       return attachmentsStart.getTypeDefinition(type);
     },
+    getRegisteredTypeIds: () => {
+      return attachmentsStart.getRegisteredTypeIds();
+    },
     convertAttachmentTool: toolConverterFn,
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_add.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_add.ts
@@ -36,7 +36,7 @@ export const createAttachmentAddTool = ({
   tags: ['attachment'],
   handler: async ({ id, type, data, description }, _context) => {
     const definition = attachmentsService?.getTypeDefinition(type);
-    const isReadonly = definition?.isReadonly ?? true;
+    const isReadonly = definition?.isReadonly ?? false;
     if (isReadonly) {
       return {
         results: [

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_add.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_add.ts
@@ -36,7 +36,23 @@ export const createAttachmentAddTool = ({
   tags: ['attachment'],
   handler: async ({ id, type, data, description }, _context) => {
     const definition = attachmentsService?.getTypeDefinition(type);
-    const isReadonly = definition?.isReadonly ?? false;
+    if (!definition) {
+      const validTypes = attachmentsService?.getRegisteredTypeIds() ?? [];
+      return {
+        results: [
+          {
+            tool_result_id: getToolResultId(),
+            type: ToolResultType.error,
+            data: {
+              message: `Unknown attachment type '${type}'. Valid attachment types are: ${validTypes.join(
+                ', '
+              )}`,
+            },
+          },
+        ],
+      };
+    }
+    const isReadonly = definition.isReadonly ?? false;
     if (isReadonly) {
       return {
         results: [

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_read.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_read.ts
@@ -57,7 +57,7 @@ export const createAttachmentReadTool = ({
     let formattedData: unknown = versionData.data;
     if (attachmentsService && formatContext) {
       const definition = attachmentsService.getTypeDefinition(attachment.type);
-      const typeReadonly = definition?.isReadonly ?? true;
+      const typeReadonly = definition?.isReadonly ?? false;
       if (definition && typeReadonly) {
         try {
           const formatted = await definition.format(

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_update.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/attachments/attachment_update.ts
@@ -59,7 +59,7 @@ export const createAttachmentUpdateTool = ({
     }
 
     const definition = attachmentsService?.getTypeDefinition(existing.type);
-    const typeReadonly = definition?.isReadonly ?? true;
+    const typeReadonly = definition?.isReadonly ?? false;
     const isReadonly = typeReadonly || existing.readonly === true;
     if (isReadonly) {
       return {

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
@@ -96,6 +96,7 @@ export const createAttachmentsServiceStartMock = (): AttachmentsServiceStartMock
   return {
     validate: jest.fn(),
     getTypeDefinition: jest.fn(),
+    getRegisteredTypeIds: jest.fn(),
   };
 };
 
@@ -103,6 +104,7 @@ export const createAttachmentsService = (): AttachmentsServiceMock => {
   return {
     getTypeDefinition: jest.fn(),
     convertAttachmentTool: jest.fn(),
+    getRegisteredTypeIds: jest.fn(),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/screen_context.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/screen_context.ts
@@ -36,6 +36,7 @@ export const createScreenContextAttachmentType = (): AttachmentTypeDefinition<
         },
       };
     },
+    isReadonly: true,
     getTools: () => [],
   };
 };


### PR DESCRIPTION
## Summary

Makes all attachments writable by default and improves the error message when agent tries to add invalid attachment type.

<img width="1360" height="1098" alt="image" src="https://github.com/user-attachments/assets/17543563-3619-4a4d-b13d-d5983e12ac03" />
