### PR TITLE
[Fleet] Migrate Cypress tests to Scout/Playwright

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
@@ -48,9 +48,15 @@ export async function createAgentPolicy(
   return response.data?.item ?? response.item;
 }
 
-export async function deleteAgentPolicy(kbnClient: any, id: string, spaceId?: string): Promise<void> {
+export async function deleteAgentPolicy(
+  kbnClient: any,
+  id: string,
+  spaceId?: string
+): Promise<void> {
   try {
-    const path = spaceId ? `/s/${spaceId}/api/fleet/agent_policies/delete` : '/api/fleet/agent_policies/delete';
+    const path = spaceId
+      ? `/s/${spaceId}/api/fleet/agent_policies/delete`
+      : '/api/fleet/agent_policies/delete';
     await kbnClient.request({
       method: 'POST',
       path,
@@ -61,10 +67,7 @@ export async function deleteAgentPolicy(kbnClient: any, id: string, spaceId?: st
   }
 }
 
-export async function cleanupAgentPolicies(
-  kbnClient: any,
-  spaceId?: string
-): Promise<void> {
+export async function cleanupAgentPolicies(kbnClient: any, spaceId?: string): Promise<void> {
   try {
     const path = spaceId
       ? `/s/${spaceId}/api/fleet/agent_policies?withAgentCount=true`
@@ -96,7 +99,10 @@ export async function createDownloadSource(
 
 export async function cleanupDownloadSources(kbnClient: any): Promise<void> {
   try {
-    const response = await kbnClient.request({ method: 'GET', path: '/api/fleet/agent_download_sources' });
+    const response = await kbnClient.request({
+      method: 'GET',
+      path: '/api/fleet/agent_download_sources',
+    });
     const items = response.data?.items ?? response.items ?? [];
     const nonDefault = items.filter((ds: any) => !ds.is_default);
 
@@ -115,7 +121,12 @@ export async function cleanupDownloadSources(kbnClient: any): Promise<void> {
   }
 }
 
-export async function insertDoc(esClient: any, index: string, doc: any, id?: string): Promise<void> {
+export async function insertDoc(
+  esClient: any,
+  index: string,
+  doc: any,
+  id?: string
+): Promise<void> {
   await esClient.index({
     index,
     document: doc,
@@ -155,9 +166,10 @@ export async function installTestPackage(
   version: string = 'latest'
 ): Promise<any> {
   // Fleet EPM install: POST /api/fleet/epm/packages/{name}/{version}
-  const path = version === 'latest'
-    ? `/api/fleet/epm/packages/${pkgName}`
-    : `/api/fleet/epm/packages/${pkgName}/${version}`;
+  const path =
+    version === 'latest'
+      ? `/api/fleet/epm/packages/${pkgName}`
+      : `/api/fleet/epm/packages/${pkgName}/${version}`;
   const response = await kbnClient.request({
     method: 'POST',
     path,
@@ -179,12 +191,7 @@ export async function installTestPackageFromZip(
   const pathModule = await import('path');
   const fs = await import('fs').then((m) => m.promises);
   const resolvedPath =
-    zipPath ??
-    pathModule.resolve(
-      __dirname,
-      '../../../../cypress/packages',
-      `${pkgName}.zip`
-    );
+    zipPath ?? pathModule.resolve(__dirname, '../../../../cypress/packages', `${pkgName}.zip`);
   const zipContent = await fs.readFile(resolvedPath);
   const response = await kbnClient.request({
     method: 'POST',
@@ -202,7 +209,9 @@ export async function uninstallTestPackage(
   version?: string
 ): Promise<void> {
   try {
-    const path = version ? `/api/fleet/epm/packages/${pkgName}/${version}` : `/api/fleet/epm/packages/${pkgName}`;
+    const path = version
+      ? `/api/fleet/epm/packages/${pkgName}/${version}`
+      : `/api/fleet/epm/packages/${pkgName}`;
     await kbnClient.request({
       method: 'DELETE',
       path,

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-/**
- * API helpers for Fleet Scout tests.
- * Functions to create/delete agent policies, enrollment tokens, download sources,
- * insert/delete ES docs, install/uninstall test packages, etc.
- */
+import type { KbnClient, EsClient } from '@kbn/scout';
 
 function randomString(length = 8): string {
   return Math.random()
@@ -18,7 +14,7 @@ function randomString(length = 8): string {
 }
 
 export async function createAgentPolicy(
-  kbnClient: any,
+  kbnClient: KbnClient,
   name: string,
   options?: {
     id?: string;
@@ -28,7 +24,7 @@ export async function createAgentPolicy(
     download_source_id?: string;
     has_fleet_server?: boolean;
   }
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   const body = {
     name,
     namespace: options?.namespace ?? 'default',
@@ -49,7 +45,7 @@ export async function createAgentPolicy(
 }
 
 export async function deleteAgentPolicy(
-  kbnClient: any,
+  kbnClient: KbnClient,
   id: string,
   spaceId?: string
 ): Promise<void> {
@@ -67,14 +63,16 @@ export async function deleteAgentPolicy(
   }
 }
 
-export async function cleanupAgentPolicies(kbnClient: any, spaceId?: string): Promise<void> {
+export async function cleanupAgentPolicies(kbnClient: KbnClient, spaceId?: string): Promise<void> {
   try {
     const path = spaceId
       ? `/s/${spaceId}/api/fleet/agent_policies?withAgentCount=true`
       : '/api/fleet/agent_policies?withAgentCount=true';
     const response = await kbnClient.request({ method: 'GET', path });
     const items = response.data?.items ?? response.items ?? [];
-    const toDelete = items.filter((p: any) => (p.agents ?? 0) === 0);
+    const toDelete = items.filter(
+      (p: Record<string, unknown>) => ((p.agents as number) ?? 0) === 0
+    );
 
     for (const policy of toDelete) {
       await deleteAgentPolicy(kbnClient, policy.id, spaceId);
@@ -85,9 +83,9 @@ export async function cleanupAgentPolicies(kbnClient: any, spaceId?: string): Pr
 }
 
 export async function createDownloadSource(
-  kbnClient: any,
+  kbnClient: KbnClient,
   payload: { name: string; host: string; id?: string; is_default?: boolean }
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   const response = await kbnClient.request({
     method: 'POST',
     path: '/api/fleet/agent_download_sources',
@@ -97,14 +95,16 @@ export async function createDownloadSource(
   return response.data?.item ?? response.item;
 }
 
-export async function cleanupDownloadSources(kbnClient: any): Promise<void> {
+export async function cleanupDownloadSources(kbnClient: KbnClient): Promise<void> {
   try {
     const response = await kbnClient.request({
       method: 'GET',
       path: '/api/fleet/agent_download_sources',
     });
     const items = response.data?.items ?? response.items ?? [];
-    const nonDefault = items.filter((ds: any) => !ds.is_default);
+    const nonDefault = items.filter(
+      (ds: Record<string, unknown>) => !ds.is_default
+    );
 
     for (const ds of nonDefault) {
       try {
@@ -122,9 +122,9 @@ export async function cleanupDownloadSources(kbnClient: any): Promise<void> {
 }
 
 export async function insertDoc(
-  esClient: any,
+  esClient: EsClient,
   index: string,
-  doc: any,
+  doc: Record<string, unknown>,
   id?: string
 ): Promise<void> {
   await esClient.index({
@@ -135,15 +135,19 @@ export async function insertDoc(
   });
 }
 
-export async function insertDocs(esClient: any, index: string, docs: any[]): Promise<void> {
+export async function insertDocs(
+  esClient: EsClient,
+  index: string,
+  docs: Record<string, unknown>[]
+): Promise<void> {
   const operations = docs.flatMap((doc) => [{ index: { _index: index } }, doc]);
   await esClient.bulk({ operations, refresh: 'wait_for' });
 }
 
 export async function deleteDocsByQuery(
-  esClient: any,
+  esClient: EsClient,
   index: string,
-  query: any,
+  query: Record<string, unknown>,
   options?: { ignoreUnavailable?: boolean }
 ): Promise<void> {
   try {
@@ -161,10 +165,10 @@ export async function deleteDocsByQuery(
 }
 
 export async function installTestPackage(
-  kbnClient: any,
+  kbnClient: KbnClient,
   pkgName: string,
   version: string = 'latest'
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   // Fleet EPM install: POST /api/fleet/epm/packages/{name}/{version}
   const path =
     version === 'latest'
@@ -184,10 +188,10 @@ export async function installTestPackage(
  * Zip path: fleet plugin root / cypress / packages / {pkgName}.zip
  */
 export async function installTestPackageFromZip(
-  kbnClient: any,
+  kbnClient: KbnClient,
   pkgName: string,
   zipPath?: string
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   const pathModule = await import('path');
   const fs = await import('fs').then((m) => m.promises);
   const resolvedPath =
@@ -204,7 +208,7 @@ export async function installTestPackageFromZip(
 }
 
 export async function uninstallTestPackage(
-  kbnClient: any,
+  kbnClient: KbnClient,
   pkgName: string,
   version?: string
 ): Promise<void> {
@@ -222,7 +226,7 @@ export async function uninstallTestPackage(
 }
 
 export async function setFleetServerHost(
-  kbnClient: any,
+  kbnClient: KbnClient,
   host: string = 'https://fleetserver:8220'
 ): Promise<void> {
   await kbnClient.request({
@@ -295,8 +299,8 @@ export function createAgentDoc(
 }
 
 export async function setupFleetServer(
-  kbnClient: any,
-  esClient: any,
+  kbnClient: KbnClient,
+  esClient: EsClient,
   kibanaVersion: string = '8.1.0'
 ): Promise<string> {
   const FLEET_SERVER_POLICY_ID = 'fleet-server-policy';
@@ -312,8 +316,9 @@ export async function setupFleetServer(
         has_fleet_server: true,
       },
     });
-  } catch (e: any) {
-    if (e?.response?.status !== 409) {
+  } catch (e: unknown) {
+    const error = e as { response?: { status?: number } };
+    if (error?.response?.status !== 409) {
       throw e;
     }
   }
@@ -326,10 +331,10 @@ export async function setupFleetServer(
 }
 
 export async function createEnrollmentToken(
-  kbnClient: any,
+  kbnClient: KbnClient,
   policyId: string,
   name?: string
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   const response = await kbnClient.request({
     method: 'POST',
     path: '/api/fleet/enrollment_api_keys',
@@ -342,7 +347,7 @@ export async function createEnrollmentToken(
   return response.data?.item ?? response.item;
 }
 
-export async function enableSpaceAwareness(kbnClient: any): Promise<void> {
+export async function enableSpaceAwareness(kbnClient: KbnClient): Promise<void> {
   try {
     await kbnClient.request({
       method: 'POST',
@@ -354,11 +359,11 @@ export async function enableSpaceAwareness(kbnClient: any): Promise<void> {
 }
 
 export async function createSpace(
-  kbnClient: any,
+  kbnClient: KbnClient,
   id: string,
   name: string,
   options?: { description?: string; color?: string; initials?: string }
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   const body = {
     id,
     name,
@@ -378,7 +383,7 @@ export async function createSpace(
   return response.data ?? response;
 }
 
-export async function unenrollAgents(kbnClient: any): Promise<void> {
+export async function unenrollAgents(kbnClient: KbnClient): Promise<void> {
   try {
     const response = await kbnClient.request({
       method: 'GET',

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
@@ -43,13 +43,51 @@ export async function createAgentPolicy(
     ...(options?.has_fleet_server !== undefined && { has_fleet_server: options.has_fleet_server }),
   };
 
-  const response = await kbnClient.request<FleetItemResponse>({
-    method: 'POST',
-    path: '/api/fleet/agent_policies',
-    body,
-  });
+  try {
+    const response = await kbnClient.request<FleetItemResponse>({
+      method: 'POST',
+      path: '/api/fleet/agent_policies',
+      body,
+    });
+    return response.data.item;
+  } catch (e: unknown) {
+    const error = e as { response?: { status?: number } };
+    if (error?.response?.status === 409 && options?.id) {
+      const resp = await kbnClient.request<FleetItemResponse>({
+        method: 'GET',
+        path: `/api/fleet/agent_policies/${options.id}`,
+      });
+      return resp.data.item;
+    }
+    throw e;
+  }
+}
 
-  return response.data.item;
+export async function getOrCreateAgentPolicy(
+  kbnClient: KbnClient,
+  name: string,
+  options?: {
+    id?: string;
+    namespace?: string;
+    description?: string;
+    monitoring_enabled?: string[];
+    download_source_id?: string;
+    has_fleet_server?: boolean;
+  }
+): Promise<Record<string, unknown>> {
+  try {
+    return await createAgentPolicy(kbnClient, name, options);
+  } catch (e: unknown) {
+    const error = e as { response?: { status?: number } };
+    if (error?.response?.status === 409 && options?.id) {
+      const resp = await kbnClient.request<FleetItemResponse>({
+        method: 'GET',
+        path: `/api/fleet/agent_policies/${options.id}`,
+      });
+      return resp.data.item;
+    }
+    throw e;
+  }
 }
 
 export async function deleteAgentPolicy(
@@ -380,13 +418,20 @@ export async function createSpace(
     imageUrl: undefined,
   };
 
-  const response = await kbnClient.request<Record<string, unknown>>({
-    method: 'POST',
-    path: '/api/spaces/space',
-    body,
-  });
-
-  return response.data;
+  try {
+    const response = await kbnClient.request<Record<string, unknown>>({
+      method: 'POST',
+      path: '/api/spaces/space',
+      body,
+    });
+    return response.data;
+  } catch (e: unknown) {
+    const error = e as { response?: { status?: number } };
+    if (error?.response?.status === 409) {
+      return { id, name };
+    }
+    throw e;
+  }
 }
 
 export async function unenrollAgents(kbnClient: KbnClient): Promise<void> {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
@@ -102,9 +102,7 @@ export async function cleanupDownloadSources(kbnClient: KbnClient): Promise<void
       path: '/api/fleet/agent_download_sources',
     });
     const items = response.data?.items ?? response.items ?? [];
-    const nonDefault = items.filter(
-      (ds: Record<string, unknown>) => !ds.is_default
-    );
+    const nonDefault = items.filter((ds: Record<string, unknown>) => !ds.is_default);
 
     for (const ds of nonDefault) {
       try {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { KbnClient, EsClient } from '@kbn/scout';
+import type { KbnClient, EsClient, ScoutPage } from '@kbn/scout';
 
 interface FleetItemResponse {
   item: Record<string, unknown>;
@@ -273,15 +273,41 @@ export async function setFleetServerHost(
   kbnClient: KbnClient,
   host: string = 'https://fleetserver:8220'
 ): Promise<void> {
-  await kbnClient.request({
-    method: 'POST',
-    path: '/api/fleet/fleet_server_hosts',
-    body: {
-      name: 'Default host',
-      host_urls: [host],
-      is_default: true,
-    },
-  });
+  try {
+    await kbnClient.request({
+      method: 'POST',
+      path: '/api/fleet/fleet_server_hosts',
+      body: {
+        name: 'Default host',
+        host_urls: [host],
+        is_default: true,
+      },
+    });
+  } catch (e: unknown) {
+    const error = e as { response?: { status?: number } };
+    if (error?.response?.status !== 409) {
+      throw e;
+    }
+  }
+}
+
+export async function mockFleetSetupEndpoints(page: ScoutPage): Promise<void> {
+  await page.route('**/api/fleet/agents/setup', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        isReady: true,
+        missing_optional_features: [],
+        missing_requirements: [],
+      }),
+    })
+  );
+  await page.route('**/api/fleet/setup', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ isInitialized: true, nonFatalErrors: [] }),
+    })
+  );
 }
 
 export function createAgentDoc(

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
@@ -7,6 +7,14 @@
 
 import type { KbnClient, EsClient } from '@kbn/scout';
 
+interface FleetItemResponse {
+  item: Record<string, unknown>;
+}
+
+interface FleetItemsResponse {
+  items: Array<Record<string, unknown>>;
+}
+
 function randomString(length = 8): string {
   return Math.random()
     .toString(36)
@@ -35,13 +43,13 @@ export async function createAgentPolicy(
     ...(options?.has_fleet_server !== undefined && { has_fleet_server: options.has_fleet_server }),
   };
 
-  const response = await kbnClient.request({
+  const response = await kbnClient.request<FleetItemResponse>({
     method: 'POST',
     path: '/api/fleet/agent_policies',
     body,
   });
 
-  return response.data?.item ?? response.item;
+  return response.data.item;
 }
 
 export async function deleteAgentPolicy(
@@ -68,14 +76,14 @@ export async function cleanupAgentPolicies(kbnClient: KbnClient, spaceId?: strin
     const path = spaceId
       ? `/s/${spaceId}/api/fleet/agent_policies?withAgentCount=true`
       : '/api/fleet/agent_policies?withAgentCount=true';
-    const response = await kbnClient.request({ method: 'GET', path });
-    const items = response.data?.items ?? response.items ?? [];
+    const response = await kbnClient.request<FleetItemsResponse>({ method: 'GET', path });
+    const items = response.data.items ?? [];
     const toDelete = items.filter(
       (p: Record<string, unknown>) => ((p.agents as number) ?? 0) === 0
     );
 
     for (const policy of toDelete) {
-      await deleteAgentPolicy(kbnClient, policy.id, spaceId);
+      await deleteAgentPolicy(kbnClient, policy.id as string, spaceId);
     }
   } catch {
     // Ignore cleanup failures
@@ -86,29 +94,29 @@ export async function createDownloadSource(
   kbnClient: KbnClient,
   payload: { name: string; host: string; id?: string; is_default?: boolean }
 ): Promise<Record<string, unknown>> {
-  const response = await kbnClient.request({
+  const response = await kbnClient.request<FleetItemResponse>({
     method: 'POST',
     path: '/api/fleet/agent_download_sources',
     body: payload,
   });
 
-  return response.data?.item ?? response.item;
+  return response.data.item;
 }
 
 export async function cleanupDownloadSources(kbnClient: KbnClient): Promise<void> {
   try {
-    const response = await kbnClient.request({
+    const response = await kbnClient.request<FleetItemsResponse>({
       method: 'GET',
       path: '/api/fleet/agent_download_sources',
     });
-    const items = response.data?.items ?? response.items ?? [];
+    const items = response.data.items ?? [];
     const nonDefault = items.filter((ds: Record<string, unknown>) => !ds.is_default);
 
     for (const ds of nonDefault) {
       try {
         await kbnClient.request({
           method: 'DELETE',
-          path: `/api/fleet/agent_download_sources/${ds.id}`,
+          path: `/api/fleet/agent_download_sources/${ds.id as string}`,
         });
       } catch {
         // Ignore
@@ -172,13 +180,13 @@ export async function installTestPackage(
     version === 'latest'
       ? `/api/fleet/epm/packages/${pkgName}`
       : `/api/fleet/epm/packages/${pkgName}/${version}`;
-  const response = await kbnClient.request({
+  const response = await kbnClient.request<Record<string, unknown>>({
     method: 'POST',
     path,
     body: version === 'latest' ? undefined : {},
   });
 
-  return response.data ?? response;
+  return response.data;
 }
 
 /**
@@ -195,14 +203,14 @@ export async function installTestPackageFromZip(
   const resolvedPath =
     zipPath ?? pathModule.resolve(__dirname, '../../../../cypress/packages', `${pkgName}.zip`);
   const zipContent = await fs.readFile(resolvedPath);
-  const response = await kbnClient.request({
+  const response = await kbnClient.request<Record<string, unknown>>({
     method: 'POST',
     path: '/api/fleet/epm/packages',
     body: zipContent,
     headers: { 'Content-Type': 'application/zip' },
   });
 
-  return response.data ?? response;
+  return response.data;
 }
 
 export async function uninstallTestPackage(
@@ -333,7 +341,7 @@ export async function createEnrollmentToken(
   policyId: string,
   name?: string
 ): Promise<Record<string, unknown>> {
-  const response = await kbnClient.request({
+  const response = await kbnClient.request<FleetItemResponse>({
     method: 'POST',
     path: '/api/fleet/enrollment_api_keys',
     body: {
@@ -342,7 +350,7 @@ export async function createEnrollmentToken(
     },
   });
 
-  return response.data?.item ?? response.item;
+  return response.data.item;
 }
 
 export async function enableSpaceAwareness(kbnClient: KbnClient): Promise<void> {
@@ -372,28 +380,28 @@ export async function createSpace(
     imageUrl: undefined,
   };
 
-  const response = await kbnClient.request({
+  const response = await kbnClient.request<Record<string, unknown>>({
     method: 'POST',
     path: '/api/spaces/space',
     body,
   });
 
-  return response.data ?? response;
+  return response.data;
 }
 
 export async function unenrollAgents(kbnClient: KbnClient): Promise<void> {
   try {
-    const response = await kbnClient.request({
+    const response = await kbnClient.request<FleetItemsResponse>({
       method: 'GET',
       path: '/api/fleet/agents?page=1&perPage=100&showInactive=false&showUpgradeable=false',
     });
-    const items = response.data?.items ?? response.items ?? [];
+    const items = response.data.items ?? [];
 
     for (const agent of items) {
       try {
         await kbnClient.request({
           method: 'POST',
-          path: `/api/fleet/agents/${agent.id}/unenroll`,
+          path: `/api/fleet/agents/${agent.id as string}/unenroll`,
           body: { revoke: true },
         });
       } catch {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/api_helpers.ts
@@ -1,0 +1,394 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * API helpers for Fleet Scout tests.
+ * Functions to create/delete agent policies, enrollment tokens, download sources,
+ * insert/delete ES docs, install/uninstall test packages, etc.
+ */
+
+function randomString(length = 8): string {
+  return Math.random()
+    .toString(36)
+    .substring(2, 2 + length);
+}
+
+export async function createAgentPolicy(
+  kbnClient: any,
+  name: string,
+  options?: {
+    id?: string;
+    namespace?: string;
+    description?: string;
+    monitoring_enabled?: string[];
+    download_source_id?: string;
+    has_fleet_server?: boolean;
+  }
+): Promise<any> {
+  const body = {
+    name,
+    namespace: options?.namespace ?? 'default',
+    description: options?.description ?? '',
+    monitoring_enabled: options?.monitoring_enabled ?? ['logs', 'metrics'],
+    ...(options?.id && { id: options.id }),
+    ...(options?.download_source_id && { download_source_id: options.download_source_id }),
+    ...(options?.has_fleet_server !== undefined && { has_fleet_server: options.has_fleet_server }),
+  };
+
+  const response = await kbnClient.request({
+    method: 'POST',
+    path: '/api/fleet/agent_policies',
+    body,
+  });
+
+  return response.data?.item ?? response.item;
+}
+
+export async function deleteAgentPolicy(kbnClient: any, id: string, spaceId?: string): Promise<void> {
+  try {
+    const path = spaceId ? `/s/${spaceId}/api/fleet/agent_policies/delete` : '/api/fleet/agent_policies/delete';
+    await kbnClient.request({
+      method: 'POST',
+      path,
+      body: { agentPolicyId: id },
+    });
+  } catch {
+    // Ignore — may already be deleted
+  }
+}
+
+export async function cleanupAgentPolicies(
+  kbnClient: any,
+  spaceId?: string
+): Promise<void> {
+  try {
+    const path = spaceId
+      ? `/s/${spaceId}/api/fleet/agent_policies?withAgentCount=true`
+      : '/api/fleet/agent_policies?withAgentCount=true';
+    const response = await kbnClient.request({ method: 'GET', path });
+    const items = response.data?.items ?? response.items ?? [];
+    const toDelete = items.filter((p: any) => (p.agents ?? 0) === 0);
+
+    for (const policy of toDelete) {
+      await deleteAgentPolicy(kbnClient, policy.id, spaceId);
+    }
+  } catch {
+    // Ignore cleanup failures
+  }
+}
+
+export async function createDownloadSource(
+  kbnClient: any,
+  payload: { name: string; host: string; id?: string; is_default?: boolean }
+): Promise<any> {
+  const response = await kbnClient.request({
+    method: 'POST',
+    path: '/api/fleet/agent_download_sources',
+    body: payload,
+  });
+
+  return response.data?.item ?? response.item;
+}
+
+export async function cleanupDownloadSources(kbnClient: any): Promise<void> {
+  try {
+    const response = await kbnClient.request({ method: 'GET', path: '/api/fleet/agent_download_sources' });
+    const items = response.data?.items ?? response.items ?? [];
+    const nonDefault = items.filter((ds: any) => !ds.is_default);
+
+    for (const ds of nonDefault) {
+      try {
+        await kbnClient.request({
+          method: 'DELETE',
+          path: `/api/fleet/agent_download_sources/${ds.id}`,
+        });
+      } catch {
+        // Ignore
+      }
+    }
+  } catch {
+    // Ignore cleanup failures
+  }
+}
+
+export async function insertDoc(esClient: any, index: string, doc: any, id?: string): Promise<void> {
+  await esClient.index({
+    index,
+    document: doc,
+    ...(id && { id }),
+    refresh: 'wait_for',
+  });
+}
+
+export async function insertDocs(esClient: any, index: string, docs: any[]): Promise<void> {
+  const operations = docs.flatMap((doc) => [{ index: { _index: index } }, doc]);
+  await esClient.bulk({ operations, refresh: 'wait_for' });
+}
+
+export async function deleteDocsByQuery(
+  esClient: any,
+  index: string,
+  query: any,
+  options?: { ignoreUnavailable?: boolean }
+): Promise<void> {
+  try {
+    await esClient.deleteByQuery({
+      index,
+      query,
+      ignore_unavailable: options?.ignoreUnavailable ?? false,
+      allow_no_indices: true,
+      refresh: true,
+      conflicts: 'proceed',
+    });
+  } catch {
+    // Ignore
+  }
+}
+
+export async function installTestPackage(
+  kbnClient: any,
+  pkgName: string,
+  version: string = 'latest'
+): Promise<any> {
+  // Fleet EPM install: POST /api/fleet/epm/packages/{name}/{version}
+  const path = version === 'latest'
+    ? `/api/fleet/epm/packages/${pkgName}`
+    : `/api/fleet/epm/packages/${pkgName}/${version}`;
+  const response = await kbnClient.request({
+    method: 'POST',
+    path,
+    body: version === 'latest' ? undefined : {},
+  });
+
+  return response.data ?? response;
+}
+
+/**
+ * Install a test package from a zip file (Fleet Cypress test packages).
+ * Zip path: fleet plugin root / cypress / packages / {pkgName}.zip
+ */
+export async function installTestPackageFromZip(
+  kbnClient: any,
+  pkgName: string,
+  zipPath?: string
+): Promise<any> {
+  const pathModule = await import('path');
+  const fs = await import('fs').then((m) => m.promises);
+  const resolvedPath =
+    zipPath ??
+    pathModule.resolve(
+      __dirname,
+      '../../../../cypress/packages',
+      `${pkgName}.zip`
+    );
+  const zipContent = await fs.readFile(resolvedPath);
+  const response = await kbnClient.request({
+    method: 'POST',
+    path: '/api/fleet/epm/packages',
+    body: zipContent,
+    headers: { 'Content-Type': 'application/zip' },
+  });
+
+  return response.data ?? response;
+}
+
+export async function uninstallTestPackage(
+  kbnClient: any,
+  pkgName: string,
+  version?: string
+): Promise<void> {
+  try {
+    const path = version ? `/api/fleet/epm/packages/${pkgName}/${version}` : `/api/fleet/epm/packages/${pkgName}`;
+    await kbnClient.request({
+      method: 'DELETE',
+      path,
+    });
+  } catch {
+    // Ignore — may already be uninstalled
+  }
+}
+
+export async function setFleetServerHost(
+  kbnClient: any,
+  host: string = 'https://fleetserver:8220'
+): Promise<void> {
+  await kbnClient.request({
+    method: 'POST',
+    path: '/api/fleet/fleet_server_hosts',
+    body: {
+      name: 'Default host',
+      host_urls: [host],
+      is_default: true,
+    },
+  });
+}
+
+export function createAgentDoc(
+  id: string,
+  policyId: string,
+  status: string = 'online',
+  version: string = '8.1.0',
+  data?: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    access_api_key_id: 'abcdefghijklmn',
+    action_seq_no: [-1],
+    active: true,
+    agent: { id, version },
+    enrolled_at: new Date().toISOString(),
+    local_metadata: {
+      elastic: {
+        agent: {
+          'build.original': version,
+          id,
+          log_level: 'info',
+          snapshot: true,
+          upgradeable: status !== 'online',
+          version,
+        },
+      },
+      host: {
+        architecture: 'x86_64',
+        hostname: id,
+        id: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+        ip: ['127.0.0.1/8'],
+        mac: ['ab:cd:12:34:56:78'],
+        name: id,
+      },
+      os: {
+        family: 'darwin',
+        full: 'Mac OS X(10.16)',
+        kernel: '21.3.0',
+        name: 'Mac OS X',
+        platform: 'darwin',
+        version: '10.16',
+      },
+    },
+    policy_id: policyId,
+    type: 'PERMANENT',
+    default_api_key: 'abcdefg',
+    default_api_key_id: 'abcd',
+    policy_output_permissions_hash: 'somehash',
+    updated_at: '2022-03-07T16:35:03Z',
+    last_checkin_status: status,
+    last_checkin: new Date().toISOString(),
+    policy_revision_idx: 1,
+    policy_coordinator_idx: 1,
+    policy_revision: 1,
+    status,
+    packages: [],
+    ...data,
+  };
+}
+
+export async function setupFleetServer(
+  kbnClient: any,
+  esClient: any,
+  kibanaVersion: string = '8.1.0'
+): Promise<string> {
+  const FLEET_SERVER_POLICY_ID = 'fleet-server-policy';
+
+  try {
+    await kbnClient.request({
+      method: 'POST',
+      path: '/api/fleet/agent_policies',
+      body: {
+        id: FLEET_SERVER_POLICY_ID,
+        name: 'Fleet Server policy',
+        namespace: 'default',
+        has_fleet_server: true,
+      },
+    });
+  } catch (e: any) {
+    if (e?.response?.status !== 409) {
+      throw e;
+    }
+  }
+
+  const agentDoc = createAgentDoc('fleet-server', FLEET_SERVER_POLICY_ID, 'online', kibanaVersion);
+  await insertDocs(esClient, '.fleet-agents', [agentDoc]);
+  await setFleetServerHost(kbnClient);
+
+  return FLEET_SERVER_POLICY_ID;
+}
+
+export async function createEnrollmentToken(
+  kbnClient: any,
+  policyId: string,
+  name?: string
+): Promise<any> {
+  const response = await kbnClient.request({
+    method: 'POST',
+    path: '/api/fleet/enrollment_api_keys',
+    body: {
+      policy_id: policyId,
+      name: name ?? `Token ${randomString()}`,
+    },
+  });
+
+  return response.data?.item ?? response.item;
+}
+
+export async function enableSpaceAwareness(kbnClient: any): Promise<void> {
+  try {
+    await kbnClient.request({
+      method: 'POST',
+      path: '/internal/fleet/enable_space_awareness',
+    });
+  } catch {
+    // May already be enabled
+  }
+}
+
+export async function createSpace(
+  kbnClient: any,
+  id: string,
+  name: string,
+  options?: { description?: string; color?: string; initials?: string }
+): Promise<any> {
+  const body = {
+    id,
+    name,
+    description: options?.description ?? 'Test space',
+    color: options?.color ?? '#aabbcc',
+    initials: options?.initials ?? 'TE',
+    disabledFeatures: [],
+    imageUrl: undefined,
+  };
+
+  const response = await kbnClient.request({
+    method: 'POST',
+    path: '/api/spaces/space',
+    body,
+  });
+
+  return response.data ?? response;
+}
+
+export async function unenrollAgents(kbnClient: any): Promise<void> {
+  try {
+    const response = await kbnClient.request({
+      method: 'GET',
+      path: '/api/fleet/agents?page=1&perPage=100&showInactive=false&showUpgradeable=false',
+    });
+    const items = response.data?.items ?? response.items ?? [];
+
+    for (const agent of items) {
+      try {
+        await kbnClient.request({
+          method: 'POST',
+          path: `/api/fleet/agents/${agent.id}/unenroll`,
+          body: { revoke: true },
+        });
+      } catch {
+        // Ignore
+      }
+    }
+  } catch {
+    // Ignore
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/selectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/selectors.ts
@@ -52,7 +52,8 @@ export const ADD_AGENT_POLICY_BTN = 'createAgentPolicyButton';
 
 export const PLATFORM_TYPE_LINUX_BUTTON = 'platformTypeLinux';
 export const ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON = 'fleetServerAddHostBtn';
-export const ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON = 'fleetServerGenerateServiceTokenBtn';
+export const ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON =
+  'fleetServerGenerateServiceTokenBtn';
 export const CREATE_FLEET_SERVER_POLICY_BTN = 'createFleetServerPolicyBtn';
 
 export const AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD = 'createAgentPolicyNameField';

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/selectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/common/selectors.ts
@@ -1,0 +1,298 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Fleet Scout test selectors - mapped from Cypress screens directory.
+ * Use page.testSubj.locator(SELECTOR) for data-test-subj elements.
+ */
+
+// Navigation
+export const TOGGLE_NAVIGATION_BTN = 'toggleNavButton';
+export const NAV_APP_LINK = 'collapsibleNavAppLink';
+export const LOADING_SPINNER = '.euiLoadingSpinner';
+export const TOAST_CLOSE_BTN = 'toastCloseButton';
+export const CONFIRM_MODAL = {
+  CONFIRM_BUTTON: 'confirmModalConfirmButton',
+  CANCEL_BUTTON: 'confirmModalCancelButton',
+};
+
+// Fleet home / main
+export const ADD_AGENT_BUTTON = 'addAgentButton';
+export const ADD_AGENT_BUTTON_TOP = 'addAgentBtnTop';
+export const LANDING_PAGE_ADD_FLEET_SERVER_BUTTON = 'fleetServerLanding.addFleetServerButton';
+export const AGENTS_TAB = 'fleet-agents-tab';
+export const AGENT_POLICIES_TAB = 'fleet-agent-policies-tab';
+export const ENROLLMENT_TOKENS_TAB = 'fleet-enrollment-tokens-tab';
+export const UNINSTALL_TOKENS_TAB = 'fleet-uninstall-tokens-tab';
+export const DATA_STREAMS_TAB = 'fleet-datastreams-tab';
+export const SETTINGS_TAB = 'fleet-settings-tab';
+
+export const MISSING_PRIVILEGES = {
+  PROMPT: 'missingPrivilegesPrompt',
+  TITLE: 'missingPrivilegesPromptTitle',
+  MESSAGE: 'missingPrivilegesPromptMessage',
+};
+
+export const FLEET_SERVER_MISSING_PRIVILEGES = {
+  PROMPT: 'fleetServerMissingPrivilegesPrompt',
+  MESSAGE: 'fleetServerMissingPrivilegesMessage',
+  TITLE: 'fleetServerMissingPrivilegesTitle',
+};
+
+export const AGENT_POLICY_SAVE_INTEGRATION = 'saveIntegration';
+export const PACKAGE_POLICY_TABLE_LINK = 'PackagePoliciesTableLink';
+export const ADD_PACKAGE_POLICY_BTN = 'addPackagePolicyButton';
+export const GENERATE_FLEET_SERVER_POLICY_BUTTON = 'generateFleetServerPolicyButton';
+export const ADD_FLEET_SERVER_HEADER = 'addFleetServerHeader';
+export const ADD_AGENT_POLICY_BTN = 'createAgentPolicyButton';
+
+export const PLATFORM_TYPE_LINUX_BUTTON = 'platformTypeLinux';
+export const ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON = 'fleetServerAddHostBtn';
+export const ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON = 'fleetServerGenerateServiceTokenBtn';
+export const CREATE_FLEET_SERVER_POLICY_BTN = 'createFleetServerPolicyBtn';
+
+export const AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD = 'createAgentPolicyNameField';
+export const AGENT_POLICIES_FLYOUT_ADVANCED_DEFAULT_NAMESPACE_HEADER = 'defaultNamespaceHeader';
+export const AGENT_POLICY_FLYOUT_CREATE_BUTTON = 'createAgentPolicyFlyoutBtn';
+export const AGENT_POLICIES_TABLE = 'agentPoliciesTable';
+
+export const ENROLLMENT_TOKENS = {
+  CREATE_TOKEN_BUTTON: 'createEnrollmentTokenButton',
+  CREATE_TOKEN_MODAL_NAME_FIELD: 'createEnrollmentTokenNameField',
+  CREATE_TOKEN_MODAL_SELECT_FIELD: 'createEnrollmentTokenSelectField',
+  LIST_TABLE: 'enrollmentTokenListTable',
+  TABLE_REVOKE_BTN: 'enrollmentTokenTable.revokeBtn',
+};
+
+export const UNINSTALL_TOKENS = {
+  POLICY_ID_SEARCH_FIELD: 'uninstallTokensPolicyIdSearchInput',
+  POLICY_ID_TABLE_FIELD: 'uninstallTokensPolicyIdField',
+  VIEW_UNINSTALL_COMMAND_BUTTON: 'uninstallTokensViewCommandButton',
+  UNINSTALL_COMMAND_FLYOUT: 'uninstall-command-flyout',
+  TOKEN_FIELD: 'apiKeyField',
+  SHOW_HIDE_TOKEN_BUTTON: 'showHideTokenButton',
+};
+
+export const SETTINGS_FLEET_SERVER_HOST_HEADING = 'fleetServerHostHeader';
+export const SETTINGS_SAVE_BTN = 'saveApplySettingsBtn';
+
+export const AGENT_POLICY_SYSTEM_MONITORING_CHECKBOX = 'agentPolicyFormSystemMonitoringCheckbox';
+export const INSTALL_INTEGRATIONS_ADVANCE_OPTIONS_BTN = 'AgentPolicyAdvancedOptions.AccordionBtn';
+export const AGENT_POLICY_CREATE_STATUS_CALLOUT = 'agentPolicyCreateStatusCallOut';
+
+export const EXISTING_HOSTS_TAB = 'existingHostsTab';
+export const NEW_HOSTS_TAB = 'newHostsTab';
+
+export const AGENT_FLYOUT = {
+  CREATE_POLICY_BUTTON: 'createPolicyBtn',
+  CLOSE_BUTTON: 'euiFlyoutCloseButton',
+  POLICY_DROPDOWN: 'agentPolicyDropdown',
+  QUICK_START_TAB_BUTTON: 'fleetServerFlyoutTab-quickStart',
+  ADVANCED_TAB_BUTTON: 'fleetServerFlyoutTab-advanced',
+  AGENT_POLICY_CODE_BLOCK: 'agentPolicyCodeBlock',
+  STANDALONE_TAB: 'standaloneTab',
+  MANAGED_TAB: 'managedTab',
+  CONFIRM_AGENT_ENROLLMENT_BUTTON: 'ConfirmAgentEnrollmentButton',
+  INCOMING_DATA_CONFIRMED_CALL_OUT: 'IncomingDataConfirmedCallOut',
+  PLATFORM_SELECTOR_EXTENDED: 'platformSelectorExtended',
+  KUBERNETES_PLATFORM_TYPE: 'platformTypeKubernetes',
+};
+
+export const AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT = {
+  TITLE: 'createAgentPolicyFlyoutTitle',
+  CREATE_BUTTON: 'createAgentPolicyButton',
+  ADVANCED_OPTIONS_TOGGLE: 'advancedOptionsButton',
+  COLLECT_LOGS_CHECKBOX: 'collectLogsCheckbox',
+  COLLECT_METRICS_CHECKBOX: 'collectMetricsCheckbox',
+};
+
+export const AGENT_BINARY_SOURCES_TABLE = 'AgentDownloadSourcesTable';
+export const AGENT_BINARY_SOURCES_TABLE_ACTIONS = {
+  DEFAULT_VALUE: 'editDownloadSourceTable.defaultIcon',
+  HOST: 'editDownloadSourceTable.host',
+  ADD: 'addDownloadSourcesBtn',
+  EDIT: 'editDownloadSourceTable.edit.btn',
+  DELETE: 'editDownloadSourceTable.delete.btn',
+  DEFAULT_ICON: 'editDownloadSourceTable.defaultIcon',
+  HOST_NAME: 'editDownloadSourceTable.host',
+};
+export const AGENT_BINARY_SOURCES_FLYOUT = {
+  NAME_INPUT: 'editDownloadSourcesFlyout.nameInput',
+  HOST_INPUT: 'editDownloadSourcesFlyout.hostInput',
+  IS_DEFAULT_SWITCH: 'editDownloadSourcesFlyout.isDefaultSwitch',
+  SUBMIT_BUTTON: 'editDownloadSourcesFlyout.submitBtn',
+  CANCEL_BUTTON: 'editDownloadSourcesFlyout.cancelBtn',
+};
+
+export const SETTINGS_OUTPUTS = {
+  EDIT_BTN: 'editOutputBtn',
+  ADD_BTN: 'addOutputBtn',
+  TABLE: 'settingsOutputsTable',
+  NAME_INPUT: 'settingsOutputsFlyout.nameInput',
+  TYPE_INPUT: 'settingsOutputsFlyout.typeInput',
+  ADD_HOST_ROW_BTN: 'fleetServerHosts.multiRowInput.addRowButton',
+  WARNING_ELASTICSEARCH_CALLOUT: 'settingsOutputsFlyout.elasticsearchOutputTypeCallout',
+  PRESET_INPUT: 'settingsOutputsFlyout.presetInput',
+  SSL_BUTTON: 'advancedSSLOptionsButton',
+};
+
+export const SETTINGS_OUTPUTS_KAFKA = {
+  VERSION_SELECT: 'settingsOutputsFlyout.kafkaVersionInput',
+  AUTHENTICATION_SELECT: 'settingsOutputsFlyout.kafkaAuthenticationRadioInput',
+  AUTHENTICATION_NONE_OPTION: 'kafkaAuthenticationNoneRadioButton',
+  AUTHENTICATION_USERNAME_PASSWORD_OPTION: 'kafkaAuthenticationUsernamePasswordRadioButton',
+  AUTHENTICATION_SSL_OPTION: 'kafkaAuthenticationSSLRadioButton',
+  AUTHENTICATION_KERBEROS_OPTION: 'kafkaAuthenticationKerberosRadioButton',
+  AUTHENTICATION_USERNAME_INPUT: 'settingsOutputsFlyout.kafkaUsernameInput',
+  AUTHENTICATION_PASSWORD_INPUT: 'settingsOutputsFlyout.kafkaPasswordSecretInput',
+  AUTHENTICATION_VERIFICATION_MODE_INPUT: 'settingsOutputsFlyout.kafkaVerificationModeInput',
+  AUTHENTICATION_CONNECTION_TYPE_SELECT: 'settingsOutputsFlyout.kafkaConnectionTypeRadioInput',
+  AUTHENTICATION_CONNECTION_TYPE_PLAIN_OPTION: 'kafkaConnectionTypePlaintextRadioButton',
+  AUTHENTICATION_CONNECTION_TYPE_ENCRYPTION_OPTION: 'kafkaConnectionTypeEncryptionRadioButton',
+  AUTHENTICATION_SASL_SELECT: 'settingsOutputsFlyout.kafkaSaslInput',
+  AUTHENTICATION_SASL_PLAIN_OPTION: 'kafkaSaslPlainRadioButton',
+  AUTHENTICATION_SASL_SCRAM_256_OPTION: 'kafkaSaslScramSha256RadioButton',
+  AUTHENTICATION_SASL_SCRAM_512_OPTION: 'kafkaSaslScramSha512RadioButton',
+  PARTITIONING_PANEL: 'settingsOutputsFlyout.kafkaPartitionPanel',
+  PARTITIONING_SELECT: 'settingsOutputsFlyout.kafkaPartitioningRadioInput',
+  PARTITIONING_RANDOM_OPTION: 'kafkaPartitionRandomRadioButton',
+  PARTITIONING_HASH_OPTION: 'kafkaPartitionHashRadioButton',
+  PARTITIONING_ROUND_ROBIN_OPTION: 'kafkaPartitionRoundRobinRadioButton',
+  PARTITIONING_EVENTS_INPUT: 'settingsOutputsFlyout.kafkaPartitionTypeRandomInput',
+  PARTITIONING_HASH_INPUT: 'settingsOutputsFlyout.kafkaPartitionTypeHashInput',
+  TOPICS_PANEL: 'settingsOutputsFlyout.kafkaTopicsPanel',
+  TOPICS_DEFAULT_TOPIC_INPUT: 'settingsOutputsFlyout.kafkaStaticTopicInput',
+  TOPICS_DYNAMIC_TOPIC_INPUT: 'settingsOutputsFlyout.kafkaDynamicTopicInput',
+  HEADERS_PANEL: 'settingsOutputsFlyout.kafkaHeadersPanel',
+  HEADERS_KEY_INPUT: 'settingsOutputsFlyout.kafkaHeadersKeyInput0',
+  HEADERS_VALUE_INPUT: 'settingsOutputsFlyout.kafkaHeadersValueInput0',
+  HEADERS_ADD_ROW_BUTTON: 'kafkaHeaders.multiRowInput.addRowButton',
+  HEADERS_REMOVE_ROW_BUTTON: 'settingsOutputsFlyout.kafkaHeadersDeleteButton0',
+  HEADERS_CLIENT_ID_INPUT: 'settingsOutputsFlyout.kafkaClientIdInput',
+  COMPRESSION_PANEL: 'settingsOutputsFlyout.kafkaCompressionPanel',
+  COMPRESSION_SWITCH: 'settingsOutputsFlyout.kafkaCompressionSwitch',
+  COMPRESSION_CODEC_INPUT: 'settingsOutputsFlyout.kafkaCompressionCodecInput',
+  COMPRESSION_LEVEL_INPUT: 'settingsOutputsFlyout.kafkaCompressionLevelInput',
+  BROKER_PANEL: 'settingsOutputsFlyout.kafkaBrokerSettingsPanel',
+  BROKER_TIMEOUT_SELECT: 'settingsOutputsFlyout.kafkaBrokerTimeoutInput',
+  BROKER_REACHABILITY_TIMEOUT_SELECT: 'settingsOutputsFlyout.kafkaBrokerReachabilityTimeoutInput',
+  BROKER_ACK_RELIABILITY_SELECT: 'settingsOutputsFlyout.kafkaBrokerAckReliabilityInputLabel',
+  KEY_INPUT: 'settingsOutputsFlyout.kafkaKeyInput',
+};
+
+export const SETTINGS_FLEET_SERVER_HOSTS = {
+  ADD_BUTTON: 'settings.fleetServerHosts.addFleetServerHostBtn',
+  EDIT_BUTTON: 'fleetServerHostsTable.edit.btn',
+  TABLE: 'settingsFleetServerHostsTable',
+};
+
+export const AGENT_POLICY_FORM = {
+  DOWNLOAD_SOURCE_SELECT: 'agentPolicyForm.downloadSource.select',
+};
+
+export const FLEET_AGENT_LIST_PAGE = {
+  TABLE: 'fleetAgentListTable',
+  STATUS_FILTER: 'agentList.statusFilter',
+  TAGS_FILTER: 'agentList.tagsFilter',
+  POLICY_FILTER: 'agentList.policyFilter',
+  QUERY_INPUT: 'agentList.queryInput',
+  SHOW_UPGRADEABLE: 'agentList.showUpgradeable',
+  CHECKBOX_SELECT_ALL: 'checkboxSelectAll',
+  BULK_ACTIONS_BUTTON: 'agentBulkActionsButton',
+  ACTIVITY_BUTTON: 'agentActivityButton',
+  ACTIVITY_FLYOUT: {
+    FLYOUT_ID: 'agentActivityFlyout',
+    CLOSE_BUTTON: 'euiFlyoutCloseButton',
+  },
+  BULK_ACTIONS: {
+    ADD_REMOVE_TAG_INPUT: 'addRemoveTags',
+  },
+};
+
+export const FLEET_SERVER_HOST_FLYOUT = {
+  NAME_INPUT: 'fleetServerHostsFlyout.nameInput',
+  DEFAULT_SWITCH: 'fleetServerHostsFlyout.isDefaultSwitch',
+};
+
+export const FLEET_SERVER_SETUP = {
+  NAME_INPUT: 'fleetServerSetup.nameInput',
+  HOST_INPUT: 'fleetServerSetup.multiRowInput',
+  DEFAULT_SWITCH: 'fleetServerHostsFlyout.isDefaultSwitch',
+  ADD_HOST_BTN: 'fleetServerSetup.addNewHostBtn',
+  SELECT_HOSTS: 'fleetServerSetup.fleetServerHostsSelect',
+};
+
+export const AGENT_POLICY_DETAILS_PAGE = {
+  ADD_AGENT_LINK: 'addAgentLink',
+  SETTINGS_TAB: 'agentPolicySettingsTab',
+  SPACE_SELECTOR_COMBOBOX: 'spaceSelectorComboBox',
+  SAVE_BUTTON: 'agentPolicyDetailsSaveButton',
+};
+
+// Integrations
+export const ADD_INTEGRATION_POLICY_BTN = 'addIntegrationPolicyButton';
+export const CREATE_PACKAGE_POLICY_SAVE_BTN = 'createPackagePolicySaveButton';
+export const INTEGRATION_NAME_LINK = 'integrationNameLink';
+export const AGENT_POLICY_NAME_LINK = 'agentPolicyNameLink';
+export const AGENT_ACTIONS_BTN = 'agentActionsBtn';
+export const SETTINGS_TAB_INTEGRATIONS = 'tab-settings';
+export const POLICIES_TAB = 'tab-policies';
+export const ADVANCED_TAB = 'tab-custom';
+export const UPDATE_PACKAGE_BTN = 'updatePackageBtn';
+export const LATEST_VERSION = 'epmSettings.latestVersionTitle';
+export const INSTALLED_VERSION = 'epmSettings.installedVersionTitle';
+export const PACKAGE_VERSION = 'packageVersionText';
+export const INTEGRATION_LIST = 'epmList.integrationCards';
+export const INTEGRATIONS_SEARCHBAR = {
+  INPUT: 'epmList.searchBar',
+  BADGE: 'epmList.categoryBadge',
+  REMOVE_BADGE_BUTTON: 'epmList.categoryBadge.closeBtn',
+};
+export const POLICY_EDITOR = {
+  POLICY_NAME_INPUT: 'packagePolicyNameInput',
+  DATASET_SELECT: 'datasetComboBox',
+  AGENT_POLICY_SELECT: 'agentPolicyMultiSelect',
+  AGENT_POLICY_CLEAR: 'comboBoxClearButton',
+  INSPECT_PIPELINES_BTN: 'datastreamInspectPipelineBtn',
+  EDIT_MAPPINGS_BTN: 'datastreamEditMappingsBtn',
+  CREATE_MAPPINGS_BTN: 'datastreamAddCustomComponentTemplateBtn',
+};
+
+// Integration automatic import
+export const UPLOAD_PACKAGE_LINK = 'uploadPackageLink';
+export const ASSISTANT_BUTTON = 'assistantButton';
+export const MISSING_PRIVILEGES_AUTOMATIC_IMPORT = 'missingPrivilegesCallOut';
+export const BUTTON_FOOTER_NEXT = 'buttonsFooter-nextButton';
+export const INTEGRATION_TITLE_INPUT = 'integrationTitleInput';
+export const INTEGRATION_DESCRIPTION_INPUT = 'integrationDescriptionInput';
+export const DATASTREAM_TITLE_INPUT = 'dataStreamTitleInput';
+export const DATASTREAM_DESCRIPTION_INPUT = 'dataStreamDescriptionInput';
+export const DATASTREAM_NAME_INPUT = 'dataStreamNameInput';
+export const DATA_COLLECTION_METHOD_INPUT = 'dataCollectionMethodInput';
+export const LOGS_SAMPLE_FILE_PICKER = 'logsSampleFilePicker';
+export const LICENSE_PAYWALL_CARD = 'LicensePaywallCard';
+export const EDIT_PIPELINE_BUTTON = 'editPipelineButton';
+export const SAVE_PIPELINE_BUTTON = 'savePipelineButton';
+export const VIEW_INTEGRATION_BUTTON = 'viewIntegrationButton';
+export const INTEGRATION_SUCCESS_SECTION = 'integrationSuccessSection';
+export const SAVE_ZIP_BUTTON = 'saveZipButton';
+
+// Assets
+export const ASSETS_PAGE = {
+  TAB: 'tab-assets',
+  getButtonId: (type: string) => `fleetAssetsAccordion.button.${type}`,
+  getContentId: (type: string, id?: string | number) =>
+    `fleetAssetsAccordion.content.${type}${id ? `.${id}` : ''}`,
+};
+
+export function getIntegrationCard(integration: string): string {
+  return `integration-card:epr:${integration}`;
+}
+
+export function getIntegrationCategories(category: string): string {
+  return `epmList.categories.${category}`;
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
@@ -37,10 +37,7 @@ export const test = baseTest.extend<FleetTestFixtures, ScoutWorkerFixtures>({
       return response;
     }) as ScoutPage['goto'];
 
-    page.gotoApp = (async (
-      appName: string,
-      options?: Parameters<ScoutPage['gotoApp']>[1]
-    ) => {
+    page.gotoApp = (async (appName: string, options?: Parameters<ScoutPage['gotoApp']>[1]) => {
       await originalGotoApp(appName, options);
       await waitForPageReady(page);
     }) as ScoutPage['gotoApp'];

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
@@ -18,12 +18,11 @@ export interface FleetTestFixtures extends ScoutTestFixtures {
 const LOADING_INDICATOR = 'globalLoadingIndicator';
 
 async function waitForPageReady(page: ScoutPage) {
-  await page.testSubj
-    .locator(LOADING_INDICATOR)
-    .waitFor({ state: 'hidden', timeout: 30_000 })
-    .catch(() => {
-      // Indicator may never appear for already-loaded pages
-    });
+  try {
+    await page.testSubj.locator(LOADING_INDICATOR).waitFor({ state: 'hidden', timeout: 30_000 });
+  } catch {
+    // Indicator may never appear for already-loaded pages
+  }
 }
 
 export const test = baseTest.extend<FleetTestFixtures, ScoutWorkerFixtures>({
@@ -38,8 +37,9 @@ export const test = baseTest.extend<FleetTestFixtures, ScoutWorkerFixtures>({
     }) as ScoutPage['goto'];
 
     page.gotoApp = (async (appName: string, options?: Parameters<ScoutPage['gotoApp']>[1]) => {
-      await originalGotoApp(appName, options);
+      const response = await originalGotoApp(appName, options);
       await waitForPageReady(page);
+      return response;
     }) as ScoutPage['gotoApp'];
 
     await use(page);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ScoutPage, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
+import type { ScoutPage, ScoutTestFixtures, ScoutWorkerFixtures, KibanaUrl } from '@kbn/scout';
 import { test as baseTest } from '@kbn/scout';
 
 import type { FleetPageObjects } from './page_objects';
@@ -26,12 +26,16 @@ async function waitForPageReady(page: ScoutPage) {
 }
 
 export const test = baseTest.extend<FleetTestFixtures, ScoutWorkerFixtures>({
-  page: async ({ page }: { page: ScoutPage }, use: (page: ScoutPage) => Promise<void>) => {
+  page: async (
+    { page, kbnUrl }: { page: ScoutPage; kbnUrl: KibanaUrl },
+    use: (page: ScoutPage) => Promise<void>
+  ) => {
     const originalGoto = page.goto.bind(page);
     const originalGotoApp = page.gotoApp.bind(page);
 
     page.goto = (async (url: string, options?: Parameters<ScoutPage['goto']>[1]) => {
-      const response = await originalGoto(url, options);
+      const resolvedUrl = url.startsWith('/') ? kbnUrl.get(url) : url;
+      const response = await originalGoto(resolvedUrl, options);
       await waitForPageReady(page);
       return response;
     }) as ScoutPage['goto'];

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
@@ -8,23 +8,23 @@
 import type { ScoutPage, ScoutTestFixtures, ScoutWorkerFixtures } from '@kbn/scout';
 import { test as baseTest } from '@kbn/scout';
 
-import type { StreamsPageObjects } from './page_objects';
+import type { FleetPageObjects } from './page_objects';
 import { extendPageObjects } from './page_objects';
 
-export interface StreamsTestFixtures extends ScoutTestFixtures {
-  pageObjects: StreamsPageObjects;
+export interface FleetTestFixtures extends ScoutTestFixtures {
+  pageObjects: FleetPageObjects;
 }
 
-export const test = baseTest.extend<StreamsTestFixtures, ScoutWorkerFixtures>({
+export const test = baseTest.extend<FleetTestFixtures, ScoutWorkerFixtures>({
   pageObjects: async (
     {
       pageObjects,
       page,
     }: {
-      pageObjects: StreamsPageObjects;
+      pageObjects: FleetPageObjects;
       page: ScoutPage;
     },
-    use: (pageObjects: StreamsPageObjects) => Promise<void>
+    use: (pageObjects: FleetPageObjects) => Promise<void>
   ) => {
     const extendedPageObjects = extendPageObjects(pageObjects, page);
     await use(extendedPageObjects);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/index.ts
@@ -15,7 +15,38 @@ export interface FleetTestFixtures extends ScoutTestFixtures {
   pageObjects: FleetPageObjects;
 }
 
+const LOADING_INDICATOR = 'globalLoadingIndicator';
+
+async function waitForPageReady(page: ScoutPage) {
+  await page.testSubj
+    .locator(LOADING_INDICATOR)
+    .waitFor({ state: 'hidden', timeout: 30_000 })
+    .catch(() => {
+      // Indicator may never appear for already-loaded pages
+    });
+}
+
 export const test = baseTest.extend<FleetTestFixtures, ScoutWorkerFixtures>({
+  page: async ({ page }: { page: ScoutPage }, use: (page: ScoutPage) => Promise<void>) => {
+    const originalGoto = page.goto.bind(page);
+    const originalGotoApp = page.gotoApp.bind(page);
+
+    page.goto = (async (url: string, options?: Parameters<ScoutPage['goto']>[1]) => {
+      const response = await originalGoto(url, options);
+      await waitForPageReady(page);
+      return response;
+    }) as ScoutPage['goto'];
+
+    page.gotoApp = (async (
+      appName: string,
+      options?: Parameters<ScoutPage['gotoApp']>[1]
+    ) => {
+      await originalGotoApp(appName, options);
+      await waitForPageReady(page);
+    }) as ScoutPage['gotoApp'];
+
+    await use(page);
+  },
   pageObjects: async (
     {
       pageObjects,

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_flyout_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_flyout_page.ts
@@ -21,7 +21,9 @@ export class AgentFlyoutPage {
   async openFromLanding() {
     await this.page.gotoApp('fleet');
     await this.page.testSubj.locator(LANDING_PAGE_ADD_FLEET_SERVER_BUTTON).click();
-    await this.page.testSubj.locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+    await this.page.testSubj
+      .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
   }
 
   getQuickStartTab() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_flyout_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_flyout_page.ts
@@ -90,6 +90,6 @@ export class AgentFlyoutPage {
     await this.getFleetServerSetupSelectHosts().click();
     await this.getFleetServerSetupAddHostButton().click();
     await this.getFleetServerSetupNameInput().fill(name);
-    await this.page.locator('[placeholder="Specify host URL"]').first().fill(hostUrl);
+    await this.page.getByPlaceholder('Specify host URL').fill(hostUrl);
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_flyout_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_flyout_page.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import {
+  AGENT_FLYOUT,
+  LANDING_PAGE_ADD_FLEET_SERVER_BUTTON,
+  FLEET_SERVER_SETUP,
+  PLATFORM_TYPE_LINUX_BUTTON,
+  ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON,
+  ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON,
+} from '../../common/selectors';
+
+export class AgentFlyoutPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async openFromLanding() {
+    await this.page.gotoApp('fleet');
+    await this.page.testSubj.locator(LANDING_PAGE_ADD_FLEET_SERVER_BUTTON).click();
+    await this.page.testSubj.locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+  }
+
+  getQuickStartTab() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON);
+  }
+
+  getAdvancedTab() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.ADVANCED_TAB_BUTTON);
+  }
+
+  getCloseButton() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.CLOSE_BUTTON);
+  }
+
+  getCreatePolicyButton() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.CREATE_POLICY_BUTTON);
+  }
+
+  getPolicyDropdown() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.POLICY_DROPDOWN);
+  }
+
+  getConfirmAgentEnrollmentButton() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.CONFIRM_AGENT_ENROLLMENT_BUTTON);
+  }
+
+  getIncomingDataConfirmedCallOut() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.INCOMING_DATA_CONFIRMED_CALL_OUT);
+  }
+
+  getPlatformSelectorExtended() {
+    return this.page.testSubj.locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED);
+  }
+
+  getLinuxPlatformButton() {
+    return this.page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON);
+  }
+
+  getFleetServerSetupSelectHosts() {
+    return this.page.testSubj.locator(FLEET_SERVER_SETUP.SELECT_HOSTS);
+  }
+
+  getFleetServerSetupAddHostButton() {
+    return this.page.testSubj.locator(FLEET_SERVER_SETUP.ADD_HOST_BTN);
+  }
+
+  getFleetServerSetupNameInput() {
+    return this.page.testSubj.locator(FLEET_SERVER_SETUP.NAME_INPUT);
+  }
+
+  getAddHostButton() {
+    return this.page.testSubj.locator(ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON);
+  }
+
+  getGenerateServiceTokenButton() {
+    return this.page.testSubj.locator(ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON);
+  }
+
+  async switchToAdvancedTab() {
+    await this.getAdvancedTab().click();
+  }
+
+  async addFleetServerHost(name: string, hostUrl: string) {
+    await this.getFleetServerSetupSelectHosts().click();
+    await this.getFleetServerSetupAddHostButton().click();
+    await this.getFleetServerSetupNameInput().fill(name);
+    await this.page.locator('[placeholder="Specify host URL"]').first().fill(hostUrl);
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
@@ -13,7 +13,9 @@ export class AgentListPage {
 
   async navigateTo() {
     await this.page.gotoApp('fleet');
-    await this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).waitFor({ state: 'visible', timeout: 20_000 });
+    await this.page.testSubj
+      .locator(FLEET_AGENT_LIST_PAGE.TABLE)
+      .waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   getTable() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import { FLEET_AGENT_LIST_PAGE } from '../../common/selectors';
+
+export class AgentListPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async navigateTo() {
+    await this.page.gotoApp('fleet');
+    await this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).waitFor({ state: 'visible', timeout: 20_000 });
+  }
+
+  getTable() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE);
+  }
+
+  getQueryInput() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.QUERY_INPUT);
+  }
+
+  getStatusFilter() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.STATUS_FILTER);
+  }
+
+  getTagsFilter() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TAGS_FILTER);
+  }
+
+  getPolicyFilter() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.POLICY_FILTER);
+  }
+
+  getShowUpgradeable() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.SHOW_UPGRADEABLE);
+  }
+
+  getCheckboxSelectAll() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.CHECKBOX_SELECT_ALL);
+  }
+
+  getBulkActionsButton() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.BULK_ACTIONS_BUTTON);
+  }
+
+  getActivityButton() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.ACTIVITY_BUTTON);
+  }
+
+  getAddRemoveTagInput() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.BULK_ACTIONS.ADD_REMOVE_TAG_INPUT);
+  }
+
+  getActivityFlyoutCloseButton() {
+    return this.page.testSubj.locator(FLEET_AGENT_LIST_PAGE.ACTIVITY_FLYOUT.CLOSE_BUTTON);
+  }
+
+  async selectPolicyFilterOption(optionText: string) {
+    await this.getPolicyFilter().click();
+    await this.page.getByText(optionText).first().click();
+  }
+
+  async selectStatusFilterOption(optionText: string) {
+    await this.getStatusFilter().click();
+    await this.page.getByText(optionText).first().click({ force: true });
+  }
+
+  async selectTagsFilterOption(optionText: string) {
+    await this.getTagsFilter().click();
+    await this.page.getByText(optionText).first().click();
+  }
+
+  async clickBulkAction(buttonText: string) {
+    await this.page.getByRole('button', { name: buttonText }).first().click();
+  }
+
+  async clickSubmenuAction(buttonText: string) {
+    await this.page.getByRole('button', { name: buttonText }).first().click();
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
@@ -64,23 +64,17 @@ export class AgentListPage {
 
   async selectPolicyFilterOption(optionText: string) {
     await this.getPolicyFilter().click();
-    await this.page
-      .getByRole('option', { name: optionText })
-      .click();
+    await this.page.getByRole('option', { name: optionText }).click();
   }
 
   async selectStatusFilterOption(optionText: string) {
     await this.getStatusFilter().click();
-    await this.page
-      .getByRole('option', { name: optionText })
-      .click();
+    await this.page.getByRole('option', { name: optionText }).click();
   }
 
   async selectTagsFilterOption(optionText: string) {
     await this.getTagsFilter().click();
-    await this.page
-      .getByRole('option', { name: optionText })
-      .click();
+    await this.page.getByRole('option', { name: optionText }).click();
   }
 
   async clickBulkAction(buttonText: string) {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_list_page.ts
@@ -64,24 +64,33 @@ export class AgentListPage {
 
   async selectPolicyFilterOption(optionText: string) {
     await this.getPolicyFilter().click();
-    await this.page.getByText(optionText).first().click();
+    await this.page
+      .getByRole('option', { name: optionText })
+      .click();
   }
 
   async selectStatusFilterOption(optionText: string) {
     await this.getStatusFilter().click();
-    await this.page.getByText(optionText).first().click({ force: true });
+    await this.page
+      .getByRole('option', { name: optionText })
+      .click();
   }
 
   async selectTagsFilterOption(optionText: string) {
     await this.getTagsFilter().click();
-    await this.page.getByText(optionText).first().click();
+    await this.page
+      .getByRole('option', { name: optionText })
+      .click();
   }
 
   async clickBulkAction(buttonText: string) {
-    await this.page.getByRole('button', { name: buttonText }).first().click();
+    await this.getBulkActionsButton()
+      .locator('..')
+      .getByRole('button', { name: buttonText })
+      .click();
   }
 
   async clickSubmenuAction(buttonText: string) {
-    await this.page.getByRole('button', { name: buttonText }).first().click();
+    await this.page.getByRole('menuitem', { name: buttonText }).click();
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_policy_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_policy_page.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import {
+  AGENT_POLICY_DETAILS_PAGE,
+  AGENT_POLICIES_TABLE,
+  ADD_AGENT_POLICY_BTN,
+  AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD,
+  AGENT_POLICY_FLYOUT_CREATE_BUTTON,
+  AGENT_POLICY_SYSTEM_MONITORING_CHECKBOX,
+  AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT,
+  AGENT_POLICY_FORM,
+} from '../../common/selectors';
+
+export class AgentPolicyPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async navigateToPolicies() {
+    await this.page.gotoApp('fleet');
+    await this.page.testSubj.locator('fleet-agent-policies-tab').click();
+    await this.page.testSubj.locator(AGENT_POLICIES_TABLE).waitFor({ state: 'visible', timeout: 15_000 });
+  }
+
+  async navigateToPolicySettings(policyId: string) {
+    await this.page.goto(`/app/fleet/policies/${policyId}/settings`);
+    await this.page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SETTINGS_TAB).waitFor({ state: 'visible', timeout: 15_000 });
+  }
+
+  getCreateAgentPolicyButton() {
+    return this.page.testSubj.locator(ADD_AGENT_POLICY_BTN);
+  }
+
+  getCreateFlyoutButton() {
+    return this.page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON);
+  }
+
+  getNameField() {
+    return this.page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD);
+  }
+
+  getSystemMonitoringCheckbox() {
+    return this.page.testSubj.locator(AGENT_POLICY_SYSTEM_MONITORING_CHECKBOX);
+  }
+
+  getFlyoutCreateButton() {
+    return this.page.testSubj.locator(AGENT_POLICY_FLYOUT_CREATE_BUTTON);
+  }
+
+  getSettingsTab() {
+    return this.page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SETTINGS_TAB);
+  }
+
+  getSpaceSelectorComboBox() {
+    return this.page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SPACE_SELECTOR_COMBOBOX);
+  }
+
+  getSaveButton() {
+    return this.page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SAVE_BUTTON);
+  }
+
+  getDownloadSourceSelect() {
+    return this.page.testSubj.locator(AGENT_POLICY_FORM.DOWNLOAD_SOURCE_SELECT);
+  }
+
+  async createAgentPolicy(name: string, options?: { uncheckSystemMonitoring?: boolean }) {
+    await this.getCreateFlyoutButton().click();
+    await this.page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE).waitFor({ state: 'visible', timeout: 15_000 });
+    await this.getNameField().fill(name);
+    if (options?.uncheckSystemMonitoring) {
+      await this.getSystemMonitoringCheckbox().uncheck();
+    }
+    await this.getFlyoutCreateButton().click();
+  }
+
+  getPolicyLink(title: string) {
+    return this.page.getByRole('link', { name: title });
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_policy_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/agent_policy_page.ts
@@ -23,12 +23,16 @@ export class AgentPolicyPage {
   async navigateToPolicies() {
     await this.page.gotoApp('fleet');
     await this.page.testSubj.locator('fleet-agent-policies-tab').click();
-    await this.page.testSubj.locator(AGENT_POLICIES_TABLE).waitFor({ state: 'visible', timeout: 15_000 });
+    await this.page.testSubj
+      .locator(AGENT_POLICIES_TABLE)
+      .waitFor({ state: 'visible', timeout: 15_000 });
   }
 
   async navigateToPolicySettings(policyId: string) {
     await this.page.goto(`/app/fleet/policies/${policyId}/settings`);
-    await this.page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SETTINGS_TAB).waitFor({ state: 'visible', timeout: 15_000 });
+    await this.page.testSubj
+      .locator(AGENT_POLICY_DETAILS_PAGE.SETTINGS_TAB)
+      .waitFor({ state: 'visible', timeout: 15_000 });
   }
 
   getCreateAgentPolicyButton() {
@@ -69,7 +73,9 @@ export class AgentPolicyPage {
 
   async createAgentPolicy(name: string, options?: { uncheckSystemMonitoring?: boolean }) {
     await this.getCreateFlyoutButton().click();
-    await this.page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE).waitFor({ state: 'visible', timeout: 15_000 });
+    await this.page.testSubj
+      .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE)
+      .waitFor({ state: 'visible', timeout: 15_000 });
     await this.getNameField().fill(name);
     if (options?.uncheckSystemMonitoring) {
       await this.getSystemMonitoringCheckbox().uncheck();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/browse_integrations_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/browse_integrations_page.ts
@@ -6,7 +6,6 @@
  */
 
 import { type ScoutPage } from '@kbn/scout';
-import { expect } from '@kbn/scout/ui';
 import { APP_MAIN_SCROLL_CONTAINER_ID } from '@kbn/core-chrome-layout-constants';
 
 export class BrowseIntegrationPage {
@@ -17,16 +16,16 @@ export class BrowseIntegrationPage {
   }
 
   async searchForIntegration(integrationName: string) {
-    const searchInput = this.page.getByTestId('browseIntegrations.searchBar.input');
+    const searchInput = this.page.testSubj.locator('browseIntegrations.searchBar.input');
     await searchInput.fill(integrationName);
   }
 
   async sortIntegrations(sort: 'z-a' | 'a-z') {
-    await this.page.getByTestId('browseIntegrations.searchBar.sortBtn').click();
+    await this.page.testSubj.locator('browseIntegrations.searchBar.sortBtn').click();
     if (sort === 'z-a') {
-      await this.page.getByTestId('browseIntegrations.searchBar.sortByZAOption').click();
+      await this.page.testSubj.locator('browseIntegrations.searchBar.sortByZAOption').click();
     } else {
-      await this.page.getByTestId('browseIntegrations.searchBar.sortByAZOption').click();
+      await this.page.testSubj.locator('browseIntegrations.searchBar.sortByAZOption').click();
     }
   }
 
@@ -62,10 +61,10 @@ export class BrowseIntegrationPage {
   }
 
   getMainColumn() {
-    return this.page.getByTestId('epmList.mainColumn');
+    return this.page.testSubj.locator('epmList.mainColumn');
   }
 
-  async expectIntegrationCardToBeVisible(integrationName: string) {
-    return expect(this.page.getByTestId(`integration-card:epr:${integrationName}`)).toBeVisible();
+  getIntegrationCard(integrationName: string) {
+    return this.page.testSubj.locator(`integration-card:epr:${integrationName}`);
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
@@ -15,14 +15,12 @@ export class CopyIntegrationPage {
   }
 
   async waitForPageToLoad() {
-    await this.page.testSubj.waitForSelector('fleetSetupLoading', {
-      state: 'hidden',
-      timeout: 30_000,
-    });
-    await this.page.testSubj.waitForSelector('createPackagePolicy_page', {
-      state: 'visible',
-      timeout: 20_000,
-    });
+    await this.page.testSubj
+      .locator('fleetSetupLoading')
+      .waitFor({ state: 'hidden', timeout: 30_000 });
+    await this.page.testSubj
+      .locator('createPackagePolicy_page')
+      .waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   getPackagePolicyNameInput() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/enrollment_tokens_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/enrollment_tokens_page.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import { ENROLLMENT_TOKENS, CONFIRM_MODAL } from '../../common/selectors';
+
+export class EnrollmentTokensPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async navigateTo() {
+    await this.page.goto('/app/fleet/enrollment-tokens');
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  getCreateTokenButton() {
+    return this.page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON);
+  }
+
+  getNameField() {
+    return this.page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD);
+  }
+
+  getPolicySelectField() {
+    return this.page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_SELECT_FIELD);
+  }
+
+  getConfirmButton() {
+    return this.page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON);
+  }
+
+  getListTable() {
+    return this.page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE);
+  }
+
+  getRevokeButtons() {
+    return this.page.testSubj.locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN);
+  }
+
+  async createToken(name: string, policyName?: string) {
+    await this.getCreateTokenButton().click();
+    await this.getNameField().waitFor({ state: 'visible', timeout: 15_000 });
+    await this.getNameField().clear();
+    await this.getNameField().fill(name);
+    if (policyName) {
+      await this.getPolicySelectField().locator('input').fill(`${policyName}`);
+      await this.page.getByRole('option').filter({ hasText: policyName }).first().click();
+    } else {
+      await this.getPolicySelectField().locator('input').press('ArrowDown');
+      await this.getPolicySelectField().locator('input').press('Enter');
+    }
+    await this.getConfirmButton().click();
+  }
+
+  async revokeFirstToken() {
+    await this.getRevokeButtons().first().click();
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/enrollment_tokens_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/enrollment_tokens_page.ts
@@ -13,7 +13,7 @@ export class EnrollmentTokensPage {
 
   async navigateTo() {
     await this.page.goto('/app/fleet/enrollment-tokens');
-    await this.page.waitForLoadState('networkidle');
+    await this.getListTable().waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   getCreateTokenButton() {
@@ -46,16 +46,17 @@ export class EnrollmentTokensPage {
     await this.getNameField().clear();
     await this.getNameField().fill(name);
     if (policyName) {
-      await this.getPolicySelectField().locator('input').fill(`${policyName}`);
-      await this.page.getByRole('option').filter({ hasText: policyName }).first().click();
+      await this.getPolicySelectField().getByRole('textbox').fill(`${policyName}`);
+      await this.page.getByRole('option', { name: policyName }).click();
     } else {
-      await this.getPolicySelectField().locator('input').press('ArrowDown');
-      await this.getPolicySelectField().locator('input').press('Enter');
+      await this.getPolicySelectField().getByRole('textbox').press('ArrowDown');
+      await this.getPolicySelectField().getByRole('textbox').press('Enter');
     }
     await this.getConfirmButton().click();
   }
 
-  async revokeFirstToken() {
-    await this.getRevokeButtons().first().click();
+  async revokeToken(policyName: string) {
+    const row = this.getListTable().getByRole('row', { name: policyName });
+    await row.locator(this.page.testSubj.locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN)).click();
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_home.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_home.ts
@@ -21,9 +21,7 @@ export class FleetHomePage {
     await this.page.testSubj
       .locator(FLEET_AGENTS_TAB_SELECTOR)
       .waitFor({ state: 'visible', timeout: 20_000 });
-    await this.page.testSubj
-      .locator(FLEET_SETUP_LOADING_SELECTOR)
-      .waitFor({ state: 'hidden' });
+    await this.page.testSubj.locator(FLEET_SETUP_LOADING_SELECTOR).waitFor({ state: 'hidden' });
   }
 
   getMissingPrivilegesPromptTitle() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_home.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_home.ts
@@ -18,11 +18,12 @@ export class FleetHomePage {
   }
 
   async waitForPageToLoad() {
-    await this.page.testSubj.waitForSelector(FLEET_AGENTS_TAB_SELECTOR, {
-      state: 'visible',
-      timeout: 20_000,
-    });
-    await this.page.testSubj.waitForSelector(FLEET_SETUP_LOADING_SELECTOR, { state: 'hidden' });
+    await this.page.testSubj
+      .locator(FLEET_AGENTS_TAB_SELECTOR)
+      .waitFor({ state: 'visible', timeout: 20_000 });
+    await this.page.testSubj
+      .locator(FLEET_SETUP_LOADING_SELECTOR)
+      .waitFor({ state: 'hidden' });
   }
 
   getMissingPrivilegesPromptTitle() {
@@ -70,7 +71,7 @@ export class FleetHomePage {
   }
 
   getPackagePolicyLink(name: string) {
-    return this.page.locator(`a[title="${name}"]`);
+    return this.page.getByRole('link', { name });
   }
 
   getCreateAgentPolicyButton() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import {
+  SETTINGS_OUTPUTS,
+  SETTINGS_OUTPUTS_KAFKA,
+  SETTINGS_SAVE_BTN,
+  CONFIRM_MODAL,
+} from '../../common/selectors';
+
+export class FleetOutputsPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async navigateTo() {
+    await this.page.goto('/app/fleet/settings');
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async navigateToOutput(outputId: string) {
+    await this.page.goto(`/app/fleet/settings/outputs/${outputId}`);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  getAddOutputButton() {
+    return this.page.testSubj.locator(SETTINGS_OUTPUTS.ADD_BTN);
+  }
+
+  getTypeInput() {
+    return this.page.testSubj.locator(SETTINGS_OUTPUTS.TYPE_INPUT);
+  }
+
+  getNameInput() {
+    return this.page.testSubj.locator(SETTINGS_OUTPUTS.NAME_INPUT);
+  }
+
+  getSaveButton() {
+    return this.page.testSubj.locator(SETTINGS_SAVE_BTN);
+  }
+
+  getConfirmModalButton() {
+    return this.page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON);
+  }
+
+  getKafkaAuthUsernamePasswordOption() {
+    return this.page.testSubj.locator(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_USERNAME_PASSWORD_OPTION);
+  }
+
+  getKafkaUsernameInput() {
+    return this.page.testSubj.locator(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_USERNAME_INPUT);
+  }
+
+  getKafkaPasswordInput() {
+    return this.page.testSubj.locator(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_PASSWORD_INPUT);
+  }
+
+  async addESOutput(name: string, hosts: string[]) {
+    await this.getAddOutputButton().click();
+    await this.getTypeInput().selectOption('elasticsearch');
+    await this.getNameInput().fill(name);
+    const hostInput = this.page.locator('[placeholder="Specify host"]').first();
+    await hostInput.fill(hosts[0]);
+  }
+
+  async addRemoteESOutput(name: string, hosts: string[]) {
+    await this.getAddOutputButton().click();
+    await this.getTypeInput().selectOption('remote_elasticsearch');
+    await this.getNameInput().fill(name);
+  }
+
+  async addKafkaOutput(name: string) {
+    await this.getAddOutputButton().click();
+    await this.getTypeInput().selectOption('kafka');
+    await this.getKafkaAuthUsernamePasswordOption().locator('label').click();
+    await this.getNameInput().fill(name);
+  }
+
+  async save() {
+    await this.getSaveButton().click();
+    await this.getConfirmModalButton().click();
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
@@ -18,12 +18,16 @@ export class FleetOutputsPage {
 
   async navigateTo() {
     await this.page.goto('/app/fleet/settings');
-    await this.page.waitForLoadState('networkidle');
+    await this.page.testSubj
+      .locator(SETTINGS_OUTPUTS.TABLE)
+      .waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   async navigateToOutput(outputId: string) {
     await this.page.goto(`/app/fleet/settings/outputs/${outputId}`);
-    await this.page.waitForLoadState('networkidle');
+    await this.page.testSubj
+      .locator(SETTINGS_OUTPUTS.NAME_INPUT)
+      .waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   getAddOutputButton() {
@@ -64,8 +68,7 @@ export class FleetOutputsPage {
     await this.getAddOutputButton().click();
     await this.getTypeInput().selectOption('elasticsearch');
     await this.getNameInput().fill(name);
-    const hostInput = this.page.locator('[placeholder="Specify host"]').first();
-    await hostInput.fill(hosts[0]);
+    await this.page.getByPlaceholder('Specify host').fill(hosts[0]);
   }
 
   async addRemoteESOutput(name: string, hosts: string[]) {
@@ -77,7 +80,7 @@ export class FleetOutputsPage {
   async addKafkaOutput(name: string) {
     await this.getAddOutputButton().click();
     await this.getTypeInput().selectOption('kafka');
-    await this.getKafkaAuthUsernamePasswordOption().locator('label').click();
+    await this.getKafkaAuthUsernamePasswordOption().getByRole('radio').click();
     await this.getNameInput().fill(name);
   }
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
@@ -47,7 +47,9 @@ export class FleetOutputsPage {
   }
 
   getKafkaAuthUsernamePasswordOption() {
-    return this.page.testSubj.locator(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_USERNAME_PASSWORD_OPTION);
+    return this.page.testSubj.locator(
+      SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_USERNAME_PASSWORD_OPTION
+    );
   }
 
   getKafkaUsernameInput() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_outputs_page.ts
@@ -71,7 +71,7 @@ export class FleetOutputsPage {
     await this.page.getByPlaceholder('Specify host').fill(hosts[0]);
   }
 
-  async addRemoteESOutput(name: string, hosts: string[]) {
+  async addRemoteESOutput(name: string, _hosts: string[]) {
     await this.getAddOutputButton().click();
     await this.getTypeInput().selectOption('remote_elasticsearch');
     await this.getNameInput().fill(name);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_settings_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_settings_page.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import {
+  SETTINGS_TAB,
+  SETTINGS_FLEET_SERVER_HOST_HEADING,
+  SETTINGS_SAVE_BTN,
+  CONFIRM_MODAL,
+  SETTINGS_FLEET_SERVER_HOSTS,
+  AGENT_BINARY_SOURCES_TABLE,
+  AGENT_BINARY_SOURCES_TABLE_ACTIONS,
+  AGENT_BINARY_SOURCES_FLYOUT,
+} from '../../common/selectors';
+
+export class FleetSettingsPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async navigateTo() {
+    await this.page.gotoApp('fleet');
+    await this.page.testSubj.locator('fleet-settings-tab').click();
+    await this.page.testSubj.locator(SETTINGS_FLEET_SERVER_HOST_HEADING).waitFor({ state: 'visible', timeout: 15_000 });
+  }
+
+  async navigateToOutputs() {
+    await this.page.goto('/app/fleet/settings');
+  }
+
+  getFleetServerHostHeader() {
+    return this.page.testSubj.locator(SETTINGS_FLEET_SERVER_HOST_HEADING);
+  }
+
+  getSaveButton() {
+    return this.page.testSubj.locator(SETTINGS_SAVE_BTN);
+  }
+
+  getConfirmModalButton() {
+    return this.page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON);
+  }
+
+  getAddFleetServerHostButton() {
+    return this.page.testSubj.locator(SETTINGS_FLEET_SERVER_HOSTS.ADD_BUTTON);
+  }
+
+  getFleetServerHostsTable() {
+    return this.page.testSubj.locator(SETTINGS_FLEET_SERVER_HOSTS.TABLE);
+  }
+
+  // Agent binary download sources
+  getAgentBinarySourcesTable() {
+    return this.page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE);
+  }
+
+  getAddDownloadSourceButton() {
+    return this.page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.ADD);
+  }
+
+  getEditDownloadSourceButton() {
+    return this.page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT);
+  }
+
+  getDownloadSourceFlyoutNameInput() {
+    return this.page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT);
+  }
+
+  getDownloadSourceFlyoutHostInput() {
+    return this.page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT);
+  }
+
+  getDownloadSourceFlyoutIsDefaultSwitch() {
+    return this.page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.IS_DEFAULT_SWITCH);
+  }
+
+  getDownloadSourceFlyoutSubmitButton() {
+    return this.page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON);
+  }
+
+  async addDownloadSource(name: string, host: string, isDefault = false) {
+    await this.getAddDownloadSourceButton().click();
+    await this.getDownloadSourceFlyoutNameInput().fill(name);
+    await this.getDownloadSourceFlyoutHostInput().fill(host);
+    if (isDefault) {
+      await this.getDownloadSourceFlyoutIsDefaultSwitch().click();
+    }
+    await this.getDownloadSourceFlyoutSubmitButton().click();
+    await this.getConfirmModalButton().click();
+  }
+
+  async editDownloadSource(name: string, host: string) {
+    await this.getEditDownloadSourceButton().first().click();
+    await this.getDownloadSourceFlyoutNameInput().clear();
+    await this.getDownloadSourceFlyoutNameInput().fill(name);
+    await this.getDownloadSourceFlyoutHostInput().clear();
+    await this.getDownloadSourceFlyoutHostInput().fill(host);
+    await this.getDownloadSourceFlyoutSubmitButton().click();
+    await this.getConfirmModalButton().click();
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_settings_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_settings_page.ts
@@ -7,7 +7,6 @@
 
 import type { ScoutPage } from '@kbn/scout';
 import {
-  SETTINGS_TAB,
   SETTINGS_FLEET_SERVER_HOST_HEADING,
   SETTINGS_SAVE_BTN,
   CONFIRM_MODAL,
@@ -23,7 +22,9 @@ export class FleetSettingsPage {
   async navigateTo() {
     await this.page.gotoApp('fleet');
     await this.page.testSubj.locator('fleet-settings-tab').click();
-    await this.page.testSubj.locator(SETTINGS_FLEET_SERVER_HOST_HEADING).waitFor({ state: 'visible', timeout: 15_000 });
+    await this.page.testSubj
+      .locator(SETTINGS_FLEET_SERVER_HOST_HEADING)
+      .waitFor({ state: 'visible', timeout: 15_000 });
   }
 
   async navigateToOutputs() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_settings_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_settings_page.ts
@@ -92,7 +92,11 @@ export class FleetSettingsPage {
   }
 
   async editDownloadSource(name: string, host: string) {
-    await this.getEditDownloadSourceButton().first().click();
+    await this.getAgentBinarySourcesTable()
+      .getByRole('row')
+      .filter({ has: this.page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT) })
+      .locator(this.page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT))
+      .click();
     await this.getDownloadSourceFlyoutNameInput().clear();
     await this.getDownloadSourceFlyoutNameInput().fill(name);
     await this.getDownloadSourceFlyoutHostInput().clear();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/index.ts
@@ -8,27 +8,51 @@
 import type { PageObjects, ScoutPage } from '@kbn/scout';
 import { createLazyPageObject } from '@kbn/scout';
 
+import { AgentFlyoutPage } from './agent_flyout_page';
+import { AgentListPage } from './agent_list_page';
+import { AgentPolicyPage } from './agent_policy_page';
 import { BrowseIntegrationPage } from './browse_integrations_page';
 import { CopyIntegrationPage } from './copy_integration_page';
 import { CreateIntegrationLandingPage } from './create_integration_landing_page';
+import { EnrollmentTokensPage } from './enrollment_tokens_page';
 import { FleetHomePage } from './fleet_home';
+import { FleetOutputsPage } from './fleet_outputs_page';
+import { FleetSettingsPage } from './fleet_settings_page';
 import { IntegrationHomePage } from './integration_home';
+import { PackagePolicyPage } from './package_policy_page';
+import { UninstallTokensPage } from './uninstall_tokens_page';
 
-export interface StreamsPageObjects extends PageObjects {
+export interface FleetPageObjects extends PageObjects {
+  agentFlyout: AgentFlyoutPage;
+  agentList: AgentListPage;
+  agentPolicy: AgentPolicyPage;
   browseIntegrations: BrowseIntegrationPage;
-  createIntegrationLanding: CreateIntegrationLandingPage;
-  fleetHome: FleetHomePage;
-  integrationHome: IntegrationHomePage;
   copyIntegration: CopyIntegrationPage;
+  createIntegrationLanding: CreateIntegrationLandingPage;
+  enrollmentTokens: EnrollmentTokensPage;
+  fleetHome: FleetHomePage;
+  fleetOutputs: FleetOutputsPage;
+  fleetSettings: FleetSettingsPage;
+  integrationHome: IntegrationHomePage;
+  packagePolicy: PackagePolicyPage;
+  uninstallTokens: UninstallTokensPage;
 }
 
-export function extendPageObjects(pageObjects: PageObjects, page: ScoutPage): StreamsPageObjects {
+export function extendPageObjects(pageObjects: PageObjects, page: ScoutPage): FleetPageObjects {
   return {
     ...pageObjects,
+    agentFlyout: createLazyPageObject(AgentFlyoutPage, page),
+    agentList: createLazyPageObject(AgentListPage, page),
+    agentPolicy: createLazyPageObject(AgentPolicyPage, page),
     browseIntegrations: createLazyPageObject(BrowseIntegrationPage, page),
     copyIntegration: createLazyPageObject(CopyIntegrationPage, page),
     createIntegrationLanding: createLazyPageObject(CreateIntegrationLandingPage, page),
+    enrollmentTokens: createLazyPageObject(EnrollmentTokensPage, page),
     fleetHome: createLazyPageObject(FleetHomePage, page),
+    fleetOutputs: createLazyPageObject(FleetOutputsPage, page),
+    fleetSettings: createLazyPageObject(FleetSettingsPage, page),
     integrationHome: createLazyPageObject(IntegrationHomePage, page),
+    packagePolicy: createLazyPageObject(PackagePolicyPage, page),
+    uninstallTokens: createLazyPageObject(UninstallTokensPage, page),
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/integration_home.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/integration_home.ts
@@ -16,10 +16,9 @@ export class IntegrationHomePage {
   }
 
   async waitForPageToLoad() {
-    await this.page.testSubj.waitForSelector('epmList.integrationCards', {
-      state: 'visible',
-      timeout: 20_000,
-    });
+    await this.page.testSubj
+      .locator('epmList.integrationCards')
+      .waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   getIntegrationCard(integration: string) {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/package_policy_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/package_policy_page.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import {
+  POLICY_EDITOR,
+  CREATE_PACKAGE_POLICY_SAVE_BTN,
+  ADD_PACKAGE_POLICY_BTN,
+  PACKAGE_POLICY_TABLE_LINK,
+} from '../../common/selectors';
+
+export class PackagePolicyPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  getPolicyNameInput() {
+    return this.page.testSubj.locator(POLICY_EDITOR.POLICY_NAME_INPUT);
+  }
+
+  getDatasetSelect() {
+    return this.page.testSubj.locator(POLICY_EDITOR.DATASET_SELECT);
+  }
+
+  getAgentPolicySelect() {
+    return this.page.testSubj.locator(POLICY_EDITOR.AGENT_POLICY_SELECT);
+  }
+
+  getSaveButton() {
+    return this.page.testSubj.locator(CREATE_PACKAGE_POLICY_SAVE_BTN);
+  }
+
+  getAddPackagePolicyButton() {
+    return this.page.testSubj.locator(ADD_PACKAGE_POLICY_BTN);
+  }
+
+  getPackagePolicyLink(name: string) {
+    return this.page.locator(`a[title="${name}"]`);
+  }
+
+  getInspectPipelinesButton() {
+    return this.page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN);
+  }
+
+  getEditMappingsButton() {
+    return this.page.testSubj.locator(POLICY_EDITOR.EDIT_MAPPINGS_BTN);
+  }
+
+  getCreateMappingsButton() {
+    return this.page.testSubj.locator(POLICY_EDITOR.CREATE_MAPPINGS_BTN);
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/package_policy_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/package_policy_page.ts
@@ -36,7 +36,7 @@ export class PackagePolicyPage {
   }
 
   getPackagePolicyLink(name: string) {
-    return this.page.locator(`a[title="${name}"]`);
+    return this.page.getByRole('link', { name });
   }
 
   getInspectPipelinesButton() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/package_policy_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/package_policy_page.ts
@@ -10,7 +10,6 @@ import {
   POLICY_EDITOR,
   CREATE_PACKAGE_POLICY_SAVE_BTN,
   ADD_PACKAGE_POLICY_BTN,
-  PACKAGE_POLICY_TABLE_LINK,
 } from '../../common/selectors';
 
 export class PackagePolicyPage {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/uninstall_tokens_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/uninstall_tokens_page.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage } from '@kbn/scout';
+import { UNINSTALL_TOKENS } from '../../common/selectors';
+
+export class UninstallTokensPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async navigateTo() {
+    await this.page.gotoApp('fleet');
+    await this.page.testSubj.locator('fleet-uninstall-tokens-tab').click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  getPolicyIdSearchInput() {
+    return this.page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD);
+  }
+
+  getPolicyIdTableField() {
+    return this.page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD);
+  }
+
+  getViewUninstallCommandButtons() {
+    return this.page.testSubj.locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON);
+  }
+
+  getUninstallCommandFlyout() {
+    return this.page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT);
+  }
+
+  getTokenField() {
+    return this.page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD);
+  }
+
+  getShowHideTokenButton() {
+    return this.page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON);
+  }
+
+  async openUninstallCommandFlyout() {
+    await this.getViewUninstallCommandButtons().first().click();
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/uninstall_tokens_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/uninstall_tokens_page.ts
@@ -14,7 +14,7 @@ export class UninstallTokensPage {
   async navigateTo() {
     await this.page.gotoApp('fleet');
     await this.page.testSubj.locator('fleet-uninstall-tokens-tab').click();
-    await this.page.waitForLoadState('networkidle');
+    await this.getPolicyIdSearchInput().waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   getPolicyIdSearchInput() {
@@ -41,7 +41,13 @@ export class UninstallTokensPage {
     return this.page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON);
   }
 
-  async openUninstallCommandFlyout() {
-    await this.getViewUninstallCommandButtons().first().click();
+  async openUninstallCommandFlyout(policyId: string) {
+    const row = this.page.testSubj
+      .locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)
+      .filter({ hasText: policyId })
+      .locator('..');
+    await row
+      .locator(this.page.testSubj.locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON))
+      .click();
   }
 }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -13,7 +13,7 @@ import {
   createAgentPolicy,
   deleteAgentPolicy,
   cleanupAgentPolicies,
-  setFleetServerHost,
+  setupFleetServer,
   unenrollAgents,
   mockFleetSetupEndpoints,
 } from '../../common/api_helpers';
@@ -35,8 +35,8 @@ import {
 test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
   let policyIdA11y: string;
 
-  test.beforeAll(async ({ kbnClient }) => {
-    await setFleetServerHost(kbnClient, 'https://fleetserver:8220');
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -54,7 +54,9 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
       await pageObjects.fleetHome.navigateTo();
       await pageObjects.fleetHome.waitForPageToLoad();
       await pageObjects.fleetHome.getAddFleetServerHeader().click();
-      await page.testSubj.locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+        .waitFor({ state: 'visible', timeout: 15_000 });
     });
 
     test('Get started with fleet', async ({ page }) => {
@@ -70,7 +72,9 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
       await hostInput.fill('https://localhost:8220');
       await page.testSubj.locator(GENERATE_FLEET_SERVER_POLICY_BUTTON).click();
       await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
-      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({ timeout: 15_000 });
+      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({
+        timeout: 15_000,
+      });
     });
   });
 
@@ -79,7 +83,9 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
       await pageObjects.fleetHome.navigateTo();
       await pageObjects.fleetHome.waitForPageToLoad();
       await pageObjects.fleetHome.getAddFleetServerHeader().click();
-      await page.testSubj.locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+        .waitFor({ state: 'visible', timeout: 15_000 });
       await page.testSubj.locator(AGENT_FLYOUT.ADVANCED_TAB_BUTTON).click();
     });
 
@@ -98,7 +104,9 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
     test('Generate service token', async ({ page }) => {
       await page.testSubj.locator(ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON).click();
       await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
-      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({ timeout: 15_000 });
+      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({
+        timeout: 15_000,
+      });
     });
   });
 
@@ -106,7 +114,9 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
     test.beforeEach(async ({ pageObjects, page }) => {
       await pageObjects.fleetHome.navigateTo();
       await pageObjects.fleetHome.navigateToAgentPoliciesTab();
-      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON)
+        .waitFor({ state: 'visible', timeout: 15_000 });
     });
 
     test('Agent Table', async ({ page }) => {
@@ -115,25 +125,38 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
 
     test('Create Policy Flyout', async ({ page }) => {
       await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
-      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE)
+        .waitFor({ state: 'visible', timeout: 15_000 });
       await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
-      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.ADVANCED_OPTIONS_TOGGLE).click();
-      await page.testSubj.locator('defaultNamespaceHeader').waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.ADVANCED_OPTIONS_TOGGLE)
+        .click();
+      await page.testSubj
+        .locator('defaultNamespaceHeader')
+        .waitFor({ state: 'visible', timeout: 15_000 });
     });
 
     test('Agent Table After Adding Another Agent', async ({ page }) => {
       await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
-      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE)
+        .waitFor({ state: 'visible', timeout: 15_000 });
       await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
       await page.testSubj.locator(AGENT_POLICY_FLYOUT_CREATE_BUTTON).click();
-      await page.getByRole('link', { name: /testName/ }).first().waitFor({ state: 'visible', timeout: 15_000 });
+      await page
+        .getByRole('link', { name: /testName/ })
+        .first()
+        .waitFor({ state: 'visible', timeout: 15_000 });
     });
   });
 
   test.describe('Enrollment Tokens', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/app/fleet/enrollment-tokens');
-      await page.testSubj.locator('tableHeaderCell_name_0').waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator('tableHeaderCell_name_0')
+        .waitFor({ state: 'visible', timeout: 15_000 });
     });
 
     test('Enrollment Tokens Table', async ({ page }) => {
@@ -142,13 +165,17 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
 
     test('Create Enrollment Token Modal', async ({ page }) => {
       await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON).click();
-      await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj
+        .locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD)
+        .waitFor({ state: 'visible', timeout: 15_000 });
     });
   });
 
   test.describe('Uninstall Tokens', () => {
     test.beforeAll(async ({ kbnClient }) => {
-      const policy = await createAgentPolicy(kbnClient, 'Agent policy for A11y test', { id: 'agent-policy-a11y' });
+      const policy = await createAgentPolicy(kbnClient, 'Agent policy for A11y test', {
+        id: 'agent-policy-a11y',
+      });
       policyIdA11y = policy.id;
     });
 
@@ -166,7 +193,9 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
     });
 
     test('Uninstall Tokens Table', async ({ page }) => {
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD).first()).toBeVisible();
+      await expect(
+        page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD).first()
+      ).toBeVisible();
     });
 
     test('Uninstall Command Flyout', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../../fixtures';
+import {
+  createAgentPolicy,
+  deleteAgentPolicy,
+  cleanupAgentPolicies,
+  setFleetServerHost,
+  unenrollAgents,
+} from '../../common/api_helpers';
+import {
+  AGENT_FLYOUT,
+  FLEET_SERVER_SETUP,
+  GENERATE_FLEET_SERVER_POLICY_BUTTON,
+  PLATFORM_TYPE_LINUX_BUTTON,
+  ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON,
+  ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON,
+  AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT,
+  AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD,
+  AGENT_POLICY_FLYOUT_CREATE_BUTTON,
+  ENROLLMENT_TOKENS,
+  UNINSTALL_TOKENS,
+  DATA_STREAMS_TAB,
+} from '../../common/selectors';
+
+test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    await setFleetServerHost(kbnClient, 'https://fleetserver:8220');
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    try {
+      await unenrollAgents(kbnClient);
+      await cleanupAgentPolicies(kbnClient);
+    } catch {
+      // Ignore cleanup
+    }
+  });
+
+  test.describe('Agents', () => {
+    test.beforeEach(async ({ pageObjects, page }) => {
+      await pageObjects.fleetHome.navigateTo();
+      await pageObjects.fleetHome.waitForPageToLoad();
+      await pageObjects.fleetHome.getAddFleetServerHeader().click();
+      await page.testSubj.locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+    });
+
+    test('Get started with fleet', async ({ page }) => {
+      await expect(page.locator('main')).toBeVisible();
+    });
+
+    test('Install Fleet Server', async ({ page }) => {
+      await page.testSubj.locator(FLEET_SERVER_SETUP.SELECT_HOSTS).click();
+      await page.testSubj.locator(FLEET_SERVER_SETUP.ADD_HOST_BTN).click();
+      await page.testSubj.locator(FLEET_SERVER_SETUP.NAME_INPUT).fill('Host edited');
+      const hostInput = page.locator('[placeholder="Specify host URL"]').first();
+      await expect(hostInput).toBeVisible({ timeout: 15_000 });
+      await hostInput.fill('https://localhost:8220');
+      await page.testSubj.locator(GENERATE_FLEET_SERVER_POLICY_BUTTON).click();
+      await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
+      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({ timeout: 15_000 });
+    });
+  });
+
+  test.describe('Advanced', () => {
+    test.beforeEach(async ({ pageObjects, page }) => {
+      await pageObjects.fleetHome.navigateTo();
+      await pageObjects.fleetHome.waitForPageToLoad();
+      await pageObjects.fleetHome.getAddFleetServerHeader().click();
+      await page.testSubj.locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj.locator(AGENT_FLYOUT.ADVANCED_TAB_BUTTON).click();
+    });
+
+    test('Select policy for fleet', async ({ page }) => {
+      await expect(page.locator('main')).toBeVisible();
+    });
+
+    test('Add your fleet sever host', async ({ page }) => {
+      await page.testSubj.locator(FLEET_SERVER_SETUP.SELECT_HOSTS).click();
+      await page.testSubj.locator(FLEET_SERVER_SETUP.ADD_HOST_BTN).click();
+      await page.testSubj.locator(FLEET_SERVER_SETUP.NAME_INPUT).fill('New host');
+      await page.locator('[placeholder="Specify host URL"]').first().fill('https://localhost:8220');
+      await page.testSubj.locator(ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON).click();
+    });
+
+    test('Generate service token', async ({ page }) => {
+      await page.testSubj.locator(ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON).click();
+      await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
+      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({ timeout: 15_000 });
+    });
+  });
+
+  test.describe('Agent Policies', () => {
+    test.beforeEach(async ({ pageObjects, page }) => {
+      await pageObjects.fleetHome.navigateTo();
+      await pageObjects.fleetHome.navigateToAgentPoliciesTab();
+      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).waitFor({ state: 'visible', timeout: 15_000 });
+    });
+
+    test('Agent Table', async ({ page }) => {
+      await expect(page.testSubj.locator('agentPoliciesTable')).toBeVisible();
+    });
+
+    test('Create Policy Flyout', async ({ page }) => {
+      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
+      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
+      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.ADVANCED_OPTIONS_TOGGLE).click();
+      await page.testSubj.locator('defaultNamespaceHeader').waitFor({ state: 'visible', timeout: 15_000 });
+    });
+
+    test('Agent Table After Adding Another Agent', async ({ page }) => {
+      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
+      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
+      await page.testSubj.locator(AGENT_POLICY_FLYOUT_CREATE_BUTTON).click();
+      await page.getByRole('link', { name: /testName/ }).first().waitFor({ state: 'visible', timeout: 15_000 });
+    });
+  });
+
+  test.describe('Enrollment Tokens', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/app/fleet/enrollment-tokens');
+      await page.testSubj.locator('tableHeaderCell_name_0').waitFor({ state: 'visible', timeout: 15_000 });
+    });
+
+    test('Enrollment Tokens Table', async ({ page }) => {
+      await expect(page.testSubj.locator('tableHeaderCell_name_0')).toBeVisible();
+    });
+
+    test('Create Enrollment Token Modal', async ({ page }) => {
+      await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON).click();
+      await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).waitFor({ state: 'visible', timeout: 15_000 });
+    });
+  });
+
+  test.describe('Uninstall Tokens', () => {
+    test.beforeAll(async ({ kbnClient }) => {
+      const policy = await createAgentPolicy(kbnClient, 'Agent policy for A11y test', { id: 'agent-policy-a11y' });
+      policyIdA11y = policy.id;
+    });
+
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await deleteAgentPolicy(kbnClient, 'agent-policy-a11y');
+      } catch {
+        // Ignore
+      }
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/app/fleet/uninstall-tokens');
+      await page.testSubj.locator('fleet-uninstall-tokens-tab').click();
+    });
+
+    test('Uninstall Tokens Table', async ({ page }) => {
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD).first()).toBeVisible();
+    });
+
+    test('Uninstall Command Flyout', async ({ page }) => {
+      await page.testSubj.locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON).first().click();
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)).toBeVisible();
+    });
+  });
+
+  test.describe('Data Streams', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.gotoApp('fleet');
+      await page.testSubj.locator(DATA_STREAMS_TAB).waitFor({ state: 'visible', timeout: 15_000 });
+      await page.testSubj.locator(DATA_STREAMS_TAB).click();
+    });
+
+    test('Datastreams Empty Table', async ({ page }) => {
+      await expect(page.testSubj.locator('tableHeaderSortButton')).toBeVisible({ timeout: 15_000 });
+    });
+  });
+
+  test.describe.skip('Settings', () => {
+    // A11y Violation https://github.com/elastic/kibana/issues/138474
+    test.beforeEach(async ({ page }) => {
+      await page.gotoApp('fleet');
+      await page.testSubj.locator('fleet-settings-tab').click();
+    });
+
+    test('Settings Form', async ({ page }) => {
+      await expect(page.testSubj.locator('fleetServerHostHeader')).toBeVisible({ timeout: 15_000 });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -15,6 +15,7 @@ import {
   cleanupAgentPolicies,
   setFleetServerHost,
   unenrollAgents,
+  mockFleetSetupEndpoints,
 } from '../../common/api_helpers';
 import {
   AGENT_FLYOUT,
@@ -38,8 +39,9 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
     await setFleetServerHost(kbnClient, 'https://fleetserver:8220');
   });
 
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsAdmin();
+    await mockFleetSetupEndpoints(page);
   });
 
   test.afterAll(async ({ kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -206,7 +206,7 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
     const policy = await createAgentPolicy(kbnClient, 'Agent policy for A11y test', {
       id: 'agent-policy-a11y',
     });
-    policyIdA11y = policy.id;
+    policyIdA11y = policy.id as string;
 
     try {
       await page.goto('/app/fleet/uninstall-tokens');

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -32,6 +32,8 @@ import {
 } from '../../common/selectors';
 
 test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
+  let policyIdA11y: string;
+
   test.beforeAll(async ({ kbnClient }) => {
     await setFleetServerHost(kbnClient, 'https://fleetserver:8220');
   });
@@ -49,182 +51,223 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
     }
   });
 
-  test.describe('Agents', () => {
-    test.beforeEach(async ({ pageObjects, page }) => {
-      await pageObjects.fleetHome.navigateTo();
-      await pageObjects.fleetHome.waitForPageToLoad();
-      await pageObjects.fleetHome.getAddFleetServerHeader().click();
-      await page.testSubj
-        .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
-        .waitFor({ state: 'visible', timeout: 15_000 });
-    });
+  test('Agents - Get started with fleet', async ({ pageObjects, page }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.waitForPageToLoad();
+    await pageObjects.fleetHome.getAddFleetServerHeader().click();
+    await page.testSubj
+      .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
 
-    test('Get started with fleet', async ({ page }) => {
-      await expect(page.locator('main')).toBeVisible();
-    });
+    await expect(page.locator('main')).toBeVisible();
+  });
 
-    test('Install Fleet Server', async ({ page }) => {
-      await page.testSubj.locator(FLEET_SERVER_SETUP.SELECT_HOSTS).click();
-      await page.testSubj.locator(FLEET_SERVER_SETUP.ADD_HOST_BTN).click();
-      await page.testSubj.locator(FLEET_SERVER_SETUP.NAME_INPUT).fill('Host edited');
-      const hostInput = page.locator('[placeholder="Specify host URL"]').first();
-      await expect(hostInput).toBeVisible({ timeout: 15_000 });
-      await hostInput.fill('https://localhost:8220');
-      await page.testSubj.locator(GENERATE_FLEET_SERVER_POLICY_BUTTON).click();
-      await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
-      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({
-        timeout: 15_000,
-      });
+  test('Agents - Install Fleet Server', async ({ pageObjects, page }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.waitForPageToLoad();
+    await pageObjects.fleetHome.getAddFleetServerHeader().click();
+    await page.testSubj
+      .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
+
+    await page.testSubj.locator(FLEET_SERVER_SETUP.SELECT_HOSTS).click();
+    await page.testSubj.locator(FLEET_SERVER_SETUP.ADD_HOST_BTN).click();
+    await page.testSubj.locator(FLEET_SERVER_SETUP.NAME_INPUT).fill('Host edited');
+    const hostInput = page.testSubj
+      .locator(FLEET_SERVER_SETUP.HOST_INPUT)
+      .getByPlaceholder('Specify host URL');
+    await expect(hostInput).toBeVisible({ timeout: 15_000 });
+    await hostInput.fill('https://localhost:8220');
+    await page.testSubj.locator(GENERATE_FLEET_SERVER_POLICY_BUTTON).click();
+    await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
+    await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({
+      timeout: 15_000,
     });
   });
 
-  test.describe('Advanced', () => {
-    test.beforeEach(async ({ pageObjects, page }) => {
-      await pageObjects.fleetHome.navigateTo();
-      await pageObjects.fleetHome.waitForPageToLoad();
-      await pageObjects.fleetHome.getAddFleetServerHeader().click();
-      await page.testSubj
-        .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
-        .waitFor({ state: 'visible', timeout: 15_000 });
-      await page.testSubj.locator(AGENT_FLYOUT.ADVANCED_TAB_BUTTON).click();
-    });
+  test('Advanced - Select policy for fleet', async ({ pageObjects, page }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.waitForPageToLoad();
+    await pageObjects.fleetHome.getAddFleetServerHeader().click();
+    await page.testSubj
+      .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator(AGENT_FLYOUT.ADVANCED_TAB_BUTTON).click();
 
-    test('Select policy for fleet', async ({ page }) => {
-      await expect(page.locator('main')).toBeVisible();
-    });
+    await expect(page.locator('main')).toBeVisible();
+  });
 
-    test('Add your fleet sever host', async ({ page }) => {
-      await page.testSubj.locator(FLEET_SERVER_SETUP.SELECT_HOSTS).click();
-      await page.testSubj.locator(FLEET_SERVER_SETUP.ADD_HOST_BTN).click();
-      await page.testSubj.locator(FLEET_SERVER_SETUP.NAME_INPUT).fill('New host');
-      await page.locator('[placeholder="Specify host URL"]').first().fill('https://localhost:8220');
-      await page.testSubj.locator(ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON).click();
-    });
+  test('Advanced - Add your fleet server host', async ({ pageObjects, page }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.waitForPageToLoad();
+    await pageObjects.fleetHome.getAddFleetServerHeader().click();
+    await page.testSubj
+      .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator(AGENT_FLYOUT.ADVANCED_TAB_BUTTON).click();
 
-    test('Generate service token', async ({ page }) => {
-      await page.testSubj.locator(ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON).click();
-      await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
-      await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({
-        timeout: 15_000,
-      });
+    await page.testSubj.locator(FLEET_SERVER_SETUP.SELECT_HOSTS).click();
+    await page.testSubj.locator(FLEET_SERVER_SETUP.ADD_HOST_BTN).click();
+    await page.testSubj.locator(FLEET_SERVER_SETUP.NAME_INPUT).fill('New host');
+    await page.testSubj
+      .locator(FLEET_SERVER_SETUP.HOST_INPUT)
+      .getByPlaceholder('Specify host URL')
+      .fill('https://localhost:8220');
+    await page.testSubj.locator(ADVANCED_FLEET_SERVER_ADD_HOST_BUTTON).click();
+  });
+
+  test('Advanced - Generate service token', async ({ pageObjects, page }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.waitForPageToLoad();
+    await pageObjects.fleetHome.getAddFleetServerHeader().click();
+    await page.testSubj
+      .locator(AGENT_FLYOUT.QUICK_START_TAB_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator(AGENT_FLYOUT.ADVANCED_TAB_BUTTON).click();
+
+    await page.testSubj.locator(ADVANCED_FLEET_SERVER_GENERATE_SERVICE_TOKEN_BUTTON).click();
+    await page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON).scrollIntoViewIfNeeded();
+    await expect(page.testSubj.locator(PLATFORM_TYPE_LINUX_BUTTON)).toBeVisible({
+      timeout: 15_000,
     });
   });
 
-  test.describe('Agent Policies', () => {
-    test.beforeEach(async ({ pageObjects, page }) => {
-      await pageObjects.fleetHome.navigateTo();
-      await pageObjects.fleetHome.navigateToAgentPoliciesTab();
-      await page.testSubj
-        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON)
-        .waitFor({ state: 'visible', timeout: 15_000 });
-    });
+  test('Agent Policies - Agent Table', async ({ pageObjects, page }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.navigateToAgentPoliciesTab();
+    await page.testSubj
+      .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
 
-    test('Agent Table', async ({ page }) => {
-      await expect(page.testSubj.locator('agentPoliciesTable')).toBeVisible();
-    });
-
-    test('Create Policy Flyout', async ({ page }) => {
-      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
-      await page.testSubj
-        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE)
-        .waitFor({ state: 'visible', timeout: 15_000 });
-      await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
-      await page.testSubj
-        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.ADVANCED_OPTIONS_TOGGLE)
-        .click();
-      await page.testSubj
-        .locator('defaultNamespaceHeader')
-        .waitFor({ state: 'visible', timeout: 15_000 });
-    });
-
-    test('Agent Table After Adding Another Agent', async ({ page }) => {
-      await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
-      await page.testSubj
-        .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE)
-        .waitFor({ state: 'visible', timeout: 15_000 });
-      await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
-      await page.testSubj.locator(AGENT_POLICY_FLYOUT_CREATE_BUTTON).click();
-      await page
-        .getByRole('link', { name: /testName/ })
-        .first()
-        .waitFor({ state: 'visible', timeout: 15_000 });
-    });
+    await expect(page.testSubj.locator('agentPoliciesTable')).toBeVisible();
   });
 
-  test.describe('Enrollment Tokens', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.goto('/app/fleet/enrollment-tokens');
-      await page.testSubj
-        .locator('tableHeaderCell_name_0')
-        .waitFor({ state: 'visible', timeout: 15_000 });
-    });
+  test('Agent Policies - Create Policy Flyout', async ({ pageObjects, page }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.navigateToAgentPoliciesTab();
+    await page.testSubj
+      .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
 
-    test('Enrollment Tokens Table', async ({ page }) => {
-      await expect(page.testSubj.locator('tableHeaderCell_name_0')).toBeVisible();
-    });
-
-    test('Create Enrollment Token Modal', async ({ page }) => {
-      await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON).click();
-      await page.testSubj
-        .locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD)
-        .waitFor({ state: 'visible', timeout: 15_000 });
-    });
+    await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
+    await page.testSubj
+      .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE)
+      .waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
+    await page.testSubj
+      .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.ADVANCED_OPTIONS_TOGGLE)
+      .click();
+    await page.testSubj
+      .locator('defaultNamespaceHeader')
+      .waitFor({ state: 'visible', timeout: 15_000 });
   });
 
-  test.describe('Uninstall Tokens', () => {
-    test.beforeAll(async ({ kbnClient }) => {
-      const policy = await createAgentPolicy(kbnClient, 'Agent policy for A11y test', {
-        id: 'agent-policy-a11y',
-      });
-      policyIdA11y = policy.id;
-    });
+  test('Agent Policies - Agent Table After Adding Another Agent', async ({
+    pageObjects,
+    page,
+  }) => {
+    await pageObjects.fleetHome.navigateTo();
+    await pageObjects.fleetHome.navigateToAgentPoliciesTab();
+    await page.testSubj
+      .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON)
+      .waitFor({ state: 'visible', timeout: 15_000 });
 
-    test.afterAll(async ({ kbnClient }) => {
+    await page.testSubj.locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.CREATE_BUTTON).click();
+    await page.testSubj
+      .locator(AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT.TITLE)
+      .waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill('testName');
+    await page.testSubj.locator(AGENT_POLICY_FLYOUT_CREATE_BUTTON).click();
+    await page.testSubj
+      .locator('agentPoliciesTable')
+      .getByRole('link', { name: /testName/ })
+      .waitFor({ state: 'visible', timeout: 15_000 });
+  });
+
+  test('Enrollment Tokens - Table', async ({ page }) => {
+    await page.goto('/app/fleet/enrollment-tokens');
+    await page.testSubj
+      .locator('tableHeaderCell_name_0')
+      .waitFor({ state: 'visible', timeout: 15_000 });
+
+    await expect(page.testSubj.locator('tableHeaderCell_name_0')).toBeVisible();
+  });
+
+  test('Enrollment Tokens - Create Token Modal', async ({ page }) => {
+    await page.goto('/app/fleet/enrollment-tokens');
+    await page.testSubj
+      .locator('tableHeaderCell_name_0')
+      .waitFor({ state: 'visible', timeout: 15_000 });
+
+    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON).click();
+    await page.testSubj
+      .locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD)
+      .waitFor({ state: 'visible', timeout: 15_000 });
+  });
+
+  test('Uninstall Tokens - Table', async ({ kbnClient, page }) => {
+    const policy = await createAgentPolicy(kbnClient, 'Agent policy for A11y test', {
+      id: 'agent-policy-a11y',
+    });
+    policyIdA11y = policy.id;
+
+    try {
+      await page.goto('/app/fleet/uninstall-tokens');
+      await page.testSubj.locator('fleet-uninstall-tokens-tab').click();
+
+      await expect(
+        page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD).getByText(policyIdA11y)
+      ).toBeVisible();
+    } finally {
       try {
         await deleteAgentPolicy(kbnClient, 'agent-policy-a11y');
       } catch {
         // Ignore
       }
+    }
+  });
+
+  test('Uninstall Tokens - Command Flyout', async ({ kbnClient, page }) => {
+    await createAgentPolicy(kbnClient, 'Agent policy for A11y flyout test', {
+      id: 'agent-policy-a11y-flyout',
     });
 
-    test.beforeEach(async ({ page }) => {
+    try {
       await page.goto('/app/fleet/uninstall-tokens');
       await page.testSubj.locator('fleet-uninstall-tokens-tab').click();
-    });
+      await page.testSubj
+        .locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)
+        .waitFor({ state: 'visible', timeout: 15_000 });
 
-    test('Uninstall Tokens Table', async ({ page }) => {
+      await page.testSubj
+        .locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON)
+        .getByRole('button')
+        .click();
       await expect(
-        page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD).first()
+        page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)
       ).toBeVisible();
-    });
-
-    test('Uninstall Command Flyout', async ({ page }) => {
-      await page.testSubj.locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON).first().click();
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)).toBeVisible();
-    });
+    } finally {
+      try {
+        await deleteAgentPolicy(kbnClient, 'agent-policy-a11y-flyout');
+      } catch {
+        // Ignore
+      }
+    }
   });
 
-  test.describe('Data Streams', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.gotoApp('fleet');
-      await page.testSubj.locator(DATA_STREAMS_TAB).waitFor({ state: 'visible', timeout: 15_000 });
-      await page.testSubj.locator(DATA_STREAMS_TAB).click();
-    });
+  test('Data Streams - Empty Table', async ({ page }) => {
+    await page.gotoApp('fleet');
+    await page.testSubj.locator(DATA_STREAMS_TAB).waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator(DATA_STREAMS_TAB).click();
 
-    test('Datastreams Empty Table', async ({ page }) => {
-      await expect(page.testSubj.locator('tableHeaderSortButton')).toBeVisible({ timeout: 15_000 });
-    });
+    await expect(page.testSubj.locator('tableHeaderSortButton')).toBeVisible({ timeout: 15_000 });
   });
 
-  test.describe.skip('Settings', () => {
+  test.skip('Settings - Form', async ({ page }) => {
     // A11y Violation https://github.com/elastic/kibana/issues/138474
-    test.beforeEach(async ({ page }) => {
-      await page.gotoApp('fleet');
-      await page.testSubj.locator('fleet-settings-tab').click();
-    });
+    await page.gotoApp('fleet');
+    await page.testSubj.locator('fleet-settings-tab').click();
 
-    test('Settings Form', async ({ page }) => {
-      await expect(page.testSubj.locator('fleetServerHostHeader')).toBeVisible({ timeout: 15_000 });
-    });
+    await expect(page.testSubj.locator('fleetServerHostHeader')).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -162,10 +162,7 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
       .waitFor({ state: 'visible', timeout: 15_000 });
   });
 
-  test('Agent Policies - Agent Table After Adding Another Agent', async ({
-    pageObjects,
-    page,
-  }) => {
+  test('Agent Policies - Agent Table After Adding Another Agent', async ({ pageObjects, page }) => {
     await pageObjects.fleetHome.navigateTo();
     await pageObjects.fleetHome.navigateToAgentPoliciesTab();
     await page.testSubj
@@ -243,9 +240,7 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
         .locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON)
         .getByRole('button')
         .click();
-      await expect(
-        page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)
-      ).toBeVisible();
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)).toBeVisible();
     } finally {
       try {
         await deleteAgentPolicy(kbnClient, 'agent-policy-a11y-flyout');

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/a11y/home_page.spec.ts
@@ -40,8 +40,8 @@ test.describe('Home page A11y', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsAdmin();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsAdmin();
   });
 
   test.afterAll(async ({ kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
@@ -42,20 +42,27 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
 
   test('has a default value and allows to edit an existing object', async ({
     page,
-    browserAuth,
   }) => {
-    await browserAuth.loginAsAdmin();
     await page.gotoApp('fleet');
     await page.testSubj.locator(SETTINGS_TAB).click();
 
-    await expect(page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE).locator('tr')).toHaveCount(2);
+    const tableRows = page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE).locator('tr');
+    await expect(tableRows).toHaveCount(2);
+    const defaultRow = page.testSubj
+      .locator(AGENT_BINARY_SOURCES_TABLE)
+      .getByRole('row')
+      .filter({
+        has: page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.DEFAULT_VALUE),
+      });
     await expect(
-      page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.HOST).first()
+      defaultRow.locator(`[data-test-subj="${AGENT_BINARY_SOURCES_TABLE_ACTIONS.HOST}"]`)
     ).toContainText('https://artifacts.elastic.co/downloads/');
     await expect(
-      page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.DEFAULT_VALUE).first()
+      defaultRow.locator(`[data-test-subj="${AGENT_BINARY_SOURCES_TABLE_ACTIONS.DEFAULT_VALUE}"]`)
     ).toBeVisible();
-    await page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT).first().click();
+    await defaultRow
+      .locator(`[data-test-subj="${AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT}"]`)
+      .click();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).clear();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).fill('New Name');
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).clear();
@@ -66,8 +73,7 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
     await page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON).click();
   });
 
-  test('allows to create new download source objects', async ({ page, browserAuth }) => {
-    await browserAuth.loginAsAdmin();
+  test('allows to create new download source objects', async ({ page }) => {
     await page.gotoApp('fleet');
     await page.testSubj.locator(SETTINGS_TAB).click();
 
@@ -95,7 +101,6 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
   test('the download source is displayed in agent policy settings', async ({
     page,
     kbnClient,
-    browserAuth,
   }) => {
     await createDownloadSource(kbnClient, {
       name: 'Custom Host',
@@ -107,7 +112,6 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
       download_source_id: 'fleet-local-registry',
     });
 
-    await browserAuth.loginAsAdmin();
     await page.goto('/app/fleet/policies/new-agent-policy/settings');
     await expect(page.testSubj.locator(AGENT_POLICY_FORM.DOWNLOAD_SOURCE_SELECT)).toContainText(
       'Custom Host'

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
@@ -10,6 +10,7 @@ import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import {
+  setupFleetServer,
   createAgentPolicy,
   createDownloadSource,
   cleanupAgentPolicies,
@@ -25,6 +26,10 @@ import {
 } from '../common/selectors';
 
 test.describe('Agent binary download source section', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ kbnClient, browserAuth }) => {
     await browserAuth.loginAsAdmin();
     await cleanupDownloadSources(kbnClient);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
@@ -52,12 +52,16 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
     await expect(
       page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.HOST).first()
     ).toContainText('https://artifacts.elastic.co/downloads/');
-    await expect(page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.DEFAULT_VALUE).first()).toBeVisible();
+    await expect(
+      page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.DEFAULT_VALUE).first()
+    ).toBeVisible();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT).first().click();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).clear();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).fill('New Name');
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).clear();
-    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).fill('https://edited-default-host.co');
+    await page.testSubj
+      .locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT)
+      .fill('https://edited-default-host.co');
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON).click();
     await page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON).click();
   });
@@ -71,7 +75,9 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).clear();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).fill('New Host');
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).clear();
-    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).fill('https://new-test-host.co');
+    await page.testSubj
+      .locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT)
+      .fill('https://new-test-host.co');
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON).click();
     await expect(page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE).locator('tr')).toHaveCount(3);
 
@@ -79,7 +85,9 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).clear();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).fill('New Default Host');
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).clear();
-    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).fill('https://new-default-host.co');
+    await page.testSubj
+      .locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT)
+      .fill('https://new-default-host.co');
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.IS_DEFAULT_SWITCH).click();
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON).click();
   });
@@ -101,8 +109,8 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
 
     await browserAuth.loginAsAdmin();
     await page.goto('/app/fleet/policies/new-agent-policy/settings');
-    await expect(
-      page.testSubj.locator(AGENT_POLICY_FORM.DOWNLOAD_SOURCE_SELECT)
-    ).toContainText('Custom Host');
+    await expect(page.testSubj.locator(AGENT_POLICY_FORM.DOWNLOAD_SOURCE_SELECT)).toContainText(
+      'Custom Host'
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
@@ -40,9 +40,7 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
     }
   });
 
-  test('has a default value and allows to edit an existing object', async ({
-    page,
-  }) => {
+  test('has a default value and allows to edit an existing object', async ({ page }) => {
     await page.gotoApp('fleet');
     await page.testSubj.locator(SETTINGS_TAB).click();
 
@@ -98,10 +96,7 @@ test.describe('Agent binary download source section', { tag: [...tags.stateful.c
     await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON).click();
   });
 
-  test('the download source is displayed in agent policy settings', async ({
-    page,
-    kbnClient,
-  }) => {
+  test('the download source is displayed in agent policy settings', async ({ page, kbnClient }) => {
     await createDownloadSource(kbnClient, {
       name: 'Custom Host',
       id: 'fleet-local-registry',

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_binary_download_source.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  createAgentPolicy,
+  createDownloadSource,
+  cleanupAgentPolicies,
+  cleanupDownloadSources,
+} from '../common/api_helpers';
+import {
+  SETTINGS_TAB,
+  AGENT_BINARY_SOURCES_TABLE,
+  AGENT_BINARY_SOURCES_TABLE_ACTIONS,
+  AGENT_BINARY_SOURCES_FLYOUT,
+  AGENT_POLICY_FORM,
+  CONFIRM_MODAL,
+} from '../common/selectors';
+
+test.describe('Agent binary download source section', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ kbnClient, browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+    await cleanupDownloadSources(kbnClient);
+    await cleanupAgentPolicies(kbnClient);
+  });
+
+  test.afterEach(async ({ kbnClient }) => {
+    try {
+      await cleanupDownloadSources(kbnClient);
+      await cleanupAgentPolicies(kbnClient);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test('has a default value and allows to edit an existing object', async ({
+    page,
+    browserAuth,
+  }) => {
+    await browserAuth.loginAsAdmin();
+    await page.gotoApp('fleet');
+    await page.testSubj.locator(SETTINGS_TAB).click();
+
+    await expect(page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE).locator('tr')).toHaveCount(2);
+    await expect(
+      page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.HOST).first()
+    ).toContainText('https://artifacts.elastic.co/downloads/');
+    await expect(page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.DEFAULT_VALUE).first()).toBeVisible();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.EDIT).first().click();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).clear();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).fill('New Name');
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).clear();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).fill('https://edited-default-host.co');
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON).click();
+    await page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON).click();
+  });
+
+  test('allows to create new download source objects', async ({ page, browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+    await page.gotoApp('fleet');
+    await page.testSubj.locator(SETTINGS_TAB).click();
+
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.ADD).click();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).clear();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).fill('New Host');
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).clear();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).fill('https://new-test-host.co');
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON).click();
+    await expect(page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE).locator('tr')).toHaveCount(3);
+
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_TABLE_ACTIONS.ADD).click();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).clear();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.NAME_INPUT).fill('New Default Host');
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).clear();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.HOST_INPUT).fill('https://new-default-host.co');
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.IS_DEFAULT_SWITCH).click();
+    await page.testSubj.locator(AGENT_BINARY_SOURCES_FLYOUT.SUBMIT_BUTTON).click();
+  });
+
+  test('the download source is displayed in agent policy settings', async ({
+    page,
+    kbnClient,
+    browserAuth,
+  }) => {
+    await createDownloadSource(kbnClient, {
+      name: 'Custom Host',
+      id: 'fleet-local-registry',
+      host: 'https://new-custom-host.co',
+    });
+    await createAgentPolicy(kbnClient, 'Test Agent policy', {
+      id: 'new-agent-policy',
+      download_source_id: 'fleet-local-registry',
+    });
+
+    await browserAuth.loginAsAdmin();
+    await page.goto('/app/fleet/policies/new-agent-policy/settings');
+    await expect(
+      page.testSubj.locator(AGENT_POLICY_FORM.DOWNLOAD_SOURCE_SELECT)
+    ).toContainText('Custom Host');
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
@@ -18,8 +18,8 @@ import { AGENT_FLYOUT, AGENT_POLICY_DETAILS_PAGE } from '../common/selectors';
 
 test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsPrivilegedUser();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should edit agent policy', async ({ page, kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
@@ -14,7 +14,7 @@ import { AGENT_FLYOUT, AGENT_POLICY_DETAILS_PAGE } from '../common/selectors';
 
 test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should edit agent policy', async ({ page, kbnClient }) => {
@@ -41,7 +41,7 @@ test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
     });
 
     await page.goto('/app/fleet/policies/policy-1/settings');
