### PR TITLE
[9.3] [OneWorkflow] Reduce foreach footprint in index on execution (#252845)

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/enter_foreach_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/enter_foreach_node_impl.ts
@@ -8,6 +8,7 @@
  */
 
 import type { EnterForeachNode } from '@kbn/workflows/graph';
+import { isTemplateExpression } from '../../utils';
 import type { StepExecutionRuntime } from '../../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionRuntimeManager } from '../../workflow_context_manager/workflow_execution_runtime_manager';
 import type { IWorkflowEventLogger } from '../../workflow_event_logger';
@@ -31,7 +32,6 @@ export class EnterForeachNodeImpl implements NodeImplementation {
 
   private async enterForeach(): Promise<void> {
     this.stepExecutionRuntime.startStep();
-    let foreachState = this.stepExecutionRuntime.getCurrentStepState();
     this.stepExecutionRuntime.setInput({
       foreach: this.node.configuration.foreach,
     });
@@ -45,7 +45,6 @@ export class EnterForeachNodeImpl implements NodeImplementation {
         }
       );
       this.stepExecutionRuntime.setCurrentStepState({
-        items: [],
         total: 0,
       });
       this.stepExecutionRuntime.finishStep();
@@ -60,39 +59,28 @@ export class EnterForeachNodeImpl implements NodeImplementation {
       }
     );
 
-    // Initialize foreach state
-    foreachState = {
-      items: evaluatedItems,
-      item: evaluatedItems[0],
+    // Initialize foreach state — only store index and total to avoid
+    // persisting the entire items array on every iteration.
+    const foreachState = {
       index: 0,
       total: evaluatedItems.length,
     };
 
     this.stepExecutionRuntime.setCurrentStepState(foreachState);
     // Enter a new scope for the first iteration
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.wfExecutionRuntimeManager.enterScope(foreachState.index!.toString());
+    this.wfExecutionRuntimeManager.enterScope(foreachState.index.toString());
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 
   private advanceIteration(): void {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    let foreachState = this.stepExecutionRuntime.getCurrentStepState()!;
-    // Update items and index if they have changed
-    const items = foreachState.items;
+    const foreachState = this.stepExecutionRuntime.getCurrentStepState()!;
     const index = foreachState.index + 1;
-    const item = items[index];
-    const total = foreachState.total;
-    foreachState = {
-      items,
-      index,
-      item,
-      total,
-    };
+
+    // Only persist index and total — no need to store the full items array.
+    this.stepExecutionRuntime.setCurrentStepState({ index, total: foreachState.total });
     // Enter a new scope for the new iteration
-    this.stepExecutionRuntime.setCurrentStepState(foreachState);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.wfExecutionRuntimeManager.enterScope(foreachState.index!.toString());
+    this.wfExecutionRuntimeManager.enterScope(index.toString());
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 
@@ -135,7 +123,7 @@ export class EnterForeachNodeImpl implements NodeImplementation {
       );
     }
 
-    if (expression.startsWith('{{') && expression.endsWith('}}')) {
+    if (isTemplateExpression(expression)) {
       return this.stepExecutionRuntime.contextManager.evaluateExpressionInContext(expression);
     }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/exit_foreach_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/exit_foreach_node_impl.ts
@@ -28,7 +28,7 @@ export class ExitForeachNodeImpl implements NodeImplementation {
       throw new Error(`Foreach state for step ${this.node.stepId} not found`);
     }
 
-    if (foreachState.items[foreachState.index + 1]) {
+    if (foreachState.index + 1 < foreachState.total) {
       this.wfExecutionRuntimeManager.navigateToNode(this.node.startNodeId);
       return;
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/tests/enter_foreach_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/tests/enter_foreach_node_impl.test.ts
@@ -94,8 +94,6 @@ describe('EnterForeachNodeImpl', () => {
 
         expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledTimes(1);
         expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
-          items: ['item1', 'item2', 'item3'],
-          item: 'item1',
           index: 0,
           total: 3,
         });
@@ -140,8 +138,6 @@ describe('EnterForeachNodeImpl', () => {
 
         expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledTimes(1);
         expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
-          items: ['item1', 'item2', 'item3'],
-          item: 'item1',
           index: 0,
           total: 3,
         });
@@ -198,8 +194,6 @@ describe('EnterForeachNodeImpl', () => {
 
         expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledTimes(1);
         expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
-          items: ['item1', 'item2', 'item3'],
-          item: 'item1',
           index: 0,
           total: 3,
         });
@@ -229,10 +223,9 @@ describe('EnterForeachNodeImpl', () => {
         node.configuration.foreach = JSON.stringify([]);
       });
 
-      it('should set empty items and total to 0', async () => {
+      it('should set total to 0', async () => {
         await underTest.run();
         expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
-          items: [],
           total: 0,
         });
       });
@@ -286,8 +279,6 @@ describe('EnterForeachNodeImpl', () => {
   describe('on next iterations', () => {
     beforeEach(() => {
       (stepExecutionRuntime.getCurrentStepState as jest.Mock).mockReturnValue({
-        items: ['item1', 'item2', 'item3'],
-        item: 'item1',
         index: 0,
         total: 3,
       });
@@ -311,13 +302,11 @@ describe('EnterForeachNodeImpl', () => {
       expect(stepExecutionRuntime.startStep).not.toHaveBeenCalledWith();
     });
 
-    it('should initialize foreach state', async () => {
+    it('should update foreach state with incremented index', async () => {
       await underTest.run();
 
       expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledTimes(1);
       expect(stepExecutionRuntime.setCurrentStepState).toHaveBeenCalledWith({
-        items: ['item1', 'item2', 'item3'],
-        item: 'item2',
         index: 1,
         total: 3,
       });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/tests/exit_foreach_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/tests/exit_foreach_node_impl.test.ts
@@ -62,9 +62,7 @@ describe('ExitForeachNodeImpl', () => {
   describe('when there are more items to process', () => {
     beforeEach(() => {
       (stepExecutionRuntime.getCurrentStepState as jest.Mock).mockReturnValue({
-        items: ['item1', 'item2', 'item3'],
         index: 1,
-        item: 'item2',
         total: 3,
       });
     });
@@ -86,9 +84,7 @@ describe('ExitForeachNodeImpl', () => {
   describe('when no more items to process', () => {
     beforeEach(() => {
       (stepExecutionRuntime.getCurrentStepState as jest.Mock).mockReturnValue({
-        items: ['item1', 'item2', 'item3'],
         index: 2,
-        item: 'item3',
         total: 3,
       });
     });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/utils/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/utils/index.ts
@@ -15,3 +15,4 @@ export { generateExecutionTaskScope } from './generate_execution_task_scope';
 export { TimeoutAbortedError, abortableTimeout } from './abortable_timeout/abortable_timeout';
 export { ExecutionError } from './execution_error/execution_error';
 export { evaluateKql } from './eval_kql/eval_kql';
+export { isTemplateExpression } from './templates';

--- a/src/platform/plugins/shared/workflows_execution_engine/server/utils/templates.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/utils/templates.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export function isTemplateExpression(expression: string | unknown): expression is `{{${string}}}` {
+  return typeof expression === 'string' && expression.startsWith('{{') && expression.endsWith('}}');
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
@@ -26,24 +26,33 @@ import type { WorkflowExecutionState } from '../workflow_execution_state';
 const dependencies = mockContextDependencies();
 
 jest.mock('../../utils', () => ({
-  buildStepExecutionId: jest.fn().mockImplementation((executionId, stepId, path) => {
+  ...jest.requireActual<typeof import('../../utils')>('../../utils'),
+  buildStepExecutionId: jest.fn().mockImplementation((executionId: string, stepId: string) => {
     return `${stepId}_generated`;
   }),
   getKibanaUrl: jest.fn().mockReturnValue('http://localhost:5601'),
   buildWorkflowExecutionUrl: jest
     .fn()
-    .mockImplementation((kibanaUrl, spaceId, workflowId, executionId, stepExecutionId) => {
-      const spacePrefix = spaceId === 'default' ? '' : `/s/${spaceId}`;
-      const baseUrl = `${kibanaUrl}${spacePrefix}/app/workflows/${workflowId}`;
-      const params = new URLSearchParams({
-        executionId,
-        tab: 'executions',
-      });
-      if (stepExecutionId) {
-        params.set('stepExecutionId', stepExecutionId);
+    .mockImplementation(
+      (
+        kibanaUrl: string,
+        spaceId: string,
+        workflowId: string,
+        executionId: string,
+        stepExecutionId?: string
+      ) => {
+        const spacePrefix = spaceId === 'default' ? '' : `/s/${spaceId}`;
+        const baseUrl = `${kibanaUrl}${spacePrefix}/app/workflows/${workflowId}`;
+        const params = new URLSearchParams({
+          executionId,
+          tab: 'executions',
+        });
+        if (stepExecutionId) {
+          params.set('stepExecutionId', stepExecutionId);
+        }
+        return `${baseUrl}?${params.toString()}`;
       }
-      return `${baseUrl}?${params.toString()}`;
-    }),
+    ),
 }));
 
 describe('WorkflowContextManager', () => {
@@ -70,7 +79,10 @@ describe('WorkflowContextManager', () => {
       .fn()
       .mockReturnValue({} as EsWorkflowStepExecution);
     const templatingEngineMock = {} as unknown as WorkflowTemplatingEngine;
-    templatingEngineMock.render = jest.fn().mockImplementation((template) => template);
+    templatingEngineMock.render = jest.fn().mockImplementation((...args: unknown[]) => args[0]);
+    templatingEngineMock.evaluateExpression = jest
+      .fn()
+      .mockImplementation((...args: unknown[]) => args[0]);
 
     // Provide a dummy esClient as required by ContextManagerInit
     const esClient = {
@@ -502,10 +514,9 @@ describe('WorkflowContextManager', () => {
           if (stepExecutionId === 'outerForeachStep_generated') {
             return {
               stepType: 'foreach',
+              input: { foreach: JSON.stringify(['item1', 'item2', 'item3']) },
               state: {
-                items: ['item1', 'item2', 'item3'],
                 index: 0,
-                item: 'item1',
                 total: 3,
               },
             };
@@ -514,10 +525,9 @@ describe('WorkflowContextManager', () => {
           if (stepExecutionId === 'innerForeachStep_generated') {
             return {
               stepType: 'foreach',
+              input: { foreach: JSON.stringify(['1', '2', '3', '4']) },
               state: {
-                items: ['1', '2', '3', '4'],
                 index: 1,
-                item: '2',
                 total: 4,
               },
             };
@@ -596,10 +606,9 @@ describe('WorkflowContextManager', () => {
           if (stepExecutionId === 'outerForeachStep_generated') {
             return {
               stepType: 'foreach',
+              input: { foreach: JSON.stringify(['item1', 'item2', 'item3']) },
               state: {
-                items: ['item1', 'item2', 'item3'],
                 index: 0,
-                item: 'item1',
                 total: 3,
               },
             };
@@ -613,6 +622,95 @@ describe('WorkflowContextManager', () => {
         index: 0,
         item: 'item1',
         total: 3,
+      });
+    });
+
+    describe('nested foreach with inner expression {{foreach.item}}', () => {
+      const outerItems = [
+        ['innerA', 'innerB'],
+        ['innerC', 'innerD'],
+      ];
+      const outerCurrentIndex = 0;
+      const outerCurrentItem = outerItems[outerCurrentIndex];
+      const innerCurrentIndex = 1;
+
+      beforeEach(() => {
+        testContainer.workflowExecutionState.getWorkflowExecution = jest.fn().mockReturnValue({
+          workflowDefinition: workflow,
+          scopeStack: [
+            {
+              stepId: 'outerForeachStep',
+              nestedScopes: [{ nodeId: 'enterForeach_outerForeachStep' }],
+            },
+            {
+              stepId: 'innerForeachStep',
+              nestedScopes: [{ nodeId: 'enterForeach_innerForeachStep' }],
+            },
+          ],
+        } as EsWorkflowExecution);
+        testContainer.workflowExecutionState.getStepExecution = jest
+          .fn()
+          .mockImplementation((stepExecutionId) => {
+            if (stepExecutionId === 'outerForeachStep_generated') {
+              return {
+                stepType: 'foreach',
+                input: { foreach: JSON.stringify(outerItems) },
+                state: { index: outerCurrentIndex, total: outerItems.length },
+              };
+            }
+            if (stepExecutionId === 'innerForeachStep_generated') {
+              return {
+                stepType: 'foreach',
+                input: { foreach: '{{foreach.item}}' },
+                state: { index: innerCurrentIndex, total: outerCurrentItem.length },
+              };
+            }
+            return undefined;
+          });
+      });
+
+      it('should resolve inner foreach items from outer current item when inner expression is {{foreach.item}}', () => {
+        (testContainer.templatingEngineMock.evaluateExpression as jest.Mock).mockImplementation(
+          (expr: string, ctx: Record<string, unknown>) => {
+            if (expr.includes('foreach.item')) {
+              return (ctx as { foreach?: { item: unknown } }).foreach?.item;
+            }
+            return expr;
+          }
+        );
+        (testContainer.templatingEngineMock.render as jest.Mock).mockImplementation(
+          (...args: unknown[]) => args[0]
+        );
+
+        const context = testContainer.underTest.getContext();
+
+        expect(context.foreach).toEqual({
+          items: outerCurrentItem,
+          item: outerCurrentItem[innerCurrentIndex],
+          index: innerCurrentIndex,
+          total: outerCurrentItem.length,
+        });
+      });
+
+      it('should expose innermost foreach as context.foreach (current loop)', () => {
+        (testContainer.templatingEngineMock.evaluateExpression as jest.Mock).mockImplementation(
+          (expr: string, ctx: Record<string, unknown>) => {
+            if (expr.includes('foreach.item')) {
+              return (ctx as { foreach?: { item: unknown } }).foreach?.item;
+            }
+            return expr;
+          }
+        );
+        (testContainer.templatingEngineMock.render as jest.Mock).mockImplementation(
+          (...args: unknown[]) => args[0]
+        );
+
+        const context = testContainer.underTest.getContext();
+
+        expect(context.foreach?.item).toBe('innerB');
+        expect(context.foreach?.index).toBe(innerCurrentIndex);
+        expect(context.foreach?.total).toBe(outerCurrentItem.length);
+        expect(context.foreach?.items).toEqual(['innerA', 'innerB']);
       });
     });
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -10,7 +10,7 @@
 import type { CoreStart, KibanaRequest } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { KQLSyntaxError } from '@kbn/es-query';
-import type { SerializedError, StackFrame, StepContext, WorkflowContext } from '@kbn/workflows';
+import type { EsWorkflowStepExecution, SerializedError, StackFrame, StepContext, WorkflowContext } from '@kbn/workflows';
 import { parseJsPropertyAccess } from '@kbn/workflows/common/utils';
 import type { GraphNodeUnion, WorkflowGraph } from '@kbn/workflows/graph';
 import { buildWorkflowContext } from './build_workflow_context';
@@ -18,7 +18,7 @@ import type { ContextDependencies } from './types';
 import type { WorkflowExecutionState } from './workflow_execution_state';
 import { WorkflowScopeStack } from './workflow_scope_stack';
 import type { WorkflowTemplatingEngine } from '../templating_engine';
-import { buildStepExecutionId, evaluateKql } from '../utils';
+import { buildStepExecutionId, evaluateKql, isTemplateExpression } from '../utils';
 
 export interface ContextManagerInit {
   // New properties for logging
@@ -32,6 +32,11 @@ export interface ContextManagerInit {
   fakeRequest: KibanaRequest;
   coreStart: CoreStart; // For using Kibana's internal HTTP client
   dependencies: ContextDependencies;
+}
+
+interface ScopeEntry {
+  topFrame: NonNullable<ReturnType<WorkflowScopeStack['getCurrentScope']>>;
+  stepExecution: EsWorkflowStepExecution | undefined;
 }
 
 export class WorkflowContextManager {
@@ -278,40 +283,126 @@ export class WorkflowContextManager {
       this.workflowExecutionState.getWorkflowExecution().scopeStack
     );
 
+    const executionId = this.workflowExecutionState.getWorkflowExecution().id;
+    const scopeEntries: Array<ScopeEntry> = [];
+    const foreachEntries: Array<ScopeEntry> = [];
+
     while (!scopeStack.isEmpty()) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const topFrame = scopeStack.getCurrentScope()!;
       scopeStack = scopeStack.exitScope();
       const stepExecution = this.workflowExecutionState.getStepExecution(
-        buildStepExecutionId(
-          this.workflowExecutionState.getWorkflowExecution().id,
-          topFrame.stepId,
-          scopeStack.stackFrames
-        )
+        buildStepExecutionId(executionId, topFrame.stepId, scopeStack.stackFrames)
       );
+      scopeEntries.push({ topFrame, stepExecution });
+      if (stepExecution?.stepType === 'foreach') {
+        foreachEntries.push({ topFrame, stepExecution });
+      }
+    }
 
+    // When there is only one foreach frame (e.g. single-step run with subgraph), use
+    // contextOverride.foreach as the parent so inner expressions like {{foreach.item}} resolve.
+    const contextOverride =
+      this.workflowExecutionState.getWorkflowExecution().context?.contextOverride;
+    if (foreachEntries.length === 1 && contextOverride?.foreach != null) {
+      stepContext.foreach = contextOverride.foreach;
+    }
+
+    // Build foreach context in outer-to-inner order so inner expressions like
+    // {{foreach.item}} resolve against the outer foreach context.
+    for (const { stepExecution } of foreachEntries.reverse()) {
       if (stepExecution) {
-        switch (stepExecution.stepType) {
-          case 'foreach':
-            if (!stepContext.foreach) {
-              stepContext.foreach = stepExecution.state as StepContext['foreach'];
-            }
-            break;
-        }
+        stepContext.foreach = this.buildForeachContext(stepExecution, stepContext);
+      }
+    }
 
-        if (topFrame.scopeId === 'fallback') {
-          // This is not good approach, but we can't do it better right now.
-          // The problem is that Context is dynamic depending on the step scopes (like whether the current step is inside foreach, fallback path, etc)
-          // but here we are trying to mutate the static StepContext object.
-          // Proper solution would be to have dynamic context object that would resolve properties on demand,
-          // but it requires significant changes in the codebase.
-          // So for now, we just set the error on the context when we are in fallback scope.
-          const stepContextGeneric = stepContext as Record<string, unknown>;
-          if (!stepContextGeneric.error) {
-            stepContextGeneric.error = stepExecution.state?.error;
-          }
+    // Apply fallback scope error in original (innermost-first) order.
+    for (const { topFrame, stepExecution } of scopeEntries) {
+      if (topFrame.scopeId === 'fallback' && stepExecution) {
+        // This is not good approach, but we can't do it better right now.
+        // The problem is that Context is dynamic depending on the step scopes (like whether the current step is inside foreach, fallback path, etc)
+        // but here we are trying to mutate the static StepContext object.
+        // Proper solution would be to have dynamic context object that would resolve properties on demand,
+        // but it requires significant changes in the codebase.
+        // So for now, we just set the error on the context when we are in fallback scope.
+        const stepContextGeneric = stepContext as Record<string, unknown>;
+        if (!stepContextGeneric.error) {
+          stepContextGeneric.error = stepExecution.state?.error;
         }
       }
+    }
+  }
+
+  /**
+   * Builds the foreach context by combining the persisted state (index, total)
+   * with items derived by re-evaluating the foreach expression at resolution time.
+   * This avoids storing the entire items array in the step execution state on every iteration.
+   */
+  private buildForeachContext(
+    stepExecution: EsWorkflowStepExecution,
+    stepContext: StepContext
+  ): StepContext['foreach'] {
+    const foreachState = stepExecution.state ?? {};
+    const index = typeof foreachState.index === 'number' ? foreachState.index : 0;
+    const total = typeof foreachState.total === 'number' ? foreachState.total : 0;
+
+    // Re-evaluate the foreach expression (stored in the step input at entry time)
+    // to derive the full items array and current item without persisting them in state.
+    const foreachExpression = this.extractForeachExpression(stepExecution.input);
+    const items = foreachExpression
+      ? this.resolveForeachItems(foreachExpression, stepContext)
+      : undefined;
+
+    const availableItems = items ?? [];
+
+    return {
+      items: availableItems,
+      item: availableItems[index],
+      index,
+      total,
+    };
+  }
+
+  /**
+   * Extracts the foreach expression string from a step execution's input.
+   * The input is typed as JsonValue, so we narrow it to a record and pull the `foreach` key.
+   */
+  private extractForeachExpression(input: EsWorkflowStepExecution['input']): string | undefined {
+    if (input !== null && typeof input === 'object' && !Array.isArray(input)) {
+      const { foreach: expression } = input;
+      return typeof expression === 'string' ? expression : undefined;
+    }
+    return undefined;
+  }
+
+  /**
+   * Evaluates a foreach expression against the given context and returns the resulting array.
+   * Mirrors the evaluation logic in EnterForeachNodeImpl.processForeachConfiguration / getItems.
+   */
+  private resolveForeachItems(
+    foreachExpression: string,
+    context: Record<string, unknown>
+  ): unknown[] | undefined {
+    try {
+      let resolvedValue: unknown;
+
+      if (isTemplateExpression(foreachExpression)) {
+        resolvedValue = this.templateEngine.evaluateExpression(foreachExpression, context);
+      } else {
+        resolvedValue = this.templateEngine.render(foreachExpression, context);
+      }
+
+      if (typeof resolvedValue === 'string') {
+        try {
+          resolvedValue = JSON.parse(resolvedValue);
+        } catch {
+          return undefined;
+        }
+      }
+
+      return Array.isArray(resolvedValue) ? resolvedValue : undefined;
+    } catch {
+      return undefined;
     }
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -10,7 +10,13 @@
 import type { CoreStart, KibanaRequest } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { KQLSyntaxError } from '@kbn/es-query';
-import type { EsWorkflowStepExecution, SerializedError, StackFrame, StepContext, WorkflowContext } from '@kbn/workflows';
+import type {
+  EsWorkflowStepExecution,
+  SerializedError,
+  StackFrame,
+  StepContext,
+  WorkflowContext,
+} from '@kbn/workflows';
 import { parseJsPropertyAccess } from '@kbn/workflows/common/utils';
 import type { GraphNodeUnion, WorkflowGraph } from '@kbn/workflows/graph';
 import { buildWorkflowContext } from './build_workflow_context';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[OneWorkflow] Reduce foreach footprint in index on execution (#252845)](https://github.com/elastic/kibana/pull/252845)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Liberati","email":"dej611@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-20T08:51:11Z","message":"[OneWorkflow] Reduce foreach footprint in index on execution (#252845)\n\n## Summary\n\nOptimizes the foreach step execution by reducing the data persisted in\nthe step state on every iteration. Previously, the full `items` array\nand the current `item` were stored alongside `index` and `total` in the\nstep state on every loop iteration. For large arrays this meant\nrepeatedly persisting a potentially large payload to Elasticsearch with\nno benefit—the items array is static and the current item can be\nderived.\n\n<img width=\"1501\" height=\"651\" alt=\"Screenshot 2026-02-13 at 09 33 54\"\nsrc=\"https://github.com/user-attachments/assets/fd1018ef-c0c8-4c9a-90a6-22df9f4f889f\"\n/>\n\n### Changes\n\n- **`EnterForeachNodeImpl`**: The foreach state now stores only `{\nindex, total }` instead of `{ items, item, index, total }`. The\n`advanceIteration` method simply increments the index rather than\nreading and re-storing the full items array.\n- **`ExitForeachNodeImpl`**: The \"has more items\" check changed from an\narray lookup (`items[index + 1]`) to an index-based bounds check (`index\n+ 1 < total`), removing the dependency on the persisted items array.\n- **Tests**: Updated all mock state shapes and assertions to match the\nlean `{ index, total }` format.\n- **`WorkflowContentManager`**: whenever a `foreach` step is encountered\nthe context is dynamically rebuilt from the `input`\n- **Tests**: Updated all mock state shapes and assertions to match the\nlean `{ input, state: { index, total }}` format.\n\nLuckily integration tests caught deeper issues with the change as the\ninitial `foreachResolveValue()` was not working for nested scopes.\nThe `enrich` step within `WorkflowContextManager` class had to change in\norder to rebuild the correct context, this time in reverse order:\n\n```mermaid\nsequenceDiagram\n  participant Stack\n  participant Enrich\n  participant StepContext\n\n  Note over Enrich: Walk stack (inner to outer)\n  Enrich->>Stack: getCurrentScope / exitScope\n  Enrich->>Enrich: Collect entries [inner, outer]\n\n  Note over Enrich: Apply foreach reverse order\n  Enrich->>StepContext: foreach = outer context\n  Enrich->>StepContext: foreach = inner context (uses outer for {{foreach.item}})\n\n  Note over Enrich: Apply fallback in original order\n  Enrich->>StepContext: error from fallback if any\n```","sha":"be1553078b79fa0969f603cf589ea8cb30d7525c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:One Workflow","v9.4.0","v9.3.1"],"title":"[OneWorkflow] Reduce foreach footprint in index on execution","number":252845,"url":"https://github.com/elastic/kibana/pull/252845","mergeCommit":{"message":"[OneWorkflow] Reduce foreach footprint in index on execution (#252845)\n\n## Summary\n\nOptimizes the foreach step execution by reducing the data persisted in\nthe step state on every iteration. Previously, the full `items` array\nand the current `item` were stored alongside `index` and `total` in the\nstep state on every loop iteration. For large arrays this meant\nrepeatedly persisting a potentially large payload to Elasticsearch with\nno benefit—the items array is static and the current item can be\nderived.\n\n<img width=\"1501\" height=\"651\" alt=\"Screenshot 2026-02-13 at 09 33 54\"\nsrc=\"https://github.com/user-attachments/assets/fd1018ef-c0c8-4c9a-90a6-22df9f4f889f\"\n/>\n\n### Changes\n\n- **`EnterForeachNodeImpl`**: The foreach state now stores only `{\nindex, total }` instead of `{ items, item, index, total }`. The\n`advanceIteration` method simply increments the index rather than\nreading and re-storing the full items array.\n- **`ExitForeachNodeImpl`**: The \"has more items\" check changed from an\narray lookup (`items[index + 1]`) to an index-based bounds check (`index\n+ 1 < total`), removing the dependency on the persisted items array.\n- **Tests**: Updated all mock state shapes and assertions to match the\nlean `{ index, total }` format.\n- **`WorkflowContentManager`**: whenever a `foreach` step is encountered\nthe context is dynamically rebuilt from the `input`\n- **Tests**: Updated all mock state shapes and assertions to match the\nlean `{ input, state: { index, total }}` format.\n\nLuckily integration tests caught deeper issues with the change as the\ninitial `foreachResolveValue()` was not working for nested scopes.\nThe `enrich` step within `WorkflowContextManager` class had to change in\norder to rebuild the correct context, this time in reverse order:\n\n```mermaid\nsequenceDiagram\n  participant Stack\n  participant Enrich\n  participant StepContext\n\n  Note over Enrich: Walk stack (inner to outer)\n  Enrich->>Stack: getCurrentScope / exitScope\n  Enrich->>Enrich: Collect entries [inner, outer]\n\n  Note over Enrich: Apply foreach reverse order\n  Enrich->>StepContext: foreach = outer context\n  Enrich->>StepContext: foreach = inner context (uses outer for {{foreach.item}})\n\n  Note over Enrich: Apply fallback in original order\n  Enrich->>StepContext: error from fallback if any\n```","sha":"be1553078b79fa0969f603cf589ea8cb30d7525c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252845","number":252845,"mergeCommit":{"message":"[OneWorkflow] Reduce foreach footprint in index on execution (#252845)\n\n## Summary\n\nOptimizes the foreach step execution by reducing the data persisted in\nthe step state on every iteration. Previously, the full `items` array\nand the current `item` were stored alongside `index` and `total` in the\nstep state on every loop iteration. For large arrays this meant\nrepeatedly persisting a potentially large payload to Elasticsearch with\nno benefit—the items array is static and the current item can be\nderived.\n\n<img width=\"1501\" height=\"651\" alt=\"Screenshot 2026-02-13 at 09 33 54\"\nsrc=\"https://github.com/user-attachments/assets/fd1018ef-c0c8-4c9a-90a6-22df9f4f889f\"\n/>\n\n### Changes\n\n- **`EnterForeachNodeImpl`**: The foreach state now stores only `{\nindex, total }` instead of `{ items, item, index, total }`. The\n`advanceIteration` method simply increments the index rather than\nreading and re-storing the full items array.\n- **`ExitForeachNodeImpl`**: The \"has more items\" check changed from an\narray lookup (`items[index + 1]`) to an index-based bounds check (`index\n+ 1 < total`), removing the dependency on the persisted items array.\n- **Tests**: Updated all mock state shapes and assertions to match the\nlean `{ index, total }` format.\n- **`WorkflowContentManager`**: whenever a `foreach` step is encountered\nthe context is dynamically rebuilt from the `input`\n- **Tests**: Updated all mock state shapes and assertions to match the\nlean `{ input, state: { index, total }}` format.\n\nLuckily integration tests caught deeper issues with the change as the\ninitial `foreachResolveValue()` was not working for nested scopes.\nThe `enrich` step within `WorkflowContextManager` class had to change in\norder to rebuild the correct context, this time in reverse order:\n\n```mermaid\nsequenceDiagram\n  participant Stack\n  participant Enrich\n  participant StepContext\n\n  Note over Enrich: Walk stack (inner to outer)\n  Enrich->>Stack: getCurrentScope / exitScope\n  Enrich->>Enrich: Collect entries [inner, outer]\n\n  Note over Enrich: Apply foreach reverse order\n  Enrich->>StepContext: foreach = outer context\n  Enrich->>StepContext: foreach = inner context (uses outer for {{foreach.item}})\n\n  Note over Enrich: Apply fallback in original order\n  Enrich->>StepContext: error from fallback if any\n```","sha":"be1553078b79fa0969f603cf589ea8cb30d7525c"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->