### PR TITLE
[CPS] Update asScoped call sites - @elastic/kibana-core

### DIFF
--- a/src/core/packages/elasticsearch/client-server-internal/src/cluster_client.test.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/cluster_client.test.ts
@@ -160,7 +160,7 @@ describe('ClusterClient', () => {
 
       expect(scopedClient.child).not.toHaveBeenCalled();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
 
       expect(scopedClient.child).not.toHaveBeenCalled();
 
@@ -188,7 +188,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
 
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
@@ -219,7 +219,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -248,7 +248,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       client = scopedClusterClient.asCurrentUser;
 
       expect(createTransportMock).toHaveBeenCalledTimes(1);
@@ -333,7 +333,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       client = scopedClusterClient.asCurrentUser;
 
       expect(createTransportMock).toHaveBeenCalledTimes(1);
@@ -357,7 +357,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       client = scopedClusterClient.asCurrentUser;
 
       // The Transport class produced by createTransport is passed to child().
@@ -380,8 +380,8 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient1 = clusterClient.asScoped(request);
-      const scopedClusterClient2 = clusterClient.asScoped(request);
+      const scopedClusterClient1 = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
+      const scopedClusterClient2 = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
 
       // trigger client instantiation via getter
       client = scopedClusterClient1.asCurrentUser;
@@ -415,7 +415,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -447,7 +447,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest({});
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -488,7 +488,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -526,7 +526,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest({});
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -564,7 +564,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -602,7 +602,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest({});
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -642,7 +642,7 @@ describe('ClusterClient', () => {
         headers: { foo: 'request' },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -680,7 +680,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -716,7 +716,7 @@ describe('ClusterClient', () => {
         headers: { [headerKey]: 'foo' },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -758,7 +758,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -795,7 +795,7 @@ describe('ClusterClient', () => {
         },
       };
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -831,7 +831,7 @@ describe('ClusterClient', () => {
         },
       };
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -863,7 +863,7 @@ describe('ClusterClient', () => {
         headers: { [AUTHORIZATION_HEADER]: 'Bearer override' },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -904,7 +904,7 @@ describe('ClusterClient', () => {
         headers: { [AUTHORIZATION_HEADER]: 'Bearer override' },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -942,7 +942,7 @@ describe('ClusterClient', () => {
         headers: { [AUTHORIZATION_HEADER]: 'Bearer essu_dev_yes' },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(fakeRequest);
+      const scopedClusterClient = clusterClient.asScoped(fakeRequest, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asCurrentUser;
 
@@ -974,7 +974,7 @@ describe('ClusterClient', () => {
 
       expect(internalClient.child).not.toHaveBeenCalled();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
 
       expect(internalClient.child).not.toHaveBeenCalled();
 
@@ -1001,7 +1001,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest();
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
 
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
@@ -1035,7 +1035,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
 
@@ -1074,7 +1074,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       expect(() => {
         client = scopedClusterClient.asSecondaryAuthUser;
@@ -1106,7 +1106,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest({});
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
 
@@ -1146,7 +1146,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
 
@@ -1184,7 +1184,7 @@ describe('ClusterClient', () => {
         },
       };
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
 
@@ -1220,7 +1220,7 @@ describe('ClusterClient', () => {
         },
       });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
 
@@ -1257,7 +1257,7 @@ describe('ClusterClient', () => {
         },
       };
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
 
       expect(() => {
         // trigger client instantiation via getter
@@ -1283,7 +1283,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest({ headers: { foo: 'bar' } });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
 
@@ -1321,7 +1321,7 @@ describe('ClusterClient', () => {
       });
       const request = httpServerMock.createKibanaRequest({ headers: { foo: 'bar' } });
 
-      const scopedClusterClient = clusterClient.asScoped(request);
+      const scopedClusterClient = clusterClient.asScoped(request, { projectRouting: 'origin-only' });
       // trigger client instantiation via getter
       client = scopedClusterClient.asSecondaryAuthUser;
 

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_route_handler_context.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_route_handler_context.ts
@@ -28,7 +28,8 @@ export class CoreElasticsearchRouteHandlerContext implements ElasticsearchReques
 
   public get client() {
     if (this.#client == null) {
-      this.#client = this.elasticsearchStart.client.asScoped(this.request);
+      // TODO REVIEW
+      this.#client = this.elasticsearchStart.client.asScoped(this.request, { projectRouting: 'space' });
     }
     return this.#client;
   }

--- a/src/core/packages/saved-objects/server-internal/src/saved_objects_service.ts
+++ b/src/core/packages/saved-objects/server-internal/src/saved_objects_service.ts
@@ -358,7 +358,8 @@ export class SavedObjectsService
         req: KibanaRequest,
         includedHiddenTypes?: string[],
         extensions?: SavedObjectsExtensions
-      ) => createRepository(client.asScoped(req).asCurrentUser, includedHiddenTypes, extensions),
+      // TODO REVIEW
+      ) => createRepository(client.asScoped(req, { projectRouting: 'space' }).asCurrentUser, includedHiddenTypes, extensions),
     };
 
     const clientProvider = new SavedObjectsClientProvider({

--- a/x-pack/platform/test/plugin_api_integration/plugins/elasticsearch_client/server/plugin.ts
+++ b/x-pack/platform/test/plugin_api_integration/plugins/elasticsearch_client/server/plugin.ts
@@ -44,7 +44,8 @@ export class ElasticsearchClientXPack implements Plugin {
       async (context, req, res) => {
         const [coreStart] = await core.getStartServices();
         const body = await coreStart.elasticsearch.client
-          .asScoped(req)
+          // TODO REVIEW
+          .asScoped(req, { projectRouting: 'space' })
           .asCurrentUser.security.getUser();
         return res.ok({ body });
       }


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/kibana-core.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.