### PR TITLE
[APM] Support ECS formatted errors in service details

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
@@ -123,6 +123,7 @@ export const ERROR_EXC_TYPE = 'error.exception.type';
 export const ERROR_PAGE_URL = 'error.page.url';
 export const ERROR_STACK_TRACE = 'error.stack_trace';
 export const ERROR_TYPE = 'error.type';
+export const ERROR_CODE = 'error.code';
 
 // METRICS
 export const METRIC_SYSTEM_FREE_MEMORY = 'system.memory.actual.free';

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/common.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/common.ts
@@ -5,6 +5,4 @@
  * 2.0.
  */
 
-export * from './src/es_fields/apm';
-export * from './src/es_fields/otel';
-export * from './src/es_fields/common';
+export const ERROR_MESSAGE = 'error.message';

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/otel.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/otel.ts
@@ -7,7 +7,6 @@
 
 export const STATUS_CODE = 'status.code';
 export const OTEL_EVENT_NAME = 'event_name';
-export const ERROR_MESSAGE = 'error.message';
 export const EXCEPTION_TYPE = 'exception.type';
 export const EXCEPTION_MESSAGE = 'exception.message';
 export const DURATION = 'duration';

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts
@@ -61,6 +61,9 @@ export interface ErrorRaw extends APMBaseDoc {
     log?: Log;
     stack_trace?: string;
     custom?: Record<string, unknown>;
+    message?: string;
+    code?: string;
+    type?: string;
   };
 
   // Shared by errors and transactions

