### PR TITLE
Consolidate Emotion type augmentations into @kbn/ambient-ui-types

### DIFF
--- a/src/core/packages/chrome/browser-internal/tsconfig.json
+++ b/src/core/packages/chrome/browser-internal/tsconfig.json
@@ -7,9 +7,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
-      "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
-      "../../../../../typings/emotion.d.ts"
+      "@kbn/ambient-storybook-types"
     ]
   },
   "include": [

--- a/src/core/packages/chrome/layout/core-chrome-layout-components/tsconfig.json
+++ b/src/core/packages/chrome/layout/core-chrome-layout-components/tsconfig.json
@@ -7,9 +7,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
-      "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
-      "../../../../../../typings/emotion.d.ts"
+      "@kbn/ambient-storybook-types"
     ]
   },
   "include": [

--- a/src/core/packages/chrome/layout/core-chrome-layout/tsconfig.json
+++ b/src/core/packages/chrome/layout/core-chrome-layout/tsconfig.json
@@ -7,9 +7,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
-      "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
-      "../../../../../../typings/emotion.d.ts",
+      "@kbn/ambient-storybook-types"
     ]
   },
   "include": [

--- a/src/core/packages/chrome/navigation/tsconfig.json
+++ b/src/core/packages/chrome/navigation/tsconfig.json
@@ -8,9 +8,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
-      "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
-      "../../../../../typings/emotion.d.ts"
+      "@kbn/ambient-storybook-types"
     ]
   },
   "include": [

--- a/src/core/packages/chrome/sidebar/sidebar-components/tsconfig.json
+++ b/src/core/packages/chrome/sidebar/sidebar-components/tsconfig.json
@@ -5,8 +5,7 @@
   },
   "include": [
     "**/*.ts",
-    "**/*.tsx",
-    "../../../../../../typings/emotion.d.ts"
+    "**/*.tsx"
   ],
   "exclude": [
     "target/**/*"

--- a/src/core/packages/chrome/sidebar/sidebar-internal/tsconfig.json
+++ b/src/core/packages/chrome/sidebar/sidebar-internal/tsconfig.json
@@ -5,8 +5,7 @@
   },
   "include": [
     "**/*.ts",
-    "**/*.tsx",
-    "../../../../../../typings/emotion.d.ts"
+    "**/*.tsx"
   ],
   "exclude": [
     "target/**/*"

--- a/src/platform/packages/shared/content-management/content_editor/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_editor/tsconfig.json
@@ -10,9 +10,8 @@
       "react",
       "@kbn/ambient-ui-types",
       "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
-      "@testing-library/react"
+      "@testing-library/react",
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/content_insights/content_insights_public/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_insights/content_insights_public/tsconfig.json
@@ -8,9 +8,8 @@
       "react",
       "@kbn/ambient-ui-types",
       "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
-      "@testing-library/react"
+      "@testing-library/react",
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/tsconfig.json
@@ -9,8 +9,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
-      "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop"
+      "@kbn/ambient-storybook-types"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
@@ -10,10 +10,8 @@
       "react",
       "@kbn/ambient-ui-types",
       "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
-      "../../../../../../../typings/emotion.d.ts"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/tsconfig.json
@@ -10,10 +10,8 @@
       "react",
       "@kbn/ambient-ui-types",
       "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
-      "../../../../../../../typings/emotion.d.ts"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/favorites/favorites_public/tsconfig.json
+++ b/src/platform/packages/shared/content-management/favorites/favorites_public/tsconfig.json
@@ -6,8 +6,7 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
-      "@kbn/ambient-ui-types"
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/kbn-content-management-tags/tsconfig.json
+++ b/src/platform/packages/shared/content-management/kbn-content-management-tags/tsconfig.json
@@ -3,11 +3,10 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
-      "react",
-      "@emotion/react/types/css-prop",
-      "../../../../../../typings/emotion.d.ts"
+      "react"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/tabbed_table_list_view/tsconfig.json
+++ b/src/platform/packages/shared/content-management/tabbed_table_list_view/tsconfig.json
@@ -8,7 +8,6 @@
       "react",
       "@kbn/ambient-ui-types",
       "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/table_list_view/tsconfig.json
+++ b/src/platform/packages/shared/content-management/table_list_view/tsconfig.json
@@ -7,8 +7,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
-      "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop"
+      "@kbn/ambient-storybook-types"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/content-management/table_list_view_table/tsconfig.json
+++ b/src/platform/packages/shared/content-management/table_list_view_table/tsconfig.json
@@ -8,7 +8,6 @@
       "react",
       "@kbn/ambient-ui-types",
       "@kbn/ambient-storybook-types",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react"
     ]

