### PR TITLE
[ES|QL] Build callbacks server side

### DIFF
--- a/src/platform/plugins/shared/esql/server/index.ts
+++ b/src/platform/plugins/shared/esql/server/index.ts
@@ -16,3 +16,4 @@ export const plugin = async (initContext: PluginInitializerContext) => {
 };
 
 export type { EsqlServerPluginSetup as PluginSetup };
+export { buildServerESQLCallbacks } from './services/build_server_esql_callbacks';

--- a/src/platform/plugins/shared/esql/server/services/build_server_esql_callbacks.ts
+++ b/src/platform/plugins/shared/esql/server/services/build_server_esql_callbacks.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ESQLCallbacks, ResolveIndexResponse } from '@kbn/esql-types';
+import type { KibanaProject as SolutionId } from '@kbn/projects-solutions-groups';
+import { EsqlService } from './esql_service';
+import type { ESQLExtensionsRegistry } from '../extensions_registry';
+
+interface BuildServerESQLCallbacksOptions {
+  client: ElasticsearchClient;
+  extensionsRegistry?: ESQLExtensionsRegistry;
+  activeSolutionId?: SolutionId;
+}
+
+/**
+ * Builds ESQLCallbacks for server-side usage, using the Elasticsearch client
+ * directly instead of going through Kibana HTTP routes.
+ *
+ * This produces the same ESQLCallbacks shape that the client-side callbacks
+ * (in @kbn/esql-utils) produce, but backed by the ES client for use in
+ * server-side contexts like NL-to-ES|QL, validation, or agent workflows.
+ */
+export const buildServerESQLCallbacks = ({
+  client,
+  extensionsRegistry,
+  activeSolutionId,
+}: BuildServerESQLCallbacksOptions): ESQLCallbacks => {
+  const service = new EsqlService({ client });
+
+  const callbacks: ESQLCallbacks = {
+    getSources: async () => {
+      return service.getAllIndices('all');
+    },
+
+    getColumnsFor: async ({ query } = { query: '' }) => {
+      if (!query) return [];
+      try {
+        return await service.getColumns(query);
+      } catch {
+        return [];
+      }
+    },
+
+    getPolicies: async () => {
+      try {
+        return await service.getPolicies();
+      } catch {
+        return [];
+      }
+    },
+
+    getJoinIndices: async (cacheOptions) => {
+      return service.getIndicesByIndexMode('lookup');
+    },
+
+    getTimeseriesIndices: async () => {
+      return service.getIndicesByIndexMode('time_series');
+    },
+
+    getViews: async () => {
+      try {
+        return await service.getViews();
+      } catch {
+        return { views: [] };
+      }
+    },
+
+    getInferenceEndpoints: async (taskType) => {
+      return service.getInferenceEndpoints(taskType);
+    },
+  };
+
+  if (extensionsRegistry && activeSolutionId) {
+    callbacks.getEditorExtensions = async (queryString: string) => {
+      const [localSources, ccsSources] = (await Promise.all([
+        client.indices.resolveIndex({ name: '*', expand_wildcards: 'open' }),
+        client.indices.resolveIndex({ name: '*:*', expand_wildcards: 'open' }),
+      ])) as [ResolveIndexResponse, ResolveIndexResponse];
+
+      const sources: ResolveIndexResponse = {
+        indices: [...(localSources.indices ?? []), ...(ccsSources.indices ?? [])],
+        aliases: [...(localSources.aliases ?? []), ...(ccsSources.aliases ?? [])],
+        data_streams: [...(localSources.data_streams ?? []), ...(ccsSources.data_streams ?? [])],
+      };
+
+      return {
+        recommendedQueries: extensionsRegistry.getRecommendedQueries(
+          queryString,
+          sources,
+          activeSolutionId
+        ),
+        recommendedFields: extensionsRegistry.getRecommendedFields(
+          queryString,
+          sources,
+          activeSolutionId
+        ),
+      };
+    };
+  }
+
+  return callbacks;
+};

--- a/src/platform/plugins/shared/esql/server/services/build_server_esql_callbacks.ts
+++ b/src/platform/plugins/shared/esql/server/services/build_server_esql_callbacks.ts
@@ -8,33 +8,26 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { ESQLCallbacks, ResolveIndexResponse } from '@kbn/esql-types';
-import type { KibanaProject as SolutionId } from '@kbn/projects-solutions-groups';
+import type { ESQLCallbacks } from '@kbn/esql-types';
 import { EsqlService } from './esql_service';
