### PR TITLE
[Streams] Add client-side field name validation for wired streams

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -39,7 +39,9 @@ export {
 export {
   keepFields,
   namespacePrefixes,
+  otelReservedFields,
   isNamespacedEcsField,
+  isOtelReservedField,
   getRegularEcsField,
 } from './src/helpers/namespaced_ecs';
 export { getAdvancedParameters } from './src/helpers/get_advanced_parameters';

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/namespaced_ecs.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/namespaced_ecs.ts
@@ -11,6 +11,22 @@ import { KEEP_FIELDS, NAMESPACE_PREFIXES } from '@kbn/streamlang';
 export const keepFields: readonly string[] = KEEP_FIELDS;
 export const namespacePrefixes: readonly string[] = NAMESPACE_PREFIXES;
 
+/**
+ * Field names that are reserved for OTel compatibility mode.
+ * These are either passthrough objects or alias fields that cannot be used as custom field names.
+ * See logs_layer.ts baseMappings for the server-side definition.
+ */
+export const otelReservedFields = [
+  'body',
+  'attributes',
+  'scope',
+  'resource',
+  'span.id',
+  'message',
+  'trace.id',
+  'log.level',
+] as const;
+
 export const aliases: Record<string, string> = {
   trace_id: 'trace.id',
   span_id: 'span.id',
@@ -37,4 +53,12 @@ export function isNamespacedEcsField(field: string): boolean {
     NAMESPACE_PREFIXES.some((prefix) => field.startsWith(prefix)) ||
     KEEP_FIELDS.includes(field as any)
   );
+}
+
+/**
+ * Checks if a field name is reserved for OTel compatibility mode.
+ * Reserved fields are either passthrough objects or alias fields that cannot be redefined.
+ */
+export function isOtelReservedField(field: string): boolean {
+  return otelReservedFields.includes(field as (typeof otelReservedFields)[number]);
 }

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/namespaced_ecs.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/namespaced_ecs.ts
@@ -14,7 +14,8 @@ export const namespacePrefixes: readonly string[] = NAMESPACE_PREFIXES;
 /**
  * Field names that are reserved for OTel compatibility mode.
  * These are either passthrough objects or alias fields that cannot be used as custom field names.
- * See logs_layer.ts baseMappings for the server-side definition.
+ * IMPORTANT: This list must match the keys of baseMappings in logs_layer.ts.
+ * A test in logs_layer.test.ts ensures these stay in sync.
  */
 export const otelReservedFields = [
   'body',

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/component_templates/logs_layer.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/component_templates/logs_layer.test.ts
@@ -6,9 +6,18 @@
  */
 
 import type { InheritedFieldDefinition, Streams } from '@kbn/streams-schema';
+import { otelReservedFields } from '@kbn/streams-schema';
 import { addAliasesForNamespacedFields, baseMappings, baseFields } from './logs_layer';
 
 describe('logs_layer', () => {
+  describe('baseMappings and otelReservedFields sync', () => {
+    it('should have baseMappings keys match otelReservedFields', () => {
+      const baseMappingsKeys = Object.keys(baseMappings).sort();
+      const reservedFieldsSorted = [...otelReservedFields].sort();
+
+      expect(baseMappingsKeys).toEqual(reservedFieldsSorted);
+    });
+  });
   describe('addAliasesForNamespacedFields', () => {
     let mockStreamDefinition: Streams.WiredStream.Definition;
     let mockInheritedFields: InheritedFieldDefinition;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.test.tsx
@@ -295,4 +295,46 @@ describe('AddFieldFlyout', () => {
       });
     });
   });
+
+  describe('Add field button state', () => {
+    it('disables the Add field button when field name validation fails', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'invalid_field');
+
+      await waitFor(() => {
+        const addFieldButton = screen.getByTestId('streamsAppSchemaEditorAddFieldButton');
+        expect(addFieldButton).toBeDisabled();
+      });
+    });
+
+    it('disables the Add field button when field name is valid but type is not selected', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'attributes.custom_field');
+
+      await waitFor(() => {
+        const addFieldButton = screen.getByTestId('streamsAppSchemaEditorAddFieldButton');
+        expect(addFieldButton).toBeDisabled();
+      });
+    });
+
+    it('enables the Add field button when all required fields are valid', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'attributes.custom_field');
+      const typeSelect = screen.getByTestId('streamsAppFieldFormTypeSelect');
+      await user.click(typeSelect);
+      const keywordOption = screen.getByTestId('option-type-keyword');
+      await user.click(keywordOption);
+
+      await waitFor(() => {
+        const addFieldButton = screen.getByTestId('streamsAppSchemaEditorAddFieldButton');
+        expect(addFieldButton).not.toBeDisabled();
+      });
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.test.tsx
@@ -1,0 +1,298 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '@kbn/i18n-react';
+import { AddFieldFlyout } from './add_field_flyout';
+import {
+  createMockClassicStreamDefinition,
+  createMockWiredStreamDefinition,
+} from '../../shared/mocks';
+import { SchemaEditorContextProvider } from '../schema_editor_context';
+
+jest.mock('../../../../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    core: {
+      docLinks: {
+        links: {
+          elasticsearch: {
+            mappingParameters: 'https://elastic.co/docs/mapping-parameters',
+          },
+        },
+      },
+    },
+    dependencies: {
+      start: {
+        streams: {
+          streamsRepositoryClient: {
+            fetch: jest.fn(),
+          },
+        },
+        fieldsMetadata: {
+          useFieldsMetadata: () => ({
+            fieldsMetadata: {},
+            loading: false,
+          }),
+        },
+      },
+    },
+  }),
+}));
+
+jest.mock('../../../../hooks/use_streams_app_router', () => ({
+  useStreamsAppRouter: () => ({
+    link: jest.fn(() => '/mock-link'),
+  }),
+}));
+
+jest.mock('@kbn/code-editor', () => ({
+  CodeEditor: () => <div data-testid="mock-code-editor">CodeEditor</div>,
+}));
+
+const renderAddFieldFlyout = (
+  streamType: 'wired' | 'classic',
+  existingFieldNames: string[] = []
+) => {
+  const definition =
+    streamType === 'wired'
+      ? createMockWiredStreamDefinition()
+      : createMockClassicStreamDefinition();
+
+  const fields = existingFieldNames.map((name) => ({
+    name,
+    type: 'keyword' as const,
+    parent: definition.stream.name,
+    status: 'mapped' as const,
+  }));
+
+  const onClose = jest.fn();
+  const onAddField = jest.fn();
+
+  return {
+    onClose,
+    onAddField,
+    ...render(
+      <I18nProvider>
+        <SchemaEditorContextProvider
+          stream={definition.stream}
+          fields={fields}
+          isLoading={false}
+          withFieldSimulation={false}
+          onFieldUpdate={jest.fn()}
+          onFieldSelection={jest.fn()}
+          fieldSelection={[]}
+        >
+          <AddFieldFlyout onClose={onClose} onAddField={onAddField} />
+        </SchemaEditorContextProvider>
+      </I18nProvider>
+    ),
+  };
+};
+
+const typeFieldName = async (user: ReturnType<typeof userEvent.setup>, fieldName: string) => {
+  const comboBox = screen.getByTestId('streamsAppSchemaEditorAddFieldFlyoutFieldName');
+  const input = comboBox.querySelector('input');
+  if (!input) throw new Error('Could not find input element');
+  await user.clear(input);
+  await user.type(input, fieldName);
+  await user.keyboard('{Enter}');
+};
+
+const getFieldNameError = () => {
+  const formRow = screen
+    .getByTestId('streamsAppSchemaEditorAddFieldFlyoutFieldName')
+    .closest('.euiFormRow');
+  return formRow?.querySelector('.euiFormErrorText')?.textContent ?? null;
+};
+
+describe('AddFieldFlyout', () => {
+  describe('Field name validation for wired streams', () => {
+    it('shows error for non-namespaced field names', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'invalid_field');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toContain(
+          "Field invalid_field is not allowed to be defined as it doesn't match the namespaced ECS or OTel schema"
+        );
+      });
+    });
+
+    it('shows error for OTel reserved field names that are also not namespaced (message)', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      // `message` is not in keepFields and doesn't start with namespace prefix,
+      // so it fails the namespacing check first (matching server-side behavior)
+      await typeFieldName(user, 'message');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toContain("doesn't match the namespaced ECS or OTel schema");
+      });
+    });
+
+    it('shows error for OTel reserved fields that are also not namespaced (trace.id)', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      // `trace.id` is not in keepFields and doesn't start with namespace prefix,
+      // so it fails the namespacing check first
+      await typeFieldName(user, 'trace.id');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toContain("doesn't match the namespaced ECS or OTel schema");
+      });
+    });
+
+    it('shows error for body passthrough object (which is in keepFields)', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      // `body` IS in keepFields, so it passes the namespacing check,
+      // but then fails the OTel reserved check
+      await typeFieldName(user, 'body');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toContain('automatic alias');
+      });
+    });
+
+    it('shows error for attributes passthrough object (not in keepFields)', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      // `attributes` is not in keepFields and doesn't start with namespace prefix,
+      // so it fails the namespacing check first
+      await typeFieldName(user, 'attributes');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toContain("doesn't match the namespaced ECS or OTel schema");
+      });
+    });
+
+    it('allows namespaced field names with attributes prefix', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'attributes.custom_field');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toBeNull();
+      });
+    });
+
+    it('allows namespaced field names with body.structured prefix', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'body.structured.data');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toBeNull();
+      });
+    });
+
+    it('allows namespaced field names with resource.attributes prefix', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'resource.attributes.host.name');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toBeNull();
+      });
+    });
+
+    it('allows keepFields like @timestamp', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, '@timestamp');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toBeNull();
+      });
+    });
+
+    it('allows keepFields like trace_id', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired');
+
+      await typeFieldName(user, 'trace_id');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toBeNull();
+      });
+    });
+  });
+
+  describe('Field name validation for classic streams', () => {
+    it('allows non-namespaced field names', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('classic');
+
+      await typeFieldName(user, 'custom_field');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toBeNull();
+      });
+    });
+
+    it('allows OTel reserved field names', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('classic');
+
+      await typeFieldName(user, 'message');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toBeNull();
+      });
+    });
+  });
+
+  describe('Common validation for all stream types', () => {
+    it('shows error for duplicate field names in wired streams', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('wired', ['attributes.existing_field']);
+
+      await typeFieldName(user, 'attributes.existing_field');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toContain('A field with this name already exists');
+      });
+    });
+
+    it('shows error for duplicate field names in classic streams', async () => {
+      const user = userEvent.setup();
+      renderAddFieldFlyout('classic', ['existing_field']);
+
+      await typeFieldName(user, 'existing_field');
+
+      await waitFor(() => {
+        const error = getFieldNameError();
+        expect(error).toContain('A field with this name already exists');
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.tsx
@@ -131,7 +131,7 @@ export const AddFieldFlyout = ({ onAddField, onClose }: AddFieldFlyoutProps) => 
           <EuiButton
             data-test-subj="streamsAppSchemaEditorAddFieldButton"
             onClick={methods.handleSubmit(handleSubmit)}
-            isDisabled={methods.formState.isSubmitted && !methods.formState.isValid}
+            isDisabled={!methods.formState.isValid}
           >
             {i18n.translate('xpack.streams.schemaEditor.addFieldFlyout.addButtonLabel', {
               defaultMessage: 'Add field',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/add_field_flyout.tsx
@@ -23,7 +23,13 @@ import {
 } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
-import { isSchema, recursiveRecord, Streams } from '@kbn/streams-schema';
+import {
+  isSchema,
+  recursiveRecord,
+  Streams,
+  isNamespacedEcsField,
+  isOtelReservedField,
+} from '@kbn/streams-schema';
 import type { SubmitHandler } from 'react-hook-form';
 import { FormProvider, useController, useForm, useFormContext, useWatch } from 'react-hook-form';
 import { CodeEditor } from '@kbn/code-editor';
@@ -149,6 +155,8 @@ export const FieldNameSelector = () => {
     source: ['ecs', 'otel'],
   });
 
+  const isWiredStream = Streams.WiredStream.Definition.is(stream);
+
   const { field, fieldState } = useController<SchemaField, 'name'>({
     name: 'name',
     rules: {
@@ -161,6 +169,28 @@ export const FieldNameSelector = () => {
             'xpack.streams.schemaEditor.addFieldFlyout.fieldNameAlreadyExistsError',
             { defaultMessage: 'A field with this name already exists.' }
           );
+        }
+        if (isWiredStream) {
+          if (!isNamespacedEcsField(name)) {
+            return i18n.translate(
+              'xpack.streams.schemaEditor.addFieldFlyout.fieldNameNotNamespacedError',
+              {
+                defaultMessage:
+                  "Field {fieldName} is not allowed to be defined as it doesn't match the namespaced ECS or OTel schema.",
+                values: { fieldName: name },
+              }
+            );
+          }
+          if (isOtelReservedField(name)) {
+            return i18n.translate(
+              'xpack.streams.schemaEditor.addFieldFlyout.fieldNameOtelReservedError',
+              {
+                defaultMessage:
+                  'Field {fieldName} is an automatic alias of another field because of OTel compatibility mode.',
+                values: { fieldName: name },
+              }
+            );
+          }
         }
         return true;
       },

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/wired_streams_schema.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/wired_streams_schema.spec.ts
@@ -190,5 +190,59 @@ test.describe(
         value: `Alias for ${ecsFieldName}`,
       });
     });
+
+    test('validates field names for wired streams', async ({ page, pageObjects }) => {
+      await pageObjects.streams.expectSchemaEditorTableVisible();
+
+      // Open the "Add field" flyout
+      await page.getByTestId('streamsAppContentAddFieldButton').click();
+      await expect(
+        page.getByTestId('streamsAppSchemaEditorAddFieldFlyoutCloseButton')
+      ).toBeVisible();
+
+      // Try to add a non-namespaced field - should show error
+      const invalidFieldName = 'invalid_field';
+      await pageObjects.streams.typeFieldName(invalidFieldName);
+
+      // Check that an error is displayed
+      const formRow = page
+        .getByTestId('streamsAppSchemaEditorAddFieldFlyoutFieldName')
+        .locator('..');
+      await expect(formRow.locator('.euiFormErrorText')).toContainText(
+        "doesn't match the namespaced ECS or OTel schema"
+      );
+
+      // Check that the Add button is disabled when there's a validation error
+      const addButton = page.getByTestId('streamsAppSchemaEditorAddFieldButton');
+      await addButton.click();
+      // Flyout should still be open because the form is invalid
+      await expect(
+        page.getByTestId('streamsAppSchemaEditorAddFieldFlyoutCloseButton')
+      ).toBeVisible();
+
+      // Clear and try with a valid namespaced field
+      const clearButton = page.getByTestId('comboBoxClearButton');
+      await clearButton.click();
+
+      const validFieldName = 'attributes.valid_field';
+      await pageObjects.streams.typeFieldName(validFieldName);
+
+      // Error should be gone
+      await expect(formRow.locator('.euiFormErrorText')).toBeHidden();
+
+      // Set field type and verify Add button works
+      await pageObjects.streams.setFieldMappingType('keyword');
+      await addButton.click();
+      await expect(
+        page.getByTestId('streamsAppSchemaEditorAddFieldFlyoutCloseButton')
+      ).toBeHidden();
+
+      // Verify the field was staged (visible in review)
+      await pageObjects.streams.reviewStagedFieldMappingChanges();
+      await expect(page.getByText(validFieldName)).toBeVisible();
+
+      // Close the modal to clean up
+      await pageObjects.streams.closeSchemaReviewModal();
+    });
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/wired_streams_schema.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping/wired_streams_schema.spec.ts
@@ -214,11 +214,7 @@ test.describe(
 
       // Check that the Add button is disabled when there's a validation error
       const addButton = page.getByTestId('streamsAppSchemaEditorAddFieldButton');
-      await addButton.click();
-      // Flyout should still be open because the form is invalid
-      await expect(
-        page.getByTestId('streamsAppSchemaEditorAddFieldFlyoutCloseButton')
-      ).toBeVisible();
+      await expect(addButton).toBeDisabled();
 
       // Clear and try with a valid namespaced field
       const clearButton = page.getByTestId('comboBoxClearButton');


### PR DESCRIPTION
## Summary

<img width="506" height="455" alt="Screenshot 2026-02-20 at 15 09 48" src="https://github.com/user-attachments/assets/de92629d-2a10-4740-9fd6-bf762bc89b39" />

<img width="495" height="533" alt="Screenshot 2026-02-20 at 15 10 05" src="https://github.com/user-attachments/assets/80250f57-e131-4639-a195-2f09345f803a" />

Adds client-side validation to the "Add field" flyout in the streams schema editor for wired streams, matching the server-side validation behavior:

- Field names must be namespaced (start with `attributes.`, `body.structured.`, `scope.attributes.`, or `resource.attributes.`) OR be in the keepFields list
- Field names cannot be OTel reserved fields (`body`, `attributes`, `scope`, `resource`, `span.id`, `message`, `trace.id`, `log.level`)

This provides immediate feedback to users when entering invalid field names, rather than waiting for a server error.

### Changes

- Export `otelReservedFields` and `isOtelReservedField` from `@kbn/streams-schema`
- Add validation rules to `FieldNameSelector` in `add_field_flyout.tsx`
- Add unit tests for validation behavior (14 tests)
- Add Scout UI integration test for field name validation

## Test plan

- [ ] Open streams schema editor for a wired stream
- [ ] Click "Add field"
- [ ] Enter a non-namespaced field like `foo` - should show error about namespaced ECS/OTel schema
- [ ] Enter `body` - should show error about OTel reserved field
- [ ] Enter `attributes.foo` - should be accepted (valid namespace)
- [ ] Verify classic streams do not have these restrictions

Closes: https://github.com/elastic/streams-program/issues/472

Made with [Cursor](https://cursor.com)