### PR TITLE
[CPS] Update asScoped call sites - @elastic/response-ops

### DIFF
--- a/src/platform/packages/private/kbn-reporting/export_types/csv/csv_searchsource.ts
+++ b/src/platform/packages/private/kbn-reporting/export_types/csv/csv_searchsource.ts
@@ -81,7 +81,8 @@ export class CsvSearchSourceExportType extends ExportType<
     const dataPluginStart = this.startDeps.data;
     const fieldFormatsRegistry = await getFieldFormats().fieldFormatServiceFactory(uiSettings);
 
-    const es = this.startDeps.esClient.asScoped(request);
+    // TODO REVIEW
+    const es = this.startDeps.esClient.asScoped(request, { projectRouting: 'space' });
     const searchSourceStart = await dataPluginStart.search.searchSource.asScoped(request);
 
     const clients = {

--- a/src/platform/packages/private/kbn-reporting/export_types/csv/csv_v2.ts
+++ b/src/platform/packages/private/kbn-reporting/export_types/csv/csv_v2.ts
@@ -133,7 +133,8 @@ export class CsvV2ExportType extends ExportType<
       const columns = params.columns as string[] | undefined;
       const timeFieldName = await locatorClient.timeFieldNameFromLocator(params);
       const filters = await locatorClient.filtersFromLocator(params);
-      const es = this.startDeps.esClient.asScoped(request);
+      // TODO REVIEW
+      const es = this.startDeps.esClient.asScoped(request, { projectRouting: 'space' });
 
       const clients = { uiSettings, data, es };
 
@@ -159,7 +160,8 @@ export class CsvV2ExportType extends ExportType<
     const columns = await locatorClient.columnsFromLocator(params);
     const searchSource = await locatorClient.searchSourceFromLocator(params);
 
-    const es = this.startDeps.esClient.asScoped(request);
+    // TODO REVIEW
+    const es = this.startDeps.esClient.asScoped(request, { projectRouting: 'space' });
     const searchSourceStart = await dataPluginStart.search.searchSource.asScoped(request);
 
     const clients = { uiSettings, data, es };

--- a/x-pack/platform/plugins/private/reporting/server/core.ts
+++ b/x-pack/platform/plugins/private/reporting/server/core.ts
@@ -440,7 +440,8 @@ export class ReportingCore {
     const { savedObjects } = await this.getPluginStartDeps();
     const savedObjectsClient = savedObjects.getScopedClient(request);
     const { indexPatterns } = await this.getDataService();
-    const { asCurrentUser: esClient } = (await this.getEsClient()).asScoped(request);
+    // TODO REVIEW
+    const { asCurrentUser: esClient } = (await this.getEsClient()).asScoped(request, { projectRouting: 'space' });
     const dataViews = await indexPatterns.dataViewsServiceFactory(savedObjectsClient, esClient);
 
     return dataViews;

--- a/x-pack/platform/plugins/shared/actions/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.ts
@@ -510,7 +510,8 @@ export class ActionsPlugin
         unsecuredSavedObjectsClient,
         actionTypeRegistry: actionTypeRegistry!,
         kibanaIndices: core.savedObjects.getAllIndices(),
-        scopedClusterClient: core.elasticsearch.client.asScoped(request),
+        // TODO REVIEW
+        scopedClusterClient: core.elasticsearch.client.asScoped(request, { projectRouting: 'space' }),
         inMemoryConnectors: this.inMemoryConnectors,
         request,
         spaceId,
@@ -748,7 +749,8 @@ export class ActionsPlugin
     return (request) => {
       return {
         savedObjectsClient: getScopedClient(request),
-        scopedClusterClient: elasticsearch.client.asScoped(request).asCurrentUser,
+        // TODO REVIEW
+        scopedClusterClient: elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser,
         connectorTokenClient: new ConnectorTokenClient({
           unsecuredSavedObjectsClient: unsecuredSavedObjectsClient(request),
           encryptedSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.ts
@@ -65,7 +65,8 @@ export const getExecutorServices = (opts: GetExecutorServicesOpts): ExecutorServ
     requestTimeout: getEsRequestTimeout(logger, ruleTaskTimeout),
   };
 
-  const scopedClusterClient = context.elasticsearch.client.asScoped(fakeRequest);
+  // TODO REVIEW
+  const scopedClusterClient = context.elasticsearch.client.asScoped(fakeRequest, { projectRouting: 'origin-only' });
   const wrappedScopedClusterClient = createWrappedScopedClusterClientFactory({
     ...wrappedClientOptions,
     scopedClusterClient,

--- a/x-pack/platform/plugins/shared/rule_registry/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/plugin.ts
@@ -167,7 +167,8 @@ export class RuleRegistryPlugin
         return plugins.alerting.getAlertingAuthorizationWithRequest(request);
       },
       async getEsClientScoped(request: KibanaRequest) {
-        return core.elasticsearch.client.asScoped(request).asCurrentUser;
+        // TODO REVIEW
+        return core.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser;
       },
       securityPluginSetup: security,
       ruleDataService,

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.ts
@@ -144,7 +144,8 @@ export function backgroundTaskUtilizationRoute(
         if (usageCounter && routeOption.isAuthenticated) {
           const clusterClient = await getClusterClient();
           const hasPrivilegesResponse = await clusterClient
-            .asScoped(req)
+            // TODO REVIEW
+            .asScoped(req, { projectRouting: 'space' })
             .asCurrentUser.security.hasPrivileges({
               application: [
                 {

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/health.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/health.ts
@@ -167,7 +167,8 @@ export function healthRoute(params: HealthRouteParams): {
       if (usageCounter) {
         const clusterClient = await getClusterClient();
         const hasPrivilegesResponse = await clusterClient
-          .asScoped(req)
+          // TODO REVIEW
+          .asScoped(req, { projectRouting: 'space' })
           .asCurrentUser.security.hasPrivileges({
             application: [
               {


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/response-ops.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.