### PR TITLE
Chrome service lifecycle and resource cleanup

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -231,8 +231,10 @@ export class ChromeService {
   }
 
   public stop() {
+    this.navControls.stop();
     this.navLinks.stop();
     this.projectNavigation.stop();
+    this.sidebar.stop();
     this.stop$.next();
   }
 }

--- a/src/core/packages/chrome/browser-internal/src/services/nav_controls/nav_controls_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/nav_controls/nav_controls_service.test.ts
@@ -10,7 +10,7 @@
 import { take } from 'rxjs';
 import { NavControlsService } from './nav_controls_service';
 
-describe('RecentlyAccessed#start()', () => {
+describe('NavControlsService#start()', () => {
   const getStart = () => {
     return new NavControlsService().start();
   };

--- a/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.test.ts
@@ -46,7 +46,7 @@ const availableApps: ReadonlyMap<string, App> = new Map([
     {
       id: 'chromelessApp',
       order: 20,
-      title: 'Chromless App',
+      title: 'Chromeless App',
       chromeless: true,
       mount: () => () => undefined,
     },
@@ -110,7 +110,7 @@ describe('NavLinksService', () => {
       ).not.toContain('chromelessApp');
     });
 
-    it('does not include `inaccesible` applications', async () => {
+    it('does not include `inaccessible` applications', async () => {
       expect(
         await lastValueFrom(
           start.getNavLinks$().pipe(

--- a/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/nav_links/nav_links_service.ts
@@ -43,7 +43,8 @@ export class NavLinksService {
                 return navLinks;
               }, [])
           );
-        })
+        }),
+        takeUntil(this.stop$)
       )
       .subscribe((navlinks) => {
         navLinks$.next(navlinks);

--- a/src/core/packages/chrome/browser-internal/src/side_effects/csp_warning.tsx
+++ b/src/core/packages/chrome/browser-internal/src/side_effects/csp_warning.tsx
@@ -28,14 +28,19 @@ export function showCspWarningIfNeeded({
     return;
   }
 
-  getNotifications().then((notifications) => {
-    notifications.toasts.addWarning({
-      title: mountReactNode(
-        <FormattedMessage
-          id="core.chrome.legacyBrowserWarning"
-          defaultMessage="Your browser does not meet the security requirements for Kibana."
-        />
-      ),
+  getNotifications()
+    .then((notifications) => {
+      notifications.toasts.addWarning({
+        title: mountReactNode(
+          <FormattedMessage
+            id="core.chrome.legacyBrowserWarning"
+            defaultMessage="Your browser does not meet the security requirements for Kibana."
+          />
+        ),
+      });
+    })
+    .catch((e) => {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to show CSP warning toast', e);
     });
-  });
 }

--- a/src/core/packages/chrome/browser-internal/src/side_effects/handle_eui_fullscreen_changes.ts
+++ b/src/core/packages/chrome/browser-internal/src/side_effects/handle_eui_fullscreen_changes.ts
@@ -60,7 +60,7 @@ export function handleEuiFullScreenChanges({
     });
   });
 
-  mutationObserver.observe(body, { attributes: true });
+  mutationObserver.observe(body, { attributes: true, attributeFilter: ['class'] });
 
   stop$.pipe(take(1)).subscribe(() => {
     mutationObserver.disconnect();

--- a/src/core/packages/chrome/sidebar/sidebar-internal/src/services/sidebar_service.ts
+++ b/src/core/packages/chrome/sidebar/sidebar-internal/src/services/sidebar_service.ts
@@ -67,6 +67,10 @@ export class SidebarService {
     };
   }
 
+  stop() {
+    this.state.stop();
+  }
+
   @bind
   @memoize
   private getApp<TState = undefined, TActions = undefined>(

--- a/src/core/packages/chrome/sidebar/sidebar-internal/src/services/sidebar_state_service.ts
+++ b/src/core/packages/chrome/sidebar/sidebar-internal/src/services/sidebar_state_service.ts
@@ -121,4 +121,8 @@ export class SidebarStateService {
   getCurrentAppId(): SidebarAppId | null {
     return this.currentAppId$.getValue();
   }
+
+  stop() {
+    window.removeEventListener('resize', this.handleWindowResize);
+  }
 }


### PR DESCRIPTION
Part of elastic/kibana-team#2651

## Problem / Intent

Several chrome sub-services have resource leaks or missing cleanup:
- `NavControlsService` and `SidebarService` are not stopped when `ChromeService.stop()` is called
- `NavLinksService` subscription to `application.applications$` is not unsubscribed on stop
- `SidebarStateService` registers a global resize listener but never removes it
- CSP warning silently swallows errors with no visibility
- `MutationObserver` in fullscreen handler observes all attribute changes instead of just `class`

## Approach

- Add `navControls.stop()` and `sidebar.stop()` calls to `ChromeService.stop()`
- Add `takeUntil(this.stop$)` to the NavLinksService subscription
- Add `stop()` methods to SidebarStateService and SidebarService for resize listener cleanup
- Replace silent `.catch()` in CSP warning with `console.warn`
- Narrow MutationObserver to `attributeFilter: ['class']`
- Fix test typos found while working in these files
