### PR TITLE
[Security Solution] Remove feature flag for "Execution events" tab

### DIFF
--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -752,4 +752,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
       description: 'Switches the Entity Store Engine to v2',
     },
   },
+  'securitySolution:extendedRuleExecutionLoggingMinLevel': {
+    type: 'keyword',
+    _meta: {
+      description: 'Minimum log level for extended rule execution logging to the event log.',
+    },
+  },
 };

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -190,4 +190,5 @@ export interface UsageStats {
   'observability:streamsEnableContentPacks': boolean;
   'observability:streamsEnableQueryStreams': boolean;
   'securitySolution:entityStoreEnableV2': boolean;
+  'securitySolution:extendedRuleExecutionLoggingMinLevel': string;
 }

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11642,7 +11642,7 @@
         "securitySolution:extendedRuleExecutionLoggingMinLevel": {
           "type": "keyword",
           "_meta": {
-            "description": "Non-default value of setting."
+            "description": "Minimum log level for extended rule execution logging to the event log."
           }
         }
       }

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11638,6 +11638,12 @@
           "_meta": {
             "description": "Switches the Entity Store Engine to v2"
           }
+        },
+        "securitySolution:extendedRuleExecutionLoggingMinLevel": {
+          "type": "keyword",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
         }
       }
     },

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_settings.ts
@@ -20,3 +20,15 @@ export enum LogLevelSetting {
   'error' = 'error',
   'off' = 'off',
 }
