### PR TITLE
Change CODEOWNERS for discover/observability functional tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1813,7 +1813,7 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 
 # Observability-ui folder level permissions (need to be before individual files inside the folder)
 /x-pack/solutions/observability/test/serverless/functional/test_suites @elastic/observability-ui
-/src/platform/test/functional/apps/discover/observability @elastic/observability-ui
+/src/platform/test/functional/apps/discover/observability @elastic/obs-exploration-team
 
 # obs-exploration-team 
 /x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links @elastic/obs-exploration-team


### PR DESCRIPTION
## Summary

Assigns `/src/platform/test/functional/apps/discover/observability` to `@elastic/obs-exploration-team` instead of `@elastic/observability-ui`.

This directory contains the observability-specific Discover functional tests, which are already maintained by obs-exploration-team — they own the subdirectories (`/embeddable`, `/logs`). The parent directory ownership should match.

## Test plan

- No code changes; CODEOWNERS-only update.


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->