### PR TITLE
[chore] Remove css-prop, emotion.d.ts for ml-ui

### DIFF
--- a/x-pack/platform/packages/private/ml/aiops_components/tsconfig.json
+++ b/x-pack/platform/packages/private/ml/aiops_components/tsconfig.json
@@ -11,7 +11,7 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop"
+      "@kbn/ambient-ui-types"
     ]
   },
   "include": [

--- a/x-pack/platform/packages/private/ml/data_grid/tsconfig.json
+++ b/x-pack/platform/packages/private/ml/data_grid/tsconfig.json
@@ -6,15 +6,14 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
       "@testing-library/jest-dom",
-      "@testing-library/react"
+      "@testing-library/react",
     ]
   },
   "include": [
     "**/*.ts",
     "**/*.tsx",
-    "../../../../../../typings/emotion.d.ts"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/platform/packages/private/ml/in_memory_table/tsconfig.json
+++ b/x-pack/platform/packages/private/ml/in_memory_table/tsconfig.json
@@ -6,7 +6,7 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
+      "@kbn/ambient-ui-types",
       "@testing-library/jest-dom",
       "@testing-library/react"
     ]

--- a/x-pack/platform/packages/shared/file-upload/tsconfig.json
+++ b/x-pack/platform/packages/shared/file-upload/tsconfig.json
@@ -7,8 +7,7 @@
       "node",
       "react",
       "@testing-library/jest-dom",
-      "@emotion/react/types/css-prop",
-      "../../../../../typings/emotion.d.ts"
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": [
@@ -17,7 +16,6 @@
     "**/*.tsx",
     "**/*.svg",
     "**/*.d.ts",
-    "../../../../../typings/emotion.d.ts"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/ml-ui`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.