### PR TITLE
[8.19] [Security][Detection Engine] ESQL Rule Execution Logic Integration Test (#252936)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
@@ -1602,6 +1602,227 @@ export default ({ getService }: FtrProviderContext) => {
         // should return 160 alerts
         expect(alertsResponse.hits.hits).toHaveLength(160);
       });
+
+      describe('identical document ids across multiple indices', () => {
+        before(async () => {
+          await esArchiver.load(
+            'x-pack/solutions/security/test/fixtures/es_archives/security_solution/ecs_compliant_synthetic_source'
+          );
+        });
+
+        after(async () => {
+          await esArchiver.unload(
+            'x-pack/solutions/security/test/fixtures/es_archives/security_solution/ecs_compliant_synthetic_source'
+          );
+        });
+
+        it('should generate alerts from events with the same id', async () => {
+          const id = uuidv4();
+          const rule: EsqlRuleCreateProps = {
+            ...getCreateEsqlRulesSchemaMock(`rule-${id}`, true),
+            query: `from ecs_compliant, ecs_compliant_synthetic_source metadata _id, _index ${internalIdPipe(
+              id
+            )} | sort @timestamp asc`,
+            from: '2020-10-28T05:15:00.000Z',
+            to: '2020-10-28T06:00:00.000Z',
+            interval: '45m',
+            enabled: true,
+          };
+
+          await es.index({
+            index: 'ecs_compliant',
+            id, // id of event in index
+            refresh: true,
+            document: {
+              id,
+              '@timestamp': '2020-10-28T05:30:00.000Z',
+              agent: { name: 'from ecs_compliant' },
+            },
+          });
+          await es.index({
+            index: 'ecs_compliant_synthetic_source',
+            id, // id of event in index
+            refresh: true,
+            document: {
+              id,
+              '@timestamp': '2020-10-28T05:35:00.000Z',
+              agent: { name: 'from ecs_compliant_synthetic_source' },
+            },
+          });
+
+          const { previewId } = await previewRule({
+            supertest,
+            rule,
+            timeframeEnd: new Date('2020-10-28T06:00:00.000Z'),
+          });
+
+          const previewAlerts = await getPreviewAlerts({
+            es,
+            previewId,
+            size: 200,
+            sort: [ALERT_ORIGINAL_TIME],
+          });
+
+          expect(previewAlerts).toHaveLength(2);
+          expect(previewAlerts[0]._source).toHaveProperty(['agent.name'], 'from ecs_compliant');
+          expect(previewAlerts[1]._source).toHaveProperty(
+            ['agent.name'],
+            'from ecs_compliant_synthetic_source'
+          );
+        });
+
+        // since we exclude _id from the query in the next page, we should be able to generate alerts from multiple documents with the same id in different indices
+        it('should generate alerts over multiple pages from different indices but same event id', async () => {
+          const id = uuidv4();
+          const rule: EsqlRuleCreateProps = {
+            ...getCreateEsqlRulesSchemaMock(`rule-${id}`, true),
+            query: `from ecs_compliant, ecs_compliant_synthetic_source metadata _id, _index ${internalIdPipe(
+              id
+            )} | sort @timestamp asc`,
+            from: '2020-10-28T05:15:00.000Z',
+            to: '2020-10-28T06:00:00.000Z',
+            interval: '45m',
+            max_signals: 2, // we would paginate with page size = 2
+            enabled: true,
+          };
+
+          const document = {
+            id,
+            '@timestamp': '2020-10-28T05:30:00.000Z',
+            agent: { name: 'test-1' },
+          };
+
+          await Promise.all(
+            Array.from({ length: 2 }, (_, i) => i).map((i) =>
+              es.index({
+                index: 'ecs_compliant',
+                id: 'id-' + id + '_' + i, // id of event in index
+                refresh: true,
+                document,
+              })
+            )
+          );
+
+          const createdRule = await createRule(supertest, log, rule);
+
+          const alertsResponseFromFirstRuleExecution = await getAlerts(
+            supertest,
+            log,
+            es,
+            createdRule,
+            RuleExecutionStatusEnum.succeeded,
+            10
+          );
+
+          expect(alertsResponseFromFirstRuleExecution.hits.hits).toHaveLength(2);
+
+          await Promise.all(
+            Array.from({ length: 2 }, (_, i) => i).map((i) =>
+              es.index({
+                index: 'ecs_compliant_synthetic_source',
+                id: 'id-' + id + '_' + i, // id of event in index
+                refresh: true,
+                document: {
+                  ...document,
+                  '@timestamp': '2020-10-28T05:53:00.000Z',
+                },
+              })
+            )
+          );
+
+          const dateRestart = new Date();
+
+          await runSoonRule(supertest, createdRule.id);
+
+          const alertsResponse = await getAlerts(
+            supertest,
+            log,
+            es,
+            createdRule,
+            RuleExecutionStatusEnum.succeeded,
+            200,
+            dateRestart
+          );
+
+          // no alert should be missed
+          expect(alertsResponse.hits.hits).toHaveLength(4);
+        });
+
+        it('should generate alerts over multiple pages from different indices but same event id for mv_expand when number alerts exceeds max signal', async () => {
+          const id = uuidv4();
+          const rule: EsqlRuleCreateProps = {
+            ...getCreateEsqlRulesSchemaMock(`rule-${id}`, true),
+            query: `from ecs_compliant, ecs_compliant_synthetic_source metadata _id, _index ${internalIdPipe(
+              id
+            )} | mv_expand agent.name | sort @timestamp asc, _index asc`, // sort by timestamp and index to ensure deterministic results, see https://github.com/elastic/kibana/issues/253849
+            from: '2020-10-28T05:15:00.000Z',
+            to: '2020-10-28T06:00:00.000Z',
+            interval: '45m',
+            enabled: true,
+          };
+
+          const document = {
+            id,
+            '@timestamp': '2020-10-28T05:30:00.000Z',
+            agent: { name: Array.from({ length: 150 }, (_, i) => `test_1_${1000 + i}`) },
+          };
+
+          await Promise.all(
+            ['ecs_compliant', 'ecs_compliant_synthetic_source'].map((index, i) =>
+              es.index({
+                index,
+                id,
+                refresh: true,
+                document,
+              })
+            )
+          );
+
+          const createdRule = await createRule(supertest, log, rule);
+
+          const alertsResponseFromFirstRuleExecution = await getAlerts(
+            supertest,
+            log,
+            es,
+            createdRule,
+            RuleExecutionStatusEnum['partial failure'], // rule has warning, alerts were truncated, thus "partial failure" status
+            200
+          );
+
+          expect(alertsResponseFromFirstRuleExecution.hits.hits).toHaveLength(100);
+
+          const dateRestart = new Date();
+
+          await runSoonRule(supertest, createdRule.id);
+
+          const alertsResponse = await getAlerts(
+            supertest,
+            log,
+            es,
+            createdRule,
+            RuleExecutionStatusEnum['partial failure'], // rule has warning, alerts were truncated, thus "partial failure" status
+            300,
+            dateRestart
+          );
+
+          const indexCounts = alertsResponse.hits.hits.reduce<Record<string, number>>(
+            (acc, curr) => {
+              const indexName = curr._source?.[ALERT_ANCESTORS][0].index;
+              if (indexName) {
+                acc[indexName] = (acc[indexName] || 0) + 1;
+              }
+              return acc;
+            },
+            {}
+          );
+          expect(alertsResponse.hits.hits).toHaveLength(200);
+
+          expect(indexCounts).toEqual({
+            ecs_compliant: 100,
+            ecs_compliant_synthetic_source: 100,
+          });
+        });
+      });
     });
 
     describe('alerts enrichment', () => {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
@@ -16,7 +16,10 @@ import {
 import { EsqlRuleCreateProps } from '@kbn/security-solution-plugin/common/api/detection_engine/model/rule_schema';
 import { getCreateEsqlRulesSchemaMock } from '@kbn/security-solution-plugin/common/api/detection_engine/model/rule_schema/mocks';
 import { RuleExecutionStatusEnum } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_monitoring';
-import { ALERT_ANCESTORS } from '@kbn/security-solution-plugin/common/field_maps/field_names';
+import {
+  ALERT_ANCESTORS,
+  ALERT_ORIGINAL_TIME,
+} from '@kbn/security-solution-plugin/common/field_maps/field_names';
 
 import { getMaxSignalsWarning as getMaxAlertsWarning } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_types/utils/utils';
 import { EXCLUDED_DATA_TIERS_FOR_RULE_EXECUTION } from '@kbn/security-solution-plugin/common/constants';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security][Detection Engine] ESQL Rule Execution Logic Integration Test (#252936)](https://github.com/elastic/kibana/pull/252936)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Brooks","email":"hannah.brooks@elastic.co"},"sourceCommit":{"committedDate":"2026-02-19T15:49:43Z","message":"[Security][Detection Engine] ESQL Rule Execution Logic Integration Test (#252936)\n\n## Summary\n\nResolves [#235895](https://github.com/elastic/kibana/issues/235895)\nWhen mv_expand is used, all documents added to indices share the same _id and @timestamp. This leads to indeterministic ordering when ElasticSearch is pulling documents. There is no tiebreaker, so we get unpredictable results. This fixes PR fixes a test that encounters this issue.","sha":"8cb144ef0002d4b54e157374d0f481ad89657a66","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","Team:Detection Engine","v9.4.0","v9.3.1","v9.2.6"],"title":"[Security][Detection Engine] ESQL Rule Execution Logic Integration Test","number":252936,"url":"https://github.com/elastic/kibana/pull/252936","mergeCommit":{"message":"[Security][Detection Engine] ESQL Rule Execution Logic Integration Test (#252936)\n\n## Summary\n\nResolves [#235895](https://github.com/elastic/kibana/issues/235895)\nWhen mv_expand is used, all documents added to indices share the same _id and @timestamp. This leads to indeterministic ordering when ElasticSearch is pulling documents. There is no tiebreaker, so we get unpredictable results. This fixes PR fixes a test that encounters this issue.","sha":"8cb144ef0002d4b54e157374d0f481ad89657a66"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252936","number":252936,"mergeCommit":{"message":"[Security][Detection Engine] ESQL Rule Execution Logic Integration Test (#252936)\n\n## Summary\n\nResolves [#235895](https://github.com/elastic/kibana/issues/235895)\nWhen mv_expand is used, all documents added to indices share the same _id and @timestamp. This leads to indeterministic ordering when ElasticSearch is pulling documents. There is no tiebreaker, so we get unpredictable results. This fixes PR fixes a test that encounters this issue.","sha":"8cb144ef0002d4b54e157374d0f481ad89657a66"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/254034","number":254034,"state":"MERGED","mergeCommit":{"sha":"afdf3f8da9b3a7b3388d5ba42aef72a9c96ea411","message":"[9.3] [Security][Detection Engine] ESQL Rule Execution Logic Integration Test (#252936) (#254034)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security][Detection Engine] ESQL Rule Execution Logic Integration\nTest (#252936)](https://github.com/elastic/kibana/pull/252936)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Hannah Brooks <hannah.brooks@elastic.co>"}},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/254033","number":254033,"state":"MERGED","mergeCommit":{"sha":"99f0e76bf2255b960579bf1d3b84925dc281e3cd","message":"[9.2] [Security][Detection Engine] ESQL Rule Execution Logic Integration Test (#252936) (#254033)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security][Detection Engine] ESQL Rule Execution Logic Integration\nTest (#252936)](https://github.com/elastic/kibana/pull/252936)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Hannah Brooks <hannah.brooks@elastic.co>"}}]}] BACKPORT-->