### PR TITLE
[ES|QL] Fixes the antlr script failure

### DIFF
--- a/.buildkite/scripts/steps/esql_grammar_sync.sh
+++ b/.buildkite/scripts/steps/esql_grammar_sync.sh
@@ -183,6 +183,9 @@ main () {
 
   # Note: We run build commands directly instead of `yarn build:antlr4` to skip
   # the prebuild:antlr4 hook which uses `brew` (macOS only). CI has antlr installed.
+  # Pin the ANTLR version to avoid the broken Sonatype Central version-lookup API
+  # in antlr4-tools (https://github.com/antlr/antlr4-tools/issues/18).
+  export ANTLR4_TOOLS_ANTLR_VERSION="4.13.2"
   cd ./src/platform/packages/shared/kbn-esql-language
   yarn build:antlr4:esql
   yarn build:antlr4:promql


### PR DESCRIPTION
## Summary

**This is not a kibana bug,  it's in the upstream antlr4-tools Python package (the antlr CLI command).**

- The antlr command is actually a Python wrapper (antlr4_tool_runner.py) that first needs to determine which ANTLR4 version to use. It does this by calling the Sonatype Central search API:
   https://central.sonatype.com/solrsearch/select?q=a:antlr4-master+g:org.antlr

- Sonatype retired the legacy /solrsearch/select API (the "Classic Search" was sunset on January 14, 2022, but the endpoint apparently kept working until recently). It now returns HTTP 400.

- When that fails, antlr4-tools falls back to checking for a previously-downloaded ANTLR JAR. On the CI machine, that resolves to /opt/buildkite-agent/.m2/repository/org/antlr/antlr4, which doesn't exist because ANTLR was never previously downloaded on that agent.

Result: FileNotFoundError and the build crashes.

Even the latest released version of antlr4-tools (v0.2.2, April 2025) still uses this broken URL, so upgrading the pip package alone won't fix it.

The simplest and most robust fix is to set the ANTLR4_TOOLS_ANTLR_VERSION environment variable in the CI script. 

Tested the script manually here https://buildkite.com/elastic/kibana-es-ql-grammar-sync/builds/196 (it by passed the failure, failed due to CI resources)