### PR TITLE
[chore] Remove css-prop, emotion.d.ts for obs-onboarding-team

### DIFF
--- a/src/platform/packages/shared/kbn-grok-ui/tsconfig.json
+++ b/src/platform/packages/shared/kbn-grok-ui/tsconfig.json
@@ -3,11 +3,11 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
       "react",
-      "@testing-library/jest-dom",
-      "@emotion/react/types/css-prop"
+      "@testing-library/jest-dom"
     ]
   },
   "include": [
@@ -24,6 +24,6 @@
     "@kbn/code-editor",
     "@kbn/i18n",
     "@kbn/object-utils",
-    "@kbn/react-hooks",
+    "@kbn/react-hooks"
   ]
 }

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/tsconfig.json
@@ -6,11 +6,12 @@
       "jest",
       "node",
       "react",
-      "@testing-library/jest-dom"
+      "@testing-library/jest-dom",
+      "@kbn/ambient-ui-types"
     ]
   },
   "include": [
-    "**/*.ts", "**/*.tsx", "../../../../../typings/emotion.d.ts"
+    "**/*.ts", "**/*.tsx"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/platform/packages/shared/kbn-streamlang-yaml-editor/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-streamlang-yaml-editor/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
-      "react",
-      "@emotion/react/types/css-prop"
+      "react"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/obs-onboarding-team`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.