### PR TITLE
[9.2] [APM] Fix span links flaky tests  (#254177)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/constants.ts
@@ -21,6 +21,11 @@ export const ERROR_GROUPING_KEY_SHORT = ERROR_GROUPING_KEY.slice(0, 5);
 // Span links test data dates
 export const SPAN_LINKS_START_DATE = '2022-01-01T00:00:00.000Z';
 export const SPAN_LINKS_END_DATE = '2022-01-01T00:15:00.000Z';
+export const SPAN_LINKS_PRODUCER_INTERNAL_ONLY_END = '2022-01-01T00:01:00.000Z';
+export const SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY = 'zzz-producer-internal-only';
+export const SERVICE_SPAN_LINKS_PRODUCER_EXTERNAL_ONLY = 'zzz-producer-external-only';
+export const SERVICE_SPAN_LINKS_PRODUCER_CONSUMER = 'zzz-producer-consumer';
+export const SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE = 'zzz-consumer-multiple';
 
 // APM-specific role definitions matching authentication.ts
 export const APM_ROLES = {

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
@@ -6,86 +6,93 @@
  */
 
 import { expect } from '@kbn/scout-oblt/ui';
+import { tags } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
-test.describe('Service overview - header filters', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsViewer();
-  });
+test.describe(
+  'Service overview - header filters',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsViewer();
+    });
 
