### PR TITLE
[chore] Remove css-prop, emotion.d.ts for kibana-presentation

### DIFF
--- a/src/platform/packages/private/kbn-controls-renderer/tsconfig.json
+++ b/src/platform/packages/private/kbn-controls-renderer/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "types": ["jest", "node", "@emotion/react/types/css-prop"]
+    "types": ["jest", "node", "@kbn/ambient-ui-types"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["target/**/*"],

--- a/src/platform/packages/private/kbn-grid-layout/tsconfig.json
+++ b/src/platform/packages/private/kbn-grid-layout/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types"
   },
-  "include": ["**/*.ts", "**/*.tsx", "../../../../../typings/emotion.d.ts"],
+  "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/i18n",

--- a/src/platform/plugins/private/links/tsconfig.json
+++ b/src/platform/plugins/private/links/tsconfig.json
@@ -8,8 +8,7 @@
     "public/**/*",
     "common/**/*",
     "server/**/*",
-    "public/**/*.json",
-    "../../../../../typings/emotion.d.ts"
+    "public/**/*.json"
   ],
   "kbn_references": [
     "@kbn/core",


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/kibana-presentation`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.