### PR TITLE
[9.3] [Discover] Unskip search source alerts tests (#253943)

### DIFF
--- a/x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/discover/search_source_alert.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/discover/search_source_alert.ts
@@ -647,8 +647,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should check that there are no errors detected after an alert is created', async () => {
+      try {
+        await deleteDataView(SOURCE_DATA_VIEW);
+      } catch {
+        // continue
+      }
+
       const newAlert = 'New Alert for checking its status';
-      await createDataView('search-source*');
+      await createDataView(SOURCE_DATA_VIEW);
 
       await PageObjects.common.navigateToApp('management');
       await PageObjects.header.waitUntilLoadingHasFinished();
@@ -678,7 +684,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       }
       const dataViewsElem = await testSubjects.find('euiSelectableList');
       const sourceDataViewOption = await dataViewsElem.findByCssSelector(
-        `[title="search-source*"]`
+        `[title="${SOURCE_DATA_VIEW}"]`
       );
       await sourceDataViewOption.click();
 

--- a/x-pack/platform/test/serverless/functional/test_suites/discover_ml_uptime/discover/search_source_alert.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover_ml_uptime/discover/search_source_alert.ts
@@ -668,8 +668,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should check that there are no errors detected after an alert is created', async () => {
+      try {
+        await deleteDataView(SOURCE_DATA_VIEW);
+      } catch {
+        // continue
+      }
+
       const newAlert = 'New Alert for checking its status';
-      await createDataView('search-source*');
+      await createDataView(SOURCE_DATA_VIEW);
 
       // Navigation to Rule Management is different in Serverless
       await PageObjects.common.navigateToApp('triggersActions');
@@ -698,7 +704,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       }
       const dataViewsElem = await testSubjects.find('euiSelectableList');
       const sourceDataViewOption = await dataViewsElem.findByCssSelector(
-        `[title="search-source*"]`
+        `[title="${SOURCE_DATA_VIEW}"]`
       );
       await sourceDataViewOption.click();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover] Unskip search source alerts tests (#253943)](https://github.com/elastic/kibana/pull/253943)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2026-02-19T19:34:54Z","message":"[Discover] Unskip search source alerts tests (#253943)\n\n- Closes https://github.com/elastic/kibana/issues/252152\n- Closes https://github.com/elastic/kibana/issues/252007\n- Closes https://github.com/elastic/kibana/issues/252146\n- Closes https://github.com/elastic/kibana/issues/252112\n- Closes https://github.com/elastic/kibana/issues/252028\n\n## Summary\n\nThe index pattern `search-source*` was matching the original user index\n`search-source-alert` and also the alerts system index\n`search-source-alert-output` resulting in the flakiness. Made the index\npattern target only the user index.\n\n<img width=\"736\" height=\"441\" alt=\"Screenshot 2026-02-19 at 14 34 41\"\nsrc=\"https://github.com/user-attachments/assets/f0595ea9-ee93-4996-ad27-97df465952e3\"\n/>\n\nThe long list of data view fields because `search-source*` targeted both\nindices:\n<img width=\"976\" height=\"726\" alt=\"Screenshot 2026-02-19 at 14 32 25\"\nsrc=\"https://github.com/user-attachments/assets/7c83b274-bc43-4189-bd58-66d7f35e826c\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a30be89e457dd1e38e78d4356bff83d84352753d","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.4.0","v9.3.1"],"title":"[Discover] Unskip search source alerts tests","number":253943,"url":"https://github.com/elastic/kibana/pull/253943","mergeCommit":{"message":"[Discover] Unskip search source alerts tests (#253943)\n\n- Closes https://github.com/elastic/kibana/issues/252152\n- Closes https://github.com/elastic/kibana/issues/252007\n- Closes https://github.com/elastic/kibana/issues/252146\n- Closes https://github.com/elastic/kibana/issues/252112\n- Closes https://github.com/elastic/kibana/issues/252028\n\n## Summary\n\nThe index pattern `search-source*` was matching the original user index\n`search-source-alert` and also the alerts system index\n`search-source-alert-output` resulting in the flakiness. Made the index\npattern target only the user index.\n\n<img width=\"736\" height=\"441\" alt=\"Screenshot 2026-02-19 at 14 34 41\"\nsrc=\"https://github.com/user-attachments/assets/f0595ea9-ee93-4996-ad27-97df465952e3\"\n/>\n\nThe long list of data view fields because `search-source*` targeted both\nindices:\n<img width=\"976\" height=\"726\" alt=\"Screenshot 2026-02-19 at 14 32 25\"\nsrc=\"https://github.com/user-attachments/assets/7c83b274-bc43-4189-bd58-66d7f35e826c\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a30be89e457dd1e38e78d4356bff83d84352753d"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253943","number":253943,"mergeCommit":{"message":"[Discover] Unskip search source alerts tests (#253943)\n\n- Closes https://github.com/elastic/kibana/issues/252152\n- Closes https://github.com/elastic/kibana/issues/252007\n- Closes https://github.com/elastic/kibana/issues/252146\n- Closes https://github.com/elastic/kibana/issues/252112\n- Closes https://github.com/elastic/kibana/issues/252028\n\n## Summary\n\nThe index pattern `search-source*` was matching the original user index\n`search-source-alert` and also the alerts system index\n`search-source-alert-output` resulting in the flakiness. Made the index\npattern target only the user index.\n\n<img width=\"736\" height=\"441\" alt=\"Screenshot 2026-02-19 at 14 34 41\"\nsrc=\"https://github.com/user-attachments/assets/f0595ea9-ee93-4996-ad27-97df465952e3\"\n/>\n\nThe long list of data view fields because `search-source*` targeted both\nindices:\n<img width=\"976\" height=\"726\" alt=\"Screenshot 2026-02-19 at 14 32 25\"\nsrc=\"https://github.com/user-attachments/assets/7c83b274-bc43-4189-bd58-66d7f35e826c\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a30be89e457dd1e38e78d4356bff83d84352753d"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->