-  test('Filtering by transaction type - changes url when selecting different value', async ({
-    page,
-    pageObjects: { serviceDetailsPage, dependencyDetailsPage },
-  }) => {
-    await test.step('Navigate to service overview', async () => {
-      await serviceDetailsPage.goToPage({
-        serviceName: 'opbeans-node',
+    test('Filtering by transaction type - changes url when selecting different value', async ({
+      page,
+      pageObjects: { serviceDetailsPage, dependencyDetailsPage },
+    }) => {
+      await test.step('Navigate to service overview', async () => {
+        await serviceDetailsPage.goToPage({
+          serviceName: 'opbeans-node',
+        });
+      });
+
+      await test.step('Verify service name is visible and initial state', async () => {
+        await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
+          'request'
+        );
+      });
+
+      await test.step('Select Worker transaction type', async () => {
+        await dependencyDetailsPage.overviewTab.selectTransactionType('Worker');
+      });
+
+      await test.step('Verify URL and filter value updated', async () => {
+        await page.waitForURL(/transactionType=Worker/);
+        expect(page.url()).toContain('transactionType=Worker');
+        await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
+          'Worker'
+        );
       });
     });
 
-    await test.step('Verify service name is visible and initial state', async () => {
-      await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
-        'request'
-      );
-    });
+    test('Filtering by searchbar - filters by transaction.name', async ({
+      page,
+      pageObjects: { serviceDetailsPage },
+    }) => {
+      await test.step('Navigate to opbeans-java service overview', async () => {
+        await serviceDetailsPage.dependenciesTab.goToTab({
+          serviceName: 'opbeans-java',
+        });
+      });
 
-    await test.step('Select Worker transaction type', async () => {
-      await dependencyDetailsPage.overviewTab.selectTransactionType('Worker');
-    });
+      await test.step('Verify service name is visible', async () => {
+        await expect(page.getByTestId('apmMainTemplateHeaderServiceName')).toHaveText(
+          'opbeans-java'
+        );
+      });
 
-    await test.step('Verify URL and filter value updated', async () => {
-      await page.waitForURL(/transactionType=Worker/);
-      expect(page.url()).toContain('transactionType=Worker');
-      await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
-        'Worker'
-      );
-    });
-  });
+      await test.step('Type transaction.n in searchbar and select autocomplete', async () => {
+        const searchBar = page.getByTestId('apmUnifiedSearchBar');
+        await searchBar.fill('transaction.n');
+        await expect(page.getByText('transaction.name', { exact: true })).toBeVisible();
+        await page.getByTestId('autocompleteSuggestion-field-transaction.name-').click();
+      });
 
-  test('Filtering by searchbar - filters by transaction.name', async ({
-    page,
-    pageObjects: { serviceDetailsPage },
-  }) => {
-    await test.step('Navigate to opbeans-java service overview', async () => {
-      await serviceDetailsPage.dependenciesTab.goToTab({
-        serviceName: 'opbeans-java',
+      await test.step('Type colon and wait for suggestions', async () => {
+        const searchBar = page.getByTestId('apmUnifiedSearchBar');
+        await searchBar.type(':');
+
+        // Wait for suggestions API call
+        await page.waitForResponse((response) =>
+          response.url().includes('/internal/kibana/suggestions/values/')
+        );
+      });
+
+      await test.step('Verify autocomplete suggestions and select value', async () => {
+        await expect(page.getByTestId('autoCompleteSuggestionText')).toHaveCount(1);
+        await page.getByTestId('autocompleteSuggestion-value-"GET-/api/product"-').click();
+      });
+
+      await test.step('Submit search and verify URL contains kuery', async () => {
+        const searchBar = page.getByTestId('apmUnifiedSearchBar');
+        await searchBar.press('Escape');
+        await searchBar.press('Enter');
+
+        // Wait for URL to update with kuery parameter
+        await page.waitForURL(/kuery=transaction\.name/);
+        expect(page.url()).toContain('&kuery=transaction.name%20:%22GET%20%2Fapi%2Fproduct%22%20');
       });
     });
-
-    await test.step('Verify service name is visible', async () => {
-      await expect(page.getByTestId('apmMainTemplateHeaderServiceName')).toHaveText('opbeans-java');
-    });
-
-    await test.step('Type transaction.n in searchbar and select autocomplete', async () => {
-      const searchBar = page.getByTestId('apmUnifiedSearchBar');
-      await searchBar.fill('transaction.n');
-      await expect(page.getByText('transaction.name', { exact: true })).toBeVisible();
-      await page.getByTestId('autocompleteSuggestion-field-transaction.name-').click();
-    });
-
-    await test.step('Type colon and wait for suggestions', async () => {
-      const searchBar = page.getByTestId('apmUnifiedSearchBar');
-      await searchBar.type(':');
-
-      // Wait for suggestions API call
-      await page.waitForResponse((response) =>
-        response.url().includes('/internal/kibana/suggestions/values/')
-      );
-    });
-
-    await test.step('Verify autocomplete suggestions and select value', async () => {
-      await expect(page.getByTestId('autoCompleteSuggestionText')).toHaveCount(1);
-      await page.getByTestId('autocompleteSuggestion-value-"GET-/api/product"-').click();
-    });
-
-    await test.step('Submit search and verify URL contains kuery', async () => {
-      const searchBar = page.getByTestId('apmUnifiedSearchBar');
-      await searchBar.press('Escape');
-      await searchBar.press('Enter');
-
-      // Wait for URL to update with kuery parameter
-      await page.waitForURL(/kuery=transaction\.name/);
-      expect(page.url()).toContain('&kuery=transaction.name%20:%22GET%20%2Fapi%2Fproduct%22%20');
-    });
-  });
-});
+  }
+);

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_links.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_links.spec.ts
@@ -8,14 +8,19 @@
 import { expect } from '@kbn/scout-oblt/ui';
 import { tags } from '@kbn/scout-oblt';
 import { test, testData } from '../../fixtures';
