### PR TITLE
[CPS] Update asScoped call sites - @elastic/kibana-data-discovery @elastic/kibana-visualizations

### DIFF
--- a/src/platform/plugins/shared/data/server/search/expressions/eql.ts
+++ b/src/platform/plugins/shared/data/server/search/expressions/eql.ts
@@ -40,7 +40,8 @@ export function getEql({
       const savedObjectsClient = core.savedObjects.getScopedClient(request);
       const dataViews = await indexPatterns.dataViewsServiceFactory(
         savedObjectsClient,
-        core.elasticsearch.client.asScoped(request).asCurrentUser,
+        // TODO REVIEW
+        core.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser,
         request
       );
       return {

--- a/src/platform/plugins/shared/data/server/search/expressions/esaggs.ts
+++ b/src/platform/plugins/shared/data/server/search/expressions/esaggs.ts
@@ -106,7 +106,8 @@ export function getEsaggs({
     getStartDependencies: async (request: KibanaRequest) => {
       const [{ elasticsearch, savedObjects }, , self] = await getStartServices();
       const { indexPatterns, search } = self;
-      const esClient = elasticsearch.client.asScoped(request);
+      // TODO REVIEW
+      const esClient = elasticsearch.client.asScoped(request, { projectRouting: 'space' });
       const savedObjectsClient = savedObjects.getScopedClient(request);
 
       return {

--- a/src/platform/plugins/shared/data/server/search/search_service.ts
+++ b/src/platform/plugins/shared/data/server/search/search_service.ts
@@ -290,7 +290,8 @@ export class SearchService {
       asScoped: this.asScoped,
       searchSource: {
         asScoped: async (request: KibanaRequest) => {
-          const esClient = elasticsearch.client.asScoped(request);
+          // TODO REVIEW
+          const esClient = elasticsearch.client.asScoped(request, { projectRouting: 'space' });
           const savedObjectsClient = savedObjects.getScopedClient(request);
           const scopedIndexPatterns = await indexPatterns.dataViewsServiceFactory(
             savedObjectsClient,
@@ -539,7 +540,8 @@ export class SearchService {
       const deps = {
         searchSessionsClient,
         savedObjectsClient,
-        esClient: elasticsearch.client.asScoped(request),
+        // TODO REVIEW
+        esClient: elasticsearch.client.asScoped(request, { projectRouting: 'space' }),
         uiSettingsClient: new CachedUiSettingsClient(
           uiSettings.asScopedToClient(savedObjectsClient)
         ),

--- a/src/platform/plugins/shared/data/server/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/server/search/session/session_service.ts
@@ -463,7 +463,8 @@ export class SearchSessionService implements ISearchSessionService {
         includedHiddenTypes: [SEARCH_SESSION_TYPE],
       });
 
-      const asCurrentUserElasticsearchClient = elasticsearch.client.asScoped(request).asCurrentUser;
+      // TODO REVIEW
+      const asCurrentUserElasticsearchClient = elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser;
 
       const deps = {
         savedObjectsClient,

--- a/src/platform/plugins/shared/data_views/server/expressions/load_index_pattern.ts
+++ b/src/platform/plugins/shared/data_views/server/expressions/load_index_pattern.ts
@@ -86,7 +86,8 @@ export function getIndexPatternLoad({
       return {
         indexPatterns: await dataViewsServiceFactory(
           savedObjects.getScopedClient(request),
-          elasticsearch.client.asScoped(request).asCurrentUser,
+          // TODO REVIEW
+          elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser,
           request
         ),
       };

--- a/src/platform/test/plugin_functional/plugins/data_search/server/plugin.ts
+++ b/src/platform/test/plugin_functional/plugins/data_search/server/plugin.ts
@@ -75,7 +75,8 @@ export class DataSearchTestPlugin
       async (context, req, res) => {
         const [{ savedObjects, elasticsearch }, { data }] = await core.getStartServices();
         const service = await data.search.searchSource.asScoped(req);
-        const clusterClient = elasticsearch.client.asScoped(req).asCurrentUser;
+        // TODO REVIEW
+        const clusterClient = elasticsearch.client.asScoped(req, { projectRouting: 'space' }).asCurrentUser;
         const savedObjectsClient = savedObjects.getScopedClient(req);
 
         // Since the index pattern ID can change on each test run, we need

--- a/src/platform/test/plugin_functional/plugins/index_patterns/server/plugin.ts
+++ b/src/platform/test/plugin_functional/plugins/index_patterns/server/plugin.ts
@@ -45,7 +45,8 @@ export class IndexPatternsTestPlugin
         const savedObjectsClient = savedObjects.getScopedClient(req);
         const service = await data.indexPatterns.dataViewsServiceFactory(
           savedObjectsClient,
-          elasticsearch.client.asScoped(req).asCurrentUser,
+          // TODO REVIEW
+          elasticsearch.client.asScoped(req, { projectRouting: 'space' }).asCurrentUser,
           req
         );
         const ids = await service.createAndSave(req.body);
@@ -69,7 +70,8 @@ export class IndexPatternsTestPlugin
         const savedObjectsClient = savedObjects.getScopedClient(req);
         const service = await data.indexPatterns.dataViewsServiceFactory(
           savedObjectsClient,
-          elasticsearch.client.asScoped(req).asCurrentUser,
+          // TODO REVIEW
+          elasticsearch.client.asScoped(req, { projectRouting: 'space' }).asCurrentUser,
           req
         );
         const ids = await service.getIds(true);
@@ -98,7 +100,8 @@ export class IndexPatternsTestPlugin
         const savedObjectsClient = savedObjects.getScopedClient(req);
         const service = await data.indexPatterns.dataViewsServiceFactory(
           savedObjectsClient,
-          elasticsearch.client.asScoped(req).asCurrentUser,
+          // TODO REVIEW
+          elasticsearch.client.asScoped(req, { projectRouting: 'space' }).asCurrentUser,
           req
         );
         const ip = await service.get(id);
@@ -127,7 +130,8 @@ export class IndexPatternsTestPlugin
         const savedObjectsClient = savedObjects.getScopedClient(req);
         const service = await data.indexPatterns.dataViewsServiceFactory(
           savedObjectsClient,
-          elasticsearch.client.asScoped(req).asCurrentUser,
+          // TODO REVIEW
+          elasticsearch.client.asScoped(req, { projectRouting: 'space' }).asCurrentUser,
           req
         );
         const ip = await service.get(id);
@@ -157,7 +161,8 @@ export class IndexPatternsTestPlugin
         const savedObjectsClient = savedObjects.getScopedClient(req);
         const service = await data.indexPatterns.dataViewsServiceFactory(
           savedObjectsClient,
-          elasticsearch.client.asScoped(req).asCurrentUser,
+          // TODO REVIEW
+          elasticsearch.client.asScoped(req, { projectRouting: 'space' }).asCurrentUser,
           req
         );
         await service.delete(id);


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/kibana-data-discovery @elastic/kibana-visualizations.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.