### PR TITLE
[chore] Remove css-prop, emotion.d.ts for eui-team

### DIFF
--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/tsconfig.json
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/tsconfig.json
@@ -5,7 +5,6 @@
     "types": [
       "jest",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@kbn/ambient-ui-types",
     ]


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/eui-team`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.