### PR TITLE
[CPS] Update asScoped call sites - @elastic/core-analysis

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainer/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainer/index.ts
@@ -113,7 +113,8 @@ export function registerEntityMaintainerTask({
                 setup,
                 run,
                 abortController,
-                esClient: start.elasticsearch.client.asScoped(fakeRequest).asCurrentUser,
+                // TODO REVIEW
+                esClient: start.elasticsearch.client.asScoped(fakeRequest, { projectRouting: 'origin-only' }).asCurrentUser,
               });
             },
           }),

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/factories.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/factories.ts
@@ -28,7 +28,8 @@ export async function createLogsExtractionClient({
 }): Promise<LogsExtractionClientFactoryResult> {
   const [coreStart, pluginsStart] = await core.getStartServices();
 
-  const clusterClient = coreStart.elasticsearch.client.asScoped(fakeRequest);
+  // TODO REVIEW
+  const clusterClient = coreStart.elasticsearch.client.asScoped(fakeRequest, { projectRouting: 'origin-only' });
   const soClient = coreStart.savedObjects.getScopedClient(fakeRequest);
   const internalUserClient = coreStart.elasticsearch.client.asInternalUser;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/auth/api_key.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/auth/api_key.ts
@@ -102,7 +102,8 @@ export const getApiKeyManager = ({
       id: apiKey.id,
       api_key: apiKey.apiKey,
     });
-    const clusterClient = core.elasticsearch.client.asScoped(fakeRequest);
+    // TODO REVIEW
+    const clusterClient = core.elasticsearch.client.asScoped(fakeRequest, { projectRouting: 'origin-only' });
     const soClient = core.savedObjects.getScopedClient(fakeRequest, {
       includedHiddenTypes: [EntityDiscoveryApiKeyType.name],
     });


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/core-analysis.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.