### PR TITLE
[chore] Remove css-prop, emotion.d.ts for security-threat-hunting-investigations

### DIFF
--- a/src/platform/packages/shared/kbn-cell-actions/moon.yml
+++ b/src/platform/packages/shared/kbn-cell-actions/moon.yml
@@ -18,16 +18,16 @@ project:
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-cell-actions
 dependsOn:
-  - '@kbn/ui-theme'
   - '@kbn/i18n'
+  - '@kbn/data-views-plugin'
   - '@kbn/core'
+  - '@kbn/field-types'
   - '@kbn/data-plugin'
   - '@kbn/es-query'
-  - '@kbn/ui-actions-plugin'
-  - '@kbn/field-types'
-  - '@kbn/data-views-plugin'
   - '@kbn/core-notifications-browser'
   - '@kbn/utility-types'
+  - '@kbn/ui-theme'
+  - '@kbn/ui-actions-plugin'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/kbn-cell-actions/tsconfig.json
+++ b/src/platform/packages/shared/kbn-cell-actions/tsconfig.json
@@ -6,23 +6,18 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
       "@testing-library/jest-dom",
-      "@testing-library/react"
+      "@testing-library/react",
     ]
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "kbn_references": [
-    "@kbn/ui-theme",
     "@kbn/i18n",
-    "@kbn/core",
-    "@kbn/data-plugin",
-    "@kbn/es-query",
-    "@kbn/ui-actions-plugin",
-    "@kbn/field-types",
-    "@kbn/data-views-plugin",
-    "@kbn/core-notifications-browser",
-    "@kbn/utility-types",
+    "@kbn/ai-assistant-connector-selector-action",
+    "@kbn/triggers-actions-ui-plugin",
+    "@kbn/management-settings-ids",
+    "@kbn/core-ui-settings-browser",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/packages/shared/kbn-cell-actions/tsconfig.json
+++ b/src/platform/packages/shared/kbn-cell-actions/tsconfig.json
@@ -14,10 +14,15 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "kbn_references": [
     "@kbn/i18n",
-    "@kbn/ai-assistant-connector-selector-action",
-    "@kbn/triggers-actions-ui-plugin",
-    "@kbn/management-settings-ids",
-    "@kbn/core-ui-settings-browser",
+    "@kbn/data-views-plugin",
+    "@kbn/core",
+    "@kbn/field-types",
+    "@kbn/data-plugin",
+    "@kbn/es-query",
+    "@kbn/core-notifications-browser",
+    "@kbn/utility-types",
+    "@kbn/ui-theme",
+    "@kbn/ui-actions-plugin",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/packages/shared/kbn-unified-data-table/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-data-table/tsconfig.json
@@ -8,7 +8,6 @@
     "**/*.tsx",
     "src/**/*",
     "__mocks__/**/*.ts",
-    "../../../../../typings/emotion.d.ts"
   ],
   "exclude": ["target/**/*"],
   "kbn_references": [

--- a/x-pack/solutions/security/packages/connectors/tsconfig.json
+++ b/x-pack/solutions/security/packages/connectors/tsconfig.json
@@ -6,9 +6,9 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/tsconfig.json
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/tsconfig.json
@@ -3,11 +3,10 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
-      "react",
-      "@emotion/react/types/css-prop",
-      "../../../../../typings/emotion.d.ts"
+      "react"
     ]
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/x-pack/solutions/security/packages/expandable-flyout/tsconfig.json
+++ b/x-pack/solutions/security/packages/expandable-flyout/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react"
     ]

--- a/x-pack/solutions/security/packages/navigation/tsconfig.json
+++ b/x-pack/solutions/security/packages/navigation/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react"
     ]

--- a/x-pack/solutions/security/packages/side-nav/tsconfig.json
+++ b/x-pack/solutions/security/packages/side-nav/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
       "@kbn/ambient-ui-types"

--- a/x-pack/solutions/security/packages/upselling/tsconfig.json
+++ b/x-pack/solutions/security/packages/upselling/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
       "@kbn/ambient-ui-types"


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/security-threat-hunting-investigations`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.