### PR TITLE
Remove CPS check from alerting UIAM grant logic

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/moon.yml
+++ b/x-pack/platform/plugins/shared/alerting/moon.yml
@@ -81,7 +81,6 @@ dependsOn:
   - '@kbn/maintenance-windows-plugin'
   - '@kbn/config'
   - '@kbn/expect'
-  - '@kbn/cps'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/alerting/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting/tsconfig.json
@@ -74,7 +74,6 @@
     "@kbn/maintenance-windows-plugin",
     "@kbn/config",
     "@kbn/expect",
-    "@kbn/cps",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
Related https://github.com/elastic/response-ops-team/issues/343

- getShouldGrantUiam now returns true when core.security.authc.apiKeys.uiam is provided
- Remove cpsEnabled check and CPS plugin dependency from alerting server plugin
- Remove CPSServerSetup import, AlertingPluginsSetup.cps, and cpsSetup usage