-import type { ESQLExtensionsRegistry } from '../extensions_registry';
 
 interface BuildServerESQLCallbacksOptions {
   client: ElasticsearchClient;
-  extensionsRegistry?: ESQLExtensionsRegistry;
-  activeSolutionId?: SolutionId;
 }
 
 /**
- * Builds ESQLCallbacks for server-side usage, using the Elasticsearch client
- * directly instead of going through Kibana HTTP routes.
+ * Builds the ESQLCallbacks required by the ES|QL validation API
+ * ({@link validateQuery} from @kbn/esql-language) for server-side usage.
  *
- * This produces the same ESQLCallbacks shape that the client-side callbacks
- * (in @kbn/esql-utils) produce, but backed by the ES client for use in
- * server-side contexts like NL-to-ES|QL, validation, or agent workflows.
+ * Uses the Elasticsearch client directly instead of going through
+ * Kibana HTTP routes, unlike the client-side callbacks in @kbn/esql-utils.
  */
 export const buildServerESQLCallbacks = ({
   client,
-  extensionsRegistry,
-  activeSolutionId,
 }: BuildServerESQLCallbacksOptions): ESQLCallbacks => {
   const service = new EsqlService({ client });
 
-  const callbacks: ESQLCallbacks = {
+  return {
     getSources: async () => {
       return service.getAllIndices('all');
     },
@@ -56,7 +49,7 @@ export const buildServerESQLCallbacks = ({
       }
     },
 
-    getJoinIndices: async (cacheOptions) => {
+    getJoinIndices: async () => {
       return service.getIndicesByIndexMode('lookup');
     },
 
@@ -76,34 +69,4 @@ export const buildServerESQLCallbacks = ({
       return service.getInferenceEndpoints(taskType);
     },
   };
-
-  if (extensionsRegistry && activeSolutionId) {
-    callbacks.getEditorExtensions = async (queryString: string) => {
-      const [localSources, ccsSources] = (await Promise.all([
-        client.indices.resolveIndex({ name: '*', expand_wildcards: 'open' }),
-        client.indices.resolveIndex({ name: '*:*', expand_wildcards: 'open' }),
-      ])) as [ResolveIndexResponse, ResolveIndexResponse];
-
-      const sources: ResolveIndexResponse = {
-        indices: [...(localSources.indices ?? []), ...(ccsSources.indices ?? [])],
-        aliases: [...(localSources.aliases ?? []), ...(ccsSources.aliases ?? [])],
-        data_streams: [...(localSources.data_streams ?? []), ...(ccsSources.data_streams ?? [])],
-      };
-
-      return {
-        recommendedQueries: extensionsRegistry.getRecommendedQueries(
-          queryString,
-          sources,
-          activeSolutionId
-        ),
-        recommendedFields: extensionsRegistry.getRecommendedFields(
-          queryString,
-          sources,
-          activeSolutionId
-        ),
-      };
-    };
-  }
-
-  return callbacks;
 };

--- a/src/platform/plugins/shared/esql/server/services/esql_service.ts
+++ b/src/platform/plugins/shared/esql/server/services/esql_service.ts
@@ -12,8 +12,10 @@ import {
   type IndicesAutocompleteResult,
   type IndexAutocompleteItem,
   type ResolveIndexResponse,
+  type ESQLFieldWithMetadata,
   SOURCES_TYPES,
 } from '@kbn/esql-types';
+import type { EsqlFieldType } from '@kbn/esql-types';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { ESQLSourceResult, InferenceEndpointsAutocompleteResult } from '@kbn/esql-types';
 import { getListOfCCSIndices } from '../lookup/utils';
@@ -207,5 +209,57 @@ export class EsqlService {
         task_type: endpoint.task_type,
       })),
     };
+  }
+
+  /**
+   * Get enrich policies formatted for ES|QL autocomplete.
+   * @returns A promise that resolves to an array of enrich policy objects.
+   */
+  public async getPolicies(): Promise<
+    Array<{
+      name: string;
+      sourceIndices: string[];
+      matchField: string;
+      enrichFields: string[];
+    }>
+  > {
+    const { client } = this.options;
+
+    const response = await client.enrich.getPolicy();
+    return response.policies.flatMap((p) => {
+      const config = p.config.match ?? p.config.range ?? p.config.geo_match;
+      if (!config?.name) return [];
+      return [
+        {
+          name: config.name,
+          sourceIndices: config.indices as string[],
+          matchField: config.match_field,
+          enrichFields: config.enrich_fields as string[],
+        },
+      ];
+    });
+  }
+
+  /**
+   * Get columns for an ES|QL query by executing it with LIMIT 0.
+   * @param esqlQuery The ES|QL query to get columns for.
+   * @returns A promise that resolves to an array of ESQLFieldWithMetadata.
+   */
+  public async getColumns(esqlQuery: string): Promise<ESQLFieldWithMetadata[]> {
+    const { client } = this.options;
+
+    const response = await client.esql.query({
+      query: `${esqlQuery} | LIMIT 0`,
+      format: 'json',
+    });
+
+    return (
+      (response.columns as Array<{ name: string; type: string }>)?.map((c) => ({
+        name: c.name,
+        type: c.type as EsqlFieldType,
+        hasConflict: false,
+        userDefined: false,
+      })) ?? []
+    );
   }
 }


### PR DESCRIPTION
## Summary

Exports the callbacks needed for validation at the server side. 

The callbacks used for validation are:

- getSources
- getPolicies
- getColumnsFor
- getJoinIndices
- getTimeseriesIndices
- getViews
- getLicense

The PR provides them all except for the license one as we also use the license plugin to get it. So I dont think it makes sense to expose it from the esql plugin too

Usage https://github.com/elastic/kibana/pull/253976


