### PR TITLE
[9.2] [scout] add globalSetupTimeout to control global hook time (#252325)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
@@ -116,8 +116,9 @@ describe('createPlaywrightConfig', () => {
     expect(config.projects![2].name).toEqual('mki');
   });
 
-  it('should add global.setup.ts as pre-step when runGlobalSetup is true', () => {
+  it('should add global.setup.ts as pre-step when runGlobalSetup is true and apply default timeout', () => {
     const testDir = './my_tests';
+    const defaultGlobalSetupTimeout = 180000;
 
     const config = createPlaywrightConfig({ testDir, runGlobalSetup: true });
     expect(config.workers).toBe(1);
@@ -125,14 +126,20 @@ describe('createPlaywrightConfig', () => {
     expect(config.projects).toHaveLength(6);
     expect(config.projects![0].name).toEqual('setup-local');
     expect(config.projects![0].testMatch).toEqual(/global.setup\.ts/);
+    expect(config.projects![0].timeout).toBe(defaultGlobalSetupTimeout);
     expect(config.projects![1].name).toEqual('local');
     expect(config.projects![1]).toHaveProperty('dependencies', ['setup-local']);
+    expect(config.projects![1]).not.toHaveProperty('timeout');
     expect(config.projects![2].name).toEqual('setup-ech');
+    expect(config.projects![2].timeout).toBe(defaultGlobalSetupTimeout);
     expect(config.projects![3].name).toEqual('ech');
     expect(config.projects![3]).toHaveProperty('dependencies', ['setup-ech']);
+    expect(config.projects![3]).not.toHaveProperty('timeout');
     expect(config.projects![4].name).toEqual('setup-mki');
+    expect(config.projects![4].timeout).toBe(defaultGlobalSetupTimeout);
     expect(config.projects![5].name).toEqual('mki');
     expect(config.projects![5]).toHaveProperty('dependencies', ['setup-mki']);
+    expect(config.projects![5]).not.toHaveProperty('timeout');
   });
 
   it('should generate and cache runId in process.env.TEST_RUN_ID', () => {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -58,6 +58,7 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
           name: `setup-${project?.name}`,
           use: project?.use ? { ...project.use } : {},
           testMatch: /global.setup\.ts/,
+          timeout: 180000, // Default to 3 minutes for global setup
         },
         { ...project, dependencies: [`setup-${project?.name}`] },
       ])


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[scout] add globalSetupTimeout to control global hook time (#252325)](https://github.com/elastic/kibana/pull/252325)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-02-09T23:23:13Z","message":"[scout] add globalSetupTimeout to control global hook time (#252325)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/685\n\nAdding new prop to control timeout for `globalSetup` hook:\n- default to 3 min\n- ~~override in Scout playwright config with `globalSetupTimeout:\nnumber`~~ We decided not to expose it for now","sha":"371044e9eb307bf6ef4e1db327b5ba446a586b9c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","test:scout","v9.4.0","Team:obs-presentation"],"title":"[scout] add globalSetupTimeout to control global hook time","number":252325,"url":"https://github.com/elastic/kibana/pull/252325","mergeCommit":{"message":"[scout] add globalSetupTimeout to control global hook time (#252325)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/685\n\nAdding new prop to control timeout for `globalSetup` hook:\n- default to 3 min\n- ~~override in Scout playwright config with `globalSetupTimeout:\nnumber`~~ We decided not to expose it for now","sha":"371044e9eb307bf6ef4e1db327b5ba446a586b9c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252325","number":252325,"mergeCommit":{"message":"[scout] add globalSetupTimeout to control global hook time (#252325)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/685\n\nAdding new prop to control timeout for `globalSetup` hook:\n- default to 3 min\n- ~~override in Scout playwright config with `globalSetupTimeout:\nnumber`~~ We decided not to expose it for now","sha":"371044e9eb307bf6ef4e1db327b5ba446a586b9c"}},{"url":"https://github.com/elastic/kibana/pull/254187","number":254187,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->