### PR TITLE
[Security Solution] add feature flag to Security Solution to conditionally show the new flyout. Load new (empty) flyout in Security Solution and Discover

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { EnhancedAlertEventOverview } from './enhanced_alert_event_overview';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+
+jest.mock('../../../../hooks/use_discover_services');
+
+const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
+  ({
+    id: '1',
+    raw: {},
+    flattened,
+    isAnchor: false,
+  } as DataTableRecord);
+
+const hit = createMockHit({
+  'event.kind': 'signal',
+});
+
+describe('EnhancedAlertEventOverview', () => {
+  it('renders the security solution overview tab feature', async () => {
+    const renderFeature = jest.fn().mockResolvedValue(() => <div>OverviewTab</div>);
+    const mockDiscoverServices = {
+      discoverShared: {
+        features: {
+          registry: {
+            getById: jest.fn().mockReturnValue({
+              id: 'security-solution-alert-flyout-overview-tab',
+              render: renderFeature,
+            }),
+          },
+        },
+      },
+    };
+
+    (useDiscoverServices as jest.Mock).mockReturnValue(mockDiscoverServices);
+
+    render(
+      <IntlProvider locale="en">
+        <EnhancedAlertEventOverview hit={hit} dataView={dataViewMock} />
+      </IntlProvider>
+    );
+
+    await waitFor(() => expect(renderFeature).toHaveBeenCalledWith(hit));
+    await act(async () => {
+      await renderFeature.mock.results[0].value;
+    });
+
+    expect(screen.getByText('OverviewTab')).toBeInTheDocument();
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
@@ -13,9 +13,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { EnhancedAlertEventOverview } from './enhanced_alert_event_overview';
-import { useDiscoverServices } from '../../../../hooks/use_discover_services';
-
-jest.mock('../../../../hooks/use_discover_services');
+import type { ProfileProviderServices } from '../../profile_provider_services';
 
 const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
   ({
@@ -32,7 +30,7 @@ const hit = createMockHit({
 describe('EnhancedAlertEventOverview', () => {
   it('renders the security solution overview tab feature', async () => {
     const renderFeature = jest.fn().mockReturnValue(<div>OverviewTab</div>);
-    const mockDiscoverServices = {
+    const providerServices = {
       discoverShared: {
         features: {
           registry: {
@@ -43,13 +41,15 @@ describe('EnhancedAlertEventOverview', () => {
           },
         },
       },
-    };
-
-    (useDiscoverServices as jest.Mock).mockReturnValue(mockDiscoverServices);
+    } as unknown as ProfileProviderServices;
 
     render(
       <IntlProvider locale="en">
-        <EnhancedAlertEventOverview hit={hit} dataView={dataViewMock} />
+        <EnhancedAlertEventOverview
+          hit={hit}
+          dataView={dataViewMock}
+          providerServices={providerServices}
+        />
       </IntlProvider>
     );
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
@@ -31,7 +31,7 @@ const hit = createMockHit({
 
 describe('EnhancedAlertEventOverview', () => {
   it('renders the security solution overview tab feature', async () => {
-    const renderFeature = jest.fn().mockResolvedValue(() => <div>OverviewTab</div>);
+    const renderFeature = jest.fn().mockReturnValue(<div>OverviewTab</div>);
     const mockDiscoverServices = {
       discoverShared: {
         features: {
@@ -54,9 +54,6 @@ describe('EnhancedAlertEventOverview', () => {
     );
 
     await waitFor(() => expect(renderFeature).toHaveBeenCalledWith(hit));
-    await act(async () => {
-      await renderFeature.mock.results[0].value;
-    });
 
     expect(screen.getByText('OverviewTab')).toBeInTheDocument();
   });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useState } from 'react';
 import type { DocViewerComponent } from '@kbn/unified-doc-viewer/types';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 
@@ -23,31 +22,6 @@ export const EnhancedAlertEventOverview: DocViewerComponent = ({ hit }) => {
     'security-solution-alert-flyout-overview-tab'
   );
 
-  const [AlertFlyoutOverviewTab, setAlertFlyoutOverviewTab] = useState<(() => JSX.Element) | null>(
-    null
-  );
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const load = async () => {
-      const render = alertFlyoutOverviewTabFeature?.render;
-      if (!render) return;
-
-      const component = await render(hit);
-      if (!isMounted) return;
-
-      setAlertFlyoutOverviewTab(() => component);
-    };
-
-    load();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [alertFlyoutOverviewTabFeature, hit]);
-
-  if (!AlertFlyoutOverviewTab) return null;
-
-  return <AlertFlyoutOverviewTab />;
+  const render = alertFlyoutOverviewTabFeature?.render;
+  return render ? render(hit) : null;
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
@@ -7,8 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { DocViewerComponent } from '@kbn/unified-doc-viewer/types';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 
 /**
  * This component is a placeholder for the new alert/event Overview tab content.
@@ -17,5 +18,36 @@ import type { DocViewerComponent } from '@kbn/unified-doc-viewer/types';
  * The feature flag will remain disabled until we're ready to ship some of the content. The target is to release an MVP by 9.4 then have it fully functional by 9.5.
  */
 export const EnhancedAlertEventOverview: DocViewerComponent = ({ hit }) => {
-  return <></>;
+  const { discoverShared } = useDiscoverServices();
+  const alertFlyoutOverviewTabFeature = discoverShared.features.registry.getById(
+    'security-solution-alert-flyout-overview-tab'
+  );
+
+  const [AlertFlyoutOverviewTab, setAlertFlyoutOverviewTab] = useState<(() => JSX.Element) | null>(
+    null
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const load = async () => {
+      const render = alertFlyoutOverviewTabFeature?.render;
+      if (!render) return;
+
+      const component = await render(hit);
+      if (!isMounted) return;
+
+      setAlertFlyoutOverviewTab(() => component);
+    };
+
+    load();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [alertFlyoutOverviewTabFeature, hit]);
+
+  if (!AlertFlyoutOverviewTab) return null;
+
+  return <AlertFlyoutOverviewTab />;
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DocViewerComponent } from '@kbn/unified-doc-viewer/types';
-import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import type { ProfileProviderServices } from '../../profile_provider_services';
 
 /**
  * This component is a placeholder for the new alert/event Overview tab content.
@@ -16,9 +16,15 @@ import { useDiscoverServices } from '../../../../hooks/use_discover_services';
  * The intention keep implementing its content as we're extracting flyout code from the Security Solution plugin to a set of package.
  * The feature flag will remain disabled until we're ready to ship some of the content. The target is to release an MVP by 9.4 then have it fully functional by 9.5.
  */
-export const EnhancedAlertEventOverview: DocViewerComponent = ({ hit }) => {
-  const { discoverShared } = useDiscoverServices();
-  const alertFlyoutOverviewTabFeature = discoverShared.features.registry.getById(
+export interface EnhancedAlertEventOverviewProps extends DocViewRenderProps {
+  providerServices: ProfileProviderServices;
+}
+
+export const EnhancedAlertEventOverview = ({
+  hit,
+  providerServices,
+}: EnhancedAlertEventOverviewProps) => {
+  const alertFlyoutOverviewTabFeature = providerServices.discoverShared.features.registry.getById(
     'security-solution-alert-flyout-overview-tab'
   );
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
@@ -35,7 +35,9 @@ export const createSecurityDocumentProfileProviders = (
               id: 'doc_view_alerts_overview',
               title: i18n.overviewTabTitle(isAlert),
               order: 0,
-              render: (props) => <EnhancedAlertEventOverviewLazy {...props} />,
+              render: (props) => (
+                <EnhancedAlertEventOverviewLazy {...props} providerServices={providerServices} />
+              ),
             });
 
             return prevDocViewer.docViewsRegistry(registry);

--- a/src/platform/plugins/shared/discover_shared/public/index.ts
+++ b/src/platform/plugins/shared/discover_shared/public/index.ts
@@ -23,6 +23,7 @@ export type {
   ObservabilityStreamsFeature,
   SecuritySolutionCellRendererFeature,
   SecuritySolutionAppWrapperFeature,
+  SecuritySolutionAlertFlyoutOverviewTabFeature,
   DiscoverFeature,
   DiscoverFeaturesServiceSetup,
   DiscoverFeaturesServiceStart,

--- a/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
+++ b/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
@@ -9,19 +9,19 @@
 
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { FunctionComponent, PropsWithChildren } from 'react';
+import type React from 'react';
 import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
 import type { Query, TimeRange } from '@kbn/es-query';
 import type {
-  SpanLinks,
   ErrorsByTraceId,
-  TraceRootSpan,
-  UnifiedSpanDocument,
   FocusedTraceWaterfallProps,
   FullTraceWaterfallProps,
+  SpanLinks,
+  TraceRootSpan,
+  UnifiedSpanDocument,
 } from '@kbn/apm-types';
 import type { HistogramItem, ProcessorEvent } from '@kbn/apm-types-shared';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import type React from 'react';
 import type { IndicatorType } from '@kbn/slo-schema';
 import type { FeaturesRegistry } from '../../../common';
 
@@ -119,9 +119,15 @@ export interface SecuritySolutionAppWrapperFeature {
   getWrapper: () => Promise<() => FunctionComponent<PropsWithChildren<{}>>>;
 }
 
+export interface SecuritySolutionAlertFlyoutOverviewTabFeature {
+  id: 'security-solution-alert-flyout-overview-tab';
+  render: (hit: DataTableRecord) => Promise<() => JSX.Element>;
+}
+
 export type SecuritySolutionFeature =
   | SecuritySolutionCellRendererFeature
-  | SecuritySolutionAppWrapperFeature;
+  | SecuritySolutionAppWrapperFeature
+  | SecuritySolutionAlertFlyoutOverviewTabFeature;
 
 /** ****************************************************************************************/
 

--- a/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
+++ b/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
@@ -121,7 +121,7 @@ export interface SecuritySolutionAppWrapperFeature {
 
 export interface SecuritySolutionAlertFlyoutOverviewTabFeature {
   id: 'security-solution-alert-flyout-overview-tab';
-  render: (hit: DataTableRecord) => Promise<() => JSX.Element>;
+  render: (hit: DataTableRecord) => JSX.Element;
 }
 
 export type SecuritySolutionFeature =

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -225,6 +225,11 @@ export const allowedExperimentalValues = Object.freeze({
    * Enables the Automatic Troubleshooting Agent Builder skill
    */
   automaticTroubleshootingSkill: false,
+
+  /**
+   * Enables the new flyout using the EUI flyout system
+   */
+  newFlyoutSystemEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/transform_control_columns.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/transform_control_columns.test.tsx
@@ -28,6 +28,7 @@ describe('transformControlColumns', () => {
     sort: [],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     theme: {} as any,
+    rawEvents: [],
   };
   test('displays loader when id is included on loadingEventIds', () => {
     const res = transformControlColumns(defaultProps);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/transform_control_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/transform_control_columns.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import type { EuiTheme } from '@kbn/kibana-react-plugin/common';
 import type { SortColumnTable } from '@kbn/securitysolution-data-table';
 import { addBuildingBlockStyle, getPageRowIndex } from '@kbn/securitysolution-data-table';
+import type { EsHitRecord } from '@kbn/discover-utils';
 import type {
   BrowserFields,
   TimelineItem,
@@ -49,6 +50,7 @@ export interface TransformColumnsProps {
   theme: EuiTheme;
   setEventsLoading: SetEventsLoading;
   setEventsDeleted: SetEventsDeleted;
+  rawEvents: Array<EsHitRecord>;
 }
 
 export const transformControlColumns = ({
@@ -71,6 +73,7 @@ export const transformControlColumns = ({
   theme,
   setEventsLoading,
   setEventsDeleted,
+  rawEvents,
 }: TransformColumnsProps): EuiDataGridControlColumn[] => {
   return controlColumns.map(
     ({ id: columnId, headerCellRender = EmptyHeaderCellRender, rowCellRender, width }, i) => ({
@@ -116,6 +119,14 @@ export const transformControlColumns = ({
           setCellProps({ style: { display: 'none' } });
         }
 
+        // We are creating this object here so we can pass it to the cell action, which will then pass it to the flyout.
+        // This way we can use the same flyout content code between Security Solution and Discover.
+        const esHitRecord: EsHitRecord = {
+          _id: rawEvents[pageRowIndex]?._id,
+          _index: rawEvents[pageRowIndex]?._index,
+          _source: rawEvents[pageRowIndex]?.fields,
+        };
+
         return (
           <RowAction
             columnId={columnId ?? ''}
@@ -123,6 +134,7 @@ export const transformControlColumns = ({
             controlColumn={controlColumns[i]}
             data={data[pageRowIndex]}
             disabled={false}
+            esHitRecord={esHitRecord}
             index={i}
             isDetails={isDetails}
             isExpanded={isExpanded}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -288,7 +288,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     [sort]
   );
 
-  const [loading, { events, loadPage, pageInfo, refetch, totalCount = 0, inspect }] =
+  const [loading, { events, rawEvents, loadPage, pageInfo, refetch, totalCount = 0, inspect }] =
     useTimelineEvents({
       // We rely on entityType to determine Events vs Alerts
       alertConsumers: SECURITY_ALERTS_CONSUMERS,
@@ -345,6 +345,11 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     () => events.filter((e) => !deletedEventIds.includes(e._id)),
     [deletedEventIds, events]
   );
+  const nonDeletedRawEvents = useMemo(
+    () => rawEvents.filter((e) => !deletedEventIds.includes(e._id as string)),
+    [deletedEventIds, rawEvents]
+  );
+
   useEffect(() => {
     setQuery({ id: tableId, inspect, loading, refetch });
   }, [inspect, loading, refetch, setQuery, tableId]);
@@ -437,6 +442,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
         columnHeaders,
         controlColumns,
         data: nonDeletedEvents,
+        rawEvents: nonDeletedRawEvents,
         fieldBrowserOptions,
         loadingEventIds,
         onRowSelected,
@@ -460,6 +466,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     leadingControlColumns,
     columnHeaders,
     nonDeletedEvents,
+    nonDeletedRawEvents,
     fieldBrowserOptions,
     loadingEventIds,
     onRowSelected,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/mock.ts
@@ -12,6 +12,7 @@ export const mockEventViewerResponse = {
     fakeTotalCount: 100,
   },
   events: [],
+  rawEvents: [],
   inspect: {
     dsl: [],
     response: [],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/use_timelines_events.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/use_timelines_events.tsx
@@ -22,6 +22,7 @@ import type {
   TimelineEventsAllStrategyResponse,
   TimelineItem,
 } from '@kbn/timelines-plugin/common';
+import type { EsHitRecord } from '@kbn/discover-utils';
 import type {
   EntityType,
   TimelineFactoryQueryTypes,
@@ -49,6 +50,7 @@ export interface TimelineArgs {
   inspect: InspectResponse;
   loadPage: LoadPage;
   pageInfo: Pick<PaginationInputPaginated, 'activePage' | 'querySize'>;
+  rawEvents: EsHitRecord[];
   refetch: Refetch;
   totalCount: number;
   updatedAt: number;
@@ -214,6 +216,7 @@ export const useTimelineEventsHandler = ({
       querySize: 0,
     },
     events: [],
+    rawEvents: [],
     loadPage: wrappedLoadPage,
     updatedAt: 0,
   });
@@ -253,6 +256,7 @@ export const useTimelineEventsHandler = ({
                       ...prevResponse,
                       consumers: response.consumers,
                       events: getTimelineEvents(response.edges),
+                      rawEvents: (response.rawResponse?.hits?.hits ?? []) as EsHitRecord[],
                       inspect: getInspectResponse(response, prevResponse.inspect),
                       pageInfo: response.pageInfo,
                       totalCount: response.totalCount,
@@ -403,6 +407,7 @@ export const useTimelineEventsHandler = ({
           querySize: 0,
         },
         events: [],
+        rawEvents: [],
         loadPage: wrappedLoadPage,
         updatedAt: 0,
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiPanel } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { DataTableRecord } from '@kbn/discover-utils';
+
+const OVERVIEW_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.document.overview.overviewContentAriaLabel',
+  { defaultMessage: 'Overview' }
+);
+
+export interface OverviewTabProps {
+  /**
+   * Document to display in the overview tab
+   */
+  hit: DataTableRecord;
+}
+
+/**
+ * Overview view displayed in the document details expandable flyout right section
+ */
+export const OverviewTab = memo(({ hit }: OverviewTabProps) => {
+  return (
+    <EuiPanel
+      hasBorder={false}
+      hasShadow={false}
+      paddingSize="none"
+      aria-label={OVERVIEW_ARIA_LABEL}
+    >
+      {hit.id}
+    </EuiPanel>
+  );
+});
+
+OverviewTab.displayName = 'OverviewTab';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/jest.config.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/jest.config.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../../../..',
+  roots: ['<rootDir>/x-pack/solutions/security/plugins/security_solution/public/flyout_v2'],
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/solutions/security/plugins/security_solution/public/flyout_v2',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/**/*.{ts,tsx}',
+  ],
+  moduleNameMapper: require('../../server/__mocks__/module_name_map'),
+  setupFilesAfterEnv: [
+    '<rootDir>/x-pack/solutions/security/plugins/security_solution/public/flyout/test/setup.ts',
+  ],
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { OverviewTab } from '../../flyout_v2/document/tabs/overview_tab';
+
+export const getAlertFlyoutOverviewTabComponent = (hit: DataTableRecord) => {
+  return <OverviewTab hit={hit} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { memo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { OverviewTab } from '../../flyout_v2/document/tabs/overview_tab';
 
-export const getAlertFlyoutOverviewTabComponent = (hit: DataTableRecord) => {
+export const AlertFlyoutOverviewTab = memo(({ hit }: { hit: DataTableRecord }) => {
   return <OverviewTab hit={hit} />;
-};
+});
+
+AlertFlyoutOverviewTab.displayName = 'AlertFlyoutOverviewTab';

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/index.tsx
@@ -6,3 +6,4 @@
  */
 
 export { getCellRendererForGivenRecord } from './cell_renderers';
+export { getAlertFlyoutOverviewTabComponent } from './alert_flyout_overview_tab_component';

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/index.tsx
@@ -6,4 +6,4 @@
  */
 
 export { getCellRendererForGivenRecord } from './cell_renderers';
-export { getAlertFlyoutOverviewTabComponent } from './alert_flyout_overview_tab_component';
+export { AlertFlyoutOverviewTab } from './alert_flyout_overview_tab_component';

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -21,7 +21,10 @@ import { AppStatus, DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { Logger } from '@kbn/logging';
 import { uiMetricService } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
-import type { SecuritySolutionCellRendererFeature } from '@kbn/discover-shared-plugin/public/services/discover_features';
+import type {
+  SecuritySolutionAlertFlyoutOverviewTabFeature,
+  SecuritySolutionCellRendererFeature,
+} from '@kbn/discover-shared-plugin/public/services/discover_features';
 import { ProductFeatureSecurityKey } from '@kbn/security-solution-features/keys';
 import { ProductFeatureAssistantKey } from '@kbn/security-solution-features/src/product_features_keys';
 import { getLazyCloudSecurityPosturePliAuthBlockExtension } from './cloud_security_posture/lazy_cloud_security_posture_pli_auth_block_extension';
@@ -288,6 +291,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
   public async registerDiscoverSharedFeatures(plugins: SetupPlugins) {
     const { discoverShared } = plugins;
     const discoverFeatureRegistry = discoverShared.features.registry;
+
     const cellRendererFeature: SecuritySolutionCellRendererFeature = {
       id: 'security-solution-cell-renderer',
       getRenderer: async () => {
@@ -295,8 +299,16 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         return getCellRendererForGivenRecord;
       },
     };
-
     discoverFeatureRegistry.register(cellRendererFeature);
+
+    const alertFlyoutOverviewTabFeature: SecuritySolutionAlertFlyoutOverviewTabFeature = {
+      id: 'security-solution-alert-flyout-overview-tab',
+      render: async (hit) => {
+        const { getAlertFlyoutOverviewTabComponent } = await this.getLazyDiscoverSharedDeps();
+        return () => getAlertFlyoutOverviewTabComponent(hit);
+      },
+    };
+    discoverFeatureRegistry.register(alertFlyoutOverviewTabFeature);
   }
 
   public async getLazyDiscoverSharedDeps() {

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -301,12 +301,18 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     };
     discoverFeatureRegistry.register(cellRendererFeature);
 
+    const LazyAlertFlyoutOverviewTab = React.lazy(async () => {
+      const { AlertFlyoutOverviewTab } = await this.getLazyDiscoverSharedDeps();
+      return { default: AlertFlyoutOverviewTab };
+    });
+
     const alertFlyoutOverviewTabFeature: SecuritySolutionAlertFlyoutOverviewTabFeature = {
       id: 'security-solution-alert-flyout-overview-tab',
-      render: async (hit) => {
-        const { getAlertFlyoutOverviewTabComponent } = await this.getLazyDiscoverSharedDeps();
-        return () => getAlertFlyoutOverviewTabComponent(hit);
-      },
+      render: (hit) => (
+        <React.Suspense fallback={null}>
+          <LazyAlertFlyoutOverviewTab hit={hit} />
+        </React.Suspense>
+      ),
     };
     discoverFeatureRegistry.register(alertFlyoutOverviewTabFeature);
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -5,15 +5,14 @@
  * 2.0.
  */
 
-import React, { memo, useMemo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type {
   UnifiedDataTableProps,
   UnifiedDataTableSettingsColumn,
 } from '@kbn/unified-data-table';
-import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
+import { DataLoadingState, UnifiedDataTable } from '@kbn/unified-data-table';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type {
   EuiDataGridControlColumn,
@@ -22,6 +21,8 @@ import type {
 } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
 import { useOnExpandableFlyoutClose } from '../../../../../flyout/shared/hooks/use_on_expandable_flyout_close';
 import { DocumentDetailsRightPanelKey } from '../../../../../flyout/document_details/shared/constants/panel_keys';
@@ -38,12 +39,12 @@ import type {
   RowRenderer,
   TimelineTabs,
 } from '../../../../../../common/types/timeline';
-import type { State, inputsModel } from '../../../../../common/store';
+import type { inputsModel, State } from '../../../../../common/store';
 import { getFormattedFields } from '../../body/renderers/formatted_field_udt';
 import ToolbarAdditionalControls from './toolbar_additional_controls';
 import {
-  StyledTimelineUnifiedDataTable,
   StyledEuiProgress,
+  StyledTimelineUnifiedDataTable,
   UnifiedTimelineGlobalStyles,
 } from '../styles';
 import { timelineActions } from '../../../../store';
@@ -54,8 +55,8 @@ import { TIMELINE_EVENT_DETAIL_ROW_ID } from '../../body/constants';
 import { DocumentEventTypes } from '../../../../../common/lib/telemetry/types';
 import { getTimelineRowTypeIndicator } from './get_row_indicator';
 import { isAttackDiscoveryRow } from './is_attack_discovery_row';
+import { OverviewTab } from '../../../../../flyout_v2/document/tabs/overview_tab';
 
-export const SAMPLE_SIZE_SETTING = 500;
 const DataGridMemoized = React.memo(UnifiedDataTable);
 
 type CommonDataTableProps = {
@@ -117,6 +118,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
     leadingControlColumns,
     onUpdatePageIndex,
   }) {
+    const newFlyoutSystemEnabled = useIsExperimentalFeatureEnabled('newFlyoutSystemEnabled');
     const dispatch = useDispatch();
 
     // Store context in state rather than creating object in provider value={} to prevent re-renders caused by a new object being created
@@ -137,6 +139,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
         telemetry,
         theme,
         data: dataPluginContract,
+        overlays,
       },
     } = useKibana();
 
@@ -177,33 +180,43 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
 
     const handleOnEventDetailPanelOpened = useCallback(
       (eventData: DataTableRecord & TimelineItem) => {
-        const isAttackRow = isAttackDiscoveryRow(eventData);
-        const indexName = eventData.ecs._index ?? '';
-        const rightPanel = isAttackRow
-          ? {
-              id: AttackDetailsRightPanelKey,
-              params: {
-                attackId: eventData._id,
-                indexName,
-              },
-            }
-          : {
-              id: DocumentDetailsRightPanelKey,
-              params: {
-                id: eventData._id,
-                indexName,
-                scopeId: timelineId,
-              },
-            };
-        openFlyout({
-          right: rightPanel,
-        });
-        telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
-          location: timelineId,
-          panel: 'right',
-        });
+        if (newFlyoutSystemEnabled) {
+          const hit: DataTableRecord = buildDataTableRecord(eventData.raw);
+          overlays.openSystemFlyout(<OverviewTab hit={hit} />, {
+            // @ts-ignore EUI to fix this typing issue
+            resizable: true,
+            type: 'overlay',
+            ownFocus: false,
+          });
+        } else {
+          const isAttackRow = isAttackDiscoveryRow(eventData);
+          const indexName = eventData.ecs._index ?? '';
+          const rightPanel = isAttackRow
+            ? {
+                id: AttackDetailsRightPanelKey,
+                params: {
+                  attackId: eventData._id,
+                  indexName,
+                },
+              }
+            : {
+                id: DocumentDetailsRightPanelKey,
+                params: {
+                  id: eventData._id,
+                  indexName,
+                  scopeId: timelineId,
+                },
+              };
+          openFlyout({
+            right: rightPanel,
+          });
+          telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
+            location: timelineId,
+            panel: 'right',
+          });
+        }
       },
-      [openFlyout, timelineId, telemetry]
+      [newFlyoutSystemEnabled, overlays, openFlyout, timelineId, telemetry]
     );
 
     const onSetExpandedDoc = useCallback(


### PR DESCRIPTION
## Summary

This PR adds a new feature flag called `newFlyoutSystemEnabled` to the Security Solutuon plugin. The flag is disabled by default, and will remain so until `9.4` feature freeze at the earliest.

When enabled, we render a new empty flyout instead of rendering the expandable flyout. The new flyout is currently empty, and is using the new EUI flyout system.
This PR only focuses on the usage of the expandable flyout for alert and events. This means that the 3 places where the change is being applied are;
- the alert table row action
- the events table row action (accessed from the explore pages for example)
- the Timeline table row action

https://github.com/user-attachments/assets/71d6e470-79b2-4d0b-9515-ebe6224999cb

And it's also rendered in Discover

<img width="1437" height="938" alt="Screenshot 2026-02-19 at 9 34 17 PM" src="https://github.com/user-attachments/assets/07ffbde6-b98f-4f30-a414-8d0c8f9bd071" />

The new `OverviewTab` component created is currently only displaying the `id` of the document investigated. The component receives a `hit` prop as a `DataTableRecord`. This is to ensure that the component will work in the Discover plugin, which provides that same property out of the box.

> [!NOTE]
> This PR is the foundation work for all the upcoming migration to the new EUI flyout system. The changes will be visible in Discover and Security Solution.

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/251749