### PR TITLE
[9.2] [APM] Support ECS formatted errors in service details (#254138)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
@@ -123,6 +123,7 @@ export const ERROR_EXC_TYPE = 'error.exception.type';
 export const ERROR_PAGE_URL = 'error.page.url';
 export const ERROR_STACK_TRACE = 'error.stack_trace';
 export const ERROR_TYPE = 'error.type';
+export const ERROR_CODE = 'error.code';
 
 // METRICS
 export const METRIC_SYSTEM_FREE_MEMORY = 'system.memory.actual.free';

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/common.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/common.ts
@@ -5,6 +5,4 @@
  * 2.0.
  */
 
-export * from './src/es_fields/apm';
-export * from './src/es_fields/otel';
-export * from './src/es_fields/common';
+export const ERROR_MESSAGE = 'error.message';

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/otel.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/otel.ts
@@ -7,7 +7,6 @@
 
 export const STATUS_CODE = 'status.code';
 export const OTEL_EVENT_NAME = 'event_name';
-export const ERROR_MESSAGE = 'error.message';
 export const EXCEPTION_TYPE = 'exception.type';
 export const EXCEPTION_MESSAGE = 'exception.message';
 export const DURATION = 'duration';

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts
@@ -61,6 +61,9 @@ export interface ErrorRaw extends APMBaseDoc {
     log?: Log;
     stack_trace?: string;
     custom?: Record<string, unknown>;
+    message?: string;
+    code?: string;
+    type?: string;
   };
 
   // Shared by errors and transactions

--- a/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
@@ -71,6 +71,8 @@ exports[`Error DURATION 1`] = `undefined`;
 
 exports[`Error ELASTIC_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
 
+exports[`Error ERROR_CODE 1`] = `undefined`;
+
 exports[`Error ERROR_CULPRIT 1`] = `"handleOopsie"`;
 
 exports[`Error ERROR_EXC_HANDLED 1`] = `undefined`;
@@ -489,6 +491,8 @@ exports[`Span DURATION 1`] = `undefined`;
 
 exports[`Span ELASTIC_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
 
+exports[`Span ERROR_CODE 1`] = `undefined`;
+
 exports[`Span ERROR_CULPRIT 1`] = `undefined`;
 
 exports[`Span ERROR_EXC_HANDLED 1`] = `undefined`;
@@ -893,6 +897,8 @@ exports[`Transaction DEVICE_MODEL_IDENTIFIER 1`] = `undefined`;
 exports[`Transaction DURATION 1`] = `undefined`;
 
 exports[`Transaction ELASTIC_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
+
+exports[`Transaction ERROR_CODE 1`] = `undefined`;
 
 exports[`Transaction ERROR_CULPRIT 1`] = `undefined`;
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -243,7 +243,7 @@ export function ErrorSampleDetails({
                     },
                   })}
                 >
-                  <EuiIcon type="merge" />
+                  <EuiIcon type="merge" aria-hidden={true} />
                   <TransactionLinkName>{transaction.transaction.name}</TransactionLinkName>
                 </TransactionDetailLink>
               </EuiToolTip>
@@ -341,17 +341,20 @@ export function ErrorSampleDetailTabContent({
 }) {
   const codeLanguage = error?.service.language?.name;
   const exceptions = error?.error.exception || [];
+  const hasExceptions = exceptions.length > 0;
   const logStackframes = error?.error.log?.stacktrace;
-  const isPlaintextException =
-    !!error.error.stack_trace && exceptions.length === 1 && !exceptions[0].stacktrace;
+  const isPlaintextException = hasExceptions
+    ? !!error.error.stack_trace && exceptions.length === 1 && !exceptions[0].stacktrace
+    : !!error.error.stack_trace;
+
   switch (currentTab.key) {
     case ErrorTabKey.LogStackTrace:
       return <Stacktrace stackframes={logStackframes} codeLanguage={codeLanguage} />;
     case ErrorTabKey.ExceptionStacktrace:
       return isPlaintextException ? (
         <PlaintextStacktrace
-          message={exceptions[0].message}
-          type={exceptions[0]?.type}
+          message={hasExceptions ? exceptions[0].message : undefined}
+          type={hasExceptions ? exceptions[0].type : undefined}
           stacktrace={error?.error.stack_trace}
           codeLanguage={codeLanguage}
         />

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.tsx
@@ -19,12 +19,12 @@ const Label = styled.div`
 
 interface Props {
   error: {
-    error: Pick<APMError['error'], 'log' | 'exception' | 'culprit'>;
+    error: Pick<APMError['error'], 'log' | 'exception' | 'culprit' | 'message'>;
   };
 }
 export function SampleSummary({ error }: Props) {
   const logMessage = error.error.log?.message;
-  const excMessage = error.error.exception?.[0].message;
+  const excMessage = error.error.exception?.[0].message || error.error.message;
   const culprit = error.error.culprit;
 
   return (

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_overview/error_group_list/index.tsx
@@ -182,7 +182,7 @@ export function ErrorGroupList({
               serviceName={serviceName}
               query={{
                 ...query,
-                kuery: `error.exception.type:"${type}"`,
+                kuery: `error.exception.type:"${type}" OR error.type:"${type}"`,
               }}
             >
               {type}

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.test.ts
@@ -15,19 +15,33 @@ describe('getErrorName', () => {
         error: {
           log: { message: 'bar' },
           exception: [{ message: 'foo' }],
+          message: 'baz',
         },
       } as APMError)
     ).toEqual('bar');
   });
+
   it('returns exception message', () => {
     expect(
       getErrorName({
         error: {
           exception: [{ message: 'foo' }],
+          message: 'baz',
         },
       } as APMError)
     ).toEqual('foo');
   });
+
+  it('returns error message', () => {
+    expect(
+      getErrorName({
+        error: {
+          message: 'baz',
+        },
+      } as APMError)
+    ).toEqual('baz');
+  });
+
   it('returns default message', () => {
     expect(getErrorName({} as APMError)).toEqual(NOT_AVAILABLE_LABEL);
   });

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.ts
@@ -12,7 +12,9 @@ import type { APMError } from '../../../typings/es_schemas/ui/apm_error';
 export function getErrorName({
   error,
 }: {
-  error: Maybe<Pick<APMError['error'], 'exception'>> & { log?: { message?: string } };
+  error: Maybe<Pick<APMError['error'], 'exception' | 'message'>> & { log?: { message?: string } };
 }): string {
-  return error?.log?.message || error?.exception?.[0]?.message || NOT_AVAILABLE_LABEL;
+  return (
+    error?.log?.message || error?.exception?.[0]?.message || error?.message || NOT_AVAILABLE_LABEL
+  );
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -18,6 +18,8 @@ import {
   ERROR_GROUP_ID,
   ERROR_GROUP_NAME,
   ERROR_LOG_MESSAGE,
+  ERROR_MESSAGE,
+  ERROR_TYPE,
   SERVICE_NAME,
   TRACE_ID,
   TRANSACTION_NAME,
@@ -105,6 +107,8 @@ export async function getErrorGroupMainStatistics({
     ERROR_EXC_MESSAGE,
     ERROR_EXC_HANDLED,
     ERROR_EXC_TYPE,
+    ERROR_MESSAGE,
+    ERROR_TYPE,
   ] as const);
 
   const response = await apmEventClient.search('get_error_group_main_statistics', {
@@ -186,7 +190,7 @@ export async function getErrorGroupMainStatistics({
         occurrences: bucket.doc_count,
         culprit: mergedEvent.error.culprit,
         handled: mergedEvent.error.exception?.[0].handled,
-        type: mergedEvent.error.exception?.[0].type,
+        type: mergedEvent.error.exception?.[0].type || mergedEvent.error.type,
         traceId: mergedEvent.trace?.id,
       };
     }) ?? [];

--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
@@ -36,6 +36,8 @@ import {
   TRANSACTION_PAGE_URL,
   USER_AGENT_NAME,
   USER_AGENT_VERSION,
+  ERROR_MESSAGE,
+  ERROR_TYPE,
 } from '../../../../common/es_fields/apm';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { ApmDocumentType } from '../../../../common/document_type';
@@ -99,6 +101,8 @@ export async function getErrorSampleDetails({
     ERROR_EXC_HANDLED,
     ERROR_EXC_TYPE,
     ERROR_ID,
+    ERROR_MESSAGE,
+    ERROR_TYPE,
     URL_FULL,
     HTTP_REQUEST_METHOD,
     HTTP_RESPONSE_STATUS_CODE,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[APM] Support ECS formatted errors in service details (#254138)](https://github.com/elastic/kibana/pull/254138)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-20T13:17:21Z","message":"[APM] Support ECS formatted errors in service details (#254138)\n\n## Summary\n\nCloses #249358\n\nThis PR aims to support ECS-formatted error documents in service details\nerror tab. This part of the UI was heavily dependent on documents having\nan `error.exception` field. While most APM data streams will include\nsuch field, some features (such as the Java agent `log_sending` feature)\ncan send ECS formatted error logs that do not include `error.exception`\nIn this cases, the UI wasn't able to render most fields (such as error\nmessage and type) properly.\n\nThe work done here revolves around adding support for ECS formatted\ndocuments so that information for these types of documents can be\nproperly displayed in the APM UI. It's mostly adding additional fields\nto check when getting error data:\n\n- **Error Message** \n  1. `error.log.message`\n  2. `error.exception.message`\n  3. `error.message` **new**\n- **Error Type**\n  1. `error.exception.type`\n  2. `error.type` **new**\n\nSupport for plain text stack traces has also been extended in order to\nproperly render ECS stack traces.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/c4fa41a9-c52d-4ee5-a9f7-8e005c52e1b8\n\n### After\n\n\nhttps://github.com/user-attachments/assets/73f0aa6a-ee9d-4363-aad0-e899bb04f978","sha":"c0deed873aca8ad3bb28ddf9138fea05094f1480","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"[APM] Support ECS formatted errors in service details","number":254138,"url":"https://github.com/elastic/kibana/pull/254138","mergeCommit":{"message":"[APM] Support ECS formatted errors in service details (#254138)\n\n## Summary\n\nCloses #249358\n\nThis PR aims to support ECS-formatted error documents in service details\nerror tab. This part of the UI was heavily dependent on documents having\nan `error.exception` field. While most APM data streams will include\nsuch field, some features (such as the Java agent `log_sending` feature)\ncan send ECS formatted error logs that do not include `error.exception`\nIn this cases, the UI wasn't able to render most fields (such as error\nmessage and type) properly.\n\nThe work done here revolves around adding support for ECS formatted\ndocuments so that information for these types of documents can be\nproperly displayed in the APM UI. It's mostly adding additional fields\nto check when getting error data:\n\n- **Error Message** \n  1. `error.log.message`\n  2. `error.exception.message`\n  3. `error.message` **new**\n- **Error Type**\n  1. `error.exception.type`\n  2. `error.type` **new**\n\nSupport for plain text stack traces has also been extended in order to\nproperly render ECS stack traces.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/c4fa41a9-c52d-4ee5-a9f7-8e005c52e1b8\n\n### After\n\n\nhttps://github.com/user-attachments/assets/73f0aa6a-ee9d-4363-aad0-e899bb04f978","sha":"c0deed873aca8ad3bb28ddf9138fea05094f1480"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254138","number":254138,"mergeCommit":{"message":"[APM] Support ECS formatted errors in service details (#254138)\n\n## Summary\n\nCloses #249358\n\nThis PR aims to support ECS-formatted error documents in service details\nerror tab. This part of the UI was heavily dependent on documents having\nan `error.exception` field. While most APM data streams will include\nsuch field, some features (such as the Java agent `log_sending` feature)\ncan send ECS formatted error logs that do not include `error.exception`\nIn this cases, the UI wasn't able to render most fields (such as error\nmessage and type) properly.\n\nThe work done here revolves around adding support for ECS formatted\ndocuments so that information for these types of documents can be\nproperly displayed in the APM UI. It's mostly adding additional fields\nto check when getting error data:\n\n- **Error Message** \n  1. `error.log.message`\n  2. `error.exception.message`\n  3. `error.message` **new**\n- **Error Type**\n  1. `error.exception.type`\n  2. `error.type` **new**\n\nSupport for plain text stack traces has also been extended in order to\nproperly render ECS stack traces.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/c4fa41a9-c52d-4ee5-a9f7-8e005c52e1b8\n\n### After\n\n\nhttps://github.com/user-attachments/assets/73f0aa6a-ee9d-4363-aad0-e899bb04f978","sha":"c0deed873aca8ad3bb28ddf9138fea05094f1480"}},{"url":"https://github.com/elastic/kibana/pull/254198","number":254198,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->