### PR TITLE
RemainingLogsToExtract value fetched by count query

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
@@ -378,13 +378,12 @@ export class AssetManager {
     const taskId = getExtractEntityTaskId(type, this.namespace);
     try {
       const task = await this.taskManager.get(taskId);
-      const countResult = await this.logsExtractionClient.extractLogs(type, { countOnly: true });
       return {
         id: taskId,
         installed: true,
         resource: 'task',
         status: task.state.status ?? null,
-        remainingLogsToExtract: countResult.success ? countResult.count : null,
+        remainingLogsToExtract: await this.logsExtractionClient.getRemainingLogsCount(type),
         runs: task.state.runs ?? 0,
         lastError: task.state.lastError ?? null,
       };

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
@@ -1156,3 +1156,39 @@ exports[`buildLogsExtractionEsqlQuery generates the expected query for user enti
  entity.EngineMetadata.Type,
  entity.EngineMetadata.FirstSeenLogInPage"
 `;
+
+exports[`buildRemainingLogsCountQuery generates the expected query for generic entity type 1`] = `
+"FROM test-index-*
+    METADATA _index
+  | WHERE ((entity.id IS NOT NULL AND entity.id != \\"\\"))
+      AND @timestamp > TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
+      AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
+  | STATS document_count = COUNT()"
+`;
+
+exports[`buildRemainingLogsCountQuery generates the expected query for host entity type 1`] = `
+"FROM test-index-*
+    METADATA _index
+  | WHERE ((host.entity.id IS NOT NULL AND host.entity.id != \\"\\") OR (host.id IS NOT NULL AND host.id != \\"\\") OR (host.name IS NOT NULL AND host.name != \\"\\") OR (host.hostname IS NOT NULL AND host.hostname != \\"\\"))
+      AND @timestamp > TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
+      AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
+  | STATS document_count = COUNT()"
+`;
+
+exports[`buildRemainingLogsCountQuery generates the expected query for service entity type 1`] = `
+"FROM test-index-*
+    METADATA _index
+  | WHERE ((service.entity.id IS NOT NULL AND service.entity.id != \\"\\") OR (service.name IS NOT NULL AND service.name != \\"\\"))
+      AND @timestamp > TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
+      AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
+  | STATS document_count = COUNT()"
+`;
+
+exports[`buildRemainingLogsCountQuery generates the expected query for user entity type 1`] = `
+"FROM test-index-*
+    METADATA _index
+  | WHERE ((user.entity.id IS NOT NULL AND user.entity.id != \\"\\") OR (user.id IS NOT NULL AND user.id != \\"\\") OR (user.name IS NOT NULL AND user.name != \\"\\") OR (user.email IS NOT NULL AND user.email != \\"\\"))
+      AND @timestamp > TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
+      AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
+  | STATS document_count = COUNT()"
+`;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.test.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { buildLogsExtractionEsqlQuery } from './logs_extraction_query_builder';
+import {
+  buildLogsExtractionEsqlQuery,
+  buildRemainingLogsCountQuery,
+} from './logs_extraction_query_builder';
 import { getEntityDefinition } from '../../../common/domain/definitions/registry';
 import { EntityType } from '../../../common/domain/definitions/entity_schema';
 
@@ -55,5 +58,19 @@ describe('buildLogsExtractionEsqlQuery', () => {
       },
     });
     expect(query).toMatchSnapshot();
+  });
+});
+
+describe('buildRemainingLogsCountQuery', () => {
+  Object.values(EntityType.Values).forEach((type) => {
+    it(`generates the expected query for ${type} entity type`, () => {
+      const query = buildRemainingLogsCountQuery({
+        indexPatterns: ['test-index-*'],
+        type,
+        fromDateISO: '2022-01-01T00:00:00.000Z',
+        toDateISO: '2022-01-01T23:59:59.999Z',
+      });
+      expect(query).toMatchSnapshot();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.test.ts
@@ -425,71 +425,6 @@ describe('LogsExtractionClient', () => {
       expect(mockEngineDescriptorClient.update).not.toHaveBeenCalled();
     });
 
-    it('should run query and return count without ingesting or updating when countOnly is true', async () => {
-      const mockEsqlResponse: ESQLSearchResponse = {
-        columns: [
-          { name: '@timestamp', type: 'date' },
-          { name: HASHED_ID_FIELD, type: 'keyword' },
-          { name: 'user.name', type: 'keyword' },
-        ],
-        values: [
-          ['2024-01-02T10:00:00.000Z', 'hash1', 'user1'],
-          ['2024-01-02T11:00:00.000Z', 'hash2', 'user2'],
-          ['2024-01-02T12:00:00.000Z', 'hash3', 'user3'],
-        ],
-      };
-
-      const mockDataView = {
-        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
-      };
-
-      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
-        createMockEngineDescriptor('user') as Awaited<
-          ReturnType<EngineDescriptorClient['findOrThrow']>
-        >
-      );
-      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
-      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
-
-      const result = await client.extractLogs('user', { countOnly: true });
-
-      expect(result.success).toBe(true);
-      expect(result.success && result.count).toBe(3);
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
-      expect(mockIngestEntities).not.toHaveBeenCalled();
-      expect(mockEngineDescriptorClient.update).not.toHaveBeenCalled();
-    });
-
-    it('should return count 0 when countOnly is true and ESQL returns no rows', async () => {
-      const mockEsqlResponse: ESQLSearchResponse = {
-        columns: [
-          { name: '@timestamp', type: 'date' },
-          { name: HASHED_ID_FIELD, type: 'keyword' },
-        ],
-        values: [],
-      };
-
-      const mockDataView = {
-        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
-      };
-
-      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
-        createMockEngineDescriptor('user') as Awaited<
-          ReturnType<EngineDescriptorClient['findOrThrow']>
-        >
-      );
-      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
-      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
-
-      const result = await client.extractLogs('user', { countOnly: true });
-
-      expect(result.success).toBe(true);
-      expect(result.success && result.count).toBe(0);
-      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
-      expect(mockIngestEntities).not.toHaveBeenCalled();
-      expect(mockEngineDescriptorClient.update).not.toHaveBeenCalled();
-    });
-
     it('should handle errors from executeEsqlQuery', async () => {
       const mockDataView = {
         getIndexPattern: jest.fn().mockReturnValue('logs-*'),
@@ -667,6 +602,197 @@ describe('LogsExtractionClient', () => {
       expect(mockExecuteEsqlQuery).not.toHaveBeenCalled();
       expect(mockIngestEntities).not.toHaveBeenCalled();
       expect(mockEngineDescriptorClient.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRemainingLogsCount', () => {
+    it('should return document_count from ESQL response when engine is started', async () => {
+      const mockEsqlResponse: ESQLSearchResponse = {
+        columns: [{ name: 'document_count', type: 'long' }],
+        values: [[42]],
+      };
+
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
+
+      const result = await client.getRemainingLogsCount('user');
+
+      expect(result).toBe(42);
+      expect(mockEngineDescriptorClient.findOrThrow).toHaveBeenCalledWith('user');
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
+        esClient: mockEsClient,
+        query: expect.stringContaining('STATS document_count = COUNT()'),
+      });
+      expect(mockIngestEntities).not.toHaveBeenCalled();
+    });
+
+    it('should return 0 when ESQL response has no rows', async () => {
+      const mockEsqlResponse: ESQLSearchResponse = {
+        columns: [{ name: 'document_count', type: 'long' }],
+        values: [],
+      };
+
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
+
+      const result = await client.getRemainingLogsCount('user');
+
+      expect(result).toBe(0);
+    });
+
+    it('should return 0 when document_count column is missing', async () => {
+      const mockEsqlResponse: ESQLSearchResponse = {
+        columns: [{ name: 'other_column', type: 'keyword' }],
+        values: [['value']],
+      };
+
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
+
+      const result = await client.getRemainingLogsCount('user');
+
+      expect(result).toBe(0);
+    });
+
+    it('should use fromDateISO from extraction window and toDateISO as now', async () => {
+      const fixedNow = new Date('2025-01-15T12:00:00.000Z');
+      jest.useFakeTimers({ now: fixedNow.getTime() });
+
+      const mockEsqlResponse: ESQLSearchResponse = {
+        columns: [{ name: 'document_count', type: 'long' }],
+        values: [[0]],
+      };
+
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user', { lookbackPeriod: '3h', delay: '5s' }) as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
+
+      await client.getRemainingLogsCount('user');
+
+      const expectedFrom = moment.utc(fixedNow).subtract(3, 'hours').toISOString();
+      const expectedTo = moment.utc(fixedNow).toISOString();
+
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
+        esClient: mockEsClient,
+        query: expect.stringContaining(expectedFrom),
+      });
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
+        esClient: mockEsClient,
+        query: expect.stringContaining(expectedTo),
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('should throw and log when executeEsqlQuery throws', async () => {
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      const testError = new Error('ESQL query failed');
+      mockExecuteEsqlQuery.mockRejectedValue(testError);
+
+      await expect(client.getRemainingLogsCount('user')).rejects.toThrow('ESQL query failed');
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to get remaining logs count for entity type "user"')
+      );
+    });
+
+    it('should pass recoveryId when engine has paginationId', async () => {
+      const mockEsqlResponse: ESQLSearchResponse = {
+        columns: [{ name: 'document_count', type: 'long' }],
+        values: [[5]],
+      };
+
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      const descriptor = createMockEngineDescriptor('user') as Awaited<
+        ReturnType<EngineDescriptorClient['findOrThrow']>
+      >;
+      descriptor.logExtractionState = {
+        ...descriptor.logExtractionState,
+        paginationId: 'recovery-cursor-id',
+      };
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(descriptor);
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
+
+      const result = await client.getRemainingLogsCount('user');
+
+      expect(result).toBe(5);
+      // When recoveryId is set, buildExtractionSourceClause uses >= for timestamp (recovery boundary)
+      expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
+        esClient: mockEsClient,
+        query: expect.stringMatching(/@timestamp\s*>=\s*TO_DATETIME/),
+      });
+    });
+
+    it('should convert document_count to number via Number()', async () => {
+      const mockEsqlResponse: ESQLSearchResponse = {
+        columns: [{ name: 'document_count', type: 'long' }],
+        values: [['100'] as unknown as ESQLSearchResponse['values'][0]],
+      };
+
+      const mockDataView = {
+        getIndexPattern: jest.fn().mockReturnValue('logs-*'),
+      };
+
+      mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
+        createMockEngineDescriptor('user') as Awaited<
+          ReturnType<EngineDescriptorClient['findOrThrow']>
+        >
+      );
+      mockDataViewsService.get.mockResolvedValue(mockDataView as any);
+      mockExecuteEsqlQuery.mockResolvedValue(mockEsqlResponse);
+
+      const result = await client.getRemainingLogsCount('user');
+
+      expect(result).toBe(100);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
@@ -18,6 +18,7 @@ import { getEntityDefinition } from '../../common/domain/definitions/registry';
 import type { PaginationParams } from './logs_extraction/logs_extraction_query_builder';
 import {
   buildLogsExtractionEsqlQuery,
+  buildRemainingLogsCountQuery,
   ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD,
   extractPaginationParams,
   HASHED_ID_FIELD,
@@ -44,7 +45,6 @@ interface LogsExtractionOptions {
     toDateISO: string;
   };
   abortController?: AbortController;
-  countOnly?: boolean;
 }
 
 interface ExtractedLogsSummarySuccess {
@@ -104,7 +104,7 @@ export class LogsExtractionClient {
         scannedIndices: indexPatterns,
       };
 
-      if (opts?.specificWindow || opts?.countOnly) {
+      if (opts?.specificWindow) {
         return operationResult;
       }
 
@@ -133,6 +133,46 @@ export class LogsExtractionClient {
       return operationResult;
     } catch (error) {
       return await this.handleError(error, type);
+    }
+  }
+
+  public async getRemainingLogsCount(type: EntityType): Promise<number> {
+    try {
+      const engineDescriptor = await this.engineDescriptorClient.findOrThrow(type);
+      const delayMs = parseDurationToMs(engineDescriptor.logExtractionState.delay);
+      const indexPatterns = await this.getIndexPatterns(
+        engineDescriptor.logExtractionState.additionalIndexPatterns
+      );
+      const { fromDateISO } = this.getExtractionWindow(
+        engineDescriptor.logExtractionState,
+        delayMs
+      );
+      const toDateISO = moment().utc().toISOString();
+      const recoveryId = engineDescriptor.logExtractionState.paginationId;
+      const query = buildRemainingLogsCountQuery({
+        indexPatterns,
+        type,
+        fromDateISO,
+        toDateISO,
+        recoveryId,
+      });
+      const esqlResponse = await executeEsqlQuery({
+        esClient: this.esClient,
+        query,
+      });
+      const countColumnIdx = esqlResponse.columns.findIndex(
+        (col) => col.name === 'document_count'
+      );
+      if (countColumnIdx === -1 || esqlResponse.values.length === 0) {
+        return 0;
+      }
+      const count = esqlResponse.values[0][countColumnIdx];
+      
+      return Number(count);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to get remaining logs count for entity type "${type}": ${message}`);
+      throw error;
     }
   }
 
@@ -211,18 +251,16 @@ export class LogsExtractionClient {
         pages++;
       }
 
-      if (!opts?.countOnly) {
-        this.logger.debug(`Found ${esqlResponse.values.length}, ingesting them`);
-        await ingestEntities({
-          esClient: this.esClient,
-          esqlResponse,
-          esIdField: HASHED_ID_FIELD,
-          fieldsToIgnore: [ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD],
-          targetIndex: latestIndex,
-          logger: this.logger,
-          abortController: opts?.abortController,
-        });
-      }
+      this.logger.debug(`Found ${esqlResponse.values.length}, ingesting them`);
+      await ingestEntities({
+        esClient: this.esClient,
+        esqlResponse,
+        esIdField: HASHED_ID_FIELD,
+        fieldsToIgnore: [ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD],
+        targetIndex: latestIndex,
+        logger: this.logger,
+        abortController: opts?.abortController,
+      });
 
       // On pagination we save the pagination to the last seen timestamp cursor
       // so we can recover from corrupt state

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction_client.ts
@@ -160,14 +160,12 @@ export class LogsExtractionClient {
         esClient: this.esClient,
         query,
       });
-      const countColumnIdx = esqlResponse.columns.findIndex(
-        (col) => col.name === 'document_count'
-      );
+      const countColumnIdx = esqlResponse.columns.findIndex((col) => col.name === 'document_count');
       if (countColumnIdx === -1 || esqlResponse.values.length === 0) {
         return 0;
       }
       const count = esqlResponse.values[0][countColumnIdx];
-      
+
       return Number(count);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
RemainingLogsToExtract uses a dedicated ESQL query that applies only the required filter per entity type, same filter as the main extraction query + a single `STATS document_count = COUNT()` part.

## Implementation 
Extracted the shared source clause (FROM + WHERE) into `buildExtractionSourceClause`. 
Added `buildRemainingLogsCountQuery` that reuses it and appends the `STATS` count. 
Removed the `countOnly` option from extractLogs. 
Added/updated tests and snapshots for the new count query.