### PR TITLE
[CPS] Update asScoped call sites - @elastic/obs-entities

### DIFF
--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/auth/api_key/api_key.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/auth/api_key/api_key.ts
@@ -37,11 +37,13 @@ export const checkIfEntityDiscoveryAPIKeyIsValid = async (
   if (!isValid) return false;
 
   // this fake kibana request is how you get an API key-scoped client...
+  // TODO REVIEW
   const esClient = server.core.elasticsearch.client.asScoped(
     getFakeKibanaRequest({
       id: apiKey.id,
       api_key: apiKey.apiKey,
-    })
+    }),
+    { projectRouting: 'origin-only' }
   ).asCurrentUser;
 
   server.logger.debug('validating API key has runtime privileges for entity discovery');

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/utils.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/utils.ts
@@ -20,7 +20,8 @@ export const getClientsFromAPIKey = ({
   server: EntityManagerServerSetup;
 }): { clusterClient: IScopedClusterClient; soClient: SavedObjectsClientContract } => {
   const fakeRequest = getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey });
-  const clusterClient = server.core.elasticsearch.client.asScoped(fakeRequest);
+  // TODO REVIEW
+  const clusterClient = server.core.elasticsearch.client.asScoped(fakeRequest, { projectRouting: 'origin-only' });
   const soClient = server.core.savedObjects.getScopedClient(fakeRequest, {
     includedHiddenTypes: [EntityDiscoveryApiKeyType.name],
   });

--- a/x-pack/platform/plugins/shared/entity_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/plugin.ts
@@ -105,7 +105,8 @@ export class EntityManagerServerPlugin
     request: KibanaRequest;
     coreStart: CoreStart;
   }) {
-    const clusterClient = coreStart.elasticsearch.client.asScoped(request);
+    // TODO REVIEW
+    const clusterClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
     const soClient = coreStart.savedObjects.getScopedClient(request);
     return new EntityClient({
       clusterClient,


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/obs-entities.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.