### PR TITLE
[EDR Workflows] Fix Run Saved Query button not respecting RBAC permission

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/reader.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/roles/reader.cy.ts
@@ -55,7 +55,7 @@ describe('Reader - only READ', { tags: ['@ess'] }, () => {
     navigateTo('/app/osquery/saved_queries');
     cy.contains(savedQueryName);
     cy.contains('Add saved query').should('be.disabled');
-    cy.get(customActionRunSavedQuerySelector(savedQueryName)).should('not.exist');
+    cy.get(customActionRunSavedQuerySelector(savedQueryName)).should('be.disabled');
     cy.get(customActionEditSavedQuerySelector(savedQueryName)).click();
     cy.get(formFieldInputSelector('id')).should('be.disabled');
     cy.get(formFieldInputSelector('description')).should('be.disabled');

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/index.tsx
@@ -45,6 +45,13 @@ export interface SavedQuerySO {
   prebuilt?: boolean;
 }
 
+const RUN_QUERY_PERMISSION_DENIED = i18n.translate(
+  'xpack.osquery.savedQueryList.permissionDeniedRunTooltip',
+  {
+    defaultMessage: 'You do not have sufficient permissions to run this query.',
+  }
+);
+
 interface PlayButtonProps {
   disabled: boolean;
   savedQuery: SavedQuerySO;
@@ -79,8 +86,10 @@ const PlayButtonComponent: React.FC<PlayButtonProps> = ({ disabled = false, save
     [savedQuery]
   );
 
+  const tooltipContent = disabled ? RUN_QUERY_PERMISSION_DENIED : playText;
+
   return (
-    <EuiToolTip position="top" content={playText} disableScreenReaderOutput>
+    <EuiToolTip position="top" content={tooltipContent}>
       <EuiButtonIcon
         color="primary"
         iconType="play"
@@ -154,13 +163,10 @@ const SavedQueriesPageComponent = () => {
   );
 
   const renderPlayAction = useCallback(
-    (item: SavedQuerySO) =>
-      permissions.runSavedQueries || permissions.writeLiveQueries ? (
-        <PlayButton savedQuery={item} disabled={false} />
-      ) : (
-        <></>
-      ),
-    [permissions.runSavedQueries, permissions.writeLiveQueries]
+    (item: SavedQuerySO) => (
+      <PlayButton savedQuery={item} disabled={!permissions.runSavedQueries} />
+    ),
+    [permissions.runSavedQueries]
   );
 
   const renderUpdatedAt = useCallback((updatedAt: any, item: any) => {


### PR DESCRIPTION
The "Run Saved Query" play button on the Saved Queries page remained visible and functional even when the "Run Saved queries" RBAC permission was unchecked. The condition used `runSavedQueries || writeLiveQueries`, so having Live queries set to "All" was enough to bypass the toggle.

This changes the button to be disabled (instead of hidden) when the permission is missing, and shows a tooltip explaining the user lacks sufficient permissions.

https://github.com/user-attachments/assets/214656f8-39e9-4a02-bfbc-f99f5c353ff6






<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->