### PR TITLE
[8.19] chore(deps): Upgrade qs dependency (#254313)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1898,7 +1898,7 @@
     "postcss-scss": "4.0.9",
     "prettier": "2.8.8",
     "proxy": "2.1.1",
-    "qs": "6.14.1",
+    "qs": "6.14.2",
     "react-refresh": "0.18.0",
     "react-test-renderer": "17.0.2",
     "recast": "0.23.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27662,10 +27662,10 @@ qs@6.13.0:
   dependencies:
     side-channel "^1.0.6"
 
-qs@6.14.1, qs@^6.11.0, qs@^6.12.3, qs@^6.14.0, qs@^6.7.0:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
-  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
+qs@6.14.2, qs@^6.11.0, qs@^6.12.3, qs@^6.14.0, qs@^6.9.7:
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
+  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
   dependencies:
     side-channel "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27662,17 +27662,10 @@ qs@6.13.0:
   dependencies:
     side-channel "^1.0.6"
 
-qs@6.14.2, qs@^6.11.0, qs@^6.12.3, qs@^6.14.0:
+qs@6.14.2, qs@^6.11.0, qs@^6.12.3, qs@^6.14.0, qs@^6.7.0:
   version "6.14.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
   integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
-  dependencies:
-    side-channel "^1.1.0"
-
-qs@^6.7.0:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
-  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
   dependencies:
     side-channel "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27662,10 +27662,17 @@ qs@6.13.0:
   dependencies:
     side-channel "^1.0.6"
 
-qs@6.14.2, qs@^6.11.0, qs@^6.12.3, qs@^6.14.0, qs@^6.9.7:
+qs@6.14.2, qs@^6.11.0, qs@^6.12.3, qs@^6.14.0:
   version "6.14.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
   integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+  dependencies:
+    side-channel "^1.1.0"
+
+qs@^6.7.0:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
+  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): Upgrade qs dependency (#254313)](https://github.com/elastic/kibana/pull/254313)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-23T11:23:18Z","message":"chore(deps): Upgrade qs dependency (#254313)","sha":"55a537ba0f5f9ce7d301f72bddd3c3a1a672eb79","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.4.0"],"title":"chore(deps): Upgrade qs dependency","number":254313,"url":"https://github.com/elastic/kibana/pull/254313","mergeCommit":{"message":"chore(deps): Upgrade qs dependency (#254313)","sha":"55a537ba0f5f9ce7d301f72bddd3c3a1a672eb79"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254313","number":254313,"mergeCommit":{"message":"chore(deps): Upgrade qs dependency (#254313)","sha":"55a537ba0f5f9ce7d301f72bddd3c3a1a672eb79"}},{"url":"https://github.com/elastic/kibana/pull/254446","number":254446,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->