### PR TITLE
Reduce noise of OTel export timeouts

### DIFF
--- a/src/platform/packages/shared/kbn-telemetry/src/set_diag_logger.ts
+++ b/src/platform/packages/shared/kbn-telemetry/src/set_diag_logger.ts
@@ -18,11 +18,19 @@ import { format } from 'util';
  * @param logLevel The {@link LogLevelId} to set the Diag logger to.
  */
 export function setDiagLogger(logger: Logger, logLevel?: LogLevelId) {
+  let lastExportTimeout = 0;
   const diagLogger: DiagLogger = {
     debug: (message, ...args) => {
       return logger.debug(() => format(message, ...args));
     },
     error: (message, ...args) => {
+      // We're OK with random export timeout errors. It could mean that Kibana is under heavy load.
+      // However, if it happens repeatedly within a short period of time, it's likely a problem, and we want to log it.
+      if (message.includes('Export took longer than') && Date.now() - lastExportTimeout > 60_000) {
+        lastExportTimeout = Date.now();
+        return;
+      }
+
       return logger.error(() => format(message, ...args));
     },
     info: (message, ...args) => {


### PR DESCRIPTION
## Summary

We've identified that in some scenarios, Kibana takes longer than the timeout (10s) to export the metrics.

This causes it to log the corresponding error. However, we're OK with some timed-out attempts, and the logs introduce unnecessary noise.

This is a potential approach to silence random logs of these timeouts.




