### PR TITLE
[chore] Remove css-prop, emotion.d.ts for appex-ai-infra

### DIFF
--- a/x-pack/platform/packages/shared/ai-assistant/ai-agent-confirmation-modal/tsconfig.json
+++ b/x-pack/platform/packages/shared/ai-assistant/ai-agent-confirmation-modal/tsconfig.json
@@ -6,7 +6,6 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@kbn/ambient-ui-types",
       "@testing-library/jest-dom",
     ]


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/appex-ai-infra`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.