### PR TITLE
[Scout] Visual improvements to Run Scout tests guide

### DIFF
--- a/docs/extend/scout/run-tests.md
+++ b/docs/extend/scout/run-tests.md
@@ -10,9 +10,13 @@ The commands below work the same way for both UI and API tests.
 
 ## Local runs [scout-run-tests-local]
 
-Scout requires Kibana and Elasticsearch to be running before running tests against a local deployment.
+Scout requires Kibana and Elasticsearch to be running before running tests against a **local deployment**.
 
-### Start servers [scout-start-servers]
+::::::{stepper}
+
+:::::{step} Start servers once
+
+Start the Kibana and Elasticsearch servers once:
 
 ```bash
 node scripts/scout.js start-server \
@@ -20,7 +24,11 @@ node scripts/scout.js start-server \
   --domain <classic|search|observability_complete|observability_logs_essentials|security_complete|security_essentials|security_ease|workplaceai>
 ```
 
-### Run tests with Playwright [scout-run-tests-playwright]
+:::::
+
+:::::{step} Run tests as often as you'd like (in a separate terminal)
+
+And then run tests how often you'd like against the same test servers:
 
 ```bash
 npx playwright test --config <plugin-path>/test/scout/ui/playwright.config.ts \
@@ -29,9 +37,14 @@ npx playwright test --config <plugin-path>/test/scout/ui/playwright.config.ts \
 ```
 
 - Use `--project local` to target your locally running Kibana/Elasticsearch processes.
-- Use `--grep` to filter by tag (for example `@local-stateful-classic`, `@cloud-serverless-search`). If you omit `--grep`, Playwright will run all suites in the config, including ones that may not be compatible with your target.
+- Use `--grep` to filter by tag (for example `@local-stateful-classic`). If you omit `--grep`, Playwright will run all suites in the config, including ones that may not be compatible with your target.
 
-### One command: start servers + run tests [scout-run-tests-cli]
+We recommend checking out Playwright's [**UI mode**](./debugging.md#playwright-ui-mode) (use `--ui`).
+
+:::::
+::::::::
+
+### Alternative: one command to start servers + run tests [scout-run-tests-cli]
 
 ```bash
 node scripts/scout.js run-tests \
@@ -66,9 +79,33 @@ node scripts/scout.js run-tests \
 All `--testFiles` paths must fall under the same Scout root (for example, `scout/ui/tests` vs `scout/ui/parallel_tests`) so Scout can discover the right config.
 :::::::
 
-## Elastic Cloud runs [scout-run-tests-cloud]
+## Run tests on Elastic Cloud [scout-run-tests-cloud]
 
-To run on ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg 'Supported on Elastic Cloud Hosted') Elastic Cloud you must provide a server config under `.scout/servers/`.
+Follow these steps to run your Scout tests on a real ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg 'Supported on Elastic Cloud Hosted') **Elastic Cloud project or deployment**.
+
+::::::{tip}
+**QAF** (internal, Elasticians-only tool) provides a `qaf kibana scout run-config` command to help you run Scout tests using a QAF-registered project or deployment. Great for CI workflows, but also works locally. Check out [Run Scout tests with QAF](https://docs.elastic.dev/appex-qa/qaf/guides/run-scout-tests-with-qaf) (Elasticians only).
+::::::
+
+::::::{stepper}
+
+:::::{step} Create Elastic Cloud users
+
+Follow our [internal guide to provision internal users](https://docs.elastic.dev/appex-qa/create-cloud-users) (Elasticians only) to then populate the `<kibana-root>/.ftr/role_users.json` file.
+
+:::::
+
+:::::{step} Create Elastic Cloud project or deployment
+
+Use the Elastic Cloud UI or [create them with QAF](https://docs.elastic.dev/appex-qa/kibana-cloud-testing#create-an-elastic-cloud-deployment-or-project) (internal guide, Elasticians only).
+
+:::::
+
+:::::{step} Tell Scout about your new project or deployment and run tests
+
+Create and fill out the relevant file in `<kibana-root>/.scout/servers`: `cloud_ech.json` for ECH deployments and `cloud_mki.json` for MKI projects.
+
+Follow the instructions below:
 
 :::::{tab-set}
 
@@ -96,7 +133,7 @@ Open `<KIBANA_ROOT>/.scout/servers/cloud_ech.json`:
 - `cloudHostName`: the Cloud environment hostname (for example `console.qa.cld.elstc.co` or `cloud.elastic.co`)
 - `cloudUsersFilePath`: credentials for Cloud role users (often `<KIBANA_ROOT>/.ftr/role_users.json`)
 
-Run tests with `--project ech`:
+#### Run tests with `--project ech`:
 
 ```bash
 npx playwright test --config <plugin-path>/test/scout/ui/playwright.config.ts \
