### PR TITLE
docs(settings-gen): add share settings YAML

### DIFF
--- a/docs/settings-gen/source/kibana-share-settings.yml
+++ b/docs/settings-gen/source/kibana-share-settings.yml
@@ -13,6 +13,8 @@ groups:
     id: url-expiration-settings
     description: |
       URL expiration settings control the behavior of the unused URLs cleanup background task, which runs using the Task Manager plugin. This task allows you to periodically clean up saved objects of type `url` that have not been accessed in the specified period of time, controlled by the `share.url_expiration.duration` configuration option. Each saved object is a representation of a URL generated through the sharing functionality. Those settings are disabled by default. You must manually configure them in order to use this feature.
+    warning: |
+      The Elasticsearch instance should have at least 2 GB RAM to use the URLs cleanup background task with its default settings. For Elasticsearch instances with less than 2 GB RAM, we do not recommend enabling this feature because it can lead to memory spikes and instability. If you still enable it on an instance with such limited RAM, `share.url_expiration.url_limit` should not exceed `1000`.
     settings:
 
       - setting: share.url_expiration.enabled
@@ -21,7 +23,7 @@ groups:
         datatype: bool
         default: false
         applies_to:
-          stack: ga 9.1
+          stack: ga 9.1+
           ess: ga
           self: ga
           serverless: unavailable
@@ -32,7 +34,7 @@ groups:
         datatype: string
         default: 1y
         applies_to:
-          stack: ga 9.1
+          stack: ga 9.1+
           ess: ga
           self: ga
           serverless: unavailable
@@ -43,7 +45,7 @@ groups:
         datatype: string
         default: 7d
         applies_to:
-          stack: ga 9.1
+          stack: ga 9.1+
           ess: ga
           self: ga
           serverless: unavailable
@@ -53,10 +55,8 @@ groups:
           Controls how many saved objects should be retrieved and scheduled for deletion per one run of the task.
         datatype: int
         default: 10000
-        warning: |
-          The Elasticsearch instance should have at least 2 GB RAM to use the URLs cleanup background task with its default settings. For Elasticsearch instances with less than 2 GB RAM, we do not recommend enabling this feature because it can lead to memory spikes and instability. If you still enable it on an instance with such limited RAM, `share.url_expiration.url_limit` should not exceed `1000`.
         applies_to:
-          stack: ga 9.1
+          stack: ga 9.1+
           ess: ga
           self: ga
           serverless: unavailable

--- a/docs/settings-gen/source/kibana-share-settings.yml
+++ b/docs/settings-gen/source/kibana-share-settings.yml
@@ -1,0 +1,62 @@
+---
+# This file is used to generate "Sharing settings in Kibana" page in the product docs
+
+product: Kibana
+collection: Sharing settings in Kibana
+id: share-settings-kb
+page_description: |
+  Configure sharing settings in your `kibana.yml` configuration file.
+  These settings allow you to customize the behavior of URL sharing in Kibana.
+
+groups:
+  - group: URL expiration settings
+    id: url-expiration-settings
+    description: |
+      URL expiration settings control the behavior of the unused URLs cleanup background task, which runs using the Task Manager plugin. This task allows you to periodically clean up saved objects of type `url` that have not been accessed in the specified period of time, controlled by the `share.url_expiration.duration` configuration option. Each saved object is a representation of a URL generated through the sharing functionality. Those settings are disabled by default. You must manually configure them in order to use this feature.
+    settings:
+
+      - setting: share.url_expiration.enabled
+        description: |
+          If `true`, the URL expiration feature is enabled.
+        datatype: bool
+        default: false
+        applies_to:
+          stack: ga 9.1
+          ess: ga
+          self: ga
+          serverless: unavailable
+
+      - setting: share.url_expiration.duration
+        description: |
+          Controls the expiration threshold. Saved objects that have not been accessed in the specified period of time will get deleted.
+        datatype: string
+        default: 1y
+        applies_to:
+          stack: ga 9.1
+          ess: ga
+          self: ga
+          serverless: unavailable
+
+      - setting: share.url_expiration.check_interval
+        description: |
+          Controls how often the cleanup task runs.
+        datatype: string
+        default: 7d
+        applies_to:
+          stack: ga 9.1
+          ess: ga
+          self: ga
+          serverless: unavailable
+
+      - setting: share.url_expiration.url_limit
+        description: |
+          Controls how many saved objects should be retrieved and scheduled for deletion per one run of the task.
+        datatype: int
+        default: 10000
+        warning: |
+          The Elasticsearch instance should have at least 2 GB RAM to use the URLs cleanup background task with its default settings. For Elasticsearch instances with less than 2 GB RAM, we do not recommend enabling this feature because it can lead to memory spikes and instability. If you still enable it on an instance with such limited RAM, `share.url_expiration.url_limit` should not exceed `1000`.
+        applies_to:
+          stack: ga 9.1
+          ess: ga
+          self: ga
+          serverless: unavailable


### PR DESCRIPTION
## Summary

Add YAML source file for the sharing settings page using the new schema with `applies_to` (per #250871).

Settings verified against the plugin config schema at `src/platform/plugins/shared/share/server/config.ts`.

**Findings:**
- All 4 documented settings (`share.url_expiration.*`) are confirmed in the config schema with matching defaults.
- `share.new_version.enabled` exists in the config schema but appears to be an internal feature flag — intentionally omitted.
- All settings have cloud icons in the current markdown, confirmed as `ess: ga`.
- Page frontmatter marks `serverless: unavailable`, carried over into per-setting `applies_to`.

Ref: #206138

## LLM usage

This PR was drafted with assistance from an LLM (Anthropic Claude).

Made with [Cursor](https://cursor.com)