### PR TITLE
[Fleet] Fix use apm connector and processor default value

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
@@ -351,6 +351,31 @@ describe('getNormalizedDataStreams', () => {
       },
     ]);
   });
+
+  it('should add use_apm var with default true for otel traces input', () => {
+    const result = getNormalizedDataStreams({
+      ...integrationPkg,
+      type: 'input',
+      policy_templates: [
+        {
+          input: 'otelcol',
+          type: 'traces',
+          name: 'otel-traces',
+          template_path: 'some/path.hbl',
+          title: 'OTel Traces',
+          description: 'OTel Traces',
+          vars: [],
+        },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].streams).toHaveLength(1);
+    const vars = result[0].streams![0].vars;
+    const useApmVar = vars?.find((v) => v.name === 'use_apm');
+    expect(useApmVar).toBeDefined();
+    expect(useApmVar?.default).toEqual(true);
+    expect(useApmVar?.title).toEqual('Use Elastic APM');
+  });
 });
 
 describe('filterPolicyTemplatesTiles', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
@@ -36,11 +36,12 @@ const DATA_STREAM_DATASET_VAR: RegistryVarsEntry = {
 const DATA_STREAM_USE_APM_VAR: RegistryVarsEntry = {
   name: USE_APM_VAR_NAME,
   type: 'bool',
-  title: 'Use APM Server',
+  title: 'Use Elastic APM',
   description: 'enables the apm collector and processor.',
   multi: false,
   required: false,
   show_user: true,
+  default: true,
 };
 
 export function packageHasNoPolicyTemplates(packageInfo: PackageInfo): boolean {


### PR DESCRIPTION
## Summary

Enable apm collector and processor for otel traces by default.

<img width="913" height="560" alt="Screenshot 2026-02-20 at 1 22 27 PM" src="https://github.com/user-attachments/assets/d4477cfd-ad13-4f46-9e39-5d81b9631242" />
