### PR TITLE
[Entity Analytics][Watchlists][Risk Scoring] Add watchlist contributions to risk score calculation

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
@@ -257,6 +257,9 @@ const ContextsSection = <T extends EntityType>({
     const privmon = riskScore[entityType].risk.modifiers?.find(
       (mod) => mod.type === 'watchlist' && mod.subtype === 'privmon'
     );
+    const watchlists = riskScore[entityType].risk.modifiers?.filter(
+      (mod) => mod.type === 'watchlist' && mod.subtype !== 'privmon'
+    );
     const criticality = riskScore[entityType].risk.modifiers?.find(
       (mod) => mod.type === 'asset_criticality'
     );
@@ -274,13 +277,17 @@ const ContextsSection = <T extends EntityType>({
         isPrivileged: privmon ? privmon.metadata?.is_privileged_user : false,
         contribution: privmon?.contribution ?? 0,
       },
+      watchlists: watchlists?.map((mod) => ({
+        name: mod.subtype,
+        contribution: mod.contribution ?? 0,
+      })),
     };
   }, [entityType, riskScore, isPrivmonEnabled]);
 
   if (loading || contributions === undefined) {
     return null;
   }
-  const { criticality, privmon } = contributions;
+  const { criticality, privmon, watchlists } = contributions;
 
   const items = [
     {
@@ -298,6 +305,23 @@ const ContextsSection = <T extends EntityType>({
       ),
       contribution: formatContribution(criticality.contribution || 0),
     },
+    ...(watchlists ?? []).map((watchlist) => ({
+      field: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.entityDetails.riskInputs.watchlistField"
+          defaultMessage="{watchlistName} watchlist"
+          values={{ watchlistName: watchlist.name }}
+        />
+      ),
+      value: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.entityDetails.riskInputs.watchlistValue"
+          defaultMessage="{value}"
+          values={{ value: 'Yes' }}
+        />
+      ),
+      contribution: formatContribution(watchlist.contribution),
+    })),
   ];
 
   if (isPrivmonEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/common.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/common.tsx
@@ -110,6 +110,13 @@ export const getItems: (
         : entityData?.risk.category_2_score ?? 0,
       count: undefined,
     },
+    ...(entityData?.risk.modifiers
+      ?.filter((modifier) => modifier.type === 'watchlist' && modifier.subtype !== 'privmon')
+      .map((watchlistModifier) => ({
+        category: watchlistModifier.subtype,
+        score: watchlistModifier.contribution ?? 0,
+        count: undefined,
+      })) ?? []),
   ];
 
   if (isPrivmonEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/apply_score_modifiers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/apply_score_modifiers.ts
@@ -28,14 +28,19 @@ import {
   buildLegacyCriticalityFields,
 } from './modifiers/asset_criticality';
 
-import { applyPrivmonModifier } from './modifiers/privileged_users';
+// import { applyPrivmonModifier } from './modifiers/privileged_users';
 import type { ExperimentalFeatures } from '../../../../common';
 import type { Modifier } from './modifiers/types';
 import { bayesianUpdate } from '../asset_criticality/helpers';
+import { applyWatchlistModifiers } from './modifiers/watchlists_modifiers';
+import type { WatchlistConfigClient } from '../watchlists/management/watchlist_config';
+import type { WatchlistEntitiesService } from '../watchlists/entities/service';
 interface ModifiersUpdateParams {
   now: string;
   deps: {
     privmonUserCrudService: PrivmonUserCrudService;
+    watchlistConfigClient: WatchlistConfigClient;
+    watchlistEntitiesService: WatchlistEntitiesService;
     assetCriticalityService: AssetCriticalityService;
     logger: Logger;
   };
@@ -65,6 +70,17 @@ export const applyScoreModifiers = async ({
     ? getGlobalWeightForIdentifierType(identifierType, weights)
     : undefined;
 
+  const watchlistPromises = await applyWatchlistModifiers({
+    page,
+    globalWeight,
+    deps: {
+      watchlistConfigClient: deps.watchlistConfigClient,
+      watchlistEntityService: deps.watchlistEntitiesService,
+      logger: deps.logger,
+    },
+    experimentalFeatures,
+  });
+
   const modifierPromises = [
     applyCriticalityModifier({
       page,
@@ -72,22 +88,31 @@ export const applyScoreModifiers = async ({
       deps: _.pick(deps, ['assetCriticalityService', 'logger']),
     }),
 
-    applyPrivmonModifier({
-      page,
-      globalWeight,
-      experimentalFeatures,
-      deps: _.pick(deps, ['privmonUserCrudService', 'logger']),
-    }),
+    //
+    ...watchlistPromises,
   ] as const;
 
-  const [criticality, privmon] = await Promise.all(modifierPromises);
+  const [criticality, ...watchlists] = await Promise.all(modifierPromises);
+  const fn = riskScoreDocFactory({ now, identifierField: page.identifierField, globalWeight });
 
-  return _.zipWith(
-    page.buckets,
-    criticality,
-    privmon,
-    riskScoreDocFactory({ now, identifierField: page.identifierField, globalWeight })
-  );
+  const zip = (
+    result: EntityRiskScoreRecord[],
+    buckets: RiskScoreBucket[],
+    crits: Array<Modifier<'asset_criticality'> | undefined>,
+    ...lists: Array<Modifier<'watchlist'> | undefined>[]
+  ) => {
+    if (buckets.length === 0) return result;
+
+    const [bucket, ...bs] = buckets;
+    const [crit, ...cs] = crits;
+    const ws = lists.map(([w]) => w);
+    const tails = lists.map(([, ...rest]) => rest);
+
+    const doc = fn(bucket, crit, ...ws);
+    result.push(doc);
+    return zip(result, bs, cs, ...tails);
+  };
+  return zip([], page.buckets, criticality, ...watchlists);
 };
 
 interface RiskScoreDocFactoryParams {
@@ -101,7 +126,7 @@ export const riskScoreDocFactory =
   (
     bucket: RiskScoreBucket,
     criticalityModifierFields: Modifier<'asset_criticality'> | undefined,
-    privmonWatchlistModifierFields: Modifier<'watchlist'> | undefined
+    ...watchlistsModifierFields: Array<Modifier<'watchlist'> | undefined>
   ): EntityRiskScoreRecord => {
     const risk = bucket.top_inputs.risk_details;
 
@@ -112,7 +137,9 @@ export const riskScoreDocFactory =
 
     const totalModifier =
       (criticalityModifierFields?.modifier_value ?? 1) *
-      (privmonWatchlistModifierFields?.modifier_value ?? 1);
+      watchlistsModifierFields.reduce((acc, curr) => acc * (curr?.modifier_value ?? 1), 1);
+    //
+    //  (watchlistsModifierFields?.modifier_value ?? 1);
 
     const originalScore = risk.value.normalized_score * globalWeight;
     const totalScoreWithModifiers = bayesianUpdate({
@@ -128,7 +155,7 @@ export const riskScoreDocFactory =
       calculated_score_norm: max10DecimalPlaces(totalScoreWithModifiers),
     };
 
-    const appliedModifiers = [criticalityModifierFields, privmonWatchlistModifierFields].filter(
+    const appliedModifiers = [criticalityModifierFields, ...watchlistsModifierFields].filter(
       isDefined
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_and_persist_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_and_persist_risk_scores.ts
@@ -15,6 +15,8 @@ import type { CalculateAndPersistScoresParams } from '../types';
 import { calculateScoresWithESQL } from './calculate_esql_risk_scores';
 import type { RiskScoresCalculationResponse } from '../../../../common/api/entity_analytics';
 import type { PrivmonUserCrudService } from '../privilege_monitoring/users/privileged_users_crud';
+import type { WatchlistConfigClient } from '../watchlists/management/watchlist_config';
+import type { WatchlistEntitiesService } from '../watchlists/entities/service';
 
 export type CalculationResults = RiskScoresCalculationResponse & {
   entities: Record<EntityType, string[]>;
@@ -24,6 +26,8 @@ export const calculateAndPersistRiskScores = async (
   params: CalculateAndPersistScoresParams & {
     assetCriticalityService: AssetCriticalityService;
     privmonUserCrudService: PrivmonUserCrudService;
+    watchlistConfigClient: WatchlistConfigClient;
+    watchlistEntitiesService: WatchlistEntitiesService;
     esClient: ElasticsearchClient;
     logger: Logger;
     spaceId: string;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
@@ -35,6 +35,8 @@ import { RIEMANN_ZETA_S_VALUE, RIEMANN_ZETA_VALUE } from './constants';
 import { filterFromRange } from './helpers';
 import { applyScoreModifiers } from './apply_score_modifiers';
 import type { PrivmonUserCrudService } from '../privilege_monitoring/users/privileged_users_crud';
+import type { WatchlistConfigClient } from '../watchlists/management/watchlist_config';
+import type { WatchlistEntitiesService } from '../watchlists/entities/service';
 
 type ESQLResults = Array<
   [EntityType, { scores: EntityRiskScoreRecord[]; afterKey: EntityAfterKey }]
@@ -44,6 +46,8 @@ export const calculateScoresWithESQL = async (
   params: {
     assetCriticalityService: AssetCriticalityService;
     privmonUserCrudService: PrivmonUserCrudService;
+    watchlistConfigClient: WatchlistConfigClient;
+    watchlistEntitiesService: WatchlistEntitiesService;
     esClient: ElasticsearchClient;
     logger: Logger;
     experimentalFeatures: ExperimentalFeatures;
@@ -200,6 +204,8 @@ export const calculateScoresWithESQL = async (
               deps: {
                 assetCriticalityService: params.assetCriticalityService,
                 privmonUserCrudService: params.privmonUserCrudService,
+                watchlistConfigClient: params.watchlistConfigClient,
+                watchlistEntitiesService: params.watchlistEntitiesService,
                 logger,
               },
               weights: params.weights,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/types.ts
@@ -13,10 +13,12 @@ interface ModifierTypeMap {
     metadata: { criticality_level: AssetCriticalityRecord['criticality_level'] | undefined };
   };
   // NOTE: When we introduce more watchlists, we'll extend this by adding a descriminated union
-  watchlist: {
-    subtype: 'privmon';
-    metadata: { is_privileged_user: boolean | undefined };
-  };
+  watchlist:
+    | {
+        subtype: 'privmon';
+        metadata: { is_privileged_user: boolean | undefined };
+      }
+    | { subtype: string; metadata: Record<string, unknown> };
 }
 export type MODIFIER_TYPE = keyof ModifierTypeMap;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/watchlists_modifiers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/watchlists_modifiers.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { Logger } from '@kbn/core/server';
+import get from 'lodash/get';
+import type { WatchlistObject } from '../../../../../common/api/entity_analytics/watchlists/management/common.gen';
+import type { ExperimentalFeatures } from '../../../../../common';
+import type { RiskScoreBucket } from '../../types';
+import type { WatchlistConfigClient } from '../../watchlists/management/watchlist_config';
+import type { Modifier } from './types';
+import type { WatchlistEntitiesService } from '../../watchlists/entities/service';
+
+interface WatchlistModifierParams {
+  page: {
+    buckets: RiskScoreBucket[];
+    identifierField: string;
+    bounds: {
+      lower?: string;
+      upper?: string;
+    };
+  };
+
+  deps: {
+    watchlistConfigClient: WatchlistConfigClient;
+    watchlistEntityService: WatchlistEntitiesService;
+    logger: Logger;
+  };
+  experimentalFeatures: ExperimentalFeatures;
+  globalWeight?: number;
+}
+
+export const applyWatchlistModifiers = async ({
+  page: { buckets, identifierField, bounds },
+  deps,
+  globalWeight,
+  experimentalFeatures,
+}: WatchlistModifierParams) => {
+  if (buckets.length === 0) {
+    return [];
+  }
+
+  if (!experimentalFeatures.entityAnalyticsWatchlistEnabled) {
+    return [];
+  }
+  const lower = bounds?.lower ? `${identifierField} > ${bounds.lower}` : undefined;
+  const upper = bounds?.upper ? `${identifierField} <= ${bounds.upper}` : undefined;
+  if (!lower && !upper) {
+    throw new Error('Either lower or upper after key must be provided for pagination');
+  }
+  const rangeClauseKQL =
+    !lower && !upper ? undefined : [lower, upper].filter(Boolean).join(' and ');
+
+  const entitiesPerWatchlist = await deps.watchlistConfigClient.list().then((watchlists) =>
+    watchlists.map(async (w) => {
+      const entities = await deps.watchlistEntityService.list(w, rangeClauseKQL);
+      return buckets.map((bucket) => {
+        const isInWatchlist = entities.some(
+          (entity) => get(entity, identifierField) === bucket.key[identifierField]
+        );
+        return buildModifier(isInWatchlist, w, globalWeight);
+      });
+    })
+  );
+
+  return entitiesPerWatchlist;
+};
+
+const buildModifier = (
+  isInWatchlist: boolean,
+  watchlist: WatchlistObject,
+  globalWeight?: number
+): Modifier<'watchlist'> | undefined => {
+  if (!isInWatchlist) {
+    return;
+  }
+
+  const weightedModifier =
+    globalWeight !== undefined ? watchlist.riskModifier * globalWeight : watchlist.riskModifier;
+
+  return {
+    type: 'watchlist',
+    subtype: watchlist.name === 'privileged_users' ? 'privmon' : watchlist.name,
+    modifier_value: weightedModifier,
+    metadata:
+      watchlist.name === 'privileged_users'
+        ? {
+            is_privileged_user: true,
+          }
+        : { inWatchlist: true },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_service.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, IUiSettingsClient, Logger } from '@kbn/core/server';
+import type {
+  ElasticsearchClient,
+  IUiSettingsClient,
+  Logger,
+  SavedObjectsClientContract,
+} from '@kbn/core/server';
 import { getPrivilegedMonitorUsersIndex } from '../../../../common/entity_analytics/privileged_user_monitoring/utils';
 import type { ExperimentalFeatures } from '../../../../common';
 import type { RiskScoresPreviewResponse } from '../../../../common/api/entity_analytics';
@@ -26,6 +31,8 @@ import { calculateScoresWithESQL } from './calculate_esql_risk_scores';
 import type { ResetToZeroDependencies } from './reset_to_zero';
 import { resetToZero } from './reset_to_zero';
 import { createPrivilegedUsersCrudService } from '../privilege_monitoring/users/privileged_users_crud';
+import { WatchlistConfigClient } from '../watchlists/management/watchlist_config';
+import { createWatchlistEntitiesService } from '../watchlists/entities/service';
 
 export type RiskEngineConfigurationWithDefaults = RiskEngineConfiguration & {
   alertSampleSizePerShard: number;
@@ -48,6 +55,7 @@ export interface RiskScoreService {
 
 export interface RiskScoreServiceFactoryParams {
   assetCriticalityService: AssetCriticalityService;
+  soClient: SavedObjectsClientContract;
   esClient: ElasticsearchClient;
   logger: Logger;
   riskEngineDataClient: RiskEngineDataClient;
@@ -61,6 +69,7 @@ export interface RiskScoreServiceFactoryParams {
 export const riskScoreServiceFactory = ({
   assetCriticalityService,
   esClient,
+  soClient,
   logger,
   riskEngineDataClient,
   riskScoreDataClient,
@@ -73,12 +82,26 @@ export const riskScoreServiceFactory = ({
     esClient,
     logger,
   });
+
+  const watchlistConfigClient = new WatchlistConfigClient({
+    namespace: spaceId,
+    esClient,
+    soClient,
+    logger,
+  });
+
+  const watchlistEntitiesService = createWatchlistEntitiesService({
+    esClient,
+    namespace: spaceId,
+  });
   return {
     calculateScores: async (params) => {
       return calculateScoresWithESQL({
         ...params,
         assetCriticalityService,
         privmonUserCrudService,
+        watchlistConfigClient,
+        watchlistEntitiesService,
         esClient,
         logger,
         experimentalFeatures,
@@ -90,6 +113,8 @@ export const riskScoreServiceFactory = ({
         ...params,
         assetCriticalityService,
         privmonUserCrudService,
+        watchlistConfigClient,
+        watchlistEntitiesService,
         esClient,
         logger,
         riskScoreDataClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/helpers.ts
@@ -17,6 +17,8 @@ export function buildRiskScoreServiceForRequest(
   logger: Logger
 ) {
   const esClient = coreContext.elasticsearch.client.asCurrentUser;
+  const soClient = coreContext.savedObjects.client;
+
   const spaceId = securityContext.getSpaceId();
   const assetCriticalityDataClient = securityContext.getAssetCriticalityDataClient();
   const assetCriticalityService = assetCriticalityServiceFactory({
@@ -32,6 +34,7 @@ export function buildRiskScoreServiceForRequest(
   return riskScoreServiceFactory({
     assetCriticalityService,
     esClient,
+    soClient,
     logger,
     riskEngineDataClient,
     riskScoreDataClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
@@ -16,6 +16,7 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
 import type { AuditLogger } from '@kbn/security-plugin-types-server';
+import { SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID } from '@kbn/core-saved-objects-server';
 import { getEntityAnalyticsEntityTypes } from '../../../../../common/entity_analytics/utils';
 import type { EntityType } from '../../../../../common/search_strategy';
 import type { ExperimentalFeatures } from '../../../../../common';
@@ -30,7 +31,7 @@ import {
   type LatestTaskStateSchema as RiskScoringTaskState,
 } from './state';
 import { INTERVAL, SCOPE, TIMEOUT, TYPE, VERSION } from './constants';
-import { buildScopedInternalSavedObjectsClientUnsafe, convertRangeToISO } from './helpers';
+import { convertRangeToISO } from './helpers';
 import {
   RISK_SCORE_EXECUTION_SUCCESS_EVENT,
   RISK_SCORE_EXECUTION_ERROR_EVENT,
@@ -80,7 +81,10 @@ export const registerRiskScoringTask = ({
   const getRiskScoreService: GetRiskScoreService = (namespace) =>
     getStartServices().then(([coreStart, _]) => {
       const esClient = coreStart.elasticsearch.client.asInternalUser;
-      const soClient = buildScopedInternalSavedObjectsClientUnsafe({ coreStart, namespace });
+
+      const soClient = coreStart.savedObjects.getUnsafeInternalClient({
+        excludedExtensions: [SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID],
+      });
 
       const assetCriticalityDataClient = new AssetCriticalityDataClient({
         esClient,
@@ -116,6 +120,7 @@ export const registerRiskScoringTask = ({
       return riskScoreServiceFactory({
         assetCriticalityService,
         esClient,
+        soClient,
         logger,
         riskEngineDataClient,
         riskScoreDataClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entities/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entities/service.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+// TODO: Replace MonitoredUserDoc with a watchlist-specific entity doc type
+import type { MonitoredUserDoc } from '../../../../../common/api/entity_analytics';
+import type { WatchlistObject } from '../../../../../common/api/entity_analytics/watchlists/management/common.gen';
+import { getIndexForWatchlist } from './utils';
+
+export type WatchlistEntitiesService = ReturnType<typeof createWatchlistEntitiesService>;
+
+interface WatchlistEntitiesServiceDeps {
+  esClient: ElasticsearchClient;
+  namespace: string;
+}
+
+export const createWatchlistEntitiesService = ({
+  esClient,
+  namespace,
+}: WatchlistEntitiesServiceDeps) => {
+  const list = async (
+    watchlist: WatchlistObject,
+    _rangeClauseKQL?: string
+  ): Promise<MonitoredUserDoc[]> => {
+    const index = getIndexForWatchlist(watchlist.name, namespace);
+
+    const response = await esClient.search<MonitoredUserDoc>({
+      index,
+      size: 10_000,
+      query: { match_all: {} },
+      _source: true,
+    });
+
+    return response.hits.hits
+      .map((hit) => hit._source)
+      .filter((source): source is MonitoredUserDoc => source !== undefined);
+  };
+
+  return { list };
+};


### PR DESCRIPTION
## Summary

This PR updates the risk engine to take watchlist contributions into account when calculating new scores.

### How it works 

- Risk scores are computed from alerts (ESQL aggregation by entity).
- **Watchlist modifiers** run during `applyScoreModifiers` in `calculate_esql_risk_scores.ts`.
- For each entity in a risk score bucket, the system checks if it appears in any watchlist.
- This is done by iterating through the watchlists and querying the respective index
- If an entity is found, the watchlist's `riskModifier` is applied via a Bayesian update.
- Modifiers are combined (asset criticality × watchlist modifiers).
- The final score and applied modifiers are stored in the risk score document.

---

## How to test

1. **Enable the watchlist feature**
   - Add `entityAnalyticsWatchlistEnabled` to `xpack.securitySolution.enableExperimental` in `kibana.yml`:
```yml
 xpack.securitySolution.enableExperimental:
  - entityAnalyticsWatchlistEnabled       
```
2. **Create a watchlist**
   - UI: Security → Entity Analytics → Watchlists 
   - API: `POST /api/entity_analytics/watchlists` with body: `name`, `description`, `riskModifier`, `managed` (false).
   - Note the returned watchlist id.

3. **Populate the watchlist with entities**
   - Watchlist index: `.entity-analytics.watchlists.{watchlistName}-{namespace}` 
   - Add entities by indexing documents into that index with the correct entity fields (`host.name`, `user.name`, etc). Ensure identifiers match those used in alerts.

4. **Trigger risk score calculation**
   - UI: Entity Analytics → Risk Engine → Schedule now.
   - API: `POST /api/entity_analytics/risk_engine/schedule_now`.

5. **Verify watchlist contribution**
   - Host/User risk tables: Open Entity Analytics and check Host Risk or User Risk.
   - Entity flyout: Open an entity that is in the watchlist and verify a higher risk score and a modifiers entry with type "watchlist" and subtype equal to the watchlist name.
   - API: Query the risk score index (e.g. `.risk-score.risk-score-*`) and inspect documents for entities in the watchlist. The modifiers array should include type "watchlist", subtype, modifier_value, and contribution.