### PR TITLE
[ResponseOps] Fix connectors Oauth2 flaky test

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/auth_config.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/auth_config.test.tsx
@@ -830,8 +830,7 @@ describe('AuthConfig renders', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/249443
-  describe.skip('AuthConfig with showOAuth2Option on', () => {
+  describe('AuthConfig with showOAuth2Option on', () => {
     it('renders OAuth2 option when showOAuth2Option is explicitly set to true', async () => {
       const testFormData = {
         config: {
@@ -962,39 +961,6 @@ describe('AuthConfig renders', () => {
         data: {}, // Data is empty because form is invalid
         isValid: false,
       });
-    });
-
-    it('validates additionalFields input for invalid JSON', async () => {
-      const testFormData = {
-        config: {
-          hasAuth: true,
-          authType: AuthType.OAuth2ClientCredentials,
-          accessTokenUrl: 'https://test.url',
-          clientId: 'testClient',
-        },
-        secrets: {
-          clientSecret: 'testSecret',
-        },
-      };
-
-      render(
-        <AuthFormTestProvider defaultValue={testFormData} onSubmit={onSubmit}>
-          <AuthConfig readOnly={false} isOAuth2Enabled={true} />
-        </AuthFormTestProvider>
-      );
-
-      let additionalFieldsInput: HTMLTextAreaElement | null = null;
-      await waitFor(() => {
-        additionalFieldsInput = document.querySelector('textarea');
-        expect(additionalFieldsInput).toBeInTheDocument();
-      });
-
-      expect(additionalFieldsInput).not.toBeNull();
-
-      await userEvent.clear(additionalFieldsInput!);
-      await userEvent.type(additionalFieldsInput!, '{{key": "value');
-
-      expect(await screen.findByText('Invalid JSON')).toBeInTheDocument();
     });
 
     it('renders OAuth2 fields as readOnly when readOnly prop is true', async () => {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/oauth2_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/oauth2_fields.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { OAuth2Fields, jsonValidator } from './oauth2_fields';
 import * as i18n from './translations';
 import { AuthFormTestProvider } from '../../connector_types/lib/test_utils';
@@ -65,6 +65,20 @@ describe('OAuth2Fields', () => {
     expect(screen.getByLabelText(i18n.CLIENT_ID)).toHaveAttribute('readonly');
     expect(screen.getByLabelText(i18n.CLIENT_SECRET)).toHaveAttribute('readonly');
     expect(screen.getByLabelText(i18n.SCOPE)).toHaveAttribute('readonly');
+  });
+
+  it('shows error message when additionalFields contain invalid JSON', async () => {
+    render(
+      <AuthFormTestProvider defaultValue={baseFormData} onSubmit={onSubmit}>
+        <OAuth2Fields readOnly={false} />
+      </AuthFormTestProvider>
+    );
+
+    fireEvent.change(screen.getByTestId('additional_fieldsJsonEditor'), {
+      target: { value: ':' },
+    });
+
+    expect(await screen.findByText(i18n.INVALID_JSON)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Closes #249443

## Summary

- The test was imo in the wrong location.
  - We were testing `OAuth2Fields` logic inside the `AuthConfig` unit tests.
- There was an unnecessary `waitFor` when the target component(JSON editor) is rendered straightaway.
- Changed from `userEvent.type` to `fireEvent.change`, which should be faster.

The test is still slow, but it is less slow 😅. From 800ms to 500ms locally. This is still above the recommended 300ms, but it might just fix the flakiness.