### PR TITLE
[Security solution][Attacks][Timeline] Handle attacks in timeline

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -47,6 +47,21 @@ const initialEnrichedColumns = getColumnHeaders(
 );
 
 const initialEnrichedColumnsIds = initialEnrichedColumns.map((c) => c.id);
+const mockAttackTimelineData = [
+  {
+    ...mockTimelineData[0],
+    _id: 'attack-1',
+    data: [
+      ...mockTimelineData[0].data,
+      { field: 'kibana.alert.attack_discovery.alert_ids', value: ['alert-1'] },
+      { field: 'kibana.alert.rule.rule_type_id', value: ['attack-discovery'] },
+    ],
+    ecs: {
+      ...mockTimelineData[0].ecs,
+      _index: 'attack-index',
+    },
+  },
+];
 
 type TestComponentProps = Partial<ComponentProps<typeof TimelineDataTable>> & {
   store?: ReturnType<typeof createMockStore>;
@@ -116,6 +131,29 @@ describe('unified data table', () => {
     async () => {
       render(<TestComponent />);
       expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+    },
+    SPECIAL_TEST_TIMEOUT
+  );
+
+  it(
+    'opens attack flyout when expanded row is an attack discovery alert',
+    async () => {
+      render(<TestComponent events={mockAttackTimelineData} />);
+      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+      fireEvent.click(screen.getByTestId('docTableExpandToggleColumn'));
+
+      await waitFor(() => {
+        expect(openFlyoutMock).toHaveBeenCalledWith({
+          right: {
+            id: 'attack-details-right',
+            params: {
+              attackId: 'attack-1',
+              indexName: 'attack-index',
+            },
+          },
+        });
+      });
     },
     SPECIAL_TEST_TIMEOUT
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/is_attack_discovery_row.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/is_attack_discovery_row.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import type { TimelineItem } from '../../../../../../common/search_strategy';
+
+const ATTACK_DISCOVERY_ALERT_IDS_FIELD = 'kibana.alert.attack_discovery.alert_ids';
+const ATTACK_DISCOVERY_RULE_TYPE_IDS = [
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+] as const;
+const ATTACK_DISCOVERY_RULE_TYPES = new Set<string>(ATTACK_DISCOVERY_RULE_TYPE_IDS);
+
+const getTimelineFieldValues = (
+  eventData: DataTableRecord & TimelineItem,
+  fieldName: string
+): string[] => {
+  const timelineField = eventData.data.find(({ field }) => field === fieldName);
+  return timelineField?.value?.filter((value): value is string => value != null) ?? [];
+};
+
+export const isAttackDiscoveryRow = (eventData: DataTableRecord & TimelineItem): boolean => {
+  const attackAlertIds = getTimelineFieldValues(eventData, ATTACK_DISCOVERY_ALERT_IDS_FIELD);
+  if (attackAlertIds.length > 0) {
+    return true;
+  }
+
+  const ruleTypeIds = getTimelineFieldValues(eventData, ALERT_RULE_TYPE_ID);
+  if (ruleTypeIds.some((ruleTypeId) => ATTACK_DISCOVERY_RULE_TYPES.has(ruleTypeId))) {
+    return true;
+  }
+
+  const indexName = eventData.ecs._index ?? '';
+  return indexName.includes(ATTACK_DISCOVERY_ALERTS_COMMON_INDEX_PREFIX);
+};


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/248999

## The problem 🛑 

Currently, opening the flyout from timeline for an attack opens the alert flyout. This is causing all the actions within the flyout (e.g. status update) to fail
<details>
<summary>Screen-recording 🎬  </summary>

https://github.com/user-attachments/assets/0dde8f14-7710-45c8-af59-cf31bb2d2969
</details>

## The solution 💡 

On the click handler, we discriminate between attack and alert using a new function called `isAttackDiscoveryRow`. This function checks for the `kibana.alert.attack_discovery.alert_ids` field (available only for attacks) as well as rule types and index names.

If the user has clicked on an attack, we open the Attack flyout instead of the alert's one.

<details>
<summary>Screen-recording 🎬  </summary>


https://github.com/user-attachments/assets/02f066f6-b2b5-430d-8a2d-0e93465623e7


</details>
