### PR TITLE
[Cases] Skip View Cases FTR serverless flaky tests

### DIFF
--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
@@ -37,8 +37,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
   // https://github.com/elastic/kibana/pull/190690
   // fails after missing `awaits` were added
-  // Flaky: See https://github.com/elastic/kibana/issues/241493
-  describe('Case View', function () {
+  // Flaky: See https://github.com/elastic/kibana/issues/253931
+  describe.skip('Case View', function () {
     before(async () => {
       await svlCommonPage.loginWithPrivilegedRole();
     });


### PR DESCRIPTION
## Summary

This PR skips View Cases tests FTR serverless tests. Details of the failure/flakiness in https://github.com/elastic/kibana/issues/253931.

Relevant older issues/PRs:
* https://github.com/elastic/kibana/issues/241493
* https://github.com/elastic/kibana/pull/250424