### PR TITLE
[8.19] moon: fix moon query, generate src groups for non-ts packages (#253657)

### DIFF
--- a/.moon/tasks/node.yml
+++ b/.moon/tasks/node.yml
@@ -5,5 +5,3 @@ fileGroups:
   default:
     - '**/*'
   production: [ ]
-
-tasks: {}

--- a/packages/kbn-eslint-config/moon.yml
+++ b/packages/kbn-eslint-config/moon.yml
@@ -22,4 +22,11 @@ tags:
   - package
   - dev
   - group-undefined
+fileGroups:
+  src:
+    - javascript.js
+    - jest.js
+    - react.js
+    - restricted_globals.js
+    - typescript.js
 tasks: {}

--- a/packages/kbn-eslint-plugin-eslint/moon.yml
+++ b/packages/kbn-eslint-plugin-eslint/moon.yml
@@ -23,6 +23,13 @@ tags:
   - dev
   - group-undefined
   - jest-unit-tests
+fileGroups:
+  src:
+    - rules/**/*
+    - helpers/**/*
+    - index.js
+    - jest.config.js
+    - lib.js
 tasks:
   jest:
     args:

--- a/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
+++ b/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
@@ -23,6 +23,7 @@ import type { ToolingLog } from '@kbn/tooling-log';
 import { KIBANA_JSONC_FILENAME, MOON_CONFIG_KEY_ORDER, MOON_CONST } from '../const';
 import type { MoonProjectConfig } from './moon_project_type';
 import {
+  compactFilePathsToGlobs,
   filterPackages,
   readFile,
   readJsonWithComments,
@@ -183,6 +184,14 @@ function applyTsConfigSettings(
 ) {
   if (!fs.existsSync(tsConfigPath)) {
     projectConfig.language = 'javascript';
+    projectConfig.fileGroups = {
+      src: compactFilePathsToGlobs(
+        fs.globSync('**/{*.js,*.ts,*.jsx,*.tsx}', {
+          exclude: (f) => f.includes('__fixtures__'),
+          cwd: projectConfig.project?.metadata?.sourceRoot,
+        })
+      ),
+    };
     logger.warning(`Skipping ${projectConfig.id} - no tsconfig.json found.`);
     return;
   }

--- a/packages/kbn-moon/src/util.ts
+++ b/packages/kbn-moon/src/util.ts
@@ -72,3 +72,18 @@ export function writeYaml(filePath: string, obj: any, preamble: string | null = 
     return true;
   }
 }
+
+export function compactFilePathsToGlobs(filePaths: string[]): string[] {
+  const folderGlobs = new Set<string>();
+  const files: string[] = [];
+  filePaths.forEach((filePath) => {
+    if (filePath.includes(path.sep)) {
+      const dirGlob = filePath.split(path.sep)[0] + path.sep + '**' + path.sep + '*';
+      folderGlobs.add(dirGlob);
+    } else {
+      files.push(filePath);
+    }
+  });
+
+  return [...folderGlobs, ...files].map((e) => e.replaceAll(path.sep, '/'));
+}

--- a/packages/kbn-spec-to-console/moon.yml
+++ b/packages/kbn-spec-to-console/moon.yml
@@ -23,6 +23,12 @@ tags:
   - dev
   - group-undefined
   - jest-unit-tests
+fileGroups:
+  src:
+    - lib/**/*
+    - bin/**/*
+    - index.js
+    - jest.config.js
 tasks:
   jest:
     args:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [moon: fix moon query, generate src groups for non-ts packages (#253657)](https://github.com/elastic/kibana/pull/253657)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-02-19T09:43:57Z","message":"moon: fix moon query, generate src groups for non-ts packages (#253657)\n\n## Summary\nIn our auto-generated moon confgis, the `@group(src)` is generated off\nthe tsconfig's prescriptions on included files. For non-ts projects,\nconfiguration projects or odd ones, this doesn't exist. Since we already\nhad some tasks referring to `src` groups, we were occasionally getting\nerrors, e.g. for when we're querying.\n\nThis PR generates a `src` group for every package - if included files\nare not prescribed in a tsconfig file, it will glob for any source files\nwithin the package. Maybe not the best/most sophisticated query for\nsource files (e.g.: it includes configs too) but for config projects\nthis is accurate.\n\nThis will enable us to run `moon query projects` without an error.\n\ncc: @tylersmalley","sha":"ee5e5ae8fd2329b4c1a7c7af901e648dde0ab97f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","v9.3.1"],"title":"moon: fix moon query, generate src groups for non-ts packages","number":253657,"url":"https://github.com/elastic/kibana/pull/253657","mergeCommit":{"message":"moon: fix moon query, generate src groups for non-ts packages (#253657)\n\n## Summary\nIn our auto-generated moon confgis, the `@group(src)` is generated off\nthe tsconfig's prescriptions on included files. For non-ts projects,\nconfiguration projects or odd ones, this doesn't exist. Since we already\nhad some tasks referring to `src` groups, we were occasionally getting\nerrors, e.g. for when we're querying.\n\nThis PR generates a `src` group for every package - if included files\nare not prescribed in a tsconfig file, it will glob for any source files\nwithin the package. Maybe not the best/most sophisticated query for\nsource files (e.g.: it includes configs too) but for config projects\nthis is accurate.\n\nThis will enable us to run `moon query projects` without an error.\n\ncc: @tylersmalley","sha":"ee5e5ae8fd2329b4c1a7c7af901e648dde0ab97f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253657","number":253657,"mergeCommit":{"message":"moon: fix moon query, generate src groups for non-ts packages (#253657)\n\n## Summary\nIn our auto-generated moon confgis, the `@group(src)` is generated off\nthe tsconfig's prescriptions on included files. For non-ts projects,\nconfiguration projects or odd ones, this doesn't exist. Since we already\nhad some tasks referring to `src` groups, we were occasionally getting\nerrors, e.g. for when we're querying.\n\nThis PR generates a `src` group for every package - if included files\nare not prescribed in a tsconfig file, it will glob for any source files\nwithin the package. Maybe not the best/most sophisticated query for\nsource files (e.g.: it includes configs too) but for config projects\nthis is accurate.\n\nThis will enable us to run `moon query projects` without an error.\n\ncc: @tylersmalley","sha":"ee5e5ae8fd2329b4c1a7c7af901e648dde0ab97f"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/253917","number":253917,"state":"MERGED","mergeCommit":{"sha":"f64404371d57850d1dcdc709843784e0a532b5fa","message":"[9.3] moon: fix moon query, generate src groups for non-ts packages (#253657) (#253917)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [moon: fix moon query, generate src groups for non-ts packages\n(#253657)](https://github.com/elastic/kibana/pull/253657)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}}]}] BACKPORT-->