### PR TITLE
[9.3] [One Workflow] Scout tests for Workflows UI (#251413)

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -20,6 +20,7 @@ plugins:
     - streams_app
     - transform
     - workflows_extensions
+    - workflows_management
   disabled:
 
 packages:

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/serverless/observability_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/serverless/observability_complete.serverless.config.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultConfig } from '../../default/serverless/observability_complete.serverless.config';
+
+/**
+ * Custom Scout server configuration for Workflows Management UI tests.
+ * Enables the workflows:ui:enabled feature flag.
+ *
+ * This config is automatically used when running tests from:
+ * workflows_management/test/scout_workflows_ui/
+ */
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [
+      ...defaultConfig.kbnTestServer.serverArgs,
+      '--uiSettings.overrides.workflows:ui:enabled=true',
+      // Allow short alert rule intervals for alert trigger tests (default minimum is 1m)
+      '--xpack.alerting.rules.minimumScheduleInterval.value=15s',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/serverless/search.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/serverless/search.serverless.config.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultConfig } from '../../default/serverless/search.serverless.config';
+
+/**
+ * Custom Scout server configuration for Workflows Management UI tests.
+ * Enables the workflows:ui:enabled feature flag.
+ *
+ * This config is automatically used when running tests from:
+ * workflows_management/test/scout_workflows_ui/
+ */
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [
+      ...defaultConfig.kbnTestServer.serverArgs,
+      '--uiSettings.overrides.workflows:ui:enabled=true',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/serverless/security_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/serverless/security_complete.serverless.config.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultConfig } from '../../default/serverless/security_complete.serverless.config';
+
+/**
+ * Custom Scout server configuration for Workflows Management UI tests.
+ * Enables the workflows:ui:enabled feature flag.
+ *
+ * This config is automatically used when running tests from:
+ * workflows_management/test/scout_workflows_ui/
+ */
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [
+      ...defaultConfig.kbnTestServer.serverArgs,
+      '--uiSettings.overrides.workflows:ui:enabled=true',
+      // Allow short alert rule intervals for alert trigger tests (default minimum is 1m)
+      '--xpack.alerting.rules.minimumScheduleInterval.value=15s',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/workflows_ui/stateful/classic.stateful.config.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { defaultConfig } from '../../default/stateful/base.config';
+
+/**
+ * Custom Scout server configuration for Workflows Management UI tests.
+ * Enables the workflows:ui:enabled feature flag.
+ *
+ * This config is automatically used when running tests from:
+ * workflows_management/test/scout_workflows_ui/
+ */
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [
+      ...defaultConfig.kbnTestServer.serverArgs,
+      '--uiSettings.overrides.workflows:ui:enabled=true',
+      // Allow short alert rule intervals for alert trigger tests (default minimum is 1m)
+      '--xpack.alerting.rules.minimumScheduleInterval.value=15s',
+    ],
+  },
+};

--- a/src/platform/plugins/shared/workflows_management/.storybook/decorators.tsx
+++ b/src/platform/plugins/shared/workflows_management/.storybook/decorators.tsx
@@ -10,10 +10,12 @@
 import { action } from '@storybook/addon-actions';
 import type { Decorator } from '@storybook/react';
 import React from 'react';