+
+export const getExtendedLoggingSettings = (
+  minLevel: LogLevelSetting = LogLevelSetting.info
+): RuleExecutionSettings['extendedLogging'] => ({
+  isEnabled: minLevel !== LogLevelSetting.off,
+  minLevel,
+});
+
+export const DEFAULT_EXTENDED_LOGGING_SETTINGS: RuleExecutionSettings['extendedLogging'] = {
+  isEnabled: true,
+  minLevel: LogLevelSetting.info,
+};

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -23,15 +23,6 @@ export const allowedExperimentalValues = Object.freeze({
   previewTelemetryUrlEnabled: false,
 
   /**
-   * Enables extended rule execution logging to Event Log. When this setting is enabled:
-   * - Rules write their console error, info, debug, and trace messages to Event Log,
-   *   in addition to other events they log there (status changes and execution metrics).
-   * - We add a Kibana Advanced Setting that controls this behavior (on/off and log level).
-   * - We show a table with plain execution logs on the Rule Details page.
-   */
-  extendedRuleExecutionLoggingEnabled: true,
-
-  /**
    * Enables the SOC trends timerange and stats on D&R page
    */
   socTrendsEnabled: false,

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -29,7 +29,7 @@ export const allowedExperimentalValues = Object.freeze({
    * - We add a Kibana Advanced Setting that controls this behavior (on/off and log level).
    * - We show a table with plain execution logs on the Rule Details page.
    */
-  extendedRuleExecutionLoggingEnabled: false,
+  extendedRuleExecutionLoggingEnabled: true,
 
   /**
    * Enables the SOC trends timerange and stats on D&R page

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring/logic/execution_settings/use_execution_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_monitoring/logic/execution_settings/use_execution_settings.ts
@@ -7,29 +7,27 @@
 
 import { useMemo } from 'react';
 
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useUiSetting$ } from '../../../../common/lib/kibana';
 
 import { EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING } from '../../../../../common/constants';
-import type { RuleExecutionSettings } from '../../../../../common/api/detection_engine/rule_monitoring';
-import { LogLevelSetting } from '../../../../../common/api/detection_engine/rule_monitoring';
+import type {
+  RuleExecutionSettings,
+  LogLevelSetting,
+} from '../../../../../common/api/detection_engine/rule_monitoring';
+import {
+  DEFAULT_EXTENDED_LOGGING_SETTINGS,
+  getExtendedLoggingSettings,
+} from '../../../../../common/api/detection_engine/rule_monitoring';
 
 export const useRuleExecutionSettings = (): RuleExecutionSettings => {
-  const featureFlagEnabled = useIsExperimentalFeatureEnabled('extendedRuleExecutionLoggingEnabled');
-
   const minLevel = useAdvancedSettingSafely<LogLevelSetting>(
     EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING,
-    featureFlagEnabled ? LogLevelSetting.info : LogLevelSetting.off
+    DEFAULT_EXTENDED_LOGGING_SETTINGS.minLevel
   );
 
   return useMemo<RuleExecutionSettings>(() => {
-    return {
-      extendedLogging: {
-        isEnabled: featureFlagEnabled && minLevel !== LogLevelSetting.off,
-        minLevel,
-      },
-    };
-  }, [featureFlagEnabled, minLevel]);
+    return { extendedLogging: getExtendedLoggingSettings(minLevel) };
+  }, [minLevel]);
 };
 
 const useAdvancedSettingSafely = <T>(key: string, defaultValue: T): T => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/execution_settings/fetch_rule_execution_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/execution_settings/fetch_rule_execution_settings.ts
@@ -6,16 +6,20 @@
  */
 
 import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
-import type { ConfigType } from '../../../../../../config';
 import { withSecuritySpan } from '../../../../../../utils/with_security_span';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../../../../plugin_contract';
 
 import { EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING } from '../../../../../../../common/constants';
-import type { RuleExecutionSettings } from '../../../../../../../common/api/detection_engine/rule_monitoring';
-import { LogLevelSetting } from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import type {
+  RuleExecutionSettings,
+  LogLevelSetting,
+} from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import {
+  DEFAULT_EXTENDED_LOGGING_SETTINGS,
+  getExtendedLoggingSettings,
+} from '../../../../../../../common/api/detection_engine/rule_monitoring';
 
 export const fetchRuleExecutionSettings = async (
-  config: ConfigType,
   logger: Logger,
   core: SecuritySolutionPluginCoreSetupDependencies,
   savedObjectsClient: SavedObjectsClientContract
@@ -31,7 +35,13 @@ export const fetchRuleExecutionSettings = async (
         return settingsClient.getAll();
       });
 
-      return getRuleExecutionSettingsFrom(config, kibanaAdvancedSettings);
+      const minLevel = getSetting<LogLevelSetting>(
+        kibanaAdvancedSettings,
+        EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING,
+        DEFAULT_EXTENDED_LOGGING_SETTINGS.minLevel
+      );
+
+      return { extendedLogging: getExtendedLoggingSettings(minLevel) };
     });
 
     return ruleExecutionSettings;
@@ -40,40 +50,8 @@ export const fetchRuleExecutionSettings = async (
     const logReason = e instanceof Error ? e.stack ?? e.message : String(e);
     logger.error(`${logMessage}: ${logReason}`);
 
-    return getRuleExecutionSettingsDefault(config);
+    return { extendedLogging: DEFAULT_EXTENDED_LOGGING_SETTINGS };
   }
-};
-
-const getRuleExecutionSettingsFrom = (
-  config: ConfigType,
-  advancedSettings: Record<string, unknown>
-): RuleExecutionSettings => {
-  const featureFlagEnabled = config.experimentalFeatures.extendedRuleExecutionLoggingEnabled;
-  const minLevel = featureFlagEnabled
-    ? getSetting<LogLevelSetting>(
-        advancedSettings,
-        EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING,
-        LogLevelSetting.info
-      )
-    : LogLevelSetting.off;
-
-  return {
-    extendedLogging: {
-      isEnabled: featureFlagEnabled && minLevel !== LogLevelSetting.off,
-      minLevel,
-    },
-  };
-};
-
-const getRuleExecutionSettingsDefault = (config: ConfigType): RuleExecutionSettings => {
-  const featureFlagEnabled = config.experimentalFeatures.extendedRuleExecutionLoggingEnabled;
-
-  return {
-    extendedLogging: {
-      isEnabled: featureFlagEnabled,
-      minLevel: featureFlagEnabled ? LogLevelSetting.info : LogLevelSetting.off,
-    },
-  };
 };
 
 const getSetting = <T>(settings: Record<string, unknown>, key: string, defaultValue: T): T => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/service.ts
@@ -137,7 +137,6 @@ export const createRuleMonitoringService = (
           const childLogger = logger.get('ruleExecution');
 
           const ruleExecutionSettings = await fetchRuleExecutionSettings(
-            config,
             childLogger,
             coreSetup,
             savedObjectsClient

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.test.ts
@@ -15,7 +15,6 @@ describe('initUiSettings', () => {
   const mockExperimentalFeatures = {
     enableAlertsAndAttacksAlignment: false,
     siemReadinessDashboard: false,
-    extendedRuleExecutionLoggingEnabled: false,
   } as ExperimentalFeatures;
 
   beforeEach(() => {

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -513,85 +513,81 @@ export const initUiSettings = (
       solutionViews: ['classic', 'security'],
     },
     ...getDefaultValueReportSettings(),
-    ...(experimentalFeatures.extendedRuleExecutionLoggingEnabled
-      ? {
-          [EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING]: {
-            name: i18n.translate(
-              'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelLabel',
-              {
-                defaultMessage: 'Extended rule execution logging: min level',
-              }
-            ),
-            description: i18n.translate(
-              'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelDescription',
-              {
-                defaultMessage:
-                  '<p>Sets minimum log level starting from which rules will write extended logs to .kibana-event-log-* indices. This affects only events of type Message, other events are being written to .kibana-event-log-* regardless of this setting and their log level.</p>',
-                values: { p: (chunks) => `<p>${chunks}</p>` },
-              }
-            ),
-            type: 'select',
-            schema: schema.oneOf([
-              schema.literal(LogLevelSetting.off),
-              schema.literal(LogLevelSetting.error),
-              schema.literal(LogLevelSetting.warn),
-              schema.literal(LogLevelSetting.info),
-              schema.literal(LogLevelSetting.debug),
-              schema.literal(LogLevelSetting.trace),
-            ]),
-            value: LogLevelSetting.info,
-            options: [
-              LogLevelSetting.off,
-              LogLevelSetting.error,
-              LogLevelSetting.warn,
-              LogLevelSetting.info,
-              LogLevelSetting.debug,
-              LogLevelSetting.trace,
-            ],
-            optionLabels: {
-              [LogLevelSetting.off]: i18n.translate(
-                'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelOff',
-                {
-                  defaultMessage: 'Off',
-                }
-              ),
-              [LogLevelSetting.error]: i18n.translate(
-                'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelError',
-                {
-                  defaultMessage: 'Error',
-                }
-              ),
-              [LogLevelSetting.warn]: i18n.translate(
-                'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelWarn',
-                {
-                  defaultMessage: 'Warn',
-                }
-              ),
-              [LogLevelSetting.info]: i18n.translate(
-                'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelInfo',
-                {
-                  defaultMessage: 'Info',
-                }
-              ),
-              [LogLevelSetting.debug]: i18n.translate(
-                'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelDebug',
-                {
-                  defaultMessage: 'Debug',
-                }
-              ),
-              [LogLevelSetting.trace]: i18n.translate(
-                'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelTrace',
-                {
-                  defaultMessage: 'Trace',
-                }
-              ),
-            },
-            category: [APP_ID],
-            requiresPageReload: false,
-            solutionViews: ['classic', 'security'],
-          },
+    [EXTENDED_RULE_EXECUTION_LOGGING_MIN_LEVEL_SETTING]: {
+      name: i18n.translate(
+        'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelLabel',
+        {
+          defaultMessage: 'Extended rule execution logging: minimum level',
         }
-      : {}),
+      ),
+      description: i18n.translate(
+        'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelDescription',
+        {
+          defaultMessage:
+            '<p>Sets minimum log level starting from which rules will write extended logs to .kibana-event-log-* indices. This affects only events of type Message, other events are being written to .kibana-event-log-* regardless of this setting and their log level.</p>',
+          values: { p: (chunks) => `<p>${chunks}</p>` },
+        }
+      ),
+      type: 'select',
+      schema: schema.oneOf([
+        schema.literal(LogLevelSetting.off),
+        schema.literal(LogLevelSetting.error),
+        schema.literal(LogLevelSetting.warn),
+        schema.literal(LogLevelSetting.info),
+        schema.literal(LogLevelSetting.debug),
+        schema.literal(LogLevelSetting.trace),
+      ]),
+      value: LogLevelSetting.info,
+      options: [
+        LogLevelSetting.off,
+        LogLevelSetting.error,
+        LogLevelSetting.warn,
+        LogLevelSetting.info,
+        LogLevelSetting.debug,
+        LogLevelSetting.trace,
+      ],
+      optionLabels: {
+        [LogLevelSetting.off]: i18n.translate(
+          'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelOff',
+          {
+            defaultMessage: 'Off',
+          }
+        ),
+        [LogLevelSetting.error]: i18n.translate(
+          'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelError',
+          {
+            defaultMessage: 'Error',
+          }
+        ),
+        [LogLevelSetting.warn]: i18n.translate(
+          'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelWarn',
+          {
+            defaultMessage: 'Warn',
+          }
+        ),
+        [LogLevelSetting.info]: i18n.translate(
+          'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelInfo',
+          {
+            defaultMessage: 'Info',
+          }
+        ),
+        [LogLevelSetting.debug]: i18n.translate(
+          'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelDebug',
+          {
+            defaultMessage: 'Debug',
+          }
+        ),
+        [LogLevelSetting.trace]: i18n.translate(
+          'xpack.securitySolution.uiSettings.extendedRuleExecutionLoggingMinLevelTrace',
+          {
+            defaultMessage: 'Trace',
+          }
+        ),
+      },
+      category: [APP_ID],
+      requiresPageReload: false,
+      solutionViews: ['classic', 'security'],
+    },
   };
 
   uiSettings.register(orderSettings(securityUiSettings));

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_events.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_events.cy.ts
@@ -38,15 +38,6 @@ describe(
   'Execution events table',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'extendedRuleExecutionLoggingEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   function () {
     before(() => {


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/251213**

Will be merged once the exploratory testing is complete and the [docs](https://github.com/elastic/docs-content/issues/5282) are written.

## Summary

This PR:
- removes the `extendedRuleExecutionLoggingEnabled` feature flag for a recently merged feature – the "Execution events" tab. Removing the feature flag makes the tab visible on the rule details page.
- adds `securitySolution:extendedRuleExecutionLoggingMinLevel` advanced setting to usage collection. This is required by the CI. 

<img width="2301" height="1096" alt="Screenshot 2026-02-20 at 15 14 50" src="https://github.com/user-attachments/assets/19dec716-f277-419e-86da-682438e7a3d7" />

