### PR TITLE
[Dashboard] Fix flaky ES|QL chart test by awaiting render completion

### DIFF
--- a/src/platform/test/functional/apps/dashboard/group6/dashboard_esql_chart.ts
+++ b/src/platform/test/functional/apps/dashboard/group6/dashboard_esql_chart.ts
@@ -110,8 +110,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboardAddPanel.clickAddNewPanelFromUIActionLink('ES|QL');
       await dashboardAddPanel.expectAddPanelFlyoutClosed();
       await dashboard.waitForRenderComplete();
+      await header.waitUntilLoadingHasFinished();
 
       await monacoEditor.setCodeEditorValue('from logstash-* | stats maxB = max(bytes)');
+      const editorValue = await monacoEditor.getCodeEditorValue();
+      expect(editorValue).to.be('from logstash-* | stats maxB = max(bytes)');
       await testSubjects.click('ESQLEditor-run-query-button');
       await header.waitUntilLoadingHasFinished();
       // wait for Lens to re-render the suggestion with the new query results

--- a/src/platform/test/functional/apps/dashboard/group6/dashboard_esql_chart.ts
+++ b/src/platform/test/functional/apps/dashboard/group6/dashboard_esql_chart.ts
@@ -21,8 +21,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dashboardPanelActions = getService('dashboardPanelActions');
   const log = getService('log');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/250420
-  describe.skip('dashboard add ES|QL chart', function () {
+  describe('dashboard add ES|QL chart', function () {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.importExport.load(
@@ -117,7 +116,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await header.waitUntilLoadingHasFinished();
 
       await testSubjects.click('applyFlyoutButton');
-      expect(await testSubjects.exists('mtrVis')).to.be(true);
+      await dashboard.waitForRenderComplete();
+      await retry.try(async () => {
+        expect(await testSubjects.exists('mtrVis')).to.be(true);
+      });
     });
 
     it('should add a second panel and remove when hitting cancel', async () => {

--- a/src/platform/test/functional/apps/dashboard/group6/dashboard_esql_chart.ts
+++ b/src/platform/test/functional/apps/dashboard/group6/dashboard_esql_chart.ts
@@ -114,6 +114,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await monacoEditor.setCodeEditorValue('from logstash-* | stats maxB = max(bytes)');
       await testSubjects.click('ESQLEditor-run-query-button');
       await header.waitUntilLoadingHasFinished();
+      // wait for Lens to re-render the suggestion with the new query results
+      await retry.try(async () => {
+        expect(await testSubjects.exists('mtrVis')).to.be(true);
+      });
 
       await testSubjects.click('applyFlyoutButton');
       await dashboard.waitForRenderComplete();


### PR DESCRIPTION
Resolves #250420

Flaky test runner - all test runs passed.  https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10830
Second FTR - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10831

The test was sporadically failing because the default datatable was still displayed instead of the metric when Apply was clicked - likely because the metric visualization hadn’t finished loading for the new query yet or due to an issue with the Monaco editor. This has now been safeguarded by ensuring the test waits for the visualization to be fully ready before applying.
See the screenshot of the failing test below: 
<img width="1311" height="657" alt="Screenshot 2026-02-23 at 12 08 27" src="https://github.com/user-attachments/assets/61a54f3d-235f-43ac-9cd6-c27b13304419" />
