### PR TITLE
[Streams] Downsampling UI fixes

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/base_metric_card.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/base_metric_card.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText, useEuiTheme } from '@elastic/eui';
 
 interface Metric {
   data: React.ReactNode;
@@ -29,10 +29,11 @@ export const BaseMetricCard: React.FC<BaseMetricCardProps> = ({
   'data-test-subj': dataTestSubj,
 }) => {
   const metric = metrics[0];
+  const { euiTheme } = useEuiTheme();
 
   return (
-    <EuiPanel hasShadow={false} hasBorder grow color="subdued">
-      <EuiFlexGroup direction="column" justifyContent="spaceBetween" css={{ height: '100%' }}>
+    <EuiPanel hasShadow={false} hasBorder grow color="subdued" css={{ height: '100%' }}>
+      <EuiFlexGroup direction="column" gutterSize="none" css={{ height: '100%' }}>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup
             direction="row"
@@ -40,7 +41,7 @@ export const BaseMetricCard: React.FC<BaseMetricCardProps> = ({
             alignItems="center"
             justifyContent="spaceBetween"
             responsive={false}
-            css={{ minHeight: '32px' }}
+            css={{ minHeight: euiTheme.size.xxl }}
           >
             <EuiFlexItem>
               <EuiText size="s">
@@ -57,6 +58,9 @@ export const BaseMetricCard: React.FC<BaseMetricCardProps> = ({
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
+          <EuiSpacer size="m" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false} css={{ marginTop: 'auto' }}>
           <EuiText size="m">
             <h2 data-test-subj={metric['data-test-subj'] && `${metric['data-test-subj']}-metric`}>
               {metric.data}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/chart_components.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/chart_components.tsx
@@ -220,7 +220,7 @@ function ChartBarPhasesSeriesBase({
         css={{ width: '100%', height: '100%' }}
         gutterSize="s"
       >
-        <EuiFlexItem grow={9} css={{ minHeight: '200px' }}>
+        <EuiFlexItem grow={9}>
           <Chart size={{ height: '100%', width: '100%' }}>
             <Settings showLegend={false} baseTheme={chartBaseTheme} />
             {Object.entries(ingestionRate.buckets).map(([tier, buckets]) => (
@@ -342,7 +342,7 @@ function PhasesLegend({ phases }: { phases?: IlmPolicyPhases }) {
                   }}
                 />
               ) : (
-                <EuiIcon type={phase.icon} />
+                <EuiIcon type={phase.icon} aria-hidden={true} />
               )}
             </EuiFlexItem>
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/data_lifecycle_summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/data_lifecycle_summary.tsx
@@ -63,25 +63,35 @@ export const DataLifecycleSummary = ({
   const phaseColumnSpans = getPhaseColumnSpans(phases, timelineSegments);
 
   return (
-    <EuiPanel hasShadow={false} hasBorder grow paddingSize="s">
-      <EuiFlexGroup
-        direction="column"
-        gutterSize="s"
-        justifyContent="spaceBetween"
-        css={{ height: '100%' }}
-      >
+    <EuiPanel
+      hasShadow={false}
+      hasBorder
+      grow={false}
+      paddingSize="s"
+      css={{ height: '100%', borderTopLeftRadius: '0', borderBottomLeftRadius: '0' }}
+    >
+      <EuiFlexGroup direction="column" gutterSize="s" css={{ height: '100%' }}>
         <EuiPanel hasShadow={false} hasBorder={false} paddingSize="s" grow={false}>
-          <EuiText>
-            <h5 data-test-subj="dataLifecycleSummary-title">
-              {i18n.translate('xpack.streams.streamDetailLifecycle.dataLifecycle', {
-                defaultMessage: 'Data lifecycle',
-              })}
-            </h5>
-          </EuiText>
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiText>
+                <h5 data-test-subj="dataLifecycleSummary-title">
+                  {i18n.translate('xpack.streams.streamDetailLifecycle.dataLifecycle', {
+                    defaultMessage: 'Data lifecycle',
+                  })}
+                </h5>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiPanel>
 
         <EuiPanel grow hasShadow={false} hasBorder={false} paddingSize="s">
-          <EuiFlexGroup direction="column" justifyContent="center" css={{ height: '100%' }}>
+          <EuiFlexGroup
+            direction="column"
+            gutterSize="none"
+            justifyContent="center"
+            css={{ height: '100%' }}
+          >
             {showSkeleton ? (
               <EuiSkeletonRectangle
                 width="100%"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/downsampling_phase.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/downsampling_phase.tsx
@@ -89,14 +89,13 @@ export const DownsamplingPhase = ({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             maxWidth: '100%',
+            fontWeight: euiTheme.font.weight.semiBold,
           }}
         >
-          <b>
-            {downsample.fixed_interval}{' '}
-            {i18n.translate('xpack.streams.downsamplingPhaseBar.b.intervalLabel', {
-              defaultMessage: 'interval',
-            })}
-          </b>
+          {downsample.fixed_interval}{' '}
+          {i18n.translate('xpack.streams.downsamplingPhaseBar.b.intervalLabel', {
+            defaultMessage: 'interval',
+          })}
         </EuiText>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase.tsx
@@ -117,7 +117,7 @@ export const LifecyclePhase = (props: LifecyclePhaseProps) => {
       <EuiPopoverTitle data-test-subj={`${prefix}lifecyclePhase-${label}-popoverTitle`}>
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
+            <EuiFlexGroup gutterSize="xs" alignItems="flexEnd" responsive={false}>
               <EuiFlexItem grow={false}>
                 {i18n.translate('xpack.streams.streamDetailLifecycle.phasePopoverTitleLabel', {
                   defaultMessage: '{phase} phase',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase.tsx
@@ -117,7 +117,7 @@ export const LifecyclePhase = (props: LifecyclePhaseProps) => {
       <EuiPopoverTitle data-test-subj={`${prefix}lifecyclePhase-${label}-popoverTitle`}>
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="xs" alignItems="flexEnd" responsive={false}>
+            <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
                 {i18n.translate('xpack.streams.streamDetailLifecycle.phasePopoverTitleLabel', {
                   defaultMessage: '{phase} phase',
@@ -128,6 +128,7 @@ export const LifecyclePhase = (props: LifecyclePhaseProps) => {
                 <EuiFlexItem
                   grow={false}
                   data-test-subj={`${prefix}lifecyclePhase-${label}-readOnly`}
+                  style={{ position: 'relative', top: -1 }}
                 >
                   <EuiIconTip
                     type="readOnly"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/data_lifecycle/lifecycle_phase_button.tsx
@@ -80,7 +80,14 @@ export const LifecyclePhaseButton = ({
           style={{ width: '100%', height: '100%' }}
         >
           <EuiFlexItem grow={false}>
-            <EuiIcon size="m" type="trash" data-test-subj={`${prefix}dataLifecycle-delete-icon`} />
+            <EuiIcon
+              size="m"
+              type="trash"
+              data-test-subj={`${prefix}dataLifecycle-delete-icon`}
+              title={i18n.translate('xpack.streams.streamDetailLifecycle.deletePhase.iconTitle', {
+                defaultMessage: 'Delete phase',
+              })}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       ) : (
@@ -94,9 +101,10 @@ export const LifecyclePhaseButton = ({
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
               maxWidth: '100%',
+              fontWeight: euiTheme.font.weight.semiBold,
             }}
           >
-            <b>{capitalize(label)}</b>
+            {capitalize(label)}
           </EuiText>
           {size && (
             <EuiText

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/ingestion_rate_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/ingestion_rate_panel.tsx
@@ -27,10 +27,10 @@ export function IngestionRatePanel({
       hasBorder
       paddingSize="m"
       grow={false}
-      css={{ height: '100%', minHeight: '256px' }}
+      css={{ height: '100%', borderTopLeftRadius: '0', borderBottomLeftRadius: '0' }}
       data-test-subj="ingestionRatePanel"
     >
-      <EuiFlexGroup direction="column" gutterSize="none" css={{ height: '100%' }}>
+      <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
         <EuiFlexItem grow={false}>
           <EuiPanel hasShadow={false} hasBorder={false} paddingSize="s">
             <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
@@ -59,9 +59,7 @@ export function IngestionRatePanel({
           </EuiPanel>
         </EuiFlexItem>
 
-        <EuiFlexItem grow css={{ minHeight: '200px' }}>
-          {children}
-        </EuiFlexItem>
+        <EuiFlexItem grow>{children}</EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/section_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/common/section_panel.tsx
@@ -17,26 +17,18 @@ export const SectionPanel = ({ topCard, bottomCard, children }: SectionPanelProp
   const { euiTheme } = useEuiTheme();
 
   return (
-    <EuiPanel
-      hasShadow={false}
-      hasBorder
-      grow={false}
-      paddingSize="none"
-      css={{ minHeight: '320px' }}
-    >
-      <EuiFlexGroup gutterSize="none" css={{ minHeight: '320px' }}>
+    <EuiPanel hasShadow={false} hasBorder grow={false} paddingSize="none">
+      <EuiFlexGroup gutterSize="none">
         <EuiFlexItem grow={2}>
           <EuiFlexGroup gutterSize="none" direction="column" css={{ height: '100%' }}>
-            <EuiFlexItem grow={1} css={{ minHeight: '160px' }}>
-              {topCard}
-            </EuiFlexItem>
-            <EuiFlexItem grow={1} css={{ borderTop: euiTheme.border.thin, minHeight: '160px' }}>
+            <EuiFlexItem grow={1}>{topCard}</EuiFlexItem>
+            <EuiFlexItem grow={1} css={{ borderTop: euiTheme.border.thin }}>
               {bottomCard}
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem grow={5} css={{ minHeight: '320px' }}>
-          <EuiFlexGroup direction="column" css={{ height: '100%' }}>
+        <EuiFlexItem grow={5}>
+          <EuiFlexGroup direction="column" gutterSize="none" css={{ height: '100%' }}>
             <EuiFlexItem grow>{children}</EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
@@ -157,6 +157,7 @@ export function EditPolicyModal({
               }}
               color="subdued"
               data-test-subj="editPolicyModal-affectedResourcesList"
+              tabIndex={0}
             >
               <EuiFlexGroup direction="column" gutterSize="s">
                 {affectedResources.map((resource) => (


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/249992

## Summary

This PR addresses a few UI fixes in the downsampling project 

### Fix panel corners

Related  [comment](https://github.com/elastic/kibana/pull/249744/changes#r2710165156)

> On the left side of this panel, I noticed the top-left and bottom-left corners had their default 4px border-radius. Would it be possible to remove this so that it appears the line in the middle is perfectly straight vertically? I imagine we can do this by either 1) setting the panel prop for border radius to none and adding a style of overflow: hidden; to the larger containing element or 2) overriding the CSS specifically for the top-left and bottom-left borders.

| before | after |
|---|---|
|<img width="190" height="394" alt="Screenshot 2026-02-19 at 11 03 54" src="https://github.com/user-attachments/assets/cb96c9fa-836d-4b2c-8e6b-a92c659c3bc1" />|<img width="105" height="323" alt="Screenshot 2026-02-19 at 11 04 25" src="https://github.com/user-attachments/assets/3a982db1-7199-40fb-a199-cc1fe22901b5" /> |

### Fix card margins and min-height

**For the margins**

Related [comment](https://github.com/elastic/kibana/pull/249744#discussion_r2710135757)

> Not related to this file, but I notice that there was a min-height of 160px being applied to the left-hand "Retention" and "Storage size" panels, causing the larger container to be a bit taller than desired. Would it be possible to remove this min-height and instead just add a 16px margin between the header and content portions of those panels?

**For the height**

Related [comment](https://github.com/elastic/kibana/pull/253393#discussion_r2818780311)

>Can we remove the min-height styles on the retention, storage size, data lifecycle, daily ingestion average, monthly ingestion average, ingestion over time, and containing panels to better match the designs?


| before | after |
|---|---|
|<img width="1401" height="682" alt="Screenshot 2026-02-19 at 11 02 56" src="https://github.com/user-attachments/assets/efe73c7a-d451-4cde-827d-0bae3da28be1" /> |<img width="1498" height="572" alt="Screenshot 2026-02-19 at 11 04 08" src="https://github.com/user-attachments/assets/61883f33-7fb5-4c12-accb-de02f70030d0" />|

### Fix accessibility issue in Edit policy Modal


<img width="395" height="405" alt="Image" src="https://github.com/user-attachments/assets/06194bc2-0039-41df-9cc7-b4fa479b5d23" />

https://dequeuniversity.com/rules/axe/4.7/scrollable-region-focusable?application=axeAPI


| before | after |
|---|---|
| <img width="960" height="792" alt="Screenshot 2026-02-19 at 11 05 15" src="https://github.com/user-attachments/assets/fc859b11-3701-402e-94ca-775b5419c92f" />|<img width="977" height="753" alt="Screenshot 2026-02-19 at 11 04 48" src="https://github.com/user-attachments/assets/bf460d33-8cbd-49ee-a92c-ed29f18b7573" />|

### Read-only icon in the pop-up is not well aligned

The icon is too close to the text, it's missing some space there

| before | after |
|---|---|
| <img width="502" height="292" alt="Screenshot 2026-02-19 at 11 03 39" src="https://github.com/user-attachments/assets/33457f7c-1ac2-4826-85b8-abec23b12c9d" />|<img width="409" height="221" alt="Screenshot 2026-02-19 at 11 20 58" src="https://github.com/user-attachments/assets/884e07f7-d496-4082-9594-af11a628b8b0" />|

### Adjust data phases font-weight

The mocks changed and Michael adjusted the font-weight of the data phase and downsample step titles from semi-bold (600) to medium (500)

| before | after |
|---|---|
| <img width="952" height="229" alt="Screenshot 2026-02-19 at 11 03 50" src="https://github.com/user-attachments/assets/e0a336aa-a97c-4fd0-b4f6-c74fce7f3f0a" />|<img width="1042" height="222" alt="Screenshot 2026-02-19 at 11 04 19" src="https://github.com/user-attachments/assets/d8e4ae4f-e2fc-4f35-a302-8d3362ea1052" />|
