### PR TITLE
scout: fix NO_COLOR startup error in Kibana test runners

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/run_kibana_server.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/run_kibana_server.ts
@@ -28,6 +28,15 @@ export async function runKibanaServer(options: {
   const installDir = runOptions.alwaysUseSource ? undefined : options.installDir;
   const devMode = !installDir;
   const useTaskRunner = options.config.get('kbnTestServer.useDedicatedTaskRunner');
+  const env = {
+    ...process.env,
+    ...options.config.get('kbnTestServer.env'),
+  };
+  if (env.NO_COLOR !== undefined) {
+    delete env.FORCE_COLOR;
+  } else if (env.FORCE_COLOR === undefined) {
+    env.FORCE_COLOR = '1';
+  }
 
   const procRunnerOpts = {
     cwd: installDir || REPO_ROOT,
@@ -36,11 +45,7 @@ export async function runKibanaServer(options: {
         ? Path.resolve(installDir, 'bin/kibana.bat')
         : Path.resolve(installDir, 'bin/kibana')
       : process.execPath,
-    env: {
-      FORCE_COLOR: 1,
-      ...process.env,
-      ...options.config.get('kbnTestServer.env'),
-    },
+    env,
     wait: runOptions.wait,
     onEarlyExit: options.onEarlyExit,
   };

--- a/src/platform/packages/shared/kbn-test/src/functional_tests/lib/run_kibana_server.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_tests/lib/run_kibana_server.ts
@@ -33,6 +33,15 @@ export async function runKibanaServer(options: {
   const installDir = runOptions.alwaysUseSource ? undefined : options.installDir;
   const devMode = !installDir;
   const useTaskRunner = options.config.get('kbnTestServer.useDedicatedTaskRunner');
+  const env = {
+    ...process.env,
+    ...options.config.get('kbnTestServer.env'),
+  };
+  if (env.NO_COLOR !== undefined) {
+    delete env.FORCE_COLOR;
+  } else if (env.FORCE_COLOR === undefined) {
+    env.FORCE_COLOR = '1';
+  }
 
   const procRunnerOpts = {
     cwd: installDir || REPO_ROOT,
@@ -41,11 +50,7 @@ export async function runKibanaServer(options: {
         ? Path.resolve(installDir, 'bin/kibana.bat')
         : Path.resolve(installDir, 'bin/kibana')
       : process.execPath,
-    env: {
-      FORCE_COLOR: 1,
-      ...process.env,
-      ...options.config.get('kbnTestServer.env'),
-    },
+    env,
     wait: runOptions.wait,
     onEarlyExit: options.onEarlyExit,
   };


### PR DESCRIPTION
Unset FORCE_COLOR when NO_COLOR is set to avoid warning-triggered early exit.

Seen when running in Codex sandbox.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->