### PR TITLE
[Automatic Migrations] Enables Splunk v2 Dashboard parsing. 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -209,7 +209,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the Automatic Migration of Splunk dashboards in Security Solution
    */
-  splunkV2DashboardsEnabled: false,
+  splunkV2DashboardsEnabled: true,
 
   /**
    * Enables Detection Engine Health UI


### PR DESCRIPTION
## Summary

We introduced feature flag for v2 dashboard parsing in [[Automatic Migrations] Adds the feature flag to disable Dashboard v2 parsing](https://github.com/elastic/kibana/pull/251963).

This PR just enables it so that users can now parse v2 dashboards.

### Testing 

1. Install a sample data set for kibana ecommerce.
2. Migrate dashboard export file `dashboard_v2_v1_mixed.json` from Automatic Migrations Testing [folder](https://drive.google.com/drive/folders/18eecoQ0yKNYcWTqN95JMniOxk14dH4eb).
3. Ideally all dashboards should be installable when migration is completed.
4. All panels of the dashboard should have an ESQL query. It can be invalid because of no index pattern found.