### PR TITLE
[Fleet] hide fields not relevant to collectors

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -57,6 +57,164 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
   const latestAgentVersion = useAgentVersion();
   const [effectiveConfigFlyoutOpen, setEffectiveConfigFlyoutOpen] = React.useState(false);
 
+  const platformField = {
+    title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
+      defaultMessage: 'Platform',
+    }),
+    description:
+      typeof agent.local_metadata?.os?.platform === 'string'
+        ? agent.local_metadata.os.platform
+        : '-',
+  };
+  const tagsField = {
+    title: i18n.translate('xpack.fleet.agentDetails.tagsLabel', {
+      defaultMessage: 'Tags',
+    }),
+    description: (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
+  };
+
+  const capabilitiesField = Array.isArray(agent.capabilities)
+    ? [
+        {
+          title: i18n.translate('xpack.fleet.agentDetails.capabilitiesLabel', {
+            defaultMessage: 'Collector capabilities',
+          }),
+          description: (
+            <EuiFlexGroup direction="column" alignItems="flexStart" justifyContent="flexStart">
+              {agent.capabilities.sort().map((capability) => (
+                <FlexItemWithMinWidth grow={false} key={capability}>
+                  <EuiDescriptionListDescription
+                    css={`
+                      ${euiTextBreakWord()};
+                    `}
+                  >
+                    {capability}
+                  </EuiDescriptionListDescription>
+                </FlexItemWithMinWidth>
+              ))}
+            </EuiFlexGroup>
+          ),
+        },
+      ]
+    : [];
+
+  const opAMPFields = [platformField, tagsField, ...capabilitiesField];
+
+  const agentFields = [
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
+        defaultMessage: 'Output for integrations',
+      }),
+      description: outputs ? <AgentPolicyOutputsSummary outputs={outputs} /> : '-',
+    },
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
+        defaultMessage: 'Output for monitoring',
+      }),
+      description: outputs ? (
+        <AgentPolicyOutputsSummary outputs={outputs} isMonitoring={true} />
+      ) : (
+        '-'
+      ),
+    },
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.logLevel', {
+        defaultMessage: 'Logging level',
+      }),
+      description:
+        typeof agent.local_metadata?.elastic?.agent?.log_level === 'string'
+          ? agent.local_metadata.elastic.agent.log_level
+          : '-',
+    },
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.privilegeModeLabel', {
+        defaultMessage: 'Privilege mode',
+      }),
+      description:
+        agent.local_metadata.elastic.agent.unprivileged === true ? (
+          <FormattedMessage
+            id="xpack.fleet.agentDetails.privilegeModeUnprivilegedText"
+            defaultMessage="Running as non-root"
+          />
+        ) : (
+          <FormattedMessage
+            id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
+            defaultMessage="Running as root"
+          />
+        ),
+    },
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.releaseLabel', {
+        defaultMessage: 'Agent release',
+      }),
+      description:
+        typeof agent.local_metadata?.elastic?.agent?.snapshot === 'boolean'
+          ? agent.local_metadata.elastic.agent.snapshot === true
+            ? 'snapshot'
+            : 'stable'
+          : '-',
+    },
+    platformField,
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.monitorLogsLabel', {
+        defaultMessage: 'Monitor logs',
+      }),
+      description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
+        agentPolicy?.monitoring_enabled?.includes('logs') ? (
+          <FormattedMessage
+            id="xpack.fleet.agentList.monitorLogsEnabledText"
+            defaultMessage="Enabled"
+          />
+        ) : (
+          <FormattedMessage
+            id="xpack.fleet.agentList.monitorLogsDisabledText"
+            defaultMessage="Disabled"
+          />
+        )
+      ) : (
+        <EuiSkeletonText lines={1} />
+      ),
+    },
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.monitorMetricsLabel', {
+        defaultMessage: 'Monitor metrics',
+      }),
+      description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
+        agentPolicy?.monitoring_enabled?.includes('metrics') ? (
+          <FormattedMessage
+            id="xpack.fleet.agentList.monitorMetricsEnabledText"
+            defaultMessage="Enabled"
+          />
+        ) : (
+          <FormattedMessage
+            id="xpack.fleet.agentList.monitorMetricsDisabledText"
+            defaultMessage="Disabled"
+          />
+        )
+      ) : (
+        <EuiSkeletonText lines={1} />
+      ),
+    },
+    tagsField,
+    {
+      title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
+        defaultMessage: 'FIPS mode',
+      }),
+      description:
+        agent.local_metadata.elastic.agent.fips === true ? (
+          <FormattedMessage
+            id="xpack.fleet.agentDetails.fipsModeCompliantText"
+            defaultMessage="Enabled"
+          />
+        ) : (
+          <FormattedMessage
+            id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
+            defaultMessage="Not enabled"
+          />
+        ),
+    },
+  ];
+
   return (
     <EuiPanel>
       <EuiDescriptionList compressed>
@@ -240,6 +398,7 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                   ? agent.local_metadata.host.id
                   : '-',
             },
