### PR TITLE
[ci] Guard against empty ingest metadata

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -30,7 +30,9 @@ fi
 # Annotate ingestable meta-data (prefixed with 'ingest:')
 if [[ "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" != "" ]]; then # if we're in a PR build
   # GITHUB_PR_DRAFT is set by our pr build trigger bot
-  buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-}"
+  buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-false}"
   # GITHUB_PR_LABELS is set by our pr build trigger bot, and is a comma-separated list of labels on the PR
-  buildkite-agent meta-data set "ingest:pr_labels" "${GITHUB_PR_LABELS:-}"
+  if [[ -n "${GITHUB_PR_LABELS:-}" ]]; then
+    buildkite-agent meta-data set "ingest:pr_labels" "$GITHUB_PR_LABELS"
+  fi
 fi

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -32,7 +32,7 @@ if [[ "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" != "" ]]; then # if we're in a P
   # GITHUB_PR_DRAFT is set by our pr build trigger bot
   buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-false}"
   # GITHUB_PR_LABELS is set by our pr build trigger bot, and is a comma-separated list of labels on the PR
-  # if [[ -n "${GITHUB_PR_LABELS:-}" ]]; then
-  buildkite-agent meta-data set "ingest:pr_labels" "$GITHUB_PR_LABELS"
-  # fi
+  if [[ -n "${GITHUB_PR_LABELS:-}" ]]; then
+    buildkite-agent meta-data set "ingest:pr_labels" "$GITHUB_PR_LABELS"
+  fi
 fi

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -32,7 +32,7 @@ if [[ "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" != "" ]]; then # if we're in a P
   # GITHUB_PR_DRAFT is set by our pr build trigger bot
   buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-false}"
   # GITHUB_PR_LABELS is set by our pr build trigger bot, and is a comma-separated list of labels on the PR
-  if [[ -n "${GITHUB_PR_LABELS:-}" ]]; then
-    buildkite-agent meta-data set "ingest:pr_labels" "$GITHUB_PR_LABELS"
-  fi
+  # if [[ -n "${GITHUB_PR_LABELS:-}" ]]; then
+  buildkite-agent meta-data set "ingest:pr_labels" "$GITHUB_PR_LABELS"
+  # fi
 fi


### PR DESCRIPTION
Fixes an issue where pull requests (not on-merge) without labels were passing without running checks.  

Related to https://github.com/elastic/kibana/pull/252722
Example failure [here](https://buildkite.com/elastic/kibana-pull-request/builds/398087#019c7778-7d1f-46b7-b659-5ef7ec43b250/L204)

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->