### PR TITLE
[One Workflow] Enable run button when schema errors but syntax valid

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
@@ -172,12 +172,12 @@ describe('WorkflowDetailHeader', () => {
     expect(result.getByTestId('runWorkflowHeaderButton')).toBeDisabled();
   });
 
-  it('disables run workflow button when yaml has validation errors', () => {
+  it('enables run workflow button when yaml has validation errors', () => {
     const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
       isValid: true,
       hasYamlSchemaValidationErrors: true,
     });
-    expect(result.getByTestId('runWorkflowHeaderButton')).toBeDisabled();
+    expect(result.getByTestId('runWorkflowHeaderButton')).toBeEnabled();
   });
 
   it('disables enabled toggle when yaml has validation errors', () => {

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -139,15 +139,16 @@ export const WorkflowDetailHeader = React.memo(
 
     // Combined validity: syntax must parse AND no strict validation errors AND server considers it valid.
     // workflow?.valid !== false covers the initial page load before Monaco validates.
-    const isValid = isSyntaxValid && !hasYamlSchemaValidationErrors && workflow?.valid !== false;
+    const isSchemaValid =
+      isSyntaxValid && !hasYamlSchemaValidationErrors && workflow?.valid !== false;
 
     const runWorkflowTooltipContent = useMemo(() => {
       return getTestRunTooltipContent({
         isExecutionsTab,
-        isValid,
+        isValid: isSyntaxValid,
         canRunWorkflow: canExecuteWorkflow,
       });
-    }, [isValid, canExecuteWorkflow, isExecutionsTab]);
+    }, [isSyntaxValid, canExecuteWorkflow, isExecutionsTab]);
 
     const saveWorkflowTooltipContent = useMemo(() => {
       const isCreate = !workflowId;
@@ -268,7 +269,7 @@ export const WorkflowDetailHeader = React.memo(
                       ? i18n.translate('workflows.workflowDetailHeader.unsaved', {
                           defaultMessage: 'Save changes to enable/disable workflow',
                         })
-                      : !isValid
+                      : !isSchemaValid
                       ? i18n.translate('workflows.workflowDetailHeader.invalid', {
                           defaultMessage: 'Fix validation errors to enable workflow',
                         })
@@ -280,7 +281,7 @@ export const WorkflowDetailHeader = React.memo(
                       !workflowId ||
                       isLoading ||
                       !canUpdateWorkflow ||
-                      !isValid ||
+                      !isSchemaValid ||
                       hasUnsavedChanges
                     }
                     checked={isEnabled}
@@ -298,7 +299,7 @@ export const WorkflowDetailHeader = React.memo(
                     iconType="play"
                     size="s"
                     onClick={handleRunClickWithUnsavedCheck}
-                    disabled={isExecutionsTab || !canExecuteWorkflow || isLoading || !isValid}
+                    disabled={isExecutionsTab || !canExecuteWorkflow || isLoading || !isSyntaxValid}
                     aria-label={Translations.runWorkflow}
                     data-test-subj="runWorkflowHeaderButton"
                   />


### PR DESCRIPTION
## Summary

Rolls back the `Run` button changes in this PR https://github.com/elastic/kibana/pull/252698. Maintaining the changes in the 
`Enabled` switch.

### Screenshot

<img width="1917" height="987" alt="Captura de pantalla 2026-02-20 a les 17 46 42" src="https://github.com/user-attachments/assets/542bc02a-2379-4b48-973c-10cf1e296bea" />


