### PR TITLE
[Workplace AI] Remove Data Source Config

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -75,10 +75,6 @@ xpack.serverless.search.enabled: true
 ## Set the home route
 uiSettings.overrides.defaultRoute: /app/elasticsearch
 
-## Enable tech-preview pages
-uiSettings.overrides:
-  dataSources:enabled: false
-
 # Specify in telemetry the project type
 telemetry.labels.serverless: search
 


### PR DESCRIPTION
## Summary

We previously introduced a `uiSettings` config to control (enable/disable) the `dataSources` plugin. We now need to manage this feature flag via Dev Tools instead, which means this config should be removed. Going forward, we will enable or disable dataSources directly in ES3.



https://github.com/user-attachments/assets/b17e819f-fcee-47c2-9b95-6a00fd6f1f79

