### PR TITLE
[CSP] Fix data view name display in misconfigurations flyout

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/overview_tab.tsx
@@ -30,8 +30,8 @@ import type {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
-  CDR_MISCONFIGURATIONS_INDEX_PATTERN,
   CDR_MISCONFIGURATIONS_DATA_VIEW_ID_PREFIX,
+  CDR_MISCONFIGURATIONS_DATA_VIEW_NAME,
   INTERNAL_FEATURE_FLAGS,
 } from '@kbn/cloud-security-posture-common';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -159,7 +159,8 @@ const getDetailsList = (
   data: CspFinding,
   ruleFlyoutLink?: string,
   discoverDataViewLink?: string,
-  euiTheme?: EuiThemeComputed<{}>
+  euiTheme?: EuiThemeComputed<{}>,
+  dataViewName?: string
 ) => [
   {
     title: (
@@ -232,9 +233,11 @@ const getDetailsList = (
       </EuiTitle>
     ),
     description: discoverDataViewLink ? (
-      <EuiLink href={discoverDataViewLink}>{CDR_MISCONFIGURATIONS_INDEX_PATTERN}</EuiLink>
+      <EuiLink href={discoverDataViewLink}>
+        {dataViewName ?? CDR_MISCONFIGURATIONS_DATA_VIEW_NAME}
+      </EuiLink>
     ) : (
-      CDR_MISCONFIGURATIONS_INDEX_PATTERN
+      dataViewName ?? CDR_MISCONFIGURATIONS_DATA_VIEW_NAME
     ),
   },
 ];
@@ -324,7 +327,13 @@ export const OverviewTab = ({
             defaultMessage: 'About',
           }),
           id: 'detailsAccordion',
-          listItems: getDetailsList(data, ruleFlyoutLink, discoverDataViewLink, euiTheme),
+          listItems: getDetailsList(
+            data,
+            ruleFlyoutLink,
+            discoverDataViewLink,
+            euiTheme,
+            cdrMisconfigurationsDataView.data?.name
+          ),
         },
         {
           initialIsOpen: true,
@@ -353,7 +362,14 @@ export const OverviewTab = ({
             listItems: getEvidenceList(evidence),
           },
       ].filter(truthy),
-    [data, discoverDataViewLink, euiTheme, ruleFlyoutLink, evidence]
+    [
+      data,
+      discoverDataViewLink,
+      euiTheme,
+      ruleFlyoutLink,
+      evidence,
+      cdrMisconfigurationsDataView.data?.name,
+    ]
   );
 
   return (


### PR DESCRIPTION
## Summary

Fixes:
- https://github.com/elastic/kibana/issues/195967

Use the actual data view name from the API instead of hardcoded index pattern. Falls back to a static default name when the data view hasn't loaded yet.

<img width="1728" height="871" alt="Screenshot 2026-02-23 at 18 40 01" src="https://github.com/user-attachments/assets/29b35977-5106-49c5-89e3-ea003a64d50f" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


