### PR TITLE
[CPS] Update asScoped call sites - @elastic/kibana-management

### DIFF
--- a/x-pack/platform/plugins/private/reindex_service/server/src/lib/worker.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/src/lib/worker.ts
@@ -229,7 +229,8 @@ export class ReindexWorker {
 
   private getCredentialScopedReindexService = (credential: Credential) => {
     const fakeRequest: FakeRequest = { headers: credential };
-    const scopedClusterClient = this.clusterClient.asScoped(fakeRequest);
+    // TODO REVIEW
+    const scopedClusterClient = this.clusterClient.asScoped(fakeRequest, { projectRouting: 'origin-only' });
     const callAsCurrentUser = scopedClusterClient.asCurrentUser;
     const actions = reindexActionsFactory(
       this.client,


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/kibana-management.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.