### PR TITLE
[9.3] [APM] Fix span links flaky tests  (#254177)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/constants.ts
@@ -21,6 +21,11 @@ export const ERROR_GROUPING_KEY_SHORT = ERROR_GROUPING_KEY.slice(0, 5);
 // Span links test data dates
 export const SPAN_LINKS_START_DATE = '2022-01-01T00:00:00.000Z';
 export const SPAN_LINKS_END_DATE = '2022-01-01T00:15:00.000Z';
+export const SPAN_LINKS_PRODUCER_INTERNAL_ONLY_END = '2022-01-01T00:01:00.000Z';
+export const SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY = 'zzz-producer-internal-only';
+export const SERVICE_SPAN_LINKS_PRODUCER_EXTERNAL_ONLY = 'zzz-producer-external-only';
+export const SERVICE_SPAN_LINKS_PRODUCER_CONSUMER = 'zzz-producer-consumer';
+export const SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE = 'zzz-consumer-multiple';
 
 // APM-specific role definitions matching authentication.ts
 export const APM_ROLES = {

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_operation_detail.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_operation_detail.spec.ts
@@ -6,82 +6,87 @@
  */
 
 import { expect } from '@kbn/scout-oblt/ui';
+import { tags } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
-test.describe('Dependency Operation Detail Page', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeEach(async ({ browserAuth, pageObjects: { dependencyDetailsPage } }) => {
-    await browserAuth.loginAsViewer();
-    await dependencyDetailsPage.operationDetailSubpage.goToPage();
-  });
-
-  test('Renders expected content', async ({ page, pageObjects: { dependencyDetailsPage } }) => {
-    await test.step('renders operation detail content', async () => {
-      await expect(
-        page.getByRole('heading', { name: dependencyDetailsPage.SPAN_NAME })
-      ).toBeVisible();
-      await expect(dependencyDetailsPage.operationDetailSubpage.latencyChart).toBeVisible();
-      await expect(dependencyDetailsPage.operationDetailSubpage.throughputChart).toBeVisible();
-      await expect(
-        dependencyDetailsPage.operationDetailSubpage.failedTransactionRateChart
-      ).toBeVisible();
-      await expect(dependencyDetailsPage.operationDetailSubpage.correlationsChart).toBeVisible();
-      await expect(
-        dependencyDetailsPage.operationDetailSubpage.waterfallInvestigateButton
-      ).toBeVisible();
-    });
-  });
-
-  test('Links back to dependency operations list', async ({
-    page,
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step('click breadcrumb link to go back to dependency operations list', async () => {
-      await expect(dependencyDetailsPage.operationDetailSubpage.breadcrumb).toBeVisible();
-      await expect(dependencyDetailsPage.operationDetailSubpage.breadcrumb).toHaveText(
-        'All operations'
-      );
-      await dependencyDetailsPage.operationDetailSubpage.breadcrumb.click();
+test.describe(
+  'Dependency Operation Detail Page',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth, pageObjects: { dependencyDetailsPage } }) => {
+      await browserAuth.loginAsViewer();
+      await dependencyDetailsPage.operationDetailSubpage.goToPage();
     });
 
-    await test.step("verify we're on the dependency operations list page", () => {
-      const url = new URL(page.url());
-      expect(url.pathname).toContain(`/dependencies/operations`);
-      expect(url.searchParams.get('dependencyName')).toBe(dependencyDetailsPage.DEPENDENCY_NAME);
-    });
-  });
-
-  test("Investigate trace popup opens when clicking 'Investigate trace' button", async ({
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step("click 'Investigate trace' button", async () => {
-      await dependencyDetailsPage.operationDetailSubpage.waterfallInvestigateButton.click();
-    });
-
-    await test.step('verify investigate trace popup is visible', async () => {
-      await expect(
-        dependencyDetailsPage.operationDetailSubpage.waterfallInvestigatePopup
-      ).toBeVisible();
-    });
-  });
-
-  test("Span link flyout opens when clicking 'Span links' button", async ({
-    page,
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step("click 'Span links' button", async () => {
-      await dependencyDetailsPage.operationDetailSubpage.waterfallPaginationLastButton.click();
-      await dependencyDetailsPage.operationDetailSubpage.waterfallSpanLinksBadge.click();
+    test('Renders expected content', async ({ page, pageObjects: { dependencyDetailsPage } }) => {
+      await test.step('renders operation detail content', async () => {
+        await expect(
+          page.getByRole('heading', { name: dependencyDetailsPage.SPAN_NAME })
+        ).toBeVisible();
+        await expect(dependencyDetailsPage.operationDetailSubpage.latencyChart).toBeVisible();
+        await expect(dependencyDetailsPage.operationDetailSubpage.throughputChart).toBeVisible();
+        await expect(
+          dependencyDetailsPage.operationDetailSubpage.failedTransactionRateChart
+        ).toBeVisible();
+        await expect(dependencyDetailsPage.operationDetailSubpage.correlationsChart).toBeVisible();
+        await expect(
+          dependencyDetailsPage.operationDetailSubpage.waterfallInvestigateButton
+        ).toBeVisible();
+      });
     });
 
-    await test.step('verify span link flyout is visible', async () => {
-      const flyoutLocator = page.getByRole('dialog');
-      await expect(flyoutLocator).toBeVisible();
-      await expect(flyoutLocator.getByRole('heading', { name: 'Span details' })).toBeVisible();
-    });
-  });
+    test('Links back to dependency operations list', async ({
+      page,
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step('click breadcrumb link to go back to dependency operations list', async () => {
+        await expect(dependencyDetailsPage.operationDetailSubpage.breadcrumb).toBeVisible();
+        await expect(dependencyDetailsPage.operationDetailSubpage.breadcrumb).toHaveText(
+          'All operations'
+        );
+        await dependencyDetailsPage.operationDetailSubpage.breadcrumb.click();
+      });
 
-  test('Has no detectable a11y violations on load', async ({ page }) => {
-    const { violations } = await page.checkA11y({ include: ['main'] });
-    expect(violations).toHaveLength(0);
-  });
-});
+      await test.step("verify we're on the dependency operations list page", () => {
+        const url = new URL(page.url());
+        expect(url.pathname).toContain(`/dependencies/operations`);
+        expect(url.searchParams.get('dependencyName')).toBe(dependencyDetailsPage.DEPENDENCY_NAME);
+      });
+    });
+
+    test("Investigate trace popup opens when clicking 'Investigate trace' button", async ({
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step("click 'Investigate trace' button", async () => {
+        await dependencyDetailsPage.operationDetailSubpage.waterfallInvestigateButton.click();
+      });
+
+      await test.step('verify investigate trace popup is visible', async () => {
+        await expect(
+          dependencyDetailsPage.operationDetailSubpage.waterfallInvestigatePopup
+        ).toBeVisible();
+      });
+    });
+
+    test("Span link flyout opens when clicking 'Span links' button", async ({
+      page,
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step("click 'Span links' button", async () => {
+        await dependencyDetailsPage.operationDetailSubpage.waterfallPaginationLastButton.click();
+        await dependencyDetailsPage.operationDetailSubpage.waterfallSpanLinksBadge.click();
+      });
+
+      await test.step('verify span link flyout is visible', async () => {
+        const flyoutLocator = page.getByRole('dialog');
+        await expect(flyoutLocator).toBeVisible();
+        await expect(flyoutLocator.getByRole('heading', { name: 'Span details' })).toBeVisible();
+      });
+    });
+
+    test('Has no detectable a11y violations on load', async ({ page }) => {
+      const { violations } = await page.checkA11y({ include: ['main'] });
+      expect(violations).toHaveLength(0);
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_operations.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_operations.spec.ts
@@ -6,80 +6,85 @@
  */
 
 import { expect } from '@kbn/scout-oblt/ui';
+import { tags } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
 const SPAN_NAME = 'SELECT * FROM product';
 
-test.describe('Dependency Operations Tab', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsViewer();
-  });
-
-  test('Is accessible from the default tab', async ({
-    page,
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step('land on dependency details page', async () => {
-      await dependencyDetailsPage.goToPage();
+test.describe(
+  'Dependency Operations Tab',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsViewer();
     });
 
-    await test.step('navigate to operations tab', async () => {
-      await expect(dependencyDetailsPage.operationsTab.tab).toBeVisible();
-      await dependencyDetailsPage.operationsTab.goToTab();
+    test('Is accessible from the default tab', async ({
+      page,
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step('land on dependency details page', async () => {
+        await dependencyDetailsPage.goToPage();
+      });
+
+      await test.step('navigate to operations tab', async () => {
+        await expect(dependencyDetailsPage.operationsTab.tab).toBeVisible();
+        await dependencyDetailsPage.operationsTab.goToTab();
+      });
+
+      await test.step('land on operations tab', async () => {
+        expect(page.url()).toContain(`/dependencies`);
+        await expect(dependencyDetailsPage.operationsTab.tab).toHaveAttribute(
+          'aria-selected',
+          'true'
+        );
+      });
     });
 
-    await test.step('land on operations tab', async () => {
-      expect(page.url()).toContain(`/dependencies`);
-      await expect(dependencyDetailsPage.operationsTab.tab).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
-    });
-  });
+    test('Renders expected content', async ({ pageObjects: { dependencyDetailsPage } }) => {
+      await test.step('land on operations tab', async () => {
+        await dependencyDetailsPage.operationsTab.goToTab();
+      });
 
-  test('Renders expected content', async ({ pageObjects: { dependencyDetailsPage } }) => {
-    await test.step('land on operations tab', async () => {
-      await dependencyDetailsPage.operationsTab.goToTab();
-    });
-
-    await test.step('renders operations content', async () => {
-      await expect(dependencyDetailsPage.operationsTab.operationsTable).toBeVisible();
-      await expect(
-        dependencyDetailsPage.operationsTab.getOperationInOperationsTable(SPAN_NAME)
-      ).toBeVisible();
-    });
-  });
-
-  test('Links to dependency operation detail when clicking on an operation in operations table', async ({
-    page,
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step('land on operations tab', async () => {
-      await dependencyDetailsPage.operationsTab.goToTab();
+      await test.step('renders operations content', async () => {
+        await expect(dependencyDetailsPage.operationsTab.operationsTable).toBeVisible();
+        await expect(
+          dependencyDetailsPage.operationsTab.getOperationInOperationsTable(SPAN_NAME)
+        ).toBeVisible();
+      });
     });
 
-    await test.step('click on operation in operations table', async () => {
-      await dependencyDetailsPage.operationsTab.clickOperationInOperationsTable(SPAN_NAME);
+    test('Links to dependency operation detail when clicking on an operation in operations table', async ({
+      page,
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step('land on operations tab', async () => {
+        await dependencyDetailsPage.operationsTab.goToTab();
+      });
+
+      await test.step('click on operation in operations table', async () => {
+        await dependencyDetailsPage.operationsTab.clickOperationInOperationsTable(SPAN_NAME);
+      });
+
+      await test.step('land on dependency operation page', async () => {
+        const url = new URL(page.url());
+        expect(url.pathname).toContain(`/dependencies/operation`);
+        expect(url.searchParams.get('spanName')).toBe(SPAN_NAME);
+      });
     });
 
-    await test.step('land on dependency operation page', async () => {
-      const url = new URL(page.url());
-      expect(url.pathname).toContain(`/dependencies/operation`);
-      expect(url.searchParams.get('spanName')).toBe(SPAN_NAME);
-    });
-  });
+    test('Has no a11y violations on load', async ({
+      page,
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step('land on operations tab', async () => {
+        await dependencyDetailsPage.operationsTab.goToTab();
+      });
 
-  test('Has no a11y violations on load', async ({
-    page,
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step('land on operations tab', async () => {
-      await dependencyDetailsPage.operationsTab.goToTab();
+      await test.step('check a11y', async () => {
+        const { violations } = await page.checkA11y({ include: ['main'] });
+        expect(violations).toHaveLength(0);
+      });
     });
-
-    await test.step('check a11y', async () => {
-      const { violations } = await page.checkA11y({ include: ['main'] });
-      expect(violations).toHaveLength(0);
-    });
-  });
-});
+  }
+);

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
@@ -6,88 +6,93 @@
  */
 
 import { expect } from '@kbn/scout-oblt/ui';
+import { tags } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
-test.describe('Service overview - header filters', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsViewer();
-  });
+test.describe(
+  'Service overview - header filters',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsViewer();
+    });
 
-  test('Filtering by transaction type - changes url when selecting different value', async ({
-    page,
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step('Navigate to service overview', async () => {
-      await dependencyDetailsPage.overviewTab.goToTab({
-        serviceName: dependencyDetailsPage.DEPENDENCY_NAME,
+    test('Filtering by transaction type - changes url when selecting different value', async ({
+      page,
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step('Navigate to service overview', async () => {
+        await dependencyDetailsPage.overviewTab.goToTab({
+          serviceName: dependencyDetailsPage.DEPENDENCY_NAME,
+        });
+      });
+
+      await test.step('Verify service name is visible and initial state', async () => {
+        await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
+          'request'
+        );
+      });
+
+      await test.step('Select Worker transaction type', async () => {
+        await dependencyDetailsPage.overviewTab.selectTransactionType('Worker');
+      });
+
+      await test.step('Verify URL and filter value updated', async () => {
+        await page.waitForURL(/transactionType=Worker/);
+        expect(page.url()).toContain('transactionType=Worker');
+        await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
+          'Worker'
+        );
       });
     });
 
-    await test.step('Verify service name is visible and initial state', async () => {
-      await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
-        'request'
-      );
-    });
+    test('Filtering by searchbar - filters by transaction.name', async ({
+      page,
+      pageObjects: { dependencyDetailsPage },
+    }) => {
+      await test.step('Navigate to opbeans-java service overview', async () => {
+        await dependencyDetailsPage.overviewTab.goToTab({
+          serviceName: dependencyDetailsPage.DEPENDENCY_NAME,
+        });
+      });
 
-    await test.step('Select Worker transaction type', async () => {
-      await dependencyDetailsPage.overviewTab.selectTransactionType('Worker');
-    });
+      await test.step('Verify service name is visible', async () => {
+        await expect(page.getByTestId('apmMainTemplateHeaderServiceName')).toHaveText(
+          dependencyDetailsPage.DEPENDENCY_NAME
+        );
+      });
 
-    await test.step('Verify URL and filter value updated', async () => {
-      await page.waitForURL(/transactionType=Worker/);
-      expect(page.url()).toContain('transactionType=Worker');
-      await expect(dependencyDetailsPage.overviewTab.getTransactionTypeFilter()).toHaveValue(
-        'Worker'
-      );
-    });
-  });
+      await test.step('Type transaction.n in searchbar and select autocomplete', async () => {
+        const searchBar = page.getByTestId('apmUnifiedSearchBar');
+        await searchBar.fill('transaction.n');
+        await expect(page.getByText('transaction.name', { exact: true })).toBeVisible();
+        await page.getByTestId('autocompleteSuggestion-field-transaction.name-').click();
+      });
 
-  test('Filtering by searchbar - filters by transaction.name', async ({
-    page,
-    pageObjects: { dependencyDetailsPage },
-  }) => {
-    await test.step('Navigate to opbeans-java service overview', async () => {
-      await dependencyDetailsPage.overviewTab.goToTab({
-        serviceName: dependencyDetailsPage.DEPENDENCY_NAME,
+      await test.step('Type colon and wait for suggestions', async () => {
+        const searchBar = page.getByTestId('apmUnifiedSearchBar');
+        await searchBar.type(':');
+
+        // Wait for suggestions API call
+        await page.waitForResponse((response) =>
+          response.url().includes('/internal/kibana/suggestions/values/')
+        );
+      });
+
+      await test.step('Verify autocomplete suggestions and select value', async () => {
+        await expect(page.getByTestId('autoCompleteSuggestionText')).toHaveCount(1);
+        await page.getByTestId('autocompleteSuggestion-value-"GET-/api/product"-').click();
+      });
+
+      await test.step('Submit search and verify URL contains kuery', async () => {
+        const searchBar = page.getByTestId('apmUnifiedSearchBar');
+        await searchBar.press('Escape');
+        await searchBar.press('Enter');
+
+        // Wait for URL to update with kuery parameter
+        await page.waitForURL(/kuery=transaction\.name/);
+        expect(page.url()).toContain('&kuery=transaction.name%20:%22GET%20%2Fapi%2Fproduct%22%20');
       });
     });
-
-    await test.step('Verify service name is visible', async () => {
-      await expect(page.getByTestId('apmMainTemplateHeaderServiceName')).toHaveText(
-        dependencyDetailsPage.DEPENDENCY_NAME
-      );
-    });
-
-    await test.step('Type transaction.n in searchbar and select autocomplete', async () => {
-      const searchBar = page.getByTestId('apmUnifiedSearchBar');
-      await searchBar.fill('transaction.n');
-      await expect(page.getByText('transaction.name', { exact: true })).toBeVisible();
-      await page.getByTestId('autocompleteSuggestion-field-transaction.name-').click();
-    });
-
-    await test.step('Type colon and wait for suggestions', async () => {
-      const searchBar = page.getByTestId('apmUnifiedSearchBar');
-      await searchBar.type(':');
-
-      // Wait for suggestions API call
-      await page.waitForResponse((response) =>
-        response.url().includes('/internal/kibana/suggestions/values/')
-      );
-    });
-
-    await test.step('Verify autocomplete suggestions and select value', async () => {
-      await expect(page.getByTestId('autoCompleteSuggestionText')).toHaveCount(1);
-      await page.getByTestId('autocompleteSuggestion-value-"GET-/api/product"-').click();
-    });
-
-    await test.step('Submit search and verify URL contains kuery', async () => {
-      const searchBar = page.getByTestId('apmUnifiedSearchBar');
-      await searchBar.press('Escape');
-      await searchBar.press('Enter');
-
-      // Wait for URL to update with kuery parameter
-      await page.waitForURL(/kuery=transaction\.name/);
-      expect(page.url()).toContain('&kuery=transaction.name%20:%22GET%20%2Fapi%2Fproduct%22%20');
-    });
-  });
-});
+  }
+);

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
@@ -9,7 +9,7 @@ import { expect } from '@kbn/scout-oblt/ui';
 import { tags } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
-test.describe.skip(
+test.describe(
   'Service overview - header filters',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
@@ -19,11 +19,11 @@ test.describe.skip(
 
     test('Filtering by transaction type - changes url when selecting different value', async ({
       page,
-      pageObjects: { dependencyDetailsPage },
+      pageObjects: { serviceDetailsPage, dependencyDetailsPage },
     }) => {
       await test.step('Navigate to service overview', async () => {
-        await dependencyDetailsPage.overviewTab.goToTab({
-          serviceName: dependencyDetailsPage.DEPENDENCY_NAME,
+        await serviceDetailsPage.goToPage({
+          serviceName: 'opbeans-node',
         });
       });
 
@@ -48,17 +48,17 @@ test.describe.skip(
 
     test('Filtering by searchbar - filters by transaction.name', async ({
       page,
-      pageObjects: { dependencyDetailsPage },
+      pageObjects: { serviceDetailsPage },
     }) => {
       await test.step('Navigate to opbeans-java service overview', async () => {
-        await dependencyDetailsPage.overviewTab.goToTab({
-          serviceName: dependencyDetailsPage.DEPENDENCY_NAME,
+        await serviceDetailsPage.dependenciesTab.goToTab({
+          serviceName: 'opbeans-java',
         });
       });
 
       await test.step('Verify service name is visible', async () => {
         await expect(page.getByTestId('apmMainTemplateHeaderServiceName')).toHaveText(
-          dependencyDetailsPage.DEPENDENCY_NAME
+          'opbeans-java'
         );
       });
 

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
@@ -9,7 +9,7 @@ import { expect } from '@kbn/scout-oblt/ui';
 import { tags } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
-test.describe(
+test.describe.skip(
   'Service overview - header filters',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_links.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_links.spec.ts
@@ -5,196 +5,219 @@
  * 2.0.
  */
 
+import { tags } from '@kbn/scout-oblt';
 import { expect } from '@kbn/scout-oblt/ui';
 import { test, testData } from '../../fixtures';
+import {
+  SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY,
+  SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+  SERVICE_SPAN_LINKS_PRODUCER_EXTERNAL_ONLY,
+  SERVICE_SPAN_LINKS_PRODUCER_CONSUMER,
+} from '../../fixtures/constants';
 
 const timeRange = {
   rangeFrom: testData.SPAN_LINKS_START_DATE,
   rangeTo: testData.SPAN_LINKS_END_DATE,
 };
 
-test.describe('Span links', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsViewer();
-  });
-
-  test('shows span links for producer-internal-only Span A', async ({
-    page,
-    pageObjects: { transactionDetailsPage },
-  }) => {
-    await transactionDetailsPage.gotoServiceInventory('zzz-producer-internal-only', timeRange);
-    await page.getByText('Transaction A').click();
-    await page.waitForLoadingIndicatorHidden();
-
-    await test.step('shows span links badge with correct count', async () => {
-      await expect(page.getByText('2 Span links')).toBeVisible();
+test.describe(
+  'Span links',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsViewer();
     });
 
-    await test.step('shows tooltip with incoming/outgoing links', async () => {
-      await page.getByRole('button', { name: 'Open span links details' }).hover();
-      await expect(page.getByText('2 Span links found')).toBeVisible();
-      await expect(page.getByText('2 incoming')).toBeVisible();
-      await expect(page.getByText('0 outgoing')).toBeVisible();
+    test('shows span links for producer-internal-only Span A', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      await test.step('shows span links badge with correct count', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY,
+          transactionName: 'Transaction A',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
+        await expect(page.getByText('2 Span links')).toBeVisible();
+      });
+
+      await test.step('opens span flyout and shows span links details', async () => {
+        await page.getByText('Span A').click();
+        await transactionDetailsPage.getSpanLinksTab().click();
+
+        const producerConsumerLink = page.getByRole('link', { name: 'zzz-producer-consumer' });
+        await expect(producerConsumerLink).toBeVisible();
+        await expect(producerConsumerLink).toHaveAttribute(
+          'href',
+          /\/services\/zzz-producer-consumer\/overview/
+        );
+
+        const transactionCLink = page.getByRole('link', { name: 'Transaction C' });
+        await expect(transactionCLink).toBeVisible();
+
+        const consumerMultipleLink = page.getByRole('link', {
+          name: SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+        });
+        await expect(consumerMultipleLink).toBeVisible();
+        await expect(consumerMultipleLink).toHaveAttribute(
+          'href',
+          new RegExp(`/services/${SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE}/overview`)
+        );
+
+        const transactionDLink = page.getByRole('link', { name: 'Transaction D' });
+        await expect(transactionDLink).toBeVisible();
+
+        await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
+          'Outgoing links (0)'
+        );
+      });
     });
 
-    await test.step('opens span flyout and shows span links details', async () => {
-      await page.getByText('Span A').click();
-      await transactionDetailsPage.getSpanLinksTab().click();
+    test('shows span links for producer-external-only Span B', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      await test.step('shows span links badge with correct count', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_PRODUCER_EXTERNAL_ONLY,
+          transactionName: 'Transaction B',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
+        await expect(page.getByText('2 Span links')).toBeVisible();
+      });
 
-      const producerConsumerLink = page.getByRole('link', { name: 'zzz-producer-consumer' });
-      await expect(producerConsumerLink).toBeVisible();
-      await expect(producerConsumerLink).toHaveAttribute(
-        'href',
-        /\/services\/zzz-producer-consumer\/overview/
-      );
+      await test.step('opens span flyout and shows span links details', async () => {
+        await page
+          .getByTestId('waterfall')
+          .getByLabel('View details for Span B', { exact: true })
+          .click();
+        await transactionDetailsPage.getSpanLinksTab().click();
 
-      const transactionCLink = page.getByRole('link', { name: 'Transaction C' });
-      await expect(transactionCLink).toBeVisible();
+        const consumerMultipleLink = page.getByRole('link', {
+          name: SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+        });
+        await expect(consumerMultipleLink).toBeVisible();
 
-      const consumerMultipleLink = page.getByRole('link', { name: 'zzz-consumer-multiple' });
-      await expect(consumerMultipleLink).toBeVisible();
-      await expect(consumerMultipleLink).toHaveAttribute(
-        'href',
-        /\/services\/zzz-consumer-multiple\/overview/
-      );
+        const spanELink = page.getByRole('link', { name: 'Span E' });
+        await expect(spanELink).toBeVisible();
 
-      const transactionDLink = page.getByRole('link', { name: 'Transaction D' });
-      await expect(transactionDLink).toBeVisible();
-
-      await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
-        'Outgoing links (0)'
-      );
-    });
-  });
-
-  test('shows span links for producer-external-only Span B', async ({
-    page,
-    pageObjects: { transactionDetailsPage },
-  }) => {
-    await transactionDetailsPage.gotoServiceInventory('zzz-producer-external-only', timeRange);
-    await page.getByText('Transaction B').click();
-    await page.waitForLoadingIndicatorHidden();
-
-    await test.step('shows span links badge with correct count', async () => {
-      await expect(page.getByText('2 Span links')).toBeVisible();
+        await transactionDetailsPage.getSpanLinkTypeSelect().selectOption('Outgoing links (1)');
+        // External links may not have service names, so we just verify the select shows the count
+        await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
+          'Outgoing links (1)'
+        );
+      });
     });
 
-    await test.step('shows tooltip with incoming/outgoing links', async () => {
-      await page.getByRole('button', { name: 'Open span links details' }).hover();
-      await expect(page.getByText('2 Span links found')).toBeVisible();
-      await expect(page.getByText('1 incoming')).toBeVisible();
-      await expect(page.getByText('1 outgoing')).toBeVisible();
+    test('shows span links flyout details on producer-consumer Transaction C', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      await test.step('opens transaction flyout and shows span links', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_PRODUCER_CONSUMER,
+          transactionName: 'Transaction C',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
+
+        await page.getByRole('button', { name: '1 View details for' }).click();
+        await transactionDetailsPage.getSpanLinksTab().click();
+
+        const consumerMultipleLink = page.getByRole('link', {
+          name: SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+        });
+        await expect(consumerMultipleLink).toBeVisible();
+
+        const spanELink = page.getByRole('link', { name: 'Span E' });
+        await expect(spanELink).toBeVisible();
+      });
+
+      await test.step('switches to outgoing links and shows linked services', async () => {
+        await transactionDetailsPage.getSpanLinkTypeSelect().selectOption('Outgoing links (1)');
+
+        const producerInternalLink = page.getByRole('link', {
+          name: SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY,
+        });
+        await expect(producerInternalLink).toBeVisible();
+
+        const spanALink = page.getByRole('link', { name: 'Span A' });
+        await expect(spanALink).toBeVisible();
+      });
     });
 
-    await test.step('opens span flyout and shows span links details', async () => {
-      await page.locator('button').filter({ hasText: 'Span B100 ms' }).click();
-      await transactionDetailsPage.getSpanLinksTab().click();
+    test('shows span links flyout details on consumer-multiple Transaction D', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      await test.step('opens transaction flyout and shows span links', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+          transactionName: 'Transaction D',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
 
-      const consumerMultipleLink = page.getByRole('link', { name: 'zzz-consumer-multiple' });
-      await expect(consumerMultipleLink).toBeVisible();
+        await page.getByRole('button', { name: '1 View details for' }).click();
+        await transactionDetailsPage.getSpanLinksTab().click();
 
-      const spanELink = page.getByRole('link', { name: 'Span E' });
-      await expect(spanELink).toBeVisible();
+        const producerConsumerLink = page.getByRole('link', { name: 'zzz-producer-consumer' });
+        await expect(producerConsumerLink).toBeVisible();
 
-      await transactionDetailsPage.getSpanLinkTypeSelect().selectOption('Outgoing links (1)');
-      // External links may not have service names, so we just verify the select shows the count
-      await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
-        'Outgoing links (1)'
-      );
-    });
-  });
+        const spanCLink = page.getByRole('link', { name: 'Span C' });
+        await expect(spanCLink).toBeVisible();
 
-  test('shows span links flyout details on producer-consumer Transaction C', async ({
-    page,
-    pageObjects: { transactionDetailsPage },
-  }) => {
-    await transactionDetailsPage.gotoServiceInventory('zzz-producer-consumer', timeRange);
-    await page.getByText('Transaction C').click();
-    await page.waitForLoadingIndicatorHidden();
+        const producerInternalLink = page.getByRole('link', {
+          name: SERVICE_SPAN_LINKS_PRODUCER_INTERNAL_ONLY,
+        });
+        await expect(producerInternalLink).toBeVisible();
 
-    await test.step('opens transaction flyout and shows span links', async () => {
-      await page.getByRole('button', { name: '1 View details for' }).click();
-      await transactionDetailsPage.getSpanLinksTab().click();
+        const spanALink = page.getByRole('link', { name: 'Span A' });
+        await expect(spanALink).toBeVisible();
 
-      const consumerMultipleLink = page.getByRole('link', { name: 'zzz-consumer-multiple' });
-      await expect(consumerMultipleLink).toBeVisible();
-
-      const spanELink = page.getByRole('link', { name: 'Span E' });
-      await expect(spanELink).toBeVisible();
+        await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
+          'Incoming links (0)'
+        );
+      });
     });
 
-    await test.step('switches to outgoing links and shows linked services', async () => {
-      await transactionDetailsPage.getSpanLinkTypeSelect().selectOption('Outgoing links (1)');
+    test('shows span links flyout details on consumer-multiple Span E', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      await test.step('opens span flyout and shows span links', async () => {
+        await transactionDetailsPage.goToTransactionDetails({
+          serviceName: SERVICE_SPAN_LINKS_CONSUMER_MULTIPLE,
+          transactionName: 'Transaction D',
+          start: timeRange.rangeFrom,
+          end: timeRange.rangeTo,
+        });
 
-      const producerInternalLink = page.getByRole('link', { name: 'zzz-producer-internal-only' });
-      await expect(producerInternalLink).toBeVisible();
+        await page.getByText('Span E').click();
+        await transactionDetailsPage.getSpanLinksTab().click();
 
-      const spanALink = page.getByRole('link', { name: 'Span A' });
-      await expect(spanALink).toBeVisible();
+        await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
+          'Incoming links (0)'
+        );
+      });
+
+      await test.step('switches to outgoing links and shows linked services', async () => {
+        await transactionDetailsPage.getSpanLinkTypeSelect().selectOption('Outgoing links (2)');
+
+        const producerExternalLink = page.getByRole('link', { name: 'zzz-producer-external-only' });
+        await expect(producerExternalLink).toBeVisible();
+
+        const spanBLink = page.getByRole('link', { name: 'Span B' });
+        await expect(spanBLink).toBeVisible();
+
+        const producerConsumerLink = page.getByRole('link', { name: 'zzz-producer-consumer' });
+        await expect(producerConsumerLink).toBeVisible();
+
+        const transactionCLink = page.getByRole('link', { name: 'Transaction C' });
+        await expect(transactionCLink).toBeVisible();
+      });
     });
-  });
-
-  test('shows span links flyout details on consumer-multiple Transaction D', async ({
-    page,
-    pageObjects: { transactionDetailsPage },
-  }) => {
-    await transactionDetailsPage.gotoServiceInventory('zzz-consumer-multiple', timeRange);
-    await page.getByText('Transaction D').click();
-    await page.waitForLoadingIndicatorHidden();
-
-    await test.step('opens transaction flyout and shows span links', async () => {
-      await page.getByRole('button', { name: '1 View details for' }).click();
-      await transactionDetailsPage.getSpanLinksTab().click();
-
-      const producerConsumerLink = page.getByRole('link', { name: 'zzz-producer-consumer' });
-      await expect(producerConsumerLink).toBeVisible();
-
-      const spanCLink = page.getByRole('link', { name: 'Span C' });
-      await expect(spanCLink).toBeVisible();
-
-      const producerInternalLink = page.getByRole('link', { name: 'zzz-producer-internal-only' });
-      await expect(producerInternalLink).toBeVisible();
-
-      const spanALink = page.getByRole('link', { name: 'Span A' });
-      await expect(spanALink).toBeVisible();
-
-      await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
-        'Incoming links (0)'
-      );
-    });
-  });
-
-  test('shows span links flyout details on consumer-multiple Span E', async ({
-    page,
-    pageObjects: { transactionDetailsPage },
-  }) => {
-    await transactionDetailsPage.gotoServiceInventory('zzz-consumer-multiple', timeRange);
-    await page.getByText('Transaction D').click();
-    await page.waitForLoadingIndicatorHidden();
-
-    await test.step('opens span flyout and shows span links', async () => {
-      await page.getByText('Span E').click();
-      await transactionDetailsPage.getSpanLinksTab().click();
-
-      await expect(transactionDetailsPage.getSpanLinkTypeSelect()).toContainText(
-        'Incoming links (0)'
-      );
-    });
-
-    await test.step('switches to outgoing links and shows linked services', async () => {
-      await transactionDetailsPage.getSpanLinkTypeSelect().selectOption('Outgoing links (2)');
-
-      const producerExternalLink = page.getByRole('link', { name: 'zzz-producer-external-only' });
-      await expect(producerExternalLink).toBeVisible();
-
-      const spanBLink = page.getByRole('link', { name: 'Span B' });
-      await expect(spanBLink).toBeVisible();
-
-      const producerConsumerLink = page.getByRole('link', { name: 'zzz-producer-consumer' });
-      await expect(producerConsumerLink).toBeVisible();
-
-      const transactionCLink = page.getByRole('link', { name: 'Transaction C' });
-      await expect(transactionCLink).toBeVisible();
-    });
-  });
-});
+  }
+);

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_stacktrace.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_stacktrace.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { expect } from '@kbn/scout-oblt/ui';
+import { tags } from '@kbn/scout-oblt';
 import { test, testData } from '../../fixtures';
 
 const timeRange = {
@@ -13,58 +14,62 @@ const timeRange = {
   rangeTo: testData.SPAN_LINKS_END_DATE,
 };
 
-test.describe('Span stacktrace', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsViewer();
-  });
-
-  test('shows APM agent generated stacktrace', async ({
-    page,
-    pageObjects: { transactionDetailsPage },
-  }) => {
-    await transactionDetailsPage.gotoServiceInventory('apm-generated', timeRange);
-    await page.getByText('Transaction A').click();
-    await page.waitForLoadingIndicatorHidden();
-
-    await test.step('opens span flyout', async () => {
-      await page.getByText('Span A').click();
+test.describe(
+  'Span stacktrace',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsViewer();
     });
 
-    await test.step('clicks stacktrace tab', async () => {
-      await transactionDetailsPage.getStacktraceTab().click();
+    test('shows APM agent generated stacktrace', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      await transactionDetailsPage.gotoServiceInventory('apm-generated', timeRange);
+      await page.getByText('Transaction A').click();
+      await page.waitForLoadingIndicatorHidden();
+
+      await test.step('opens span flyout', async () => {
+        await page.getByText('Span A').click();
+      });
+
+      await test.step('clicks stacktrace tab', async () => {
+        await transactionDetailsPage.getStacktraceTab().click();
+      });
+
+      await test.step('shows Java APM agent stacktrace', async () => {
+        await expect(
+          page.getByText(
+            'at org.apache.catalina.connector.OutputBuffer.flushByteBuffer(OutputBuffer.java:825)'
+          )
+        ).toBeVisible();
+      });
     });
 
-    await test.step('shows Java APM agent stacktrace', async () => {
-      await expect(
-        page.getByText(
-          'at org.apache.catalina.connector.OutputBuffer.flushByteBuffer(OutputBuffer.java:825)'
-        )
-      ).toBeVisible();
-    });
-  });
+    test('shows Otel generated stacktrace', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      await transactionDetailsPage.gotoServiceInventory('otel-generated', timeRange);
+      await page.getByText('Transaction A').click();
+      await page.waitForLoadingIndicatorHidden();
 
-  test('shows Otel generated stacktrace', async ({
-    page,
-    pageObjects: { transactionDetailsPage },
-  }) => {
-    await transactionDetailsPage.gotoServiceInventory('otel-generated', timeRange);
-    await page.getByText('Transaction A').click();
-    await page.waitForLoadingIndicatorHidden();
+      await test.step('opens span flyout', async () => {
+        await page.getByText('Span A').click();
+      });
 
-    await test.step('opens span flyout', async () => {
-      await page.getByText('Span A').click();
-    });
+      await test.step('clicks stacktrace tab', async () => {
+        await transactionDetailsPage.getStacktraceTab().click();
+      });
 
-    await test.step('clicks stacktrace tab', async () => {
-      await transactionDetailsPage.getStacktraceTab().click();
+      await test.step('shows OpenTelemetry stacktrace', async () => {
+        await expect(
+          page.getByText(
+            'java.lang.Throwable at co.elastic.otel.ElasticSpanProcessor.captureStackTrace(ElasticSpanProcessor.java:81)'
+          )
+        ).toBeVisible();
+      });
     });
-
-    await test.step('shows OpenTelemetry stacktrace', async () => {
-      await expect(
-        page.getByText(
-          'java.lang.Throwable at co.elastic.otel.ElasticSpanProcessor.captureStackTrace(ElasticSpanProcessor.java:81)'
-        )
-      ).toBeVisible();
-    });
-  });
-});
+  }
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[APM] Fix span links flaky tests  (#254177)](https://github.com/elastic/kibana/pull/254177)

Besides backport, this PR also updates the tests at
- x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_operation_detail.spec.ts
- x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/dependencies/dependency_operations.spec.ts
- x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/header_filters.spec.ts
- x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_stacktrace.spec.ts
to use the new tagging system for scout tests that were missed by #252844

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-23T09:43:11Z","message":"[APM] Fix span links flaky tests  (#254177)\n\n## Summary\nCloses #253040\n\nThis PR aims to fix flaky span links tests for transaction details page.\nThe improvements introduced to combat flakiness are:\n\n1. **Direct navigation to page** Instead of programatically navigating\nto service details and then using the UI to land on the proper\ntransaction details view, I've update the tests to use direct\nnavigation. This way, the URL we navigate to using fixtures already\ncontains the required transaction name simplifying the test and reducing\nthe amount of interactions that aren't really tied to what is being\ntested. This change also removes the usage of the deprecated\n`page.waitForLoadingIndicatorHidden()` which is known to be a source of\nflakiness\n2. **Remove tooltip steps** Part of the tests were testing the contents\nof a tooltip that shows up on hover. This is actually the source of\nflakiness detected in the issue as the popover would sometimes not\nrender. I figured the easiest way to stabilise the tests was to remove\nthe problematics parts, specially since we already have [component\ntests](x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/span_links_badge.test.tsx)\nthat specifically target tooltip behaviour\n\n\n## Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n## Backports\n\nSeems like flakiness is specially bad in 9.2. as the failed tests issue\ncontains errors exclusively in this version. I did the PR against main\nas I think all versions can benefit from the improvements developed\nhere. I'll be then backporting the fixes to all open branches that have\nthe tests. The 9.2 backport will be created manually to ensure, via\nflaky test runner, that the flakiness issues have been addressed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cf9ecc0fac340c64f8979ad4d3c50d88b07bf297","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","Team:obs-presentation","v9.3.1"],"title":"[APM] Fix span links flaky tests ","number":254177,"url":"https://github.com/elastic/kibana/pull/254177","mergeCommit":{"message":"[APM] Fix span links flaky tests  (#254177)\n\n## Summary\nCloses #253040\n\nThis PR aims to fix flaky span links tests for transaction details page.\nThe improvements introduced to combat flakiness are:\n\n1. **Direct navigation to page** Instead of programatically navigating\nto service details and then using the UI to land on the proper\ntransaction details view, I've update the tests to use direct\nnavigation. This way, the URL we navigate to using fixtures already\ncontains the required transaction name simplifying the test and reducing\nthe amount of interactions that aren't really tied to what is being\ntested. This change also removes the usage of the deprecated\n`page.waitForLoadingIndicatorHidden()` which is known to be a source of\nflakiness\n2. **Remove tooltip steps** Part of the tests were testing the contents\nof a tooltip that shows up on hover. This is actually the source of\nflakiness detected in the issue as the popover would sometimes not\nrender. I figured the easiest way to stabilise the tests was to remove\nthe problematics parts, specially since we already have [component\ntests](x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/span_links_badge.test.tsx)\nthat specifically target tooltip behaviour\n\n\n## Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n## Backports\n\nSeems like flakiness is specially bad in 9.2. as the failed tests issue\ncontains errors exclusively in this version. I did the PR against main\nas I think all versions can benefit from the improvements developed\nhere. I'll be then backporting the fixes to all open branches that have\nthe tests. The 9.2 backport will be created manually to ensure, via\nflaky test runner, that the flakiness issues have been addressed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cf9ecc0fac340c64f8979ad4d3c50d88b07bf297"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254177","number":254177,"mergeCommit":{"message":"[APM] Fix span links flaky tests  (#254177)\n\n## Summary\nCloses #253040\n\nThis PR aims to fix flaky span links tests for transaction details page.\nThe improvements introduced to combat flakiness are:\n\n1. **Direct navigation to page** Instead of programatically navigating\nto service details and then using the UI to land on the proper\ntransaction details view, I've update the tests to use direct\nnavigation. This way, the URL we navigate to using fixtures already\ncontains the required transaction name simplifying the test and reducing\nthe amount of interactions that aren't really tied to what is being\ntested. This change also removes the usage of the deprecated\n`page.waitForLoadingIndicatorHidden()` which is known to be a source of\nflakiness\n2. **Remove tooltip steps** Part of the tests were testing the contents\nof a tooltip that shows up on hover. This is actually the source of\nflakiness detected in the issue as the popover would sometimes not\nrender. I figured the easiest way to stabilise the tests was to remove\nthe problematics parts, specially since we already have [component\ntests](x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/span_links_badge.test.tsx)\nthat specifically target tooltip behaviour\n\n\n## Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n## Backports\n\nSeems like flakiness is specially bad in 9.2. as the failed tests issue\ncontains errors exclusively in this version. I did the PR against main\nas I think all versions can benefit from the improvements developed\nhere. I'll be then backporting the fixes to all open branches that have\nthe tests. The 9.2 backport will be created manually to ensure, via\nflaky test runner, that the flakiness issues have been addressed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cf9ecc0fac340c64f8979ad4d3c50d88b07bf297"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"url":"https://github.com/elastic/kibana/pull/254388","number":254388,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->