### PR TITLE
[chore] Remove css-prop, emotion.d.ts for kibana-security

### DIFF
--- a/src/platform/packages/shared/kbn-user-profile-components/tsconfig.json
+++ b/src/platform/packages/shared/kbn-user-profile-components/tsconfig.json
@@ -5,7 +5,8 @@
     "types": [
       "jest",
       "node",
-      "@emotion/react/types/css-prop",
+      "react",
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [

--- a/x-pack/platform/packages/shared/security/form_components/tsconfig.json
+++ b/x-pack/platform/packages/shared/security/form_components/tsconfig.json
@@ -6,8 +6,7 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
-      "../../../../../../typings/emotion.d.ts"
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [

--- a/x-pack/platform/plugins/shared/security/tsconfig.json
+++ b/x-pack/platform/plugins/shared/security/tsconfig.json
@@ -8,8 +8,7 @@
     "public/**/*",
     "server/**/*",
     "test/**/*",
-    "__mocks__/**/*",
-    "../../../../../typings/emotion.d.ts"
+    "__mocks__/**/*"
   ],
   "kbn_references": [
     "@kbn/cloud-plugin",


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/kibana-security`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.