### PR TITLE
[Core] User activity actions dictionary

### DIFF
--- a/examples/user_activity_example/server/routes.ts
+++ b/examples/user_activity_example/server/routes.ts
@@ -29,8 +29,9 @@ export function registerRoutes(router: IRouter, core: CoreSetup) {
       // Track the user action
       coreStart.userActivity.trackUserAction({
         event: {
-          action: 'example_button_click',
-          type: 'user',
+          // using as any so we can create a testing action id
+          action: 'example_button_click' as any,
+          type: 'change',
         },
         object: {
           id: 'example-object-1',

--- a/examples/user_activity_example/server/routes.ts
+++ b/examples/user_activity_example/server/routes.ts
@@ -29,7 +29,7 @@ export function registerRoutes(router: IRouter, core: CoreSetup) {
       // Track the user action
       coreStart.userActivity.trackUserAction({
         event: {
-          // using `as any` because we don't want to add this action to the public docs 
+          // using `as any` because we don't want to add this action to the public docs
           action: 'example_button_click' as any,
           type: 'change',
         },

--- a/examples/user_activity_example/server/routes.ts
+++ b/examples/user_activity_example/server/routes.ts
@@ -29,7 +29,7 @@ export function registerRoutes(router: IRouter, core: CoreSetup) {
       // Track the user action
       coreStart.userActivity.trackUserAction({
         event: {
-          // using as any so we can create a testing action id
+          // using `as any` because we don't want to add this action to the public docs 
           action: 'example_button_click' as any,
           type: 'change',
         },

--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -635,7 +635,7 @@ export class HttpServer {
         user: user
           ? {
               id: user.profile_uid,
-              username: user.username,
+              name: user.username,
               email: user.email,
               roles: user.roles ? [...user.roles] : undefined,
             }

--- a/src/core/packages/user-activity/server-internal/src/types.ts
+++ b/src/core/packages/user-activity/server-internal/src/types.ts
@@ -28,8 +28,8 @@ export interface SpaceContext {
 export interface UserContext {
   /** User profile id. */
   id?: string;
-  /** Username. */
-  username?: string;
+  /** Username / login name. */
+  name?: string;
   /** User email address. */
   email?: string;
   /** User roles. */

--- a/src/core/packages/user-activity/server-internal/src/user_activity_service.ts
+++ b/src/core/packages/user-activity/server-internal/src/user_activity_service.ts
@@ -90,7 +90,7 @@ export class UserActivityService
     const injectedContext = this.getInjectedContext();
 
     if (!message) {
-      message = `User ${injectedContext.user?.username} performed ${event.action} on ${object.name} (${object.id})`;
+      message = `User ${injectedContext.user?.name} performed ${event.action} on ${object.name} (${object.id})`;
     }
 
     this.logger.info(message, { message, event, object, ...injectedContext });

--- a/src/core/packages/user-activity/server/README.md
+++ b/src/core/packages/user-activity/server/README.md
@@ -23,6 +23,25 @@ core.userActivity.trackUserAction({
 });
 ```
 
+## Registering new actions
+
+Every action must be registered in `userActivityActions` (`src/user_activity_actions.ts`).
+Each entry requires a `description`, an `ownerTeam` (GitHub team handle), and a `versionAddedAt` (Stack version when the action was introduced).
+
+```ts
+export const userActivityActions = {
+  // ... existing actions ...
+  archive_case: {
+    description: 'Archive a case',
+    ownerTeam: '@elastic/kibana-security',
+    groupName: 'Cases',
+    versionAddedAt: '9.3',
+  },
+} as const satisfies Record<string, UserActivityActionDefinition>;
+```
+
+When an action is removed, move it from `userActivityActions` to `removedUserActivityActions` and add `versionRemovedAt`.
+
 ## Configuration
 
 Configure the service in `kibana.yml`:
@@ -53,7 +72,7 @@ The following context is automatically added to every log entry by Kibana's HTTP
 | Field | Description |
 |-------|-------------|
 | `user.id` | User's profile UID |
-| `user.username` | Username |
+| `user.name` | Username |
 | `user.email` | Email address |
 | `user.roles` | Array of roles |
 | `client.ip` | IP address |

--- a/src/core/packages/user-activity/server/README.md
+++ b/src/core/packages/user-activity/server/README.md
@@ -33,7 +33,7 @@ export const userActivityActions = {
   // ... existing actions ...
   archive_case: {
     description: 'Archive a case',
-    ownerTeam: '@elastic/kibana-security',
+    ownerTeam: '@elastic/kibana-cases',
     groupName: 'Cases',
     versionAddedAt: '9.3',
   },

--- a/src/core/packages/user-activity/server/index.ts
+++ b/src/core/packages/user-activity/server/index.ts
@@ -15,3 +15,10 @@ export type {
   UserActivityServiceSetup,
   UserActivityServiceStart,
 } from './src/types';
+
+export type {
+  UserActivityActionDefinition,
+  UserActivityActionId,
+} from './src/user_activity_actions';
+
+export { userActivityActions } from './src/user_activity_actions';

--- a/src/core/packages/user-activity/server/src/types.ts
+++ b/src/core/packages/user-activity/server/src/types.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { UserActivityActionId } from './user_activity_actions';
+
 /**
  * Information about the object being acted upon.
  * @public
@@ -52,7 +54,7 @@ export type UserActivityEventType =
  */
 export interface UserActivityEvent {
   /** Descriptive action name, e.g., 'view_dashboard', 'edit_case', 'save_search' */
-  action: string;
+  action: UserActivityActionId;
   /** Event type {@link UserActivityEventType}. */
   type: UserActivityEventType;
 }
@@ -74,7 +76,7 @@ export interface TrackUserActionParams {
  * @example
  * ```ts
  * core.userActivity.trackUserAction({
- *   event: { action: 'create_dashboard', type: 'creation' },
+ *   event: { action: 'edit_dashboard', type: 'change' },
  *   object: { id: 'dash-123', name: 'My Dashboard', type: 'dashboard', tags: [] },
  * });
  * ```

--- a/src/core/packages/user-activity/server/src/user_activity_actions.test.ts
+++ b/src/core/packages/user-activity/server/src/user_activity_actions.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { removedUserActivityActions, userActivityActions } from './user_activity_actions';
+
+// These counts are intentional guards to keep the registries tidy.
+// If you remove an action id, move it to `removedUserActivityActions` (don't delete it),
+// then update these numbers.
+const EXPECTED_TOTAL_COUNT = 3; // active + removed
+const EXPECTED_REMOVED_COUNT = 2; // removed only
+
+describe('userActivityActions registry', () => {
+  it('keeps the total number of action ids stable', () => {
+    const activeCount = Object.keys(userActivityActions).length;
+    const removedCount = Object.keys(removedUserActivityActions).length;
+
+    expect(activeCount + removedCount).toBe(EXPECTED_TOTAL_COUNT);
+  });
+
+  it('keeps removed action ids listed', () => {
+    expect(Object.keys(removedUserActivityActions)).toHaveLength(EXPECTED_REMOVED_COUNT);
+  });
+
+  it('does not allow overlapping action ids', () => {
+    const activeIds = new Set(Object.keys(userActivityActions));
+    const overlaps = Object.keys(removedUserActivityActions).filter((id) => activeIds.has(id));
+
+    expect(overlaps).toHaveLength(0);
+  });
+});

--- a/src/core/packages/user-activity/server/src/user_activity_actions.ts
+++ b/src/core/packages/user-activity/server/src/user_activity_actions.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Definition for a user-activity action.
+ * @public
+ */
+export interface UserActivityActionDefinition {
+  /** Human-readable description of the action. */
+  description: string;
+  /** Team that owns this action, for example: `@elastic/kibana-core`. */
+  ownerTeam: string;
+  /** Group name used to organize actions in UIs/docs (for example: `dashboard`, `cases`). */
+  groupName: string;
+  /** Stack version where the action was introduced (for example: `9.5`). */
+  versionAddedAt: string;
+}
+
+/**
+ * Central registry of all known user-activity actions.
+ * To add a new action, add an entry with a `description`, `ownerTeam`, `groupName` and `versionAddedAt`.
+ * @private
+ */
+export const userActivityActions = {
+  dashboard_created: {
+    description:
+      '[THIS IS AN EXAMPLE AND WILL BE REMOVED LATER] User created a dashboard in Kibana.',
+    ownerTeam: '@elastic/kibana-core',
+    groupName: 'Dashboards',
+    versionAddedAt: '9.4',
+  },
+} as const satisfies Record<string, UserActivityActionDefinition>;
+
+/** Closed union derived from the keys of {@link userActivityActions}. @public */
+export type UserActivityActionId = keyof typeof userActivityActions;
+
+/**
+ * Definition for a user-activity action that has been removed.
+ * Just adding the version when it was removed for documentation purposes.
+ * @private
+ */
+export interface RemovedUserActivityActionDefinition extends UserActivityActionDefinition {
+  /** Stack version where the action was removed (for example: `9.6`). */
+  versionRemovedAt: string;
+}
+
+/**
+ * Registry for actions that have been removed.
+ * @private
+ */
+export const removedUserActivityActions = {
+  rule_schedule_updated: {
+    description:
+      '[THIS IS AN EXAMPLE AND WILL BE REMOVED LATER] User updated an alerting rule schedule.',
+    ownerTeam: '@elastic/kibana-core',
+    groupName: 'Rules',
+    versionAddedAt: '9.0',
+    versionRemovedAt: '9.3',
+  },
+  dashboard_duplicated: {
+    description: '[THIS IS AN EXAMPLE AND WILL BE REMOVED LATER] User duplicated a dashboard.',
+    ownerTeam: '@elastic/kibana-core',
+    groupName: 'Dashboards',
+    versionAddedAt: '8.4',
+    versionRemovedAt: '8.10',
+  },
+} as const satisfies Record<string, RemovedUserActivityActionDefinition>;

--- a/src/core/server/integration_tests/http/user_activity_injected_context.test.ts
+++ b/src/core/server/integration_tests/http/user_activity_injected_context.test.ts
@@ -90,7 +90,7 @@ describe('user activity injected context', () => {
       async (context, request, response) => {
         userActivity.trackUserAction({
           message: 'ua-test',
-          event: { action: 'ua_test_action', type: 'user' },
+          event: { action: 'ua_test_action' as any, type: 'user' },
           object: { id: 'obj-1', name: 'Test Object', type: 'test', tags: ['tag-a'] },
         });
         return response.ok({ body: { ok: true } });
@@ -126,7 +126,7 @@ describe('user activity injected context', () => {
       },
       user: {
         id: 'test_profile_uid',
-        username: 'test_user',
+        name: 'test_user',
         email: 'test_user@example.com',
         roles: ['superuser'],
       },


### PR DESCRIPTION
## Summary

This PR intentionally focuses on the **user activity actions dictionary/registry** so other teams can start referencing stable, typed action ids while we continue working on the remaining documentation/follow-ups in https://github.com/elastic/kibana/pull/253095.

- Add a central `userActivityActions` registry and derive a `UserActivityActionId` union from it.
- Export the registry and types from `@kbn/core-user-activity-server`.
- Type `trackUserAction({ event.action })` as `UserActivityActionId`.
- Update the example route and package README.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### Identify risks

None.

## Test plan

- `yarn test:jest src/core/packages/user-activity/server-internal/src/user_activity_service.test.ts`
- `yarn test:jest src/core/packages/user-activity/server/src/user_activity_actions.test.ts`
- `yarn test:jest_integration src/core/server/integration_tests/http/user_activity_injected_context.test.ts`

All passing locally.

Made with [Cursor](https://cursor.com)