### PR TITLE
Add @elastic/actionable-obs-team CODEOWNERS for alerts pages and scout fixtures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1581,6 +1581,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_update_api_key.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/locators @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/pages/alert_details @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/observability/public/pages/alerts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/pages/annotations @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/pages/cases @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/pages/rule_details @elastic/actionable-obs-team
@@ -1595,6 +1596,9 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/observability/server/routes/rules @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/saved_objects/threshold.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/services @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/observability/public/plugin.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/rule_details_page.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/rules_page.ts @elastic/actionable-obs-team
 
 # Observability AI Assistant
 /x-pack/platform/test/serverless/api_integration/test_suites/data_usage @elastic/kibana-management

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1596,7 +1596,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/observability/server/routes/rules @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/saved_objects/threshold.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/services @elastic/actionable-obs-team
-/x-pack/solutions/observability/plugins/observability/public/plugin.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/rule_details_page.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/rules_page.ts @elastic/actionable-obs-team
 


### PR DESCRIPTION
## Summary

Adds missing CODEOWNERS entries so `@elastic/actionable-obs-team` is correctly assigned as reviewer for:

- `public/pages/alerts/` (alerts.tsx, alerts.test.tsx)
- `test/scout/ui/fixtures/page_objects/rule_details_page.ts`
- `test/scout/ui/fixtures/page_objects/rules_page.ts`

All under `x-pack/solutions/observability/plugins/observability/`. These were previously falling through to the default `@elastic/observability-ui` ownership.