### PR TITLE
[Streams] Fix useTaskPolling call to use named parameters

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/streams_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/streams_view.tsx
@@ -95,7 +95,11 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
   const [{ value: insightsTask }, getInsightsTaskStatus] = useAsyncFn(
     getInsightsDiscoveryTaskStatus
   );
-  useTaskPolling(insightsTask, getInsightsDiscoveryTaskStatus, getInsightsTaskStatus);
+  useTaskPolling({
+    task: insightsTask,
+    onPoll: getInsightsDiscoveryTaskStatus,
+    onRefresh: getInsightsTaskStatus,
+  });
 
   const [{ loading: isSchedulingInsights }, scheduleInsightsTask] = useAsyncFn(async () => {
     const streamNames =


### PR DESCRIPTION
## Summary

The useTaskPolling hook was refactored from positional arguments to a single object parameter in #253637, but the call in streams_view.tsx was missed, causing type errors in on-merge builds.
