### PR TITLE
[ResponseOps][Alerting] throw error not caught from `scheduleUnusedUrlsCleanupTask()`

### DIFF
--- a/src/platform/plugins/shared/share/server/plugin.ts
+++ b/src/platform/plugins/shared/share/server/plugin.ts
@@ -164,6 +164,7 @@ export class SharePlugin
         taskManager,
         checkInterval: this.config.url_expiration.check_interval,
         isEnabled: this.config.url_expiration.enabled,
+        logger: this.logger,
       });
     }
 

--- a/src/platform/plugins/shared/share/server/unused_urls_task/task.test.ts
+++ b/src/platform/plugins/shared/share/server/unused_urls_task/task.test.ts
@@ -451,34 +451,39 @@ describe('unused_urls_task', () => {
         taskManager: mockTaskManager,
         checkInterval,
         isEnabled: true,
+        logger: mockLogger,
       });
 
       expect(mockTaskManager.ensureScheduled).toHaveBeenCalledWith(expectedTaskInstance);
     });
 
-    it('should throw an error if scheduling fails with a message', async () => {
+    it('should log an error if scheduling fails with a message', async () => {
       const errorMessage = 'Scheduling failed';
       mockTaskManager.ensureScheduled.mockRejectedValue(new Error(errorMessage));
 
-      await expect(
-        scheduleUnusedUrlsCleanupTask({
-          taskManager: mockTaskManager,
-          checkInterval,
-          isEnabled: true,
-        })
-      ).rejects.toThrow(errorMessage);
+      await scheduleUnusedUrlsCleanupTask({
+        taskManager: mockTaskManager,
+        checkInterval,
+        isEnabled: true,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to schedule unused URLs cleanup task. Error: Scheduling failed'
+      );
     });
 
-    it('should throw a generic error if scheduling fails without a message', async () => {
+    it('should log a generic error if scheduling fails without a message', async () => {
       mockTaskManager.ensureScheduled.mockRejectedValue(new Error());
 
-      await expect(
-        scheduleUnusedUrlsCleanupTask({
-          taskManager: mockTaskManager,
-          checkInterval,
-          isEnabled: true,
-        })
-      ).rejects.toThrow('Failed to schedule unused URLs cleanup task');
+      await scheduleUnusedUrlsCleanupTask({
+        taskManager: mockTaskManager,
+        checkInterval,
+        isEnabled: true,
+        logger: mockLogger,
+      });
+
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to schedule unused URLs cleanup task.');
     });
 
     it('should remove the task if isEnabled is false and not run it', async () => {
@@ -488,6 +493,7 @@ describe('unused_urls_task', () => {
         taskManager: mockTaskManager,
         checkInterval,
         isEnabled: false,
+        logger: mockLogger,
       });
 
       expect(mockTaskManager.ensureScheduled).not.toHaveBeenCalled();

--- a/src/platform/plugins/shared/share/server/unused_urls_task/task.ts
+++ b/src/platform/plugins/shared/share/server/unused_urls_task/task.ts
@@ -167,10 +167,12 @@ export const scheduleUnusedUrlsCleanupTask = async ({
   taskManager,
   checkInterval,
   isEnabled,
+  logger,
 }: {
   taskManager: TaskManagerStartContract;
   checkInterval: Duration;
   isEnabled: boolean;
+  logger: Logger;
 }) => {
   try {
     if (!isEnabled) {
@@ -185,6 +187,8 @@ export const scheduleUnusedUrlsCleanupTask = async ({
       interval: durationToSeconds(checkInterval),
     });
   } catch (e) {
-    throw new Error(e.message || 'Failed to schedule unused URLs cleanup task');
+    logger.error(
+      `Failed to schedule unused URLs cleanup task.${e.message ? ` Error: ${e.message}` : ''}`
+    );
   }
 };


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/247871

## Summary

During the `share` pluging startup, an async function is called - `scheduleUnusedUrlsCleanupTask()`. If an error is thrown while trying the schedule the task it's caught and thrown again, so when this occurs, Kibana will crash. This PR updates `scheduleUnusedUrlsCleanupTask()` to log the error instead of throwing it to make sure Kibana doesn't crash with an unhandled error if this task fails to schedule.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### To verify

1. Update `scheduleUnusedUrlsCleanupTask` to throw an error at the start of the try/catch block in`src/platform/plugins/shared/share/server/unused_urls_task/task.ts`
2. Start Kibana and ES
3. Verify that Kibana doesn't crash and you see an error log that starts with `Failed to schedule unused URLs cleanup task.`







<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->