### PR TITLE
[chore] Remove css-prop, emotion.d.ts for obs-presentation-team

### DIFF
--- a/x-pack/platform/packages/shared/kbn-event-stacktrace/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-event-stacktrace/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
+      "@kbn/ambient-ui-types",
       "jest",
       "node",
       "react",
@@ -12,8 +13,7 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
-    "src/**/*.json",
-    "../../../../../typings/emotion.d.ts"
+    "src/**/*.json"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/tsconfig.json
@@ -6,11 +6,12 @@
       "jest",
       "node",
       "react",
-      "@testing-library/jest-dom"
+      "@testing-library/jest-dom",
+      "@kbn/ambient-ui-types"
     ]
   },
   "include": [
-    "**/*.ts", "**/*.tsx", "../../../../../typings/emotion.d.ts"
+    "**/*.ts", "**/*.tsx"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/obs-presentation-team`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.