### PR TITLE
[8.19] Fix Logs tab performance issues (#253326)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/content/content.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/content/content.tsx
@@ -94,12 +94,21 @@ const TabPanel = ({
 }) => {
   const { renderedTabsSet, activeTabId } = useTabSwitcherContext();
 
+  // The logs tab is a special case because it is not rendered in the DOM until it is clicked due to performance reasons.
+  if (activeWhen === ContentTabIds.LOGS && activeTabId === activeWhen) {
+    return <div data-test-subj={makeTabPanelDataTestSubj({ tabId: activeWhen })}>{children}</div>;
+  }
+
   return renderedTabsSet.current.has(activeWhen) ? (
     <div
       hidden={activeTabId !== activeWhen}
-      data-test-subj={`infraAssetDetails${capitalize(activeWhen)}TabContent`}
+      data-test-subj={makeTabPanelDataTestSubj({ tabId: activeWhen })}
     >
       {children}
     </div>
   ) : null;
 };
+
+function makeTabPanelDataTestSubj({ tabId }: { tabId: ContentTabIds }) {
+  return `infraAssetDetails${capitalize(tabId)}TabContent`;
+}

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/hooks/use_tab_switcher.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/hooks/use_tab_switcher.tsx
@@ -7,7 +7,7 @@
 
 import createContainer from 'constate';
 import { useLazyRef } from '../../../hooks/use_lazy_ref';
-import type { TabIds } from '../types';
+import { ContentTabIds, type TabIds } from '../types';
 import { useAssetDetailsUrlState } from './use_asset_details_url_state';
 
 interface TabSwitcherParams {
@@ -23,8 +23,10 @@ export function useTabSwitcher({ defaultActiveTabId }: TabSwitcherParams) {
   const renderedTabsSet = useLazyRef(() => new Set([activeTabId]));
 
   const showTab = (tabId: TabIds, options?: { scrollTo?: string }) => {
-    // On a tab click, mark the tab content as allowed to be rendered
-    renderedTabsSet.current.add(tabId);
+    // On a tab click, mark the tab content as allowed to be rendered except for the logs tab.
+    if (tabId !== ContentTabIds.LOGS) {
+      renderedTabsSet.current.add(tabId);
+    }
 
     setUrlState({
       tabId: options?.scrollTo ? `${tabId}#${options?.scrollTo}` : tabId,

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/tabs.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/tabs.tsx
@@ -52,7 +52,13 @@ export const Tabs = () => {
       {...tab}
       key={index}
       onClick={() => {
-        renderedTabsSet.current.add(tab.id); // On a tab click, mark the tab content as allowed to be rendered
+        if (tab.id === selectedTabId) return;
+
+        // On a tab click, mark the tab content as allowed to be rendered except for the logs tab.
+        if (tab.id !== TabIds.LOGS) {
+          renderedTabsSet.current.add(tab.id);
+        }
+
         setSelectedTabId(tab.id);
       }}
       isSelected={tab.id === selectedTabId}
@@ -71,11 +77,7 @@ export const Tabs = () => {
           <MetricsGrid />
         </div>
       )}
-      {renderedTabsSet.current.has(TabIds.LOGS) && (
-        <div hidden={selectedTabId !== TabIds.LOGS}>
-          <LogsTabContent />
-        </div>
-      )}
+      {selectedTabId === TabIds.LOGS && <LogsTabContent />}
       {renderedTabsSet.current.has(TabIds.ALERTS) && (
         <div hidden={selectedTabId !== TabIds.ALERTS}>
           <AlertsTabContent />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix Logs tab performance issues (#253326)](https://github.com/elastic/kibana/pull/253326)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Samuel Brito","email":"samuel.brito@elastic.co"},"sourceCommit":{"committedDate":"2026-02-19T09:44:48Z","message":"Fix Logs tab performance issues (#253326)\n\nCloses https://github.com/elastic/kibana/issues/252094\n\n## Summary\n- The **Logs** Tab will **always unmount** after changing/selecting\nanother tab in the following pages:\n    - Assets Details Page\n    - Hosts Details Page","sha":"c18fcd802a58035087bc1b2a4ec00a8039077d02","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation","v9.2.6"],"title":"Fix Logs tab performance issues","number":253326,"url":"https://github.com/elastic/kibana/pull/253326","mergeCommit":{"message":"Fix Logs tab performance issues (#253326)\n\nCloses https://github.com/elastic/kibana/issues/252094\n\n## Summary\n- The **Logs** Tab will **always unmount** after changing/selecting\nanother tab in the following pages:\n    - Assets Details Page\n    - Hosts Details Page","sha":"c18fcd802a58035087bc1b2a4ec00a8039077d02"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253326","number":253326,"mergeCommit":{"message":"Fix Logs tab performance issues (#253326)\n\nCloses https://github.com/elastic/kibana/issues/252094\n\n## Summary\n- The **Logs** Tab will **always unmount** after changing/selecting\nanother tab in the following pages:\n    - Assets Details Page\n    - Hosts Details Page","sha":"c18fcd802a58035087bc1b2a4ec00a8039077d02"}},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/253918","number":253918,"state":"MERGED","mergeCommit":{"sha":"059c9445a894d6c80a7b5d28275336443d1b7225","message":"[9.2] Fix Logs tab performance issues (#253326) (#253918)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Fix Logs tab performance issues\n(#253326)](https://github.com/elastic/kibana/pull/253326)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Samuel Brito <samuel.brito@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/253919","number":253919,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->