### PR TITLE
Enrich READMEs for Elasticsearch Service and CPS Plugin

### DIFF
--- a/docs/extend/plugin-list.md
+++ b/docs/extend/plugin-list.md
@@ -23,7 +23,7 @@ mapped_pages:
 | [console](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/console/README.md) | Console provides the user with tools for storing and executing requests against Elasticsearch. |
 | [contentManagement](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/content_management/README.md) | The content management plugin provides functionality to manage content in Kibana. |
 | [controls](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/controls/README.mdx) | The Controls plugin contains Embeddables which can be used to add user-friendly interactivity to apps. |
-| [cps](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/cps/README.md) | Retrieves project tags from Elasticsearch using the /_project/tags endpoint. |
+| [cps](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/cps/README.md) | This plugin implements the Cross-Project Search (CPS) logic for Kibana. CPS enables users to search data across multiple Elastic projects as if it were local, without needing to manually specify project names in queries. |
 | [customIntegrations](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/custom_integrations/README.md) | Register add-data cards |
 | [dashboard](kibana-dashboard-plugin.md) | - Registers the dashboard application. - Adds a dashboard embeddable that can be used in other applications. |
 | [dashboardMarkdown](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/dashboard_markdown/README.md) | This plugin provides a simple Markdown component for embedding editable Markdown content in Kibana dashboards. |

--- a/src/core/packages/elasticsearch/server-internal/README.md
+++ b/src/core/packages/elasticsearch/server-internal/README.md
@@ -1,3 +1,27 @@
 # @kbn/core-elasticsearch-server-internal
 
 This package contains the internal types and implementation for Core's server-side elasticsearch service.
+
+## ElasticsearchService
+
+The `ElasticsearchService` is one of the Core services (instantiated in `@src/core/packages/root/server-internal/src/server.ts`) that provides connectivity to Elasticsearch for Kibana.
+
+### Purpose
+It manages the lifecycle of Elasticsearch clients, ensures the connection is healthy and compatible, and exposes APIs for plugins to interact with Elasticsearch.
+
+### Key Features
+- **Client Management**: Creates and manages `ClusterClient` instances (e.g., `data` client), providing both internal-user and request-scoped access.
+- **Connection Health**: Periodically polls Elasticsearch nodes to verify version compatibility (`esNodesCompatibility$`) and calculates the overall service status (`status$`).
+- **Preboot & Setup**:
+  - Loads configuration (`elasticsearch.hosts`, `username`/`password` or `serviceAccountToken`, etc.).
+  - Initializes the `AgentManager` for HTTP agent reuse.
+  - Registers analytics context providers.
+- **Startup Checks**:
+  - Validates the connection to Elasticsearch.
+  - Verifies that inline scripting is enabled on the cluster.
+  - Fetches and exposes cluster capabilities.
+- **Cross-Project Search (CPS) Handling**:
+  - Configures the `CpsRequestHandler` based on the `cps.cpsEnabled` configuration flag (read from `coreContext.configService`).
+  - **Behavior based on `cpsEnabled`**:
+    - **Enabled (`true`)**: The `CpsRequestHandler` injects `project_routing: '_alias:_origin'` into requests if `project_routing` is missing (unless it's a PIT request, where it is stripped).
+    - **Disabled (`false`)**: The `CpsRequestHandler` strictly strips any `project_routing` parameter from request bodies to prevent unintended cross-project queries.

--- a/src/platform/plugins/shared/cps/README.md
+++ b/src/platform/plugins/shared/cps/README.md
@@ -1,6 +1,23 @@
 # @kbn/cps
 
-## Holds CPS related logic
+## Overview
+
+This plugin implements the **Cross-Project Search (CPS)** logic for Kibana. CPS enables users to search data across multiple Elastic projects as if it were local, without needing to manually specify project names in queries.
+
+Kibana acts as a **transparent orchestrator**. It does not execute cross-project searches itself but forwards requests with the appropriate `project_routing` context to Elasticsearch. Elasticsearch then handles the execution, security enforcement, and result aggregation.
+
+## Client-Side (`public/`)
+
+- **CPSManager**: The central service for managing CPS state in the browser.
+  - **Project Routing**: Manages the `projectRouting$` observable (defaults to searching all projects) and allows applications to set/get the current routing.
+  - **Project Fetching**: Fetches and caches project data using `ProjectFetcher`.
+  - **UI Access Control**: Determines if the project picker should be editable, read-only, or disabled based on the current application and location (via `getProjectPickerAccess$`).
+
+
+## Server-Side (`server/`)
+
+- **API Routes**: Registers endpoints like `POST /internal/cps/projects_tags` to retrieve project tags from Elasticsearch (`/_project/tags`), delegating authorization to the scoped Elasticsearch client.
+- **Configuration**: Exposes the `cpsEnabled` flag via its setup contract, which is used by other parts of the system (like Core's `ElasticsearchService`) to toggle CPS behaviors.
 
 ### API Routes
 


### PR DESCRIPTION
Enriches the READMEs for the Elasticsearch Service and CPS Plugin with details about their roles, features, and CPS integration.

## Summary

- **ElasticsearchService**: Added details about client management, connection health, startup checks, and `CpsRequestHandler` behavior.
- **CPS Plugin**: Added overview, server-side routes, and client-side `CPSManager` details.


Made with [Cursor](https://cursor.com)