### PR TITLE
Discover(Metrics-flyout): use esql instead of sql

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/esql_query_tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/esql_query_tab.tsx
@@ -21,7 +21,7 @@ export const EsqlQueryTab = ({ esqlQuery, metric }: EsqlQueryTabProps) => {
   return (
     <>
       <TabTitleAndDescription metric={metric} />
-      <EuiCodeBlock language="sql" fontSize="s" paddingSize="s" isCopyable>
+      <EuiCodeBlock language="esql" fontSize="s" paddingSize="s" isCopyable>
         {esqlQuery}
       </EuiCodeBlock>
     </>


### PR DESCRIPTION
Closes: #244044

## Summary

Fix the code block language in the metrics flyout (Discover) to use `esql` instead of `sql` for proper ES|QL syntax highlighting.

> **Note:** The rendered highlighting may not look visually identical to the text editor due to an inconsistency on the EUI side that is currently being addressed. Once EUI resolves this, the fix should be transparent to us with no additional changes needed.

## Demo

| Before | After |
|--------|-------|
| <img width="533" height="277" alt="2026-02-24_09-35-26" src="https://github.com/user-attachments/assets/c0eae77a-40c3-4623-95de-a273a6b4853d" /> | <img width="531" height="273" alt="2026-02-24_09-35-55" src="https://github.com/user-attachments/assets/e6e2920e-5124-4ce8-a94b-97b37b3c94db" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