--- a/src/platform/packages/shared/kbn-ambient-ui-types/.eslintrc.json
+++ b/src/platform/packages/shared/kbn-ambient-ui-types/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "overrides": [
+    {
+      "files": [
+        "**/*.d.ts"
+      ],
+      "rules": {
+        "@typescript-eslint/triple-slash-reference": "off",
+        "spaced-comment": "off"
+      }
+    }
+  ]
+}

--- a/src/platform/packages/shared/kbn-ambient-ui-types/emotion.d.ts
+++ b/src/platform/packages/shared/kbn-ambient-ui-types/emotion.d.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import '@emotion/react';
+import '@emotion/react/types/css-prop';
+import type { UseEuiTheme } from '@elastic/eui';
+
+declare module '@emotion/react' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends UseEuiTheme {}
+}

--- a/src/platform/packages/shared/kbn-ambient-ui-types/index.d.ts
+++ b/src/platform/packages/shared/kbn-ambient-ui-types/index.d.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+/// <reference path="./emotion.d.ts" />
+
 declare module '*.html' {
   const template: string;
   // eslint-disable-next-line import/no-default-export

--- a/src/platform/packages/shared/kbn-developer-toolbar/tsconfig.json
+++ b/src/platform/packages/shared/kbn-developer-toolbar/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "types": ["jest", "node", "react", "@emotion/react/types/css-prop"]
+    "types": ["jest", "node", "react", "@kbn/ambient-ui-types"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["target/**/*"],

--- a/src/platform/packages/shared/kbn-shared-ux-utility/tsconfig.json
+++ b/src/platform/packages/shared/kbn-shared-ux-utility/tsconfig.json
@@ -5,7 +5,7 @@
     "types": [
       "jest",
       "node",
-      "@emotion/react/types/css-prop"
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [

--- a/src/platform/packages/shared/shared-ux/ai-components/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/ai-components/tsconfig.json
@@ -5,7 +5,6 @@
     "types": [
       "jest",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
       "@testing-library/jest-dom"
     ]

--- a/src/platform/packages/shared/shared-ux/button/exit_full_screen/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/button/exit_full_screen/tsconfig.json
@@ -5,7 +5,6 @@
     "types": [
       "jest",
       "node",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types"
     ]
   },

--- a/src/platform/packages/shared/shared-ux/card/no_data/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/card/no_data/impl/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
       "@testing-library/jest-dom"
     ]

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
     ]
   },

--- a/src/platform/packages/shared/shared-ux/code_editor/mocks/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/code_editor/mocks/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
     ]
   },

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/tsconfig.json
@@ -5,11 +5,9 @@
     "types": [
       "jest",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
       "@kbn/ambient-ui-types",
-      "../../../../../../../typings/emotion.d.ts"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/shared-ux/error_boundary/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/error_boundary/tsconfig.json
@@ -5,7 +5,6 @@
     "types": [
       "jest",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
       "@kbn/ambient-ui-types"

--- a/src/platform/packages/shared/shared-ux/file/file_picker/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/file/file_picker/impl/tsconfig.json
@@ -6,7 +6,7 @@
       "node",
       "jest",
       "react",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [

--- a/src/platform/packages/shared/shared-ux/file/file_upload/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/file/file_upload/impl/tsconfig.json
@@ -6,7 +6,7 @@
       "node",
       "jest",
       "react",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [

--- a/src/platform/packages/shared/shared-ux/link/redirect_app/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/link/redirect_app/impl/tsconfig.json
@@ -6,8 +6,7 @@
       "jest",
       "node",
       "react",
-      "@kbn/ambient-ui-types",
-      "@emotion/react/types/css-prop"
+      "@kbn/ambient-ui-types"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/shared-ux/page/kibana_no_data/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/page/kibana_no_data/impl/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
       "@testing-library/jest-dom"
     ]

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/tsconfig.json
@@ -6,8 +6,7 @@
       "jest",
       "node",
       "react",
-      "@kbn/ambient-ui-types",
-      "@emotion/react/types/css-prop"
+      "@kbn/ambient-ui-types"
     ]
   },
   "include": [

--- a/src/platform/packages/shared/shared-ux/prompt/no_data_views/impl/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/prompt/no_data_views/impl/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
       "@testing-library/jest-dom"
     ]

--- a/src/platform/plugins/private/kibana_overview/tsconfig.json
+++ b/src/platform/plugins/private/kibana_overview/tsconfig.json
@@ -5,8 +5,7 @@
   },
   "include": [
     "public/**/*",
-    "common/**/*",
-    "../../../../../typings/emotion.d.ts"
+    "common/**/*"
   ],
   "kbn_references": [
     "@kbn/core",

--- a/src/platform/plugins/shared/home/tsconfig.json
+++ b/src/platform/plugins/shared/home/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "target/types",
     "isolatedModules": true
   },
