### PR TITLE
Add AI development tools: Cursor rules, skills, CLAUDE.md, and setup scripts

### DIFF
--- a/docs/ai-development/CLAUDE.md
+++ b/docs/ai-development/CLAUDE.md
@@ -1,0 +1,93 @@
+# Kibana — Project context for AI coding tools
+
+Kibana is a large TypeScript monorepo: the Elastic stack UI for search, observability, and security. This file gives AI tools a quick map of the codebase, build, and where to put new code.
+
+## Build and test (common commands)
+
+```bash
+# First-time and after dependency changes
+yarn kbn bootstrap
+
+# Type check (run before pushing)
+node scripts/type_check
+
+# Lint (run before pushing)
+node scripts/eslint_all_files --no-cache
+# Or with auto-fix:
+node scripts/eslint_all_files --no-cache --fix
+
+# Unit tests (Jest)
+yarn test:jest
+# Single package:
+yarn test:jest packages/kbn-ui-actions
+
+# FTR (functional test runner) — API tests
+node scripts/functional_tests_server --config test/api_integration/config.js
+node scripts/functional_test_runner --config test/api_integration/config.js
+
+# FTR — UI / functional tests
+node scripts/functional_tests --config test/functional/config.js
+
+# Build (production)
+yarn build
+```
+
+## Architecture summary
+
+### Plugin system
+
+- **Plugins** are the main unit of feature code. Each plugin has:
+  - `public/` — browser code (React, UI)
+  - `server/` — Node.js code (routes, saved objects, services)
+  - `common/` — shared types and utilities used by both
+- **Lifecycle:** `constructor` → `setup()` (register APIs, routes) → `start()` (use other plugins’ APIs). No module-level side effects; use lifecycle methods.
+- **Contracts:** Plugins depend on each other via **plugin contracts** (public API). Never import from another plugin’s internal paths (e.g. `plugin/server/lib/foo`). Use the plugin’s public or server contract.
+- **Manifest:** `kibana.jsonc` declares the plugin id, required/optional dependencies, and config.
+
+### Packages and boundaries
+
+- **`packages/`** — Shared packages under `@kbn/` (e.g. `@kbn/core`, `@kbn/ui-actions`). Use for code shared across many plugins.
+- **`x-pack/packages/`** — X-Pack–specific packages (license, ML, etc.).
+- **`src/`** — Legacy/core source; new features live in plugins or packages.
+- **Naming:** Package scope is `@kbn/<name>`. Plugin IDs are kebab-case (e.g. `my_plugin` or `my-plugin` depending on Kibana convention in use).
+
+### Solutions (solution areas)
+
+- **Security** — `x-pack/solutions/security/` (SIEM, detection rules, timeline, etc.)
+- **Observability** — `x-pack/solutions/observability/` (APM, logs, metrics, SLO)
+- **Search** — `x-pack/solutions/search/` (enterprise search, connectors, applications)
+
+New features in one of these areas usually live under the corresponding solution’s plugins.
+
+## Key conventions
+
+- **TypeScript:** Strict mode. Use `import type { ... }` for type-only imports. Prefer explicit return types on public APIs.
+- **React:** Functional components and hooks. Use **EUI** components from `@elastic/eui` (e.g. `EuiButton`, `EuiFlexGroup`). Add `data-test-subj` to interactive elements for tests.
+- **Server:** Route handlers with proper error handling. Use **Zod** (or Kibana’s validation pattern) for request/response validation. Register routes in the plugin’s `setup()`.
+- **Testing:** Jest for unit tests; **FTR** for API and functional tests. Use `describe`/`it` with clear descriptions; inject services in FTR; use page objects and retries for UI tests.
+- **i18n:** Use `i18n.translate()` and `<FormattedMessage>` for user-facing strings.
+
+## Where does this go? (decision tree)
+
+| If you are… | Then put it… |
+|-------------|--------------|
+| Adding a feature to an existing plugin | In that plugin’s `public/`, `server/`, or `common/` as appropriate |
+| Creating a new plugin | New directory under `src/plugins/` or under a solution (e.g. `x-pack/plugins/` or solution folder) with `public/`, `server/`, `common/`, and `kibana.jsonc` |
+| Adding code shared by multiple plugins | New or existing `@kbn/` package in `packages/` or `x-pack/packages/` |
+| Adding a shared type or util used only inside one plugin | That plugin’s `common/` directory |
+| Adding an HTTP API | Route handler in plugin’s `server/` and register in `setup()`; use request/response validation |
+| Adding a saved object type | Define type and migrations in plugin’s `server/` (or `common/` for types); register in plugin `setup()` |
+| Writing a unit test | Next to the module (e.g. `foo.test.ts`) or in `__tests__/` following existing package layout |
+| Writing an API or functional test | Under `test/` (e.g. `test/api_integration/`, `test/functional/`) with the right FTR config |
+
+## CI and PR preparation
+
+- **CI runs:** Type check, ESLint, i18n check, unit tests, FTR (selected suites), bundle size checks.
+- **Before pushing:** Run `node scripts/type_check`, `node scripts/eslint_all_files`, and the relevant test suites locally. On **draft PRs**, CI does not start automatically — comment `/ci` on the PR to trigger the pipeline. If CI pushes an auto-fix commit (e.g. eslint fix), comment `/ci` again to re-trigger.
+
+## Cursor-specific setup
+
+- **Rules:** `.cursor/rules/` — domain-specific rule files (e.g. `kibana-core.mdc`, `kibana-plugin-architecture.mdc`). Activate the rule sets that match your work area.
+- **Skills:** `.cursor/skills/` — step-by-step skills for creating plugins, adding routes, writing tests, preparing PRs. Use the onboarding script or copy `.cursor/` from this deliverable into your Kibana repo root.
+
+For full setup instructions, see the README in the same deliverable as this file.

