### PR TITLE
[CPS] Update asScoped call sites - @elastic/obs-onboarding-team @elastic/obs-sig-events-team

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
@@ -39,7 +39,8 @@ export class StreamsService {
 
     const logger = this.logger;
 
-    const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
+    // TODO REVIEW
+    const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
     const isServerless = coreStart.elasticsearch.getCapabilities().serverless;
 
     return new StreamsClient({

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -139,7 +139,8 @@ export class StreamsPlugin
         coreStart.savedObjects.getScopedClient(request)
       );
 
-      const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
+      // TODO REVIEW
+      const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' });
       const soClient = coreStart.savedObjects.getScopedClient(request);
       const inferenceClient = pluginsStart.inference.getClient({ request });
       const licensing = pluginsStart.licensing;

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -150,7 +150,8 @@ const getProgressRoute = createObservabilityOnboardingServerRoute({
 
     const progress = { ...savedObservabilityOnboardingState?.progress };
 
-    const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+    // TODO REVIEW
+    const esClient = coreStart.elasticsearch.client.asScoped(request, { projectRouting: 'space' }).asCurrentUser;
 
     if (progress['ea-status']?.status === 'complete') {
       const { agentId } = progress['ea-status']?.payload as ElasticAgentStepPayload;


### PR DESCRIPTION
## Background

Cross-Project Search (CPS) is a Serverless feature that orchestrates searches across Elastic projects using `project_routing` headers, injected at the ES client level by Kibana.

#254186 introduced a new optional `opts` parameter to `elasticsearch.client.asScoped()` that lets callers explicitly declare their CPS routing intent. This PR is one of a series that updates call sites owned by @elastic/obs-onboarding-team @elastic/obs-sig-events-team.

## What changed

All `asScoped()` call sites in this PR have been annotated with a `// TODO REVIEW` comment and an explicit `projectRouting` option (pre-selected based on whether the request carries a `url: URL` property). The annotation is intentional: it is meant to prompt the owning team to review each call site and confirm or adjust the routing choice.

## What you need to do

Please review each `// TODO REVIEW` annotated call site and decide the correct routing strategy:

- `projectRouting: 'space'` — the client will inject the current space NPRE (Named Project Routing Expression) so that searches are scoped to the user's space. The request object passed to `asScoped()` **must carry a `url: URL` property**; if it does not (e.g. `FakeRequest`, background tasks), this will throw at runtime.
- `projectRouting: 'origin-only'` — no project routing is injected automatically. Use this for system/background requests or any context where the request object has no URL.

Once you have confirmed the routing choice for each call site, please take ownership of this PR, update the options as needed, and remove the `// TODO REVIEW` comments before merging.