+            ...(agent.type !== 'OPAMP' ? agentFields : opAMPFields),
           ].map(({ title, description }) => {
             const tooltip =
               typeof description === 'string' && description.length > 20 ? description : '';
@@ -258,182 +417,6 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
               </EuiFlexGroup>
             );
           })}
-          <EuiFlexGroup>
-            <FlexItemWithMinWidth grow={2}>
-              <EuiFlexGroup direction="column" gutterSize="m">
-                {[
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
-                      defaultMessage: 'Output for integrations',
-                    }),
-                    description: outputs ? <AgentPolicyOutputsSummary outputs={outputs} /> : '-',
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
-                      defaultMessage: 'Output for monitoring',
-                    }),
-                    description: outputs ? (
-                      <AgentPolicyOutputsSummary outputs={outputs} isMonitoring={true} />
-                    ) : (
-                      '-'
-                    ),
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.logLevel', {
-                      defaultMessage: 'Logging level',
-                    }),
-                    description:
-                      typeof agent.local_metadata?.elastic?.agent?.log_level === 'string'
-                        ? agent.local_metadata.elastic.agent.log_level
-                        : '-',
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.privilegeModeLabel', {
-                      defaultMessage: 'Privilege mode',
-                    }),
-                    description:
-                      agent.local_metadata.elastic.agent.unprivileged === true ? (
-                        <FormattedMessage
-                          id="xpack.fleet.agentDetails.privilegeModeUnprivilegedText"
-                          defaultMessage="Running as non-root"
-                        />
-                      ) : (
-                        <FormattedMessage
-                          id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
-                          defaultMessage="Running as root"
-                        />
-                      ),
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.releaseLabel', {
-                      defaultMessage: 'Agent release',
-                    }),
-                    description:
-                      typeof agent.local_metadata?.elastic?.agent?.snapshot === 'boolean'
-                        ? agent.local_metadata.elastic.agent.snapshot === true
-                          ? 'snapshot'
-                          : 'stable'
-                        : '-',
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
-                      defaultMessage: 'Platform',
-                    }),
-                    description:
-                      typeof agent.local_metadata?.os?.platform === 'string'
-                        ? agent.local_metadata.os.platform
-                        : '-',
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.monitorLogsLabel', {
-                      defaultMessage: 'Monitor logs',
-                    }),
-                    description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
-                      agentPolicy?.monitoring_enabled?.includes('logs') ? (
-                        <FormattedMessage
-                          id="xpack.fleet.agentList.monitorLogsEnabledText"
-                          defaultMessage="Enabled"
-                        />
-                      ) : (
-                        <FormattedMessage
-                          id="xpack.fleet.agentList.monitorLogsDisabledText"
-                          defaultMessage="Disabled"
-                        />
-                      )
-                    ) : (
-                      <EuiSkeletonText lines={1} />
-                    ),
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.monitorMetricsLabel', {
-                      defaultMessage: 'Monitor metrics',
-                    }),
-                    description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
-                      agentPolicy?.monitoring_enabled?.includes('metrics') ? (
-                        <FormattedMessage
-                          id="xpack.fleet.agentList.monitorMetricsEnabledText"
-                          defaultMessage="Enabled"
-                        />
-                      ) : (
-                        <FormattedMessage
-                          id="xpack.fleet.agentList.monitorMetricsDisabledText"
-                          defaultMessage="Disabled"
-                        />
-                      )
-                    ) : (
-                      <EuiSkeletonText lines={1} />
-                    ),
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.tagsLabel', {
-                      defaultMessage: 'Tags',
-                    }),
-                    description:
-                      (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
-                  },
-                  {
-                    title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
-                      defaultMessage: 'FIPS mode',
-                    }),
-                    description:
-                      agent.local_metadata.elastic.agent.fips === true ? (
-                        <FormattedMessage
-                          id="xpack.fleet.agentDetails.fipsModeCompliantText"
-                          defaultMessage="Enabled"
-                        />
-                      ) : (
-                        <FormattedMessage
-                          id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
-                          defaultMessage="Not enabled"
-                        />
-                      ),
-                  },
-                ].map(({ title, description }) => {
-                  const tooltip =
-                    typeof description === 'string' && description.length > 20 ? description : '';
-                  return (
-                    <EuiFlexGroup>
-                      <FlexItemWithMinWidth grow={3}>
-                        <EuiDescriptionListTitle>{title}</EuiDescriptionListTitle>
-                      </FlexItemWithMinWidth>
-                      <FlexItemWithMinWidth grow={7}>
-                        <EuiToolTip position="top" content={tooltip}>
-                          <EuiDescriptionListDescription className="eui-textTruncate">
-                            {description}
-                          </EuiDescriptionListDescription>
-                        </EuiToolTip>
-                      </FlexItemWithMinWidth>
-                    </EuiFlexGroup>
-                  );
-                })}
-              </EuiFlexGroup>
-            </FlexItemWithMinWidth>
-            {agent.capabilities && (
-              <FlexItemWithMinWidth grow={1} key="agent-capabilities">
-                <EuiFlexGroup direction="column" alignItems="flexStart" justifyContent="flexStart">
-                  <FlexItemWithMinWidth grow={false}>
-                    <EuiDescriptionListTitle>
-                      <FormattedMessage
-                        id="xpack.fleet.agentDetails.collectorCapabilitiesLabel"
-                        defaultMessage="Collector Capabilities"
-                      />
-                    </EuiDescriptionListTitle>
-                  </FlexItemWithMinWidth>
-                  {agent.capabilities.sort().map((capability) => (
-                    <FlexItemWithMinWidth grow={false} key={capability}>
-                      <EuiDescriptionListDescription
-                        css={`
-                          ${euiTextBreakWord()};
-                        `}
-                      >
-                        {capability}
-                      </EuiDescriptionListDescription>
-                    </FlexItemWithMinWidth>
-                  ))}
-                </EuiFlexGroup>
-              </FlexItemWithMinWidth>
-            )}
-          </EuiFlexGroup>
         </EuiFlexGroup>
       </EuiDescriptionList>
       {effectiveConfigFlyoutOpen && (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -379,7 +379,7 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
               }),
               description: (
                 <EuiFlexGroup direction="column" alignItems="flexStart" justifyContent="flexStart">
-                  {agent.capabilities.sort().map((capability) => (
+                  {agent.capabilities?.sort().map((capability) => (
                     <FlexItemWithMinWidth grow={false} key={capability}>
                       <EuiDescriptionListDescription
                         css={`

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -57,164 +57,6 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
   const latestAgentVersion = useAgentVersion();
   const [effectiveConfigFlyoutOpen, setEffectiveConfigFlyoutOpen] = React.useState(false);
 
-  const platformField = {
-    title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
-      defaultMessage: 'Platform',
-    }),
-    description:
-      typeof agent.local_metadata?.os?.platform === 'string'
-        ? agent.local_metadata.os.platform
-        : '-',
-  };
-  const tagsField = {
-    title: i18n.translate('xpack.fleet.agentDetails.tagsLabel', {
-      defaultMessage: 'Tags',
-    }),
-    description: (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
-  };
-
-  const capabilitiesField = Array.isArray(agent.capabilities)
-    ? [
-        {
-          title: i18n.translate('xpack.fleet.agentDetails.capabilitiesLabel', {
-            defaultMessage: 'Collector capabilities',
-          }),
-          description: (
-            <EuiFlexGroup direction="column" alignItems="flexStart" justifyContent="flexStart">
-              {agent.capabilities.sort().map((capability) => (
-                <FlexItemWithMinWidth grow={false} key={capability}>
-                  <EuiDescriptionListDescription
-                    css={`
-                      ${euiTextBreakWord()};
-                    `}
-                  >
-                    {capability}
-                  </EuiDescriptionListDescription>
-                </FlexItemWithMinWidth>
-              ))}
-            </EuiFlexGroup>
-          ),
-        },
-      ]
-    : [];
-
-  const opAMPFields = [platformField, tagsField, ...capabilitiesField];
-
-  const agentFields = [
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
-        defaultMessage: 'Output for integrations',
-      }),
-      description: outputs ? <AgentPolicyOutputsSummary outputs={outputs} /> : '-',
-    },
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
-        defaultMessage: 'Output for monitoring',
-      }),
-      description: outputs ? (
-        <AgentPolicyOutputsSummary outputs={outputs} isMonitoring={true} />
-      ) : (
-        '-'
-      ),
-    },
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.logLevel', {
-        defaultMessage: 'Logging level',
-      }),
-      description:
-        typeof agent.local_metadata?.elastic?.agent?.log_level === 'string'
-          ? agent.local_metadata.elastic.agent.log_level
-          : '-',
-    },
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.privilegeModeLabel', {
-        defaultMessage: 'Privilege mode',
-      }),
-      description:
-        agent.local_metadata.elastic.agent.unprivileged === true ? (
-          <FormattedMessage
-            id="xpack.fleet.agentDetails.privilegeModeUnprivilegedText"
-            defaultMessage="Running as non-root"
-          />
-        ) : (
-          <FormattedMessage
-            id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
-            defaultMessage="Running as root"
-          />
-        ),
-    },
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.releaseLabel', {
-        defaultMessage: 'Agent release',
-      }),
-      description:
-        typeof agent.local_metadata?.elastic?.agent?.snapshot === 'boolean'
-          ? agent.local_metadata.elastic.agent.snapshot === true
-            ? 'snapshot'
-            : 'stable'
-          : '-',
-    },
-    platformField,
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.monitorLogsLabel', {
-        defaultMessage: 'Monitor logs',
-      }),
-      description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
-        agentPolicy?.monitoring_enabled?.includes('logs') ? (
-          <FormattedMessage
-            id="xpack.fleet.agentList.monitorLogsEnabledText"
-            defaultMessage="Enabled"
-          />
-        ) : (
-          <FormattedMessage
-            id="xpack.fleet.agentList.monitorLogsDisabledText"
-            defaultMessage="Disabled"
-          />
-        )
-      ) : (
-        <EuiSkeletonText lines={1} />
-      ),
-    },
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.monitorMetricsLabel', {
-        defaultMessage: 'Monitor metrics',
-      }),
-      description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
-        agentPolicy?.monitoring_enabled?.includes('metrics') ? (
-          <FormattedMessage
-            id="xpack.fleet.agentList.monitorMetricsEnabledText"
-            defaultMessage="Enabled"
-          />
-        ) : (
-          <FormattedMessage
-            id="xpack.fleet.agentList.monitorMetricsDisabledText"
-            defaultMessage="Disabled"
-          />
-        )
-      ) : (
-        <EuiSkeletonText lines={1} />
-      ),
-    },
-    tagsField,
-    {
-      title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
-        defaultMessage: 'FIPS mode',
-      }),
-      description:
-        agent.local_metadata.elastic.agent.fips === true ? (
-          <FormattedMessage
-            id="xpack.fleet.agentDetails.fipsModeCompliantText"
-            defaultMessage="Enabled"
-          />
-        ) : (
-          <FormattedMessage
-            id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
-            defaultMessage="Not enabled"
-          />
-        ),
-    },
-  ];
-
   return (
     <EuiPanel>
       <EuiDescriptionList compressed>
@@ -398,25 +240,180 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                   ? agent.local_metadata.host.id
                   : '-',
             },
-            ...(agent.type === 'OPAMP' ? opAMPFields : agentFields),
-          ].map(({ title, description }) => {
-            const tooltip =
-              typeof description === 'string' && description.length > 20 ? description : '';
-            return (
-              <EuiFlexGroup>
-                <FlexItemWithMinWidth grow={3}>
-                  <EuiDescriptionListTitle>{title}</EuiDescriptionListTitle>
-                </FlexItemWithMinWidth>
-                <FlexItemWithMinWidth grow={7}>
-                  <EuiToolTip position="top" content={tooltip}>
-                    <EuiDescriptionListDescription className="eui-textTruncate">
-                      {description}
-                    </EuiDescriptionListDescription>
-                  </EuiToolTip>
-                </FlexItemWithMinWidth>
-              </EuiFlexGroup>
-            );
-          })}
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
+                defaultMessage: 'Output for integrations',
+              }),
+              description: outputs ? <AgentPolicyOutputsSummary outputs={outputs} /> : '-',
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.outputForMonitoringLabel', {
+                defaultMessage: 'Output for monitoring',
+              }),
+              description: outputs ? (
+                <AgentPolicyOutputsSummary outputs={outputs} isMonitoring={true} />
+              ) : (
+                '-'
+              ),
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.logLevel', {
+                defaultMessage: 'Logging level',
+              }),
+              description:
+                typeof agent.local_metadata?.elastic?.agent?.log_level === 'string'
+                  ? agent.local_metadata.elastic.agent.log_level
+                  : '-',
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.privilegeModeLabel', {
+                defaultMessage: 'Privilege mode',
+              }),
+              description:
+                agent.local_metadata.elastic.agent.unprivileged === true ? (
+                  <FormattedMessage
+                    id="xpack.fleet.agentDetails.privilegeModeUnprivilegedText"
+                    defaultMessage="Running as non-root"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
+                    defaultMessage="Running as root"
+                  />
+                ),
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.releaseLabel', {
+                defaultMessage: 'Agent release',
+              }),
+              description:
+                typeof agent.local_metadata?.elastic?.agent?.snapshot === 'boolean'
+                  ? agent.local_metadata.elastic.agent.snapshot === true
+                    ? 'snapshot'
+                    : 'stable'
+                  : '-',
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
+                defaultMessage: 'Platform',
+              }),
+              description:
+                typeof agent.local_metadata?.os?.platform === 'string'
+                  ? agent.local_metadata.os.platform
+                  : '-',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.monitorLogsLabel', {
+                defaultMessage: 'Monitor logs',
+              }),
+              description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
+                agentPolicy?.monitoring_enabled?.includes('logs') ? (
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.monitorLogsEnabledText"
+                    defaultMessage="Enabled"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.monitorLogsDisabledText"
+                    defaultMessage="Disabled"
+                  />
+                )
+              ) : (
+                <EuiSkeletonText lines={1} />
+              ),
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.monitorMetricsLabel', {
+                defaultMessage: 'Monitor metrics',
+              }),
+              description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
+                agentPolicy?.monitoring_enabled?.includes('metrics') ? (
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.monitorMetricsEnabledText"
+                    defaultMessage="Enabled"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.fleet.agentList.monitorMetricsDisabledText"
+                    defaultMessage="Disabled"
+                  />
+                )
+              ) : (
+                <EuiSkeletonText lines={1} />
+              ),
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.tagsLabel', {
+                defaultMessage: 'Tags',
+              }),
+              description: (agent.tags ?? []).length > 0 ? <Tags tags={agent.tags ?? []} /> : '-',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.platformLabel', {
+                defaultMessage: 'FIPS mode',
+              }),
+              description:
+                agent.local_metadata.elastic.agent.fips === true ? (
+                  <FormattedMessage
+                    id="xpack.fleet.agentDetails.fipsModeCompliantText"
+                    defaultMessage="Enabled"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.fleet.agentDetails.privilegeModePrivilegedText"
+                    defaultMessage="Not enabled"
+                  />
+                ),
+              hidden: agent.type === 'OPAMP',
+            },
+            {
+              title: i18n.translate('xpack.fleet.agentDetails.capabilitiesLabel', {
+                defaultMessage: 'Collector capabilities',
+              }),
+              description: (
+                <EuiFlexGroup direction="column" alignItems="flexStart" justifyContent="flexStart">
+                  {agent.capabilities.sort().map((capability) => (
+                    <FlexItemWithMinWidth grow={false} key={capability}>
+                      <EuiDescriptionListDescription
+                        css={`
+                          ${euiTextBreakWord()};
+                        `}
+                      >
+                        {capability}
+                      </EuiDescriptionListDescription>
+                    </FlexItemWithMinWidth>
+                  ))}
+                </EuiFlexGroup>
+              ),
+              hidden: !Array.isArray(agent.capabilities),
+            },
+          ]
+            .filter(({ hidden }) => !hidden)
+            .map(({ title, description }) => {
+              const tooltip =
+                typeof description === 'string' && description.length > 20 ? description : '';
+              return (
+                <EuiFlexGroup>
+                  <FlexItemWithMinWidth grow={3}>
+                    <EuiDescriptionListTitle>{title}</EuiDescriptionListTitle>
+                  </FlexItemWithMinWidth>
+                  <FlexItemWithMinWidth grow={7}>
+                    <EuiToolTip position="top" content={tooltip}>
+                      <EuiDescriptionListDescription className="eui-textTruncate">
+                        {description}
+                      </EuiDescriptionListDescription>
+                    </EuiToolTip>
+                  </FlexItemWithMinWidth>
+                </EuiFlexGroup>
+              );
+            })}
         </EuiFlexGroup>
       </EuiDescriptionList>
       {effectiveConfigFlyoutOpen && (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -398,7 +398,7 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                   ? agent.local_metadata.host.id
                   : '-',
             },
-            ...(agent.type !== 'OPAMP' ? agentFields : opAMPFields),
+            ...(agent.type === 'OPAMP' ? opAMPFields : agentFields),
           ].map(({ title, description }) => {
             const tooltip =
               typeof description === 'string' && description.length > 20 ? description : '';


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/ingest-dev/issues/6982

Hide fields not relevant to collectors (e.g. fields coming from agent policy settings or elastic-agent state)

Collector:

<img width="898" height="854" alt="image" src="https://github.com/user-attachments/assets/f6e94bb3-99de-4259-aaaf-84804b994922" />

Elastic Agent:

<img width="745" height="1013" alt="image" src="https://github.com/user-attachments/assets/9cbe5d0a-89fa-4c41-a57d-ecffcb63ed30" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



