### PR TITLE
[Fleet] Disable agent rollback button if agent is upgrading

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/hooks/use_single_agent_menu_items.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/hooks/use_single_agent_menu_items.test.tsx
@@ -235,6 +235,61 @@ describe('useSingleAgentMenuItems', () => {
       expect(upgradeManagement?.children).toBeDefined();
     });
 
+    it('should disable rollback when agent is upgrading', () => {
+      mockedExperimentalFeaturesService.get.mockReturnValue({
+        enableAgentPrivilegeLevelChange: true,
+        enableAgentRollback: true,
+      } as any);
+
+      const validUntil = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const { result } = renderer.renderHook(() =>
+        useSingleAgentMenuItems({
+          agent: createMockAgent({
+            status: 'updating',
+            upgrade_started_at: new Date().toISOString(),
+            upgrade_details: {
+              state: 'UPG_DOWNLOADING',
+              target_version: '8.9.0',
+              action_id: 'action-1',
+            },
+            upgrade: { rollbacks: [{ valid_until: validUntil, version: '8.7.0' }] },
+            local_metadata: { elastic: { agent: { version: '8.8.0', upgradeable: true } } },
+          }),
+          agentPolicy: createMockAgentPolicy(),
+          callbacks: mockCallbacks,
+        })
+      );
+
+      const upgradeManagement = result.current.find((item) => item.id === 'upgrade-management');
+      const rollbackItem = upgradeManagement?.children?.find((item) => item.id === 'rollback');
+      expect(rollbackItem).toBeDefined();
+      expect(rollbackItem?.disabled).toBe(true);
+    });
+
+    it('should enable rollback when agent is not upgrading and has valid rollback', () => {
+      mockedExperimentalFeaturesService.get.mockReturnValue({
+        enableAgentPrivilegeLevelChange: true,
+        enableAgentRollback: true,
+      } as any);
+
+      const validUntil = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const { result } = renderer.renderHook(() =>
+        useSingleAgentMenuItems({
+          agent: createMockAgent({
+            upgrade: { rollbacks: [{ valid_until: validUntil, version: '8.7.0' }] },
+            local_metadata: { elastic: { agent: { version: '8.8.0', upgradeable: true } } },
+          }),
+          agentPolicy: createMockAgentPolicy(),
+          callbacks: mockCallbacks,
+        })
+      );
+
+      const upgradeManagement = result.current.find((item) => item.id === 'upgrade-management');
+      const rollbackItem = upgradeManagement?.children?.find((item) => item.id === 'rollback');
+      expect(rollbackItem).toBeDefined();
+      expect(rollbackItem?.disabled).toBe(false);
+    });
+
     it('should include Maintenance and diagnostics submenu', () => {
       const { result } = renderer.renderHook(() =>
         useSingleAgentMenuItems({

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/hooks/use_single_agent_menu_items.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/hooks/use_single_agent_menu_items.tsx
@@ -205,6 +205,7 @@ export function useSingleAgentMenuItems({
                   icon: 'clockCounter',
                   disabled:
                     !agentHasValidRollback ||
+                    isAgentUpgrading(agent) ||
                     !licenseService.hasAtLeast(LICENSE_FOR_AGENT_ROLLBACK),
                   onClick: () => {
                     callbacks.onRollbackClick();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/250027

Disable upgrade rollback button for single agent if the agent is still upgrading (including Upgrade Monitoring state).

<img width="1919" height="657" alt="Screenshot 2026-02-19 at 17 00 55" src="https://github.com/user-attachments/assets/c05a2dd7-b771-4126-80e1-bce9db881f2c" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Negligible: minor logic change for disabling upgrade rollback menu item for single agents in Fleet UI.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->