-  "include": ["common/**/*", "public/**/*", "server/**/*", ".storybook/**/*", "../../../../../typings/emotion.d.ts"],
+  "include": ["common/**/*", "public/**/*", "server/**/*", ".storybook/**/*"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/data-views-plugin",

--- a/src/platform/plugins/shared/saved_objects/tsconfig.json
+++ b/src/platform/plugins/shared/saved_objects/tsconfig.json
@@ -6,9 +6,7 @@
   "include": [
     "common/**/*",
     "public/**/*",
-    "server/**/*",
-    // Emotion theme typing
-    "../../../../../typings/emotion.d.ts"
+    "server/**/*"
   ],
   "kbn_references": [
     "@kbn/core",

--- a/src/platform/plugins/shared/share/tsconfig.json
+++ b/src/platform/plugins/shared/share/tsconfig.json
@@ -7,8 +7,7 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
-    "test/**/*",
-    "../../../../../typings/emotion.d.ts"
+    "test/**/*"
   ],
   "kbn_references": [
     "@kbn/core",

--- a/x-pack/platform/packages/shared/ai-assistant/ai-assistant-connector-selector-action/tsconfig.json
+++ b/x-pack/platform/packages/shared/ai-assistant/ai-assistant-connector-selector-action/tsconfig.json
@@ -6,20 +6,19 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
-      "@testing-library/jest-dom",
+      "@testing-library/jest-dom"
     ]
   },
   "include": [
     "**/*.ts",
     "**/*.tsx",
-    "../../../../../../typings/**/*",
+    "../../../../../../typings/**/*"
   ],
   "exclude": [
     "target/**/*"
   ],
   "kbn_references": [
-    "@kbn/i18n",
+    "@kbn/i18n"
   ]
 }

--- a/x-pack/platform/packages/shared/ai-assistant/ai-assistant-cta/tsconfig.json
+++ b/x-pack/platform/packages/shared/ai-assistant/ai-assistant-cta/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
       "@testing-library/jest-dom",
     ]

--- a/x-pack/platform/packages/shared/ai-assistant/icon/tsconfig.json
+++ b/x-pack/platform/packages/shared/ai-assistant/icon/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types"
     ]
   },

--- a/x-pack/platform/plugins/private/global_search_bar/tsconfig.json
+++ b/x-pack/platform/plugins/private/global_search_bar/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types",
   },
-  "include": ["common/**/*", "public/**/*", "server/**/*", "../../../../../typings/emotion.d.ts"],
+  "include": ["common/**/*", "public/**/*", "server/**/*"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/usage-collection-plugin",

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/tsconfig.json
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types",
   },
-  "include": ["common/**/*", "public/**/*", "server/**/*", "../../../../../typings/emotion.d.ts"],
+  "include": ["common/**/*", "public/**/*", "server/**/*"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/usage-collection-plugin",

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/moon.yml
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/moon.yml
@@ -21,7 +21,6 @@ dependsOn:
   - '@kbn/cloud-security-posture-common'
   - '@kbn/data-views-plugin'
   - '@kbn/kibana-react-plugin'
-  - '@kbn/ui-theme'
   - '@kbn/utility-types'
   - '@kbn/unified-search-plugin'
   - '@kbn/es-query'

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/callout/callout.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/callout/callout.stories.tsx
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider } from '@emotion/react';
 import { action } from '@storybook/addon-actions';
 import { Callout, type CalloutProps } from './callout';
 import { getCalloutConfig } from './callout.config';
