### PR TITLE
[CPS] Update asScoped call sites - @elastic/kibana-security

### DIFF
--- a/packages/kbn-mock-idp-plugin/server/plugin.ts
+++ b/packages/kbn-mock-idp-plugin/server/plugin.ts
@@ -271,9 +271,11 @@ export const plugin: PluginInitializer<void, void, PluginSetupDependencies> = as
             const [{ elasticsearch }] = await core.getStartServices();
 
             // Get scoped client with UIAM headers
-            const scopedClient = elasticsearch.client.asScoped({
-              headers: { authorization: `ApiKey ${request.body.apiKey}` },
-            });
+            // TODO REVIEW
+            const scopedClient = elasticsearch.client.asScoped(
+              { headers: { authorization: `ApiKey ${request.body.apiKey}` } },
+              { projectRouting: 'origin-only' }
+            );
 
             if (!scopedClient) {
               return response.badRequest({

--- a/x-pack/platform/plugins/shared/security/server/anonymous_access/anonymous_access_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/anonymous_access/anonymous_access_service.ts
@@ -138,8 +138,9 @@ export class AnonymousAccessService {
    */
   private async canAuthenticateAnonymousServiceAccount(clusterClient: IClusterClient) {
     try {
+      // TODO REVIEW
       await clusterClient
-        .asScoped(this.createFakeAnonymousRequest({ authenticateRequest: true }))
+        .asScoped(this.createFakeAnonymousRequest({ authenticateRequest: true }), { projectRouting: 'origin-only' })
         .asCurrentUser.security.authenticate();
     } catch (err) {
       this.logger.warn(

--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/api_keys.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/api_keys.ts
@@ -160,7 +160,8 @@ export class APIKeys implements NativeAPIKeysType {
       return null;
     }
     const { type, expiration, name, metadata } = createParams;
-    const scopedClusterClient = this.clusterClient.asScoped(request);
+    // TODO REVIEW
+    const scopedClusterClient = this.clusterClient.asScoped(request, { projectRouting: 'space' });
 
     this.logger.debug('Trying to create an API key');
 
@@ -215,7 +216,8 @@ export class APIKeys implements NativeAPIKeysType {
     }
 
     const { type, id, metadata } = updateParams;
-    const scopedClusterClient = this.clusterClient.asScoped(request);
+    // TODO REVIEW
+    const scopedClusterClient = this.clusterClient.asScoped(request, { projectRouting: 'space' });
 
     this.logger.debug('Trying to edit an API key');
 
@@ -338,7 +340,8 @@ export class APIKeys implements NativeAPIKeysType {
     let result: InvalidateAPIKeyResult;
     try {
       // User needs `manage_api_key` privilege to use this API
-      result = await this.clusterClient.asScoped(request).asCurrentUser.security.invalidateApiKey({
+      // TODO REVIEW
+      result = await this.clusterClient.asScoped(request, { projectRouting: 'space' }).asCurrentUser.security.invalidateApiKey({
         ids: params.ids,
       });
       this.logger.debug(
@@ -398,7 +401,8 @@ export class APIKeys implements NativeAPIKeysType {
 
     this.logger.debug(`Trying to validate an API key`);
     try {
-      await this.clusterClient.asScoped(fakeRequest).asCurrentUser.security.authenticate();
+      // TODO REVIEW
+      await this.clusterClient.asScoped(fakeRequest, { projectRouting: 'origin-only' }).asCurrentUser.security.authenticate();
       this.logger.debug(`API key was validated successfully`);
       return true;
     } catch (e) {

--- a/x-pack/platform/plugins/shared/security/server/authorization/check_privileges.ts
+++ b/x-pack/platform/plugins/shared/security/server/authorization/check_privileges.ts
@@ -106,7 +106,8 @@ export function checkPrivilegesFactory(
         { requireLoginAction }
       );
 
-      const clusterClient = (await getClusterClient()).asScoped(request);
+      // TODO REVIEW
+      const clusterClient = (await getClusterClient()).asScoped(request, { projectRouting: 'space' });
       const hasPrivilegesResponse = await clusterClient.asCurrentUser.security.hasPrivileges({
         cluster: privileges.elasticsearch?.cluster as estypes.SecurityClusterPrivilege[],
         index: Object.entries(privileges.elasticsearch?.index ?? {}).map(

--- a/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/user_profile/user_profile_service.ts
@@ -288,7 +288,8 @@ export class UserProfileService {
     request: UserProfileGetCurrentParams['request']
   ): Promise<string | undefined> {
     try {
-      const response = await clusterClient.asScoped(request).asCurrentUser.security.getApiKey({
+      // TODO REVIEW
+      const response = await clusterClient.asScoped(request, { projectRouting: 'space' }).asCurrentUser.security.getApiKey({
         with_profile_uid: true,
       });
 

--- a/x-pack/platform/test/security_functional/plugins/test_endpoints/server/init_routes.ts
+++ b/x-pack/platform/test/security_functional/plugins/test_endpoints/server/init_routes.ts
@@ -122,13 +122,15 @@ export function initRoutes(
 
       let scopedClient;
       if (request.body.client === 'start-contract') {
-        scopedClient = (await core.getStartServices())[0].elasticsearch.client.asScoped(request);
+        // TODO REVIEW
+        scopedClient = (await core.getStartServices())[0].elasticsearch.client.asScoped(request, { projectRouting: 'space' });
       } else if (request.body.client === 'request-context') {
         scopedClient = (await context.core).elasticsearch.client;
       } else {
         scopedClient = (await core.getStartServices())[0].elasticsearch
           .createClient('custom')
-          .asScoped(request);
+          // TODO REVIEW
+          .asScoped(request, { projectRouting: 'space' });
       }
 
       await scopedClient.asCurrentUser.security.authenticate();


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/kibana-security.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.