### PR TITLE
[Discover] Fix flaky esql test

### DIFF
--- a/src/platform/test/functional/apps/discover/esql/_esql_view.ts
+++ b/src/platform/test/functional/apps/discover/esql/_esql_view.ts
@@ -79,6 +79,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     describe('ES|QL in Discover', () => {
+      beforeEach(async () => {
+        await timePicker.setDefaultAbsoluteRangeViaUiSettings();
+        await common.navigateToApp('discover');
+        await discover.waitUntilTabIsLoaded();
+      });
+
       it('should render esql view correctly', async function () {
         await discover.waitUntilTabIsLoaded();
         await unifiedFieldList.waitUntilSidebarHasLoaded();

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -146,12 +146,14 @@ export class DiscoverPageObject extends FtrService {
     await this.testSubjects.missingOrFail('loadingSpinner', {
       timeout: this.defaultFindTimeout * 10,
     });
-    // TODO: Should we add a check for `discoverDataGridUpdating` too?
   }
 
   public async waitUntilTabIsLoaded() {
     await this.header.waitUntilLoadingHasFinished();
     await this.waitUntilSearchingHasFinished();
+    await this.testSubjects.missingOrFail('discoverDataGridUpdating', {
+      timeout: this.defaultFindTimeout * 10,
+    });
   }
 
   public async getColumnHeaders() {

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/esql/_esql_view.ts
@@ -67,6 +67,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     describe('ES|QL in Discover', () => {
+      beforeEach(async () => {
+        await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
+        await PageObjects.common.navigateToApp('discover');
+        await PageObjects.discover.waitUntilTabIsLoaded();
+      });
+
       it('should render esql view correctly', async function () {
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/253908
- Closes https://github.com/elastic/kibana/issues/254128
- Closes https://github.com/elastic/kibana/issues/254143

## Summary

Another fix for it.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->