+import { TypeRegistry } from '@kbn/alerts-ui-shared/lib';
 import type { CoreStart } from '@kbn/core/public';
 import { CommonGlobalAppStyles } from '@kbn/core-chrome-layout/layouts/common/global_app_styles';
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import type { ActionTypeModel } from '@kbn/triggers-actions-ui-plugin/public';
 import { mockUiSettingsService } from '../public/shared/mocks/mock_ui_settings_service';
 
 const createMockWebStorage = () => ({
@@ -31,6 +33,19 @@ const createMockStorage = () => ({
   remove: action('STORAGE_REMOVE'),
   clear: action('STORAGE_CLEAR'),
   get: action('STORAGE_GET'),
+});
+
+const createMockTriggersActionsUi = () => ({
+  actionTypeRegistry: new TypeRegistry<ActionTypeModel>(),
+  ruleTypeRegistry: new TypeRegistry(),
+});
+
+const createMockWorkflowsExtensions = () => ({
+  getStepDefinition: (stepType: string) => {
+    // Return undefined for all step types in Storybook
+    // This allows the component to fall back to default icons
+    return undefined;
+  },
 });
 
 /**
@@ -57,6 +72,8 @@ export const kibanaReactDecorator: Decorator = (story: Function) => {
               client: mockUiSettingsService(),
             },
             storage: createMockStorage(),
+            triggersActionsUi: createMockTriggersActionsUi(),
+            workflowsExtensions: createMockWorkflowsExtensions(),
           } as unknown as CoreStart
         }
       >

--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -81,6 +81,7 @@ dependsOn:
   - '@kbn/shared-ux-utility'
   - '@kbn/licensing-types'
   - '@kbn/core-lifecycle-server-mocks'
+  - '@kbn/scout'
 tags:
   - plugin
   - prod
@@ -93,6 +94,7 @@ fileGroups:
     - common/**/*
     - public/**/*
     - server/**/*
+    - test/**/*
     - .storybook/**/*.ts
     - .storybook/**/*.tsx
     - server/**/*.json

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
@@ -29,6 +29,8 @@ export const selectHasChanges = createSelector(
   (detail) => detail.yamlString !== detail.workflow?.yaml
 );
 
+export const selectIsYamlSynced = createSelector(selectDetail, (detail) => detail.isYamlSynced);
+
 export const selectYamlDocument = createSelector(
   selectYamlComputed,
   (computed) => computed?.yamlDocument

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/slice.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/slice.ts
@@ -17,6 +17,7 @@ import { getWorkflowZodSchema } from '../../../../../common/schema';
 // Initial state
 const initialState: WorkflowDetailState = {
   yamlString: '',
+  isYamlSynced: true,
   computed: undefined,
   workflow: undefined,
   execution: undefined,
@@ -45,6 +46,9 @@ const workflowDetailSlice = createSlice({
     },
     setYamlString: (state, action: { payload: string }) => {
       state.yamlString = action.payload;
+    },
+    setIsYamlSynced: (state, action: { payload: boolean }) => {
+      state.isYamlSynced = action.payload;
     },
     setCursorPosition: (state, action: { payload: { lineNumber: number } }) => {
       if (!state.computed?.workflowLookup) {
@@ -103,6 +107,7 @@ export const {
   setWorkflow,
   updateWorkflow,
   setYamlString,
+  setIsYamlSynced,
   setCursorPosition,
   setHighlightedStepId,
   setIsTestModalOpen,

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/types.ts
@@ -19,6 +19,12 @@ import type { ConnectorsResponse } from '../../../connectors/model/types';
 export interface WorkflowDetailState {
   /** The yaml string used by the workflow yaml editor */
   yamlString: string;
+  /**
+   * Whether the YAML editor's internal value is synced with the Redux store.
+   * When false, there are pending debounced changes that haven't been dispatched yet.
+   * The save button should be disabled when this is false to prevent saving stale data.
+   */
+  isYamlSynced: boolean;
   /** The persisted workflow detail data */
   workflow?: WorkflowDetailDto;
   /** The computed data derived from the workflow yaml string, it is updated by the workflowComputationMiddleware */

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/test_step_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/test_step_modal.tsx
@@ -17,6 +17,7 @@ import {
   euiFontSize,
   EuiModal,
   EuiModalBody,
+  EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
   useGeneratedHtmlId,
@@ -143,7 +144,12 @@ export function TestStepModal({
   }
 
   return (
-    <EuiModal aria-labelledby={modalTitleId} maxWidth={false} onClose={onClose}>
+    <EuiModal
+      aria-labelledby={modalTitleId}
+      maxWidth={false}
+      onClose={onClose}
+      data-test-subj="workflowTestStepModal"
+    >
       <EuiModalHeader>
         <EuiModalHeaderTitle id={modalTitleId}>
           <EuiFlexGroup direction="column" gutterSize="xs">
@@ -204,6 +210,18 @@ export function TestStepModal({
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton
+          onClick={handleSubmit}
+          disabled={!isJsonValid}
+          color="success"
+          iconType="play"
+          size="s"
+          data-test-subj="workflowSubmitStepRun"
+        >
+          <FormattedMessage id="workflows.testStepModal.submitRunBtn" defaultMessage="Run" />
+        </EuiButton>
+      </EuiModalFooter>
     </EuiModal>
   );
 }

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -160,6 +160,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
           onClose={onClose}
           maxWidth={1400}
           style={{ width: '1200px', height: '100vh' }}
+          data-test-subj="workflowExecuteModal"
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle id={modalTitleId}>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_execution_tree_item_label.tsx
@@ -54,7 +54,7 @@ export function StepExecutionTreeItemLabel({
           isInactiveStatus && styles.inactiveStepName,
         ]}
       >
-        {stepId}
+        <span data-test-subj="workflowStepName">{stepId}</span>
         {status === ExecutionStatus.SKIPPED && (
           <>
             {' '}

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_overview.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_overview.tsx
@@ -59,6 +59,7 @@ export const WorkflowExecutionOverview = React.memo<WorkflowExecutionOverviewPro
         hasShadow={false}
         paddingSize="m"
         css={{ height: '100%', paddingTop: euiTheme.size.m /* overrides EuiPanel's paddingTop */ }}
+        data-test-subj="workflowExecutionOverview"
       >
         <EuiFlexGroup
           direction="column"
@@ -76,7 +77,9 @@ export const WorkflowExecutionOverview = React.memo<WorkflowExecutionOverviewPro
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiText>
-                          <h3>{getStatusLabel(stepExecution.status)}</h3>
+                          <h3 data-test-subj="workflowExecutionStatus">
+                            {getStatusLabel(stepExecution.status)}
+                          </h3>
                         </EuiText>
                       </EuiFlexItem>
                     </EuiFlexGroup>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_execution_panel.tsx
@@ -71,10 +71,17 @@ export const WorkflowExecutionPanel = React.memo<WorkflowExecutionPanelProps>(
         justifyContent="flexStart"
         gutterSize="none"
         css={{ height: '100%' }}
+        data-test-subj="workflowExecutionPanel"
+        data-execution-status={execution?.status}
       >
         {showBackButton && (
           <EuiFlexItem grow={false}>
-            <EuiLink onClick={onClose} color="text" aria-label={i18nTexts.backToExecutions}>
+            <EuiLink
+              onClick={onClose}
+              color="text"
+              aria-label={i18nTexts.backToExecutions}
+              data-test-subj="workflowBackToExecutionsLink"
+            >
               <EuiPanel paddingSize="m" hasShadow={false} css={styles.linkCss}>
                 <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="s">
                   <EuiFlexItem grow={false}>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -102,6 +102,9 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
         hasShadow={false}
         paddingSize="m"
         css={{ height: '100%', paddingTop: '13px' /* overrides EuiPanel's paddingTop */ }}
+        data-test-subj={
+          isTriggerPseudoStep ? 'workflowExecutionTrigger' : 'workflowStepExecutionDetails'
+        }
       >
         <EuiFlexGroup
           direction="column"
@@ -116,6 +119,7 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
                   isSelected={tab.id === selectedTabId}
                   key={tab.id}
                   css={{ lineHeight: 'normal' }}
+                  data-test-subj={`workflowStepTab_${tab.id}`}
                 >
                   {tab.name}
                 </EuiTab>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_tree.stories.tsx
@@ -13,8 +13,7 @@ import type { WorkflowYaml } from '@kbn/workflows';
 import { ExecutionStatus } from '@kbn/workflows';
 import { WorkflowStepExecutionTree } from './workflow_step_execution_tree';
 import { kibanaReactDecorator } from '../../../../.storybook/decorators';
-import { parseWorkflowYamlToJSON } from '../../../../common/lib/yaml';
-import { WORKFLOW_ZOD_SCHEMA_LOOSE } from '../../../../common/schema';
+import { parseYamlToJSONWithoutValidation } from '../../../../common/lib/yaml';
 
 const meta: Meta<typeof WorkflowStepExecutionTree> = {
   component: WorkflowStepExecutionTree,
@@ -93,9 +92,9 @@ steps:
     with:
       message: '--------------------------'
 `;
-const result = parseWorkflowYamlToJSON(yaml, WORKFLOW_ZOD_SCHEMA_LOOSE);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- it's a storybook story, we don't need to type it
-const definition = (result as any).data as WorkflowYaml;
+const result = parseYamlToJSONWithoutValidation(yaml);
+// @ts-expect-error -- it's a storybook story, we don't need to type it
+const definition = result.json as WorkflowYaml;
 
 // export interface WorkflowExecutionDto {
 //   spaceId: string;
@@ -131,6 +130,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
       stepExecutions: [
         {
           stepId: 'analysis',
+          stepType: 'inference.completion',
           topologicalIndex: 0,
           status: ExecutionStatus.PENDING,
           startedAt: '2025-09-02T20:43:57.466Z',
@@ -153,6 +153,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'debug_ai_response',
+          stepType: 'console',
           topologicalIndex: 1,
           status: ExecutionStatus.RUNNING,
           startedAt: '2025-09-02T20:44:02.142Z',
@@ -175,6 +176,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'print-enter-dash',
+          stepType: 'slack',
           topologicalIndex: 2,
           status: ExecutionStatus.COMPLETED,
           startedAt: '2025-09-02T20:44:03.171Z',
@@ -195,6 +197,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'foreachstep',
+          stepType: 'foreach',
           topologicalIndex: 4,
           status: ExecutionStatus.SKIPPED,
           startedAt: '2025-09-02T20:44:05.233Z',
@@ -235,6 +238,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'log-name-surname',
+          stepType: 'console',
           topologicalIndex: 5,
           status: ExecutionStatus.WAITING_FOR_INPUT,
           startedAt: '2025-09-02T20:44:12.598Z',
@@ -260,6 +264,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'log-name-surname',
+          stepType: 'console',
           topologicalIndex: 5,
           status: ExecutionStatus.WAITING,
           startedAt: '2025-09-02T20:44:10.456Z',
@@ -285,6 +290,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'log-name-surname',
+          stepType: 'console',
           topologicalIndex: 5,
           status: ExecutionStatus.COMPLETED,
           startedAt: '2025-09-02T20:44:08.396Z',
@@ -310,6 +316,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'log-name-surname',
+          stepType: 'console',
           topologicalIndex: 5,
           status: ExecutionStatus.FAILED,
           startedAt: '2025-09-02T20:44:06.265Z',
@@ -335,6 +342,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'slack_it',
+          stepType: 'slack',
           topologicalIndex: 6,
           status: ExecutionStatus.COMPLETED,
           startedAt: '2025-09-02T20:44:13.480Z',
@@ -360,6 +368,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'slack_it',
+          stepType: 'slack',
           topologicalIndex: 6,
           status: ExecutionStatus.COMPLETED,
           startedAt: '2025-09-02T20:44:11.422Z',
@@ -385,6 +394,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'slack_it',
+          stepType: 'slack',
           topologicalIndex: 6,
           status: ExecutionStatus.COMPLETED,
           startedAt: '2025-09-02T20:44:09.363Z',
@@ -410,6 +420,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'slack_it',
+          stepType: 'slack',
           topologicalIndex: 6,
           status: ExecutionStatus.COMPLETED,
           startedAt: '2025-09-02T20:44:07.300Z',
@@ -435,6 +446,7 @@ export const Default: StoryObj<typeof WorkflowStepExecutionTree> = {
         },
         {
           stepId: 'print-exit-dash',
+          stepType: 'slack',
           topologicalIndex: 8,
           status: ExecutionStatus.COMPLETED,
           startedAt: '2025-09-02T20:44:15.553Z',

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.tsx
@@ -169,6 +169,7 @@ export const WorkflowExecutionList = ({
       gutterSize="s"
       justifyContent="flexStart"
       css={styles.container}
+      data-test-subj="workflowExecutionList"
     >
       <header>
         <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_item.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_item.tsx
@@ -70,7 +70,14 @@ export const WorkflowExecutionListItem = React.memo<WorkflowExecutionListItemPro
     }, [selected, onClick, styles]);
 
     return (
-      <EuiPanel onClick={onClick} hasShadow={false} paddingSize="m" hasBorder css={panelCss}>
+      <EuiPanel
+        onClick={onClick}
+        hasShadow={false}
+        paddingSize="m"
+        hasBorder
+        css={panelCss}
+        data-test-subj="workflowExecutionListItem"
+      >
         <EuiFlexGroup
           gutterSize="m"
           alignItems="center"

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
@@ -175,6 +175,8 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
                       display: block;
                       max-width: 100%;
                     `}
+                    title={name}
+                    data-test-subj="workflowNameLink"
                   >
                     {name}
                   </Link>
@@ -254,6 +256,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
                   }
                 >
                   <EuiSwitch
+                    data-test-subj={`workflowToggleSwitch-${item.id}`}
                     disabled={!canUpdateWorkflow || !item.valid}
                     checked={item.enabled}
                     onChange={() => handleToggleWorkflow(item)}
@@ -292,6 +295,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
             name: i18n.translate('workflows.workflowList.run', {
               defaultMessage: 'Run',
             }),
+            'data-test-subj': 'runWorkflowAction',
             icon: 'play',
             description: (item: WorkflowListItemDto) =>
               getRunTooltipContent({
@@ -314,6 +318,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
             name: i18n.translate('workflows.workflowList.edit', {
               defaultMessage: 'Edit',
             }),
+            'data-test-subj': 'editWorkflowAction',
             icon: 'pencil',
             description: i18n.translate('workflows.workflowList.edit', {
               defaultMessage: 'Edit workflow',
@@ -327,6 +332,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
             name: i18n.translate('workflows.workflowList.clone', {
               defaultMessage: 'Clone',
             }),
+            'data-test-subj': 'cloneWorkflowAction',
             icon: 'copy',
             description: i18n.translate('workflows.workflowList.clone', {
               defaultMessage: 'Clone workflow',
@@ -342,6 +348,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
             name: i18n.translate('workflows.workflowList.export', {
               defaultMessage: 'Export',
             }),
+            'data-test-subj': 'exportWorkflowAction',
             icon: 'export',
             description: i18n.translate('workflows.workflowList.export', {
               defaultMessage: 'Export workflow',
@@ -354,6 +361,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
             name: i18n.translate('workflows.workflowList.delete', {
               defaultMessage: 'Delete',
             }),
+            'data-test-subj': 'deleteWorkflowAction',
             icon: 'trash',
             description: i18n.translate('workflows.workflowList.delete', {
               defaultMessage: 'Delete workflow',
@@ -436,6 +444,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
         showEnd={showEnd}
       />
       <EuiBasicTable
+        data-test-subj="workflowListTable"
         css={css`
           .euiBasicTableAction-showOnHover {
             opacity: 1 !important;

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.test.tsx
@@ -80,7 +80,7 @@ jest.mock('../../../features/run_workflow/ui/test_step_modal', () => ({
     <div data-test-subj="test-step-modal">
       <button
         type="button"
-        data-test-subj="submit-step-run"
+        data-test-subj="workflowSubmitStepRun"
         onClick={() => onSubmit({ stepInputs: {} })}
       >
         {'Submit'}
@@ -250,7 +250,7 @@ describe('WorkflowDetailEditor', () => {
         expect(queryByTestId('test-step-modal')).toBeInTheDocument();
       });
 
-      const submitButton = getByTestId('submit-step-run');
+      const submitButton = getByTestId('workflowSubmitStepRun');
       await act(async () => {
         submitButton.click();
       });

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -39,6 +39,7 @@ import {
   selectHasChanges,
   selectIsExecutionsTab,
   selectIsSavingYaml,
+  selectIsYamlSynced,
   selectIsYamlSyntaxValid,
   selectWorkflow,
 } from '../../../entities/workflows/store/workflow_detail/selectors';
@@ -106,6 +107,7 @@ export const WorkflowDetailHeader = React.memo(
     const isSyntaxValid = useSelector(selectIsYamlSyntaxValid);
     const hasUnsavedChanges = useSelector(selectHasChanges);
     const isExecutionsTab = useSelector(selectIsExecutionsTab);
+    const isYamlSynced = useSelector(selectIsYamlSynced);
 
     const { name, isEnabled, lastUpdatedAt } = useMemo(
       () => ({
@@ -181,7 +183,7 @@ export const WorkflowDetailHeader = React.memo(
             paddingSize="m"
             alignItems="bottom"
           >
-            <EuiPageHeaderSection css={styles.headerSection}>
+            <EuiPageHeaderSection css={styles.headerSection} data-test-subj="workflowDetailHeader">
               <EuiButtonEmpty
                 iconType="sortLeft"
                 size="xs"
@@ -301,8 +303,11 @@ export const WorkflowDetailHeader = React.memo(
                     color="primary"
                     size="s"
                     onClick={handleSaveWorkflow}
-                    disabled={isExecutionsTab || !canSaveWorkflow || isLoading || isSaving}
+                    disabled={
+                      isExecutionsTab || !canSaveWorkflow || isLoading || isSaving || !isYamlSynced
+                    }
                     isLoading={isSaving}
+                    data-test-subj="saveWorkflowHeaderButton"
                   >
                     <FormattedMessage
                       id="keepWorkflows.buttonText"
@@ -317,6 +322,7 @@ export const WorkflowDetailHeader = React.memo(
         </EuiPageTemplate>
         {showRunConfirmation && (
           <EuiConfirmModal
+            data-test-subj="runWorkflowWithUnsavedChangesConfirmationModal"
             title={Translations.runWithUnsavedChangesQuestion}
             onCancel={handleCancelRun}
             onConfirm={handleConfirmRun}

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflows/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflows/index.tsx
@@ -83,6 +83,7 @@ export function WorkflowsPage() {
                   size="m"
                   fill
                   onClick={navigateToCreateWorkflow}
+                  data-test-subj="createWorkflowButton"
                 >
                   <FormattedMessage
                     id="workflows.createWorkflowButton"

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.test.tsx
@@ -63,7 +63,7 @@ describe('ExecutionDataViewer', () => {
     it('should render in table view mode by default', () => {
       render(<ExecutionDataViewer data={mockData} />);
 
-      expect(screen.getByTestId('jsonDataTable')).toBeInTheDocument();
+      expect(screen.getByTestId('workflowJsonDataViewer')).toBeInTheDocument();
       expect(screen.getByTestId('mocked-json-data-table')).toBeInTheDocument();
       expect(screen.queryByTestId('mocked-json-data-code')).not.toBeInTheDocument();
     });
@@ -94,12 +94,12 @@ describe('ExecutionDataViewer', () => {
 
       expect(screen.getByTestId('mocked-json-data-table')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('json'));
+      fireEvent.click(screen.getByTestId('workflowViewMode_json'));
       expect(screen.queryByTestId('mocked-json-data-table')).not.toBeInTheDocument();
       expect(screen.getByTestId('mocked-json-data-code')).toBeInTheDocument();
       expect(mockJsonDataCode).toHaveBeenCalledWith({ json: mockData });
 
-      fireEvent.click(screen.getByTestId('table'));
+      fireEvent.click(screen.getByTestId('workflowViewMode_table'));
       expect(screen.getByTestId('mocked-json-data-table')).toBeInTheDocument();
       expect(screen.queryByTestId('mocked-json-data-code')).not.toBeInTheDocument();
     });
@@ -111,7 +111,7 @@ describe('ExecutionDataViewer', () => {
 
       expect(screen.getByPlaceholderText('Filter by field, value')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('json'));
+      fireEvent.click(screen.getByTestId('workflowViewMode_json'));
       expect(screen.queryByPlaceholderText('Filter by field, value')).not.toBeInTheDocument();
     });
 
@@ -175,7 +175,7 @@ describe('ExecutionDataViewer', () => {
 
       expect(mockJSONDataTable).toHaveBeenCalledWith(expect.objectContaining({ data: testData }));
 
-      fireEvent.click(screen.getByTestId('json'));
+      fireEvent.click(screen.getByTestId('workflowViewMode_json'));
       expect(mockJsonDataCode).toHaveBeenCalledWith({ json: testData });
     });
   });

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/execution_data_viewer.tsx
@@ -22,6 +22,7 @@ const SearchTermStorageKey = 'workflows_management.step_execution.searchTerm';
 const ViewModeOptions: EuiButtonGroupOptionProps[] = [
   {
     id: 'table',
+    'data-test-subj': 'workflowViewMode_table',
     label: i18n.translate('workflows.jsonDataTable.viewMode.table', {
       defaultMessage: 'Table',
     }),
@@ -29,6 +30,7 @@ const ViewModeOptions: EuiButtonGroupOptionProps[] = [
   },
   {
     id: 'json',
+    'data-test-subj': 'workflowViewMode_json',
     label: i18n.translate('workflows.jsonDataTable.viewMode.json', {
       defaultMessage: 'JSON',
     }),
@@ -76,7 +78,7 @@ export const ExecutionDataViewer = React.memo<ExecutionDataViewerProps>(
 
     return (
       <EuiFlexGroup
-        data-test-subj={'jsonDataTable'}
+        data-test-subj="workflowJsonDataViewer"
         direction="column"
         gutterSize="none"
         responsive={false}

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_data_code.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_data_code.tsx
@@ -22,6 +22,7 @@ export const JsonDataCode = ({ json }: JsonDataCodeProps) => {
 
   return (
     <JSONCodeEditorCommonMemoized
+      data-test-subj="workflowStepResultJsonEditor"
       jsonValue={formattedJson}
       onEditorDidMount={() => {}}
       height="100%"

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_editor_common.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_editor_common.tsx
@@ -31,6 +31,7 @@ interface JsonCodeEditorCommonProps {
   hasLineNumbers?: boolean;
   hideCopyButton?: boolean;
   enableFindAction?: boolean;
+  'data-test-subj'?: string;
 }
 
 export const JsonCodeEditorCommon = ({
@@ -41,6 +42,7 @@ export const JsonCodeEditorCommon = ({
   onEditorDidMount,
   hideCopyButton,
   enableFindAction,
+  'data-test-subj': dataTestSubj,
 }: JsonCodeEditorCommonProps) => {
   const styles = useMemoCss(componentStyles);
   if (jsonValue === '') {
@@ -82,7 +84,12 @@ export const JsonCodeEditorCommon = ({
     return codeEditor;
   }
   return (
-    <EuiFlexGroup css={styles.codeEditor} direction="column" gutterSize="s">
+    <EuiFlexGroup
+      css={styles.codeEditor}
+      direction="column"
+      gutterSize="s"
+      data-test-subj={dataTestSubj}
+    >
       <EuiFlexItem grow={false} css={styles.copyButtonContainer}>
         <EuiCopy textToCopy={jsonValue}>
           {(copy) => (

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/formatted_relative_enhanced/formatted_relative_enhanced.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/formatted_relative_enhanced/formatted_relative_enhanced.tsx
@@ -13,7 +13,7 @@ import moment from 'moment';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedRelativeTime } from '@kbn/i18n-react';
-import { useFormattedDateTime } from '..';
+import { useFormattedDateTime } from '../use_formatted_date';
 
 export interface FormattedRelativeEnhancedProps extends Intl.RelativeTimeFormatOptions {
   value: Date | number | string;

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/yaml_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/yaml_editor.test.tsx
@@ -111,7 +111,12 @@ jest.mock('@kbn/code-editor', () => {
 // Mock lodash debounce to execute immediately in tests
 jest.mock('lodash', () => ({
   ...jest.requireActual('lodash'),
-  debounce: (fn: Function) => fn,
+  debounce: (fn: Function) => {
+    const debouncedFn = fn as Function & { flush: () => void; cancel: () => void };
+    debouncedFn.flush = () => {};
+    debouncedFn.cancel = () => {};
+    return debouncedFn;
+  },
 }));
 
 // Mock the configureMonacoYamlSchema function
@@ -497,6 +502,82 @@ describe('YamlEditor', () => {
         '[data-testid="code-editor-textarea"]'
       ) as HTMLTextAreaElement;
       expect(textarea.value).toBe(newPropValue);
+    });
+  });
+
+  describe('onSyncStateChange callback', () => {
+    it('should call onSyncStateChange(false) then onSyncStateChange(true) when text changes', () => {
+      const onChange = jest.fn();
+      const onSyncStateChange = jest.fn();
+
+      const { container } = render(
+        <YamlEditor
+          value="test: initial"
+          onChange={onChange}
+          onSyncStateChange={onSyncStateChange}
+          schemas={null}
+        />
+      );
+
+      const textarea = container.querySelector(
+        '[data-testid="code-editor-textarea"]'
+      ) as HTMLTextAreaElement;
+
+      fireEvent.change(textarea, { target: { value: 'test: updated' } });
+
+      // With debounce mocked to execute immediately, both calls happen synchronously:
+      // 1. onSyncStateChange(false) — pending changes
+      // 2. onSyncStateChange(true) — debounced onChange flushed
+      expect(onSyncStateChange).toHaveBeenCalledTimes(2);
+      expect(onSyncStateChange).toHaveBeenNthCalledWith(1, false);
+      expect(onSyncStateChange).toHaveBeenNthCalledWith(2, true);
+    });
+
+    it('should call onSyncStateChange for each text change', () => {
+      const onChange = jest.fn();
+      const onSyncStateChange = jest.fn();
+
+      const { container } = render(
+        <YamlEditor
+          value="test: initial"
+          onChange={onChange}
+          onSyncStateChange={onSyncStateChange}
+          schemas={null}
+        />
+      );
+
+      const textarea = container.querySelector(
+        '[data-testid="code-editor-textarea"]'
+      ) as HTMLTextAreaElement;
+
+      fireEvent.change(textarea, { target: { value: 'test: first' } });
+      fireEvent.change(textarea, { target: { value: 'test: second' } });
+
+      // Each change produces a false then true call
+      expect(onSyncStateChange).toHaveBeenCalledTimes(4);
+      expect(onSyncStateChange).toHaveBeenNthCalledWith(1, false);
+      expect(onSyncStateChange).toHaveBeenNthCalledWith(2, true);
+      expect(onSyncStateChange).toHaveBeenNthCalledWith(3, false);
+      expect(onSyncStateChange).toHaveBeenNthCalledWith(4, true);
+    });
+
+    it('should work without onSyncStateChange (optional prop)', () => {
+      const onChange = jest.fn();
+
+      const { container } = render(
+        <YamlEditor value="test: initial" onChange={onChange} schemas={null} />
+      );
+
+      const textarea = container.querySelector(
+        '[data-testid="code-editor-textarea"]'
+      ) as HTMLTextAreaElement;
+
+      // Should not throw when onSyncStateChange is not provided
+      expect(() => {
+        fireEvent.change(textarea, { target: { value: 'test: updated' } });
+      }).not.toThrow();
+
+      expect(onChange).toHaveBeenCalledWith('test: updated');
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/run_step_button.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/run_step_button.tsx
@@ -34,7 +34,7 @@ export const RunStepButton = React.memo<RunStepButtonProps>(({ onClick }) => {
         iconType="play"
         onClick={onClick}
         color="success"
-        data-test-subj="runStep"
+        data-test-subj="workflowRunStep"
         iconSize="s"
         aria-label={isValidSyntax ? Text.run : Text.invalid}
         disabled={!isValidSyntax}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_unsaved_changes_badge.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_unsaved_changes_badge.tsx
@@ -55,6 +55,7 @@ export function WorkflowUnsavedChangesBadge({
         </EuiBadge>
       ) : (
         <EuiBadge
+          data-test-subj="workflowSavedChangesBadge"
           iconType="check"
           color={euiTheme.colors.backgroundBaseDisabled}
           aria-label={fullDateFormatted}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -41,6 +41,7 @@ import {
   selectEditorYamlDocument,
   selectSchema,
   setCursorPosition,
+  setIsYamlSynced,
   setYamlString,
 } from '../../../entities/workflows/store';
 import {
@@ -150,6 +151,13 @@ export const WorkflowYAMLEditor = ({
   const onChange = useCallback(
     (yaml: string) => {
       dispatch(setYamlString(yaml));
+    },
+    [dispatch]
+  );
+
+  const onSyncStateChange = useCallback(
+    (isSynced: boolean) => {
+      dispatch(setIsYamlSynced(isSynced));
     },
     [dispatch]
   );
@@ -575,9 +583,12 @@ export const WorkflowYAMLEditor = ({
           editorDidMount={handleEditorDidMount}
           editorWillUnmount={handleEditorWillUnmount}
           onChange={onChange}
+          onSyncStateChange={onSyncStateChange}
           options={options}
           schemas={schemas}
           value={workflowYaml}
+          enableFindAction={true}
+          dataTestSubj="workflowYamlEditor"
         />
       </div>
       <div css={styles.validationErrorsContainer}>

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
@@ -151,7 +151,7 @@ export function WorkflowYamlValidationAccordion({
   return (
     <EuiAccordion
       id={accordionId}
-      data-testid="wf-yaml-editor-validation-errors-list"
+      data-test-subj="workflowYamlEditorValidationErrorsList"
       buttonContent={
         <EuiFlexGroup alignItems="center" gutterSize="s" css={styles.buttonContent}>
           <EuiFlexItem grow={false}>{icon}</EuiFlexItem>

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/apis/workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/apis/workflows.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KbnClient } from '@kbn/scout';
+
+export interface WorkflowDetailDto {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  yaml: string;
+  valid: boolean;
+  createdAt: string;
+  createdBy: string;
+  lastUpdatedAt: string;
+  lastUpdatedBy: string;
+}
+
+export interface BulkCreateResult {
+  created: WorkflowDetailDto[];
+  failed: Array<{ index: number; error: string }>;
+}
+
+export interface WorkflowsApiService {
+  /** POST /api/workflows — create a single workflow from YAML. */
+  create: (spaceId: string, yaml: string) => Promise<WorkflowDetailDto>;
+  /** POST /api/workflows/_bulk_create — create multiple workflows at once. */
+  bulkCreate: (spaceId: string, yamls: string[]) => Promise<BulkCreateResult>;
+  /** PUT /api/workflows/{id} — partially update a workflow (e.g. toggle enabled). */
+  update: (
+    spaceId: string,
+    id: string,
+    body: Partial<Pick<WorkflowDetailDto, 'name' | 'description' | 'enabled' | 'yaml'>>
+  ) => Promise<WorkflowDetailDto>;
+  /** DELETE /api/workflows — delete workflows by IDs. */
+  bulkDelete: (spaceId: string, ids: string[]) => Promise<void>;
+  /** POST /api/workflows/search + DELETE — delete all workflows in a space. */
+  deleteAll: (spaceId: string) => Promise<void>;
+}
+
+export const getWorkflowsApiService = (kbnClient: KbnClient): WorkflowsApiService => {
+  return {
+    create: async (spaceId: string, yaml: string): Promise<WorkflowDetailDto> => {
+      const response = await kbnClient.request<WorkflowDetailDto>({
+        method: 'POST',
+        path: `/s/${spaceId}/api/workflows`,
+        body: { yaml },
+      });
+      return response.data;
+    },
+
+    update: async (
+      spaceId: string,
+      id: string,
+      body: Partial<Pick<WorkflowDetailDto, 'name' | 'description' | 'enabled' | 'yaml'>>
+    ): Promise<WorkflowDetailDto> => {
+      const response = await kbnClient.request<WorkflowDetailDto>({
+        method: 'PUT',
+        path: `/s/${spaceId}/api/workflows/${id}`,
+        body,
+      });
+      return response.data;
+    },
+
+    bulkCreate: async (spaceId: string, yamls: string[]): Promise<BulkCreateResult> => {
+      const response = await kbnClient.request<BulkCreateResult>({
+        method: 'POST',
+        path: `/s/${spaceId}/api/workflows/_bulk_create`,
+        body: { workflows: yamls.map((yaml) => ({ yaml })) },
+      });
+      return response.data;
+    },
+
+    bulkDelete: async (spaceId: string, ids: string[]): Promise<void> => {
+      if (ids.length > 0) {
+        await kbnClient.request({
+          method: 'DELETE',
+          path: `/s/${spaceId}/api/workflows`,
+          body: { ids },
+        });
+      }
+    },
+
+    deleteAll: async (spaceId: string): Promise<void> => {
+      const response = await kbnClient.request<{ results?: Array<{ id: string }> }>({
+        method: 'POST',
+        path: `/s/${spaceId}/api/workflows/search`,
+        body: { size: 10000, page: 1 },
+      });
+
+      const workflowIds = response.data.results?.map((w) => w.id) || [];
+      if (workflowIds.length > 0) {
+        await kbnClient.request({
+          method: 'DELETE',
+          path: `/s/${spaceId}/api/workflows`,
+          body: { ids: workflowIds },
+        });
+      }
+    },
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/cleanup.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/cleanup.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutSpaceParallelFixture } from '@kbn/scout/src/playwright/fixtures/scope/worker/scout_space';
+import type { WorkflowsApiServicesFixture } from '.';
+
+/**
+ * Cleanup function to delete workflows and alert rules in a space.
+ * Workflows are stored in ES indices (not saved objects) and must be deleted explicitly.
+ * This prevents orphaned task manager tasks when the space is deleted.
+ * See https://github.com/elastic/kibana/issues/139227
+ */
+export async function cleanupWorkflowsAndRules({
+  scoutSpace,
+  apiServices,
+}: {
+  scoutSpace: ScoutSpaceParallelFixture;
+  apiServices: WorkflowsApiServicesFixture;
+}) {
+  await apiServices.workflows.deleteAll(scoutSpace.id);
+  await apiServices.alerting.cleanup.deleteAllRules(scoutSpace.id);
+  await scoutSpace.savedObjects.cleanStandardList();
+}

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/constants.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/constants.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Centralized timeout values for workflow Scout UI tests.
+ * Tune these in one place when environment speed changes.
+ */
+
+/** Timeout for a simple workflow execution to complete (e.g. console steps). */
+export const EXECUTION_TIMEOUT = 30_000;
+
+/** Timeout for a long-running workflow execution (e.g. many iterations, alert trigger chain). */
+export const LONG_EXECUTION_TIMEOUT = 60_000;
+
+/** Timeout for waiting on asynchronous alert-triggered executions to appear in the list. */
+export const ALERT_PROPAGATION_TIMEOUT = 60_000;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/index.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/index.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { test as base, spaceTest as spaceBaseTest } from '@kbn/scout';
+import type {
+  ApiServicesFixture,
+  KbnClient,
+  ScoutPage,
+  ScoutParallelWorkerFixtures,
+  ScoutTestFixtures,
+  ScoutWorkerFixtures,
+} from '@kbn/scout';
+
+import type { WorkflowsApiService } from './apis/workflows';
+import { getWorkflowsApiService } from './apis/workflows';
+import type { WorkflowsPageObjects } from './page_objects';
+import { extendPageObjects } from './page_objects';
+
+export interface WorkflowsApiServicesFixture extends ApiServicesFixture {
+  workflows: WorkflowsApiService;
+}
+
+export interface WorkflowsTestFixtures extends ScoutTestFixtures {
+  pageObjects: WorkflowsPageObjects;
+}
+
+export interface WorkflowsWorkerFixtures extends ScoutParallelWorkerFixtures {
+  apiServices: WorkflowsApiServicesFixture;
+}
+
+export const test = base.extend<WorkflowsTestFixtures, ScoutWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: WorkflowsPageObjects;
+      page: ScoutPage;
+    },
+    use: (pageObjects: WorkflowsPageObjects) => Promise<void>
+  ) => {
+    const extendedPageObjects = extendPageObjects(pageObjects, page);
+    await use(extendedPageObjects);
+  },
+});
+
+export const spaceTest = spaceBaseTest.extend<WorkflowsTestFixtures, WorkflowsWorkerFixtures>({
+  pageObjects: async (
+    { pageObjects, page }: { pageObjects: WorkflowsPageObjects; page: ScoutPage },
+    use: (pageObjects: WorkflowsPageObjects) => Promise<void>
+  ) => {
+    const extendedPageObjects = extendPageObjects(pageObjects, page);
+    await use(extendedPageObjects);
+  },
+  apiServices: [
+    async (
+      { apiServices, kbnClient }: { apiServices: ApiServicesFixture; kbnClient: KbnClient },
+      use: (extendedApiServices: WorkflowsApiServicesFixture) => Promise<void>
+    ) => {
+      const extendedApiServices = apiServices as WorkflowsApiServicesFixture;
+      extendedApiServices.workflows = getWorkflowsApiService(kbnClient);
+      await use(extendedApiServices);
+    },
+    { scope: 'worker' },
+  ],
+});

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/index.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PageObjects, ScoutPage } from '@kbn/scout';
+import { createLazyPageObject } from '@kbn/scout';
+import { WorkflowEditorPage } from './workflow_editor_page';
+import { WorkflowExecutionPage } from './workflow_execution_page';
+import { WorkflowListPage } from './workflow_list_page';
+
+export interface WorkflowsPageObjects extends PageObjects {
+  workflowEditor: WorkflowEditorPage;
+  workflowExecution: WorkflowExecutionPage;
+  workflowList: WorkflowListPage;
+}
+
+export function extendPageObjects(pageObjects: PageObjects, page: ScoutPage): WorkflowsPageObjects {
+  return {
+    ...pageObjects,
+    workflowEditor: createLazyPageObject(WorkflowEditorPage, page),
+    workflowExecution: createLazyPageObject(WorkflowExecutionPage, page),
+    workflowList: createLazyPageObject(WorkflowListPage, page),
+  };
+}

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_editor_page.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { PLUGIN_ID } from '../../../../../common';
+
+export class WorkflowEditorPage {
+  public yamlEditor: Locator;
+  public saveButton: Locator;
+  public runButton: Locator;
+  public validationErrorsAccordion: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.yamlEditor = this.page.testSubj.locator('workflowYamlEditor');
+    this.saveButton = this.page.testSubj.locator('saveWorkflowHeaderButton');
+    this.runButton = this.page.testSubj.locator('runWorkflowHeaderButton');
+    this.validationErrorsAccordion = this.page.testSubj.locator(
+      'workflowYamlEditorValidationErrorsList'
+    );
+  }
+
+  /**
+   * Navigate to the workflow editor for a new workflow
+   */
+  async gotoNewWorkflow() {
+    await this.page.gotoApp(PLUGIN_ID);
+    await this.page.testSubj.click('createWorkflowButton');
+    await this.waitForEditorToLoad();
+  }
+
+  /**
+   * Navigate to the workflow editor for an existing workflow by ID
+   */
+  async gotoWorkflow(workflowId: string) {
+    await this.page.gotoApp(`${PLUGIN_ID}/${workflowId}`);
+    await this.waitForEditorToLoad();
+  }
+
+  /**
+   * Navigate directly to the executions tab for a workflow.
+   */
+  async gotoWorkflowExecutions(workflowId: string) {
+    await this.page.gotoApp(`${PLUGIN_ID}/${workflowId}`, {
+      params: { tab: 'executions' },
+    });
+    await this.page.testSubj.waitForSelector('workflowExecutionList', { state: 'visible' });
+  }
+
+  /**
+   * Wait for navigation to the editor page and the YAML editor to be visible.
+   * Useful after triggering navigation from an external entry point (e.g. workflow list actions).
+   */
+  async waitForEditorView() {
+    await this.page.waitForURL('**/workflows/*');
+    await this.waitForEditorToLoad();
+  }
+
+  /**
+   * Wait for the YAML editor to be visible and ready
+   */
+  async waitForEditorToLoad() {
+    await this.yamlEditor.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Set the value of the main workflow YAML editor
+   */
+  async setYamlEditorValue(value: string): Promise<void> {
+    await this.setEditorValue(this.yamlEditor, value);
+  }
+
+  /**
+   * Set the value of any Monaco editor by its container locator.
+   * Uses the Monaco model API directly for reliable, non-flaky value setting.
+   */
+  async setEditorValue(editor: Locator, value: string): Promise<void> {
+    const uri = await editor.locator('.monaco-editor[data-uri]').getAttribute('data-uri');
+    if (!uri) {
+      throw new Error('Editor data-uri not found');
+    }
+    await this.page.evaluate(
+      ({ modelUri, editorValue }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monaco environment is global, but we don't have a type for it
+        const monacoEnv = (window as any).MonacoEnvironment;
+
+        if (!monacoEnv?.monaco?.editor) {
+          throw new Error('MonacoEnvironment.monaco.editor is not available');
+        }
+        const editorModel = monacoEnv.monaco.editor.getModel(modelUri);
+        if (!editorModel) {
+          throw new Error('Editor not found');
+        }
+        editorModel.setValue(editorValue);
+      },
+      { modelUri: uri, editorValue: value }
+    );
+  }
+
+  public getYamlEditorSuggestWidget() {
+    return this.page.locator(
+      '[data-test-subj="kbnCodeEditorEditorOverflowWidgetsContainer"] .suggest-widget'
+    );
+  }
+
+  /**
+   * Save the workflow
+   */
+  async saveWorkflow() {
+    await this.saveButton.click();
+    await this.page.testSubj.waitForSelector('workflowSavedChangesBadge');
+  }
+
+  /**
+   * Click the run button (opens execute modal or unsaved changes confirmation)
+   */
+  async clickRunButton() {
+    await this.runButton.click();
+  }
+
+  /**
+   * Run the workflow and confirm if there are unsaved changes
+   */
+  async runWorkflowWithUnsavedChanges() {
+    await this.runButton.click();
+    await this.page.testSubj.waitForSelector('runWorkflowWithUnsavedChangesConfirmationModal', {
+      state: 'visible',
+    });
+    await this.page.testSubj.click('confirmModalConfirmButton');
+  }
+
+  /**
+   * Execute the workflow from the execute modal with the given inputs.
+   * Assumes the run button has already been clicked or the execute modal is about to appear.
+   */
+  async executeWorkflowWithInputs(inputs: Record<string, unknown>) {
+    await this.clickRunButton();
+    await this.setExecuteModalInputs(inputs);
+    await this.page.testSubj.click('executeWorkflowButton');
+  }
+
+  /**
+   * Wait for the test step modal to be visible
+   */
+  async waitForTestStepModal() {
+    await this.page.testSubj.waitForSelector('workflowTestStepModal', { state: 'visible' });
+  }
+
+  /**
+   * Set the step inputs in the test step modal
+   * @param inputs - The JSON object to set as step inputs
+   */
+  async setTestStepInputs(inputs: Record<string, unknown>) {
+    await this.waitForTestStepModal();
+    const stepInputsEditor = this.page.testSubj.locator('workflow-event-json-editor');
+    await stepInputsEditor.waitFor({ state: 'visible' });
+    await this.setEditorValue(stepInputsEditor, JSON.stringify(inputs, null, 2));
+  }
+
+  /**
+   * Set the inputs in the execute workflow modal
+   */
+  async setExecuteModalInputs(inputs: Record<string, unknown>) {
+    await this.page.testSubj.waitForSelector('workflowExecuteModal', { state: 'visible' });
+    const executeModalInputsEditor = this.page.testSubj.locator('workflow-manual-json-editor');
+    await executeModalInputsEditor.waitFor({ state: 'visible' });
+    await this.setEditorValue(executeModalInputsEditor, JSON.stringify(inputs, null, 2));
+  }
+
+  /**
+   * Returns a locator for the current Monaco error markers inside the given
+   * editor container.
+   *
+   * @param testSubjId - `data-test-subj` of the editor container.
+   *   Defaults to `'kibanaCodeEditor'`.
+   * @returns A Playwright `Locator` for the current error markers.
+   */
+  getCurrentMarkers(testSubjId: string = 'kibanaCodeEditor'): Locator {
+    const selector = `[data-test-subj="${testSubjId}"] .cdr.squiggly-error`;
+    return this.page.locator(selector);
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_execution_page.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_execution_page.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout';
+
+/**
+ * Page object for the workflow execution detail view.
+ *
+ * Although editing and execution currently live on the same page,
+ * this class isolates execution-specific interactions (step tree,
+ * step results, execution status) from editor interactions so tests
+ * can express intent clearly and the code is future-proof for when
+ * the execution view becomes a separate page.
+ */
+export class WorkflowExecutionPage {
+  public executionPanel: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.executionPanel = this.page.testSubj.locator('workflowExecutionPanel');
+  }
+
+  /**
+   * Wait for the execution view to load (URL contains executionId and panel is visible).
+   * Useful after triggering a workflow execution from any entry point.
+   */
+  async waitForExecutionView() {
+    await this.page.waitForURL('**/workflows/*?executionId=*');
+    await this.executionPanel.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Wait for the workflow execution panel to show the specified status.
+   *
+   * Automatically waits for the execution view to load first (URL navigation
+   * and panel visibility), then polls for the expected status badge.
+   *
+   * When expecting 'completed', this method also watches for 'failed' status
+   * so it can fail fast with a descriptive error (including the step error JSON)
+   * instead of timing out with no diagnostic info.
+   *
+   * @param status - The execution status to wait for ('completed' or 'failed')
+   * @param timeout - The timeout in milliseconds
+   */
+  async waitForExecutionStatus(status: 'completed' | 'failed', timeout: number) {
+    await this.waitForExecutionView();
+    const withStatus = (s: string) =>
+      this.executionPanel.and(this.page.locator(`[data-execution-status="${s}"]`));
+
+    const expectedPanel = withStatus(status);
+
+    if (status === 'completed') {
+      const failedPanel = withStatus('failed');
+
+      // Race: wait for either 'completed' or 'failed' — whichever comes first
+      const winner = await Promise.race([
+        expectedPanel.waitFor({ state: 'visible', timeout }).then(() => 'completed' as const),
+        failedPanel.waitFor({ state: 'visible', timeout }).then(() => 'failed' as const),
+      ]);
+
+      if (winner === 'failed') {
+        const errorDetails = await this.extractFailedStepError();
+        throw new Error(
+          `Expected execution status "completed" but got "failed".\n\n${errorDetails}`
+        );
+      }
+    } else {
+      await expectedPanel.waitFor({ state: 'visible', timeout });
+    }
+  }
+
+  /**
+   * Clicks the last step in the execution tree (typically the failed one)
+   * and extracts the error JSON from the step details panel.
+   * Returns a formatted string for use in error messages.
+   */
+  private async extractFailedStepError(): Promise<string> {
+    try {
+      // Find the last step button in the tree — when execution fails, the last
+      // executed step is the one that errored.
+      const stepButtons = this.executionPanel.locator(
+        'button:has(span[data-test-subj="workflowStepName"])'
+      );
+      const count = await stepButtons.count();
+      if (count === 0) {
+        return 'No steps found in execution tree.';
+      }
+
+      // eslint-disable-next-line playwright/no-nth-methods -- we need the last step (the failed one)
+      const lastStep = stepButtons.nth(count - 1);
+      const stepName =
+        (await lastStep.locator('span[data-test-subj="workflowStepName"]').textContent()) ??
+        'unknown';
+      await lastStep.click();
+
+      const errorJson = await this.getStepResultJson<unknown>('error');
+      return `Failed step: "${stepName.trim()}"\nError:\n${JSON.stringify(errorJson, null, 2)}`;
+    } catch (e) {
+      return `(could not extract step error details: ${
+        e instanceof Error ? e.message : String(e)
+      })`;
+    }
+  }
+
+  /**
+   * Expands all collapsed steps in the workflow execution panel tree view.
+   * Iterates through collapsed nodes and clicks their expansion arrows until all steps are expanded.
+   */
+  async expandStepsTree() {
+    while (true) {
+      const collapsedLocators = await this.executionPanel
+        .locator('button[aria-expanded="false"]')
+        .all();
+
+      if (!collapsedLocators.length) {
+        break;
+      }
+      await collapsedLocators[0].scrollIntoViewIfNeeded();
+      await collapsedLocators[0].locator('.euiTreeView__expansionArrow[role=presentation]').click();
+    }
+  }
+
+  /**
+   * Selects a step in the execution tree by navigating through a hierarchical path.
+   *
+   * @param path - The hierarchical path to the step, using '>' as separator
+   *   (e.g., "Parent > Child > Target Step" or "loop_over_results > 0 > process-item")
+   * @returns A promise that resolves to the locator for the target step button
+   * @throws Error if any node in the path is not found
+   */
+  async getStep(path: string): Promise<Locator> {
+    const nodes = path.split('>').map((substring) => substring.trim());
+    let parentLocator = this.executionPanel.locator('[data-test-subj="workflowStepExecutionTree"]');
+
+    for (let i = 0; i < nodes.length; i++) {
+      const currentNode = nodes[i];
+      const allListItems = await parentLocator.locator('> li').all();
+      let found = false;
+
+      for (const listItem of allListItems) {
+        const buttonLocator = listItem.locator('> button');
+        const buttonText = await buttonLocator
+          .locator('span[data-test-subj="workflowStepName"]')
+          .textContent();
+
+        if (buttonText?.trim() === currentNode) {
+          found = true;
+
+          if (i === nodes.length - 1) {
+            return buttonLocator;
+          }
+
+          parentLocator = listItem.locator('> div > ul');
+          break;
+        }
+      }
+
+      if (!found) {
+        throw new Error(
+          `Step not found: "${currentNode}" in path "${path}" (failed at level ${i + 1})`
+        );
+      }
+    }
+
+    throw new Error(`Failed to navigate step path: ${path}`);
+  }
+
+  /**
+   * Retrieves and parses the step result JSON from the workflow step execution details panel.
+   *
+   * @template TOutput - The expected type of the parsed JSON output
+   * @param type - The type of result to retrieve: 'input', 'output', or 'error'
+   * @returns A promise that resolves to the parsed JSON result
+   */
+  async getStepResultJson<TOutput = unknown>(type: 'input' | 'output' | 'error'): Promise<TOutput> {
+    const workflowStepExecutionDetails = this.page.testSubj.locator('workflowStepExecutionDetails');
+
+    await workflowStepExecutionDetails
+      .locator(`button[data-test-subj="workflowStepTab_${type}"]`)
+      .click();
+    await workflowStepExecutionDetails
+      .locator('button[data-test-subj="workflowViewMode_json"]')
+      .click();
+
+    const jsonEditor = this.page.testSubj.locator('workflowStepResultJsonEditor');
+    await jsonEditor.waitFor({ state: 'visible' });
+
+    const uri = await jsonEditor.locator('.monaco-editor[data-uri]').getAttribute('data-uri');
+    if (!uri) {
+      throw new Error('Step result JSON editor data-uri not found');
+    }
+
+    const stringValue = await this.page.evaluate((modelUri) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monaco environment is global, but we don't have a type for it
+      const monacoEnv = (window as any).MonacoEnvironment;
+      if (!monacoEnv?.monaco?.editor) {
+        throw new Error('MonacoEnvironment.monaco.editor is not available');
+      }
+      const model = monacoEnv.monaco.editor.getModel(modelUri);
+      if (!model) {
+        throw new Error('Step result JSON editor model not found');
+      }
+      return model.getValue();
+    }, uri);
+
+    return JSON.parse(stringValue);
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_list_page.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/page_objects/workflow_list_page.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { PLUGIN_ID } from '../../../../../common';
+
+export class WorkflowListPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  /** Navigates to the workflows list page. */
+  async navigate() {
+    await this.page.gotoApp(PLUGIN_ID);
+  }
+
+  /** Returns the table row locator for the specified workflow. */
+  getWorkflowRow(workflowName: string): Locator {
+    return this.page.locator('tr').filter({ hasText: workflowName });
+  }
+
+  /** Returns the state toggle switch locator for the specified workflow. */
+  getWorkflowStateToggle(workflowName: string): Locator {
+    return this.getWorkflowRow(workflowName).locator('[data-test-subj^="workflowToggleSwitch-"]');
+  }
+
+  /** Returns the checkbox locator for selecting the specified workflow. */
+  getSelectCheckboxForWorkflow(workflowName: string): Locator {
+    return this.getWorkflowRow(workflowName).locator('td:first-child input[type="checkbox"]');
+  }
+
+  // Single Workflow Actions
+
+  /** Returns the direct action button locator (run or edit) for the specified workflow. */
+  getWorkflowAction(
+    workflowName: string,
+    action: 'runWorkflowAction' | 'editWorkflowAction'
+  ): Locator {
+    return this.getWorkflowRow(workflowName).locator(`[data-test-subj="${action}"]`);
+  }
+
+  /** Opens the three dots menu and returns the specified action button locator. */
+  async getThreeDotsMenuAction(
+    workflowName: string,
+    action:
+      | 'runWorkflowAction'
+      | 'editWorkflowAction'
+      | 'cloneWorkflowAction'
+      | 'deleteWorkflowAction'
+  ): Promise<Locator> {
+    await this.getWorkflowRow(workflowName)
+      .locator('[data-test-subj="euiCollapsedItemActionsButton"]')
+      .click();
+    return this.page.locator(`.euiContextMenuPanel [data-test-subj="${action}"]`);
+  }
+
+  // Bulk Actions
+
+  /** Selects multiple workflows by clicking their checkboxes. */
+  async selectWorkflows(workflowNamesToCheck: string[]) {
+    for (const workflowName of workflowNamesToCheck) {
+      await this.getSelectCheckboxForWorkflow(workflowName).click();
+    }
+  }
+
+  /** Performs a bulk action (enable, disable, or delete) on selected workflows. */
+  async performBulkAction(workflowNamesToCheck: string[], action: 'enable' | 'disable' | 'delete') {
+    await this.selectWorkflows(workflowNamesToCheck);
+    await this.page.testSubj.waitForSelector('workflows-table-bulk-actions-button', {
+      state: 'visible',
+    });
+    await this.page.testSubj.click('workflows-table-bulk-actions-button');
+    await this.page.testSubj.click(`workflows-bulk-action-${action}`);
+  }
+
+  // Filter/Search/Sort
+  async getFilterOption(filterName: 'enabled-filter-popover-button', optionName: string) {
+    await this.page.testSubj.click(filterName);
+    return this.page.locator('.euiSelectable li').filter({ hasText: optionName });
+  }
+
+  /** Returns the search field locator. */
+  getSearchField(): Locator {
+    return this.page.testSubj.locator('workflowSearchField');
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/alert_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/alert_workflows.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Workflow that prints received alerts (both aggregated and per-item).
+ * Used as both the single-alert and multiple-alert target workflow
+ * in the alert trigger integration test.
+ */
+export const getPrintAlertsWorkflowYaml = (name: string) => `
+name: ${name}
+enabled: true
+description: Prints all received alerts
+triggers:
+ - type: manual
+ - type: alert
+steps:
+ - name: log
+   type: console
+   foreach: \${{event.alerts}}
+   with:
+     message: \${{event}}
+ - name: log_each_alert
+   type: console
+   foreach: \${{event.alerts}}
+   with:
+     message: \${{foreach.item}}
+`;
+
+/** Index name used for alert trigger test documents. */
+export const TEST_ALERTS_INDEX = 'test-workflow-alerts-index';
+
+/**
+ * Workflow that creates a security detection rule with two workflow actions:
+ * one in single-alert mode (summaryMode: false) and one in summary mode
+ * (summaryMode: true). Takes the target workflow IDs as inputs.
+ *
+ * Only works with the Security solution (uses the detection engine API).
+ */
+export const getCreateSecurityAlertRuleWorkflowYaml = (name: string) => `
+name: ${name}
+description: Create security detection rule
+enabled: true
+triggers:
+  - type: manual
+inputs:
+  - name: wf_multiple_alerts
+    type: string
+    required: true
+  - name: wf_single_alert
+    type: string
+    required: true
+consts:
+  alerts_index_name: ${TEST_ALERTS_INDEX}
+steps:
+  - name: create_security_alert_rule
+    type: kibana.request
+    with:
+      method: POST
+      path: /s/{{workflow.spaceId}}/api/detection_engine/rules
+      body:
+        type: query
+        index:
+          - ${TEST_ALERTS_INDEX}
+        filters: []
+        language: kuery
+        query: "not severity: foo"
+        required_fields: []
+        author: []
+        false_positives: []
+        references: []
+        risk_score: 21
+        risk_score_mapping: []
+        severity: low
+        severity_mapping: []
+        threat: []
+        max_signals: 100
+        name: Security alert test
+        description: Security alert test
+        tags: []
+        setup: ""
+        license: ""
+        interval: 15s
+        from: now-20s
+        to: now
+        actions:
+          - id: system-connector-.workflows
+            params:
+              subAction: run
+              subActionParams:
+                workflowId: "{{inputs.wf_single_alert}}"
+                summaryMode: false
+            action_type_id: .workflows
+            uuid: b8bc90a9-2112-41c4-a797-bb6cbb52f5da
+          - id: system-connector-.workflows
+            params:
+              subAction: run
+              subActionParams:
+                workflowId: "{{inputs.wf_multiple_alerts}}"
+                summaryMode: true
+            action_type_id: .workflows
+            uuid: b8bc90a9-2112-41c4-a797-bb6cbb52f5da
+        enabled: true
+`;
+
+/**
+ * Workflow that creates an ES|QL alert rule via the generic Kibana alerting API
+ * with two workflow actions: one per-alert (summaryMode: false) and one summary
+ * (summaryMode: true). Takes the target workflow IDs as inputs.
+ *
+ * Uses searchType: esqlQuery with groupBy: row so the rule creates one alert per
+ * document — matching the security detection engine's per-document alert behavior.
+ *
+ * Works with Observability (and ESS) — uses the standard alerting framework
+ * instead of the Security detection engine.
+ */
+export const getCreateObsAlertRuleWorkflowYaml = (name: string) => `
+name: ${name}
+description: Create ES|QL alert rule
+enabled: true
+triggers:
+  - type: manual
+inputs:
+  - name: wf_multiple_alerts
+    type: string
+    required: true
+  - name: wf_single_alert
+    type: string
+    required: true
+consts:
+  alerts_index_name: ${TEST_ALERTS_INDEX}
+steps:
+  - name: delete_index
+    type: elasticsearch.indices.delete
+    with:
+      index: "{{consts.alerts_index_name}}"
+    on-failure:
+      continue: true
+  - name: create_obs_alert_rule
+    type: kibana.request
+    with:
+      method: POST
+      path: /s/{{workflow.spaceId}}/api/alerting/rule
+      body:
+        name: ES|QL alert test
+        rule_type_id: .es-query
+        consumer: alerts
+        params:
+          searchType: esqlQuery
+          esqlQuery:
+            esql: "FROM {{consts.alerts_index_name}} METADATA _id | KEEP _id, severity, alert_id, description, category"
+          timeWindowSize: 20
+          timeWindowUnit: s
+          threshold:
+            - 0
+          thresholdComparator: ">"
+          size: 100
+          aggType: count
+          groupBy: row
+          excludeHitsFromPreviousRun: true
+          timeField: "@timestamp"
+        schedule:
+          interval: 15s
+        actions:
+          - id: system-connector-.workflows
+            group: query matched
+            params:
+              subAction: run
+              subActionParams:
+                workflowId: "{{inputs.wf_single_alert}}"
+                summaryMode: false
+          - id: system-connector-.workflows
+            group: query matched
+            params:
+              subAction: run
+              subActionParams:
+                workflowId: "{{inputs.wf_multiple_alerts}}"
+                summaryMode: true
+        tags: []
+        alert_delay:
+          active: 1
+`;
+
+/**
+ * Workflow that creates a timestamp ingest pipeline and indexes alert
+ * documents, which triggers an alert rule monitoring the test index.
+ */
+export const getTriggerAlertWorkflowYaml = (name: string) => `
+name: ${name}
+description: Add timestamp ingest pipeline, ingest docs, which will trigger the alert
+enabled: true
+triggers:
+  - type: manual
+consts:
+  pipeline_name: add_timestamp_if_missing
+  alerts_index_name: ${TEST_ALERTS_INDEX}
+inputs:
+  type: object
+  properties:
+    alerts:
+      type: array
+      items:
+        type: object
+  required:
+    - "alerts"
+steps:
+  - name: create_ingest_pipeline
+    type: elasticsearch.request
+    on-failure:
+      continue: true
+    with:
+      method: PUT
+      path: _ingest/pipeline/add_timestamp_if_missing
+      body:
+        processors:
+          - set:
+              if: ctx['@timestamp'] == null
+              field: "@timestamp"
+              value: "{% raw %}{{_ingest.timestamp}}{% endraw %}"
+  - name: index
+    type: elasticsearch.request
+    foreach: "{{inputs.alerts}}"
+    with:
+      method: POST
+      path: /{{consts.alerts_index_name}}/_doc?pipeline={{consts.pipeline_name}}
+      body: \${{foreach.item}}
+`;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/console_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/console_workflows.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Minimal workflow with configurable properties for list-level tests (bulk actions, filtering, etc.).
+ */
+export const getListTestWorkflowYaml = ({
+  name,
+  description,
+  enabled,
+}: {
+  name: string;
+  description: string;
+  enabled: boolean;
+}) => `
+name: ${name}
+enabled: ${enabled}
+description: ${description}
+triggers:
+  - type: manual
+steps:
+  - name: hello_world_step
+    type: console
+    with:
+      message: "Test run: {{ execution.isTestRun }}"
+`;
+
+/**
+ * Simple workflow with a single console step that logs the isTestRun flag.
+ * Used in test-run execution tests (saved, unsaved, disabled-then-enabled).
+ */
+export const getTestRunWorkflowYaml = (name: string) => `
+name: ${name}
+enabled: false
+description: This is a new workflow
+triggers:
+  - type: manual
+
+inputs:
+  - name: message
+    type: string
+    default: "hello world"
+
+steps:
+  - name: hello_world_step
+    type: console
+    with:
+      message: "Test run: {{ execution.isTestRun }}"
+`;
+
+/**
+ * Workflow with a foreach loop (4 items) and a nested console step.
+ * Used for individual step run and context override tests.
+ */
+export const getWorkflowWithLoopYaml = (name: string) => `
+name: ${name}
+enabled: false
+description: This is a new workflow
+triggers:
+  - type: manual
+
+inputs:
+  - name: message
+    type: string
+    default: "hello world"
+
+steps:
+  - name: first_step
+    type: console
+    with:
+      message: "This is the first step!"
+
+  - name: loop
+    type: foreach
+    foreach: '[1,2,3,4]'
+    steps:
+      - name: hello_world_step
+        type: console
+        with:
+          message: "Test run: {{ execution.isTestRun }}"
+`;
+
+/**
+ * Workflow with a foreach loop (2 items) that logs the iteration index.
+ * Used for verifying execution tree with foreach iterations.
+ */
+export const getIterationLoopWorkflowYaml = (name: string) => `
+name: ${name}
+enabled: false
+description: This is a new workflow
+triggers:
+  - type: manual
+
+inputs:
+  - name: message
+    type: string
+    default: "hello world"
+
+steps:
+  - name: first_step
+    type: console
+    with:
+      message: "This is the first step!"
+
+  - name: loop
+    type: foreach
+    foreach: '[1,2]'
+    steps:
+      - name: log_iteration
+        type: console
+        with:
+          message: "Iteration is {{foreach.index}}"
+`;
+
+/**
+ * Workflow with 50 foreach iterations for scroll/virtualization tests.
+ */
+export const getManyIterationsWorkflowYaml = (name: string) => `
+name: ${name}
+enabled: false
+description: This is a new workflow
+triggers:
+  - type: manual
+steps:
+  - name: hello_world_step
+    type: console
+    foreach: '[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50]'
+    with:
+      message: "Hello world"
+`;
+
+/**
+ * Simple enabled workflow that echoes its message input.
+ * Used for editor sanity tests (create, save, run, validate).
+ */
+export const getDummyWorkflowYaml = (name: string) => `
+name: ${name}
+description: Dummy workflow description
+enabled: true
+inputs:
+  - name: message
+    type: string
+    default: "hello world"
+triggers:
+  - type: manual
+steps:
+  - name: hello_world_step
+    type: console
+    with:
+      message: "{{ inputs.message }}"
+`;
+
+/**
+ * Invalid workflow YAML missing the required "steps" property.
+ * Used for validation error tests.
+ */
+export const getInvalidWorkflowYaml = (name: string) => `
+name: ${name}
+description: Invalid workflow - missing steps
+enabled: true
+triggers:
+  - type: manual
+`;
+
+/**
+ * Workflow with an empty step type field.
+ * Used for autocompletion suggestion tests.
+ */
+export const getIncompleteStepTypeYaml = (name: string) => `
+name: ${name}
+description: Test workflow
+enabled: true
+triggers:
+  - type: manual
+steps:
+  - name: hello_world_step
+    type:`;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/create_get_update_case.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/create_get_update_case.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const getCreateGetUpdateCaseWorkflowYaml = (owner: string) => `
+name: Case E2E test
+enabled: false
+description: This is a workflow to test case kibana E2E
+triggers:
+  - type: manual
+
+inputs:
+  type: object
+  title: Alert
+  description: Alert metadata with severity level and comments
+
+  properties:
+    title:
+      type: string
+      description: Short human-readable title
+
+    description:
+      type: string
+      description: Detailed description of the alert
+
+    severity:
+      type: string
+      description: Severity level of the alert
+      enum:
+        - low
+        - medium
+        - high
+        - critical
+
+    comments:
+      type: array
+      description: List of comments associated with the alert
+      items:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - user
+            description: Comment category
+
+          comment:
+            type: string
+            description: Comment text
+
+        required:
+          - type
+          - comment
+        additionalProperties: false
+
+  required:
+    - title
+    - description
+    - severity
+
+  additionalProperties: false
+
+steps:
+  - name: create_case
+    type: kibana.createCaseDefaultSpace
+    with:
+      title: "{{ inputs.title }}"
+      description: "{{ inputs.description }}"
+      severity: low
+      connector:
+        fields: null
+        id: none
+        name: none
+        type: .none
+      owner: "${owner}"
+      settings:
+        syncAlerts: false
+      tags:
+        - Example
+  - name: set_version
+    type: data.set
+    with:
+      case_id: \${{steps.create_case.output.id}}
+      case_version: \${{steps.create_case.output.version}}
+  
+  - name: wait
+    type: wait
+    with:
+      duration: 7s
+  
+  - name: loop_through_comments
+    type: foreach
+    foreach: \${{inputs.comments}}
+    steps:
+      - name: create_case_comment
+        type: kibana.addCaseComment
+        with:
+          caseId: \${{variables.case_id}}
+          comment: \${{foreach.item.comment}}
+          type: user
+          owner: "${owner}"
+
+      - name: set_new_version
+        type: data.set
+        with:
+          case_version: \${{steps.create_case_comment.output.version}}
+
+  - name: update_case
+    type: kibana.updateCase
+    with:
+      cases:
+        - id: \${{variables.case_id}}
+          version: \${{variables.case_version}}
+          title: 'Updated: {{inputs.title}}'
+          description: 'Updated: {{inputs.description}}'
+
+  - name: get_case
+    type: kibana.getCase
+    with:
+      caseId: \${{variables.case_id}}
+      includeComments: false
+`;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { nationalParksWorkflow } from './national_parks_workflow';
+export { getCreateGetUpdateCaseWorkflowYaml } from './create_get_update_case';
+export {
+  getListTestWorkflowYaml,
+  getTestRunWorkflowYaml,
+  getWorkflowWithLoopYaml,
+  getIterationLoopWorkflowYaml,
+  getManyIterationsWorkflowYaml,
+  getDummyWorkflowYaml,
+  getInvalidWorkflowYaml,
+  getIncompleteStepTypeYaml,
+} from './console_workflows';
+export {
+  TEST_ALERTS_INDEX,
+  getPrintAlertsWorkflowYaml,
+  getCreateSecurityAlertRuleWorkflowYaml,
+  getCreateObsAlertRuleWorkflowYaml,
+  getTriggerAlertWorkflowYaml,
+} from './alert_workflows';

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/national_parks_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/national_parks_workflow.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const nationalParksWorkflow = `
+name: 🏔️ National Parks Demo
+description: Creates an Elasticsearch index, loads sample national park data using bulk operations, searches for parks by category, and displays the results.
+enabled: true
+tags: ["demo", "getting-started"]
+consts:
+  indexName: national-parks
+triggers:
+  - type: manual
+steps:
+  - name: get_index
+    type: elasticsearch.indices.exists
+    with:
+      index: "{{ consts.indexName }}"
+  - name: check_if_index_exists
+    type: if
+    condition: 'steps.get_index.output : true'
+    steps:
+      - name: index_already_exists
+        type: console
+        with:
+          message: "index: {{ consts.indexName }} already exists. Will proceed to delete it and re-create"
+      - name: delete_index
+        type: elasticsearch.indices.delete
+        with:
+          index: "{{ consts.indexName }}"
+    else:
+      - name: no_index_found
+        type: console
+        with:
+          message: "index: {{ consts.indexName }} Not found. Will proceed to create"
+
+  - name: create_parks_index
+    type: elasticsearch.indices.create
+    with:
+      index: "{{ consts.indexName }}"
+      mappings:
+        properties:
+          name: { type: text }
+          category: { type: keyword }
+          description: { type: text }
+  - name: bulk_index_park_data
+    type: elasticsearch.request
+    with:
+      method: POST
+      path: /{{ consts.indexName }}/_bulk?refresh=wait_for
+      headers:
+        Content-Type: application/x-ndjson
+      body: |
+        {"index":{}}
+        {"name": "Yellowstone National Park", "category": "geothermal", "description": "America's first national park, established in 1872, famous for Old Faithful geyser and diverse wildlife including grizzly bears, wolves, and herds of bison and elk."}
+        {"index":{}}
+        {"name": "Grand Canyon National Park", "category": "canyon", "description": "Home to the immense Grand Canyon, a mile deep gorge carved by the Colorado River, revealing millions of years of geological history in its colorful rock layers."}
+        {"index":{}}
+        {"name": "Yosemite National Park", "category": "mountain", "description": "Known for its granite cliffs, waterfalls, clear streams, giant sequoia groves, and biological diversity. El Capitan and Half Dome are iconic rock formations."}
+        {"index":{}}
+        {"name": "Zion National Park", "category": "canyon", "description": "Utah's first national park featuring cream, pink, and red sandstone cliffs soaring into a blue sky. Famous for the Narrows wade through the Virgin River."}
+        {"index":{}}
+        {"name": "Rocky Mountain National Park", "category": "mountain", "description": "Features mountain environments, from wooded forests to mountain tundra, with over 150 riparian lakes and diverse wildlife at various elevations."}
+  - name: search_park_data
+    type: elasticsearch.search
+    with:
+      index: "{{ consts.indexName }}"
+      size: 5
+      query:
+        term:
+          category: canyon
+  - name: loop_over_results
+    type: foreach
+    foreach: "{{steps.search_park_data.output.hits.hits | json}}"
+    steps:
+      - name: process-item
+        type: console
+        with:
+          message: "{{foreach.item._source.name}}"
+`;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel.playwright.config.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel.playwright.config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './parallel_tests/',
+  workers: 2,
+});

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/internal_actions/create_get_update_case.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/internal_actions/create_get_update_case.spec.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { EXECUTION_TIMEOUT } from '../../fixtures/constants';
+import { getCreateGetUpdateCaseWorkflowYaml } from '../../fixtures/workflows';
+
+/**
+ * Returns the correct case owner based on the project type.
+ * - Observability: uses 'observability'
+ * - Security / ESS: uses 'securitySolution'
+ * - ES: uses 'cases'
+ */
+const getCaseOwner = (projectType: string | undefined) => {
+  if (projectType === 'es' || projectType === undefined) {
+    return 'cases';
+  }
+  if (projectType === 'oblt') {
+    return 'observability';
+  }
+  return 'securitySolution';
+};
+
+test.describe(
+  'InternalActions/Cases',
+  {
+    tag: [
+      ...tags.stateful.classic,
+      ...tags.serverless.observability.complete,
+      ...tags.serverless.security.complete,
+    ],
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsPrivilegedUser();
+    });
+
+    test.afterAll(async ({ scoutSpace, apiServices }) => {
+      await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+    });
+
+    test('should run create_get_update_case workflow successfully', async ({
+      page,
+      pageObjects,
+      config,
+    }) => {
+      const caseOwner = getCaseOwner(config.projectType);
+      const workflowInput = {
+        title: `Test Case ${Math.floor(Math.random() * 10000)}`,
+        description: 'This is a test case description',
+        severity: 'low',
+        comments: [
+          {
+            type: 'user',
+            comment: 'This is the case comment 1',
+          },
+          {
+            type: 'user',
+            comment: 'This is the case comment 2',
+          },
+        ],
+      };
+
+      // Navigate to new workflow and set YAML
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+      await pageObjects.workflowEditor.setYamlEditorValue(
+        getCreateGetUpdateCaseWorkflowYaml(caseOwner)
+      );
+
+      // Run workflow with unsaved changes
+      await page.testSubj.click('runWorkflowHeaderButton');
+      await page.testSubj.waitForSelector('runWorkflowWithUnsavedChangesConfirmationModal');
+      await page.testSubj.click('confirmModalConfirmButton');
+
+      // Set workflow inputs in the execute modal
+      await page.testSubj.waitForSelector('workflowExecuteModal', { state: 'visible' });
+      await pageObjects.workflowEditor.setExecuteModalInputs(workflowInput);
+
+      // Execute the workflow
+      await page.testSubj.click('executeWorkflowButton');
+
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      // Expand all steps in the tree
+      await pageObjects.workflowExecution.expandStepsTree();
+
+      // Verify create_case step output
+      const createCaseStep = await pageObjects.workflowExecution.getStep('create_case');
+      await createCaseStep.click();
+
+      const createCaseOutput = await pageObjects.workflowExecution.getStepResultJson<{
+        id: string;
+        version: string;
+        title: string;
+        description: string;
+        severity: string;
+      }>('output');
+      expect(createCaseOutput.title).toBe(workflowInput.title);
+      expect(createCaseOutput.description).toBe(workflowInput.description);
+      expect(createCaseOutput.severity).toBe(workflowInput.severity);
+      expect(createCaseOutput.id).toBeDefined();
+      expect(createCaseOutput.version).toBeDefined();
+
+      const caseId = createCaseOutput.id;
+      const initialVersion = createCaseOutput.version;
+
+      // Verify add_case_comment step outputs
+      for (let i = 0; i < workflowInput.comments.length; i++) {
+        const comment = workflowInput.comments[i];
+        const createCaseCommentStep = await pageObjects.workflowExecution.getStep(
+          `loop_through_comments > ${i} > create_case_comment`
+        );
+        await createCaseCommentStep.click();
+
+        const createCaseCommentOutput = await pageObjects.workflowExecution.getStepResultJson<{
+          comments: {
+            owner: string;
+            type: string;
+            comment: string;
+          }[];
+        }>('output');
+        expect(createCaseCommentOutput.comments).toHaveLength(i + 1);
+        expect(createCaseCommentOutput.comments[i].owner).toBe(caseOwner);
+        expect(createCaseCommentOutput.comments[i].type).toBe(comment.type);
+        expect(createCaseCommentOutput.comments[i].comment).toBe(comment.comment);
+      }
+
+      // Verify update_case step output
+      const updateCaseStep = await pageObjects.workflowExecution.getStep('update_case');
+      await updateCaseStep.click();
+
+      const updateCaseOutput = await pageObjects.workflowExecution.getStepResultJson<
+        Array<{
+          id: string;
+          version: string;
+          title: string;
+        }>
+      >('output');
+      expect(updateCaseOutput).toBeDefined();
+      expect(updateCaseOutput.length).toBeGreaterThan(0);
+      expect(updateCaseOutput[0].id).toBe(caseId);
+      expect(updateCaseOutput[0].title).toBe(`Updated: ${workflowInput.title}`);
+      // Version should be incremented after update
+      expect(updateCaseOutput[0].version).not.toBe(initialVersion);
+
+      // Verify get_case step output
+      const getCaseStep = await pageObjects.workflowExecution.getStep('get_case');
+      await getCaseStep.click();
+
+      const getCaseOutput = await pageObjects.workflowExecution.getStepResultJson<{
+        id: string;
+        version: string;
+        title: string;
+        description: string;
+      }>('output');
+      expect(getCaseOutput.id).toBe(caseId);
+      expect(getCaseOutput.title).toBe(`Updated: ${workflowInput.title}`);
+      expect(getCaseOutput.description).toBe(`Updated: ${workflowInput.description}`);
+      expect(getCaseOutput.version).toBeDefined();
+    });
+  }
+);

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/internal_actions/national_parks.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/internal_actions/national_parks.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { EXECUTION_TIMEOUT } from '../../fixtures/constants';
+import { nationalParksWorkflow } from '../../fixtures/workflows';
+
+test.describe('InternalActions/Elasticsearch', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginWithCustomRole({
+      elasticsearch: {
+        cluster: ['manage_index_templates'],
+        indices: [
+          {
+            names: ['national-parks'],
+            privileges: ['create_index', 'read', 'view_index_metadata', 'write', 'delete_index'],
+          },
+        ],
+      },
+      kibana: [
+        {
+          base: ['all'],
+          feature: {},
+          spaces: ['*'],
+        },
+      ],
+    });
+  });
+
+  test.afterAll(async ({ scoutSpace, apiServices }) => {
+    await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+  });
+
+  test('should run national park workflow successfully', async ({ page, pageObjects }) => {
+    await pageObjects.workflowEditor.gotoNewWorkflow();
+    await pageObjects.workflowEditor.setYamlEditorValue(nationalParksWorkflow);
+    await page.testSubj.click('runWorkflowHeaderButton');
+    await page.testSubj.waitForSelector('runWorkflowWithUnsavedChangesConfirmationModal');
+    await page.testSubj.click('confirmModalConfirmButton');
+
+    await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+    await pageObjects.workflowExecution.expandStepsTree();
+
+    // verify output of create_parks_index
+    const createParksIndexStep = await pageObjects.workflowExecution.getStep('create_parks_index');
+    await createParksIndexStep.click();
+    expect(
+      await pageObjects.workflowExecution.getStepResultJson<Record<string, unknown>>('output')
+    ).toStrictEqual({
+      acknowledged: true,
+      shards_acknowledged: true,
+      index: 'national-parks',
+    });
+
+    // verify output of bulk_index_park_data
+    const bulkIndexParkDataStep = await pageObjects.workflowExecution.getStep(
+      'bulk_index_park_data'
+    );
+    await bulkIndexParkDataStep.click();
+    const bulkIndexOutput = await pageObjects.workflowExecution.getStepResultJson<
+      Record<string, unknown>
+    >('output');
+    expect(bulkIndexOutput.errors).toBe(false);
+    expect(bulkIndexOutput.items).toHaveLength(5);
+
+    // verify output of search_park_data
+    const searchParkDataStep = await pageObjects.workflowExecution.getStep('search_park_data');
+    await searchParkDataStep.click();
+    const searchParkOutput = await pageObjects.workflowExecution.getStepResultJson<{
+      hits: {
+        total: { value: number };
+        hits: unknown[];
+      };
+    }>('output');
+    expect(searchParkOutput.hits).toBeDefined();
+    expect(searchParkOutput.hits.total.value).toBe(2);
+    expect(searchParkOutput.hits.hits).toHaveLength(2);
+
+    // verify outputs of process-item
+    const requiredOutputs = ['Grand Canyon National Park', 'Zion National Park'];
+
+    for (let i = 0; i < requiredOutputs.length; i++) {
+      const step = await pageObjects.workflowExecution.getStep(
+        `loop_over_results > ${i} > process-item`
+      );
+      await step.click();
+
+      const stepOutput = await pageObjects.workflowExecution.getStepResultJson<string>('output');
+      expect(stepOutput).toBe(requiredOutputs[i]);
+    }
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../fixtures';
+import { cleanupWorkflowsAndRules } from '../fixtures/cleanup';
+import { EXECUTION_TIMEOUT } from '../fixtures/constants';
+import {
+  getDummyWorkflowYaml,
+  getIncompleteStepTypeYaml,
+  getInvalidWorkflowYaml,
+} from '../fixtures/workflows';
+
+test.describe(
+  'Sanity tests for workflows',
+  {
+    tag: [
+      ...tags.stateful.classic,
+      ...tags.serverless.observability.complete,
+      ...tags.serverless.security.complete,
+    ],
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsPrivilegedUser();
+    });
+
+    test.afterAll(async ({ scoutSpace, apiServices }) => {
+      await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+    });
+
+    test('Create, save, run and view a dummy workflow', async ({ pageObjects, page }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+
+      const workflowName = 'Dummy Workflow';
+
+      // Set the editor value
+      await pageObjects.workflowEditor.setYamlEditorValue(getDummyWorkflowYaml(workflowName));
+
+      // Now the save button should be enabled and clicking it will save the correct value
+      await pageObjects.workflowEditor.saveWorkflow();
+      await pageObjects.workflowList.navigate();
+      await page.testSubj.waitForSelector('workflowListTable', { state: 'visible' });
+
+      const workflowRow = pageObjects.workflowList.getWorkflowRow(workflowName);
+      await expect(workflowRow).toBeVisible();
+      await workflowRow.getByLabel('Run').click();
+      await page.testSubj.waitForSelector('workflowExecuteModal', { state: 'visible' });
+
+      const inputEditor = page.testSubj.locator('workflow-manual-json-editor');
+      await expect(inputEditor).toBeVisible();
+      await pageObjects.workflowEditor.setExecuteModalInputs({ message: 'Hello Kibana' });
+      await page.testSubj.click('executeWorkflowButton');
+
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      const helloWorldStep = await pageObjects.workflowExecution.getStep('hello_world_step');
+      await helloWorldStep.click();
+      const stepOutput = await pageObjects.workflowExecution.getStepResultJson<string>('output');
+      expect(stepOutput).toBe('Hello Kibana');
+    });
+
+    test('should show validation errors for invalid workflow YAML and clear them when fixed', async ({
+      pageObjects,
+    }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+      const workflowName = 'Invalid Workflow';
+      await pageObjects.workflowEditor.setYamlEditorValue(getInvalidWorkflowYaml(workflowName));
+
+      // Wait for validation to complete and show errors
+      const validationAccordion = pageObjects.workflowEditor.validationErrorsAccordion;
+      await expect(validationAccordion).toBeVisible();
+      await expect(validationAccordion).toContainText('error');
+
+      // Click to expand the accordion and verify the specific error message
+      await validationAccordion.getByRole('button', { name: 'error' }).click();
+      await expect(validationAccordion.getByText('missing property "steps"')).toBeVisible();
+
+      // Fix the workflow by pasting valid YAML
+      await pageObjects.workflowEditor.setYamlEditorValue(getDummyWorkflowYaml(workflowName));
+
+      // Validation errors should disappear
+      await expect(validationAccordion).toContainText('No validation errors');
+    });
+
+    test('should show step type autocompletion suggestions', async ({ pageObjects, page }) => {
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+      const workflowName = 'Autocomplete Test';
+      await pageObjects.workflowEditor.setYamlEditorValue(getIncompleteStepTypeYaml(workflowName));
+
+      // Set incomplete YAML with empty step type
+      await pageObjects.workflowEditor.setYamlEditorValue(getIncompleteStepTypeYaml(workflowName));
+
+      // Click on the "type:" line to focus the editor at that position
+      await page.getByText('type:', { exact: true }).click();
+
+      // Move to end of line and trigger autocomplete
+      await page.keyboard.press('End');
+      await page.keyboard.press('Space');
+
+      // Verify the suggest widget appears with step type options
+      const suggestWidget = pageObjects.workflowEditor.getYamlEditorSuggestWidget();
+      await expect(suggestWidget).toBeVisible();
+
+      await page.keyboard.type('ela');
+
+      // Verify step types are shown in suggestions (alphabetically sorted, starting with 'a')
+      await expect(
+        suggestWidget.getByRole('option', { name: 'elasticsearch.search' })
+      ).toBeVisible();
+      await expect(
+        suggestWidget.getByRole('option', { name: 'elasticsearch.index' })
+      ).toBeVisible();
+      await expect(suggestWidget.getByRole('option', { name: 'elasticsearch.bulk' })).toBeVisible();
+
+      await suggestWidget.getByRole('option', { name: 'elasticsearch.search' }).click();
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('with:');
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Space');
+
+      await expect(suggestWidget).toBeVisible();
+      await page.keyboard.type('ind');
+
+      await expect(suggestWidget.getByRole('option', { name: 'index' })).toBeVisible();
+    });
+  }
+);

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/alert_trigger.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/alert_trigger.spec.ts
@@ -1,0 +1,284 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { ALERT_PROPAGATION_TIMEOUT, EXECUTION_TIMEOUT } from '../../fixtures/constants';
+import {
+  getCreateObsAlertRuleWorkflowYaml,
+  getCreateSecurityAlertRuleWorkflowYaml,
+  getPrintAlertsWorkflowYaml,
+  getTriggerAlertWorkflowYaml,
+  TEST_ALERTS_INDEX,
+} from '../../fixtures/workflows';
+
+/**
+ * Returns the correct "create alert rule" workflow YAML based on the project type.
+ * - Security: uses the detection engine API
+ * - Observability / ESS: uses the generic Kibana alerting API with .es-query rule type
+ */
+const getCreateAlertRuleWorkflow = (projectType: string | undefined) => {
+  if (projectType === 'security') {
+    return getCreateSecurityAlertRuleWorkflowYaml;
+  }
+  return getCreateObsAlertRuleWorkflowYaml;
+};
+
+// Alert trigger tests run on Security and Observability (and ESS), but NOT on Elasticsearch/Search.
+// Security uses the detection engine API; Observability uses the generic alerting API.
+test.describe(
+  'Workflow execution - Alert triggers',
+  {
+    tag: [
+      ...tags.stateful.classic,
+      ...tags.serverless.security.complete,
+      ...tags.serverless.observability.complete,
+    ],
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      // Custom role with extra privileges beyond the default editor:
+      // 1. Write to test index (workflow indexes alert docs to trigger the rule)
+      // 2. Create ingest pipelines (workflow creates add_timestamp_if_missing pipeline)
+      // Detection/alerting rule creation uses kibana.request, so Kibana 'all' base privilege covers it.
+      await browserAuth.loginWithCustomRole({
+        elasticsearch: {
+          cluster: ['manage_ingest_pipelines'],
+          indices: [
+            {
+              names: [TEST_ALERTS_INDEX],
+              privileges: ['write', 'read', 'view_index_metadata', 'create_index', 'delete_index'],
+            },
+          ],
+        },
+        kibana: [
+          {
+            base: ['all'],
+            feature: {},
+            spaces: ['*'],
+          },
+        ],
+      });
+    });
+
+    test.afterEach(async ({ scoutSpace, apiServices }) => {
+      await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+    });
+
+    test('should trigger workflow from alert', async ({
+      pageObjects,
+      page,
+      apiServices,
+      scoutSpace,
+      config,
+    }) => {
+      const getCreateAlertRuleYaml = getCreateAlertRuleWorkflow(config.projectType);
+
+      const singleWorkflowName = 'Handle single alert';
+      const multipleWorkflowName = 'Handle multiple alerts';
+      const createAlertRuleWorkflowName = 'Create alert rule workflow';
+      const triggerAlertWorkflowName = 'Trigger alert workflow';
+      const mockAlerts = [
+        {
+          severity: 'high',
+          alert_id: 'bruteforce_login_attempt',
+          description:
+            'Multiple failed login attempts detected from IP 192.168.1.45 targeting admin account. 15 failures in 3 minutes exceeding threshold.',
+          category: 'authentication',
+          timestamp: '2023-11-15T08:23:45Z',
+        },
+        {
+          severity: 'critical',
+          alert_id: 'suspicious_data_transfer',
+          description:
+            'Unusual outbound data transfer of 2.3GB to unrecognized external domain detected from workstation WS-0023. Transfer occurred outside business hours.',
+          category: 'data_exfiltration',
+          timestamp: '2023-11-15T09:17:32Z',
+        },
+      ];
+
+      // Create all 4 workflows via bulk API in a single request
+      const { created } = await apiServices.workflows.bulkCreate(scoutSpace.id, [
+        getPrintAlertsWorkflowYaml(singleWorkflowName),
+        getPrintAlertsWorkflowYaml(multipleWorkflowName),
+        getCreateAlertRuleYaml(createAlertRuleWorkflowName),
+        getTriggerAlertWorkflowYaml(triggerAlertWorkflowName),
+      ]);
+      const [singleWorkflow, multipleWorkflow, createAlertRuleWorkflow, triggerAlertWorkflow] =
+        created;
+
+      // Navigate to alert rule creation workflow and execute
+      await pageObjects.workflowEditor.gotoWorkflow(createAlertRuleWorkflow.id);
+      await pageObjects.workflowEditor.executeWorkflowWithInputs({
+        wf_single_alert: singleWorkflow.id,
+        wf_multiple_alerts: multipleWorkflow.id,
+      });
+
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      // Navigate to alert trigger workflow and execute (indexes docs that fire the rule)
+      await pageObjects.workflowEditor.gotoWorkflow(triggerAlertWorkflow.id);
+      await pageObjects.workflowEditor.executeWorkflowWithInputs({ alerts: mockAlerts });
+
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      // Validate single-alert workflow executions (one alert per execution)
+      await pageObjects.workflowEditor.gotoWorkflowExecutions(singleWorkflow.id);
+
+      const singleWorkflowExecutions = page.testSubj.locator('workflowExecutionListItem');
+      await expect(singleWorkflowExecutions).toHaveCount(mockAlerts.length, {
+        timeout: ALERT_PROPAGATION_TIMEOUT,
+      });
+
+      // Security detection alerts embed the original document, so we can assert on alert_id.
+      // Generic alerting alerts (obs/ESS) contain Kibana alert metadata without original doc fields,
+      // so we only verify execution structure (counts, iterations) for those.
+      const isSecurityProject = config.projectType === 'security';
+
+      // Most recent execution first -> last alert first
+      const expectedSingleAlertIds = mockAlerts.map((a) => a.alert_id).reverse();
+
+      for (let i = 0; i < expectedSingleAlertIds.length; i++) {
+        // eslint-disable-next-line playwright/no-nth-methods -- iterating over execution list items by index
+        await singleWorkflowExecutions.nth(i).click();
+
+        await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+        await pageObjects.workflowExecution.expandStepsTree();
+
+        // Only 1 iteration per execution (single-alert mode)
+        const logEachAlertButton = await pageObjects.workflowExecution.getStep(
+          'foreach_log_each_alert > 0 > log_each_alert'
+        );
+        await logEachAlertButton.click();
+
+        const stepOutput = await pageObjects.workflowExecution.getStepResultJson<unknown>('output');
+        const stepOutputStr = JSON.stringify(stepOutput);
+        // Security detection alerts embed the original document, so we can assert on alert_id.
+        // Generic alerting alerts (obs/ESS) contain Kibana alert metadata without original doc
+        // fields — we verify the output is non-empty (the step ran) and contains alert info.
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        const expectedContent = isSecurityProject ? expectedSingleAlertIds[i] : 'alert';
+        expect(stepOutputStr).toContain(expectedContent);
+
+        await page.testSubj.click('workflowBackToExecutionsLink');
+        await page.testSubj.waitForSelector('workflowExecutionList', { state: 'visible' });
+      }
+
+      // Validate multiple-alerts workflow execution (all alerts in one execution)
+      await pageObjects.workflowEditor.gotoWorkflowExecutions(multipleWorkflow.id);
+
+      const multipleWorkflowExecutions = page.testSubj.locator('workflowExecutionListItem');
+      await expect(multipleWorkflowExecutions).toHaveCount(1, {
+        timeout: ALERT_PROPAGATION_TIMEOUT,
+      });
+
+      await multipleWorkflowExecutions.click();
+
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+      await pageObjects.workflowExecution.expandStepsTree();
+
+      // 2 iterations (both alerts in single execution)
+      for (let i = 0; i < mockAlerts.length; i++) {
+        const logEachAlertButton = await pageObjects.workflowExecution.getStep(
+          `foreach_log_each_alert > ${i} > log_each_alert`
+        );
+        await logEachAlertButton.click();
+
+        const alertOutput = await pageObjects.workflowExecution.getStepResultJson<unknown>(
+          'output'
+        );
+        // Security alerts contain the original document with alert_id;
+        // generic alerting alerts contain Kibana alert metadata.
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        const expectedAlertContent = isSecurityProject ? mockAlerts[i].alert_id : 'alert';
+        expect(JSON.stringify(alertOutput)).toContain(expectedAlertContent);
+      }
+    });
+
+    test('should not trigger a disabled workflow when alert fires', async ({
+      pageObjects,
+      page,
+      apiServices,
+      scoutSpace,
+      config,
+    }) => {
+      const getCreateAlertRuleYaml = getCreateAlertRuleWorkflow(config.projectType);
+
+      const disabledWorkflowName = 'Disabled alert target';
+      const canaryWorkflowName = 'Canary alert target';
+      const createRuleWorkflowName = 'Create rule for disabled test';
+      const triggerAlertWorkflowName = 'Trigger alert for disabled test';
+
+      const mockAlerts = [
+        {
+          severity: 'medium',
+          alert_id: 'disabled_workflow_test_alert',
+          description: 'Alert that should NOT trigger a disabled workflow.',
+          category: 'test',
+          timestamp: '2023-12-01T00:00:00Z',
+        },
+      ];
+
+      // Create four workflows: the target to be disabled, a canary that stays enabled
+      // (to prove alerts actually propagated), plus rule-creation and alert-trigger helpers.
+      const { created } = await apiServices.workflows.bulkCreate(scoutSpace.id, [
+        getPrintAlertsWorkflowYaml(disabledWorkflowName),
+        getPrintAlertsWorkflowYaml(canaryWorkflowName),
+        getCreateAlertRuleYaml(createRuleWorkflowName),
+        getTriggerAlertWorkflowYaml(triggerAlertWorkflowName),
+      ]);
+      const [disabledWorkflow, canaryWorkflow, createRuleWorkflow, triggerAlertWorkflow] = created;
+
+      // Set up the alert rule with two actions:
+      // - wf_single_alert -> the workflow we will disable
+      // - wf_multiple_alerts -> the canary that stays enabled (proves alerts fired)
+      await pageObjects.workflowEditor.gotoWorkflow(createRuleWorkflow.id);
+      await pageObjects.workflowEditor.executeWorkflowWithInputs({
+        wf_single_alert: disabledWorkflow.id,
+        wf_multiple_alerts: canaryWorkflow.id,
+      });
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      // Disable the target workflow from the workflows list UI
+      await pageObjects.workflowList.navigate();
+      await page.testSubj.waitForSelector('workflowListTable', { state: 'visible' });
+
+      const toggleSwitch = pageObjects.workflowList.getWorkflowStateToggle(disabledWorkflowName);
+      await expect(toggleSwitch).toBeChecked();
+      await toggleSwitch.click();
+      await expect(toggleSwitch).not.toBeChecked();
+
+      // Trigger alerts — the rule will fire both actions, but only the canary should execute
+      await pageObjects.workflowEditor.gotoWorkflow(triggerAlertWorkflow.id);
+      await pageObjects.workflowEditor.executeWorkflowWithInputs({ alerts: mockAlerts });
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      // Wait for the canary workflow to receive executions — this proves alerts propagated
+      await pageObjects.workflowEditor.gotoWorkflowExecutions(canaryWorkflow.id);
+
+      const canaryExecutions = page.testSubj.locator('workflowExecutionListItem');
+      await expect(canaryExecutions).toHaveCount(1, { timeout: ALERT_PROPAGATION_TIMEOUT });
+
+      // Now verify the disabled workflow has zero executions.
+      // The canary already received its execution, so any alert-triggered execution
+      // for the disabled workflow would have appeared by now.
+      await pageObjects.workflowList.navigate();
+      await pageObjects.workflowList
+        .getWorkflowAction(disabledWorkflowName, 'editWorkflowAction')
+        .click();
+      await page.getByRole('button', { name: 'Executions' }).click();
+      await page.testSubj.waitForSelector('workflowExecutionList', { state: 'visible' });
+
+      const disabledExecutions = page.testSubj.locator('workflowExecutionListItem');
+      await expect(disabledExecutions).toHaveCount(0);
+    });
+  }
+);

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/foreach_iterations.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/foreach_iterations.spec.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { EXECUTION_TIMEOUT } from '../../fixtures/constants';
+import {
+  getIterationLoopWorkflowYaml,
+  getManyIterationsWorkflowYaml,
+} from '../../fixtures/workflows';
+
+test.describe(
+  'Workflow execution - Foreach iterations',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsPrivilegedUser();
+    });
+
+    test.afterAll(async ({ scoutSpace, apiServices }) => {
+      await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+    });
+
+    test('should display execution tree with foreach loops showing multiple iterations', async ({
+      pageObjects,
+      page,
+    }) => {
+      const workflowName = 'Test Workflow Foreach Iterations';
+
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+      await pageObjects.workflowEditor.setYamlEditorValue(
+        getIterationLoopWorkflowYaml(workflowName)
+      );
+      await pageObjects.workflowEditor.saveWorkflow();
+
+      // Run with custom input
+      await pageObjects.workflowEditor.executeWorkflowWithInputs({ message: 'test message' });
+
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      // Verify overview section
+      const overviewSection = page.testSubj.locator('workflowExecutionOverview');
+      await expect(overviewSection).toBeVisible();
+      await expect(overviewSection.getByText('Execution started')).toBeVisible();
+      await expect(overviewSection.getByText('Execution ended')).toBeVisible();
+
+      await pageObjects.workflowExecution.expandStepsTree();
+
+      // Verify trigger section shows the manual input
+      const manualStep = await pageObjects.workflowExecution.getStep('manual');
+      await manualStep.click();
+      const triggerSection = page.testSubj.locator('workflowExecutionTrigger');
+      await expect(triggerSection).toBeVisible();
+      await expect(triggerSection.getByText('test message')).toBeVisible();
+
+      // Verify execution tree structure
+      const firstStepButton = await pageObjects.workflowExecution.getStep('first_step');
+      await expect(firstStepButton).toHaveCount(1);
+
+      const loopStepButton = await pageObjects.workflowExecution.getStep('loop');
+      await loopStepButton.click();
+      await expect(loopStepButton).toHaveCount(1);
+
+      // Verify foreach produced 2 iterations
+      const logIterationButtons = pageObjects.workflowExecution.executionPanel.getByRole('button', {
+        name: 'log_iteration',
+      });
+      await expect(logIterationButtons).toHaveCount(2);
+
+      // eslint-disable-next-line playwright/no-nth-methods -- it's useful here, as it's a list, not a hacky workaround
+      await logIterationButtons.first().click();
+      let stepDetails = page.testSubj.locator('workflowStepExecutionDetails');
+      await expect(stepDetails.getByTestId('workflowJsonDataViewer')).toContainText(
+        'Iteration is 0'
+      );
+
+      // eslint-disable-next-line playwright/no-nth-methods -- it's useful here, as it's a list, not a hacky workaround
+      await logIterationButtons.last().click();
+      stepDetails = page.testSubj.locator('workflowStepExecutionDetails');
+      await expect(stepDetails.getByTestId('workflowJsonDataViewer')).toContainText(
+        'Iteration is 1'
+      );
+    });
+
+    test('should display scrollable step executions with many iterations', async ({
+      pageObjects,
+    }) => {
+      const workflowName = 'Scroll Test Workflow';
+
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+      await pageObjects.workflowEditor.setYamlEditorValue(
+        getManyIterationsWorkflowYaml(workflowName)
+      );
+      await pageObjects.workflowEditor.saveWorkflow();
+
+      await pageObjects.workflowEditor.clickRunButton();
+
+      await pageObjects.workflowExecution.waitForExecutionStatus('completed', EXECUTION_TIMEOUT);
+
+      await pageObjects.workflowExecution.expandStepsTree();
+
+      // Verify 50 leaf step executions (exclude the parent foreach step)
+      const stepButtons = pageObjects.workflowExecution.executionPanel.getByRole('button', {
+        name: /^(?!foreach_).*hello_world_step/,
+      });
+      await expect(stepButtons).toHaveCount(50);
+
+      // eslint-disable-next-line playwright/no-nth-methods -- it's useful here, as it's a list, not a hacky workaround
+      const firstStep = stepButtons.first();
+      // eslint-disable-next-line playwright/no-nth-methods -- it's useful here, as it's a list, not a hacky workaround
+      const lastStep = stepButtons.last();
+
+      await expect(firstStep).toBeVisible();
+
+      // Scroll to the last step to verify scrollability
+      await lastStep.scrollIntoViewIfNeeded();
+      await expect(lastStep).toBeVisible();
+    });
+  }
+);

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/test_run.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/test_run.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { getTestRunWorkflowYaml, getWorkflowWithLoopYaml } from '../../fixtures/workflows';
+
+test.describe('Workflow execution - Test runs', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
+  test.afterAll(async ({ scoutSpace, apiServices }) => {
+    await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+  });
+
+  test('should run unsaved workflow as test run with isTestRun: true', async ({
+    pageObjects,
+    page,
+  }) => {
+    const workflowName = 'Test Workflow Unsaved';
+
+    await pageObjects.workflowEditor.gotoNewWorkflow();
+    await pageObjects.workflowEditor.setYamlEditorValue(getTestRunWorkflowYaml(workflowName));
+
+    // Run without saving -- should prompt for unsaved changes confirmation
+    await pageObjects.workflowEditor.runWorkflowWithUnsavedChanges();
+    await page.testSubj.waitForSelector('workflowExecuteModal', { state: 'visible' });
+    await page.testSubj.click('executeWorkflowButton');
+
+    await pageObjects.workflowExecution.waitForExecutionView();
+
+    await pageObjects.workflowExecution.executionPanel
+      .getByRole('button', { name: 'hello_world_step' })
+      .click();
+    const stepDetails = page.testSubj.locator('workflowStepExecutionDetails');
+    await expect(stepDetails.getByTestId('workflowJsonDataViewer')).toContainText('Test run: true');
+  });
+
+  test('should run saved workflow from editor as test run with isTestRun: true', async ({
+    pageObjects,
+    page,
+  }) => {
+    const workflowName = 'Test Workflow Saved';
+
+    await pageObjects.workflowEditor.gotoNewWorkflow();
+    await pageObjects.workflowEditor.setYamlEditorValue(getTestRunWorkflowYaml(workflowName));
+    await pageObjects.workflowEditor.saveWorkflow();
+
+    await pageObjects.workflowEditor.clickRunButton();
+    await page.testSubj.waitForSelector('workflowExecuteModal', { state: 'visible' });
+    await page.testSubj.click('executeWorkflowButton');
+
+    await pageObjects.workflowExecution.waitForExecutionView();
+
+    await pageObjects.workflowExecution.executionPanel
+      .getByRole('button', { name: 'hello_world_step' })
+      .click();
+    const stepDetails = page.testSubj.locator('workflowStepExecutionDetails');
+    await expect(stepDetails.getByTestId('workflowJsonDataViewer')).toContainText('Test run: true');
+  });
+
+  test('should not allow running a disabled workflow, then enable and run it', async ({
+    pageObjects,
+    page,
+  }) => {
+    const workflowName = 'Test Workflow Disabled Then Enabled';
+
+    await pageObjects.workflowEditor.gotoNewWorkflow();
+    await pageObjects.workflowEditor.setYamlEditorValue(getTestRunWorkflowYaml(workflowName));
+    await pageObjects.workflowEditor.saveWorkflow();
+
+    // Navigate to list and verify the workflow is disabled
+    await pageObjects.workflowList.navigate();
+    await page.testSubj.waitForSelector('workflowListTable', { state: 'visible' });
+
+    const workflowRow = pageObjects.workflowList.getWorkflowRow(workflowName);
+    await expect(workflowRow).toBeVisible();
+
+    const toggleSwitch = workflowRow.locator('[data-test-subj^="workflowToggleSwitch-"]');
+    await expect(toggleSwitch).not.toBeChecked();
+
+    const runButton = workflowRow.getByRole('button', { name: 'Run' });
+    await expect(runButton).toBeDisabled();
+
+    // Enable the workflow via toggle and verify Run becomes available
+    await toggleSwitch.click();
+    await expect(toggleSwitch).toBeChecked();
+
+    await runButton.click();
+    await page.testSubj.waitForSelector('workflowExecuteModal', { state: 'visible' });
+    await page.testSubj.click('executeWorkflowButton');
+
+    await pageObjects.workflowExecution.waitForExecutionView();
+
+    // Not a test run since we ran from the list (enabled workflow), so isTestRun: false
+    await pageObjects.workflowExecution.executionPanel
+      .getByRole('button', { name: 'hello_world_step' })
+      .click();
+    const stepDetails = page.testSubj.locator('workflowStepExecutionDetails');
+    await expect(stepDetails.getByTestId('workflowJsonDataViewer')).toContainText(
+      'Test run: false'
+    );
+  });
+
+  test('should run individual step with custom context override', async ({ pageObjects, page }) => {
+    const workflowName = 'Test Workflow Step Override';
+
+    await pageObjects.workflowEditor.gotoNewWorkflow();
+    await pageObjects.workflowEditor.setYamlEditorValue(getWorkflowWithLoopYaml(workflowName));
+
+    // Navigate to the nested hello_world_step in the editor
+    await page.getByText('enabled: false').click();
+    await page.keyboard.press('PageDown');
+    await page.getByText('name: hello_world_step').click();
+    await page.getByText('name: hello_world_step').click();
+    await page.keyboard.press('End');
+
+    // Click the inline "run step" button
+    const runStepButton = page.testSubj.locator('workflowRunStep');
+    await expect(runStepButton).toBeVisible();
+    await runStepButton.click();
+
+    // Set custom context in the test step modal and execute
+    await pageObjects.workflowEditor.setTestStepInputs({ execution: { isTestRun: false } });
+    await page.testSubj.click('workflowSubmitStepRun');
+
+    await pageObjects.workflowExecution.waitForExecutionView();
+
+    // Only one hello_world_step should run (not 4 from the loop)
+    const helloWorldSteps = pageObjects.workflowExecution.executionPanel.getByRole('button', {
+      name: 'hello_world_step',
+    });
+    await expect(helloWorldSteps).toHaveCount(1);
+
+    await helloWorldSteps.click();
+    const stepDetails = page.testSubj.locator('workflowStepExecutionDetails');
+    await expect(stepDetails.getByTestId('workflowJsonDataViewer')).toContainText(
+      'Test run: false'
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflows_list/bulk_actions.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflows_list/bulk_actions.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { getListTestWorkflowYaml } from '../../fixtures/workflows';
+
+test.describe('WorkflowsList/BulkActions', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
+  test.afterAll(async ({ scoutSpace, apiServices }) => {
+    await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+  });
+
+  test('should enable disabled workflows', async ({
+    page,
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const workflows = [
+      { name: 'BulkTest Enabled Workflow 1', description: 'Bulk workflow 1', enabled: false },
+      { name: 'BulkTest Enabled Workflow 2', description: 'Bulk workflow 2', enabled: false },
+    ];
+    await apiServices.workflows.bulkCreate(scoutSpace.id, workflows.map(getListTestWorkflowYaml));
+
+    await pageObjects.workflowList.navigate();
+    await pageObjects.workflowList.performBulkAction(
+      workflows.map((w) => w.name),
+      'enable'
+    );
+    const checkEnabled = () =>
+      Promise.all(
+        workflows.map((workflow) =>
+          expect(pageObjects.workflowList.getWorkflowStateToggle(workflow.name)).toBeChecked()
+        )
+      );
+    await checkEnabled();
+    await page.reload();
+    await checkEnabled();
+  });
+
+  test('should disable enabled workflows', async ({
+    page,
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const workflows = [
+      { name: 'BulkTest Disabled Workflow 1', description: 'Bulk workflow 1', enabled: true },
+      { name: 'BulkTest Disabled Workflow 2', description: 'Bulk workflow 2', enabled: true },
+    ];
+    await apiServices.workflows.bulkCreate(scoutSpace.id, workflows.map(getListTestWorkflowYaml));
+
+    await pageObjects.workflowList.navigate();
+    await pageObjects.workflowList.performBulkAction(
+      workflows.map((w) => w.name),
+      'disable'
+    );
+    const checkDisabled = () =>
+      Promise.all(
+        workflows.map((workflow) =>
+          expect(pageObjects.workflowList.getWorkflowStateToggle(workflow.name)).not.toBeChecked()
+        )
+      );
+    await checkDisabled();
+    await page.reload();
+    await checkDisabled();
+  });
+
+  test('should delete workflows', async ({ page, pageObjects, apiServices, scoutSpace }) => {
+    const workflows = [
+      { name: 'BulkTest Delete Workflow 1', description: 'To be deleted', enabled: true },
+      { name: 'BulkTest Delete Workflow 2', description: 'To be deleted', enabled: true },
+    ];
+    await apiServices.workflows.bulkCreate(scoutSpace.id, workflows.map(getListTestWorkflowYaml));
+
+    await pageObjects.workflowList.navigate();
+    await pageObjects.workflowList.performBulkAction(
+      workflows.map((w) => w.name),
+      'delete'
+    );
+    await page.testSubj.click('confirmModalConfirmButton');
+    const checkDeleted = () =>
+      Promise.all(
+        workflows.map((workflow) =>
+          expect(pageObjects.workflowList.getWorkflowRow(workflow.name)).toHaveCount(0)
+        )
+      );
+    await checkDeleted();
+    await page.reload();
+    await checkDeleted();
+  });
+
+  test('should clear selection', async ({ page, pageObjects, apiServices, scoutSpace }) => {
+    const workflows = [
+      {
+        name: 'BulkTest Clear Selection Workflow 1',
+        description: 'Bulk workflow 1',
+        enabled: true,
+      },
+      {
+        name: 'BulkTest Clear Selection Workflow 2',
+        description: 'Bulk workflow 2',
+        enabled: true,
+      },
+    ];
+    await apiServices.workflows.bulkCreate(scoutSpace.id, workflows.map(getListTestWorkflowYaml));
+
+    await pageObjects.workflowList.navigate();
+    await pageObjects.workflowList.selectWorkflows(workflows.map((w) => w.name));
+    await page.testSubj.waitForSelector('workflows-table-bulk-actions-button', {
+      state: 'visible',
+    });
+    await page.testSubj.click('workflows-clear-selection-button');
+    await page.testSubj.waitForSelector('workflows-table-bulk-actions-button', {
+      state: 'hidden',
+    });
+
+    await Promise.all(
+      workflows.map((workflow) =>
+        expect(
+          pageObjects.workflowList.getSelectCheckboxForWorkflow(workflow.name)
+        ).not.toBeChecked()
+      )
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflows_list/filter_sort_search.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflows_list/filter_sort_search.spec.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { getListTestWorkflowYaml } from '../../fixtures/workflows';
+
+test.describe('WorkflowsList/FilterSortSearch', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
+  test.afterAll(async ({ scoutSpace, apiServices }) => {
+    await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+  });
+
+  test('should filter workflows by enabling state', async ({
+    page,
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const enabledWorkflow = {
+      name: 'FilterSortSearch Enabled Workflow 1',
+      description: 'Enabled workflow for filter test',
+      enabled: true,
+    };
+    const disabledWorkflow = {
+      name: 'FilterSortSearch Disabled Workflow 1',
+      description: 'Disabled workflow for filter test',
+      enabled: false,
+    };
+    await apiServices.workflows.bulkCreate(
+      scoutSpace.id,
+      [enabledWorkflow, disabledWorkflow].map(getListTestWorkflowYaml)
+    );
+
+    await pageObjects.workflowList.navigate();
+    const filterOption = await pageObjects.workflowList.getFilterOption(
+      'enabled-filter-popover-button',
+      'true'
+    );
+    await filterOption.click();
+    await expect(
+      page.locator('tr [data-test-subj^="workflowToggleSwitch-"][aria-checked="false"]')
+    ).toHaveCount(0);
+    await expect(pageObjects.workflowList.getWorkflowRow(disabledWorkflow.name)).toBeHidden();
+    await expect(pageObjects.workflowList.getWorkflowRow(enabledWorkflow.name)).toBeVisible();
+  });
+
+  test('should filter workflows by disabling state', async ({
+    page,
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const enabledWorkflow = {
+      name: 'FilterSortSearch Enabled Workflow 2',
+      description: 'Enabled workflow for disable filter test',
+      enabled: true,
+    };
+    const disabledWorkflow = {
+      name: 'FilterSortSearch Disabled Workflow 2',
+      description: 'Disabled workflow for disable filter test',
+      enabled: false,
+    };
+    await apiServices.workflows.bulkCreate(
+      scoutSpace.id,
+      [enabledWorkflow, disabledWorkflow].map(getListTestWorkflowYaml)
+    );
+
+    await pageObjects.workflowList.navigate();
+    const filterOption = await pageObjects.workflowList.getFilterOption(
+      'enabled-filter-popover-button',
+      'false'
+    );
+    await filterOption.click();
+    await expect(
+      page.locator('tr [data-test-subj^="workflowToggleSwitch-"][aria-checked="true"]')
+    ).toHaveCount(0);
+    await expect(pageObjects.workflowList.getWorkflowRow(enabledWorkflow.name)).toBeHidden();
+    await expect(pageObjects.workflowList.getWorkflowRow(disabledWorkflow.name)).toBeVisible();
+  });
+
+  test('should search by name and description', async ({
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const workflows = [
+      {
+        name: 'Search Test Apple Workflow',
+        description: 'Workflow for testing apple search',
+        enabled: true,
+      },
+      {
+        name: 'Search Test Banana Workflow',
+        description: 'Workflow for testing banana search',
+        enabled: true,
+      },
+      {
+        name: 'Search Test Orange Workflow',
+        description: 'Contains apple in description',
+        enabled: false,
+      },
+    ];
+    await apiServices.workflows.bulkCreate(scoutSpace.id, workflows.map(getListTestWorkflowYaml));
+
+    await pageObjects.workflowList.navigate();
+
+    // Search by name
+    const searchField = pageObjects.workflowList.getSearchField();
+    await searchField.fill('Banana');
+    await searchField.press('Enter');
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[1].name)).toBeVisible();
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[0].name)).toBeHidden();
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[2].name)).toBeHidden();
+
+    // Search by description
+    await searchField.clear();
+    await searchField.fill('apple');
+    await searchField.press('Enter');
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[0].name)).toBeVisible();
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[2].name)).toBeVisible();
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[1].name)).toBeHidden();
+
+    // Clear search
+    await searchField.clear();
+    await searchField.press('Enter');
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[0].name)).toBeVisible();
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[1].name)).toBeVisible();
+    await expect(pageObjects.workflowList.getWorkflowRow(workflows[2].name)).toBeVisible();
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflows_list/single_actions.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflows_list/single_actions.spec.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
+import { getListTestWorkflowYaml } from '../../fixtures/workflows';
+
+test.describe('WorkflowsList/SingleActions', { tag: [...tags.stateful.classic] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
+  test.afterAll(async ({ scoutSpace, apiServices }) => {
+    await cleanupWorkflowsAndRules({ scoutSpace, apiServices });
+  });
+
+  test('should run enabled workflow', async ({ page, pageObjects, apiServices, scoutSpace }) => {
+    const enabledWorkflow = {
+      name: 'ThreeDotsTest Enabled Workflow',
+      description: 'Enabled workflow for run test',
+      enabled: true,
+    };
+    await apiServices.workflows.create(scoutSpace.id, getListTestWorkflowYaml(enabledWorkflow));
+
+    // verify run via direct action button
+    await pageObjects.workflowList.navigate();
+    await pageObjects.workflowList
+      .getWorkflowAction(enabledWorkflow.name, 'runWorkflowAction')
+      .click();
+    await pageObjects.workflowExecution.waitForExecutionView();
+    await expect(page.testSubj.locator('workflowDetailHeader')).toContainText(enabledWorkflow.name);
+
+    // verify run via three dots menu action
+    await pageObjects.workflowList.navigate();
+    const runThreeDotsAction = await pageObjects.workflowList.getThreeDotsMenuAction(
+      enabledWorkflow.name,
+      'runWorkflowAction'
+    );
+    await runThreeDotsAction.click();
+    await pageObjects.workflowExecution.waitForExecutionView();
+    await expect(page.testSubj.locator('workflowDetailHeader')).toContainText(enabledWorkflow.name);
+  });
+
+  test('should not run disabled workflow', async ({ pageObjects, apiServices, scoutSpace }) => {
+    const disabledWorkflow = {
+      name: 'ThreeDotsTest Disabled Workflow',
+      description: 'Disabled workflow for run test',
+      enabled: false,
+    };
+    await apiServices.workflows.create(scoutSpace.id, getListTestWorkflowYaml(disabledWorkflow));
+    await pageObjects.workflowList.navigate();
+
+    // verify disabled via direct action button
+    await expect(
+      pageObjects.workflowList.getWorkflowAction(disabledWorkflow.name, 'runWorkflowAction')
+    ).toBeDisabled();
+
+    // verify disabled via three dots menu action
+    const runThreeDotsAction = await pageObjects.workflowList.getThreeDotsMenuAction(
+      disabledWorkflow.name,
+      'runWorkflowAction'
+    );
+    await expect(runThreeDotsAction).toBeDisabled();
+  });
+
+  test('should enable disabled workflow via toggle', async ({
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const disabledWorkflow = {
+      name: 'Toggle Enable Workflow',
+      description: 'This workflow starts disabled and should be enabled via toggle',
+      enabled: false,
+    };
+    await apiServices.workflows.create(scoutSpace.id, getListTestWorkflowYaml(disabledWorkflow));
+    await pageObjects.workflowList.navigate();
+
+    const toggle = pageObjects.workflowList.getWorkflowStateToggle(disabledWorkflow.name);
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.click();
+    await expect(toggle).toBeChecked();
+
+    await expect(
+      pageObjects.workflowList.getWorkflowAction(disabledWorkflow.name, 'runWorkflowAction')
+    ).toBeEnabled();
+  });
+
+  test('should disable enabled workflow via toggle', async ({
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const enabledWorkflow = {
+      name: 'Toggle Disable Workflow',
+      description: 'This workflow starts enabled and should be disabled via toggle',
+      enabled: true,
+    };
+    await apiServices.workflows.create(scoutSpace.id, getListTestWorkflowYaml(enabledWorkflow));
+    await pageObjects.workflowList.navigate();
+
+    const toggle = pageObjects.workflowList.getWorkflowStateToggle(enabledWorkflow.name);
+    await expect(toggle).toBeChecked();
+
+    await toggle.click();
+    await expect(toggle).not.toBeChecked();
+
+    await expect(
+      pageObjects.workflowList.getWorkflowAction(enabledWorkflow.name, 'runWorkflowAction')
+    ).toBeDisabled();
+  });
+
+  test('should open workflow for editing via edit action', async ({
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const workflow = {
+      name: 'Edit Action Test Workflow',
+      description: 'This workflow should be opened for editing',
+      enabled: true,
+    };
+    await apiServices.workflows.create(scoutSpace.id, getListTestWorkflowYaml(workflow));
+    await pageObjects.workflowList.navigate();
+
+    // verify edit via direct action button
+    await pageObjects.workflowList.getWorkflowAction(workflow.name, 'editWorkflowAction').click();
+    await pageObjects.workflowEditor.waitForEditorView();
+
+    // verify edit via three dots menu action
+    await pageObjects.workflowList.navigate();
+    const editThreeDotsAction = await pageObjects.workflowList.getThreeDotsMenuAction(
+      workflow.name,
+      'editWorkflowAction'
+    );
+    await editThreeDotsAction.click();
+    await pageObjects.workflowEditor.waitForEditorView();
+  });
+
+  test('should clone workflow via three dots menu', async ({
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const workflow = {
+      name: 'Clone Action Test Workflow',
+      description: 'This workflow should be cloned',
+      enabled: true,
+    };
+    await apiServices.workflows.create(scoutSpace.id, getListTestWorkflowYaml(workflow));
+    await pageObjects.workflowList.navigate();
+
+    const cloneAction = await pageObjects.workflowList.getThreeDotsMenuAction(
+      workflow.name,
+      'cloneWorkflowAction'
+    );
+    await cloneAction.click();
+
+    // Verify the cloned workflow appears in the list with " Copy" suffix
+    const clonedWorkflowName = `${workflow.name} Copy`;
+    await expect(pageObjects.workflowList.getWorkflowRow(clonedWorkflowName)).toBeVisible();
+  });
+
+  test('should delete workflow via three dots menu', async ({
+    page,
+    pageObjects,
+    apiServices,
+    scoutSpace,
+  }) => {
+    const workflow = {
+      name: 'Delete Action Test Workflow',
+      description: 'This workflow should be deleted',
+      enabled: true,
+    };
+    await apiServices.workflows.create(scoutSpace.id, getListTestWorkflowYaml(workflow));
+    await pageObjects.workflowList.navigate();
+
+    // Set up dialog handler to accept the confirmation dialog
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Are you sure you want to delete');
+      await dialog.accept();
+    });
+
+    const deleteAction = await pageObjects.workflowList.getThreeDotsMenuAction(
+      workflow.name,
+      'deleteWorkflowAction'
+    );
+    await deleteAction.click();
+
+    // Verify the workflow is removed from the list
+    await expect(pageObjects.workflowList.getWorkflowRow(workflow.name)).toBeHidden();
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -75,8 +75,6 @@
     "@kbn/licensing-plugin",
     "@kbn/securitysolution-rules",
     "@kbn/alerts-as-data-utils",
-    "@kbn/shared-ux-utility",
-    "@kbn/licensing-types",
     "@kbn/core-lifecycle-server-mocks",
     "@kbn/scout"
   ],

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -8,6 +8,7 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
+    "test/**/*",
     "../../../../../typings/**/*",
     ".storybook/**/*.ts",
     ".storybook/**/*.tsx",
@@ -74,7 +75,10 @@
     "@kbn/licensing-plugin",
     "@kbn/securitysolution-rules",
     "@kbn/alerts-as-data-utils",
-    "@kbn/core-lifecycle-server-mocks"
+    "@kbn/shared-ux-utility",
+    "@kbn/licensing-types",
+    "@kbn/core-lifecycle-server-mocks",
+    "@kbn/scout"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[One Workflow] Scout tests for Workflows UI (#251413)](https://github.com/elastic/kibana/pull/251413)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kirill Chernakov","email":"yakiryous@gmail.com"},"sourceCommit":{"committedDate":"2026-02-12T18:33:54Z","message":"[One Workflow] Scout tests for Workflows UI (#251413)\n\nClose https://github.com/elastic/security-team/issues/15647\n\n## Test Coverage\n\n### ✅ Covered\n- [x] Workflow execution with foreach loops showing multiple iterations\n- Tests workflow with nested foreach loops, verifies step execution tree\nstructure with multiple iterations displayed\n- [x] Step execution scroll behavior - Tests scrollable step executions\nwith 49 iterations to ensure UI handles many step executions\n- [x] Execution overview details - Verifies execution start/end times,\ncontext display, trigger information, and status badge\n- [x] Test run (unsaved workflow) with `isTestRun: true`\n- [x] Test run (saved workflow) with `isTestRun: true`\n- [x] Production run from workflows list (disabled → enabled → run)\n- [x] Individual step run with custom context override\n- [x] Bulk actions (enable, disable, delete, clear selection)\n- [x] Filter workflows by enabled/disabled state\n- [x] Search workflows by name and description\n- [x] Single workflow actions (run, edit, clone, delete via three dots\nmenu)\n- [x] Toggle workflow enabled/disabled state\n\n### TODO\n#### High Priority\n- [ ] Scheduled workflows with short intervals (TBD if we want scout for\nthat)\n- [x] Alert-triggered workflows (single & multiple per rule)\n- [x] Alert context passed to workflows\n- [ ] Template variables (`{{consts.foo}}`,\n`{{steps.previousStep.output}}`, `{{context.var}}`)\n- [x] Basic Elasticsearch steps (search, index, delete)\n- [x] Basic Kibana steps\n- [ ] Workflow list sorting functionality\n\n#### Medium Priority\n- [ ] HTTP steps (GET, POST, PUT, DELETE)\n- [ ] Error handling scenarios (step failures, timeouts)\n- [ ] Workflow editor validation errors\n- [ ] Nested flow controls (if inside foreach)\n- [ ] Wait/delay steps\n- [ ] On-failure handlers (continue, retry, fallback)\n\n#### Low Priority (May Remain Manual)\n- [ ] Long-running scheduled workflows\n- [ ] Connector steps (Slack, PagerDuty, Jira, Email, Webhook)\n- [ ] Performance/scale tests (10+ steps, 100+ iterations)\n- [ ] RBAC & permissions testing\n- [ ] Cross-environment testing (ESS, Serverless, On-prem)\n\n---\n\n**Page objects added:**\n\n- **`WorkflowListPage`** — navigating to the workflows list, locating\nworkflow rows, toggling workflow state, selecting workflows via\ncheckboxes, performing bulk actions (enable/disable/delete), accessing\nthree-dots menu actions (run/edit/clone/delete), and\nfiltering/searching.\n\n- **`WorkflowEditorPage`** — navigating to the YAML editor (new or\nexisting workflow), setting Monaco editor values via the model API,\nsaving and running workflows, handling unsaved-changes confirmation,\nexecuting workflows with JSON inputs, interacting with the test-step\nmodal, and inspecting editor error markers.\n\n- **`WorkflowExecutionPage`** — waiting for execution view to load,\npolling for execution status (completed/failed) with fast-fail\ndiagnostics that extract the failed step's error JSON, expanding the\nexecution step tree, navigating steps by hierarchical path, and reading\nstep result JSON (input/output/error) from the details panel.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Ihor Panasiuk <igorskynet13@gmail.com>","sha":"b64991fba00ef0e0e0a1f814cf6c876dc1391fd8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:One Workflow","v9.4.0"],"title":"[One Workflow] Scout tests for Workflows UI","number":251413,"url":"https://github.com/elastic/kibana/pull/251413","mergeCommit":{"message":"[One Workflow] Scout tests for Workflows UI (#251413)\n\nClose https://github.com/elastic/security-team/issues/15647\n\n## Test Coverage\n\n### ✅ Covered\n- [x] Workflow execution with foreach loops showing multiple iterations\n- Tests workflow with nested foreach loops, verifies step execution tree\nstructure with multiple iterations displayed\n- [x] Step execution scroll behavior - Tests scrollable step executions\nwith 49 iterations to ensure UI handles many step executions\n- [x] Execution overview details - Verifies execution start/end times,\ncontext display, trigger information, and status badge\n- [x] Test run (unsaved workflow) with `isTestRun: true`\n- [x] Test run (saved workflow) with `isTestRun: true`\n- [x] Production run from workflows list (disabled → enabled → run)\n- [x] Individual step run with custom context override\n- [x] Bulk actions (enable, disable, delete, clear selection)\n- [x] Filter workflows by enabled/disabled state\n- [x] Search workflows by name and description\n- [x] Single workflow actions (run, edit, clone, delete via three dots\nmenu)\n- [x] Toggle workflow enabled/disabled state\n\n### TODO\n#### High Priority\n- [ ] Scheduled workflows with short intervals (TBD if we want scout for\nthat)\n- [x] Alert-triggered workflows (single & multiple per rule)\n- [x] Alert context passed to workflows\n- [ ] Template variables (`{{consts.foo}}`,\n`{{steps.previousStep.output}}`, `{{context.var}}`)\n- [x] Basic Elasticsearch steps (search, index, delete)\n- [x] Basic Kibana steps\n- [ ] Workflow list sorting functionality\n\n#### Medium Priority\n- [ ] HTTP steps (GET, POST, PUT, DELETE)\n- [ ] Error handling scenarios (step failures, timeouts)\n- [ ] Workflow editor validation errors\n- [ ] Nested flow controls (if inside foreach)\n- [ ] Wait/delay steps\n- [ ] On-failure handlers (continue, retry, fallback)\n\n#### Low Priority (May Remain Manual)\n- [ ] Long-running scheduled workflows\n- [ ] Connector steps (Slack, PagerDuty, Jira, Email, Webhook)\n- [ ] Performance/scale tests (10+ steps, 100+ iterations)\n- [ ] RBAC & permissions testing\n- [ ] Cross-environment testing (ESS, Serverless, On-prem)\n\n---\n\n**Page objects added:**\n\n- **`WorkflowListPage`** — navigating to the workflows list, locating\nworkflow rows, toggling workflow state, selecting workflows via\ncheckboxes, performing bulk actions (enable/disable/delete), accessing\nthree-dots menu actions (run/edit/clone/delete), and\nfiltering/searching.\n\n- **`WorkflowEditorPage`** — navigating to the YAML editor (new or\nexisting workflow), setting Monaco editor values via the model API,\nsaving and running workflows, handling unsaved-changes confirmation,\nexecuting workflows with JSON inputs, interacting with the test-step\nmodal, and inspecting editor error markers.\n\n- **`WorkflowExecutionPage`** — waiting for execution view to load,\npolling for execution status (completed/failed) with fast-fail\ndiagnostics that extract the failed step's error JSON, expanding the\nexecution step tree, navigating steps by hierarchical path, and reading\nstep result JSON (input/output/error) from the details panel.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Ihor Panasiuk <igorskynet13@gmail.com>","sha":"b64991fba00ef0e0e0a1f814cf6c876dc1391fd8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251413","number":251413,"mergeCommit":{"message":"[One Workflow] Scout tests for Workflows UI (#251413)\n\nClose https://github.com/elastic/security-team/issues/15647\n\n## Test Coverage\n\n### ✅ Covered\n- [x] Workflow execution with foreach loops showing multiple iterations\n- Tests workflow with nested foreach loops, verifies step execution tree\nstructure with multiple iterations displayed\n- [x] Step execution scroll behavior - Tests scrollable step executions\nwith 49 iterations to ensure UI handles many step executions\n- [x] Execution overview details - Verifies execution start/end times,\ncontext display, trigger information, and status badge\n- [x] Test run (unsaved workflow) with `isTestRun: true`\n- [x] Test run (saved workflow) with `isTestRun: true`\n- [x] Production run from workflows list (disabled → enabled → run)\n- [x] Individual step run with custom context override\n- [x] Bulk actions (enable, disable, delete, clear selection)\n- [x] Filter workflows by enabled/disabled state\n- [x] Search workflows by name and description\n- [x] Single workflow actions (run, edit, clone, delete via three dots\nmenu)\n- [x] Toggle workflow enabled/disabled state\n\n### TODO\n#### High Priority\n- [ ] Scheduled workflows with short intervals (TBD if we want scout for\nthat)\n- [x] Alert-triggered workflows (single & multiple per rule)\n- [x] Alert context passed to workflows\n- [ ] Template variables (`{{consts.foo}}`,\n`{{steps.previousStep.output}}`, `{{context.var}}`)\n- [x] Basic Elasticsearch steps (search, index, delete)\n- [x] Basic Kibana steps\n- [ ] Workflow list sorting functionality\n\n#### Medium Priority\n- [ ] HTTP steps (GET, POST, PUT, DELETE)\n- [ ] Error handling scenarios (step failures, timeouts)\n- [ ] Workflow editor validation errors\n- [ ] Nested flow controls (if inside foreach)\n- [ ] Wait/delay steps\n- [ ] On-failure handlers (continue, retry, fallback)\n\n#### Low Priority (May Remain Manual)\n- [ ] Long-running scheduled workflows\n- [ ] Connector steps (Slack, PagerDuty, Jira, Email, Webhook)\n- [ ] Performance/scale tests (10+ steps, 100+ iterations)\n- [ ] RBAC & permissions testing\n- [ ] Cross-environment testing (ESS, Serverless, On-prem)\n\n---\n\n**Page objects added:**\n\n- **`WorkflowListPage`** — navigating to the workflows list, locating\nworkflow rows, toggling workflow state, selecting workflows via\ncheckboxes, performing bulk actions (enable/disable/delete), accessing\nthree-dots menu actions (run/edit/clone/delete), and\nfiltering/searching.\n\n- **`WorkflowEditorPage`** — navigating to the YAML editor (new or\nexisting workflow), setting Monaco editor values via the model API,\nsaving and running workflows, handling unsaved-changes confirmation,\nexecuting workflows with JSON inputs, interacting with the test-step\nmodal, and inspecting editor error markers.\n\n- **`WorkflowExecutionPage`** — waiting for execution view to load,\npolling for execution status (completed/failed) with fast-fail\ndiagnostics that extract the failed step's error JSON, expanding the\nexecution step tree, navigating steps by hierarchical path, and reading\nstep result JSON (input/output/error) from the details panel.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Ihor Panasiuk <igorskynet13@gmail.com>","sha":"b64991fba00ef0e0e0a1f814cf6c876dc1391fd8"}}]}] BACKPORT-->