### PR TITLE
[SharedUX][A11y] Add announcement for table list view selection

### DIFF
--- a/src/platform/packages/shared/content-management/table_list_view_table/src/components/table.tsx
+++ b/src/platform/packages/shared/content-management/table_list_view_table/src/components/table.tsx
@@ -19,7 +19,14 @@ import type {
   Search,
   EuiTableSelectionType,
 } from '@elastic/eui';
-import { EuiButton, EuiInMemoryTable, useEuiTheme, EuiCode, EuiText } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiInMemoryTable,
+  useEuiTheme,
+  EuiCode,
+  EuiText,
+  EuiLiveAnnouncer,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
 import {
@@ -164,6 +171,17 @@ export function Table<T extends UserContentCommonSchema>({
       };
     }
   }, [deleteItems, dispatch, tableItemsRowActions]);
+
+  const selectionAnnouncement = useMemo(() => {
+    if (selectedIds.length === 0) return '';
+    return i18n.translate('contentManagement.tableList.listing.selectionAnnouncement', {
+      defaultMessage: '{count} {entityName} selected. Delete button is now available.',
+      values: {
+        count: selectedIds.length,
+        entityName: selectedIds.length === 1 ? entityName : entityNamePlural,
+      },
+    });
+  }, [selectedIds.length, entityName, entityNamePlural]);
 
   const {
     isPopoverOpen,
@@ -365,6 +383,7 @@ export function Table<T extends UserContentCommonSchema>({
         totalActiveFilters={totalActiveFilters}
         clearTagSelection={clearTagSelection}
       >
+        <EuiLiveAnnouncer>{selectionAnnouncement}</EuiLiveAnnouncer>
         <EuiInMemoryTable<T>
           itemId="id"
           items={visibleItems}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/236107

## Summary

- Added [EuiLiveAnnouncer](https://eui.elastic.co/docs/utilities/accessibility/#live-announcer-region-) to announce the table list view 'delete' button which renders conditionally. 

### Testing

Chrome + VO + Maps (reported combination)
<img width="1201" height="459" alt="Screenshot 2026-02-23 at 15 41 56" src="https://github.com/user-attachments/assets/1847d61d-5817-4dbc-b688-22de8f0ac19a" />

Safari + VO + Dashboards
<img width="1265" height="644" alt="Screenshot 2026-02-23 at 15 42 29" src="https://github.com/user-attachments/assets/a5bdef7f-dbc9-46cf-8b58-882d3e72e6bc" />

VMWareFusion + Chrome + NVDA + Dashboards
<img width="1728" height="623" alt="Screenshot 2026-02-23 at 15 50 55" src="https://github.com/user-attachments/assets/19b29841-babd-410b-9f23-82ce9b40c8f9" />



<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->