@@ -22,14 +20,7 @@ const mockLinks = {
 export default {
   title: 'Components/Graph Components/Callout',
   component: Callout,
-  decorators: [
-    GlobalStylesStorybookDecorator,
-    (Story) => (
-      <ThemeProvider theme={{ darkMode: false }}>
-        <Story />
-      </ThemeProvider>
-    ),
-  ],
+  decorators: [GlobalStylesStorybookDecorator],
 } satisfies Meta<typeof Callout>;
 
 const onDismiss = action('onDismiss');

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/actions.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/actions.stories.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider, css } from '@emotion/react';
+import { css } from '@emotion/react';
 import { action } from '@storybook/addon-actions';
 import { Actions as ActionsComponent, type ActionsProps } from './actions';
 import { GlobalStylesStorybookDecorator } from '../../../.storybook/decorators';
@@ -16,16 +16,14 @@ export default {
   title: 'Components/Graph Components/Additional Components',
   render: (props) => {
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
-        <ActionsComponent
-          css={css`
-            width: 42px;
-          `}
-          onInvestigateInTimeline={action('investigateInTimeline')}
-          onSearchToggle={action('searchToggle')}
-          {...props}
-        />
-      </ThemeProvider>
+      <ActionsComponent
+        css={css`
+          width: 42px;
+        `}
+        onInvestigateInTimeline={action('investigateInTimeline')}
+        onSearchToggle={action('searchToggle')}
+        {...props}
+      />
     );
   },
   argTypes: {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/controls/controls.stories.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider, css } from '@emotion/react';
+import { css } from '@emotion/react';
 import { ReactFlowProvider } from '@xyflow/react';
 import { action } from '@storybook/addon-actions';
 import { Controls as ControlsComponent, type ControlsProps } from './controls';