-    const descInput = page.locator('[placeholder="Optional description"]').first();
+    const descInput = page.getByPlaceholder('Optional description');
     await descInput.clear();
     await descInput.fill('desc');
 
@@ -49,7 +49,7 @@ test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
       (res) =>
         res.url().includes('/api/fleet/agent_policies/policy-1') && res.request().method() === 'PUT'
     );
-    await page.getByRole('button', { name: 'Save changes' }).first().click();
+    await page.getByRole('button', { name: 'Save changes' }).click();
     const response = await updateResponse;
     const body = JSON.parse((await response.request().postData()) ?? '{}');
     expect(body.description).toBe('desc');
@@ -127,7 +127,8 @@ test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
     await page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.ADD_AGENT_LINK).click();
     await page.testSubj.locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED).click();
     await page.testSubj.locator(AGENT_FLYOUT.KUBERNETES_PLATFORM_TYPE).click();
-    await expect(page.getByText('https://xxx.yyy.zzz:443').first()).toBeVisible();
-    await expect(page.getByText('this-is-the-api-key').first()).toBeVisible();
+    const flyout = page.testSubj.locator('agentEnrollmentFlyout');
+    await expect(flyout.getByText('https://xxx.yyy.zzz:443')).toBeVisible();
+    await expect(flyout.getByText('this-is-the-api-key')).toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  setupFleetServer,
+  createAgentPolicy,
+} from '../common/api_helpers';
+import { AGENT_FLYOUT, AGENT_POLICY_DETAILS_PAGE } from '../common/selectors';
+
+test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should edit agent policy', async ({ page, kbnClient }) => {
+    await createAgentPolicy(kbnClient, 'Agent policy 1', { id: 'policy-1' });
+
+    await page.route('**/api/fleet/agent_policies/policy-1**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify({
+            item: {
+              id: 'policy-1',
+              name: 'Agent policy 1',
+              description: '',
+              namespace: 'default',
+              monitoring_enabled: ['logs', 'metrics'],
+              status: 'active',
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/app/fleet/policies/policy-1/settings');
+    const descInput = page.locator('[placeholder="Optional description"]').first();
+    await descInput.clear();
+    await descInput.fill('desc');
+
+    const updateResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/fleet/agent_policies/policy-1') && res.request().method() === 'PUT'
+    );
+    await page.getByRole('button', { name: 'Save changes' }).first().click();
+    const response = await updateResponse;
+    const body = JSON.parse((await response.request().postData()) ?? '{}');
+    expect(body.description).toBe('desc');
+  });
+
+  test('should show correct fleet server host for custom URL', async ({
+    page,
+    kbnClient,
+    esClient,
+  }) => {
+    const kibanaVersion = '8.1.0';
+    await setupFleetServer(kbnClient, esClient, kibanaVersion);
+
+    await page.route('**/api/fleet/agent_policies/policy-1**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          item: {
+            id: 'policy-1',
+            name: 'Agent policy 1',
+            description: 'desc',
+            namespace: 'default',
+            monitoring_enabled: ['logs', 'metrics'],
+            status: 'active',
+            fleet_server_host_id: 'fleet-server-1',
+            package_policies: [],
+          },
+        }),
+      });
+    });
+
+    const apiKey = {
+      id: 'key-1',
+      active: true,
+      api_key_id: 'PefGQYoB0MXWbqVD6jhr',
+      api_key: 'this-is-the-api-key',
+      name: 'key-1',
+      policy_id: 'policy-1',
+      created_at: '2023-08-29T14:51:10.473Z',
+    };
+
+    await page.route('**/api/fleet/enrollment_api_keys**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({ items: [apiKey], total: 1, page: 1, perPage: 10000 }),
+      });
+    });
+
+    await page.route('**/internal/fleet/settings/enrollment**', async (route) => {
+      const url = route.request().url();
+      if (url.includes('agentPolicyId=policy-1')) {
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify({
+            fleet_server: {
+              policies: [],
+              has_active: true,
+              host: {
+                id: 'fleet-server-1',
+                name: 'custom host',
+                host_urls: ['https://xxx.yyy.zzz:443'],
+                is_default: false,
+                is_preconfigured: false,
+              },
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await createAgentPolicy(kbnClient, 'Agent policy 1', { id: 'policy-1' });
+    await page.goto('/app/fleet/policies/policy-1');
+    await page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.ADD_AGENT_LINK).click();
+    await page.testSubj.locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED).click();
+    await page.testSubj.locator(AGENT_FLYOUT.KUBERNETES_PLATFORM_TYPE).click();
+    await expect(page.getByText('https://xxx.yyy.zzz:443').first()).toBeVisible();
+    await expect(page.getByText('this-is-the-api-key').first()).toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
@@ -9,10 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import {
-  setupFleetServer,
-  createAgentPolicy,
-} from '../common/api_helpers';
+import { setupFleetServer, createAgentPolicy } from '../common/api_helpers';
 import { AGENT_FLYOUT, AGENT_POLICY_DETAILS_PAGE } from '../common/selectors';
 
 test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
@@ -9,12 +9,17 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { setupFleetServer, createAgentPolicy } from '../common/api_helpers';
+import {
+  setupFleetServer,
+  createAgentPolicy,
+  mockFleetSetupEndpoints,
+} from '../common/api_helpers';
 import { AGENT_FLYOUT, AGENT_POLICY_DETAILS_PAGE } from '../common/selectors';
 
 test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsPrivilegedUser();
+    await mockFleetSetupEndpoints(page);
   });
 
   test('should edit agent policy', async ({ page, kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agent_policy.spec.ts
@@ -17,6 +17,10 @@ import {
 import { AGENT_FLYOUT, AGENT_POLICY_DETAILS_PAGE } from '../common/selectors';
 
 test.describe('Edit agent policy', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth, page }) => {
     await mockFleetSetupEndpoints(page);
     await browserAuth.loginAsPrivilegedUser();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
@@ -55,8 +55,8 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsPrivilegedUser();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsPrivilegedUser();
     await page.route('**/api/fleet/agents_status', (route) =>
       route.fulfill({
         status: 200,

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
@@ -68,7 +68,7 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsAdmin();
+    await browserAuth.loginAsPrivilegedUser();
     await page.route('**/api/fleet/agents/setup', (route) =>
       route.fulfill({
         status: 200,
@@ -124,7 +124,7 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
   test('should filter on single policy (no results)', async ({ page }) => {
     await page.goto('/app/fleet/agents');
     await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.POLICY_FILTER).click();
-    await page.getByText('Agent policy 4').first().click();
+    await page.getByRole('option', { name: 'Agent policy 4' }).click();
     await expect(
       page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('No agents found')
     ).toBeVisible();
@@ -133,7 +133,7 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
   test('should filter on single policy', async ({ page }) => {
     await page.goto('/app/fleet/agents');
     await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.POLICY_FILTER).click();
-    await page.getByText('Agent policy 1').first().click();
+    await page.getByRole('option', { name: 'Agent policy 1' }).click();
     await expect(
       page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')
     ).toBeVisible();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
@@ -28,7 +28,12 @@ const POLICIES = [
 
 test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
   test.beforeAll(async ({ kbnClient, esClient }) => {
-    await deleteDocsByQuery(esClient, '.fleet-agents', { match_all: {} }, { ignoreUnavailable: true });
+    await deleteDocsByQuery(
+      esClient,
+      '.fleet-agents',
+      { match_all: {} },
+      { ignoreUnavailable: true }
+    );
     await cleanupAgentPolicies(kbnClient);
     await setupFleetServer(kbnClient, esClient, '8.1.0');
 
@@ -50,7 +55,12 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
 
   test.afterAll(async ({ kbnClient, esClient }) => {
     try {
-      await deleteDocsByQuery(esClient, '.fleet-agents', { match_all: {} }, { ignoreUnavailable: true });
+      await deleteDocsByQuery(
+        esClient,
+        '.fleet-agents',
+        { match_all: {} },
+        { ignoreUnavailable: true }
+      );
       await cleanupAgentPolicies(kbnClient);
     } catch {
       // Ignore
@@ -60,10 +70,20 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsAdmin();
     await page.route('**/api/fleet/agents/setup', (route) =>
-      route.fulfill({ status: 200, body: JSON.stringify({ isReady: true, missing_optional_features: [], missing_requirements: [] }) })
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          isReady: true,
+          missing_optional_features: [],
+          missing_requirements: [],
+        }),
+      })
     );
     await page.route('**/api/fleet/setup', (route) =>
-      route.fulfill({ status: 200, body: JSON.stringify({ isInitialized: true, nonFatalErrors: [] }) })
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({ isInitialized: true, nonFatalErrors: [] }),
+      })
     );
     await page.route('**/api/fleet/agents_status', (route) =>
       route.fulfill({
@@ -88,26 +108,34 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
     await page.goto('/app/fleet/agents');
     await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.QUERY_INPUT).fill('agent.id: "agent-1"');
     await page.keyboard.press('Enter');
-    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')).toBeVisible();
+    await expect(
+      page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')
+    ).toBeVisible();
   });
 
   test('should only show agents with upgrade available after click', async ({ page }) => {
     await page.goto('/app/fleet/agents');
     await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.SHOW_UPGRADEABLE).click();
-    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')).toBeVisible();
+    await expect(
+      page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')
+    ).toBeVisible();
   });
 
   test('should filter on single policy (no results)', async ({ page }) => {
     await page.goto('/app/fleet/agents');
     await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.POLICY_FILTER).click();
     await page.getByText('Agent policy 4').first().click();
-    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('No agents found')).toBeVisible();
+    await expect(
+      page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('No agents found')
+    ).toBeVisible();
   });
 
   test('should filter on single policy', async ({ page }) => {
     await page.goto('/app/fleet/agents');
     await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.POLICY_FILTER).click();
     await page.getByText('Agent policy 1').first().click();
-    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')).toBeVisible();
+    await expect(
+      page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')
+    ).toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
@@ -16,6 +16,7 @@ import {
   insertDocs,
   deleteDocsByQuery,
   cleanupAgentPolicies,
+  mockFleetSetupEndpoints,
 } from '../../common/api_helpers';
 import { FLEET_AGENT_LIST_PAGE } from '../../common/selectors';
 
@@ -55,22 +56,7 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
 
   test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsPrivilegedUser();
-    await page.route('**/api/fleet/agents/setup', (route) =>
-      route.fulfill({
-        status: 200,
-        body: JSON.stringify({
-          isReady: true,
-          missing_optional_features: [],
-          missing_requirements: [],
-        }),
-      })
-    );
-    await page.route('**/api/fleet/setup', (route) =>
-      route.fulfill({
-        status: 200,
-        body: JSON.stringify({ isInitialized: true, nonFatalErrors: [] }),
-      })
-    );
+    await mockFleetSetupEndpoints(page);
     await page.route('**/api/fleet/agents_status', (route) =>
       route.fulfill({
         status: 200,

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../../fixtures';
+import {
+  setupFleetServer,
+  createAgentPolicy,
+  createAgentDoc,
+  insertDocs,
+  deleteDocsByQuery,
+  cleanupAgentPolicies,
+} from '../../common/api_helpers';
+import { FLEET_AGENT_LIST_PAGE } from '../../common/selectors';
+
+const POLICIES = [
+  { id: 'policy-1', name: 'Agent policy 1' },
+  { id: 'policy-2', name: 'Agent policy 2' },
+  { id: 'policy-3', name: 'Agent policy 3' },
+  { id: 'policy-4', name: 'Agent policy 4' },
+];
+
+test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await deleteDocsByQuery(esClient, '.fleet-agents', { match_all: {} }, { ignoreUnavailable: true });
+    await cleanupAgentPolicies(kbnClient);
+    await setupFleetServer(kbnClient, esClient, '8.1.0');
+
+    const docs = [
+      createAgentDoc('agent-1', 'policy-1'),
+      createAgentDoc('agent-2', 'policy-2', 'error'),
+      createAgentDoc('agent-3', 'policy-3', 'online', '8.1.0', { tags: ['tag1', 'tag2'] }),
+      createAgentDoc('agent-4', 'policy-3', 'online', '8.1.0', { tags: ['tag1', 'tag2'] }),
+      createAgentDoc('agent-5', 'policy-3', 'online', '8.1.0', { tags: ['tag2'] }),
+      createAgentDoc('agent-6', 'policy-3', 'online', '8.1.0', { tags: ['tag2'] }),
+      ...Array.from({ length: 11 }, (_, i) => createAgentDoc(`agent-${i + 7}`, 'policy-3')),
+    ];
+    await insertDocs(esClient, '.fleet-agents', docs);
+
+    for (const p of POLICIES) {
+      await createAgentPolicy(kbnClient, p.name, { id: p.id });
+    }
+  });
+
+  test.afterAll(async ({ kbnClient, esClient }) => {
+    try {
+      await deleteDocsByQuery(esClient, '.fleet-agents', { match_all: {} }, { ignoreUnavailable: true });
+      await cleanupAgentPolicies(kbnClient);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test.beforeEach(async ({ browserAuth, page }) => {
+    await browserAuth.loginAsAdmin();
+    await page.route('**/api/fleet/agents/setup', (route) =>
+      route.fulfill({ status: 200, body: JSON.stringify({ isReady: true, missing_optional_features: [], missing_requirements: [] }) })
+    );
+    await page.route('**/api/fleet/setup', (route) =>
+      route.fulfill({ status: 200, body: JSON.stringify({ isInitialized: true, nonFatalErrors: [] }) })
+    );
+    await page.route('**/api/fleet/agents_status', (route) =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          total: 18,
+          inactive: 0,
+          online: 18,
+          error: 0,
+          offline: 0,
+          updating: 0,
+          other: 0,
+          events: 0,
+          orphaned: 0,
+          uninstalled: 0,
+        }),
+      })
+    );
+  });
+
+  test('should filter based on agent id', async ({ page }) => {
+    await page.goto('/app/fleet/agents');
+    await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.QUERY_INPUT).fill('agent.id: "agent-1"');
+    await page.keyboard.press('Enter');
+    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')).toBeVisible();
+  });
+
+  test('should only show agents with upgrade available after click', async ({ page }) => {
+    await page.goto('/app/fleet/agents');
+    await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.SHOW_UPGRADEABLE).click();
+    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')).toBeVisible();
+  });
+
+  test('should filter on single policy (no results)', async ({ page }) => {
+    await page.goto('/app/fleet/agents');
+    await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.POLICY_FILTER).click();
+    await page.getByText('Agent policy 4').first().click();
+    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('No agents found')).toBeVisible();
+  });
+
+  test('should filter on single policy', async ({ page }) => {
+    await page.goto('/app/fleet/agents');
+    await page.testSubj.locator(FLEET_AGENT_LIST_PAGE.POLICY_FILTER).click();
+    await page.getByText('Agent policy 1').first().click();
+    await expect(page.testSubj.locator(FLEET_AGENT_LIST_PAGE.TABLE).getByText('agent-1')).toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agent_list.spec.ts
@@ -53,20 +53,6 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
     }
   });
 
-  test.afterAll(async ({ kbnClient, esClient }) => {
-    try {
-      await deleteDocsByQuery(
-        esClient,
-        '.fleet-agents',
-        { match_all: {} },
-        { ignoreUnavailable: true }
-      );
-      await cleanupAgentPolicies(kbnClient);
-    } catch {
-      // Ignore
-    }
-  });
-
   test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsPrivilegedUser();
     await page.route('**/api/fleet/agents/setup', (route) =>
@@ -102,6 +88,20 @@ test.describe('View agents list', { tag: [...tags.stateful.classic] }, () => {
         }),
       })
     );
+  });
+
+  test.afterAll(async ({ kbnClient, esClient }) => {
+    try {
+      await deleteDocsByQuery(
+        esClient,
+        '.fleet-agents',
+        { match_all: {} },
+        { ignoreUnavailable: true }
+      );
+      await cleanupAgentPolicies(kbnClient);
+    } catch {
+      // Ignore
+    }
   });
 
   test('should filter based on agent id', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
@@ -16,7 +16,10 @@ test.describe('Agentless policy', { tag: [...tags.stateful.classic] }, () => {
     await browserAuth.loginAsAdmin();
   });
 
-  test('should not show Add integration button for agentless policy', async ({ page, kbnClient }) => {
+  test('should not show Add integration button for agentless policy', async ({
+    page,
+    kbnClient,
+  }) => {
     await page.route('**/api/fleet/agent_policies/**', async (route) => {
       const url = route.request().url();
       if (url.includes('policy-1') && route.request().method() === 'GET') {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
@@ -9,9 +9,13 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../../fixtures';
-import { createAgentPolicy } from '../../common/api_helpers';
+import { setupFleetServer, createAgentPolicy } from '../../common/api_helpers';
 
 test.describe('Agentless policy', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth }) => {
     await browserAuth.loginAsPrivilegedUser();
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
@@ -13,7 +13,7 @@ import { createAgentPolicy } from '../../common/api_helpers';
 
 test.describe('Agentless policy', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should not show Add integration button for agentless policy', async ({
@@ -45,6 +45,6 @@ test.describe('Agentless policy', { tag: [...tags.stateful.classic] }, () => {
 
     await createAgentPolicy(kbnClient, 'Agentless policy', { id: 'policy-1' });
     await page.goto('/app/fleet/policies/policy-1');
-    await expect(page.getByText('Add integration').first()).not.toBeVisible();
+    await expect(page.testSubj.locator('addPackagePolicyButton')).not.toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/agents/agentless.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../../fixtures';
+import { createAgentPolicy } from '../../common/api_helpers';
+
+test.describe('Agentless policy', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should not show Add integration button for agentless policy', async ({ page, kbnClient }) => {
+    await page.route('**/api/fleet/agent_policies/**', async (route) => {
+      const url = route.request().url();
+      if (url.includes('policy-1') && route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify({
+            item: {
+              id: 'policy-1',
+              name: 'Agentless policy',
+              description: '',
+              namespace: 'default',
+              monitoring_enabled: [],
+              status: 'active',
+              supports_agentless: true,
+              package_policies: [],
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await createAgentPolicy(kbnClient, 'Agentless policy', { id: 'policy-1' });
+    await page.goto('/app/fleet/policies/policy-1');
+    await expect(page.getByText('Add integration').first()).not.toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import { installTestPackage, uninstallTestPackage } from '../common/api_helpers';
+import { ASSETS_PAGE } from '../common/selectors';
+
+const LMD_PACKAGE = 'lmd';
+
+test.describe('Assets integration with ML and transforms', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    await installTestPackage(kbnClient, LMD_PACKAGE, 'latest');
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    try {
+      await uninstallTestPackage(kbnClient, LMD_PACKAGE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should display integration assets including ML and transforms', async ({ page }) => {
+    await page.goto(`/app/integrations/detail/${LMD_PACKAGE}/overview`);
+    await page.testSubj.locator(ASSETS_PAGE.TAB).click();
+    await expect(
+      page.testSubj.locator(ASSETS_PAGE.getButtonId('index_templates'))
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
@@ -14,28 +14,32 @@ import { ASSETS_PAGE } from '../common/selectors';
 
 const LMD_PACKAGE = 'lmd';
 
-test.describe('Assets integration with ML and transforms', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeAll(async ({ kbnClient }) => {
-    await installTestPackage(kbnClient, LMD_PACKAGE, 'latest');
-  });
+test.describe(
+  'Assets integration with ML and transforms',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    test.beforeAll(async ({ kbnClient }) => {
+      await installTestPackage(kbnClient, LMD_PACKAGE, 'latest');
+    });
 
-  test.afterAll(async ({ kbnClient }) => {
-    try {
-      await uninstallTestPackage(kbnClient, LMD_PACKAGE);
-    } catch {
-      // Ignore
-    }
-  });
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await uninstallTestPackage(kbnClient, LMD_PACKAGE);
+      } catch {
+        // Ignore
+      }
+    });
 
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
-  });
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
 
-  test('should display integration assets including ML and transforms', async ({ page }) => {
-    await page.goto(`/app/integrations/detail/${LMD_PACKAGE}/overview`);
-    await page.testSubj.locator(ASSETS_PAGE.TAB).click();
-    await expect(
-      page.testSubj.locator(ASSETS_PAGE.getButtonId('index_templates'))
-    ).toBeVisible({ timeout: 15_000 });
-  });
-});
+    test('should display integration assets including ML and transforms', async ({ page }) => {
+      await page.goto(`/app/integrations/detail/${LMD_PACKAGE}/overview`);
+      await page.testSubj.locator(ASSETS_PAGE.TAB).click();
+      await expect(page.testSubj.locator(ASSETS_PAGE.getButtonId('index_templates'))).toBeVisible({
+        timeout: 15_000,
+      });
+    });
+  }
+);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
@@ -9,7 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { installTestPackage, uninstallTestPackage } from '../common/api_helpers';
+import { setupFleetServer, installTestPackage, uninstallTestPackage } from '../common/api_helpers';
 import { ASSETS_PAGE } from '../common/selectors';
 
 const LMD_PACKAGE = 'lmd';
@@ -18,7 +18,8 @@ test.describe(
   'Assets integration with ML and transforms',
   { tag: [...tags.stateful.classic] },
   () => {
-    test.beforeAll(async ({ kbnClient }) => {
+    test.beforeAll(async ({ kbnClient, esClient }) => {
+      await setupFleetServer(kbnClient, esClient);
       await installTestPackage(kbnClient, LMD_PACKAGE, 'latest');
     });
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/assets_integration_with_ml_and_transforms.spec.ts
@@ -22,16 +22,16 @@ test.describe(
       await installTestPackage(kbnClient, LMD_PACKAGE, 'latest');
     });
 
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
+
     test.afterAll(async ({ kbnClient }) => {
       try {
         await uninstallTestPackage(kbnClient, LMD_PACKAGE);
       } catch {
         // Ignore
       }
-    });
-
-    test.beforeEach(async ({ browserAuth }) => {
-      await browserAuth.loginAsAdmin();
     });
 
     test('should display integration assets including ML and transforms', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
@@ -62,7 +62,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
 
     await browseIntegrations.sortIntegrations('z-a');
 
-    await browseIntegrations.expectIntegrationCardToBeVisible('zoom');
+    await expect(browseIntegrations.getIntegrationCard('zoom')).toBeVisible();
   });
 
   test('it allow to search for an integration', async ({ pageObjects, browserAuth }) => {
@@ -75,6 +75,6 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
 
     await browseIntegrations.searchForIntegration('nginx');
 
-    await browseIntegrations.expectIntegrationCardToBeVisible('nginx');
+    await expect(browseIntegrations.getIntegrationCard('nginx')).toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
@@ -6,10 +6,11 @@
  */
 
 import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 
-test.describe('Copy integration', { tag: '@local-stateful-classic' }, () => {
+test.describe('Copy integration', { tag: [...tags.stateful.classic] }, () => {
   // This test can take a bit longer on ECH
   test.setTimeout(2 * 60 * 1000); // 2 minutes
   const testAgentPolicyName = 'Test Agent Policy for Copy';

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
@@ -10,7 +10,7 @@ import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import { createAgentPolicy, cleanupAgentPolicies } from '../common/api_helpers';
-import { ENROLLMENT_TOKENS, CONFIRM_MODAL } from '../common/selectors';
+import { ENROLLMENT_TOKENS } from '../common/selectors';
 
 test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () => {
   test.beforeAll(async ({ kbnClient }) => {
@@ -26,47 +26,34 @@ test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () =
   });
 
   test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
+    await browserAuth.loginAsPrivilegedUser();
   });
 
-  test('Create new Token', async ({ page }) => {
-    await page.goto('/app/fleet/enrollment-tokens');
-    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON).click();
-    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).clear();
-    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).fill('New Token');
-    await page.testSubj
-      .locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_SELECT_FIELD)
-      .locator('input')
-      .fill('Agent policy 1');
-    await page.getByRole('option').filter({ hasText: 'Agent policy 1' }).first().click();
-    await page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON).click();
+  test('Create new Token', async ({ pageObjects }) => {
+    await pageObjects.enrollmentTokens.navigateTo();
+    await pageObjects.enrollmentTokens.createToken('New Token', 'Agent policy 1');
 
     await expect(
-      page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE).getByText('Agent policy 1')
+      pageObjects.enrollmentTokens.getListTable().getByText('Agent policy 1')
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('Delete Token - inactivates the token', async ({ page }) => {
-    await page.goto('/app/fleet/enrollment-tokens');
-    await expect(page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE).locator('tr')).toHaveCount(2);
-    await page.testSubj.locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN).first().click();
-    await expect(
-      page
-        .locator('.euiPanel')
-        .getByText(/Are you sure you want to revoke/)
-        .first()
-    ).toBeVisible();
-    await page
-      .getByRole('button', { name: 'Revoke enrollment token' })
-      .first()
-      .click({ force: true });
+  test('Delete Token - inactivates the token', async ({ page, pageObjects }) => {
+    await pageObjects.enrollmentTokens.navigateTo();
+
+    const listTable = pageObjects.enrollmentTokens.getListTable();
+    await expect(listTable.getByRole('row')).toHaveCount(2);
+
+    await pageObjects.enrollmentTokens.revokeToken('Agent policy 1');
 
     await expect(
-      page.testSubj
-        .locator(ENROLLMENT_TOKENS.LIST_TABLE)
-        .locator('.euiTableRow')
-        .first()
-        .locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN)
+      page.getByRole('dialog').getByText(/Are you sure you want to revoke/)
+    ).toBeVisible();
+    await page.getByRole('dialog').getByRole('button', { name: 'Revoke enrollment token' }).click();
+
+    const row = listTable.getByRole('row', { name: 'Agent policy 1' });
+    await expect(
+      row.locator(page.testSubj.locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN))
     ).not.toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
@@ -9,10 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import {
-  createAgentPolicy,
-  cleanupAgentPolicies,
-} from '../common/api_helpers';
+import { createAgentPolicy, cleanupAgentPolicies } from '../common/api_helpers';
 import { ENROLLMENT_TOKENS, CONFIRM_MODAL } from '../common/selectors';
 
 test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () => {
@@ -37,7 +34,10 @@ test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () =
     await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON).click();
     await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).clear();
     await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).fill('New Token');
-    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_SELECT_FIELD).locator('input').fill('Agent policy 1');
+    await page.testSubj
+      .locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_SELECT_FIELD)
+      .locator('input')
+      .fill('Agent policy 1');
     await page.getByRole('option').filter({ hasText: 'Agent policy 1' }).first().click();
     await page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON).click();
 
@@ -50,11 +50,23 @@ test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () =
     await page.goto('/app/fleet/enrollment-tokens');
     await expect(page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE).locator('tr')).toHaveCount(2);
     await page.testSubj.locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN).first().click();
-    await expect(page.locator('.euiPanel').getByText(/Are you sure you want to revoke/).first()).toBeVisible();
-    await page.getByRole('button', { name: 'Revoke enrollment token' }).first().click({ force: true });
+    await expect(
+      page
+        .locator('.euiPanel')
+        .getByText(/Are you sure you want to revoke/)
+        .first()
+    ).toBeVisible();
+    await page
+      .getByRole('button', { name: 'Revoke enrollment token' })
+      .first()
+      .click({ force: true });
 
     await expect(
-      page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE).locator('.euiTableRow').first().locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN)
+      page.testSubj
+        .locator(ENROLLMENT_TOKENS.LIST_TABLE)
+        .locator('.euiTableRow')
+        .first()
+        .locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN)
     ).not.toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  createAgentPolicy,
+  cleanupAgentPolicies,
+} from '../common/api_helpers';
+import { ENROLLMENT_TOKENS, CONFIRM_MODAL } from '../common/selectors';
+
+test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    await createAgentPolicy(kbnClient, 'Agent policy 1', { id: 'agent-policy-1' });
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    try {
+      await cleanupAgentPolicies(kbnClient);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('Create new Token', async ({ page }) => {
+    await page.goto('/app/fleet/enrollment-tokens');
+    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_BUTTON).click();
+    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).clear();
+    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_NAME_FIELD).fill('New Token');
+    await page.testSubj.locator(ENROLLMENT_TOKENS.CREATE_TOKEN_MODAL_SELECT_FIELD).locator('input').fill('Agent policy 1');
+    await page.getByRole('option').filter({ hasText: 'Agent policy 1' }).first().click();
+    await page.testSubj.locator(CONFIRM_MODAL.CONFIRM_BUTTON).click();
+
+    await expect(
+      page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE).getByText('Agent policy 1')
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('Delete Token - inactivates the token', async ({ page }) => {
+    await page.goto('/app/fleet/enrollment-tokens');
+    await expect(page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE).locator('tr')).toHaveCount(2);
+    await page.testSubj.locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN).first().click();
+    await expect(page.locator('.euiPanel').getByText(/Are you sure you want to revoke/).first()).toBeVisible();
+    await page.getByRole('button', { name: 'Revoke enrollment token' }).first().click({ force: true });
+
+    await expect(
+      page.testSubj.locator(ENROLLMENT_TOKENS.LIST_TABLE).locator('.euiTableRow').first().locator(ENROLLMENT_TOKENS.TABLE_REVOKE_BTN)
+    ).not.toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
@@ -10,6 +10,7 @@ import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import {
+  setupFleetServer,
   createAgentPolicy,
   cleanupAgentPolicies,
   mockFleetSetupEndpoints,
@@ -17,7 +18,8 @@ import {
 import { ENROLLMENT_TOKENS } from '../common/selectors';
 
 test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeAll(async ({ kbnClient }) => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
     await createAgentPolicy(kbnClient, 'Agent policy 1', { id: 'agent-policy-1' });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
@@ -9,7 +9,11 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { createAgentPolicy, cleanupAgentPolicies } from '../common/api_helpers';
+import {
+  createAgentPolicy,
+  cleanupAgentPolicies,
+  mockFleetSetupEndpoints,
+} from '../common/api_helpers';
 import { ENROLLMENT_TOKENS } from '../common/selectors';
 
 test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () => {
@@ -17,8 +21,9 @@ test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () =
     await createAgentPolicy(kbnClient, 'Agent policy 1', { id: 'agent-policy-1' });
   });
 
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsPrivilegedUser();
+    await mockFleetSetupEndpoints(page);
   });
 
   test.afterAll(async ({ kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
@@ -17,16 +17,16 @@ test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () =
     await createAgentPolicy(kbnClient, 'Agent policy 1', { id: 'agent-policy-1' });
   });
 
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
   test.afterAll(async ({ kbnClient }) => {
     try {
       await cleanupAgentPolicies(kbnClient);
     } catch {
       // Ignore
     }
-  });
-
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('Create new Token', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/enrollment_token.spec.ts
@@ -22,8 +22,8 @@ test.describe('Enrollment token page', { tag: [...tags.stateful.classic] }, () =
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsPrivilegedUser();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test.afterAll(async ({ kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
@@ -10,7 +10,7 @@ import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import {
-  setFleetServerHost,
+  setupFleetServer,
   createAgentPolicy,
   createAgentDoc,
   insertDocs,
@@ -22,7 +22,7 @@ import { AGENT_FLYOUT } from '../common/selectors';
 
 test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
   test.beforeAll(async ({ kbnClient, esClient }) => {
-    await setFleetServerHost(kbnClient);
+    await setupFleetServer(kbnClient, esClient);
     const policy = await createAgentPolicy(kbnClient, `Scout test policy ${Date.now()}`);
     const agentDoc = createAgentDoc('scout-agent-1', policy.id as string, 'online', '8.1.0');
     await insertDocs(esClient, '.fleet-agents', [agentDoc]);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
@@ -23,8 +23,12 @@ test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
   test.beforeAll(async ({ kbnClient, esClient }) => {
     await setFleetServerHost(kbnClient);
     const policy = await createAgentPolicy(kbnClient, `Scout test policy ${Date.now()}`);
-    const agentDoc = createAgentDoc('scout-agent-1', policy.id, 'online', '8.1.0');
+    const agentDoc = createAgentDoc('scout-agent-1', policy.id as string, 'online', '8.1.0');
     await insertDocs(esClient, '.fleet-agents', [agentDoc]);
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test.afterAll(async ({ kbnClient, esClient }) => {
@@ -39,10 +43,6 @@ test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
     } catch {
       // Ignore
     }
-  });
-
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should show add agent flyout with Fleet Server already set up', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
@@ -16,6 +16,7 @@ import {
   insertDocs,
   deleteDocsByQuery,
   cleanupAgentPolicies,
+  mockFleetSetupEndpoints,
 } from '../common/api_helpers';
 import { AGENT_FLYOUT } from '../common/selectors';
 
@@ -27,8 +28,9 @@ test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
     await insertDocs(esClient, '.fleet-agents', [agentDoc]);
   });
 
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsPrivilegedUser();
+    await mockFleetSetupEndpoints(page);
   });
 
   test.afterAll(async ({ kbnClient, esClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
@@ -42,7 +42,7 @@ test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should show add agent flyout with Fleet Server already set up', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  setFleetServerHost,
+  createAgentPolicy,
+  createAgentDoc,
+  insertDocs,
+  deleteDocsByQuery,
+  cleanupAgentPolicies,
+} from '../common/api_helpers';
+import { AGENT_FLYOUT } from '../common/selectors';
+
+test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setFleetServerHost(kbnClient);
+    const policy = await createAgentPolicy(kbnClient, `Scout test policy ${Date.now()}`);
+    const agentDoc = createAgentDoc('scout-agent-1', policy.id, 'online', '8.1.0');
+    await insertDocs(esClient, '.fleet-agents', [agentDoc]);
+  });
+
+  test.afterAll(async ({ kbnClient, esClient }) => {
+    try {
+      await deleteDocsByQuery(esClient, '.fleet-agents', { match: { 'agent.id': 'scout-agent-1' } }, { ignoreUnavailable: true });
+      await cleanupAgentPolicies(kbnClient);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should show add agent flyout with Fleet Server already set up', async ({ page }) => {
+    await page.gotoApp('fleet');
+    await page.testSubj.locator('addAgentButton').click();
+    await page.testSubj.locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED).waitFor({ state: 'visible', timeout: 15_000 });
+    await expect(page.testSubj.locator(AGENT_FLYOUT.POLICY_DROPDOWN)).toBeVisible();
+  });
+
+  test('should show incoming data confirmed after enrollment', async ({ page }) => {
+    await page.gotoApp('fleet');
+    await page.testSubj.locator('addAgentButton').click();
+    await page.testSubj.locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED).waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator(AGENT_FLYOUT.CONFIRM_AGENT_ENROLLMENT_BUTTON).click();
+    await expect(page.testSubj.locator(AGENT_FLYOUT.INCOMING_DATA_CONFIRMED_CALL_OUT)).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
@@ -29,8 +29,8 @@ test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsPrivilegedUser();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test.afterAll(async ({ kbnClient, esClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_agent_flyout.spec.ts
@@ -29,7 +29,12 @@ test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
 
   test.afterAll(async ({ kbnClient, esClient }) => {
     try {
-      await deleteDocsByQuery(esClient, '.fleet-agents', { match: { 'agent.id': 'scout-agent-1' } }, { ignoreUnavailable: true });
+      await deleteDocsByQuery(
+        esClient,
+        '.fleet-agents',
+        { match: { 'agent.id': 'scout-agent-1' } },
+        { ignoreUnavailable: true }
+      );
       await cleanupAgentPolicies(kbnClient);
     } catch {
       // Ignore
@@ -43,15 +48,21 @@ test.describe('Add agent flyout', { tag: [...tags.stateful.classic] }, () => {
   test('should show add agent flyout with Fleet Server already set up', async ({ page }) => {
     await page.gotoApp('fleet');
     await page.testSubj.locator('addAgentButton').click();
-    await page.testSubj.locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED).waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj
+      .locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED)
+      .waitFor({ state: 'visible', timeout: 15_000 });
     await expect(page.testSubj.locator(AGENT_FLYOUT.POLICY_DROPDOWN)).toBeVisible();
   });
 
   test('should show incoming data confirmed after enrollment', async ({ page }) => {
     await page.gotoApp('fleet');
     await page.testSubj.locator('addAgentButton').click();
-    await page.testSubj.locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED).waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj
+      .locator(AGENT_FLYOUT.PLATFORM_SELECTOR_EXTENDED)
+      .waitFor({ state: 'visible', timeout: 15_000 });
     await page.testSubj.locator(AGENT_FLYOUT.CONFIRM_AGENT_ENROLLMENT_BUTTON).click();
-    await expect(page.testSubj.locator(AGENT_FLYOUT.INCOMING_DATA_CONFIRMED_CALL_OUT)).toBeVisible({ timeout: 30_000 });
+    await expect(page.testSubj.locator(AGENT_FLYOUT.INCOMING_DATA_CONFIRMED_CALL_OUT)).toBeVisible({
+      timeout: 30_000,
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
@@ -9,7 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { SETTINGS_OUTPUTS, SETTINGS_SAVE_BTN, CONFIRM_MODAL } from '../common/selectors';
+import { SETTINGS_OUTPUTS } from '../common/selectors';
 
 test.describe('Fleet settings outputs', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth }) => {
@@ -34,7 +34,10 @@ test.describe('Fleet settings outputs', { tag: [...tags.stateful.classic] }, () 
     await page.goto('/app/fleet/settings');
     await page.testSubj.locator(SETTINGS_OUTPUTS.ADD_BTN).click();
     await page.testSubj.locator(SETTINGS_OUTPUTS.TYPE_INPUT).selectOption('kafka');
-    await page.testSubj.locator('kafkaAuthenticationUsernamePasswordRadioButton').locator('label').click();
+    await page.testSubj
+      .locator('kafkaAuthenticationUsernamePasswordRadioButton')
+      .locator('label')
+      .click();
     await expect(page.testSubj.locator(SETTINGS_OUTPUTS.NAME_INPUT)).toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import { SETTINGS_OUTPUTS, SETTINGS_SAVE_BTN, CONFIRM_MODAL } from '../common/selectors';
+
+test.describe('Fleet settings outputs', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should add ES output', async ({ page }) => {
+    await page.goto('/app/fleet/settings');
+    await page.testSubj.locator(SETTINGS_OUTPUTS.ADD_BTN).click();
+    await page.testSubj.locator(SETTINGS_OUTPUTS.TYPE_INPUT).selectOption('elasticsearch');
+    await expect(page.testSubj.locator(SETTINGS_OUTPUTS.NAME_INPUT)).toBeVisible();
+  });
+
+  test('should add Remote ES output', async ({ page }) => {
+    await page.goto('/app/fleet/settings');
+    await page.testSubj.locator(SETTINGS_OUTPUTS.ADD_BTN).click();
+    await page.testSubj.locator(SETTINGS_OUTPUTS.TYPE_INPUT).selectOption('remote_elasticsearch');
+    await expect(page.testSubj.locator(SETTINGS_OUTPUTS.NAME_INPUT)).toBeVisible();
+  });
+
+  test('should add Kafka output', async ({ page }) => {
+    await page.goto('/app/fleet/settings');
+    await page.testSubj.locator(SETTINGS_OUTPUTS.ADD_BTN).click();
+    await page.testSubj.locator(SETTINGS_OUTPUTS.TYPE_INPUT).selectOption('kafka');
+    await page.testSubj.locator('kafkaAuthenticationUsernamePasswordRadioButton').locator('label').click();
+    await expect(page.testSubj.locator(SETTINGS_OUTPUTS.NAME_INPUT)).toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
@@ -13,7 +13,7 @@ import { SETTINGS_OUTPUTS } from '../common/selectors';
 
 test.describe('Fleet settings outputs', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should add ES output', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_settings_outputs.spec.ts
@@ -9,9 +9,14 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
+import { setupFleetServer } from '../common/api_helpers';
 import { SETTINGS_OUTPUTS } from '../common/selectors';
 
 test.describe('Fleet settings outputs', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth }) => {
     await browserAuth.loginAsPrivilegedUser();
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
@@ -17,7 +17,7 @@ test.describe('Fleet startup', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should create agent policy with System integration', async ({ page }) => {
@@ -29,7 +29,9 @@ test.describe('Fleet startup', { tag: [...tags.stateful.classic] }, () => {
       .waitFor({ state: 'visible', timeout: 15_000 });
     await page.testSubj.locator('createAgentPolicyNameField').fill(`Test policy ${Date.now()}`);
     await page.testSubj.locator('createAgentPolicyFlyoutBtn').click();
-    await expect(page.getByRole('link', { name: /Test policy/ }).first()).toBeVisible({
+    await expect(
+      page.testSubj.locator('agentPoliciesTable').getByRole('link', { name: /Test policy/ })
+    ).toBeVisible({
       timeout: 15_000,
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
@@ -9,15 +9,16 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { setFleetServerHost } from '../common/api_helpers';
+import { setFleetServerHost, mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Fleet startup', { tag: [...tags.stateful.classic] }, () => {
   test.beforeAll(async ({ kbnClient }) => {
     await setFleetServerHost(kbnClient);
   });
 
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsPrivilegedUser();
+    await mockFleetSetupEndpoints(page);
   });
 
   test('should create agent policy with System integration', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import { setFleetServerHost } from '../common/api_helpers';
+
+test.describe('Fleet startup', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    await setFleetServerHost(kbnClient);
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should create agent policy with System integration', async ({ page }) => {
+    await page.gotoApp('fleet');
+    await page.testSubj.locator('fleet-agent-policies-tab').click();
+    await page.testSubj.locator('createAgentPolicyButton').click();
+    await page.testSubj.locator('createAgentPolicyNameField').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj.locator('createAgentPolicyNameField').fill(`Test policy ${Date.now()}`);
+    await page.testSubj.locator('createAgentPolicyFlyoutBtn').click();
+    await expect(page.getByRole('link', { name: /Test policy/ }).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('should create Fleet Server policy', async ({ page }) => {
+    await page.gotoApp('fleet');
+    await page.testSubj.locator('fleetServerLanding.addFleetServerButton').click();
+    await page.testSubj.locator('fleetServerFlyoutTab-quickStart').waitFor({ state: 'visible', timeout: 15_000 });
+    await expect(page.testSubj.locator('createPolicyBtn')).toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
@@ -24,16 +24,22 @@ test.describe('Fleet startup', { tag: [...tags.stateful.classic] }, () => {
     await page.gotoApp('fleet');
     await page.testSubj.locator('fleet-agent-policies-tab').click();
     await page.testSubj.locator('createAgentPolicyButton').click();
-    await page.testSubj.locator('createAgentPolicyNameField').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj
+      .locator('createAgentPolicyNameField')
+      .waitFor({ state: 'visible', timeout: 15_000 });
     await page.testSubj.locator('createAgentPolicyNameField').fill(`Test policy ${Date.now()}`);
     await page.testSubj.locator('createAgentPolicyFlyoutBtn').click();
-    await expect(page.getByRole('link', { name: /Test policy/ }).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('link', { name: /Test policy/ }).first()).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
   test('should create Fleet Server policy', async ({ page }) => {
     await page.gotoApp('fleet');
     await page.testSubj.locator('fleetServerLanding.addFleetServerButton').click();
-    await page.testSubj.locator('fleetServerFlyoutTab-quickStart').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.testSubj
+      .locator('fleetServerFlyoutTab-quickStart')
+      .waitFor({ state: 'visible', timeout: 15_000 });
     await expect(page.testSubj.locator('createPolicyBtn')).toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
@@ -9,11 +9,11 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { setFleetServerHost, mockFleetSetupEndpoints } from '../common/api_helpers';
+import { setupFleetServer, mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Fleet startup', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeAll(async ({ kbnClient }) => {
-    await setFleetServerHost(kbnClient);
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/fleet_startup.spec.ts
@@ -17,8 +17,8 @@ test.describe('Fleet startup', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsPrivilegedUser();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test('should create agent policy with System integration', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
@@ -28,7 +27,10 @@ test.describe('Input packages real', { tag: [...tags.stateful.classic] }, () => 
     try {
       await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
     } catch (e) {
-      test.skip(true, `Test package ${INPUT_TEST_PACKAGE}.zip not found - run from Fleet Cypress env`);
+      test.skip(
+        true,
+        `Test package ${INPUT_TEST_PACKAGE}.zip not found - run from Fleet Cypress env`
+      );
     }
     await createAgentPolicy(kbnClient, 'Test input package policy', {
       id: 'test-input-package-policy',
@@ -54,7 +56,10 @@ test.describe('Input packages real', { tag: [...tags.stateful.classic] }, () => 
     await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/overview`);
     await page.testSubj.locator(ADD_INTEGRATION_POLICY_BTN).click();
     await page.testSubj.locator(POLICY_EDITOR.POLICY_NAME_INPUT).fill('input-package-policy');
-    await page.testSubj.locator('multiTextInput-paths').locator('[data-test-subj="multiTextInputRow-0"]').fill('/var/log/test.log');
+    await page.testSubj
+      .locator('multiTextInput-paths')
+      .locator('[data-test-subj="multiTextInputRow-0"]')
+      .fill('/var/log/test.log');
     await page.testSubj.locator(CREATE_PACKAGE_POLICY_SAVE_BTN).click();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  installTestPackageFromZip,
+  uninstallTestPackage,
+  createAgentPolicy,
+  cleanupAgentPolicies,
+} from '../common/api_helpers';
+import {
+  ADD_INTEGRATION_POLICY_BTN,
+  POLICY_EDITOR,
+  CREATE_PACKAGE_POLICY_SAVE_BTN,
+} from '../common/selectors';
+
+const INPUT_TEST_PACKAGE = 'input_package-1.0.0';
+
+test.describe('Input packages real', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    try {
+      await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
+    } catch (e) {
+      test.skip(true, `Test package ${INPUT_TEST_PACKAGE}.zip not found - run from Fleet Cypress env`);
+    }
+    await createAgentPolicy(kbnClient, 'Test input package policy', {
+      id: 'test-input-package-policy',
+    });
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    try {
+      await cleanupAgentPolicies(kbnClient);
+      await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should create package policy for input package', async ({ page }) => {
+    test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
+
+    await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/overview`);
+    await page.testSubj.locator(ADD_INTEGRATION_POLICY_BTN).click();
+    await page.testSubj.locator(POLICY_EDITOR.POLICY_NAME_INPUT).fill('input-package-policy');
+    await page.testSubj.locator('multiTextInput-paths').locator('[data-test-subj="multiTextInputRow-0"]').fill('/var/log/test.log');
+    await page.testSubj.locator(CREATE_PACKAGE_POLICY_SAVE_BTN).click();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
@@ -26,7 +26,7 @@ test.describe('Input packages real', { tag: [...tags.stateful.classic] }, () => 
   test.beforeAll(async ({ kbnClient }) => {
     try {
       await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
-    } catch (e) {
+    } catch {
       test.skip(
         true,
         `Test package ${INPUT_TEST_PACKAGE}.zip not found - run from Fleet Cypress env`
@@ -37,6 +37,10 @@ test.describe('Input packages real', { tag: [...tags.stateful.classic] }, () => 
     });
   });
 
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
   test.afterAll(async ({ kbnClient }) => {
     try {
       await cleanupAgentPolicies(kbnClient);
@@ -44,10 +48,6 @@ test.describe('Input packages real', { tag: [...tags.stateful.classic] }, () => 
     } catch {
       // Ignore
     }
-  });
-
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
   });
 
   test('should create package policy for input package', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/input_packages_real.spec.ts
@@ -9,6 +9,7 @@ import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import {
+  setupFleetServer,
   installTestPackageFromZip,
   uninstallTestPackage,
   createAgentPolicy,
@@ -23,7 +24,8 @@ import {
 const INPUT_TEST_PACKAGE = 'input_package-1.0.0';
 
 test.describe('Input packages real', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeAll(async ({ kbnClient }) => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
     try {
       await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
     } catch {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -43,6 +43,8 @@ test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
 
     await page.goto('/app/integrations/detail/test-package-1.0.0/overview');
     await page.testSubj.locator('installAssetsButton').click();
-    await expect(page.getByRole('heading', { name: /Install unverified integration/ })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Install unverified integration/ })
+    ).toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -43,6 +43,6 @@ test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
 
     await page.goto('/app/integrations/detail/test-package-1.0.0/overview');
     await page.testSubj.locator('installAssetsButton').click();
-    await expect(page.getByText(/Install unverified integration/).first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Install unverified integration/ })).toBeVisible();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -9,9 +9,13 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { mockFleetSetupEndpoints } from '../common/api_helpers';
+import { setupFleetServer, mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth, page }) => {
     await mockFleetSetupEndpoints(page);
     await browserAuth.loginAsAdmin();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -15,21 +15,21 @@ test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
     await browserAuth.loginAsAdmin();
     await page.route('**/api/fleet/epm/packages/**/install**', (route) => {
       if (route.request().method() === 'POST') {
-        route.fulfill({
+        return route.fulfill({
           status: 200,
           body: JSON.stringify({
             items: [{ name: 'test-package', version: '1.0.0', status: 'installed' }],
           }),
         });
       } else {
-        route.continue();
+        return route.continue();
       }
     });
   });
 
   test('should show unverified package force-install modal', async ({ page }) => {
     await page.route('**/api/fleet/epm/packages/test-package/1.0.0**', (route) => {
-      route.fulfill({
+      return route.fulfill({
         status: 200,
         body: JSON.stringify({
           item: {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -9,7 +9,6 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { CONFIRM_MODAL } from '../common/selectors';
 
 test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth, page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -13,8 +13,8 @@ import { mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsAdmin();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsAdmin();
     await page.route('**/api/fleet/epm/packages/**/install**', (route) => {
       if (route.request().method() === 'POST') {
         return route.fulfill({

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import { CONFIRM_MODAL } from '../common/selectors';
+
+test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth, page }) => {
+    await browserAuth.loginAsAdmin();
+    await page.route('**/api/fleet/epm/packages/**/install**', (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 200,
+          body: JSON.stringify({
+            items: [{ name: 'test-package', version: '1.0.0', status: 'installed' }],
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+  });
+
+  test('should show unverified package force-install modal', async ({ page }) => {
+    await page.route('**/api/fleet/epm/packages/test-package/1.0.0**', (route) => {
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          item: {
+            name: 'test-package',
+            version: '1.0.0',
+            verification_status: 'unverified',
+          },
+        }),
+      });
+    });
+
+    await page.goto('/app/integrations/detail/test-package-1.0.0/overview');
+    await page.testSubj.locator('installAssetsButton').click();
+    await expect(page.getByText(/Install unverified integration/).first()).toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/install_assets.spec.ts
@@ -9,10 +9,12 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
+import { mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Install assets', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsAdmin();
+    await mockFleetSetupEndpoints(page);
     await page.route('**/api/fleet/epm/packages/**/install**', (route) => {
       if (route.request().method() === 'POST') {
         return route.fulfill({

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_automatic_import.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_automatic_import.spec.ts
@@ -9,11 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import {
-  ASSISTANT_BUTTON,
-  UPLOAD_PACKAGE_LINK,
-  BUTTON_FOOTER_NEXT,
-} from '../common/selectors';
+import { ASSISTANT_BUTTON, UPLOAD_PACKAGE_LINK } from '../common/selectors';
 
 test.describe('Integrations automatic import', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_automatic_import.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_automatic_import.spec.ts
@@ -9,9 +9,14 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
+import { setupFleetServer } from '../common/api_helpers';
 import { ASSISTANT_BUTTON, UPLOAD_PACKAGE_LINK } from '../common/selectors';
 
 test.describe('Integrations automatic import', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth }) => {
     await browserAuth.loginAsAdmin();
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_automatic_import.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_automatic_import.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  ASSISTANT_BUTTON,
+  UPLOAD_PACKAGE_LINK,
+  BUTTON_FOOTER_NEXT,
+} from '../common/selectors';
+
+test.describe('Integrations automatic import', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should show create integration landing page', async ({ page }) => {
+    await page.goto('/app/integrations/create');
+    await expect(page.testSubj.locator(ASSISTANT_BUTTON)).toBeVisible();
+    await expect(page.testSubj.locator(UPLOAD_PACKAGE_LINK)).toBeVisible();
+  });
+
+  test('should navigate to assistant', async ({ page }) => {
+    await page.goto('/app/integrations/create');
+    await page.testSubj.locator(ASSISTANT_BUTTON).click();
+    await expect(page).toHaveURL(/\/create\/assistant/);
+  });
+
+  test('should navigate to upload', async ({ page }) => {
+    await page.goto('/app/integrations/create');
+    await page.testSubj.locator(UPLOAD_PACKAGE_LINK).click();
+    await expect(page).toHaveURL(/\/create\/upload/);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+
+test.describe('Integrations mock', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should verify upgrade package and policy flow', async ({ page }) => {
+    await page.route('**/api/fleet/epm/packages**', (route) => {
+      if (route.request().method() === 'GET' && route.request().url().includes('nginx')) {
+        route.fulfill({
+          status: 200,
+          body: JSON.stringify({
+            item: {
+              name: 'nginx',
+              version: '2.0.0',
+              status: 'installed',
+              savedObject: { id: 'nginx' },
+            },
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto('/app/integrations/detail/nginx/overview');
+    await expect(page.testSubj.locator('updatePackageBtn')).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
@@ -9,9 +9,13 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { mockFleetSetupEndpoints } from '../common/api_helpers';
+import { setupFleetServer, mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Integrations mock', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth, page }) => {
     await mockFleetSetupEndpoints(page);
     await browserAuth.loginAsAdmin();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
@@ -9,10 +9,12 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
+import { mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Integrations mock', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsAdmin();
+    await mockFleetSetupEndpoints(page);
   });
 
   test('should verify upgrade package and policy flow', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
@@ -18,7 +18,7 @@ test.describe('Integrations mock', { tag: [...tags.stateful.classic] }, () => {
   test('should verify upgrade package and policy flow', async ({ page }) => {
     await page.route('**/api/fleet/epm/packages**', (route) => {
       if (route.request().method() === 'GET' && route.request().url().includes('nginx')) {
-        route.fulfill({
+        return route.fulfill({
           status: 200,
           body: JSON.stringify({
             item: {
@@ -30,7 +30,7 @@ test.describe('Integrations mock', { tag: [...tags.stateful.classic] }, () => {
           }),
         });
       } else {
-        route.continue();
+        return route.continue();
       }
     });
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_mock.spec.ts
@@ -13,8 +13,8 @@ import { mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Integrations mock', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsAdmin();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsAdmin();
   });
 
   test('should verify upgrade package and policy flow', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_real.spec.ts
@@ -34,6 +34,8 @@ test.describe('Integrations real', { tag: [...tags.stateful.classic] }, () => {
   test('should search for integrations', async ({ page }) => {
     await page.goto('/app/integrations');
     await page.testSubj.locator(INTEGRATIONS_SEARCHBAR.INPUT).fill('nginx');
-    await expect(page.testSubj.locator(getIntegrationCard('nginx'))).toBeVisible({ timeout: 10_000 });
+    await expect(page.testSubj.locator(getIntegrationCard('nginx'))).toBeVisible({
+      timeout: 10_000,
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_real.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import { INTEGRATIONS_SEARCHBAR, getIntegrationCard } from '../common/selectors';
+
+test.describe('Integrations real', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should browse integrations with different viewports', async ({ page }) => {
+    await page.goto('/app/integrations');
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect(page.testSubj.locator(INTEGRATIONS_SEARCHBAR.INPUT)).toBeVisible();
+
+    await page.setViewportSize({ width: 768, height: 900 });
+    await expect(page.testSubj.locator(INTEGRATIONS_SEARCHBAR.INPUT)).toBeVisible();
+  });
+
+  test('should filter integrations by category', async ({ page }) => {
+    await page.goto('/app/integrations');
+    await page.testSubj.locator('epmList.categories.security').click();
+    await expect(page.testSubj.locator('epmList.integrationCards')).toBeVisible();
+  });
+
+  test('should search for integrations', async ({ page }) => {
+    await page.goto('/app/integrations');
+    await page.testSubj.locator(INTEGRATIONS_SEARCHBAR.INPUT).fill('nginx');
+    await expect(page.testSubj.locator(getIntegrationCard('nginx'))).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/integrations_real.spec.ts
@@ -9,9 +9,14 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
+import { setupFleetServer } from '../common/api_helpers';
 import { INTEGRATIONS_SEARCHBAR, getIntegrationCard } from '../common/selectors';
 
 test.describe('Integrations real', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth }) => {
     await browserAuth.loginAsAdmin();
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -21,7 +21,7 @@ test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
     await page.route('**/api/fleet/package_policies/**', (route) => route.continue());
     await page.route('**/api/fleet/agent_policies/policy-1**', (route) => {
       if (route.request().method() === 'GET') {
-        route.fulfill({
+        return route.fulfill({
           status: 200,
           body: JSON.stringify({
             item: {
@@ -34,7 +34,7 @@ test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
           }),
         });
       } else {
-        route.continue();
+        return route.continue();
       }
     });
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -12,8 +12,8 @@ import { createAgentPolicy, mockFleetSetupEndpoints } from '../common/api_helper
 
 test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsAdmin();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsAdmin();
   });
 
   test('should edit package policy', async ({ page, kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import { createAgentPolicy } from '../common/api_helpers';
+
+test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should edit package policy', async ({ page, kbnClient }) => {
+    const policy = await createAgentPolicy(kbnClient, 'Test policy', { id: 'policy-1' });
+
+    await page.route('**/api/fleet/package_policies/**', (route) => route.continue());
+    await page.route('**/api/fleet/agent_policies/policy-1**', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          body: JSON.stringify({
+            item: {
+              id: 'policy-1',
+              name: 'Test policy',
+              package_policies: [
+                { id: 'pkg-1', name: 'system-1', package: { name: 'system', version: '1.0.0' } },
+              ],
+            },
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto('/app/fleet/policies/policy-1');
+    await page.getByRole('link', { name: 'system-1' }).first().click();
+    await page.getByRole('button', { name: 'Edit integration' }).first().click();
+    const descInput = page.locator('[placeholder="Optional description"]').first();
+    await descInput.clear();
+    await descInput.fill('Updated description');
+
+    const updatePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/fleet/package_policies') && res.request().method() === 'PUT'
+    );
+    await page.getByRole('button', { name: 'Save integration' }).first().click();
+    await updatePromise;
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
@@ -47,8 +46,7 @@ test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
     await descInput.fill('Updated description');
 
     const updatePromise = page.waitForResponse(
-      (res) =>
-        res.url().includes('/api/fleet/package_policies') && res.request().method() === 'PUT'
+      (res) => res.url().includes('/api/fleet/package_policies') && res.request().method() === 'PUT'
     );
     await page.getByRole('button', { name: 'Save integration' }).first().click();
     await updatePromise;

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -39,16 +39,16 @@ test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
     });
 
     await page.goto('/app/fleet/policies/policy-1');
-    await page.getByRole('link', { name: 'system-1' }).first().click();
-    await page.getByRole('button', { name: 'Edit integration' }).first().click();
-    const descInput = page.locator('[placeholder="Optional description"]').first();
+    await page.testSubj.locator('PackagePoliciesTableLink').click();
+    await page.getByRole('button', { name: 'Edit integration' }).click();
+    const descInput = page.getByPlaceholder('Optional description');
     await descInput.clear();
     await descInput.fill('Updated description');
 
     const updatePromise = page.waitForResponse(
       (res) => res.url().includes('/api/fleet/package_policies') && res.request().method() === 'PUT'
     );
-    await page.getByRole('button', { name: 'Save integration' }).first().click();
+    await page.getByRole('button', { name: 'Save integration' }).click();
     await updatePromise;
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -8,9 +8,17 @@
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { createAgentPolicy, mockFleetSetupEndpoints } from '../common/api_helpers';
+import {
+  setupFleetServer,
+  createAgentPolicy,
+  mockFleetSetupEndpoints,
+} from '../common/api_helpers';
 
 test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
+  });
+
   test.beforeEach(async ({ browserAuth, page }) => {
     await mockFleetSetupEndpoints(page);
     await browserAuth.loginAsAdmin();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -16,7 +16,7 @@ test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
   });
 
   test('should edit package policy', async ({ page, kbnClient }) => {
-    const policy = await createAgentPolicy(kbnClient, 'Test policy', { id: 'policy-1' });
+    await createAgentPolicy(kbnClient, 'Test policy', { id: 'policy-1' });
 
     await page.route('**/api/fleet/package_policies/**', (route) => route.continue());
     await page.route('**/api/fleet/agent_policies/policy-1**', (route) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy.spec.ts
@@ -8,11 +8,12 @@
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { createAgentPolicy } from '../common/api_helpers';
+import { createAgentPolicy, mockFleetSetupEndpoints } from '../common/api_helpers';
 
 test.describe('Package policy', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsAdmin();
+    await mockFleetSetupEndpoints(page);
   });
 
   test('should edit package policy', async ({ page, kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
@@ -20,62 +20,66 @@ import { POLICY_EDITOR } from '../common/selectors';
 const INPUT_TEST_PACKAGE = 'input_package-1.0.0';
 const INTEGRATION_TEST_PACKAGE = 'logs_integration-1.0.0';
 
-test.describe('Package policy pipelines and mappings real', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
-  });
+test.describe(
+  'Package policy pipelines and mappings real',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
 
-  test.describe('Input package', () => {
-    test.beforeAll(async ({ kbnClient }) => {
-      try {
-        await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
-      } catch {
-        test.skip(true, `Requires ${INPUT_TEST_PACKAGE}.zip`);
-      }
-      await createAgentPolicy(kbnClient, 'Test input package policy', {
-        id: 'test-input-package-policy',
+    test.describe('Input package', () => {
+      test.beforeAll(async ({ kbnClient }) => {
+        try {
+          await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
+        } catch {
+          test.skip(true, `Requires ${INPUT_TEST_PACKAGE}.zip`);
+        }
+        await createAgentPolicy(kbnClient, 'Test input package policy', {
+          id: 'test-input-package-policy',
+        });
+      });
+
+      test.afterAll(async ({ kbnClient }) => {
+        try {
+          await cleanupAgentPolicies(kbnClient);
+          await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
+        } catch {
+          // Ignore
+        }
+      });
+
+      test('should show pipelines and mappings for input package', async ({ page }) => {
+        test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
+
+        await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/policies`);
+        await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
       });
     });
 
-    test.afterAll(async ({ kbnClient }) => {
-      try {
-        await cleanupAgentPolicies(kbnClient);
-        await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
-      } catch {
-        // Ignore
-      }
+    test.describe('Integration package', () => {
+      test.beforeAll(async ({ kbnClient }) => {
+        try {
+          await installTestPackageFromZip(kbnClient, INTEGRATION_TEST_PACKAGE);
+        } catch {
+          test.skip(true, `Requires ${INTEGRATION_TEST_PACKAGE}.zip`);
+        }
+      });
+
+      test.afterAll(async ({ kbnClient }) => {
+        try {
+          await uninstallTestPackage(kbnClient, INTEGRATION_TEST_PACKAGE);
+        } catch {
+          // Ignore
+        }
+      });
+
+      test('should show pipelines and mappings for integration package', async ({ page }) => {
+        test.skip(true, 'Requires logs_integration-1.0.0.zip from Fleet Cypress packages');
+
+        await page.goto(`/app/integrations/detail/${INTEGRATION_TEST_PACKAGE}/policies`);
+        await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
+      });
     });
-
-    test('should show pipelines and mappings for input package', async ({ page }) => {
-      test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
-
-      await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/policies`);
-      await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
-    });
-  });
-
-  test.describe('Integration package', () => {
-    test.beforeAll(async ({ kbnClient }) => {
-      try {
-        await installTestPackageFromZip(kbnClient, INTEGRATION_TEST_PACKAGE);
-      } catch {
-        test.skip(true, `Requires ${INTEGRATION_TEST_PACKAGE}.zip`);
-      }
-    });
-
-    test.afterAll(async ({ kbnClient }) => {
-      try {
-        await uninstallTestPackage(kbnClient, INTEGRATION_TEST_PACKAGE);
-      } catch {
-        // Ignore
-      }
-    });
-
-    test('should show pipelines and mappings for integration package', async ({ page }) => {
-      test.skip(true, 'Requires logs_integration-1.0.0.zip from Fleet Cypress packages');
-
-      await page.goto(`/app/integrations/detail/${INTEGRATION_TEST_PACKAGE}/policies`);
-      await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
-    });
-  });
-});
+  }
+);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
@@ -20,72 +20,49 @@ import { POLICY_EDITOR } from '../common/selectors';
 const INPUT_TEST_PACKAGE = 'input_package-1.0.0';
 const INTEGRATION_TEST_PACKAGE = 'logs_integration-1.0.0';
 
-test.describe(
-  'Package policy pipelines and mappings - Input package',
-  { tag: [...tags.stateful.classic] },
-  () => {
-    test.beforeEach(async ({ browserAuth }) => {
-      await browserAuth.loginAsAdmin();
+test.describe('Package policy pipelines and mappings', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test('should show pipelines and mappings for input package', async ({ page, kbnClient }) => {
+    test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
+
+    try {
+      await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
+    } catch {
+      test.skip(true, `Requires ${INPUT_TEST_PACKAGE}.zip`);
+    }
+    await createAgentPolicy(kbnClient, 'Test input package policy', {
+      id: 'test-input-package-policy',
     });
 
-    test.beforeAll(async ({ kbnClient }) => {
-      try {
-        await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
-      } catch {
-        test.skip(true, `Requires ${INPUT_TEST_PACKAGE}.zip`);
-      }
-      await createAgentPolicy(kbnClient, 'Test input package policy', {
-        id: 'test-input-package-policy',
-      });
-    });
-
-    test.afterAll(async ({ kbnClient }) => {
-      try {
-        await cleanupAgentPolicies(kbnClient);
-        await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
-      } catch {
-        // Ignore
-      }
-    });
-
-    test('should show pipelines and mappings for input package', async ({ page }) => {
-      test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
-
+    try {
       await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/policies`);
       await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
-    });
-  }
-);
+    } finally {
+      await cleanupAgentPolicies(kbnClient);
+      await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
+    }
+  });
 
-test.describe(
-  'Package policy pipelines and mappings - Integration package',
-  { tag: [...tags.stateful.classic] },
-  () => {
-    test.beforeEach(async ({ browserAuth }) => {
-      await browserAuth.loginAsAdmin();
-    });
+  test('should show pipelines and mappings for integration package', async ({
+    page,
+    kbnClient,
+  }) => {
+    test.skip(true, 'Requires logs_integration-1.0.0.zip from Fleet Cypress packages');
 
-    test.beforeAll(async ({ kbnClient }) => {
-      try {
-        await installTestPackageFromZip(kbnClient, INTEGRATION_TEST_PACKAGE);
-      } catch {
-        test.skip(true, `Requires ${INTEGRATION_TEST_PACKAGE}.zip`);
-      }
-    });
+    try {
+      await installTestPackageFromZip(kbnClient, INTEGRATION_TEST_PACKAGE);
+    } catch {
+      test.skip(true, `Requires ${INTEGRATION_TEST_PACKAGE}.zip`);
+    }
 
-    test.afterAll(async ({ kbnClient }) => {
-      try {
-        await uninstallTestPackage(kbnClient, INTEGRATION_TEST_PACKAGE);
-      } catch {
-        // Ignore
-      }
-    });
-
-    test('should show pipelines and mappings for integration package', async ({ page }) => {
-      test.skip(true, 'Requires logs_integration-1.0.0.zip from Fleet Cypress packages');
-
+    try {
       await page.goto(`/app/integrations/detail/${INTEGRATION_TEST_PACKAGE}/policies`);
       await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
-    });
-  }
-);
+    } finally {
+      await uninstallTestPackage(kbnClient, INTEGRATION_TEST_PACKAGE);
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
@@ -21,65 +21,71 @@ const INPUT_TEST_PACKAGE = 'input_package-1.0.0';
 const INTEGRATION_TEST_PACKAGE = 'logs_integration-1.0.0';
 
 test.describe(
-  'Package policy pipelines and mappings real',
+  'Package policy pipelines and mappings - Input package',
   { tag: [...tags.stateful.classic] },
   () => {
     test.beforeEach(async ({ browserAuth }) => {
       await browserAuth.loginAsAdmin();
     });
 
-    test.describe('Input package', () => {
-      test.beforeAll(async ({ kbnClient }) => {
-        try {
-          await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
-        } catch {
-          test.skip(true, `Requires ${INPUT_TEST_PACKAGE}.zip`);
-        }
-        await createAgentPolicy(kbnClient, 'Test input package policy', {
-          id: 'test-input-package-policy',
-        });
-      });
-
-      test.afterAll(async ({ kbnClient }) => {
-        try {
-          await cleanupAgentPolicies(kbnClient);
-          await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
-        } catch {
-          // Ignore
-        }
-      });
-
-      test('should show pipelines and mappings for input package', async ({ page }) => {
-        test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
-
-        await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/policies`);
-        await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
+    test.beforeAll(async ({ kbnClient }) => {
+      try {
+        await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
+      } catch {
+        test.skip(true, `Requires ${INPUT_TEST_PACKAGE}.zip`);
+      }
+      await createAgentPolicy(kbnClient, 'Test input package policy', {
+        id: 'test-input-package-policy',
       });
     });
 
-    test.describe('Integration package', () => {
-      test.beforeAll(async ({ kbnClient }) => {
-        try {
-          await installTestPackageFromZip(kbnClient, INTEGRATION_TEST_PACKAGE);
-        } catch {
-          test.skip(true, `Requires ${INTEGRATION_TEST_PACKAGE}.zip`);
-        }
-      });
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await cleanupAgentPolicies(kbnClient);
+        await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
+      } catch {
+        // Ignore
+      }
+    });
 
-      test.afterAll(async ({ kbnClient }) => {
-        try {
-          await uninstallTestPackage(kbnClient, INTEGRATION_TEST_PACKAGE);
-        } catch {
-          // Ignore
-        }
-      });
+    test('should show pipelines and mappings for input package', async ({ page }) => {
+      test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
 
-      test('should show pipelines and mappings for integration package', async ({ page }) => {
-        test.skip(true, 'Requires logs_integration-1.0.0.zip from Fleet Cypress packages');
+      await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/policies`);
+      await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
+    });
+  }
+);
 
-        await page.goto(`/app/integrations/detail/${INTEGRATION_TEST_PACKAGE}/policies`);
-        await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
-      });
+test.describe(
+  'Package policy pipelines and mappings - Integration package',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
+
+    test.beforeAll(async ({ kbnClient }) => {
+      try {
+        await installTestPackageFromZip(kbnClient, INTEGRATION_TEST_PACKAGE);
+      } catch {
+        test.skip(true, `Requires ${INTEGRATION_TEST_PACKAGE}.zip`);
+      }
+    });
+
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await uninstallTestPackage(kbnClient, INTEGRATION_TEST_PACKAGE);
+      } catch {
+        // Ignore
+      }
+    });
+
+    test('should show pipelines and mappings for integration package', async ({ page }) => {
+      test.skip(true, 'Requires logs_integration-1.0.0.zip from Fleet Cypress packages');
+
+      await page.goto(`/app/integrations/detail/${INTEGRATION_TEST_PACKAGE}/policies`);
+      await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
     });
   }
 );

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/package_policy_pipelines_and_mappings_real.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  installTestPackageFromZip,
+  uninstallTestPackage,
+  createAgentPolicy,
+  cleanupAgentPolicies,
+} from '../common/api_helpers';
+import { POLICY_EDITOR } from '../common/selectors';
+
+const INPUT_TEST_PACKAGE = 'input_package-1.0.0';
+const INTEGRATION_TEST_PACKAGE = 'logs_integration-1.0.0';
+
+test.describe('Package policy pipelines and mappings real', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.describe('Input package', () => {
+    test.beforeAll(async ({ kbnClient }) => {
+      try {
+        await installTestPackageFromZip(kbnClient, INPUT_TEST_PACKAGE);
+      } catch {
+        test.skip(true, `Requires ${INPUT_TEST_PACKAGE}.zip`);
+      }
+      await createAgentPolicy(kbnClient, 'Test input package policy', {
+        id: 'test-input-package-policy',
+      });
+    });
+
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await cleanupAgentPolicies(kbnClient);
+        await uninstallTestPackage(kbnClient, INPUT_TEST_PACKAGE);
+      } catch {
+        // Ignore
+      }
+    });
+
+    test('should show pipelines and mappings for input package', async ({ page }) => {
+      test.skip(true, 'Requires input_package-1.0.0.zip from Fleet Cypress packages');
+
+      await page.goto(`/app/integrations/detail/${INPUT_TEST_PACKAGE}/policies`);
+      await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
+    });
+  });
+
+  test.describe('Integration package', () => {
+    test.beforeAll(async ({ kbnClient }) => {
+      try {
+        await installTestPackageFromZip(kbnClient, INTEGRATION_TEST_PACKAGE);
+      } catch {
+        test.skip(true, `Requires ${INTEGRATION_TEST_PACKAGE}.zip`);
+      }
+    });
+
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await uninstallTestPackage(kbnClient, INTEGRATION_TEST_PACKAGE);
+      } catch {
+        // Ignore
+      }
+    });
+
+    test('should show pipelines and mappings for integration package', async ({ page }) => {
+      test.skip(true, 'Requires logs_integration-1.0.0.zip from Fleet Cypress packages');
+
+      await page.goto(`/app/integrations/detail/${INTEGRATION_TEST_PACKAGE}/policies`);
+      await expect(page.testSubj.locator(POLICY_EDITOR.INSPECT_PIPELINES_BTN)).toBeVisible();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_fleet_agents_read_integrations_none.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_fleet_agents_read_integrations_none.spec.ts
@@ -6,14 +6,14 @@
  */
 
 import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import { getFleetAgentsReadIntegrationsNoneRole } from '../fixtures/services/privileges';
 
 test.describe(
   'When the user has Fleet Agents Read built-in role',
-  // until QAF/Scout doesn't support custom roles in ECH
-  { tag: '@local-stateful-classic' },
+  { tag: [...tags.stateful.classic] },
   () => {
     test('is accessible but user cannot perform any write actions on agent tabs', async ({
       browserAuth,

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
@@ -9,11 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../../fixtures';
-import {
-  enableSpaceAwareness,
-  createSpace,
-  cleanupAgentPolicies,
-} from '../../common/api_helpers';
+import { enableSpaceAwareness, createSpace, cleanupAgentPolicies } from '../../common/api_helpers';
 import {
   ADD_AGENT_POLICY_BTN,
   AGENT_POLICIES_TABLE,
@@ -51,10 +47,14 @@ test.describe('Space aware policies creation', { tag: [...tags.stateful.classic]
 
   test('the created policy should not be visible in the default space', async ({ page }) => {
     await page.goto('/app/fleet/policies');
-    await expect(page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(NO_AGENT_POLICIES)).toBeVisible();
+    await expect(
+      page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(NO_AGENT_POLICIES)
+    ).toBeVisible();
   });
 
-  test('should allow to update that policy to belong to both test and default space', async ({ page }) => {
+  test('should allow to update that policy to belong to both test and default space', async ({
+    page,
+  }) => {
     await page.goto('/s/test/app/fleet/policies');
     await page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(POLICY_NAME).click();
     await page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SETTINGS_TAB).click();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
@@ -36,8 +36,8 @@ test.describe('Space aware policies creation', { tag: [...tags.stateful.classic]
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsAdmin();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsAdmin();
     await page.route('**/api/fleet/agent_policies**', (route) => route.continue());
     await page.route('**/internal/fleet/agent_policies_spaces**', (route) => route.continue());
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
@@ -10,6 +10,7 @@ import { tags } from '@kbn/scout';
 
 import { test } from '../../fixtures';
 import {
+  setupFleetServer,
   enableSpaceAwareness,
   createSpace,
   cleanupAgentPolicies,
@@ -28,7 +29,8 @@ const POLICY_NAME = 'Policy 1 space test';
 const NO_AGENT_POLICIES = 'No agent policies';
 
 test.describe('Space aware policies creation', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeAll(async ({ kbnClient }) => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
     await enableSpaceAwareness(kbnClient);
     await createSpace(kbnClient, 'test', 'Test');
     await cleanupAgentPolicies(kbnClient);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../../fixtures';
+import {
+  enableSpaceAwareness,
+  createSpace,
+  cleanupAgentPolicies,
+} from '../../common/api_helpers';
+import {
+  ADD_AGENT_POLICY_BTN,
+  AGENT_POLICIES_TABLE,
+  AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD,
+  AGENT_POLICY_FLYOUT_CREATE_BUTTON,
+  AGENT_POLICY_SYSTEM_MONITORING_CHECKBOX,
+  AGENT_POLICY_DETAILS_PAGE,
+} from '../../common/selectors';
+
+const POLICY_NAME = 'Policy 1 space test';
+const NO_AGENT_POLICIES = 'No agent policies';
+
+test.describe('Space aware policies creation', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    await enableSpaceAwareness(kbnClient);
+    await createSpace(kbnClient, 'test', 'Test');
+    await cleanupAgentPolicies(kbnClient);
+    await cleanupAgentPolicies(kbnClient, 'test');
+  });
+
+  test.beforeEach(async ({ browserAuth, page }) => {
+    await browserAuth.loginAsAdmin();
+    await page.route('**/api/fleet/agent_policies**', (route) => route.continue());
+    await page.route('**/internal/fleet/agent_policies_spaces**', (route) => route.continue());
+  });
+
+  test('should allow to create an agent policy in the test space', async ({ page }) => {
+    await page.goto('/s/test/app/fleet/policies');
+    await page.testSubj.locator(ADD_AGENT_POLICY_BTN).click();
+    await page.testSubj.locator(AGENT_POLICY_CREATE_AGENT_POLICY_NAME_FIELD).fill(POLICY_NAME);
+    await page.testSubj.locator(AGENT_POLICY_SYSTEM_MONITORING_CHECKBOX).uncheck();
+    await page.testSubj.locator(AGENT_POLICY_FLYOUT_CREATE_BUTTON).click();
+    await expect(page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(POLICY_NAME)).toBeVisible();
+  });
+
+  test('the created policy should not be visible in the default space', async ({ page }) => {
+    await page.goto('/app/fleet/policies');
+    await expect(page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(NO_AGENT_POLICIES)).toBeVisible();
+  });
+
+  test('should allow to update that policy to belong to both test and default space', async ({ page }) => {
+    await page.goto('/s/test/app/fleet/policies');
+    await page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(POLICY_NAME).click();
+    await page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SETTINGS_TAB).click();
+    await page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SPACE_SELECTOR_COMBOBOX).click();
+    await page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SPACE_SELECTOR_COMBOBOX).fill('default');
+    await page.keyboard.press('Enter');
+    await page.testSubj.locator(AGENT_POLICY_DETAILS_PAGE.SAVE_BUTTON).click();
+  });
+
+  test('the policy should be visible in the test space', async ({ page }) => {
+    await page.goto('/s/test/app/fleet/policies');
+    await expect(page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(POLICY_NAME)).toBeVisible();
+  });
+
+  test('the policy should be visible in the default space', async ({ page }) => {
+    await page.goto('/app/fleet/policies');
+    await expect(page.testSubj.locator(AGENT_POLICIES_TABLE).getByText(POLICY_NAME)).toBeVisible();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/space_awareness/policies.spec.ts
@@ -9,7 +9,12 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../../fixtures';
-import { enableSpaceAwareness, createSpace, cleanupAgentPolicies } from '../../common/api_helpers';
+import {
+  enableSpaceAwareness,
+  createSpace,
+  cleanupAgentPolicies,
+  mockFleetSetupEndpoints,
+} from '../../common/api_helpers';
 import {
   ADD_AGENT_POLICY_BTN,
   AGENT_POLICIES_TABLE,
@@ -32,6 +37,7 @@ test.describe('Space aware policies creation', { tag: [...tags.stateful.classic]
 
   test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsAdmin();
+    await mockFleetSetupEndpoints(page);
     await page.route('**/api/fleet/agent_policies**', (route) => route.continue());
     await page.route('**/internal/fleet/agent_policies_spaces**', (route) => route.continue());
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -6,26 +6,34 @@
  */
 
 import { expect } from '@kbn/scout/ui';
+import type { KbnClient, ScoutPage } from '@kbn/scout';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import { createAgentPolicy, cleanupAgentPolicies } from '../common/api_helpers';
 import { UNINSTALL_TOKENS } from '../common/selectors';
 
-function generatePolicies(kbnClient: any) {
+const TARGET_POLICY_ID = 'agent-policy-100';
+
+function generatePolicies(kbnClient: KbnClient) {
   return Promise.all([
-    createAgentPolicy(kbnClient, 'Agent policy 100', { id: 'agent-policy-100' }),
+    createAgentPolicy(kbnClient, 'Agent policy 100', { id: TARGET_POLICY_ID }),
     createAgentPolicy(kbnClient, 'Agent policy 200', { id: 'agent-policy-200' }),
     createAgentPolicy(kbnClient, 'Agent policy 300', { id: 'agent-policy-300' }),
   ]);
 }
 
-test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsAdmin();
-  });
+function getPolicyRow(page: ScoutPage, policyId: string) {
+  return page.testSubj
+    .locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)
+    .filter({ hasText: policyId })
+    .locator('..');
+}
 
-  test.describe('When not removing policies before checking uninstall tokens', () => {
+test.describe(
+  'Uninstall token page - with existing policies',
+  { tag: [...tags.stateful.classic] },
+  () => {
     test.beforeAll(async ({ kbnClient }) => {
       await cleanupAgentPolicies(kbnClient);
       await generatePolicies(kbnClient);
@@ -37,50 +45,65 @@ test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () =>
       } catch {
         // Ignore
       }
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsPrivilegedUser();
     });
 
     test('should show token by clicking on the eye button', async ({ page }) => {
       await page.goto('/app/fleet/uninstall-tokens');
-      await page.route('**/api/fleet/uninstall_tokens/*', (route) => route.continue());
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()).toContainText(
-        '••••••••••••••••••••••••••••••••'
+      const row = getPolicyRow(page, TARGET_POLICY_ID);
+      const tokenField = row.locator(
+        page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD)
       );
-      await page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON).first().click();
-      await page.waitForTimeout(2000);
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()).not.toContainText(
-        '••••••••••••••••••••••••••••••••'
+      const showHideButton = row.locator(
+        page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON)
       );
+
+      await expect(tokenField).toContainText('••••••••••••••••••••••••••••••••');
+      await showHideButton.click();
+      await expect(tokenField).not.toContainText('••••••••••••••••••••••••••••••••');
     });
 
-    test("should show flyout by clicking on 'View uninstall command' button", async ({ page }) => {
-      await page.goto('/app/fleet/uninstall-tokens');
-      await page.testSubj.locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON).first().click();
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)).toBeVisible();
+    test("should show flyout by clicking on 'View uninstall command' button", async ({
+      pageObjects,
+    }) => {
+      const { uninstallTokens } = pageObjects;
+      await uninstallTokens.navigateTo();
+      await uninstallTokens.openUninstallCommandFlyout(TARGET_POLICY_ID);
+      await expect(uninstallTokens.getUninstallCommandFlyout()).toBeVisible();
       await expect(
-        page.getByText(/sudo elastic-agent uninstall --uninstall-token/).first()
+        uninstallTokens.getUninstallCommandFlyout().getByText(/sudo elastic-agent uninstall --uninstall-token/)
       ).toBeVisible();
     });
 
-    test('should filter for policy ID by partial match', async ({ page }) => {
-      await page.goto('/app/fleet/uninstall-tokens');
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, {
+    test('should filter for policy ID by partial match', async ({ pageObjects }) => {
+      const { uninstallTokens } = pageObjects;
+      await uninstallTokens.navigateTo();
+      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(3, {
         timeout: 10_000,
       });
-      await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('licy-300');
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(1);
+      await uninstallTokens.getPolicyIdSearchInput().fill('licy-300');
+      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(1);
     });
 
-    test('should filter for policy name by partial match', async ({ page }) => {
-      await page.goto('/app/fleet/uninstall-tokens');
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, {
+    test('should filter for policy name by partial match', async ({ pageObjects }) => {
+      const { uninstallTokens } = pageObjects;
+      await uninstallTokens.navigateTo();
+      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(3, {
         timeout: 10_000,
       });
-      await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('Agent 200');
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(1);
+      await uninstallTokens.getPolicyIdSearchInput().fill('Agent 200');
+      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(1);
     });
-  });
+  }
+);
 
-  test.describe('When removing policies before checking uninstall tokens', () => {
+test.describe(
+  'Uninstall token page - with removed policies',
+  { tag: [...tags.stateful.classic] },
+  () => {
     test.beforeAll(async ({ kbnClient }) => {
       await cleanupAgentPolicies(kbnClient);
       await generatePolicies(kbnClient);
@@ -95,11 +118,17 @@ test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () =>
       }
     });
 
-    test('should not be able to filter for policy name by partial match', async ({ page }) => {
-      await page.goto('/app/fleet/uninstall-tokens');
-      await page.waitForLoadState('networkidle');
-      await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('Agent 200');
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(0);
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsPrivilegedUser();
     });
-  });
-});
+
+    test('should not be able to filter for policy name by partial match', async ({
+      pageObjects,
+    }) => {
+      const { uninstallTokens } = pageObjects;
+      await uninstallTokens.navigateTo();
+      await uninstallTokens.getPolicyIdSearchInput().fill('Agent 200');
+      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(0);
+    });
+  }
+);

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -10,7 +10,11 @@ import type { KbnClient, ScoutPage } from '@kbn/scout';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import { createAgentPolicy, cleanupAgentPolicies } from '../common/api_helpers';
+import {
+  createAgentPolicy,
+  cleanupAgentPolicies,
+  mockFleetSetupEndpoints,
+} from '../common/api_helpers';
 import { UNINSTALL_TOKENS } from '../common/selectors';
 
 const TARGET_POLICY_ID = 'agent-policy-100';
@@ -36,8 +40,9 @@ test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () =>
     await generatePolicies(kbnClient);
   });
 
-  test.beforeEach(async ({ browserAuth }) => {
+  test.beforeEach(async ({ browserAuth, page }) => {
     await browserAuth.loginAsPrivilegedUser();
+    await mockFleetSetupEndpoints(page);
   });
 
   test.afterAll(async ({ kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -41,8 +41,8 @@ test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () =>
   });
 
   test.beforeEach(async ({ browserAuth, page }) => {
-    await browserAuth.loginAsPrivilegedUser();
     await mockFleetSetupEndpoints(page);
+    await browserAuth.loginAsPrivilegedUser();
   });
 
   test.afterAll(async ({ kbnClient }) => {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -9,10 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
-import {
-  createAgentPolicy,
-  cleanupAgentPolicies,
-} from '../common/api_helpers';
+import { createAgentPolicy, cleanupAgentPolicies } from '../common/api_helpers';
 import { UNINSTALL_TOKENS } from '../common/selectors';
 
 function generatePolicies(kbnClient: any) {
@@ -45,33 +42,39 @@ test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () =>
     test('should show token by clicking on the eye button', async ({ page }) => {
       await page.goto('/app/fleet/uninstall-tokens');
       await page.route('**/api/fleet/uninstall_tokens/*', (route) => route.continue());
-      await expect(
-        page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()
-      ).toContainText('••••••••••••••••••••••••••••••••');
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()).toContainText(
+        '••••••••••••••••••••••••••••••••'
+      );
       await page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON).first().click();
       await page.waitForTimeout(2000);
-      await expect(
-        page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()
-      ).not.toContainText('••••••••••••••••••••••••••••••••');
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()).not.toContainText(
+        '••••••••••••••••••••••••••••••••'
+      );
     });
 
     test("should show flyout by clicking on 'View uninstall command' button", async ({ page }) => {
       await page.goto('/app/fleet/uninstall-tokens');
       await page.testSubj.locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON).first().click();
       await expect(page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)).toBeVisible();
-      await expect(page.getByText(/sudo elastic-agent uninstall --uninstall-token/).first()).toBeVisible();
+      await expect(
+        page.getByText(/sudo elastic-agent uninstall --uninstall-token/).first()
+      ).toBeVisible();
     });
 
     test('should filter for policy ID by partial match', async ({ page }) => {
       await page.goto('/app/fleet/uninstall-tokens');
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, { timeout: 10_000 });
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, {
+        timeout: 10_000,
+      });
       await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('licy-300');
       await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(1);
     });
 
     test('should filter for policy name by partial match', async ({ page }) => {
       await page.goto('/app/fleet/uninstall-tokens');
-      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, { timeout: 10_000 });
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, {
+        timeout: 10_000,
+      });
       await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('Agent 200');
       await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(1);
     });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -30,105 +30,79 @@ function getPolicyRow(page: ScoutPage, policyId: string) {
     .locator('..');
 }
 
-test.describe(
-  'Uninstall token page - with existing policies',
-  { tag: [...tags.stateful.classic] },
-  () => {
-    test.beforeAll(async ({ kbnClient }) => {
+test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeAll(async ({ kbnClient }) => {
+    await cleanupAgentPolicies(kbnClient);
+    await generatePolicies(kbnClient);
+  });
+
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
+  test.afterAll(async ({ kbnClient }) => {
+    try {
       await cleanupAgentPolicies(kbnClient);
-      await generatePolicies(kbnClient);
-    });
+    } catch {
+      // Ignore
+    }
+  });
 
-    test.afterAll(async ({ kbnClient }) => {
-      try {
-        await cleanupAgentPolicies(kbnClient);
-      } catch {
-        // Ignore
-      }
-    });
+  test('should show token by clicking on the eye button', async ({ page }) => {
+    await page.goto('/app/fleet/uninstall-tokens');
+    const row = getPolicyRow(page, TARGET_POLICY_ID);
+    const tokenField = row.locator(page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD));
+    const showHideButton = row.locator(
+      page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON)
+    );
 
-    test.beforeEach(async ({ browserAuth }) => {
-      await browserAuth.loginAsPrivilegedUser();
-    });
+    await expect(tokenField).toContainText('••••••••••••••••••••••••••••••••');
+    await showHideButton.click();
+    await expect(tokenField).not.toContainText('••••••••••••••••••••••••••••••••');
+  });
 
-    test('should show token by clicking on the eye button', async ({ page }) => {
-      await page.goto('/app/fleet/uninstall-tokens');
-      const row = getPolicyRow(page, TARGET_POLICY_ID);
-      const tokenField = row.locator(page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD));
-      const showHideButton = row.locator(
-        page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON)
-      );
+  test("should show flyout by clicking on 'View uninstall command' button", async ({
+    pageObjects,
+  }) => {
+    const { uninstallTokens } = pageObjects;
+    await uninstallTokens.navigateTo();
+    await uninstallTokens.openUninstallCommandFlyout(TARGET_POLICY_ID);
+    await expect(uninstallTokens.getUninstallCommandFlyout()).toBeVisible();
+    await expect(
+      uninstallTokens
+        .getUninstallCommandFlyout()
+        .getByText(/sudo elastic-agent uninstall --uninstall-token/)
+    ).toBeVisible();
+  });
 
-      await expect(tokenField).toContainText('••••••••••••••••••••••••••••••••');
-      await showHideButton.click();
-      await expect(tokenField).not.toContainText('••••••••••••••••••••••••••••••••');
+  test('should filter for policy ID by partial match', async ({ pageObjects }) => {
+    const { uninstallTokens } = pageObjects;
+    await uninstallTokens.navigateTo();
+    await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(3, {
+      timeout: 10_000,
     });
+    await uninstallTokens.getPolicyIdSearchInput().fill('licy-300');
+    await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(1);
+  });
 
-    test("should show flyout by clicking on 'View uninstall command' button", async ({
-      pageObjects,
-    }) => {
-      const { uninstallTokens } = pageObjects;
-      await uninstallTokens.navigateTo();
-      await uninstallTokens.openUninstallCommandFlyout(TARGET_POLICY_ID);
-      await expect(uninstallTokens.getUninstallCommandFlyout()).toBeVisible();
-      await expect(
-        uninstallTokens
-          .getUninstallCommandFlyout()
-          .getByText(/sudo elastic-agent uninstall --uninstall-token/)
-      ).toBeVisible();
+  test('should filter for policy name by partial match', async ({ pageObjects }) => {
+    const { uninstallTokens } = pageObjects;
+    await uninstallTokens.navigateTo();
+    await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(3, {
+      timeout: 10_000,
     });
+    await uninstallTokens.getPolicyIdSearchInput().fill('Agent 200');
+    await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(1);
+  });
 
-    test('should filter for policy ID by partial match', async ({ pageObjects }) => {
-      const { uninstallTokens } = pageObjects;
-      await uninstallTokens.navigateTo();
-      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(3, {
-        timeout: 10_000,
-      });
-      await uninstallTokens.getPolicyIdSearchInput().fill('licy-300');
-      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(1);
-    });
-
-    test('should filter for policy name by partial match', async ({ pageObjects }) => {
-      const { uninstallTokens } = pageObjects;
-      await uninstallTokens.navigateTo();
-      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(3, {
-        timeout: 10_000,
-      });
-      await uninstallTokens.getPolicyIdSearchInput().fill('Agent 200');
-      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(1);
-    });
-  }
-);
-
-test.describe(
-  'Uninstall token page - with removed policies',
-  { tag: [...tags.stateful.classic] },
-  () => {
-    test.beforeAll(async ({ kbnClient }) => {
-      await cleanupAgentPolicies(kbnClient);
-      await generatePolicies(kbnClient);
-      await cleanupAgentPolicies(kbnClient);
-    });
-
-    test.afterAll(async ({ kbnClient }) => {
-      try {
-        await cleanupAgentPolicies(kbnClient);
-      } catch {
-        // Ignore
-      }
-    });
-
-    test.beforeEach(async ({ browserAuth }) => {
-      await browserAuth.loginAsPrivilegedUser();
-    });
-
-    test('should not be able to filter for policy name by partial match', async ({
-      pageObjects,
-    }) => {
-      const { uninstallTokens } = pageObjects;
-      await uninstallTokens.navigateTo();
-      await uninstallTokens.getPolicyIdSearchInput().fill('Agent 200');
-      await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(0);
-    });
-  }
-);
+  test('should not filter for policy name by partial match when policies are removed', async ({
+    kbnClient,
+    pageObjects,
+  }) => {
+    await cleanupAgentPolicies(kbnClient);
+    const { uninstallTokens } = pageObjects;
+    await uninstallTokens.navigateTo();
+    await uninstallTokens.getPolicyIdSearchInput().fill('Agent 200');
+    await expect(uninstallTokens.getPolicyIdTableField()).toHaveCount(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { tags } from '@kbn/scout';
+
+import { test } from '../fixtures';
+import {
+  createAgentPolicy,
+  cleanupAgentPolicies,
+} from '../common/api_helpers';
+import { UNINSTALL_TOKENS } from '../common/selectors';
+
+function generatePolicies(kbnClient: any) {
+  return Promise.all([
+    createAgentPolicy(kbnClient, 'Agent policy 100', { id: 'agent-policy-100' }),
+    createAgentPolicy(kbnClient, 'Agent policy 200', { id: 'agent-policy-200' }),
+    createAgentPolicy(kbnClient, 'Agent policy 300', { id: 'agent-policy-300' }),
+  ]);
+}
+
+test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsAdmin();
+  });
+
+  test.describe('When not removing policies before checking uninstall tokens', () => {
+    test.beforeAll(async ({ kbnClient }) => {
+      await cleanupAgentPolicies(kbnClient);
+      await generatePolicies(kbnClient);
+    });
+
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await cleanupAgentPolicies(kbnClient);
+      } catch {
+        // Ignore
+      }
+    });
+
+    test('should show token by clicking on the eye button', async ({ page }) => {
+      await page.goto('/app/fleet/uninstall-tokens');
+      await page.route('**/api/fleet/uninstall_tokens/*', (route) => route.continue());
+      await expect(
+        page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()
+      ).toContainText('••••••••••••••••••••••••••••••••');
+      await page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON).first().click();
+      await page.waitForTimeout(2000);
+      await expect(
+        page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD).first()
+      ).not.toContainText('••••••••••••••••••••••••••••••••');
+    });
+
+    test("should show flyout by clicking on 'View uninstall command' button", async ({ page }) => {
+      await page.goto('/app/fleet/uninstall-tokens');
+      await page.testSubj.locator(UNINSTALL_TOKENS.VIEW_UNINSTALL_COMMAND_BUTTON).first().click();
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.UNINSTALL_COMMAND_FLYOUT)).toBeVisible();
+      await expect(page.getByText(/sudo elastic-agent uninstall --uninstall-token/).first()).toBeVisible();
+    });
+
+    test('should filter for policy ID by partial match', async ({ page }) => {
+      await page.goto('/app/fleet/uninstall-tokens');
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, { timeout: 10_000 });
+      await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('licy-300');
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(1);
+    });
+
+    test('should filter for policy name by partial match', async ({ page }) => {
+      await page.goto('/app/fleet/uninstall-tokens');
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(3, { timeout: 10_000 });
+      await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('Agent 200');
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(1);
+    });
+  });
+
+  test.describe('When removing policies before checking uninstall tokens', () => {
+    test.beforeAll(async ({ kbnClient }) => {
+      await cleanupAgentPolicies(kbnClient);
+      await generatePolicies(kbnClient);
+      await cleanupAgentPolicies(kbnClient);
+    });
+
+    test.afterAll(async ({ kbnClient }) => {
+      try {
+        await cleanupAgentPolicies(kbnClient);
+      } catch {
+        // Ignore
+      }
+    });
+
+    test('should not be able to filter for policy name by partial match', async ({ page }) => {
+      await page.goto('/app/fleet/uninstall-tokens');
+      await page.waitForLoadState('networkidle');
+      await page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_SEARCH_FIELD).fill('Agent 200');
+      await expect(page.testSubj.locator(UNINSTALL_TOKENS.POLICY_ID_TABLE_FIELD)).toHaveCount(0);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -11,6 +11,7 @@ import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import {
+  setupFleetServer,
   createAgentPolicy,
   cleanupAgentPolicies,
   mockFleetSetupEndpoints,
@@ -35,7 +36,8 @@ function getPolicyRow(page: ScoutPage, policyId: string) {
 }
 
 test.describe('Uninstall token page', { tag: [...tags.stateful.classic] }, () => {
-  test.beforeAll(async ({ kbnClient }) => {
+  test.beforeAll(async ({ kbnClient, esClient }) => {
+    await setupFleetServer(kbnClient, esClient);
     await cleanupAgentPolicies(kbnClient);
     await generatePolicies(kbnClient);
   });

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/uninstall_token.spec.ts
@@ -54,9 +54,7 @@ test.describe(
     test('should show token by clicking on the eye button', async ({ page }) => {
       await page.goto('/app/fleet/uninstall-tokens');
       const row = getPolicyRow(page, TARGET_POLICY_ID);
-      const tokenField = row.locator(
-        page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD)
-      );
+      const tokenField = row.locator(page.testSubj.locator(UNINSTALL_TOKENS.TOKEN_FIELD));
       const showHideButton = row.locator(
         page.testSubj.locator(UNINSTALL_TOKENS.SHOW_HIDE_TOKEN_BUTTON)
       );
@@ -74,7 +72,9 @@ test.describe(
       await uninstallTokens.openUninstallCommandFlyout(TARGET_POLICY_ID);
       await expect(uninstallTokens.getUninstallCommandFlyout()).toBeVisible();
       await expect(
-        uninstallTokens.getUninstallCommandFlyout().getByText(/sudo elastic-agent uninstall --uninstall-token/)
+        uninstallTokens
+          .getUninstallCommandFlyout()
+          .getByText(/sudo elastic-agent uninstall --uninstall-token/)
       ).toBeVisible();
     });
 


### PR DESCRIPTION
## Summary

Migrates all Fleet UI Cypress tests to Scout/Playwright.

### Changes

- **Page objects**: Agent list, agent policy, enrollment tokens, uninstall tokens, fleet settings, outputs, agent flyout, and package policy
- **API helpers**: Fleet-specific operations (agent policies, download sources, fleet server hosts, space awareness, EPM package installation)
- **Test selectors**: Centralized `data-test-subj` selectors
- **20 test spec files** covering:
  - Agent list and agentless flows
  - Agent policies (create, edit, delete, space awareness)
  - Integrations (mock API, real EPM, automatic import)
  - Enrollment tokens management
  - Uninstall tokens management
  - Fleet settings and outputs (Elasticsearch, Logstash, Kafka)
  - Package policy with pipelines and mappings
  - Fleet startup and agent flyout
  - ML/Transform asset installation
  - Accessibility (a11y) checks

### Test plan
- [ ] Run Scout tests locally: `node scripts/scout run-tests --config x-pack/platform/plugins/shared/fleet/test/scout/ui/playwright.config.ts`
- [ ] Verify all page objects match current Fleet UI selectors
- [ ] Verify API helpers work against a running Kibana/ES instance