### PR TITLE
[Obs AI] POC alert investigation in chat using a skill

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
@@ -43,7 +43,6 @@ export async function registerObservabilityAgent({
         instructions:
           dedent(`You are an observability specialist agent that helps Site Reliability Engineers (SREs) investigate incidents and understand system health.
 
-        ${getAlertInvestigationInstructions()}
         ${getReasoningInstructions()}
         ${getTraceMetricFormatInstructions()}
         ${getFieldDiscoveryInstructions()}
@@ -56,19 +55,6 @@ export async function registerObservabilityAgent({
   });
 
   logger.debug('Successfully registered observability agent in agent-builder');
-}
-
-// TODO: explicit skill load needed because the platform tool selection policy overrides the skills instruction
-function getAlertInvestigationInstructions() {
-  return dedent(`
-    <alert_investigation>
-    ### Alert Investigation
-    When an alert is attached to the conversation, ALWAYS call filestore_read with path
-    '/skills/observability/alert-investigation/SKILL.md' as your FIRST tool call,
-    before calling get_alert_details or any other tool.
-    Follow the instructions in that file precisely.
-    </alert_investigation>
-  `);
 }
 
 function getReasoningInstructions() {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
@@ -43,7 +43,7 @@ export async function registerObservabilityAgent({
         instructions:
           dedent(`You are an observability specialist agent that helps Site Reliability Engineers (SREs) investigate incidents and understand system health.
 
-        ${getInvestigationInstructions()}
+        ${getAlertInvestigationInstructions()}
         ${getReasoningInstructions()}
         ${getTraceMetricFormatInstructions()}
         ${getFieldDiscoveryInstructions()}
@@ -58,18 +58,16 @@ export async function registerObservabilityAgent({
   logger.debug('Successfully registered observability agent in agent-builder');
 }
 
-function getInvestigationInstructions() {
+// TODO: explicit skill load needed because the platform tool selection policy overrides the skills instruction
+function getAlertInvestigationInstructions() {
   return dedent(`
-    <investigation_approach>
-    ### Investigation Approach
-    Follow a progressive workflow - start broad, then narrow down:
-    1. **Triage**: What's the severity? How many users/services affected?
-    2. **Scope**: Which components are affected? What's the blast radius?
-    3. **Timeline**: When did it start? What changed before symptoms appeared?
-    4. **Correlation**: What error patterns exist? What's the sequence of events?
-    5. **Root Cause**: Distinguish the SOURCE (where the problem started) from AFFECTED services (impacted downstream)
-    6. **Verification**: Does your hypothesis explain ALL the symptoms? If not, dig deeper.
-    </investigation_approach>
+    <alert_investigation>
+    ### Alert Investigation
+    When an alert is attached to the conversation, ALWAYS call filestore_read with path
+    '/skills/observability/alert-investigation/SKILL.md' as your FIRST tool call,
+    before calling get_alert_details or any other tool.
+    Follow the instructions in that file precisely.
+    </alert_investigation>
   `);
 }
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/plugin.ts
@@ -15,6 +15,7 @@ import type {
 import { registerObservabilityAgent } from './agent/register_observability_agent';
 import { registerTools } from './tools/register_tools';
 import { registerAttachments } from './attachments/register_attachments';
+import { registerSkills } from './skills/register_skills';
 import type {
   ObservabilityAgentBuilderPluginSetup,
   ObservabilityAgentBuilderPluginSetupDependencies,
@@ -68,6 +69,13 @@ export class ObservabilityAgentBuilderPlugin
       dataRegistry: this.dataRegistry,
     }).catch((error) => {
       this.logger.error(`Error registering observability attachments: ${error}`);
+    });
+
+    registerSkills({
+      plugins,
+      logger: this.logger,
+    }).catch((error) => {
+      this.logger.error(`Error registering observability skills: ${error}`);
     });
 
     registerServerRoutes({ core, plugins, logger: this.logger, dataRegistry: this.dataRegistry });

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/alert_investigation_skill.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/alert_investigation_skill.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+
+const ID = 'observability-alert-investigation';
+const NAME = 'alert-investigation';
+const BASE_PATH = 'skills/observability';
+
+/**
+ * Alert investigation skill for the Observability Agent.
+ *
+ * Guides the agent through a structured investigation sequence when an alert is present,
+ * mirroring the signal hierarchy validated by the Alert AI Insight component.
+ *
+ * Signal sequence (APM alerts):
+ *   1. Blast radius — get_service_topology (downstream, depth 1)
+ *   2. When did it start — get_trace_change_points (last 6h)
+ *   3. Error patterns — get_log_groups (last 15min)
+ *   4. Runtime pressure — get_runtime_metrics (last 15min)
+ *
+ * Signal sequence (infrastructure alerts):
+ *   1. Host resource pressure — get_hosts
+ *   2. Services on host — get_services
+ */
+export const alertInvestigationSkill = defineSkillType({
+  id: ID,
+  name: NAME,
+  basePath: BASE_PATH,
+  description:
+    'Investigate an observability alert to find root cause. Use when the user asks ' +
+    'why an alert fired, wants to understand service or infrastructure degradation, ' +
+    'or needs to identify the root cause of a performance or availability problem.',
+  content: `# Observability Alert Investigation
+
+Use this skill when the user wants to understand why an alert fired, investigate a service
+or infrastructure problem, or find the root cause of a performance or availability issue.
+
+---
+
+## Step 1: Get the alert details
+
+Call \`get_alert_details\` to fetch the full alert document. Extract:
+- \`kibana.alert.reason\` — the human-readable trigger condition
+- \`service.name\` — present for APM alerts (latency, error rate, throughput, anomaly)
+- \`host.name\` — present for infrastructure alerts (CPU, memory, disk)
+- \`kibana.alert.start\` — when the alert fired (use as the anchor for time windows)
+
+If neither \`service.name\` nor \`host.name\` is present, tell the user you cannot determine
+the affected entity and ask them to clarify.
+
+---
+
+## Step 2: Gather signals — do not stop after the first finding
+
+Run all relevant steps before drawing conclusions. Evidence must corroborate.
+
+### For APM / service alerts (service.name is present)
+
+**2a. Blast radius**
+Call \`observability.get_service_topology\` with:
+- \`serviceName\`: the service from the alert
+- \`direction\`: \`"downstream"\`
+- \`depth\`: \`1\`
+- \`start\`: alert start minus 30 minutes
+- \`end\`: \`"now"\`
+
+Look for downstream dependencies with elevated error rates or latency. A dependency
+failure here is often the root cause, not the alerted service itself.
+
+**2b. When did it start**
+Call \`observability.get_trace_change_points\` with:
+- \`start\`: alert start minus 6 hours
+- \`end\`: \`"now"\`
+- \`kqlFilter\`: \`service.name: "<service>"\`
+- \`groupBy\`: \`"service.name"\` first, then \`"transaction.name"\` if a specific transaction
+  looks affected
+
+Look for the earliest change point across latency, throughput, and failure rate. This
+tells you when the degradation actually started — which may be before the alert fired.
+
+**2c. Error patterns**
+Call \`observability.get_log_groups\` with:
+- \`start\`: alert start minus 15 minutes
+- \`end\`: \`"now"\`
+- \`kqlFilter\`: \`service.name: "<service>"\`
+- \`includeFirstSeen\`: \`true\`
+
+New exceptions (firstSeen near alert time) are strong signal. Recurring exceptions that
+predate the alert are likely pre-existing noise — flag but don't overweight.
+
+**2d. JVM / runtime pressure** (skip if not a JVM service)
+Call \`observability.get_runtime_metrics\` with:
+- \`serviceName\`: the service from the alert
+- \`start\`: alert start minus 15 minutes
+- \`end\`: \`"now"\`
+
+Look for heap saturation, GC pause spikes, or thread exhaustion. These indicate resource
+pressure rather than a code or dependency issue.
+
+### For infrastructure alerts (host.name is present, no service.name)
+
+**2a. Host resource pressure**
+Call \`observability.get_hosts\` with:
+- \`kqlFilter\`: \`host.name: "<host>"\`
+- \`start\`: alert start minus 15 minutes
+- \`end\`: \`"now"\`
+
+Look at CPU, memory, disk, and network. Identify which metric is saturated.
+
+**2b. Services on the affected host**
+Call \`observability.get_services\` with a \`kqlFilter\` scoped to the host to find which
+services are running there. Then follow the APM signal sequence above for any services
+that show degradation.
+
+---
+
+## Step 3: Synthesize
+
+After gathering all signals, respond with:
+
+**Trigger**: What changed first and when — quote the specific metric, value, and timestamp.
+
+**Blast radius**: Which other services or hosts are affected. If none, say so explicitly.
+
+**Likely cause**: The best-evidenced hypothesis. Distinguish the source (where the problem
+started) from affected services (downstream victims). If the evidence points clearly to a
+downstream dependency, name it. If evidence is weak or conflicting, say so — do not
+fabricate confidence.
+
+**Next steps**: Two or three specific, actionable recommendations. Prefer concrete actions
+("roll back the deployment of X", "check the connection pool config on Y") over vague ones
+("investigate further").
+
+---
+
+## Guidelines
+
+- Quote specific numbers: error rate %, latency in ms, throughput in tpm.
+- Temporal sequence matters: a change point that precedes the alert start is a stronger
+  causal candidate than one that follows it.
+- The alerted service is not necessarily the root cause — check downstream dependencies
+  first.
+- If a signal returns no data, note it briefly and move on. Absence of data is not
+  evidence of absence.
+- Do not repeat the alert reason verbatim. Explain what the data shows.
+`,
+  getRegistryTools: () => [],
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/alert_investigation_skill.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/alert_investigation_skill.ts
@@ -15,7 +15,6 @@ const BASE_PATH = 'skills/observability';
  * Alert investigation skill for the Observability Agent.
  *
  * Guides the agent through a structured investigation sequence when an alert is present,
- * mirroring the signal hierarchy validated by the Alert AI Insight component.
  *
  * Signal sequence (APM alerts):
  *   1. Blast radius — get_service_topology (downstream, depth 1)
@@ -32,9 +31,9 @@ export const alertInvestigationSkill = defineSkillType({
   name: NAME,
   basePath: BASE_PATH,
   description:
-    'Investigate an observability alert to find root cause. Use when the user asks ' +
-    'why an alert fired, wants to understand service or infrastructure degradation, ' +
-    'or needs to identify the root cause of a performance or availability problem.',
+    'Observability alert investigation. Use when an alert is attached and the user ' +
+    'asks to investigate it, wants to understand why it fired, or needs a full ' +
+    'root cause analysis.',
   content: `# Observability Alert Investigation
 
 Use this skill when the user wants to understand why an alert fired, investigate a service
@@ -61,7 +60,7 @@ Run all relevant steps before drawing conclusions. Evidence must corroborate.
 
 ### For APM / service alerts (service.name is present)
 
-**2a. Blast radius**
+**2a. Dependency check**
 Call \`observability.get_service_topology\` with:
 - \`serviceName\`: the service from the alert
 - \`direction\`: \`"downstream"\`
@@ -70,7 +69,13 @@ Call \`observability.get_service_topology\` with:
 - \`end\`: \`"now"\`
 
 Look for downstream dependencies with elevated error rates or latency. A dependency
-failure here is often the root cause, not the alerted service itself.
+failure here is often the root cause — the alerted service is an affected service, not the source.
+
+When interpreting topology results, direction determines causality:
+- Downstream services are called BY the alerted service. If they are failing, they are
+  causing the alert — they are the source.
+- Upstream services call the alerted service. If the alerted service is broken, upstream
+  callers are affected by it — they are impacted services, not causes.
 
 **2b. When did it start**
 Call \`observability.get_trace_change_points\` with:
@@ -125,10 +130,10 @@ After gathering all signals, respond with:
 
 **Trigger**: What changed first and when — quote the specific metric, value, and timestamp.
 
-**Blast radius**: Which other services or hosts are affected. If none, say so explicitly.
+**Dependencies**: Which downstream dependencies are degraded or failing. If none, say so explicitly.
 
 **Likely cause**: The best-evidenced hypothesis. Distinguish the source (where the problem
-started) from affected services (downstream victims). If the evidence points clearly to a
+started) from affected services (impacted callers). If the evidence points clearly to a
 downstream dependency, name it. If evidence is weak or conflicting, say so — do not
 fabricate confidence.
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/register_skills.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/register_skills.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { ObservabilityAgentBuilderPluginSetupDependencies } from '../types';
+import { alertInvestigationSkill } from './alert_investigation_skill';
+
+export async function registerSkills({
+  plugins,
+  logger,
+}: {
+  plugins: ObservabilityAgentBuilderPluginSetupDependencies;
+  logger: Logger;
+}) {
+  await plugins.agentBuilder.skills.register(alertInvestigationSkill);
+  logger.info(`Registered skill: ${alertInvestigationSkill.id}`);
+}


### PR DESCRIPTION
## Summary

Registers an alert investigation skill that guides the Obs Agent through a structured signal sequence when investigating an alert.  The skill instructions are a draft mostly generated in Cursor based off the logic in the Alert AI Insight component.

When an alert is attached and the user asks to investigate, the agent loads /skills/observability/alert-investigation/SKILL.md from the virtual filestore and follows its instructions. The skill content is only loaded on demand.

<details>
<summary> screenshots of skill </summary>

Like the insight, it was able to correctly identify the payment service as the problematic downstream dependency
<img width="1755" height="923" alt="Screenshot 2026-02-20 at 15 32 42" src="https://github.com/user-attachments/assets/c10786bb-9a80-47b5-9325-b4aeff9e0b65" />

Skill reasoning
<img width="640" height="735" alt="Screenshot 2026-02-20 at 16 01 02" src="https://github.com/user-attachments/assets/57653725-dbf5-492e-ae04-99c27b151e43" />


</details>