@@ -17,20 +17,18 @@ export default {
   title: 'Components/Graph Components/Additional Components',
   render: (props) => {
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
-        <ReactFlowProvider>
-          <ControlsComponent
-            css={css`
-              width: 42px;
-            `}
-            onZoomIn={action('zoomIn')}
-            onZoomOut={action('zoomOut')}
-            onFitView={action('fitView')}
-            onCenter={action('center')}
-            {...props}
-          />
-        </ReactFlowProvider>
-      </ThemeProvider>
+      <ReactFlowProvider>
+        <ControlsComponent
+          css={css`
+            width: 42px;
+          `}
+          onZoomIn={action('zoomIn')}
+          onZoomOut={action('zoomOut')}
+          onFitView={action('fitView')}
+          onCenter={action('center')}
+          {...props}
+        />
+      </ReactFlowProvider>
     );
   },
   argTypes: {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/edge/deafult_edge.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/edge/deafult_edge.stories.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { memo, useEffect, useMemo, useRef } from 'react';
-import { ThemeProvider } from '@emotion/react';
 import {
   ReactFlow,
   Controls,
@@ -151,7 +150,7 @@ const Template = (args: EdgeViewModel) => {
   }, [setNodes, setEdges, nodes, edges]);
 
   return (
-    <ThemeProvider theme={{ darkMode: false }}>
+    <>
       <SvgDefsMarker />
       <ReactFlow
         fitView
@@ -167,7 +166,7 @@ const Template = (args: EdgeViewModel) => {
         <Controls />
         <Background />
       </ReactFlow>
-    </ThemeProvider>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph_benchmark.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph/graph_benchmark.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { EuiListGroup, EuiHorizontalRule } from '@elastic/eui';
 import type { GraphResponse } from '@kbn/cloud-security-posture-common/types/graph/v1';
@@ -191,7 +191,7 @@ const Template = ({ nodes, edges }: GraphResponse) => {
   }, [expandButtonClickHandler, nodeClickHandler, nodes]);
 
   return (
-    <ThemeProvider theme={{ darkMode: false }}>
+    <>
       <GraphPerfMonitor />
       <Graph
         css={css`
@@ -204,7 +204,7 @@ const Template = ({ nodes, edges }: GraphResponse) => {
         isLocked={isPopoverOpen}
       />
       {popovers?.map((popover) => popover.Popover && <popover.Popover key={popover.id} />)}
-    </ThemeProvider>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_centering.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_centering.stories.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider, css } from '@emotion/react';
 import { EuiText, EuiPanel } from '@elastic/eui';
+import type { Meta, StoryObj } from '@storybook/react';
+import { css } from '@emotion/react';
 import { Graph } from './graph/graph';
 import type { NodeViewModel, EdgeViewModel } from './types';
 import { GlobalStylesStorybookDecorator } from '../../.storybook/decorators';
@@ -22,7 +22,7 @@ const meta: Meta<GraphCenteringStoryProps> = {
   title: 'Components/Graph Components/Graph Centering',
   render: ({ title, description, nodes, edges, interactive, isLocked, ...props }) => {
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
+      <>
         <EuiPanel paddingSize="m">
           {title && (
             <EuiText>
@@ -47,7 +47,7 @@ const meta: Meta<GraphCenteringStoryProps> = {
           isLocked={isLocked ?? false}
           {...props}
         />
-      </ThemeProvider>
+      </>
     );
   },
   argTypes: {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_layout.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_layout.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { ThemeProvider, css } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { StoryObj, Meta } from '@storybook/react';
 import type { Writable } from '@kbn/utility-types';
 import type { EdgeColor } from '@kbn/cloud-security-posture-common/types/graph/latest';
@@ -26,17 +26,15 @@ type GraphPropsAndCustomArgs = React.ComponentProps<typeof Graph> & {};
 const meta = {
   render: ({ nodes, edges, interactive }: Partial<GraphPropsAndCustomArgs>) => {
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
-        <Graph
-          css={css`
-            height: 100%;
-            width: 100%;
-          `}
-          nodes={nodes ?? []}
-          edges={edges ?? []}
-          interactive={interactive ?? false}
-        />
-      </ThemeProvider>
+      <Graph
+        css={css`
+          height: 100%;
+          width: 100%;
+        `}
+        nodes={nodes ?? []}
+        edges={edges ?? []}
+        interactive={interactive ?? false}
+      />
     );
   },
   title: 'Components/Graph Components/Graph Layout',

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/minimap/minimap_props.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/minimap/minimap_props.stories.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider } from '@emotion/react';
 import {
   ReactFlowProvider,
   ReactFlow,
@@ -111,11 +110,7 @@ export default {
     },
   },
   decorators: [
-    (Story) => (
-      <ThemeProvider theme={{ darkMode: false }}>
-        <ReactFlowProvider>{Story()}</ReactFlowProvider>
-      </ThemeProvider>
-    ),
+    (Story) => <ReactFlowProvider>{Story()}</ReactFlowProvider>,
     GlobalStylesStorybookDecorator,
   ],
 } satisfies Meta<typeof WrappedMinimap>;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/mock/test_providers.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/mock/test_providers.tsx
@@ -6,17 +6,14 @@
  */
 
 import React from 'react';
-import { euiDarkVars } from '@kbn/ui-theme';
-import { ThemeProvider } from '@emotion/react';
+import { EuiThemeProvider } from '@elastic/eui';
 
 interface Props {
   children?: React.ReactNode;
 }
 
 export const TestProvidersComponent = ({ children }: Props) => {
-  return (
-    <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>{children}</ThemeProvider>
-  );
+  return <EuiThemeProvider colorMode="dark">{children}</EuiThemeProvider>;
 };
 
 export const TestProviders = React.memo(TestProvidersComponent);

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/country_flags/country_flags.stories.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider } from '@emotion/react';
 import { EuiSpacer } from '@elastic/eui';
 import { CountryFlags as CountryFlagsComponent, useCountryFlagsPopover } from './country_flags';
 import { GlobalStylesStorybookDecorator } from '../../../../.storybook/decorators';
@@ -49,7 +48,7 @@ const CountryFlagsStoryComponent: React.FC = () => {
   const countryFlagsPopover = useCountryFlagsPopover(manyCountryCodes);
 
   return (
-    <ThemeProvider theme={{ darkMode: false }}>
+    <>
       <CountryFlagsComponent countryCodes={twoCountries} />
       <EuiSpacer size="l" />
       <CountryFlagsComponent countryCodes={manyCountryCodes} />
@@ -59,7 +58,7 @@ const CountryFlagsStoryComponent: React.FC = () => {
         onCountryClick={countryFlagsPopover.onCountryClick}
       />
       <countryFlagsPopover.PopoverComponent />
-    </ThemeProvider>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/ips/ips.stories.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider } from '@emotion/react';
 import { EuiSpacer, EuiText } from '@elastic/eui';
 import { Ips as IpsComponent, useIpPopover, type IpsProps } from './ips';
 import { GlobalStylesStorybookDecorator } from '../../../../.storybook/decorators';
@@ -38,7 +37,7 @@ const IpsStoryComponent: React.FC<IpsProps> = () => {
   const singleIpPopover = useIpPopover(singleIpClickable);
 
   return (
-    <ThemeProvider theme={{ darkMode: false }}>
+    <>
       {/* Single IP without click handler - renders as text */}
       <div>
         <EuiText>{'Single IP (non-clickable):'}</EuiText>
@@ -66,7 +65,7 @@ const IpsStoryComponent: React.FC<IpsProps> = () => {
 
       <singleIpPopover.PopoverComponent />
       <multipleIpsPopover.PopoverComponent />
-    </ThemeProvider>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label/label.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label/label.stories.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { ThemeProvider } from '@emotion/react';
 import { pick } from 'lodash';
 import { ReactFlow, Controls, Background } from '@xyflow/react';
 import type { StoryFn, StoryObj } from '@storybook/react';
@@ -43,24 +42,22 @@ const nodeTypes = {
 };
 
 const Template: StoryFn<NodeViewModel> = (args: NodeViewModel) => (
-  <ThemeProvider theme={{ darkMode: false }}>
-    <ReactFlow
-      fitView
-      attributionPosition={undefined}
-      nodeTypes={nodeTypes}
-      nodes={[
-        {
-          id: args.id,
-          type: args.shape,
-          data: pick(args, ['id', 'label', 'color', 'icon', 'interactive', 'expandButtonClick']),
-          position: { x: 0, y: 0 },
-        },
-      ]}
-    >
-      <Controls />
-      <Background />
-    </ReactFlow>
-  </ThemeProvider>
+  <ReactFlow
+    fitView
+    attributionPosition={undefined}
+    nodeTypes={nodeTypes}
+    nodes={[
+      {
+        id: args.id,
+        type: args.shape,
+        data: pick(args, ['id', 'label', 'color', 'icon', 'interactive', 'expandButtonClick']),
+        position: { x: 0, y: 0 },
+      },
+    ]}
+  >
+    <Controls />
+    <Background />
+  </ReactFlow>
 );
 
 export const ShortLabel: StoryObj<NodeViewModel> = {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.stories.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { ThemeProvider } from '@emotion/react';
 import { ReactFlow, Background } from '@xyflow/react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { LabelNode as LabelNodeComponent } from './label_node';
@@ -57,7 +56,7 @@ const nodeTypes = {
 };
 
 const Template: StoryFn<LabelNodeViewModel> = (args: LabelNodeViewModel) => (
-  <ThemeProvider theme={{ darkMode: false }}>
+  <>
     <ReactFlow
       fitView
       attributionPosition={undefined}
@@ -74,7 +73,7 @@ const Template: StoryFn<LabelNodeViewModel> = (args: LabelNodeViewModel) => (
       <Background />
     </ReactFlow>
     <GlobalGraphStyles />
-  </ThemeProvider>
+  </>
 );
 
 export const LabelNode: StoryObj<LabelNodeViewModel> = {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { ThemeProvider, css } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { LabelNodeViewModel } from '../..';
 import { Graph } from '../..';
@@ -117,7 +117,7 @@ const Template = () => {
   );
 
   return (
-    <ThemeProvider theme={{ darkMode: false }}>
+    <>
       <Graph
         css={css`
           height: 100%;
@@ -130,7 +130,7 @@ const Template = () => {
       {Object.values(popovers).map((popover, index) => (
         <popover.PopoverComponent key={index} />
       ))}
-    </ThemeProvider>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_details.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { ThemeProvider, css } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { LabelNodeViewModel } from '../..';
 import { Graph } from '../..';
@@ -41,17 +41,15 @@ const Template = () => {
   );
 
   return (
-    <ThemeProvider theme={{ darkMode: false }}>
-      <Graph
-        css={css`
-          height: 100%;
-          width: 100%;
-        `}
-        nodes={nodes}
-        edges={[]}
-        interactive={true}
-      />
-    </ThemeProvider>
+    <Graph
+      css={css`
+        height: 100%;
+        width: 100%;
+      `}
+      nodes={nodes}
+      edges={[]}
+      interactive={true}
+    />
   );
 };
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node.stories.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { ThemeProvider } from '@emotion/react';
 import { pick } from 'lodash';
 import { ReactFlow, Controls, Background } from '@xyflow/react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
@@ -63,7 +62,7 @@ const nodeTypes = {
 };
 
 const Template: StoryFn<NodeViewModel> = (args: NodeViewModel) => (
-  <ThemeProvider theme={{ darkMode: false }}>
+  <>
     <ReactFlow
       fitView
       attributionPosition={undefined}
@@ -93,7 +92,7 @@ const Template: StoryFn<NodeViewModel> = (args: NodeViewModel) => (
       <Background />
     </ReactFlow>
     <GlobalGraphStyles />
-  </ThemeProvider>
+  </>
 );
 
 export const Node: StoryObj<NodeViewModel> = {
@@ -121,13 +120,13 @@ export const Colors: StoryObj = {
     }));
 
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
+      <>
         <ReactFlow fitView attributionPosition={undefined} nodeTypes={nodeTypes} nodes={colorNodes}>
           <Controls />
           <Background />
         </ReactFlow>
         <GlobalGraphStyles />
-      </ThemeProvider>
+      </>
     );
   },
 };
@@ -154,13 +153,13 @@ export const Shapes: StoryObj = {
     );
 
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
+      <>
         <ReactFlow fitView attributionPosition={undefined} nodeTypes={nodeTypes} nodes={shapes}>
           <Controls />
           <Background />
         </ReactFlow>
         <GlobalGraphStyles />
-      </ThemeProvider>
+      </>
     );
   },
 };
