### PR TITLE
[ES|QL] Use adhoc esql dataview to the visor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/moon.yml
+++ b/src/platform/packages/private/kbn-esql-editor/moon.yml
@@ -50,6 +50,7 @@ dependsOn:
   - '@kbn/aiops-utils'
   - '@kbn/esql-resource-browser'
   - '@kbn/projects-solutions-groups'
+  - '@kbn/data-views-plugin'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/editor_visor.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/editor_visor.test.tsx
@@ -14,8 +14,18 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { coreMock } from '@kbn/core/public/mocks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { QuickSearchVisor, type QuickSearchVisorProps } from '.';
+
+jest.mock('@kbn/esql-utils', () => ({
+  ...jest.requireActual('@kbn/esql-utils'),
+  getESQLAdHocDataview: jest.fn().mockResolvedValue({
+    id: 'mock-adhoc-dataview',
+    title: 'test_index',
+    type: 'esql',
+  }),
+}));
 
 describe('Quick search visor', () => {
   const corePluginMock = coreMock.createStart();
@@ -32,9 +42,11 @@ describe('Quick search visor', () => {
 
   const kqlMock = kqlPluginMock.createStartContract();
   (kqlMock.autocomplete.hasQuerySuggestions as jest.Mock).mockReturnValue(true);
+  const dataMock = dataPluginMock.createStartContract();
 
   const services = {
     core: corePluginMock,
+    data: dataMock,
     kql: kqlMock,
   };
 

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -16,7 +16,8 @@ import {
   type EuiComboBoxOptionOption,
 } from '@elastic/eui';
 import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
-import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
+import { getIndexPatternFromESQLQuery, getESQLAdHocDataview } from '@kbn/esql-utils';
+import type { DataView } from '@kbn/data-views-plugin/common';
 import { calculateWidthFromCharCount } from '@kbn/calculate-width-from-char-count';
 import { isEqual } from 'lodash';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -53,11 +54,12 @@ export function QuickSearchVisor({
   onToggleVisor,
 }: QuickSearchVisorProps) {
   const kibana = useKibana<ESQLEditorDeps>();
-  const { kql } = kibana.services;
+  const { kql, data, core } = kibana.services;
   const isDarkMode = useKibanaIsDarkMode();
   const { euiTheme } = useEuiTheme();
   const [selectedSources, setSelectedSources] = useState<EuiComboBoxOptionOption[]>([]);
   const [searchValue, setSearchValue] = useState('');
+  const [adHocDataView, setAdHocDataView] = useState<DataView | null>(null);
   const kqlInputRef = useRef<HTMLDivElement>(null);
   const initializedRef = useRef(false);
   const userSelectedSourceRef = useRef(false);
@@ -104,6 +106,33 @@ export function QuickSearchVisor({
       }
     }
   }, [query, selectedSources]);
+
+  const sourcesKey = useMemo(
+    () => selectedSources.map((source) => source.label).join(', '),
+    [selectedSources]
+  );
+
+  // Create an ad-hoc data view for the selected sources
+  useEffect(() => {
+    if (!sourcesKey) {
+      setAdHocDataView(null);
+      return;
+    }
+    let cancelled = false;
+    getESQLAdHocDataview({
+      dataViewsService: data.dataViews,
+      query: `FROM ${sourcesKey}`,
+      options: { skipFetchFields: true },
+      http: core.http,
+    }).then((dataView) => {
+      if (!cancelled) {
+        setAdHocDataView(dataView);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sourcesKey, data.dataViews, core.http]);
 
   useEffect(() => {
     if (isVisible && kqlInputRef.current) {
@@ -164,7 +193,7 @@ export function QuickSearchVisor({
                 isDisabled={!isVisible}
                 iconType="search"
                 disableLanguageSwitcher={true}
-                indexPatterns={selectedSources.map((source) => source.label)}
+                indexPatterns={adHocDataView ? [adHocDataView] : []}
                 bubbleSubmitEvent={false}
                 query={{
                   query: searchValue,

--- a/src/platform/packages/private/kbn-esql-editor/tsconfig.json
+++ b/src/platform/packages/private/kbn-esql-editor/tsconfig.json
@@ -44,7 +44,8 @@
     "@kbn/search-types",
     "@kbn/aiops-utils",
     "@kbn/esql-resource-browser",
-    "@kbn/projects-solutions-groups"  ],
+    "@kbn/projects-solutions-groups",
+    "@kbn/data-views-plugin"  ],
   "exclude": [
     "target/**/*",
   ]


### PR DESCRIPTION
## Summary

I am changing the dataviews that I am passing to the KQL bar, it is more performant to send the adhoc dataview which cashes and is esql specific. Also I realized that the KQL bar doesnt work always correctly when you pass just strings. This fixes the behavior.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



