### PR TITLE
[chore] Remove css-prop, emotion.d.ts for contextual-security-apps

### DIFF
--- a/x-pack/solutions/security/packages/distribution-bar/tsconfig.json
+++ b/x-pack/solutions/security/packages/distribution-bar/tsconfig.json
@@ -6,9 +6,9 @@
       "jest",
       "node",
       "react",
-      "@emotion/react/types/css-prop",
       "@testing-library/jest-dom",
       "@testing-library/react",
+      "@kbn/ambient-ui-types",
     ]
   },
   "include": ["**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## Summary

Removes legacy `emotion.d.ts` relative-path references and `@emotion/react/types/css-prop` entries from tsconfig files owned by `elastic/contextual-security-apps`, replacing them with `@kbn/ambient-ui-types`.

Depends on https://github.com/elastic/kibana/pull/254322 -- this PR will go out for review once that PR is merged.