### PR TITLE
[8.19] [Scout] remove lastModified from manifests (#254098)

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/registry/manifest.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/registry/manifest.ts
@@ -21,7 +21,6 @@ export const getGitSHA1ForPath = async (p: string) => {
 export interface ScoutConfigManifest {
   path: string;
   exists: boolean;
-  lastModified: string;
   sha1: string;
   tests: {
     id: string;

--- a/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.test.ts
@@ -18,7 +18,6 @@ jest.mock('fast-glob');
 
 const dummyManifestProps = {
   exists: false,
-  lastModified: new Date(0).toISOString(),
   sha1: '000000000000000-000000000000000',
   tests: [],
 };
@@ -83,7 +82,6 @@ describe('test_config module', () => {
         );
         const scoutRoot = path.join(moduleRoot, 'test/scout');
         const validManifestContent = {
-          lastModified: '2025-12-03T19:04:17.097Z',
           sha1: 'b72df4fa5abc546e5f21e6c2f6eaaaa523755720',
           tests: [
             {

--- a/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.ts
@@ -83,7 +83,6 @@ export const testConfig = {
       }
     } else {
       manifestFileData = {
-        lastModified: new Date(0).toISOString(),
         sha1: '000000000000000-000000000000000',
         tests: [],
       };

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/manifest_updater/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/manifest_updater/playwright_reporter.ts
@@ -65,7 +65,6 @@ export class ScoutManifestUpdater implements Reporter {
       this.scoutConfig.manifest.path,
       JSON.stringify(
         {
-          lastModified: new Date().toISOString(),
           sha1: await getGitSHA1ForPath(path.dirname(this.scoutConfig.path)),
           tests: this.scoutConfig.manifest.tests,
         },

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -149,7 +149,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginA/config1.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'abc123',
               tests: [
                 {
@@ -176,7 +175,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginA/parallel.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'def456',
               tests: [
                 {
@@ -205,7 +203,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginB/config3.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'ghi789',
               tests: [
                 {
@@ -234,7 +231,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'packageA/config4.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'jkl012',
               tests: [
                 {
@@ -383,7 +379,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginNoMatch/config.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'mno345',
               tests: [
                 {
@@ -466,7 +461,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginNoTests/config.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'pqr678',
               tests: [
                 {
@@ -519,7 +513,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginMixedTests/config.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'stu901',
               tests: [
                 {
@@ -620,7 +613,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginTestModes/config1.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'vwx234',
               tests: [
                 {
@@ -644,7 +636,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
             manifest: {
               path: 'pluginTestModes/config2.playwright.config.ts',
               exists: true,
-              lastModified: '2024-01-01T00:00:00Z',
               sha1: 'yza567',
               tests: [
                 {
@@ -694,7 +685,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
               manifest: {
                 path: 'pluginSearch/config1.playwright.config.ts',
                 exists: true,
-                lastModified: '2024-01-01T00:00:00Z',
                 sha1: 'bcd234',
                 tests: [
                   {
@@ -714,7 +704,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
               manifest: {
                 path: 'pluginSearch/config2.playwright.config.ts',
                 exists: true,
-                lastModified: '2024-01-01T00:00:00Z',
                 sha1: 'cde345',
                 tests: [
                   {
@@ -743,7 +732,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
               manifest: {
                 path: 'pluginPlatform/config1.playwright.config.ts',
                 exists: true,
-                lastModified: '2024-01-01T00:00:00Z',
                 sha1: 'def456',
                 tests: [
                   {
@@ -772,7 +760,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
               manifest: {
                 path: 'pluginOblt/config1.playwright.config.ts',
                 exists: true,
-                lastModified: '2024-01-01T00:00:00Z',
                 sha1: 'efg567',
                 tests: [
                   {
@@ -985,7 +972,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
               manifest: {
                 path: 'pluginMultiMode/config1.playwright.config.ts',
                 exists: true,
-                lastModified: '2024-01-01T00:00:00Z',
                 sha1: 'fgh678',
                 tests: [
                   {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Scout] remove lastModified from manifests (#254098)](https://github.com/elastic/kibana/pull/254098)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-02-19T23:13:40Z","message":"[Scout] remove lastModified from manifests (#254098)\n\nIt will be a cause of merge conflicts and we can derive last modified by\nthe file/git.","sha":"836fe60a2cd91cb81d948ba76fc2964eb4f6b1c2","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"[Scout] remove lastModified from manifests","number":254098,"url":"https://github.com/elastic/kibana/pull/254098","mergeCommit":{"message":"[Scout] remove lastModified from manifests (#254098)\n\nIt will be a cause of merge conflicts and we can derive last modified by\nthe file/git.","sha":"836fe60a2cd91cb81d948ba76fc2964eb4f6b1c2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254098","number":254098,"mergeCommit":{"message":"[Scout] remove lastModified from manifests (#254098)\n\nIt will be a cause of merge conflicts and we can derive last modified by\nthe file/git.","sha":"836fe60a2cd91cb81d948ba76fc2964eb4f6b1c2"}}]}] BACKPORT-->