--- a/docs/ai-development/PR_DESCRIPTION.md
+++ b/docs/ai-development/PR_DESCRIPTION.md
@@ -1,0 +1,110 @@
+## Summary
+
+This PR adds **AI development tools** to the Kibana repo so that Cursor (and other AI coding assistants) can follow Kibana conventions and use guided workflows. It is the first phase of the [kibana-codebase-ai-plugin](https://github.com/elastic/kibana/issues/TBD) initiative, which responds to the CTO’s Feb 2026 all-hands mandate: *"We need to add skills and MD files that teach the LLMs our coding practices and help them understand how to code against our repositories."*
+
+**No runtime or CI behavior changes.** All content lives under `docs/ai-development/` and is installed into `.cursor/` (gitignored) by an optional setup script. Engineers opt in by running the script.
+
+---
+
+## Why
+
+- **Low adoption:** A key blocker to AI tool adoption is that assistants generate code that doesn’t match Kibana’s style, fails CI, or breaks architectural boundaries. This leads engineers to conclude that “AI isn’t ready for complex codebases.”
+- **Root cause:** Large repos need **rules**, **skills**, and **context** that teach LLMs the codebase’s conventions, plugin system, testing patterns, and CI workflow. Without that, outputs are inconsistent and hard to review.
+- **Goal:** Make Kibana **LLM-friendly** so that the 60% of engineers not yet using AI tools can get to productive, CI-passing contributions quickly (target: same-day setup).
+
+---
+
+## What this PR adds
+
+### 1. **Cursor rules** (`docs/ai-development/rules/`)
+
+Five rule files that Cursor (and similar tools) can load to enforce Kibana conventions:
+
+| Rule | Covers |
+|------|--------|
+| `kibana-core.mdc` | TypeScript (strict, type-only imports, interfaces), import boundaries, error handling, project structure |
+| `kibana-plugin-architecture.mdc` | public/server/common layout, plugin lifecycle (setup/start), dependency injection, cross-plugin contracts |
+| `kibana-testing.mdc` | Jest (describe/it, mocks, placement), FTR API tests, FTR functional tests, flakiness and retries |
+| `kibana-react-eui.mdc` | Functional components, EUI usage, `data-test-subj`, accessibility, i18n |
+| `kibana-ci.mdc` | Type check, eslint, i18n, pre-push checklist, draft PR `/ci` workflow, eslint auto-fix handling |
+
+### 2. **Cursor skills** (`docs/ai-development/skills/`)
+
+Five step-by-step skills with validation so the LLM can verify its own output:
+
+| Skill | Purpose |
+|-------|---------|
+| **create-kibana-plugin** | Create a new plugin: directory structure, `kibana.jsonc`, lifecycle, basic Jest test |
+| **add-http-route** | Add an HTTP route: handler, request/response validation (Zod or config-schema), registration, FTR API test |
+| **write-jest-test** | Write a Jest unit test for a module with proper mocks and structure |
+| **write-ftr-api-test** | Write an FTR API integration test with service injection and cleanup |
+| **prepare-pr** | Run type-check, eslint, i18n, affected tests; suggest commit message; remind about `/ci` on draft PRs |
+
+Each skill includes **validation steps** (e.g. run `node scripts/type_check`, run Jest) so the model checks its work before handing off.
+
+### 3. **Architecture context** (`docs/ai-development/CLAUDE.md`)
+
+A single **CLAUDE.md** that gives LLMs:
+
+- Project overview and common build/test commands
+- Plugin system and package boundaries
+- “Where does this go?” decision guidance
+- Pointers to Cursor setup in the README
+
+It is intended to be copied to the repo root by the setup script so that AI tools see it when the workspace is the Kibana root.
+
+### 4. **Setup and validation** (`docs/ai-development/`)
+
+- **`setup-ai-tools.sh`** — Copies `CLAUDE.md` to the repo root and `rules/` and `skills/` into `.cursor/rules/` and `.cursor/skills/`. Run from repo root: `./docs/ai-development/setup-ai-tools.sh` (or pass another Kibana root). Completes in under a minute.
+- **`validate-ai-setup.sh`** — Checks that CLAUDE.md and `.cursor/rules/` and `.cursor/skills/` exist and are readable after setup.
+- **`README.md`** — Quick install, manual copy instructions, what’s included, troubleshooting, and how to re-run after updates.
+
+---
+
+## How engineers use it
+
+1. **One-time setup (from repo root):**
+   ```bash
+   ./docs/ai-development/setup-ai-tools.sh
+   ./docs/ai-development/validate-ai-setup.sh
+   ```
+2. Open the Kibana repo in Cursor (or another tool that respects `.cursor/` and root `CLAUDE.md`).
+3. Use the skills (e.g. “create a new plugin”, “add an HTTP route”, “prepare my PR for CI”) and let the rules guide style and structure.
+
+`.cursor/` remains gitignored; only the **source** of the tools lives in `docs/ai-development/`.
+
+---
+
+## Impact
+
+- **Target:** Engineers using Cursor (or similar) on Kibana. No impact on those who don’t run the setup script.
+- **Runtime:** None. No new dependencies, no changes to Kibana’s bundle or server.
+- **CI:** None. No changes to Buildkite or test configs.
+- **Reusability:** This layout (rules + skills + CLAUDE.md + scripts) is intended as a template for other Elastic repos (Elasticsearch, Beats, Fleet, etc.) as part of the broader “AI adoption by Madrid” effort.
+- **Metrics (future):** A later phase may add opt-in telemetry and an adoption dashboard; this PR does not include that.
+
+---
+
+## Testing
+
+- Setup and validation scripts were run successfully against a Kibana worktree.
+- Rules and skills are written to match current Kibana patterns (plugin layout, FTR, Jest, CI) and can be refined in follow-up PRs based on feedback.
+
+---
+
+## Follow-ups (out of scope for this PR)
+
+- Phase 2: Domain-specific rules (Security, Observability, Search, Saved Objects) and additional skills (saved objects, FTR functional tests, debug-server, CI preflight, interpret-ci-failure, etc.).
+- Phase 3: MCP server for semantic code search over the Kibana codebase (Elasticsearch + embeddings).
+- Phase 4: Adoption metrics dashboard and repo template framework.
+- Phase 5: E2E validation, pilot with teams, Madrid presentation.
+
+---
+
+## Checklist
+
+- [x] No runtime or CI behavior changes
+- [x] Content is additive under `docs/ai-development/`
+- [x] `.cursor/` remains gitignored; setup script copies from `docs/ai-development/` into `.cursor/`
+- [x] README explains install, validate, and troubleshooting
+- [x] Scripts are executable and path-agnostic (run from repo root or with explicit Kibana root)

--- a/docs/ai-development/README.md
+++ b/docs/ai-development/README.md
@@ -1,0 +1,75 @@
+# Kibana AI tools (Cursor rules + skills)
+
+This directory contains Cursor rules, skills, and a root `CLAUDE.md` for the Kibana repo. Run the setup script to install them into your checkout so AI assistants follow Kibana conventions and can use the provided skills.
+
+## Quick install (recommended)
+
+From the **Kibana repo root**:
+
+```bash
+./docs/ai-development/setup-ai-tools.sh
+```
+
+This installs into the current repo. To install into a different Kibana root (e.g. another worktree):
+
+```bash
+./docs/ai-development/setup-ai-tools.sh /path/to/kibana
+```
+
+Then verify:
+
+```bash
+./docs/ai-development/validate-ai-setup.sh
+```
+
+Install completes in under a minute (copy only; no network).
+
+## Manual setup
+
+1. From the repo root, copy:
+   - `docs/ai-development/CLAUDE.md` → Kibana repo **root** (same level as `package.json`).
+   - `docs/ai-development/rules/` → `<kibana_root>/.cursor/rules/` (create `.cursor` if it doesn’t exist).
+   - `docs/ai-development/skills/` → `<kibana_root>/.cursor/skills/`.
+
+2. Verify with `./docs/ai-development/validate-ai-setup.sh` or open the repo in Cursor and confirm rules/skills are available.
+
+Note: Kibana gitignores `.cursor/`. The install copies from this tracked directory into `.cursor/` so your local AI setup stays out of version control.
+
+## What’s included
+
+- **CLAUDE.md** — Project overview, build/test commands, architecture summary, “where does this go?” guidance.
+- **Rules** (`rules/*.mdc`) — TypeScript, plugin architecture, testing, React/EUI, CI and draft PR workflow.
+- **Skills** (`skills/*/SKILL.md`) — Step-by-step guides with validation:
+  - create-kibana-plugin
+  - add-http-route
+  - write-jest-test
+  - write-ftr-api-test
+  - prepare-pr
+
+## Troubleshooting
+
+### Cursor doesn’t show the rules or skills
+
+- Ensure you ran the setup script (or manual copy) and opened the **Kibana repo root** as the workspace. Reload the window (Command Palette → “Developer: Reload Window”) after installing.
+
+### validate-ai-setup.sh reports MISSING
+
+- Run from repo root: `./docs/ai-development/validate-ai-setup.sh` or pass the Kibana root as the first argument.
+
+### Setup script fails with “does not look like a Kibana root”
+
+- The path must be the repo root that contains `package.json`. When run with no arguments from repo root, the script uses the repo root automatically.
+
+### After setup, CI still fails
+
+- Use the **prepare-pr** skill (or run manually): type check, eslint, i18n, and affected tests. On **draft** PRs, comment **`/ci`** on the PR to trigger the pipeline.
+
+## Updating
+
+Re-run the setup script after pulling changes to `docs/ai-development/`:
+
+```bash
+./docs/ai-development/setup-ai-tools.sh
+```
+
+Existing files in `.cursor/rules/` and `.cursor/skills/` are overwritten. Back up custom rules or skills first if needed.

--- a/docs/ai-development/README.md
+++ b/docs/ai-development/README.md
@@ -51,6 +51,10 @@ Note: Kibana gitignores `.cursor/`. The install copies from this tracked directo
   - interpret-ci-failure — parse CI logs and suggest fix
   - debug-server — debug server errors from stack trace
 
+## Optional: Semantic code search
+
+For semantic search over the Kibana codebase (e.g. “find where session tokens are validated”), use the official [elastic/semantic-code-search-mcp-server](https://github.com/elastic/semantic-code-search-mcp-server). Index this repo with the [semantic-code-search-indexer](https://github.com/elastic/semantic-code-search-indexer), then run the MCP server (stdio or Docker) and add it to your Cursor MCP config. Tools include `semantic_code_search`, `symbol_analysis`, `read_file_from_chunks`, and the StartInvestigation prompt.
+
 ## Troubleshooting
 
 ### Cursor doesn’t show the rules or skills

--- a/docs/ai-development/README.md
+++ b/docs/ai-development/README.md
@@ -38,13 +38,18 @@ Note: Kibana gitignores `.cursor/`. The install copies from this tracked directo
 ## What’s included
 
 - **CLAUDE.md** — Project overview, build/test commands, architecture summary, “where does this go?” guidance.
-- **Rules** (`rules/*.mdc`) — TypeScript, plugin architecture, testing, React/EUI, CI and draft PR workflow.
+- **Rules** (`rules/*.mdc`) — TypeScript, plugin architecture, testing, React/EUI, CI and draft PR workflow, saved objects.
 - **Skills** (`skills/*/SKILL.md`) — Step-by-step guides with validation:
-  - create-kibana-plugin
-  - add-http-route
-  - write-jest-test
-  - write-ftr-api-test
-  - prepare-pr
+  - create-kibana-plugin — scaffold new plugin
+  - add-http-route — HTTP route with validation and FTR API test
+  - create-saved-object — saved object type, modelVersions, CRUD
+  - write-jest-test — Jest unit test
+  - write-ftr-api-test — FTR API integration test
+  - write-ftr-functional-test — FTR functional (UI) test with page objects
+  - prepare-pr — type-check, lint, i18n, tests, commit message
+  - ci-preflight — run same checks CI runs locally
+  - interpret-ci-failure — parse CI logs and suggest fix
+  - debug-server — debug server errors from stack trace
 
 ## Troubleshooting
 

--- a/docs/ai-development/rules/kibana-ci.mdc
+++ b/docs/ai-development/rules/kibana-ci.mdc
@@ -1,0 +1,41 @@
+---
+description: Kibana CI checks, pre-push requirements, eslint auto-fix, draft PR /ci workflow
+globs: ["**/*.ts", "**/*.tsx", "**/*.json"]
+---
+
+# Kibana CI and PR workflow
+
+Apply when preparing changes for push or when interpreting CI results.
+
+## What CI runs
+
+- **Type check:** `node scripts/type_check`
+- **Lint:** `node scripts/eslint_all_files` (and related lint scripts)
+- **i18n:** i18n checks for missing or invalid translation keys
+- **Unit tests:** Jest for affected or configured packages
+- **FTR:** Selected API and functional test suites
+- **Bundle size:** Checks that bundle size stays within limits
+
+## Pre-push checklist (run locally first)
+
+1. **Type check:** `node scripts/type_check` — fix all type errors.
+2. **Lint:** `node scripts/eslint_all_files --no-cache` (add `--fix` to auto-fix where safe).
+3. **i18n:** Run the project’s i18n check (e.g. `node scripts/i18n_check` or as documented).
+4. **Unit tests:** Run Jest for the packages you changed (e.g. `yarn test:jest packages/kbn-...`).
+5. **Relevant FTR:** If you changed server or API behavior, run the related FTR API tests; if you changed UI, run the related functional tests as documented in the repo.
+
+Running these locally before pushing reduces CI failures and feedback time.
+
+## Draft PR and /ci
+
+- On **draft** pull requests, CI often does **not** run automatically. Trigger it by commenting **`/ci`** on the PR (see repo or team docs for the exact command).
+- After CI runs an **auto-fix** (e.g. eslint fix) and pushes a commit, the new commit usually does **not** re-trigger CI on draft PRs. Pull the latest branch and comment **`/ci`** again to re-run the pipeline.
+
+## After an eslint auto-fix commit
+
+- If the only new commit is from the CI bot (e.g. “Changes from node scripts/eslint_all_files --no-cache --fix”), pull that commit and then trigger CI again with `/ci` so the pipeline runs on the fixed code.
+
+## Commit and PR conventions
+
+- Follow the repo’s commit message format (e.g. conventional commits or Kibana’s format). PR title and description should clearly describe the change and any follow-ups.
+- Keep PRs scoped so that review and CI are manageable; split large features into multiple PRs where appropriate.

--- a/docs/ai-development/rules/kibana-core.mdc
+++ b/docs/ai-development/rules/kibana-core.mdc
@@ -1,0 +1,31 @@
+---
+description: Kibana TypeScript conventions, import patterns, and project structure
+globs: ["**/*.ts", "**/*.tsx"]
+---
+
+# Kibana core conventions
+
+Apply when generating or editing TypeScript/JavaScript in the Kibana repo.
+
+## TypeScript
+
+- Use **strict** TypeScript. Prefer explicit return types on exported and public API functions.
+- Use **type-only imports** when a symbol is only used in type position: `import type { Foo } from '...'`.
+- Prefer **interfaces** for object shapes; use **type** for unions, intersections, and mapped types.
+- Use Kibana utility types where they exist (e.g. from `@kbn/utility-types` or package-specific); avoid `any`; use `unknown` and narrow when needed.
+
+## Imports
+
+- **Plugin boundaries:** When importing from another plugin, use only its **public API**. Never import from another plugin’s internal paths (e.g. `plugin/server/lib/...` or `plugin/public/components/...`). Use the plugin’s contract: `import ... from 'plugin/public'` or `'plugin/server'`.
+- **Packages:** Prefer `@kbn/` package imports (e.g. `@kbn/core/public`, `@kbn/ui-actions`) over relative paths that cross package boundaries.
+- **Order:** Group imports: external (node_modules), then `@kbn/`, then relative. Sort within groups (e.g. alphabetically or by path length) if the project style does.
+
+## Error handling
+
+- Use Kibana’s error types and serialization where applicable (e.g. `Boom` or the repo’s standard error class) so errors are reported correctly in HTTP and logs.
+- In route handlers, catch errors, log appropriately, and return a proper HTTP status and body.
+
+## Project structure
+
+- New code belongs in **plugins** or **packages**. Do not add feature code under `src/` legacy roots unless the team explicitly follows that pattern.
+- Follow the existing package/plugin naming: kebab-case for directories and package names under `@kbn/`.

--- a/docs/ai-development/rules/kibana-plugin-architecture.mdc
+++ b/docs/ai-development/rules/kibana-plugin-architecture.mdc
@@ -1,0 +1,39 @@
+---
+description: Kibana plugin boundaries, lifecycle, dependency injection, cross-plugin communication
+globs: ["**/plugin.ts", "**/plugin.tsx", "**/server/**/*.ts", "**/public/**/*.ts", "**/common/**/*.ts"]
+---
+
+# Kibana plugin architecture
+
+Apply when creating or modifying plugins and their public/server/common boundaries.
+
+## Plugin layout
+
+- **`public/`** — Browser-only code (React components, client-side state, public plugin API). No Node-only APIs.
+- **`server/`** — Node.js code (HTTP routes, saved objects, server plugin API, Elasticsearch client usage). No browser globals or React.
+- **`common/`** — Types, constants, and utilities shared by both public and server. No imports from `public/` or `server/` that would create a circular dependency.
+
+## Lifecycle
+
+- **Constructor** — Lightweight; avoid heavy work.
+- **`setup(core, plugins)`** — Register routes, saved object types, and expose contracts that other plugins can depend on. Return the **setup contract**.
+- **`start(core, plugins)`** — Use other plugins’ start contracts, hold references to services, and return the **start contract**.
+- Do **not** rely on module-level side effects for initialization. All registration and startup must happen inside `setup()` and `start()`.
+
+## Dependency injection
+
+- Plugins declare **required** and **optional** dependencies in `kibana.jsonc`. Access them via the `plugins` argument in `setup()` and `start()`.
+- Depend only on **contracts** (the returned types from setup/start), not on internal modules of another plugin.
+- Cross-plugin communication is through these contracts (e.g. `plugins.data.search.search()`), not direct imports into the other plugin’s internals.
+
+## Cross-plugin communication
+
+- To use another plugin’s capability: add it as a required (or optional) dependency and use its **start** or **setup** contract in your `start()` or `setup()`.
+- Never import from another plugin’s `server/lib`, `public/lib`, or similar internal paths. If the capability is not exposed on the contract, the owning plugin should expose it via its public or server API.
+
+## New plugin checklist
+
+- Create `public/`, `server/`, `common/` and a root `plugin.ts` (or split public/server plugin files).
+- Add `kibana.jsonc` with id, version, and requiredPlugins/optionalPlugins.
+- Implement `setup()` and `start()` and return the appropriate contracts.
+- Register routes, saved object types, and other extensions inside `setup()` (or `start()` where the API requires it).

--- a/docs/ai-development/rules/kibana-react-eui.mdc
+++ b/docs/ai-development/rules/kibana-react-eui.mdc
@@ -1,0 +1,35 @@
+---
+description: React functional components, EUI usage, data-test-subj, accessibility in Kibana
+globs: ["**/public/**/*.tsx", "**/public/**/*.ts"]
+---
+
+# Kibana React and EUI patterns
+
+Apply when writing or editing UI code in plugin `public/` directories.
+
+## React style
+
+- Use **functional components** and **hooks**. No class components for new code.
+- Prefer **named exports** for components used elsewhere. Use default export only when the file is the single public component (e.g. a page).
+- Keep components focused: extract subcomponents and hooks when a file grows large or logic is reused.
+
+## EUI (Elastic UI)
+
+- Use **EUI components** from `@elastic/eui` instead of raw HTML for buttons, forms, layout, and feedback (e.g. `EuiButton`, `EuiForm`, `EuiFlexGroup`, `EuiPageTemplate`, `EuiCallOut`).
+- Follow EUI’s composition patterns (e.g. `EuiFormRow` + `EuiFieldText`) and use the recommended props for accessibility (e.g. `aria-label`, `aria-describedby` where EUI doesn’t provide them).
+- Theming: Use the Kibana theme (e.g. `useEuiTheme()` or the theme provider already in place). Do not hard-code colors that conflict with light/dark mode.
+
+## Testability
+
+- Add **`data-test-subj`** to interactive elements and key containers so tests can target them reliably. Use a consistent naming scheme (e.g. `pluginName-componentName-action`).
+- Avoid relying on CSS classes or DOM structure for test selectors; prefer `data-test-subj`.
+
+## Accessibility
+
+- Use semantic HTML and ARIA where needed (e.g. labels for form controls, `role` and `aria-*` for custom widgets). EUI components already handle many of these; ensure custom UI is also accessible.
+- Support **keyboard navigation** where the interaction is keyboard-appropriate (e.g. modals, menus, tabs).
+- Ensure **focus** is managed in modals and after dynamic content changes (e.g. focus trap in modal, focus moved to new content when appropriate).
+
+## i18n
+
+- All user-visible strings must be localized. Use `i18n.translate()` for JS and `<FormattedMessage>` (or the project’s standard) in JSX. Do not hard-code English (or any language) in the UI.

--- a/docs/ai-development/rules/kibana-saved-objects.mdc
+++ b/docs/ai-development/rules/kibana-saved-objects.mdc
@@ -1,0 +1,41 @@
+---
+description: Kibana saved object types — schema, modelVersions, migrations, registration, CRUD
+globs: ["**/server/**/*saved_object*.ts", "**/common/**/*saved_object*.ts"]
+---
+
+# Kibana saved objects
+
+Apply when creating or modifying saved object types, migrations, or code that uses the Saved Objects client.
+
+## Type definition
+
+- **SavedObjectsType** — Define in server code (e.g. `server/saved_objects/my_type.ts`). Include: `name`, `namespaceType` (`'single'`, `'multiple'`, or `'multiple-isolated'`), `mappings` (Elasticsearch field mapping for the type), and **modelVersions** (preferred) or **migrations** for schema evolution.
+- **modelVersions** — Preferred for new types. Each version has `changes` (array of change descriptions) and `schemas` with `create` and optionally `forwardCompatibility` (e.g. Zod or `@kbn/config-schema`). Use for additive or backward-compatible changes.
+- **migrations** — Legacy approach; use for existing types that already use migrations. Export a function `(doc) => doc` that transforms documents to the next version.
+- **mappings** — Must match the attributes you store. Use `dynamic: false` and explicit `properties` for known fields. Use `keyword` or `text` with `fields.keyword` as appropriate for search and aggregation.
+
+## Schema and validation
+
+- Define attribute validation with `@kbn/config-schema` (or Zod if the plugin already uses it). Export the schema and use it in `modelVersions.X.schemas.create` and optionally `forwardCompatibility`.
+- Keep the schema in a versioned folder (e.g. `schema/v1/v1.ts`) so future model versions can extend or change it.
+
+## Registration
+
+- Register the type in the plugin’s **setup** phase: `core.savedObjects.registerType(myType)`. Do not register in start.
+- Use the type name constant from `common/` so public and server stay in sync (e.g. `MY_PLUGIN_SAVED_OBJECT_TYPE`).
+
+## CRUD and access
+
+- Use **SavedObjectsClient** (or **SavedObjectsRepository** for internal code) from the request context or from `core.savedObjects.getScopedClient(request)`. Do not access the Elasticsearch index directly for saved object data.
+- For create/update, pass the attributes that match your schema; the client handles namespace and type. Use `overwrite: true` for upsert-style updates when appropriate.
+- Handle **conflict** errors (409) when creating or updating; advise the user to refresh or retry.
+
+## Index and namespace
+
+- Prefer using the standard Kibana saved object index (or solution index like `SEARCH_SOLUTION_SAVED_OBJECT_INDEX`) unless the type is solution-specific and the repo defines a custom index. Set `indexPattern` on the type if required.
+- **hidden** — Set `hidden: true` for types that are not user-facing (e.g. internal config); they are excluded from default listing and export.
+
+## Testing
+
+- Unit-test migrations or model version transforms with sample documents. Use the repo’s saved object test helpers (e.g. `createTypeRegistry`) where available.
+- For integration tests, use FTR and the savedObjects API or supertest to create/update/delete and assert; clean up in afterEach so tests are repeatable.

--- a/docs/ai-development/rules/kibana-testing.mdc
+++ b/docs/ai-development/rules/kibana-testing.mdc
@@ -9,7 +9,7 @@ Apply when writing or modifying unit and integration tests.
 
 ## FTR vs Scout
 
-Kibana uses **FTR** (Functional Test Runner, mocha) and **Scout** (Playwright-based API and UI tests). When the repo has **`.agent/skills/`** (e.g. `ftr-testing`, `scout-api-testing`, `scout-ui-testing`, `scout-migrate-from-ftr`, `scout-create-scaffold`), follow those skills for API and UI test structure, paths, auth, and run commands. Prefer **Scout** for new tests in modules that already use Scout (`test/scout*/api/`, `test/scout*/ui/`); otherwise use FTR. For migrating FTR to Scout, use the **scout-migrate-from-ftr** skill.
+Kibana uses **FTR** (Functional Test Runner, mocha) and **Scout** (Playwright-based API and UI tests). **Use FTR only for already existing tests** — when adding to or modifying tests under an existing FTR config/suite. **For new test configs** (new suite, new module, or new plugin), **default to Scout**: create Scout scaffold (`node scripts/scout.js generate --path <moduleRoot> --type api` or `ui`/`both`) and write Scout API/UI tests. When the repo has **`.agent/skills/`** (e.g. `ftr-testing`, `scout-api-testing`, `scout-ui-testing`, `scout-migrate-from-ftr`, `scout-create-scaffold`), follow those skills for structure, paths, auth, and run commands. For migrating existing FTR tests to Scout, use the **scout-migrate-from-ftr** skill.
 
 ## Jest (unit tests)
 

--- a/docs/ai-development/rules/kibana-testing.mdc
+++ b/docs/ai-development/rules/kibana-testing.mdc
@@ -1,0 +1,34 @@
+---
+description: Kibana testing patterns — Jest, FTR API tests, FTR functional tests, mocks
+globs: ["**/*.test.ts", "**/*.test.tsx", "**/test/**/*.ts", "**/__tests__/**/*.ts"]
+---
+
+# Kibana testing conventions
+
+Apply when writing or modifying unit and integration tests.
+
+## Jest (unit tests)
+
+- **Structure:** Use `describe('ModuleOrComponentName', () => { ... })` and `it('does something specific', () => { ... })`. Descriptions should be clear and start with a verb.
+- **Setup/teardown:** Use `beforeEach` for common setup; ensure mocks are cleared (e.g. `jest.clearAllMocks()`) to avoid leakage between tests.
+- **Mocks:** Use `jest.mock()` for modules; prefer `jest.spyOn()` when you need to restore. Follow existing patterns in the same package for mocking `@kbn/` and core services.
+- **File placement:** Co-locate with the module (e.g. `foo.test.ts` next to `foo.ts`) or in a `__tests__/` directory as the package already does.
+- **Assertions:** Use `expect()` with the matchers that match Kibana’s Jest setup (e.g. toEqual, toHaveBeenCalledWith). Avoid snapshot sprawl; prefer explicit assertions for behavior.
+
+## FTR — API integration tests
+
+- **Config:** Use the appropriate FTR config (e.g. `test/api_integration/config.js`). Start the test server and runner as documented in the repo.
+- **Services:** Use FTR’s service injection (e.g. `getService('supertest')`) rather than hard-coding URLs. Acquire clients and cleanup in `beforeEach`/`afterEach` as needed.
+- **Structure:** `describe` for the API surface or plugin; `it` for each request/response scenario. Clean up created data (e.g. saved objects, indices) so runs are repeatable.
+
+## FTR — Functional (UI) tests
+
+- **Page objects:** Prefer page objects or shared helpers for UI interaction so tests are stable and readable.
+- **Selectors:** Use `data-test-subj` attributes to target elements; avoid brittle CSS or XPath. Ensure the app under test adds `data-test-subj` where tests need to click or assert.
+- **Retries and waits:** Use the FTR retry/wait utilities for async UI; avoid raw `setTimeout`. Prefer waiting for specific conditions (e.g. element visible, request finished) over fixed delays.
+- **Flakiness:** If a test is flaky, add appropriate waits, narrow the scope, or isolate the cause (e.g. animation, timing) and fix the test or the app.
+
+## Test naming and scope
+
+- One logical behavior per `it`. Keep tests independent and order-agnostic.
+- Name files and describe blocks so that failures are easy to locate (e.g. by feature or API path).

--- a/docs/ai-development/rules/kibana-testing.mdc
+++ b/docs/ai-development/rules/kibana-testing.mdc
@@ -1,11 +1,15 @@
 ---
-description: Kibana testing patterns — Jest, FTR API tests, FTR functional tests, mocks
-globs: ["**/*.test.ts", "**/*.test.tsx", "**/test/**/*.ts", "**/__tests__/**/*.ts"]
+description: Kibana testing patterns — Jest, FTR API/UI tests, Scout (API/UI), mocks
+globs: ["**/*.test.ts", "**/*.test.tsx", "**/test/**/*.ts", "**/__tests__/**/*.ts", "**/test/scout*/**/*.spec.ts"]
 ---
 
 # Kibana testing conventions
 
 Apply when writing or modifying unit and integration tests.
+
+## FTR vs Scout
+
+Kibana uses **FTR** (Functional Test Runner, mocha) and **Scout** (Playwright-based API and UI tests). When the repo has **`.agent/skills/`** (e.g. `ftr-testing`, `scout-api-testing`, `scout-ui-testing`, `scout-migrate-from-ftr`, `scout-create-scaffold`), follow those skills for API and UI test structure, paths, auth, and run commands. Prefer **Scout** for new tests in modules that already use Scout (`test/scout*/api/`, `test/scout*/ui/`); otherwise use FTR. For migrating FTR to Scout, use the **scout-migrate-from-ftr** skill.
 
 ## Jest (unit tests)
 
@@ -13,20 +17,22 @@ Apply when writing or modifying unit and integration tests.
 - **Setup/teardown:** Use `beforeEach` for common setup; ensure mocks are cleared (e.g. `jest.clearAllMocks()`) to avoid leakage between tests.
 - **Mocks:** Use `jest.mock()` for modules; prefer `jest.spyOn()` when you need to restore. Follow existing patterns in the same package for mocking `@kbn/` and core services.
 - **File placement:** Co-locate with the module (e.g. `foo.test.ts` next to `foo.ts`) or in a `__tests__/` directory as the package already does.
-- **Assertions:** Use `expect()` with the matchers that match Kibana’s Jest setup (e.g. toEqual, toHaveBeenCalledWith). Avoid snapshot sprawl; prefer explicit assertions for behavior.
+- **Assertions:** Use `expect()` with the matchers that match Kibana's Jest setup (e.g. toEqual, toHaveBeenCalledWith). Avoid snapshot sprawl; prefer explicit assertions for behavior.
 
-## FTR — API integration tests
+## FTR — API integration tests (or Scout API)
 
-- **Config:** Use the appropriate FTR config (e.g. `test/api_integration/config.js`). Start the test server and runner as documented in the repo.
-- **Services:** Use FTR’s service injection (e.g. `getService('supertest')`) rather than hard-coding URLs. Acquire clients and cleanup in `beforeEach`/`afterEach` as needed.
+- **FTR:** Config: `test/api_integration/config.js`. Start the test server and runner as documented in the repo.
+- **Services:** Use FTR's service injection (e.g. `getService('supertest')`) rather than hard-coding URLs. Acquire clients and cleanup in `beforeEach`/`afterEach` as needed.
 - **Structure:** `describe` for the API surface or plugin; `it` for each request/response scenario. Clean up created data (e.g. saved objects, indices) so runs are repeatable.
+- **Scout API:** When the module uses Scout, put specs under `test/scout*/api/tests/**/*.spec.ts`; use `apiTest`, `apiClient`, `requestAuth`/`samlAuth`, `apiServices`; `expect` from `@kbn/scout/api` (or module Scout package). See `.agent/skills/scout-api-testing/SKILL.md` if present.
 
-## FTR — Functional (UI) tests
+## FTR — Functional (UI) tests (or Scout UI)
 
 - **Page objects:** Prefer page objects or shared helpers for UI interaction so tests are stable and readable.
 - **Selectors:** Use `data-test-subj` attributes to target elements; avoid brittle CSS or XPath. Ensure the app under test adds `data-test-subj` where tests need to click or assert.
 - **Retries and waits:** Use the FTR retry/wait utilities for async UI; avoid raw `setTimeout`. Prefer waiting for specific conditions (e.g. element visible, request finished) over fixed delays.
 - **Flakiness:** If a test is flaky, add appropriate waits, narrow the scope, or isolate the cause (e.g. animation, timing) and fix the test or the app.
+- **Scout UI:** When the module uses Scout, put specs under `test/scout*/ui/tests/` or `ui/parallel_tests/`; use `test`/`spaceTest` from local fixtures, **tags required**, `browserAuth`, page objects; `expect` from `@kbn/scout/ui`. See `.agent/skills/scout-ui-testing/SKILL.md` if present.
 
 ## Test naming and scope
 

--- a/docs/ai-development/setup-ai-tools.sh
+++ b/docs/ai-development/setup-ai-tools.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Install Kibana AI tools (Cursor rules, skills, CLAUDE.md) into this repo.
+# Usage: ./docs/ai-development/setup-ai-tools.sh [kibana_root]
+# Default kibana_root is the repo root (parent of docs/). Run from Kibana repo root.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DELIVERABLES_DIR="$SCRIPT_DIR"
+KIBANA_ROOT="${1:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+if [[ ! -f "$KIBANA_ROOT/package.json" ]]; then
+  echo "Usage: $0 [kibana_root]"
+  echo "Example: $0 ~/Projects/kibana"
+  echo "Error: $KIBANA_ROOT does not look like a Kibana root (no package.json)."
+  exit 1
+fi
+
+KIBANA_ROOT="$(cd "$KIBANA_ROOT" && pwd)"
+echo "Installing AI tools from $DELIVERABLES_DIR into $KIBANA_ROOT"
+
+# Create .cursor if missing
+mkdir -p "$KIBANA_ROOT/.cursor"
+
+# Copy rules (merge into existing .cursor/rules)
+mkdir -p "$KIBANA_ROOT/.cursor/rules"
+cp -R "$DELIVERABLES_DIR/rules/"* "$KIBANA_ROOT/.cursor/rules/"
+echo "  - Installed rules into .cursor/rules/"
+
+# Copy skills (merge into existing .cursor/skills)
+mkdir -p "$KIBANA_ROOT/.cursor/skills"
+cp -R "$DELIVERABLES_DIR/skills/"* "$KIBANA_ROOT/.cursor/skills/"
+echo "  - Installed skills into .cursor/skills/"
+
+# Copy CLAUDE.md to repo root
+cp "$DELIVERABLES_DIR/CLAUDE.md" "$KIBANA_ROOT/CLAUDE.md"
+echo "  - Installed CLAUDE.md at repo root"
+
+echo "Done. Validate with: $DELIVERABLES_DIR/validate-ai-setup.sh $KIBANA_ROOT"

--- a/docs/ai-development/skills/add-http-route/SKILL.md
+++ b/docs/ai-development/skills/add-http-route/SKILL.md
@@ -30,16 +30,15 @@ Use this skill when the user wants to add a new REST endpoint to an existing plu
 
 4. **Register the route** in the plugin’s `setup()` (or where other routes are registered). Use the same base path pattern as existing routes (e.g. `/api/my_plugin` or `/internal/my_plugin`).
 
-5. **Add an FTR API integration test:**
+5. **Add an API integration test:**
    - Use the repo’s FTR API test config and service injection (e.g. `getService('supertest')`)
-   - In a `describe` block for this endpoint, add `it` cases for: success (e.g. 200 and expected body), validation failure (e.g. 400), and if relevant auth or error cases
-   - Clean up any created data so the test is repeatable
+   Default to **Scout** for new configs (scout-api-testing, create Scout scaffold if needed); use **FTR** only when the plugin already has existing FTR API tests. Cover success (200), validation failure (400), auth/error cases; clean up created data. If FTR: use repo FTR API config and service injection (e.g. `getService('supertest')`).
 
 ## Validation (run these and fix any failures)
 
 1. **Type check:** Run `node scripts/type_check` from repo root. Fix any errors in the new or modified files.
 2. **Lint:** Run `node scripts/eslint_all_files` for the changed paths. Fix any violations.
-3. **FTR API test:** Run the FTR API test suite that includes the new test (e.g. the plugin’s API test group). Ensure the new test passes.
+3. **API test:** Run the API test suite (Scout or FTR) that includes the new test (e.g. the plugin’s API test group). Ensure the new test passes.
 4. **Manual (optional):** Start Kibana and call the endpoint (e.g. with curl or browser) to confirm the response.
 
-After validation, report: route method and path, file(s) changed, and that type-check, lint, and the FTR API test pass.
+After validation, report: route method and path, file(s) changed, and that type-check, lint, and the API test (Scout or FTR) pass.

--- a/docs/ai-development/skills/add-http-route/SKILL.md
+++ b/docs/ai-development/skills/add-http-route/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: add-http-route
+description: Add a new HTTP route to an existing Kibana plugin — handler, validation schemas, registration, and integration test
+---
+
+# Add HTTP route to a Kibana plugin
+
+Use this skill when the user wants to add a new REST endpoint to an existing plugin (e.g. "add a GET /api/my_plugin/foo" or "add a POST route that accepts a body and returns JSON").
+
+## Inputs
+
+- **Plugin path** — where the plugin lives (e.g. `src/plugins/my_plugin` or `x-pack/plugins/...`)
+- **Endpoint** — HTTP method and path (e.g. `GET /api/my_plugin/status`, `POST /internal/my_plugin/run`)
+- **Request/response** — short description of request (query, body) and response shape so validation and types can be defined
+
+## Steps
+
+1. **Locate the plugin’s server setup.** Find where routes are registered (usually in `server/plugin.ts` or `server/routes/index.ts`). Check how existing routes are defined (e.g. `core.http.createRouter()` or `core.http.route()`).
+
+2. **Define request validation.** Use Zod (or the repo’s standard, e.g. `@kbn/config-schema`) to define:
+   - Query parameters (if any)
+   - Body schema (for POST/PUT/PATCH)
+   - Derive TypeScript types from the schema for use in the handler
+
+3. **Implement the route handler:**
+   - Accept `context` (with core services), `request`, and `response`
+   - Parse and validate request (query/body) using the schema; return 400 with a clear message on validation failure
+   - Perform the operation; catch errors, log appropriately, and return the correct HTTP status (e.g. 500 for unexpected errors)
+   - Return the response body in the format the client expects (JSON)
+
+4. **Register the route** in the plugin’s `setup()` (or where other routes are registered). Use the same base path pattern as existing routes (e.g. `/api/my_plugin` or `/internal/my_plugin`).
+
+5. **Add an FTR API integration test:**
+   - Use the repo’s FTR API test config and service injection (e.g. `getService('supertest')`)
+   - In a `describe` block for this endpoint, add `it` cases for: success (e.g. 200 and expected body), validation failure (e.g. 400), and if relevant auth or error cases
+   - Clean up any created data so the test is repeatable
+
+## Validation (run these and fix any failures)
+
+1. **Type check:** Run `node scripts/type_check` from repo root. Fix any errors in the new or modified files.
+2. **Lint:** Run `node scripts/eslint_all_files` for the changed paths. Fix any violations.
+3. **FTR API test:** Run the FTR API test suite that includes the new test (e.g. the plugin’s API test group). Ensure the new test passes.
+4. **Manual (optional):** Start Kibana and call the endpoint (e.g. with curl or browser) to confirm the response.
+
+After validation, report: route method and path, file(s) changed, and that type-check, lint, and the FTR API test pass.

--- a/docs/ai-development/skills/ci-preflight/SKILL.md
+++ b/docs/ai-development/skills/ci-preflight/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ci-preflight
+description: Run the same checks CI will run locally — type-check, eslint, i18n, and relevant test suites
+---
+
+# Run CI preflight checks locally
+
+Use this skill when the user wants to run the **same** checks that Kibana CI runs, locally, before pushing (e.g. "run what CI runs", "preflight check", "validate like CI").
+
+## Inputs
+
+- **Scope (optional)** — specific packages or paths; if omitted, run the full set of checks that CI runs (or the subset documented in the repo for "full CI locally").
+
+## Steps
+
+1. **Type check.** Run the repo’s type-check command (e.g. `node scripts/type_check` from root). Do not push if it fails. Fix type errors and re-run until it passes.
+
+2. **Lint.** Run the repo’s ESLint (e.g. `node scripts/eslint_all_files --no-cache`). If the repo supports `--fix`, run it and then re-run without fix to confirm no remaining violations. Fix any remaining issues.
+
+3. **i18n.** Run the repo’s i18n check (e.g. `node scripts/i18n_check` or as in the repo docs). Fix any reported problems (missing keys, invalid default messages).
+
+4. **Unit tests.** Run Jest for the scope the user cares about. For "full CI" locally, run the same Jest scope CI runs (e.g. all packages or affected packages). Use the repo’s script (e.g. `yarn test:jest` or `node scripts/jest`) and any `--filter`/`--select` options documented for CI. Fix failing tests.
+
+5. **FTR API tests (if in scope).** If the change touches server or API code, run the FTR API test suite (or the subset that covers the changed area). Use the repo’s commands (e.g. start FTR server, then run functional_test_runner with the API config). Fix failures.
+
+6. **FTR functional tests (if in scope).** If the change touches UI or user flows, run the relevant FTR functional suite. Same as above: use the repo’s config and grep/filter for the affected app. Fix failures.
+
+7. **Bundle size (if applicable).** If the repo’s CI runs bundle size checks, run the same script locally and fix any over-limit bundles.
+
+Document the commands used (or point to the repo’s "run CI locally" doc) so the user can re-run the same set.
+
+## Validation
+
+- All commands from steps 1–7 that were run must complete successfully. Re-run any step that failed after applying fixes until it passes.
+
+After validation, report: list of checks run and their status (all passed), and the exact commands so the user can repeat the preflight.

--- a/docs/ai-development/skills/create-kibana-plugin/SKILL.md
+++ b/docs/ai-development/skills/create-kibana-plugin/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: create-kibana-plugin
+description: Create a new Kibana plugin from scratch — directory structure, plugin definition, lifecycle methods, registration, and basic tests
+---
+
+# Create new Kibana plugin
+
+Use this skill when the user wants to create a new Kibana plugin (e.g. "create a plugin named X" or "scaffold a plugin for solution Y").
+
+## Inputs
+
+- **Plugin name** (e.g. `my_feature`) — kebab-case, used for directory and plugin id
+- **Solution area** (optional) — e.g. `security`, `observability`, `search` — determines parent path under `x-pack/plugins/` or `src/plugins/`
+
+## Steps
+
+1. **Determine location.** If solution area is given, place the plugin under the solution’s plugins dir (e.g. `x-pack/plugins/security_solution/plugins/my_feature` or the repo’s equivalent). Otherwise use `src/plugins/my_feature` (or `x-pack/plugins/my_feature` if the repo uses x-pack for new plugins).
+
+2. **Create directory structure:**
+   - `public/` — for browser code
+   - `server/` — for Node code
+   - `common/` — for shared types/constants
+   - Root: `plugin.ts` (or split into `public/plugin.ts` and `server/plugin.ts` if the repo uses that pattern)
+
+3. **Create `kibana.jsonc`** in the plugin root with:
+   - `id`: plugin id (e.g. `myFeature`)
+   - `version`: `kibana.version` or the repo standard
+   - `requiredPlugins`: list of core and optional plugin dependencies (e.g. `['core']` or `['core', 'data']`)
+   - `optionalPlugins`: if any
+   - `server`: true
+   - `ui`: true
+
+4. **Implement the plugin class** (in `plugin.ts` or separate public/server files):
+   - Constructor: no heavy work
+   - `setup(core, plugins)`: register routes, saved object types, return setup contract
+   - `start(core, plugins)`: return start contract (and optionally hold service refs)
+   - Use proper TypeScript types for `CoreSetup`/`CoreStart` and plugin dependencies
+
+5. **Add minimal public and server entry** so the plugin loads:
+   - Public: export the plugin instance and any public contract
+   - Server: export the plugin instance and any server contract
+   - Follow existing plugins in the repo for the exact export pattern (e.g. `plugin.ts` that imports and re-exports)
+
+6. **Register the plugin** in the parent build/preset if required (e.g. add to `plugins` list in the solution’s or root config). Check the repo’s docs or existing plugins for how new plugins are discovered.
+
+7. **Add a basic Jest test** (e.g. `plugin.test.ts`) that:
+   - Mocks core and plugins
+   - Instantiates the plugin, calls `setup()` and `start()`, and asserts the returned contract is defined
+
+## Validation (run these and fix any failures)
+
+1. **Type check:** From repo root run `node scripts/type_check` (or the project’s type-check command). Fix any errors in the new plugin files.
+2. **Lint:** Run `node scripts/eslint_all_files` (or equivalent) for the new plugin path. Fix any violations.
+3. **Unit test:** Run Jest for the new plugin (e.g. `yarn test:jest src/plugins/my_feature` or the repo’s test command). Ensure the new test passes.
+4. **Smoke:** If the repo has a "list plugins" or dev server, start it and confirm the new plugin is loaded and does not crash.
+
+After validation, report to the user: plugin path, main files created, and that type-check, lint, and the basic test pass.

--- a/docs/ai-development/skills/create-saved-object/SKILL.md
+++ b/docs/ai-development/skills/create-saved-object/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: create-saved-object
+description: Create a new saved object type — schema, modelVersions, registration, and CRUD usage
+---
+
+# Create saved object type in a Kibana plugin
+
+Use this skill when the user wants to add a new saved object type to a plugin (e.g. "add a saved object for X" or "create a type that stores Y with fields Z").
+
+## Inputs
+
+- **Plugin path** — where the plugin lives
+- **Type name** — kebab-case constant (e.g. `my_plugin_workspace`) used as the saved object type
+- **Attributes** — field names and types (e.g. title: string, count: number, config: object). Decide namespace: single (one per space), multiple, or multiple-isolated
+
+## Steps
+
+1. **Define the type constant** in `common/` (e.g. `common/constants.ts`) so public and server can share it: `export const MY_TYPE_SAVED_OBJECT_TYPE = 'my_plugin_workspace';`.
+
+2. **Create attribute schema** (e.g. `server/saved_objects/my_type/schema/v1/v1.ts`) using `@kbn/config-schema`: define an object schema for all attributes. Export it (e.g. `myTypeAttributesSchema`).
+
+3. **Create the SavedObjectsType** (e.g. `server/saved_objects/my_type/my_type.ts`):
+   - `name`: the type constant
+   - `namespaceType`: `'single'`, `'multiple'`, or `'multiple-isolated'` per product requirements
+   - `hidden`: `true` only if the type is internal and should not appear in default listings
+   - `indexPattern`: use default Kibana index or the solution’s index (e.g. `SEARCH_SOLUTION_SAVED_OBJECT_INDEX`) if the plugin is in a solution
+   - `mappings`: Elasticsearch mapping — `dynamic: false`, `properties` for each attribute (use `keyword`, `text`, `integer`, etc. as appropriate)
+   - `modelVersions`: start with `1` — `changes: []`, `schemas.create`: your config-schema (or Zod). Optionally `schemas.forwardCompatibility` for lenient reads
+
+4. **Register the type** in the plugin’s `setup()`: `core.savedObjects.registerType(createMyTypeSavedObjectType())`. Call this in the same file where you set up routes (e.g. server plugin class).
+
+5. **Use the type in CRUD** — In route handlers or services, use `core.savedObjects.getScopedClient(request)` (or the client from start contract). Create with `client.create(type, attributes, { references })`, get with `client.get(type, id)`, update with `client.update(type, id, attributes)`, delete with `client.delete(type, id)`. Handle 409 conflicts and return appropriate HTTP status and body.
+
+6. **Optional: export CRUD helpers** — If the plugin will do a lot of saved object work, add small functions (e.g. `getWorkspace(client, id)`, `saveWorkspace(client, attributes)`) that wrap the client calls and keep route handlers thin.
+
+## Validation (run these and fix any failures)
+
+1. **Type check:** Run `node scripts/type_check` from repo root. Fix any errors in the new or modified files.
+2. **Lint:** Run `node scripts/eslint_all_files` for the changed paths. Fix any violations.
+3. **Unit test:** If you added migrations or model version logic, add a Jest test that applies the schema/transform to sample documents and assert the result.
+4. **Integration (optional):** Add an FTR API test that creates, reads, updates, and deletes the saved object (via supertest or the savedObjects service) and clean up in afterEach.
+
+After validation, report: type name, file(s) created, and that type-check and lint pass (and tests if added).

--- a/docs/ai-development/skills/debug-server/SKILL.md
+++ b/docs/ai-development/skills/debug-server/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: debug-server
+description: Systematically debug Kibana server-side issues — stack trace, locate code, analyze cause, suggest fix
+---
+
+# Debug server-side Kibana issue
+
+Use this skill when the user reports a server error, failed request, or stack trace from Kibana (e.g. "this route returns 500", "error when starting plugin", "stack trace from logs").
+
+## Inputs
+
+- **Error message or stack trace** — from logs, browser dev tools, or CI
+- **Context (optional)** — what action triggered it (e.g. "calling POST /api/foo", "loading Security app")
+
+## Steps
+
+1. **Identify plugin and module from the stack trace.** Look for paths like `x-pack/plugins/...`, `src/plugins/...`, or `packages/...`. The top frames usually point to the throwing code; frames below show the call chain. Note the **file path** and **line number** of the throw and the first few callers.
+
+2. **Locate the source code.** In the repo, open the file and line from the stack trace. Read the surrounding function and the call sites (call stack) to understand control flow. Check for: missing null/undefined checks, wrong argument types, async/await misuse, or missing error handling (e.g. unhandled rejection).
+
+3. **Classify the cause.** Common categories:
+   - **Contract/schema** — Request body or response doesn’t match the expected shape; fix validation or types.
+   - **Missing dependency** — A required plugin or service isn’t available in the context; fix plugin dependencies or optional handling.
+   - **Resource** — Missing or invalid saved object, index, or config; fix the data or add a guard.
+   - **Async/order** — Operation used before it’s ready or race condition; fix lifecycle or await.
+   - **Permission/auth** — Insufficient privileges or unauthenticated request; fix auth check or return 401/403 with a clear message.
+   - **Configuration** — Wrong env, missing config, or feature flag; document or fix config.
+
+4. **Suggest a concrete fix.** Propose a code change: add a null check, fix the type, add try/catch and return a proper HTTP status, fix the async flow, or return a clear error message. Prefer fixing the root cause over masking the error. If the error message is unclear, suggest improving it so future failures are easier to debug.
+
+5. **Optionally suggest a test.** If the failure is reproducible, suggest a unit test or FTR API test that would have caught it (e.g. invalid input, missing dependency).
+
+## Validation (run these after applying the fix)
+
+1. **Type check:** Run `node scripts/type_check`. Fix any new type errors.
+2. **Lint:** Run `node scripts/eslint_all_files` for the changed file(s).
+3. **Re-run the scenario** — Reproduce the original action (e.g. call the endpoint, load the app) and confirm the error is resolved or replaced by a correct response or a clearer error.
+
+After validation, report: cause category, file and change made, and that the scenario now passes or fails with an expected error.

--- a/docs/ai-development/skills/interpret-ci-failure/SKILL.md
+++ b/docs/ai-development/skills/interpret-ci-failure/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: interpret-ci-failure
+description: Parse CI failure output, identify root cause (type, lint, test, bundle), and suggest a fix
+---
+
+# Interpret Kibana CI failure and suggest fix
+
+Use this skill when the user shares a **CI failure** (Buildkite, GitHub Actions, or local run of CI scripts) and wants to understand the cause and how to fix it.
+
+## Inputs
+
+- **Failure output** — log snippet, error message, or stack trace from the failing job (type check, lint, Jest, FTR, bundle, i18n, etc.)
+- **Branch/PR context (optional)** — what changed recently so fixes can target the right area
+
+## Steps
+
+1. **Classify the failure.** From the log, determine which check failed:
+   - **Type check** — Look for "Type error", "TS2xxx", or `node scripts/type_check` in the log. The message usually includes file path and line.
+   - **Lint (ESLint)** — Look for "error" or "warning" with a rule name and file:line. Note the rule id (e.g. `@typescript-eslint/...`) and the message.
+   - **Jest** — Look for "FAIL" and the test file, describe/it title, and assertion message (e.g. "Expected X to equal Y").
+   - **FTR (API or functional)** — Look for failing test name, "AssertionError", or timeout. Note the config and test file.
+   - **i18n** — Look for missing translation key or invalid default message and the referenced file.
+   - **Bundle size** — Look for "bundle size" or "limit exceeded" and the package or chunk name.
+
+2. **Extract location.** From the failure message, get the **file path** (relative to repo root) and **line number** (and column if present). For tests, also note the test name and the assertion that failed.
+
+3. **Infer root cause.**
+   - **Type error:** Missing or wrong type (e.g. property doesn’t exist, wrong argument type). Suggest adding/correcting the type or fixing the value.
+   - **Lint:** Rule violation (e.g. unused var, missing return type, import order). Suggest the code change that satisfies the rule (or a targeted disable with a comment if justified).
+   - **Jest:** Assertion or setup wrong (e.g. expected value, mock not applied). Suggest correcting the test or the implementation so behavior and test align.
+   - **FTR:** Flakiness (timeout, element not found), wrong assertion, or missing fixture. Suggest adding a wait, fixing the selector (e.g. data-test-subj), or correcting the assertion/fixture.
+   - **i18n:** Missing key or invalid default. Suggest adding the key to the JSON or fixing the default message.
+   - **Bundle size:** New or growing dependency or chunk. Suggest code-splitting, lazy load, or removing unused code to get under the limit.
+
+4. **Suggest a concrete fix.** Provide a short, actionable change: "In file X at line Y, do Z." Include a code snippet or diff when helpful. Prefer fixing the root cause over disabling the check.
+
+5. **Remind about re-triggering CI.** If the fix is pushed to a draft PR, remind the user that they may need to comment `/ci` to re-run the pipeline.
+
+## Validation (after the user applies the fix)
+
+- The same CI check that failed should be run again (locally or via CI). It should pass. If a different error appears, repeat the steps for the new failure.
+
+After interpretation, report: (1) failure type and location, (2) root cause in one sentence, (3) suggested fix with file/line and code, (4) reminder to re-run the check or re-trigger CI.

--- a/docs/ai-development/skills/prepare-pr/SKILL.md
+++ b/docs/ai-development/skills/prepare-pr/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: prepare-pr
+description: Prepare code changes for Kibana CI — run type-check, eslint, i18n, affected tests, and format commit message
+---
+
+# Prepare PR for Kibana CI
+
+Use this skill when the user wants to get their changes ready for push or PR (e.g. "prepare for CI", "run pre-push checks", "get this ready for review").
+
+## Inputs
+
+- **Scope (optional)** — specific packages or paths to check; if omitted, run repo-wide checks (or the subset the repo recommends before a full CI run)
+
+## Steps
+
+1. **Type check.** Run the repo’s type-check command (e.g. `node scripts/type_check` from root). If it fails:
+   - List the errors and the files/lines
+   - Propose or apply fixes (e.g. add missing types, fix imports). Re-run until it passes.
+
+2. **Lint.** Run the repo’s ESLint (e.g. `node scripts/eslint_all_files --no-cache`). If there are fixable issues, run with `--fix` and then re-run to confirm no remaining violations. Fix any unfixable violations manually.
+
+3. **i18n.** Run the repo’s i18n check (e.g. `node scripts/i18n_check` or as documented). Fix any reported issues (e.g. missing translation keys, invalid default messages).
+
+4. **Unit tests.** Run Jest for the affected packages or the paths the user changed (e.g. `yarn test:jest packages/kbn-my-package` or the repo’s affected-test command). Fix any failing tests or code.
+
+5. **FTR (if relevant).** If the user changed server or API code, run the related FTR API tests; if they changed UI, run the related functional tests. Use the repo’s docs for the exact commands and configs. Fix any failures.
+
+6. **Commit message.** Suggest or format a commit message that follows the repo’s conventions (e.g. conventional commits or Kibana format). Include a short subject line and, if needed, a body explaining the change and any follow-ups.
+
+## Validation (run these and fix any failures)
+
+1. **Re-run type check** after any fixes. It must pass.
+2. **Re-run lint** after any fixes. It must pass with no violations.
+3. **Re-run i18n** after any fixes. It must pass.
+4. **Re-run the unit (and if applicable FTR) tests** that were executed in the steps. They must pass.
+
+After validation, report to the user: (1) all checks that were run and their status (passed), (2) any fixes that were applied, (3) suggested commit message, and (4) reminder that on draft PRs they may need to comment `/ci` to trigger CI.

--- a/docs/ai-development/skills/write-ftr-api-test/SKILL.md
+++ b/docs/ai-development/skills/write-ftr-api-test/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: write-ftr-api-test
-description: Generate an FTR API integration test for a Kibana API endpoint with service injection, describe/it structure, supertest assertions, and cleanup
+description: Generate an FTR or Scout API test for a Kibana API endpoint; aligns with existing .agent/skills (ftr-testing, scout-api-testing)
 ---
 
-# Write FTR API test for a Kibana endpoint
+# Write FTR or Scout API test for a Kibana endpoint
 
 Use this skill when the user wants an API integration test for a specific HTTP endpoint (e.g. "add an FTR test for GET /api/my_plugin/status" or "write API test for the new export route").
+
+## Coordination with existing Kibana skills
+
+If the Kibana repo (or worktree) has **`.agent/skills/`** (e.g. under `agent-builder-planning-mode` or a branch that ships them), **prefer those skills** for full conventions:
+
+- **ftr-testing** — FTR structure, loadTestFile, configs, services, `.buildkite/ftr_*_configs.yml`.
+- **scout-api-testing** — Scout API tests: `apiTest`, `apiClient`, `requestAuth`/`samlAuth`, `apiServices`; paths `test/scout*/api/{tests,parallel_tests}/**/*.spec.ts`; package by module (`@kbn/scout`, `@kbn/scout-oblt`, etc.); assertions from `@kbn/scout/api`; tags required for CI.
+
+**When to use which:** For **new** API tests, if the module already has Scout API tests (`<module-root>/test/scout*/api/`), use **Scout** and follow the **scout-api-testing** skill (run scaffold with `node scripts/scout.js generate --path <moduleRoot> --type api` if needed). Otherwise use **FTR** API (steps below). When in doubt, check for existing `test/scout*/api/` in the plugin; if present, use Scout.
 
 ## Inputs
 
@@ -13,7 +22,7 @@ Use this skill when the user wants an API integration test for a specific HTTP e
 - **Plugin or test suite** — which FTR config/suite this test belongs to (e.g. `test/api_integration/apis/my_plugin`)
 - **Scenarios to cover** — e.g. 200 success, 400 validation, 404, auth required; and any setup/teardown (e.g. create a saved object then delete it)
 
-## Steps
+## Steps (FTR API — use when module does not use Scout API)
 
 1. **Locate the right FTR config and test layout.** Find the API integration tests for this plugin or area (e.g. under `test/api_integration/` or `x-pack/test/api_integration`). Note the config file (e.g. `config.js`) and how services are loaded.
 
@@ -42,3 +51,7 @@ Use this skill when the user wants an API integration test for a specific HTTP e
 4. **Stability:** Run the new test twice (or in a small batch) to reduce the chance of flakiness; fix any intermittent failures.
 
 After validation, report: test file path, scenarios covered, and that type-check, lint, and FTR API run pass.
+
+## If using Scout API instead
+
+- Follow the **scout-api-testing** skill in `.agent/skills/scout-api-testing/SKILL.md`: paths under `test/scout*/api/tests/`, `apiTest.describe`, `requestAuth`/`samlAuth` for auth, `apiClient` for requests, `expect` from `@kbn/scout/api` (or module Scout package), `apiServices` for setup/teardown. Run with `node scripts/scout.js run-tests --stateful --testFiles <path>`.

--- a/docs/ai-development/skills/write-ftr-api-test/SKILL.md
+++ b/docs/ai-development/skills/write-ftr-api-test/SKILL.md
@@ -14,7 +14,7 @@ If the Kibana repo (or worktree) has **`.agent/skills/`** (e.g. under `agent-bui
 - **ftr-testing** — FTR structure, loadTestFile, configs, services, `.buildkite/ftr_*_configs.yml`.
 - **scout-api-testing** — Scout API tests: `apiTest`, `apiClient`, `requestAuth`/`samlAuth`, `apiServices`; paths `test/scout*/api/{tests,parallel_tests}/**/*.spec.ts`; package by module (`@kbn/scout`, `@kbn/scout-oblt`, etc.); assertions from `@kbn/scout/api`; tags required for CI.
 
-**When to use which:** For **new** API tests, if the module already has Scout API tests (`<module-root>/test/scout*/api/`), use **Scout** and follow the **scout-api-testing** skill (run scaffold with `node scripts/scout.js generate --path <moduleRoot> --type api` if needed). Otherwise use **FTR** API (steps below). When in doubt, check for existing `test/scout*/api/` in the plugin; if present, use Scout.
+**When to use which:** For **new** API test configs (new suite or new module), **default to Scout**: use the **scout-api-testing** skill and run **scout-create-scaffold** if needed (`node scripts/scout.js generate --path <moduleRoot> --type api`). Use **FTR** only when adding to or modifying **existing** FTR API tests (plugin already has tests under `test/api_integration/` or `x-pack/.../test/api_integration/` and no `test/scout*/api/`). When in doubt, prefer Scout for new configs.
 
 ## Inputs
 
@@ -22,7 +22,7 @@ If the Kibana repo (or worktree) has **`.agent/skills/`** (e.g. under `agent-bui
 - **Plugin or test suite** — which FTR config/suite this test belongs to (e.g. `test/api_integration/apis/my_plugin`)
 - **Scenarios to cover** — e.g. 200 success, 400 validation, 404, auth required; and any setup/teardown (e.g. create a saved object then delete it)
 
-## Steps (FTR API — use when module does not use Scout API)
+## Steps (FTR API — use only when extending existing FTR API tests)
 
 1. **Locate the right FTR config and test layout.** Find the API integration tests for this plugin or area (e.g. under `test/api_integration/` or `x-pack/test/api_integration`). Note the config file (e.g. `config.js`) and how services are loaded.
 

--- a/docs/ai-development/skills/write-ftr-api-test/SKILL.md
+++ b/docs/ai-development/skills/write-ftr-api-test/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: write-ftr-api-test
+description: Generate an FTR API integration test for a Kibana API endpoint with service injection, describe/it structure, supertest assertions, and cleanup
+---
+
+# Write FTR API test for a Kibana endpoint
+
+Use this skill when the user wants an API integration test for a specific HTTP endpoint (e.g. "add an FTR test for GET /api/my_plugin/status" or "write API test for the new export route").
+
+## Inputs
+
+- **Endpoint** — method and path (e.g. `GET /api/my_plugin/status`, `POST /internal/my_plugin/jobs`)
+- **Plugin or test suite** — which FTR config/suite this test belongs to (e.g. `test/api_integration/apis/my_plugin`)
+- **Scenarios to cover** — e.g. 200 success, 400 validation, 404, auth required; and any setup/teardown (e.g. create a saved object then delete it)
+
+## Steps
+
+1. **Locate the right FTR config and test layout.** Find the API integration tests for this plugin or area (e.g. under `test/api_integration/` or `x-pack/test/api_integration`). Note the config file (e.g. `config.js`) and how services are loaded.
+
+2. **Create or open the test file** for this endpoint (e.g. `status.ts` or `my_plugin/status.js`). Use the same extension (ts/js) as the surrounding tests.
+
+3. **Use FTR services:** In the test file, get services via the test runner’s API (e.g. `getService('supertest')`, `getService('es')`). Do not hard-code base URLs or ports.
+
+4. **Structure the test:**
+   - Top-level `describe('Plugin name or API group', () => { ... })`
+   - Nested `describe('Endpoint path or method', () => { ... })`
+   - Use `it('returns 200 when ...', async () => { ... })` for each scenario. Use async/await for HTTP calls.
+
+5. **Implement each scenario:**
+   - **Success:** Send the request with valid params/body; assert status (e.g. 200) and relevant body fields
+   - **Validation/error:** Send invalid input; assert status (e.g. 400) and optionally error message shape
+   - **Auth/forbidden:** If the endpoint requires auth, test unauthenticated request and assert 401/403 if that’s the contract
+   - Use supertest’s API (e.g. `.get(...).expect(200)`, `.post(...).send(...).expect(400)`)
+
+6. **Setup and cleanup:** If the test creates data (e.g. saved objects, indices), create them in `beforeEach` or at the start of the relevant `it`, and delete or reset in `afterEach` or at the end so runs are repeatable.
+
+## Validation (run these and fix any failures)
+
+1. **Type check:** Run `node scripts/type_check` from repo root. Fix any errors in the new test file.
+2. **Lint:** Run `node scripts/eslint_all_files` for the test file. Fix any violations.
+3. **Run the FTR API suite:** Execute the API integration suite that includes this test (e.g. `node scripts/functional_tests_server.js` and `node scripts/functional_test_runner.js --config test/api_integration/config.js --grep '...'` or the repo’s documented command). Ensure the new test passes.
+4. **Stability:** Run the new test twice (or in a small batch) to reduce the chance of flakiness; fix any intermittent failures.
+
+After validation, report: test file path, scenarios covered, and that type-check, lint, and FTR API run pass.

--- a/docs/ai-development/skills/write-ftr-functional-test/SKILL.md
+++ b/docs/ai-development/skills/write-ftr-functional-test/SKILL.md
@@ -1,19 +1,30 @@
 ---
 name: write-ftr-functional-test
-description: Generate an FTR functional (UI) test with page objects, testSubjects, retry-aware assertions
+description: Generate an FTR or Scout UI test for a Kibana UI workflow; aligns with existing .agent/skills (ftr-testing, scout-ui-testing, scout-migrate-from-ftr)
 ---
 
-# Write FTR functional test for a Kibana UI workflow
+# Write FTR or Scout UI test for a Kibana UI workflow
 
 Use this skill when the user wants a functional (UI) test for a Kibana app or workflow (e.g. "add a functional test for the X page" or "test that clicking Y does Z").
+
+## Coordination with existing Kibana skills
+
+If the Kibana repo (or worktree) has **`.agent/skills/`** (e.g. under `agent-builder-planning-mode` or a branch that ships them), **prefer those skills** for full conventions:
+
+- **ftr-testing** — FTR structure, loadTestFile, getService/getPageObjects, configs, services (testSubjects, retry, esArchiver, browser).
+- **scout-ui-testing** — Scout UI (Playwright): `test`/`spaceTest`, page objects, `browserAuth`, **tags required**; paths `test/scout*/ui/{tests,parallel_tests}/**/*.spec.ts`; package by module (`@kbn/scout`, `@kbn/scout-oblt`, etc.); assertions from `@kbn/scout/ui`; EUI wrappers, a11y checks.
+- **scout-migrate-from-ftr** — When migrating existing FTR UI tests to Scout (decide UI vs API, map services to fixtures, split loadTestFile).
+- **scout-create-scaffold** — Generate Scout scaffold: `node scripts/scout.js generate --path <moduleRoot> --type ui` (or `both`).
+
+**When to use which:** For **new** UI tests, if the module already has Scout UI tests (`<module-root>/test/scout*/ui/`), use **Scout** and follow the **scout-ui-testing** skill (and **scout-create-scaffold** if the scaffold is missing). Otherwise use **FTR** (steps below). For **migrating** an existing FTR test to Scout, use **scout-migrate-from-ftr** and its required sub-skills. When in doubt, check for existing `test/scout*/ui/` in the plugin; if present, use Scout.
 
 ## Inputs
 
 - **App or workflow** — e.g. "Dashboard save flow", "Uptime overview filters"
-- **Test location** — which FTR config and folder (e.g. `test/functional/apps/dashboard`, or `x-pack/solutions/observability/test/functional/apps/uptime`)
+- **Test location** — which FTR config and folder (e.g. `test/functional/apps/dashboard`, or `x-pack/solutions/observability/test/functional/apps/uptime`), or Scout path `test/scout*/ui/tests/` / `parallel_tests/`
 - **Scenarios** — what to assert (e.g. "page loads", "filter applies", "save button creates saved object")
 
-## Steps
+## Steps (FTR UI — use when module does not use Scout UI)
 
 1. **Locate the right FTR config and test layout.** Find the functional test suite for this app (e.g. under `test/functional/` or `x-pack/.../test/functional/`). Note the config file (e.g. `config.base.ts`) and how tests receive `FtrProviderContext` (e.g. `export default ({ getPageObjects, getService }: FtrProviderContext) => { ... }`).
 
@@ -41,3 +52,7 @@ Use this skill when the user wants a functional (UI) test for a Kibana app or wo
 3. **Run the FTR functional suite** that includes this test (e.g. the app’s functional config). Ensure the new test passes. Re-run once more to reduce flakiness; fix any intermittent failures (e.g. add waits or narrow scope).
 
 After validation, report: test file path, scenarios covered, and that type-check, lint, and the functional test run pass.
+
+## If using Scout UI instead
+
+- Follow the **scout-ui-testing** skill in `.agent/skills/scout-ui-testing/SKILL.md`: paths under `test/scout*/ui/tests/` (sequential) or `ui/parallel_tests/` (parallel with `spaceTest`); import `test` or `spaceTest` from local fixtures; **tags are required** (e.g. `tags.deploymentAgnostic`, `tags.stateful.classic`); use `browserAuth` for auth; put UI actions in page objects; use `page.testSubj.locator(...)`; optional `page.checkA11y()`. Run with `node scripts/scout.js run-tests --stateful --testFiles <path>`. For new modules, run **scout-create-scaffold** first: `node scripts/scout.js generate --path <moduleRoot> --type ui`.

--- a/docs/ai-development/skills/write-ftr-functional-test/SKILL.md
+++ b/docs/ai-development/skills/write-ftr-functional-test/SKILL.md
@@ -16,7 +16,7 @@ If the Kibana repo (or worktree) has **`.agent/skills/`** (e.g. under `agent-bui
 - **scout-migrate-from-ftr** — When migrating existing FTR UI tests to Scout (decide UI vs API, map services to fixtures, split loadTestFile).
 - **scout-create-scaffold** — Generate Scout scaffold: `node scripts/scout.js generate --path <moduleRoot> --type ui` (or `both`).
 
-**When to use which:** For **new** UI tests, if the module already has Scout UI tests (`<module-root>/test/scout*/ui/`), use **Scout** and follow the **scout-ui-testing** skill (and **scout-create-scaffold** if the scaffold is missing). Otherwise use **FTR** (steps below). For **migrating** an existing FTR test to Scout, use **scout-migrate-from-ftr** and its required sub-skills. When in doubt, check for existing `test/scout*/ui/` in the plugin; if present, use Scout.
+**When to use which:** For **new** UI test configs (new suite or new module), **default to Scout**: use the **scout-ui-testing** skill and **scout-create-scaffold** if needed (`node scripts/scout.js generate --path <moduleRoot> --type ui`). Use **FTR** only when adding to or modifying **existing** FTR functional tests (plugin already has tests under `test/functional/` or `x-pack/.../test/functional/` and no `test/scout*/ui/`). For **migrating** existing FTR to Scout, use **scout-migrate-from-ftr**. When in doubt, prefer Scout for new configs.
 
 ## Inputs
 
@@ -24,7 +24,7 @@ If the Kibana repo (or worktree) has **`.agent/skills/`** (e.g. under `agent-bui
 - **Test location** — which FTR config and folder (e.g. `test/functional/apps/dashboard`, or `x-pack/solutions/observability/test/functional/apps/uptime`), or Scout path `test/scout*/ui/tests/` / `parallel_tests/`
 - **Scenarios** — what to assert (e.g. "page loads", "filter applies", "save button creates saved object")
 
-## Steps (FTR UI — use when module does not use Scout UI)
+## Steps (FTR UI — use only when extending existing FTR functional tests)
 
 1. **Locate the right FTR config and test layout.** Find the functional test suite for this app (e.g. under `test/functional/` or `x-pack/.../test/functional/`). Note the config file (e.g. `config.base.ts`) and how tests receive `FtrProviderContext` (e.g. `export default ({ getPageObjects, getService }: FtrProviderContext) => { ... }`).
 

--- a/docs/ai-development/skills/write-ftr-functional-test/SKILL.md
+++ b/docs/ai-development/skills/write-ftr-functional-test/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: write-ftr-functional-test
+description: Generate an FTR functional (UI) test with page objects, testSubjects, retry-aware assertions
+---
+
+# Write FTR functional test for a Kibana UI workflow
+
+Use this skill when the user wants a functional (UI) test for a Kibana app or workflow (e.g. "add a functional test for the X page" or "test that clicking Y does Z").
+
+## Inputs
+
+- **App or workflow** — e.g. "Dashboard save flow", "Uptime overview filters"
+- **Test location** — which FTR config and folder (e.g. `test/functional/apps/dashboard`, or `x-pack/solutions/observability/test/functional/apps/uptime`)
+- **Scenarios** — what to assert (e.g. "page loads", "filter applies", "save button creates saved object")
+
+## Steps
+
+1. **Locate the right FTR config and test layout.** Find the functional test suite for this app (e.g. under `test/functional/` or `x-pack/.../test/functional/`). Note the config file (e.g. `config.base.ts`) and how tests receive `FtrProviderContext` (e.g. `export default ({ getPageObjects, getService }: FtrProviderContext) => { ... }`).
+
+2. **Create or open the test file** (e.g. `overview.ts` or `save_flow.ts`). Use the same extension (ts) and export pattern as neighboring tests: `export default (context: FtrProviderContext) => { ... }`.
+
+3. **Use FTR services and page objects:**
+   - **getPageObjects(names)** — Returns page objects (e.g. `common`, `dashboard`, `uptime`). Use for navigation (`navigateToApp`, `navigateToUrl`) and high-level actions.
+   - **getService(name)** — Use `retry` for retry-aware waits, `testSubjects` for `data-test-subj` selectors, `esArchiver` for loading fixtures, `browser` for URL/cookies if needed. Prefer `testSubjects` over CSS or XPath.
+
+4. **Structure the test:**
+   - Top-level `describe('feature or page name', function () { ... })`.
+   - Use `before`/`beforeEach` for fixtures (e.g. `esArchiver.load(...)`) and navigation to the app. Use `after`/`afterEach` for cleanup if needed.
+   - Use `it('does something specific', async () => { ... })` for each scenario. Use async/await for all FTR calls.
+
+5. **Interact via data-test-subj:** Use `testSubjects.find('myButton')`, `testSubjects.click('myButton')`, `testSubjects.exists('myPanel')`, `testSubjects.getVisibleText('title')`. Ensure the app under test adds the corresponding `data-test-subj` attributes so tests are stable. If they are missing, add them to the UI and then reference them in the test.
+
+6. **Use retry for flakiness:** Wrap assertions or actions that depend on async UI in `retry.try(async () => { ... })` or use the page object’s retry-aware helpers (e.g. wait for an element then click). Avoid raw `setTimeout`; prefer waiting for a specific condition.
+
+7. **Assert:** Use `@kbn/expect` (e.g. `expect(await testSubjects.getVisibleText('heading')).to.equal('Expected')`). Keep assertions focused on visible behavior and URL/state where relevant.
+
+## Validation (run these and fix any failures)
+
+1. **Type check:** Run `node scripts/type_check` from repo root. Fix any errors in the new test file.
+2. **Lint:** Run `node scripts/eslint_all_files` for the test file. Fix any violations.
+3. **Run the FTR functional suite** that includes this test (e.g. the app’s functional config). Ensure the new test passes. Re-run once more to reduce flakiness; fix any intermittent failures (e.g. add waits or narrow scope).
+
+After validation, report: test file path, scenarios covered, and that type-check, lint, and the functional test run pass.

--- a/docs/ai-development/skills/write-jest-test/SKILL.md
+++ b/docs/ai-development/skills/write-jest-test/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: write-jest-test
+description: Generate a Jest unit test for a Kibana module with proper imports, mocks, describe/it structure, and assertions
+---
+
+# Write Jest test for a Kibana module
+
+Use this skill when the user wants a unit test for a specific module, class, or function (e.g. "write a jest test for X" or "add tests for the Y module").
+
+## Inputs
+
+- **Target module** — file path or module name (e.g. `src/plugins/my_plugin/server/lib/calculator.ts` or "the route handler for /status")
+- **Scope (optional)** — specific functions or behaviors to cover; if omitted, cover the main exported behavior and important edge cases
+
+## Steps
+
+1. **Read the target module.** Identify exported functions, classes, or hooks and their inputs/outputs. Note any dependencies (other modules, core services) that should be mocked.
+
+2. **Choose test file location.** Place the test next to the module (e.g. `calculator.test.ts` beside `calculator.ts`) or in a `__tests__` directory, matching the package’s existing convention.
+
+3. **Set up the test file:**
+   - Use `describe('ModuleOrFileName', () => { ... })` for the top-level block
+   - Use `describe('functionOrBehavior', () => { ... })` for logical groups
+   - Use `it('does something specific', () => { ... })` for each case; descriptions should be clear and start with a verb
+
+4. **Mock dependencies:**
+   - Use `jest.mock('...')` for modules the target imports
+   - Use `jest.spyOn()` when you need to restore or assert on calls
+   - Follow existing patterns in the same package for mocking `@kbn/` and core (e.g. `core.savedObjects.getScopedClient`)
+
+5. **Write tests:**
+   - Happy path: typical inputs, assert expected return value or side effects
+   - Edge cases: empty input, invalid input, error paths
+   - Use `beforeEach` for common setup and clear mocks to avoid leakage between tests
+
+6. **Assert:** Use `expect(...).toEqual(...)`, `expect(...).toHaveBeenCalledWith(...)`, etc. Prefer explicit assertions over large snapshots unless the repo relies on snapshots for this code.
+
+## Validation (run these and fix any failures)
+
+1. **Type check:** Run `node scripts/type_check` from repo root. Fix any type errors in the new test file.
+2. **Lint:** Run `node scripts/eslint_all_files` for the test file. Fix any violations.
+3. **Run the test:** Execute Jest for this test file (e.g. `yarn test:jest path/to/module.test.ts`). Ensure all tests pass.
+4. **Coverage (if required):** If the repo enforces coverage, run coverage for the package and confirm the new test does not lower coverage for the target module.
+
+After validation, report: test file path, number of test cases, and that type-check, lint, and Jest all pass.

--- a/docs/ai-development/validate-ai-setup.sh
+++ b/docs/ai-development/validate-ai-setup.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Verify that Kibana AI tools (rules, skills, CLAUDE.md) are present and readable.
+# Usage: ./docs/ai-development/validate-ai-setup.sh [kibana_root]
+# Default kibana_root is current directory.
+
+set -e
+
+KIBANA_ROOT="$(cd "${1:-.}" && pwd)"
+FAIL=0
+
+check_file() {
+  if [[ -f "$1" ]]; then
+    if [[ -r "$1" ]]; then
+      echo "  OK $1"
+    else
+      echo "  FAIL (not readable) $1"
+      FAIL=1
+    fi
+  else
+    echo "  MISSING $1"
+    FAIL=1
+  fi
+}
+
+check_dir() {
+  if [[ -d "$1" ]]; then
+    if [[ -r "$1" ]]; then
+      echo "  OK $1"
+    else
+      echo "  FAIL (not readable) $1"
+      FAIL=1
+    fi
+  else
+    echo "  MISSING $1"
+    FAIL=1
+  fi
+}
+
+echo "Validating AI setup in $KIBANA_ROOT"
+echo ""
+
+echo "Root context:"
+check_file "$KIBANA_ROOT/CLAUDE.md"
+echo ""
+
+echo "Cursor rules:"
+check_dir "$KIBANA_ROOT/.cursor/rules"
+for f in "$KIBANA_ROOT/.cursor/rules"/*.mdc; do
+  [[ -e "$f" ]] && check_file "$f"
+done
+echo ""
+
+echo "Cursor skills:"
+check_dir "$KIBANA_ROOT/.cursor/skills"
+for d in "$KIBANA_ROOT/.cursor/skills"/*/; do
+  [[ -d "$d" ]] && check_file "${d}SKILL.md"
+done
+echo ""
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "Validation passed."
+  exit 0
+else
+  echo "Validation failed (missing or unreadable files)."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This PR adds **AI development tools** to the Kibana repo so that Cursor (and other AI coding assistants) can follow Kibana conventions and use guided workflows.

**No runtime or CI behavior changes.** All content lives under `docs/ai-development/` and is installed into `.cursor/` (gitignored) by an optional setup script. Engineers opt in by running the script.

---

## Why

- **Low adoption:** A key blocker to AI tool adoption is that assistants generate code that doesn’t match Kibana’s style, fails CI, or breaks architectural boundaries. This leads engineers to conclude that “AI isn’t ready for complex codebases.”
- **Root cause:** Large repos need **rules**, **skills**, and **context** that teach LLMs the codebase’s conventions, plugin system, testing patterns, and CI workflow. Without that, outputs are inconsistent and hard to review.
- **Goal:** Make Kibana **LLM-friendly** so that the engineers not yet using AI tools can get to productive, CI-passing contributions quickly (target: same-day setup).

---

## What this PR adds

### 1. **Cursor rules** (`docs/ai-development/rules/`)

Five rule files that Cursor (and similar tools) can load to enforce Kibana conventions:

| Rule | Covers |
|------|--------|
| `kibana-core.mdc` | TypeScript (strict, type-only imports, interfaces), import boundaries, error handling, project structure |
| `kibana-plugin-architecture.mdc` | public/server/common layout, plugin lifecycle (setup/start), dependency injection, cross-plugin contracts |
| `kibana-testing.mdc` | Jest (describe/it, mocks, placement), FTR API tests, FTR functional tests, flakiness and retries |
| `kibana-react-eui.mdc` | Functional components, EUI usage, `data-test-subj`, accessibility, i18n |
| `kibana-ci.mdc` | Type check, eslint, i18n, pre-push checklist, draft PR `/ci` workflow, eslint auto-fix handling |

### 2. **Cursor skills** (`docs/ai-development/skills/`)

Five step-by-step skills with validation so the LLM can verify its own output:

| Skill | Purpose |
|-------|---------|
| **create-kibana-plugin** | Create a new plugin: directory structure, `kibana.jsonc`, lifecycle, basic Jest test |
| **add-http-route** | Add an HTTP route: handler, request/response validation (Zod or config-schema), registration, FTR API test |
| **write-jest-test** | Write a Jest unit test for a module with proper mocks and structure |
| **write-ftr-api-test** | Write an FTR API integration test with service injection and cleanup |
| **prepare-pr** | Run type-check, eslint, i18n, affected tests; suggest commit message; remind about `/ci` on draft PRs |

Each skill includes **validation steps** (e.g. run `node scripts/type_check`, run Jest) so the model checks its work before handing off.

### 3. **Architecture context** (`docs/ai-development/CLAUDE.md`)

A single **CLAUDE.md** that gives LLMs:

- Project overview and common build/test commands
- Plugin system and package boundaries
- “Where does this go?” decision guidance
- Pointers to Cursor setup in the README

It is intended to be copied to the repo root by the setup script so that AI tools see it when the workspace is the Kibana root.

### 4. **Setup and validation** (`docs/ai-development/`)

- **`setup-ai-tools.sh`** — Copies `CLAUDE.md` to the repo root and `rules/` and `skills/` into `.cursor/rules/` and `.cursor/skills/`. Run from repo root: `./docs/ai-development/setup-ai-tools.sh` (or pass another Kibana root). Completes in under a minute.
- **`validate-ai-setup.sh`** — Checks that CLAUDE.md and `.cursor/rules/` and `.cursor/skills/` exist and are readable after setup.
- **`README.md`** — Quick install, manual copy instructions, what’s included, troubleshooting, and how to re-run after updates.

---

## How engineers use it

1. **One-time setup (from repo root):**
   ```bash
   ./docs/ai-development/setup-ai-tools.sh
   ./docs/ai-development/validate-ai-setup.sh
   ```
2. Open the Kibana repo in Cursor (or another tool that respects `.cursor/` and root `CLAUDE.md`).
3. Use the skills (e.g. “create a new plugin”, “add an HTTP route”, “prepare my PR for CI”) and let the rules guide style and structure.

`.cursor/` remains gitignored; only the **source** of the tools lives in `docs/ai-development/`.

---

## Impact

- **Target:** Engineers using Cursor (or similar) on Kibana. No impact on those who don’t run the setup script.
- **Runtime:** None. No new dependencies, no changes to Kibana’s bundle or server.
- **CI:** None. No changes to Buildkite or test configs.
- **Reusability:** This layout (rules + skills + CLAUDE.md + scripts) is intended as a template for other Elastic repos (Elasticsearch, Beats, Fleet, etc.) as part of the broader effort.
- **Metrics (future):** A later phase may add opt-in telemetry and an adoption dashboard; this PR does not include that.

---

## Testing

- Setup and validation scripts were run successfully against a Kibana worktree.
- Rules and skills are written to match current Kibana patterns (plugin layout, FTR, Jest, CI) and can be refined in follow-up PRs based on feedback.

---

## Follow-ups (out of scope for this PR)

- Phase 2: Domain-specific rules (Security, Observability, Search, Saved Objects) and additional skills (saved objects, FTR functional tests, debug-server, CI preflight, interpret-ci-failure, etc.).
- Phase 3: MCP server for semantic code search over the Kibana codebase (Elasticsearch + embeddings).
- Phase 4: Adoption metrics dashboard and repo template framework.
- Phase 5: E2E validation, pilot with teams

---

## Checklist

- [x] No runtime or CI behavior changes
- [x] Content is additive under `docs/ai-development/`
- [x] `.cursor/` remains gitignored; setup script copies from `docs/ai-development/` into `.cursor/`
- [x] README explains install, validate, and troubleshooting
- [x] Scripts are executable and path-agnostic (run from repo root or with explicit Kibana root)
