### PR TITLE
[8.19] [Scout] Fix config path regex to support nested plugin paths (#252620)

### DIFF
--- a/src/platform/packages/private/kbn-scout-info/src/paths.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.ts
@@ -40,7 +40,7 @@ export const TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX = new RegExp(
     `\/(?:(platform)|solutions\/(\\w+))` + // 1: platform, 2: solution
     `\/(plugins|packages)` + // 3: plugin or package
     `\/?(shared|private|)` + // 4: artifact visibility
-    `\/([\\w|-]*)` + // 5: plugin/package name
+    `\/([\\w|-]+(?:\\/[\\w|-]+)*)` + // 5: plugin/package name (supports nested paths like vis_types/timelion)
     `\/test\/scout(?:_([^\\/]*))?` // 6: custom target config set name
 );
 export const SCOUT_CONFIG_PATH_GLOB =


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Scout] Fix config path regex to support nested plugin paths (#252620)](https://github.com/elastic/kibana/pull/252620)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-02-12T12:54:35Z","message":"[Scout] Fix config path regex to support nested plugin paths (#252620)\n\nThe SCOUT_CONFIG_PATH_REGEX only matched single-segment module names\n(e.g., `dashboard`), causing `update-test-config-manifests` to fail for\nnested plugins like `vis_types/timelion`. Updated the regex group to\nallow multi-segment names and added a test case for nested paths.\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>","sha":"93f2f7436e26011a3d3721d7d20d5bfb963739df","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"[Scout] Fix config path regex to support nested plugin paths","number":252620,"url":"https://github.com/elastic/kibana/pull/252620","mergeCommit":{"message":"[Scout] Fix config path regex to support nested plugin paths (#252620)\n\nThe SCOUT_CONFIG_PATH_REGEX only matched single-segment module names\n(e.g., `dashboard`), causing `update-test-config-manifests` to fail for\nnested plugins like `vis_types/timelion`. Updated the regex group to\nallow multi-segment names and added a test case for nested paths.\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>","sha":"93f2f7436e26011a3d3721d7d20d5bfb963739df"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252620","number":252620,"mergeCommit":{"message":"[Scout] Fix config path regex to support nested plugin paths (#252620)\n\nThe SCOUT_CONFIG_PATH_REGEX only matched single-segment module names\n(e.g., `dashboard`), causing `update-test-config-manifests` to fail for\nnested plugins like `vis_types/timelion`. Updated the regex group to\nallow multi-segment names and added a test case for nested paths.\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>","sha":"93f2f7436e26011a3d3721d7d20d5bfb963739df"}}]}] BACKPORT-->