### PR TITLE
[9.3] [Discover] Address flaky esql view test (#253911)

### DIFF
--- a/src/platform/test/functional/apps/discover/esql/_esql_view.ts
+++ b/src/platform/test/functional/apps/discover/esql/_esql_view.ts
@@ -71,6 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.uiSettings.replace(defaultSettings);
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await common.navigateToApp('discover');
+      await discover.waitUntilTabIsLoaded();
     });
 
     after(async () => {
@@ -79,6 +80,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('ES|QL in Discover', () => {
       it('should render esql view correctly', async function () {
+        await discover.waitUntilTabIsLoaded();
         await unifiedFieldList.waitUntilSidebarHasLoaded();
 
         expect(await testSubjects.exists('showQueryBarMenu')).to.be(true);
@@ -97,6 +99,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await testSubjects.exists('discoverFieldListPanelEdit-@message')).to.be(true);
 
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         await unifiedFieldList.waitUntilSidebarHasLoaded();
 
         expect(await testSubjects.exists('fieldListFiltersFieldSearch')).to.be(true);
@@ -121,6 +124,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should not render the histogram for indices with no @timestamp field', async function () {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         await unifiedFieldList.waitUntilSidebarHasLoaded();
 
         const testQuery = `from kibana_sample_data_flights | limit 10`;
@@ -136,6 +140,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should render the histogram for indices with no @timestamp field when the ?_tstart, ?_tend params are in the query', async function () {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         await unifiedFieldList.waitUntilSidebarHasLoaded();
 
         const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?_tstart and timestamp <= ?_tend`;
@@ -199,7 +204,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const testQuery = `from logstash* | sort @timestamp | limit 10 | stats countB = count(bytes) by geo.dest | sort countB`;
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await header.waitUntilLoadingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
         expect(await cell.getVisibleText()).to.be('1');
@@ -223,11 +228,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should work without a FROM statement', async function () {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         const testQuery = `ROW a = 1, b = "two", c = null`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await header.waitUntilLoadingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         await discover.dragFieldToTable('a');
         const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -236,6 +242,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should allow brushing time series', async () => {
         await timePicker.setDefaultAbsoluteRange();
+        await discover.waitUntilTabIsLoaded();
         await discover.selectTextBaseLang();
         await discover.waitUntilTabIsLoaded();
         await unifiedFieldList.waitUntilSidebarHasLoaded();
@@ -252,7 +259,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         const renderingCount = await elasticChart.getVisualizationRenderingCount();
         await discover.brushHistogram();
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
         // no filter pill created for time brush
         expect(await filterBar.getFilterCount()).to.be(0);
         // chart and time picker updated
@@ -266,6 +273,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('errors', () => {
       it('should show error messages for syntax errors in query', async function () {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         const brokenQueries = [
           'from logstash-* | limit 10*',
           'from logstash-* | limit A',
@@ -293,7 +301,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('switch modal', () => {
       beforeEach(async () => {
         await common.navigateToApp('discover');
+        await discover.waitUntilTabIsLoaded();
         await timePicker.setDefaultAbsoluteRange();
+        await discover.waitUntilTabIsLoaded();
       });
 
       it('should show switch modal when switching to a data view', async () => {
@@ -323,7 +333,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await testSubjects.missingOrFail('discover-esql-to-dataview-modal');
         });
         await discover.saveSearch('esql_test');
+        await discover.waitUntilTabIsLoaded();
         await testSubjects.click('switch-to-dataviews');
+        await discover.waitUntilTabIsLoaded();
         await testSubjects.missingOrFail('discover-esql-to-dataview-modal');
       });
 
@@ -364,6 +376,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('inspector', () => {
       beforeEach(async () => {
         await common.navigateToApp('discover');
+        await discover.waitUntilTabIsLoaded();
         await timePicker.setDefaultAbsoluteRange();
         await discover.waitUntilTabIsLoaded();
       });
@@ -398,6 +411,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             ensureCurrentUrl: false,
           });
           await discover.selectTextBaseLang();
+          await discover.waitUntilTabIsLoaded();
           const testQuery = `from logstash-* | limit 10`;
           await monacoEditor.setCodeEditorValue(testQuery);
 
@@ -405,7 +419,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             window.ELASTIC_ESQL_DELAY_SECONDS = 5;
           });
           await testSubjects.click('querySubmitButton');
-          await header.waitUntilLoadingHasFinished();
+          await discover.waitUntilTabIsLoaded();
           // for some reason the chart query is taking a very long time to return (3x the delay)
           // so wait for the chart to be loaded
           await discover.waitForChartLoadingComplete(1);
@@ -427,7 +441,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('query history', () => {
       beforeEach(async () => {
         await common.navigateToApp('discover');
+        await discover.waitUntilTabIsLoaded();
         await timePicker.setDefaultAbsoluteRange();
+        await discover.waitUntilTabIsLoaded();
       });
 
       it('should see my current query in the history', async () => {
@@ -493,7 +509,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('sorting', () => {
       beforeEach(async () => {
         await common.navigateToApp('discover');
+        await discover.waitUntilTabIsLoaded();
         await timePicker.setDefaultAbsoluteRange();
+        await discover.waitUntilTabIsLoaded();
       });
 
       it('should sort correctly', async () => {
@@ -524,7 +542,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dataGrid.clickDocSortDesc('bytes', 'Sort High-Low');
 
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the highest value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -575,7 +593,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dataGrid.clickDocSortDesc('bytes', 'Sort Low-High');
 
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the lowest value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -623,6 +641,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
 
         await discover.saveSearch(savedSearchName);
+        await discover.waitUntilTabIsLoaded();
 
         await common.navigateToApp('dashboard');
         await dashboard.clickNewDashboard();
@@ -678,7 +697,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dataGrid.clickDocSortDesc('var0', 'Sort High-Low');
 
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the highest value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 1);
@@ -729,7 +748,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dataGrid.clickDocSortDesc('var0', 'Sort Low-High');
 
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the lowest value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 1);
@@ -746,11 +765,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('filtering by clicking on the table', () => {
       beforeEach(async () => {
         await common.navigateToApp('discover');
+        await discover.waitUntilTabIsLoaded();
         await timePicker.setDefaultAbsoluteRange();
+        await discover.waitUntilTabIsLoaded();
       });
 
       it('should append a where clause by clicking the table', async () => {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         const testQuery = `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB`;
         await monacoEditor.setCodeEditorValue(testQuery);
 
@@ -780,6 +802,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should append an end in existing where clause by clicking the table', async () => {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         const testQuery = `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB | where countB > 0`;
         await monacoEditor.setCodeEditorValue(testQuery);
 
@@ -799,6 +822,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should append a where clause by clicking the table without changing the chart type', async () => {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         const testQuery = `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB`;
         await monacoEditor.setCodeEditorValue(testQuery);
 
@@ -833,6 +857,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should append a where clause by clicking the table without changing the chart type nor the visualization state', async () => {
         await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
         const testQuery = `from logstash-* | sort @timestamp desc | limit 10000 | stats countB = count(bytes) by geo.dest | sort countB`;
         await monacoEditor.setCodeEditorValue(testQuery);
 
@@ -885,6 +910,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('histogram breakdown', () => {
       before(async () => {
         await common.navigateToApp('discover');
+        await discover.waitUntilTabIsLoaded();
         await timePicker.setDefaultAbsoluteRange();
         await discover.waitUntilTabIsLoaded();
       });
@@ -899,7 +925,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await discover.waitUntilTabIsLoaded();
 
         await discover.chooseBreakdownField('extension');
-        await header.waitUntilLoadingHasFinished();
+        await discover.waitUntilTabIsLoaded();
         const list = await discover.getHistogramLegendList();
         expect(list).to.eql(['css', 'gif', 'jpg', 'php', 'png']);
       });
@@ -921,6 +947,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await discover.waitUntilTabIsLoaded();
 
         await discover.saveSearch('esql view with breakdown');
+        await discover.waitUntilTabIsLoaded();
 
         await discover.clickNewSearchButton();
         await header.waitUntilLoadingHasFinished();
@@ -928,7 +955,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(prevList).to.eql([]);
 
         await discover.loadSavedSearch('esql view with breakdown');
-        await header.waitUntilLoadingHasFinished();
+        await discover.waitUntilTabIsLoaded();
         const list = await discover.getHistogramLegendList();
         expect(list).to.eql(['css', 'gif', 'jpg', 'php', 'png']);
       });
@@ -943,7 +970,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await discover.waitUntilTabIsLoaded();
 
         await unifiedFieldList.clickFieldListAddBreakdownField('extension');
-        await header.waitUntilLoadingHasFinished();
+        await discover.waitUntilTabIsLoaded();
         const list = await discover.getHistogramLegendList();
         expect(list).to.eql(['css', 'gif', 'jpg', 'php', 'png']);
       });

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
@@ -59,7 +59,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await PageObjects.svlCommonPage.loginAsAdmin();
       await PageObjects.common.navigateToApp('discover');
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.discover.waitUntilTabIsLoaded();
     });
 
     after(async () => {
@@ -86,6 +86,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await testSubjects.existOrFail('discoverFieldListPanelEdit-@message');
 
         await PageObjects.discover.selectTextBaseLang();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         await testSubjects.existOrFail('fieldListFiltersFieldSearch');
@@ -110,14 +111,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should not render the histogram for indices with no @timestamp field', async function () {
         await PageObjects.discover.selectTextBaseLang();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         const testQuery = `from kibana_sample_data_flights | limit 10`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         expect(await testSubjects.exists('ESQLEditor')).to.be(true);
         // I am not rendering the histogram for indices with no @timestamp field
@@ -126,18 +127,19 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should render the histogram for indices with no @timestamp field when the ?_tstart, ?_tend params are in the query', async function () {
         await PageObjects.discover.selectTextBaseLang();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?_tstart and timestamp <= ?_tend`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         const fromTime = 'Apr 10, 2018 @ 00:00:00.000';
         const toTime = 'Nov 15, 2018 @ 00:00:00.000';
         await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         expect(await testSubjects.exists('ESQLEditor')).to.be(true);
         expect(await testSubjects.exists('unifiedHistogramChart')).to.be(true);
@@ -145,17 +147,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should perform test query correctly', async function () {
         await PageObjects.timePicker.setDefaultAbsoluteRange();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         const testQuery = `from logstash-* | sort @timestamp | limit 10 | stats countB = count(bytes) by geo.dest | sort countB`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         // here Lens suggests a XY so it is rendered
         await testSubjects.existOrFail('unifiedHistogramChart');
         await testSubjects.existOrFail('xyVisChart');
@@ -165,40 +164,34 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should render when switching to a time range with no data, then back to a time range with data', async () => {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         const testQuery = `from logstash-* | sort @timestamp | limit 10 | stats countB = count(bytes) by geo.dest | sort countB`;
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         let cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
         expect(await cell.getVisibleText()).to.be('1');
         await PageObjects.timePicker.setAbsoluteRange(
           'Sep 19, 2015 @ 06:31:44.000',
           'Sep 19, 2015 @ 06:31:44.000'
         );
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await testSubjects.existOrFail('discoverNoResults');
         await PageObjects.timePicker.setDefaultAbsoluteRange();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
         expect(await cell.getVisibleText()).to.be('1');
       });
 
       it('should query an index pattern that doesnt translate to a dataview correctly', async function () {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         const testQuery = `from logstash* | sort @timestamp | limit 10 | stats countB = count(bytes) by geo.dest | sort countB`;
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
         expect(await cell.getVisibleText()).to.be('1');
@@ -206,14 +199,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should render correctly if there are empty fields', async function () {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         const testQuery = `from logstash-* | limit 10 | keep machine.ram_range, bytes`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         const cell = await dataGrid.getCellElementExcludingControlColumns(0, 1);
         expect(await cell.getVisibleText()).to.be(NULL_LABEL);
         expect((await dataGrid.getHeaders()).slice(-2)).to.eql([
@@ -224,11 +215,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should work without a FROM statement', async function () {
         await PageObjects.discover.selectTextBaseLang();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         const testQuery = `ROW a = 1, b = "two", c = null`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await PageObjects.discover.dragFieldToTable('a');
         const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -239,8 +231,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('errors', () => {
       it('should show error messages for syntax errors in query', async function () {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         const brokenQueries = [
           'from logstash-* | limit 10*',
@@ -251,8 +242,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         for (const testQuery of brokenQueries) {
           await monacoEditor.setCodeEditorValue(testQuery);
           await testSubjects.click('querySubmitButton');
-          await PageObjects.header.waitUntilLoadingHasFinished();
-          await PageObjects.discover.waitUntilSearchingHasFinished();
+          await PageObjects.discover.waitUntilTabIsLoaded();
           // error in fetching documents because of the invalid query
           await PageObjects.discover.showsErrorCallout();
           const message = await testSubjects.getVisibleText('discoverErrorCalloutMessage');
@@ -270,7 +260,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('switch modal', () => {
       beforeEach(async () => {
         await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.timePicker.setDefaultAbsoluteRange();
+        await PageObjects.discover.waitUntilTabIsLoaded();
       });
 
       it('should show switch modal when switching to a data view', async () => {
@@ -358,22 +350,20 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('inspector', () => {
       beforeEach(async () => {
         await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.timePicker.setDefaultAbsoluteRange();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
       });
 
       it('shows Discover and Lens requests in Inspector', async () => {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         let retries = 0;
         await retry.try(async () => {
           if (retries > 0) {
             await inspector.close();
             await testSubjects.click('querySubmitButton');
-            await PageObjects.header.waitUntilLoadingHasFinished();
-            await PageObjects.discover.waitUntilSearchingHasFinished();
+            await PageObjects.discover.waitUntilTabIsLoaded();
           }
           await inspector.open();
           retries = retries + 1;
@@ -389,13 +379,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('query history', () => {
       beforeEach(async () => {
         await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.timePicker.setDefaultAbsoluteRange();
+        await PageObjects.discover.waitUntilTabIsLoaded();
       });
 
       it('should see my current query in the history', async () => {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         await testSubjects.click('ESQLEditor-toggle-query-history-button');
@@ -405,15 +396,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('updating the query should add this to the history', async () => {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         const testQuery = 'from logstash-* | limit 100 | drop @timestamp';
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await testSubjects.click('ESQLEditor-toggle-query-history-button');
         const historyItems = await esql.getHistoryItems();
@@ -425,8 +414,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should select a query from the history and submit it', async () => {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         await testSubjects.click('ESQLEditor-toggle-query-history-button');
@@ -442,15 +430,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should add a failed query to the history', async () => {
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         const testQuery = 'from logstash-* | limit 100 | woof and meow';
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
         await testSubjects.click('ESQLEditor-toggle-query-history-button');
         await testSubjects.click('ESQLEditor-history-starred-queries-run-button');
@@ -464,20 +450,16 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const savedSearchName = 'testSorting';
 
         await PageObjects.discover.selectTextBaseLang();
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         const testQuery = 'from logstash-* | sort @timestamp | limit 100';
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         await PageObjects.unifiedFieldList.clickFieldListItemAdd('bytes');
-
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains an initial value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -491,7 +473,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dataGrid.clickDocSortDesc('bytes', 'Sort High-Low');
 
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the highest value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -504,9 +486,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
 
         await PageObjects.discover.saveSearch(savedSearchName);
-
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the same highest value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -516,8 +496,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await browser.refresh();
 
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the same highest value after reload', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -527,13 +506,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await PageObjects.discover.clickNewSearchButton();
 
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await PageObjects.discover.loadSavedSearch(savedSearchName);
 
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await retry.waitFor(
           'first cell contains the same highest value after reopening',
@@ -546,7 +523,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await dataGrid.clickDocSortDesc('bytes', 'Sort Low-High');
 
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the lowest value', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -560,8 +537,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await PageObjects.unifiedFieldList.clickFieldListItemAdd('extension');
 
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await dataGrid.clickDocSortDesc('extension', 'Sort A-Z');
 
@@ -577,8 +553,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await browser.refresh();
 
-        await PageObjects.header.waitUntilLoadingHasFinished();
-        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await retry.waitFor('first cell contains the same lowest value after reload', async () => {
           const cell = await dataGrid.getCellElementExcludingControlColumns(0, 0);
@@ -596,6 +571,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
 
         await PageObjects.discover.saveSearch(savedSearchName);
+        await PageObjects.discover.waitUntilTabIsLoaded();
 
         await PageObjects.common.navigateToApp('dashboard');
         await PageObjects.dashboard.clickNewDashboard();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover] Address flaky esql view test (#253911)](https://github.com/elastic/kibana/pull/253911)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2026-02-19T14:20:43Z","message":"[Discover] Address flaky esql view test (#253911)\n\n- Closes https://github.com/elastic/kibana/issues/253908\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"88d7eb0c6ffa22dd69fe5b3acd32001bb330d46b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.4.0","v9.3.1"],"title":"[Discover] Address flaky esql view test","number":253911,"url":"https://github.com/elastic/kibana/pull/253911","mergeCommit":{"message":"[Discover] Address flaky esql view test (#253911)\n\n- Closes https://github.com/elastic/kibana/issues/253908\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"88d7eb0c6ffa22dd69fe5b3acd32001bb330d46b"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253911","number":253911,"mergeCommit":{"message":"[Discover] Address flaky esql view test (#253911)\n\n- Closes https://github.com/elastic/kibana/issues/253908\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"88d7eb0c6ffa22dd69fe5b3acd32001bb330d46b"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->