### PR TITLE
[chore] Remove css-prop, emotion.d.ts for kibana-data-discovery

### DIFF
--- a/src/platform/packages/private/kbn-split-button/tsconfig.json
+++ b/src/platform/packages/private/kbn-split-button/tsconfig.json
@@ -6,7 +6,7 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
       "@testing-library/jest-dom",
       "@testing-library/react"
     ]

--- a/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
@@ -3,11 +3,11 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
       "react",
-      "@testing-library/jest-dom",
-      "../../../../../typings/emotion.d.ts"
+      "@testing-library/jest-dom"
     ]
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/src/platform/packages/shared/kbn-unified-data-table/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-data-table/tsconfig.json
@@ -8,7 +8,6 @@
     "**/*.tsx",
     "src/**/*",
     "__mocks__/**/*.ts",
-    "../../../../../typings/emotion.d.ts"
   ],
   "exclude": ["target/**/*"],
   "kbn_references": [

--- a/src/platform/packages/shared/kbn-unified-field-list/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-field-list/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types"
   },
-  "include": ["*.ts", "src/**/*", "__mocks__/**/*.ts", "../../../../../typings/emotion.d.ts"],
+  "include": ["*.ts", "src/**/*", "__mocks__/**/*.ts"],
   "kbn_references": [
     "@kbn/i18n",
     "@kbn/data-views-plugin",


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/kibana-data-discovery`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.