### PR TITLE
[CPS] Update asScoped call sites - @elastic/obs-ai-team

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index.ts
@@ -101,7 +101,8 @@ export class ObservabilityAIAssistantService {
     const inferenceClient = plugins.inference.getClient({ request });
 
     const { asInternalUser } = coreStart.elasticsearch.client;
-    const { asCurrentUser } = coreStart.elasticsearch.client.asScoped(request);
+    // TODO REVIEW
+    const { asCurrentUser } = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
     const analytics = coreStart.analytics;
 
     const kbService = new KnowledgeBaseService({

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/log.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/attachments/log.ts
@@ -58,7 +58,8 @@ export function createLogAttachmentType({
             handler: async (_args, context) => {
               try {
                 const [coreStart] = await core.getStartServices();
-                const esClient = coreStart.elasticsearch.client.asScoped(context.request);
+                // TODO REVIEW
+                const esClient = coreStart.elasticsearch.client.asScoped(context.request, { projectRouting: 'space' });
 
                 const logEntry = await getLogDocumentById({
                   esClient: esClient.asCurrentUser,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/alert_ai_insights/generate_alert_ai_insight.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/alert_ai_insights/generate_alert_ai_insight.ts
@@ -115,7 +115,8 @@ async function fetchAlertContext({
   const alertStart = moment(alertDoc?.['kibana.alert.start']).toISOString();
 
   const [coreStart] = await core.getStartServices();
-  const esClient = coreStart.elasticsearch.client.asScoped(request);
+  // TODO REVIEW
+  const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
 
   const results = await runSignalFetchers(
     {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/apm_error/fetch_apm_error_context.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/apm_error/fetch_apm_error_context.ts
@@ -54,7 +54,8 @@ export async function fetchApmErrorContext({
   const parsedEnd = parseDatemath(end, { roundUp: true });
 
   const [coreStart] = await core.getStartServices();
-  const esClient = coreStart.elasticsearch.client.asScoped(request);
+  // TODO REVIEW
+  const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
 
   const errorDetails = await dataRegistry.getData('apmErrorDetails', {
     request,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/route.ts
@@ -147,7 +147,8 @@ export function getObservabilityAgentBuilderAiInsightsRouteRepository(): ServerR
       const connectorId = await getDefaultConnectorId({ coreStart, inference, request });
       const inferenceClient = inference.getClient({ request });
       const connector = await inference.getConnectorById(connectorId, request);
-      const esClient = coreStart.elasticsearch.client.asScoped(request);
+      // TODO REVIEW
+      const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
 
       const result = await getLogAiInsights({
         core,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/build_apm_resources.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/build_apm_resources.ts
@@ -37,7 +37,8 @@ export async function buildApmResources({
   const savedObjectsClient = new SavedObjectsClient(
     coreStart.savedObjects.createInternalRepository()
   );
-  const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+  // TODO REVIEW
+  const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser;
   const indices = await plugins.apmDataAccess.getApmIndices(savedObjectsClient);
 
   const apmEventClient = new APMEventClient({

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/plugin.ts
@@ -98,7 +98,8 @@ export class ObservabilityAIAssistantAppPlugin
         }),
         core: Promise.resolve({
           elasticsearch: {
-            client: coreStart.elasticsearch.client.asScoped(request),
+            // TODO REVIEW
+            client: coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }),
           },
           uiSettings: {
             client: coreStart.uiSettings.asScopedToClient(savedObjectsClient),


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/obs-ai-team.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.