+import {
+  SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY,
+  SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+  SERVICE_SPAN_LINKS_PRODUCER_EXTERNAL_ONLY,
+  SERVICE_SPAN_LINKS_PRODUCER_CONSUMER,
+} from '../../fixtures/constants';
 
 const timeRange = {
   rangeFrom: testData.SPAN_LINKS_START_DATE,
   rangeTo: testData.SPAN_LINKS_END_DATE,
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/253040
-test.describe.skip(
+test.describe(
   'Span links',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
@@ -27,19 +32,14 @@ test.describe.skip(
       page,
       pageObjects: { transactionDetailsPage },
     }) => {
-      await transactionDetailsPage.gotoServiceInventory('zzz-producer-internal-only', timeRange);
-      await page.getByText('Transaction A').click();
-      await page.waitForLoadingIndicatorHidden();
-
       await test.step('shows span links badge with correct count', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY,
+          transactionName: 'Transaction A',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
         await expect(page.getByText('2 Span links')).toBeVisible();
-      });
-
-      await test.step('shows tooltip with incoming/outgoing links', async () => {
-        await page.getByRole('button', { name: 'Open span links details' }).hover();
-        await expect(page.getByText('2 Span links found')).toBeVisible();
-        await expect(page.getByText('2 incoming')).toBeVisible();
-        await expect(page.getByText('0 outgoing')).toBeVisible();
       });
 
       await test.step('opens span flyout and shows span links details', async () => {
@@ -76,19 +76,14 @@ test.describe.skip(
       page,
       pageObjects: { transactionDetailsPage },
     }) => {
-      await transactionDetailsPage.gotoServiceInventory('zzz-producer-external-only', timeRange);
-      await page.getByText('Transaction B').click();
-      await page.waitForLoadingIndicatorHidden();
-
       await test.step('shows span links badge with correct count', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_PRODUCER_EXTERNAL_ONLY,
+          transactionName: 'Transaction B',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
         await expect(page.getByText('2 Span links')).toBeVisible();
-      });
-
-      await test.step('shows tooltip with incoming/outgoing links', async () => {
-        await page.getByRole('button', { name: 'Open span links details' }).hover();
-        await expect(page.getByText('2 Span links found')).toBeVisible();
-        await expect(page.getByText('1 incoming')).toBeVisible();
-        await expect(page.getByText('1 outgoing')).toBeVisible();
       });
 
       await test.step('opens span flyout and shows span links details', async () => {
@@ -113,11 +108,14 @@ test.describe.skip(
       page,
       pageObjects: { transactionDetailsPage },
     }) => {
-      await transactionDetailsPage.gotoServiceInventory('zzz-producer-consumer', timeRange);
-      await page.getByText('Transaction C').click();
-      await page.waitForLoadingIndicatorHidden();
-
       await test.step('opens transaction flyout and shows span links', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_PRODUCER_CONSUMER,
+          transactionName: 'Transaction C',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
+
         await page.getByRole('button', { name: '1 View details for' }).click();
         await transactionDetailsPage.getSpanLinksTab().click();
 
@@ -143,11 +141,14 @@ test.describe.skip(
       page,
       pageObjects: { transactionDetailsPage },
     }) => {
-      await transactionDetailsPage.gotoServiceInventory('zzz-consumer-multiple', timeRange);
-      await page.getByText('Transaction D').click();
-      await page.waitForLoadingIndicatorHidden();
-
       await test.step('opens transaction flyout and shows span links', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+          transactionName: 'Transaction D',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
+
         await page.getByRole('button', { name: '1 View details for' }).click();
         await transactionDetailsPage.getSpanLinksTab().click();
 
@@ -173,11 +174,14 @@ test.describe.skip(
       page,
       pageObjects: { transactionDetailsPage },
     }) => {
-      await transactionDetailsPage.gotoServiceInventory('zzz-consumer-multiple', timeRange);
-      await page.getByText('Transaction D').click();
-      await page.waitForLoadingIndicatorHidden();
-
       await test.step('opens span flyout and shows span links', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+          transactionName: 'Transaction D',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
+
         await page.getByText('Span E').click();
         await transactionDetailsPage.getSpanLinksTab().click();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[APM] Fix span links flaky tests  (#254177)](https://github.com/elastic/kibana/pull/254177)

Besides backport, this PR also updates the tests at `x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts` to use the new tagging system for scout tests that were missed by #252919

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-23T09:43:11Z","message":"[APM] Fix span links flaky tests  (#254177)\n\n## Summary\nCloses #253040\n\nThis PR aims to fix flaky span links tests for transaction details page.\nThe improvements introduced to combat flakiness are:\n\n1. **Direct navigation to page** Instead of programatically navigating\nto service details and then using the UI to land on the proper\ntransaction details view, I've update the tests to use direct\nnavigation. This way, the URL we navigate to using fixtures already\ncontains the required transaction name simplifying the test and reducing\nthe amount of interactions that aren't really tied to what is being\ntested. This change also removes the usage of the deprecated\n`page.waitForLoadingIndicatorHidden()` which is known to be a source of\nflakiness\n2. **Remove tooltip steps** Part of the tests were testing the contents\nof a tooltip that shows up on hover. This is actually the source of\nflakiness detected in the issue as the popover would sometimes not\nrender. I figured the easiest way to stabilise the tests was to remove\nthe problematics parts, specially since we already have [component\ntests](x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/span_links_badge.test.tsx)\nthat specifically target tooltip behaviour\n\n\n## Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n## Backports\n\nSeems like flakiness is specially bad in 9.2. as the failed tests issue\ncontains errors exclusively in this version. I did the PR against main\nas I think all versions can benefit from the improvements developed\nhere. I'll be then backporting the fixes to all open branches that have\nthe tests. The 9.2 backport will be created manually to ensure, via\nflaky test runner, that the flakiness issues have been addressed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cf9ecc0fac340c64f8979ad4d3c50d88b07bf297","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","Team:obs-presentation","v9.3.1"],"title":"[APM] Fix span links flaky tests ","number":254177,"url":"https://github.com/elastic/kibana/pull/254177","mergeCommit":{"message":"[APM] Fix span links flaky tests  (#254177)\n\n## Summary\nCloses #253040\n\nThis PR aims to fix flaky span links tests for transaction details page.\nThe improvements introduced to combat flakiness are:\n\n1. **Direct navigation to page** Instead of programatically navigating\nto service details and then using the UI to land on the proper\ntransaction details view, I've update the tests to use direct\nnavigation. This way, the URL we navigate to using fixtures already\ncontains the required transaction name simplifying the test and reducing\nthe amount of interactions that aren't really tied to what is being\ntested. This change also removes the usage of the deprecated\n`page.waitForLoadingIndicatorHidden()` which is known to be a source of\nflakiness\n2. **Remove tooltip steps** Part of the tests were testing the contents\nof a tooltip that shows up on hover. This is actually the source of\nflakiness detected in the issue as the popover would sometimes not\nrender. I figured the easiest way to stabilise the tests was to remove\nthe problematics parts, specially since we already have [component\ntests](x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/span_links_badge.test.tsx)\nthat specifically target tooltip behaviour\n\n\n## Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n## Backports\n\nSeems like flakiness is specially bad in 9.2. as the failed tests issue\ncontains errors exclusively in this version. I did the PR against main\nas I think all versions can benefit from the improvements developed\nhere. I'll be then backporting the fixes to all open branches that have\nthe tests. The 9.2 backport will be created manually to ensure, via\nflaky test runner, that the flakiness issues have been addressed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cf9ecc0fac340c64f8979ad4d3c50d88b07bf297"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254177","number":254177,"mergeCommit":{"message":"[APM] Fix span links flaky tests  (#254177)\n\n## Summary\nCloses #253040\n\nThis PR aims to fix flaky span links tests for transaction details page.\nThe improvements introduced to combat flakiness are:\n\n1. **Direct navigation to page** Instead of programatically navigating\nto service details and then using the UI to land on the proper\ntransaction details view, I've update the tests to use direct\nnavigation. This way, the URL we navigate to using fixtures already\ncontains the required transaction name simplifying the test and reducing\nthe amount of interactions that aren't really tied to what is being\ntested. This change also removes the usage of the deprecated\n`page.waitForLoadingIndicatorHidden()` which is known to be a source of\nflakiness\n2. **Remove tooltip steps** Part of the tests were testing the contents\nof a tooltip that shows up on hover. This is actually the source of\nflakiness detected in the issue as the popover would sometimes not\nrender. I figured the easiest way to stabilise the tests was to remove\nthe problematics parts, specially since we already have [component\ntests](x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/span_links_badge.test.tsx)\nthat specifically target tooltip behaviour\n\n\n## Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n## Backports\n\nSeems like flakiness is specially bad in 9.2. as the failed tests issue\ncontains errors exclusively in this version. I did the PR against main\nas I think all versions can benefit from the improvements developed\nhere. I'll be then backporting the fixes to all open branches that have\nthe tests. The 9.2 backport will be created manually to ensure, via\nflaky test runner, that the flakiness issues have been addressed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cf9ecc0fac340c64f8979ad4d3c50d88b07bf297"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->