@@ -105,6 +142,16 @@ npx playwright test --config <plugin-path>/test/scout/ui/playwright.config.ts \
 ```
 
 Example `--grep` values: `@cloud-stateful-classic`, `@cloud-stateful-search`.
+
+Alternatively, run tests with the **Scout CLI**:
+
+```bash
+node scripts/scout.js run-tests \
+  --arch stateful \
+  --domain <classic|search|observability_complete|security_complete> \
+  --location cloud \
+  --config <plugin-path>/test/scout/ui/playwright.config.ts
+```
 
 ::::
 
@@ -134,12 +181,22 @@ Open `<KIBANA_ROOT>/.scout/servers/cloud_mki.json`:
 - `cloudHostName`: the Cloud environment hostname (for example `console.qa.cld.elstc.co` or `cloud.elastic.co`)
 - More information on how to get the `<operator_password>` in the info box below
 
-Run tests with `--project mki`:
+#### Run tests with `--project mki`:
 
 ```bash
 npx playwright test --config <plugin-path>/test/scout/ui/playwright.config.ts \
   --project mki \
   --grep @cloud-serverless-<domain>
+```
+
+Alternatively, run tests with the **Scout CLI**:
+
+```bash
+node scripts/scout.js run-tests \
+  --arch serverless \
+  --domain <search|observability_complete|observability_logs_essentials|security_complete|security_essentials|security_ease|workplaceai> \
+  --location cloud \
+  --config <plugin-path>/test/scout/ui/playwright.config.ts
 ```
 
 :::::::{note}
@@ -156,48 +213,11 @@ curl -XPOST \
 - `API_KEY`: create in the Elastic Cloud UI (Organization → API keys)
 - `CLOUD_ENV_URL`: base URL of your Cloud environment (for example `https://console.qa.cld.elstc.co`)
 - `PROJECT_ID`: serverless project ID from the Cloud UI
-  :::::::
 
-::::
-
-:::::
-
-Example `--grep` values: `@cloud-serverless-search`, `@cloud-serverless-observability_complete`, `@cloud-serverless-security_ease`.
-
-:::::::{note}
-Internal (Elasticians): provisioning Cloud users/roles and populating `<kibana root>/.ftr/role_users.json` is internal-only; see [internal AppEx QA documentation](https://docs.elastic.dev/appex-qa/create-cloud-users).
 :::::::
 
-### Run on Cloud with the Scout CLI [scout-run-tests-cloud-cli]
-
-:::::{tab-set}
-
-::::{tab-item} ECH (stateful)
-
-```bash
-node scripts/scout.js run-tests \
-  --arch stateful \
-  --domain <classic|search|observability_complete|security_complete> \
-  --location cloud \
-  --config <plugin-path>/test/scout/ui/playwright.config.ts
-```
-
-::::
-
-::::{tab-item} MKI (serverless)
-
-```bash
-node scripts/scout.js run-tests \
-  --arch serverless \
-  --domain <search|observability_complete|observability_logs_essentials|security_complete|security_essentials|security_ease|workplaceai> \
-  --location cloud \
-  --config <plugin-path>/test/scout/ui/playwright.config.ts
-```
-
 ::::
 
 :::::
 
-## Run Scout tests with QAF (internal) [scout-run-tests-qaf]
-
-QAF is an internal tool for Elasticians only. To run Scout tests with QAF, refer to [internal AppEx QA documentation](https://docs.elastic.dev/appex-qa/qaf/guides/run-scout-tests-with-qaf).
+:::::


### PR DESCRIPTION
This updates updates the [Run Scout tests](https://www.elastic.co/docs/extend/kibana/scout/run-tests) docs to simplify and visually organize Run Scout tests instructions.

## Elastic Cloud runs: before vs after

We introduce an elegant 3-step workflow that visually guides the reader through what admittedly is an involved process.

| Before | After |
| --- | --- |
| <img alt="CleanShot 2026-02-20 at 15 33 58@2x" src="https://github.com/user-attachments/assets/c2cd6ce3-1aec-4cd8-8bd8-24a639795d58" width="520" /> | <img alt="CleanShot 2026-02-20 at 15 33 29@2x" src="https://github.com/user-attachments/assets/c92e3256-2d77-4ebd-a596-b8c2134c1ddf" width="520" /> |

## Local runs: before vs after

Notice the new visual 2-step workflow:

| Before | After |
| --- | --- |
| <img alt="CleanShot 2026-02-20 at 15 31 55@2x" src="https://github.com/user-attachments/assets/bef1530f-9f7f-4f9a-ae23-69403bb3ebe2" width="520" /> | <img alt="CleanShot 2026-02-20 at 15 31 06@2x" src="https://github.com/user-attachments/assets/253f1098-7e39-4b03-9691-7732856e2d87" width="520" /> |
