### PR TITLE
[Workplace AI] Fix i18n issues with angle-bracketed text in Slack defaultMessage

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
@@ -55,7 +55,7 @@ const SlackSearchMessagesInputSchema = z.object({
         'core.kibanaConnectorSpecs.slack.actions.searchMessages.input.inChannel.description',
         {
           defaultMessage:
-            'Optional Slack search constraint. Adds `in:<channel_name>` to the query.',
+            'Optional Slack search constraint. Adds `in:CHANNEL_NAME` to the query (e.g. in:general).',
         }
       )
     ),
@@ -67,7 +67,7 @@ const SlackSearchMessagesInputSchema = z.object({
         'core.kibanaConnectorSpecs.slack.actions.searchMessages.input.fromUser.description',
         {
           defaultMessage:
-            'Optional Slack search constraint. Adds `from:<@UserID>` or `from:username` to the query.',
+            'Optional Slack search constraint. Adds `from:USER_ID` (e.g. from:U012ABCDEF) or `from:username` to the query.',
         }
       )
     ),
@@ -79,7 +79,7 @@ const SlackSearchMessagesInputSchema = z.object({
         'core.kibanaConnectorSpecs.slack.actions.searchMessages.input.after.description',
         {
           defaultMessage:
-            'Optional Slack search constraint. Adds `after:<date>` to the query (e.g. 2026-02-10).',
+            'Optional Slack search constraint. Adds `after:YYYY-MM-DD` to the query (e.g. after:2026-02-10).',
         }
       )
     ),
@@ -91,7 +91,7 @@ const SlackSearchMessagesInputSchema = z.object({
         'core.kibanaConnectorSpecs.slack.actions.searchMessages.input.before.description',
         {
           defaultMessage:
-            'Optional Slack search constraint. Adds `before:<date>` to the query (e.g. 2026-02-10).',
+            'Optional Slack search constraint. Adds `before:YYYY-MM-DD` to the query (e.g. before:2026-02-10).',
         }
       )
     ),

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/slack/workflows/search_messages.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/slack/workflows/search_messages.yaml
@@ -1,55 +1,55 @@
-version: '1'
-name: 'sources.slack.search_messages'
-description: 'Search Slack messages and return compact results suitable for LLM summaries and follow-up navigation. Uses Slack Real-time Search API (assistant.search.context). Actions and inputs: searchMessages (required query, optional in_channel, optional from_user, optional after, optional before, optional sort, optional sort_dir, optional count, optional cursor, optional raw). Output (compact default): matches with text, channel {id,name}, sender, mentions, and permalink.'
-tags: ['agent-builder-tool']
+version: "1"
+name: "sources.slack.search_messages"
+description: "Search Slack messages and return compact results suitable for LLM summaries and follow-up navigation. Uses Slack Real-time Search API (assistant.search.context). Actions and inputs: searchMessages (required query, optional in_channel, optional from_user, optional after, optional before, optional sort, optional sort_dir, optional count, optional cursor, optional raw). Output (compact default): matches with text, channel {id,name}, sender, mentions, and permalink."
+tags: ["agent-builder-tool"]
 enabled: true
 triggers:
-  - type: 'manual'
+  - type: "manual"
 inputs:
   - name: query
     type: string
     required: true
-    description: 'Search query. You can include Slack search operators directly (e.g. in:#general from:@user after:2026-02-10).'
+    description: "Search query. You can include Slack search operators directly (e.g. in:#general from:@user after:2026-02-10)."
   - name: in_channel
     type: string
     required: false
-    description: 'Optional constraint. Appends `in:<channel_name>` to the query (e.g. general).'
+    description: "Optional constraint. Appends `in:CHANNEL_NAME` to the query (e.g. in:general)."
   - name: from_user
     type: string
     required: false
-    description: 'Optional constraint. Appends `in:<display_name>` to the query. This should be the display name of the user.'
+    description: "Optional constraint. Appends `from:USER_ID` (e.g. from:U012ABCDEF) or `from:username` to the query."
   - name: after
     type: string
     required: false
-    description: 'Optional constraint. Appends `after:<date>` to the query (e.g. 2026-02-10).'
+    description: "Optional constraint. Appends `after:YYYY-MM-DD` to the query (e.g. after:2026-02-10)."
   - name: before
     type: string
     required: false
-    description: 'Optional constraint. Appends `before:<date>` to the query (e.g. 2026-02-10).'
+    description: "Optional constraint. Appends `before:YYYY-MM-DD` to the query (e.g. before:2026-02-10)."
   - name: sort
     type: string
     required: false
     default: "score"
