### PR TITLE
[chore] Remove css-prop, emotion.d.ts for kibana-esql

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/tsconfig.json
+++ b/src/platform/packages/private/kbn-esql-editor/tsconfig.json
@@ -5,7 +5,7 @@
     "types": [
       "jest",
       "node",
-      "@emotion/react/types/css-prop"
+      "@kbn/ambient-ui-types"
     ]
   },
   "include": [

--- a/src/platform/packages/private/kbn-index-editor/tsconfig.json
+++ b/src/platform/packages/private/kbn-index-editor/tsconfig.json
@@ -6,7 +6,7 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/src/platform/packages/private/kbn-language-documentation/tsconfig.json
+++ b/src/platform/packages/private/kbn-language-documentation/tsconfig.json
@@ -5,7 +5,7 @@
     "types": [
       "jest",
       "node",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/kibana-esql`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.