### PR TITLE
[CPS] Update asScoped call sites - @elastic/workchat-eng

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/user_prompts.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/user_prompts.ts
@@ -47,7 +47,8 @@ export function registerInternalUserPromptsRoutes({
     },
     wrapHandler(async (ctx, request, response) => {
       const [coreStart] = await coreSetup.getStartServices();
-      const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+      // TODO REVIEW
+      const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asInternalUser;
       const authUser = coreStart.security.authc.getCurrentUser(request);
 
       if (!authUser) {
@@ -93,7 +94,8 @@ export function registerInternalUserPromptsRoutes({
     },
     wrapHandler(async (ctx, request, response) => {
       const [coreStart] = await coreSetup.getStartServices();
-      const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+      // TODO REVIEW
+      const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asInternalUser;
       const authUser = coreStart.security.authc.getCurrentUser(request);
 
       if (!authUser) {
@@ -136,7 +138,8 @@ export function registerInternalUserPromptsRoutes({
     },
     wrapHandler(async (ctx, request, response) => {
       const [coreStart] = await coreSetup.getStartServices();
-      const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+      // TODO REVIEW
+      const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asInternalUser;
       const authUser = coreStart.security.authc.getCurrentUser(request);
 
       if (!authUser) {
@@ -180,7 +183,8 @@ export function registerInternalUserPromptsRoutes({
     },
     wrapHandler(async (ctx, request, response) => {
       const [coreStart] = await coreSetup.getStartServices();
-      const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+      // TODO REVIEW
+      const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asInternalUser;
       const authUser = coreStart.security.authc.getCurrentUser(request);
 
       if (!authUser) {
@@ -221,7 +225,8 @@ export function registerInternalUserPromptsRoutes({
     },
     wrapHandler(async (ctx, request, response) => {
       const [coreStart] = await coreSetup.getStartServices();
-      const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+      // TODO REVIEW
+      const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asInternalUser;
       const authUser = coreStart.security.authc.getCurrentUser(request);
 
       if (!authUser) {
@@ -264,7 +269,8 @@ export function registerInternalUserPromptsRoutes({
     },
     wrapHandler(async (ctx, request, response) => {
       const [coreStart] = await coreSetup.getStartServices();
-      const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+      // TODO REVIEW
+      const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asInternalUser;
       const authUser = coreStart.security.authc.getCurrentUser(request);
 
       if (!authUser) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
@@ -60,7 +60,8 @@ export const createClient = async ({
   toolsService: ToolsServiceStart;
   logger: Logger;
 }): Promise<AgentClient> => {
-  const scopedClient = elasticsearch.client.asScoped(request);
+  // TODO REVIEW
+  const scopedClient = elasticsearch.client.asScoped(request, { projectRouting: 'space' });
   const user = await getUserFromRequest({
     request,
     security,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.ts
@@ -42,7 +42,8 @@ export class ConversationServiceImpl implements ConversationService {
   }
 
   async getScopedClient({ request }: { request: KibanaRequest }): Promise<ConversationClient> {
-    const scopedClient = this.elasticsearch.client.asScoped(request);
+    // TODO REVIEW
+    const scopedClient = this.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
     const user = await getUserFromRequest({
       request,
       security: this.security,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/run_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/run_agent.ts
@@ -70,7 +70,8 @@ export const createAgentHandlerContext = async <TParams = Record<string, unknown
     spaceId,
     logger,
     modelProvider,
-    esClient: elasticsearch.client.asScoped(request),
+    // TODO REVIEW
+    esClient: elasticsearch.client.asScoped(request, { projectRouting: 'space' }),
     savedObjectsClient: savedObjects.getScopedClient(request),
     runner: manager.getRunner(),
     toolRegistry,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/run_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/run_tool.ts
@@ -225,7 +225,8 @@ export const createToolHandlerContext = async <TParams = Record<string, unknown>
     request,
     spaceId,
     logger,
-    esClient: elasticsearch.client.asScoped(request),
+    // TODO REVIEW
+    esClient: elasticsearch.client.asScoped(request, { projectRouting: 'space' }),
     savedObjectsClient: savedObjects.getScopedClient(request),
     modelProvider,
     runner: manager.getRunner(),


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/workchat-eng.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.