@@ -199,13 +198,13 @@ export const Details: StoryObj = {
     }));
 
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
+      <>
         <ReactFlow fitView attributionPosition={undefined} nodeTypes={nodeTypes} nodes={nodes}>
           <Controls />
           <Background />
         </ReactFlow>
         <GlobalGraphStyles />
-      </ThemeProvider>
+      </>
     );
   },
 };
@@ -247,7 +246,7 @@ export const Interactivity: StoryObj = {
     ];
 
     return (
-      <ThemeProvider theme={{ darkMode: false }}>
+      <>
         <ReactFlow
           fitView
           attributionPosition={undefined}
@@ -258,7 +257,7 @@ export const Interactivity: StoryObj = {
           <Background />
         </ReactFlow>
         <GlobalGraphStyles />
-      </ThemeProvider>
+      </>
     );
   },
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_expand_button.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/node_expand_button.stories.tsx
@@ -8,7 +8,6 @@
 /* eslint-disable react/jsx-no-literals */
 
 import React from 'react';
-import { ThemeProvider } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { GlobalStylesStorybookDecorator } from '../../../.storybook/decorators';
 import { NodeShapeContainer } from './styles';
@@ -17,12 +16,10 @@ import { NodeExpandButton } from './node_expand_button';
 const meta = {
   component: NodeExpandButton,
   render: (args) => (
-    <ThemeProvider theme={{ darkMode: false }}>
-      <NodeShapeContainer>
-        Hover me
-        <NodeExpandButton color={args.color} onClick={args.onClick} />
-      </NodeShapeContainer>
-    </ThemeProvider>
+    <NodeShapeContainer>
+      Hover me
+      <NodeExpandButton color={args.color} onClick={args.onClick} />
+    </NodeShapeContainer>
   ),
   title: 'Components/Graph Components/Additional Components',
   argTypes: {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/relationship_node/relationship_node.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/relationship_node/relationship_node.stories.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { ThemeProvider } from '@emotion/react';
 import { ReactFlow, Background } from '@xyflow/react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { RelationshipNode as RelationshipNodeComponent } from './relationship_node';
@@ -44,7 +43,7 @@ const nodeTypes = {
 };
 
 const Template: StoryFn<RelationshipNodeViewModel> = (args: RelationshipNodeViewModel) => (
-  <ThemeProvider theme={{ darkMode: false }}>
+  <>
     <ReactFlow
       fitView
       attributionPosition={undefined}
@@ -61,7 +60,7 @@ const Template: StoryFn<RelationshipNodeViewModel> = (args: RelationshipNodeView
       <Background />
     </ReactFlow>
     <GlobalGraphStyles />
-  </ThemeProvider>
+  </>
 );
 
 export const RelationshipNode: StoryObj<RelationshipNodeViewModel> = {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/tag/tag.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/tag/tag.stories.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
-import { ThemeProvider } from '@emotion/react';
 import { Tag as TagComponent, type TagProps } from './tag';
 import { GlobalStylesStorybookDecorator } from '../../../../.storybook/decorators';
 
@@ -24,11 +23,7 @@ const meta: Meta<TagProps> = {
 
 export default meta;
 
-const Template: StoryFn<TagProps> = (props: TagProps) => (
-  <ThemeProvider theme={{ darkMode: false }}>
-    <TagComponent {...props} />
-  </ThemeProvider>
-);
+const Template: StoryFn<TagProps> = (props: TagProps) => <TagComponent {...props} />;
 
 export const Tag: StoryObj<TagProps> = {
   render: Template,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/primitives/graph_popover.stories.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/primitives/graph_popover.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ThemeProvider, css } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { EuiListGroup, EuiHorizontalRule } from '@elastic/eui';
 import type {
@@ -230,7 +230,7 @@ const Template = () => {
   );
 
   return (
-    <ThemeProvider theme={{ darkMode: false }}>
+    <>
       <Graph
         css={css`
           height: 100%;
@@ -242,7 +242,7 @@ const Template = () => {
         isLocked={isPopoverOpen}
       />
       {popovers?.map((popover) => popover.Popover && <popover.Popover key={popover.id} />)}
-    </ThemeProvider>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/tsconfig.json
@@ -9,7 +9,6 @@
     "@kbn/cloud-security-posture-common",
     "@kbn/data-views-plugin",
     "@kbn/kibana-react-plugin",
-    "@kbn/ui-theme",
     "@kbn/utility-types",
     "@kbn/unified-search-plugin",
     "@kbn/es-query",


### PR DESCRIPTION
## Summary

This PR consolidates the Emotion type augmentations into `@kbn/ambient-ui-types`, replacing the need for fragile relative-path references to `typings/emotion.d.ts` and per-package `@emotion/react/types/css-prop` entries scattered across 80+ tsconfig files.

In a lot of cases, we forget to manually add the `css-prop` _and_ the relative `emotion.d.ts` file (for EUI theme typing through the `css` prop) for browser packages.  By incorporating these changes into the `ambient-ui-types` package, we can maintain consistency throughout Kibana.

### What changed

Two triple-slash references were added to `@kbn/ambient-ui-types/index.d.ts`:

- `/// <reference path="./emotion.d.ts" />` — augments `@emotion/react`'s `Theme` interface to extend `UseEuiTheme` from `@elastic/eui`.
- `/// <reference types="@emotion/react/types/css-prop" />` — adds the `css` prop to JSX elements.

Since `@kbn/ambient-ui-types` is already in `tsconfig.base.json`'s `types` array, every package automatically gets both augmentations. Packages that override `types` only need to list `@kbn/ambient-ui-types` instead of both `@kbn/ambient-ui-types` and `@emotion/react/types/css-prop`.

### `kbn-cloud-security-posture` graph story fixes

Making the Emotion `Theme` augmentation globally available exposed a pre-existing type error in `kbn-cloud-security-posture/graph`. The story and test-provider files were using `@emotion/react`'s `ThemeProvider` with `{ darkMode: false }` as the theme object, which is not a valid `UseEuiTheme`. This was silently accepted before because the package did not reference the `Theme` augmentation — once it became globally available, TypeScript correctly flagged `darkMode` as an unknown property.

The fix replaces `ThemeProvider` from `@emotion/react` with `EuiThemeProvider` from `@elastic/eui` across 19 story files and `test_providers.tsx`, which is the intended pattern for providing EUI theme context in Kibana.

### What's next

Draft cleanup PRs have been opened, per team, to remove the now-redundant:
- Relative-path references to `typings/emotion.d.ts` from tsconfig `types` and `include` arrays
- `@emotion/react/types/css-prop` entries from tsconfig `types` arrays
- Local `emotion.d.ts` copies in individual packages

You can track the progress in [#254341](https://github.com/elastic/kibana/issues/254351).

A final cleanup PR will remove `typings/emotion.d.ts` and `@emotion/react/types/css-prop` from `tsconfig.base.json` once all team PRs have shipped.