### PR TITLE
[CPS] Update asScoped call sites - @elastic/actionable-obs-team

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/agent_builder/register_data_provider.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/agent_builder/register_data_provider.ts
@@ -45,7 +45,8 @@ export function registerDataProviders({
         request,
         soClient: coreStart.savedObjects.getScopedClient(request),
         esClient: coreStart.elasticsearch.client.asInternalUser,
-        scopedClusterClient: coreStart.elasticsearch.client.asScoped(request),
+        // TODO REVIEW
+        scopedClusterClient: coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }),
         spaceId,
         logger,
       });

--- a/x-pack/solutions/observability/plugins/slo/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/plugin.ts
@@ -184,7 +184,8 @@ export class SLOPlugin
           const soClient = coreStart.savedObjects.getScopedClient(request, {
             includedHiddenTypes: [SO_SLO_TEMPLATE_TYPE],
           });
-          const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
+          // TODO REVIEW
+          const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
 
           const [dataViewsService, rulesClient, { id: spaceId }, racClient] = await Promise.all([
             pluginsStart.dataViews.dataViewsServiceFactory(
@@ -300,7 +301,8 @@ export class SLOPlugin
           request,
           soClient: core.savedObjects.getScopedClient(request),
           esClient: internalEsClient,
-          scopedClusterClient: core.elasticsearch.client.asScoped(request),
+          // TODO REVIEW
+          scopedClusterClient: core.elasticsearch.client.asScoped(request, { projectRouting: 'space' }),
           spaceId,
           logger: this.logger,
         });

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/bulk_delete_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/bulk_delete_task.ts
@@ -59,7 +59,8 @@ export class BulkDeleteTask {
 
               const [coreStart, pluginStart] = await core.getStartServices();
 
-              const scopedClusterClient = coreStart.elasticsearch.client.asScoped(fakeRequest);
+              // TODO REVIEW
+              const scopedClusterClient = coreStart.elasticsearch.client.asScoped(fakeRequest, { projectRouting: 'origin-only' });
               const scopedSoClient = coreStart.savedObjects.getScopedClient(fakeRequest);
               const rulesClient = await pluginStart.alerting.getRulesClientWithRequest(fakeRequest);
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/health_scan_task/health_scan_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/health_scan_task/health_scan_task.ts
@@ -85,7 +85,8 @@ export class HealthScanTask {
               }
 
               const [coreStart] = await core.getStartServices();
-              const scopedClusterClient = coreStart.elasticsearch.client.asScoped(fakeRequest);
+              // TODO REVIEW
+              const scopedClusterClient = coreStart.elasticsearch.client.asScoped(fakeRequest, { projectRouting: 'origin-only' });
               const soClient = new SavedObjectsClient(
                 coreStart.savedObjects.createInternalRepository()
               );

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
@@ -16,8 +16,9 @@ export const checkHasPrivileges = (
   apiKey: { id: string; apiKey: string }
 ) => {
   const { indices: index, cluster } = getServiceApiKeyPrivileges(server.isElasticsearchServerless);
+  // TODO REVIEW
   return server.coreStart.elasticsearch.client
-    .asScoped(getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey }))
+    .asScoped(getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey }), { projectRouting: 'origin-only' })
     .asCurrentUser.security.hasPrivileges({
       index,
       cluster,


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/actionable-obs-team.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.