--- a/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
@@ -73,6 +73,8 @@ exports[`Error DURATION 1`] = `undefined`;
 
 exports[`Error ELASTIC_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
 
+exports[`Error ERROR_CODE 1`] = `undefined`;
+
 exports[`Error ERROR_CULPRIT 1`] = `"handleOopsie"`;
 
 exports[`Error ERROR_EXC_HANDLED 1`] = `undefined`;
@@ -511,6 +513,8 @@ exports[`Span DURATION 1`] = `undefined`;
 
 exports[`Span ELASTIC_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
 
+exports[`Span ERROR_CODE 1`] = `undefined`;
+
 exports[`Span ERROR_CULPRIT 1`] = `undefined`;
 
 exports[`Span ERROR_EXC_HANDLED 1`] = `undefined`;
@@ -935,6 +939,8 @@ exports[`Transaction DEVICE_MODEL_IDENTIFIER 1`] = `undefined`;
 exports[`Transaction DURATION 1`] = `undefined`;
 
 exports[`Transaction ELASTIC_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
+
+exports[`Transaction ERROR_CODE 1`] = `undefined`;
 
 exports[`Transaction ERROR_CULPRIT 1`] = `undefined`;
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -261,7 +261,7 @@ export function ErrorSampleDetails({
                     },
                   })}
                 >
-                  <EuiIcon type="merge" />
+                  <EuiIcon type="merge" aria-hidden={true} />
                   <TransactionLinkName>{transaction.transaction.name}</TransactionLinkName>
                 </TransactionDetailLink>
               </EuiToolTip>
@@ -362,23 +362,26 @@ export function ErrorSampleDetailTabContent({
       };
     };
     [AT_TIMESTAMP]: string;
-    error: Pick<APMError['error'], 'id' | 'log' | 'stack_trace' | 'exception'>;
+    error: Pick<APMError['error'], 'id' | 'log' | 'stack_trace' | 'exception' | 'message' | 'type'>;
   };
   currentTab: ErrorTab;
 }) {
   const codeLanguage = error?.service.language?.name;
   const exceptions = error?.error.exception || [];
+  const hasExceptions = exceptions.length > 0;
   const logStackframes = error?.error.log?.stacktrace;
-  const isPlaintextException =
-    !!error.error.stack_trace && exceptions.length === 1 && !exceptions[0].stacktrace;
+  const isPlaintextException = hasExceptions
+    ? !!error.error.stack_trace && exceptions.length === 1 && !exceptions[0].stacktrace
+    : !!error.error.stack_trace;
+
   switch (currentTab.key) {
     case ErrorTabKey.LogStackTrace:
       return <Stacktrace stackframes={logStackframes} codeLanguage={codeLanguage} />;
     case ErrorTabKey.ExceptionStacktrace:
       return isPlaintextException ? (
         <PlaintextStacktrace
-          message={exceptions[0].message}
-          type={exceptions[0]?.type}
+          message={hasExceptions ? exceptions[0].message : undefined}
+          type={hasExceptions ? exceptions[0].type : undefined}
           stacktrace={error?.error.stack_trace}
           codeLanguage={codeLanguage}
         />

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -362,7 +362,7 @@ export function ErrorSampleDetailTabContent({
       };
     };
     [AT_TIMESTAMP]: string;
-    error: Pick<APMError['error'], 'id' | 'log' | 'stack_trace' | 'exception' | 'message' | 'type'>;
+    error: Pick<APMError['error'], 'id' | 'log' | 'stack_trace' | 'exception'>;
   };
   currentTab: ErrorTab;
 }) {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.tsx
@@ -19,12 +19,12 @@ const Label = styled.div`
 
 interface Props {
   error: {
-    error: Pick<APMError['error'], 'log' | 'exception' | 'culprit'>;
+    error: Pick<APMError['error'], 'log' | 'exception' | 'culprit' | 'message'>;
   };
 }
 export function SampleSummary({ error }: Props) {
   const logMessage = error.error.log?.message;
-  const excMessage = error.error.exception?.[0].message;
+  const excMessage = error.error.exception?.[0].message || error.error.message;
   const culprit = error.error.culprit;
 
   return (

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
@@ -187,7 +187,7 @@ export function ErrorGroupList({
               serviceName={serviceName}
               query={{
                 ...query,
-                kuery: `error.exception.type:"${type}"`,
+                kuery: `error.exception.type:"${type}" OR error.type:"${type}"`,
               }}
             >
               {type}

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.test.ts
@@ -11,17 +11,29 @@ import { getErrorName } from './get_error_name';
 
 describe('getErrorName', () => {
   it('returns log message', () => {
-    const event = accessKnownApmEventFields({ 'error.log.message': ['bar'] });
+    const event = accessKnownApmEventFields({
+      'error.log.message': ['bar'],
+      'error.message': ['baz'],
+    });
     const exception = { message: 'foo' };
 
     expect(getErrorName(event, exception)).toEqual('bar');
   });
+
   it('returns exception message', () => {
-    const event = accessKnownApmEventFields({} as Partial<FlattenedApmEvent>);
+    const event = accessKnownApmEventFields({ 'error.message': ['baz'] });
     const exception = { message: 'foo' };
 
     expect(getErrorName(event, exception)).toEqual('foo');
   });
+
+  it('returns error message', () => {
+    const event = accessKnownApmEventFields({ 'error.message': ['baz'] });
+    const exception = {};
+
+    expect(getErrorName(event, exception)).toEqual('baz');
+  });
+
   it('returns default message', () => {
     const event = accessKnownApmEventFields({} as Partial<FlattenedApmEvent>);
     expect(getErrorName(event, {})).toEqual(NOT_AVAILABLE_LABEL);

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.ts
@@ -9,11 +9,13 @@ import type { Exception } from '@kbn/apm-types';
 import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/utility_types';
 import type { ProxiedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/access_known_fields';
 import { NOT_AVAILABLE_LABEL } from '../../../common/i18n';
-import { ERROR_LOG_MESSAGE } from '../../../common/es_fields/apm';
+import { ERROR_LOG_MESSAGE, ERROR_MESSAGE } from '../../../common/es_fields/apm';
 
 export function getErrorName<T extends ProxiedApmEvent<Partial<FlattenedApmEvent>>>(
   event: T,
   exception: Exception
 ): string {
-  return event[ERROR_LOG_MESSAGE] || exception.message || NOT_AVAILABLE_LABEL;
+  return (
+    event[ERROR_LOG_MESSAGE] || exception.message || event[ERROR_MESSAGE] || NOT_AVAILABLE_LABEL
+  );
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -18,6 +18,8 @@ import {
   ERROR_GROUP_ID,
   ERROR_GROUP_NAME,
   ERROR_LOG_MESSAGE,
+  ERROR_MESSAGE,
+  ERROR_TYPE,
   SERVICE_NAME,
   TRACE_ID,
   TRANSACTION_NAME,
@@ -105,6 +107,8 @@ export async function getErrorGroupMainStatistics({
     ERROR_EXC_MESSAGE,
     ERROR_EXC_HANDLED,
     ERROR_EXC_TYPE,
+    ERROR_MESSAGE,
+    ERROR_TYPE,
   ] as const);
 
   const response = await apmEventClient.search('get_error_group_main_statistics', {
@@ -185,7 +189,7 @@ export async function getErrorGroupMainStatistics({
         occurrences: bucket.doc_count,
         culprit: event[ERROR_CULPRIT],
         handled: exception.handled,
-        type: exception.type,
+        type: exception.type || event[ERROR_TYPE],
         traceId: event[TRACE_ID],
       };
     }) ?? [];

--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
@@ -36,6 +36,8 @@ import {
   TRANSACTION_PAGE_URL,
   USER_AGENT_NAME,
   USER_AGENT_VERSION,
+  ERROR_MESSAGE,
+  ERROR_TYPE,
 } from '../../../../common/es_fields/apm';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { ApmDocumentType } from '../../../../common/document_type';
@@ -99,6 +101,8 @@ export async function getErrorSampleDetails({
     ERROR_EXC_HANDLED,
     ERROR_EXC_TYPE,
     ERROR_ID,
+    ERROR_MESSAGE,
+    ERROR_TYPE,
     URL_FULL,
     HTTP_REQUEST_METHOD,
     HTTP_RESPONSE_STATUS_CODE,


### PR DESCRIPTION
## Summary

Closes #249358

This PR aims to support ECS-formatted error documents in service details error tab. This part of the UI was heavily dependent on documents having an `error.exception` field. While most APM data streams will include such field, some features (such as the Java agent `log_sending` feature) can send ECS formatted error logs that do not include `error.exception` In this cases, the UI wasn't able to render most fields (such as error message and type) properly. 

The work done here revolves around adding support for ECS formatted documents so that information for these types of documents can be properly displayed in the APM UI. It's mostly adding additional fields to check when getting error data:

- **Error Message** 
  1. `error.log.message`
  2. `error.exception.message`
  3. `error.message` **new**
- **Error Type**
  1. `error.exception.type`
  2. `error.type` **new**

Support for plain text stack traces has also been extended in order to properly render ECS stack traces.

## Demo

### Before

https://github.com/user-attachments/assets/c4fa41a9-c52d-4ee5-a9f7-8e005c52e1b8

### After

https://github.com/user-attachments/assets/73f0aa6a-ee9d-4363-aad0-e899bb04f978

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->