-    description: 'Sort order. Valid values: [score, timestamp].'
+    description: "Sort order. Valid values: [score, timestamp]."
   - name: sort_dir
     type: string
     required: false
     default: "desc"
-    description: 'Sort direction. Valid values: [asc, desc].'
+    description: "Sort direction. Valid values: [asc, desc]."
   - name: count
     type: number
     required: false
     default: 20
-    description: 'Number of results to return (1-20). Slack returns up to 20 results per page.'
+    description: "Number of results to return (1-20). Slack returns up to 20 results per page."
   - name: cursor
     type: string
     required: false
-    description: 'Pagination cursor from a previous response (response_metadata.next_cursor).'
+    description: "Pagination cursor from a previous response (response_metadata.next_cursor)."
   - name: raw
     type: boolean
     required: false
     default: false
-    description: 'If true, return the full raw Slack API response (very verbose). If false, return compact results.'
+    description: "If true, return the full raw Slack API response (very verbose). If false, return compact results."
 steps:
   - name: search-messages
     type: slack2.searchMessages

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/slack/workflows/send_message.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/slack/workflows/send_message.yaml
@@ -1,29 +1,29 @@
-version: '1'
-name: 'sources.slack.send_message'
-description: 'Send a message to a Slack public channel by channel conversation ID (C...). Actions and inputs: sendMessage (channel, text, optional thread_ts, optional unfurl_links, optional unfurl_media). Use sources.slack.find first to resolve a channel name (e.g. "#general") into a channel id (C...). Requires chat:write and access to the channel.'
-tags: ['agent-builder-tool']
+version: "1"
+name: "sources.slack.send_message"
+description: "Send a message to a Slack public channel by channel conversation ID (C...). Actions and inputs: sendMessage (channel, text, optional thread_ts, optional unfurl_links, optional unfurl_media). Use sources.slack.find first to resolve a channel name (e.g. \"#general\") into a channel id (C...). Requires chat:write and access to the channel."
+tags: ["agent-builder-tool"]
 enabled: true
 triggers:
-  - type: 'manual'
+  - type: "manual"
 inputs:
   - name: channel
     type: string
-    description: 'Public channel name or conversation ID to send the message to (e.g. #general or C123...).'
+    description: "Public channel name or conversation ID to send the message to (e.g. #general or C123...)."
   - name: text
     type: string
-    description: 'Message text.'
+    description: "Message text."
   - name: thread_ts
     type: string
     required: false
-    description: 'Optional thread timestamp to reply in a thread.'
+    description: "Optional thread timestamp to reply in a thread."
   - name: unfurl_links
     type: boolean
     required: false
-    description: 'If true, enable unfurling of primarily text-based content.'
+    description: "If true, enable unfurling of primarily text-based content."
   - name: unfurl_media
     type: boolean
     required: false
-    description: 'If true, enable unfurling of media content.'
+    description: "If true, enable unfurling of media content."
 steps:
   - name: send-message
     type: slack2.sendMessage


### PR DESCRIPTION
## Summary

This PR fixes some i18n formatting issues in Slack Data Source's `defaultMessage` fields, and adds some consistency between the Workflow YAMLs and those `defaultMessage` fields.

## The Issue
The following error message was appearing in Kibana logs, presumably when translation was happening:

```
Error: [@formatjs/intl Error FORMAT_ERROR] Error formatting default message for: "core.kibanaConnectorSpecs.slack.actions.searchMessages.input.before.description", rendering default message verbatim
MessageID: core.kibanaConnectorSpecs.slack.actions.searchMessages.input.before.description
Default Message: Optional Slack search constraint. Adds `before:<date>` to the query (e.g. 2026-02-10).
Description: undefined

Locale: en

UNCLOSED_TAG
SyntaxError: UNCLOSED_TAG (at error.js:58:1)
    at IntlMessageFormat.parse [as __parse] (index.js:31:1)
    at new IntlMessageFormat (core.js:137:1)
    at utils.js:110:1
    at variadic (index.js:33:1)
    at formatMessage (message.js:69:1)
```

## The Solution
In `slack.ts`, we previously had text like `in:<date>` and `in:<channel_id>`. i18n's FormatJS treats these are rich-text tags, and expects a closing tag (ie `</data> or </channel_id>`), which, of course, is not the intent.

Angle bracket usage has now been removed everywhere.

## Impact
There should be no tangible impact to the expected output or LLM usage of the tools and Workflows.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


