### PR TITLE
[9.3] [AI Connector][Inference endpoint] Creation: adaptive allocations not set correctly on serverless (#251357)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.test.tsx
@@ -198,4 +198,38 @@ describe('InferenceFlyout', () => {
     renderComponent({ isEdit: true, inferenceEndpoint: mockEndpoint });
     expect(screen.getByTestId('num_allocations-number')).toBeEnabled();
   });
+
+  it('excludes num_allocations from update payload when adaptive allocations is enabled', async () => {
+    const mockEndpoint = {
+      config: {
+        inferenceId: 'test-id',
+        provider: 'elasticsearch',
+        taskType: 'text_embedding',
+        providerConfig: {
+          model_id: '.elser_model_2',
+          num_allocations: 1,
+          'adaptive_allocations.max_number_of_allocations': 5,
+        },
+      },
+      secrets: {
+        providerSecrets: {},
+      },
+    };
+
+    renderComponent({
+      isEdit: true,
+      enforceAdaptiveAllocations: true,
+      inferenceEndpoint: mockEndpoint,
+    });
+
+    await userEvent.click(screen.getByTestId('inference-endpoint-submit-button'));
+
+    const submittedData = mockMutationFn.mock.calls[0][0];
+    expect(submittedData.config.providerConfig.adaptive_allocations).toEqual({
+      enabled: true,
+      min_number_of_allocations: 0,
+      max_number_of_allocations: 5,
+    });
+    expect(submittedData.config.providerConfig).not.toHaveProperty('num_allocations');
+  });
 });

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
@@ -18,6 +18,7 @@ import {
   EuiTitle,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import { omit } from 'lodash';
 import React, { useCallback } from 'react';
 import type { HttpSetup, IToasts } from '@kbn/core/public';
 import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
@@ -29,25 +30,37 @@ import { useInferenceEndpointMutation } from '../hooks/use_inference_endpoint_mu
 const MIN_ALLOCATIONS = 0;
 const DEFAULT_NUM_THREADS = 1;
 
+const ADAPTIVE_ALLOCATIONS_FLAT_KEYS = [
+  'adaptive_allocations.max_number_of_allocations',
+  'adaptive_allocations.enabled',
+  'adaptive_allocations.min_number_of_allocations',
+];
+
 const formDeserializer = (data: InferenceEndpoint) => {
-  if (
+  const maxAllocations =
     data.config?.providerConfig?.adaptive_allocations?.max_number_of_allocations ||
-    data.config?.headers
-  ) {
+    data.config?.providerConfig?.['adaptive_allocations.max_number_of_allocations'];
+
+  if (maxAllocations || data.config?.headers) {
     const { headers, ...restConfig } = data.config;
-    const maxAllocations =
-      data.config.providerConfig?.adaptive_allocations?.max_number_of_allocations;
+    const restProviderConfig = omit(
+      data.config.providerConfig || {},
+      ADAPTIVE_ALLOCATIONS_FLAT_KEYS
+    );
 
     return {
       ...data,
       config: {
         ...restConfig,
         providerConfig: {
-          ...(data.config.providerConfig as InferenceEndpoint['config']['providerConfig']),
+          ...restProviderConfig,
           ...(headers ? { headers } : {}),
           ...(maxAllocations
             ? // remove the adaptive_allocations from the data config as form does not expect it
-              { max_number_of_allocations: maxAllocations, adaptive_allocations: undefined }
+              {
+                max_number_of_allocations: maxAllocations as number,
+                adaptive_allocations: undefined,
+              }
             : {}),
         },
       },
@@ -66,6 +79,7 @@ export const formSerializer = (formData: InferenceEndpoint) => {
     const {
       max_number_of_allocations: maxAllocations,
       headers,
+      num_allocations: numAllocations,
       ...restProviderConfig
     } = providerConfig || {};
 
@@ -85,7 +99,7 @@ export const formSerializer = (formData: InferenceEndpoint) => {
                 // Temporary solution until the endpoint is updated to no longer require it and to set its own default for this value
                 num_threads: DEFAULT_NUM_THREADS,
               }
-            : {}),
+            : { ...(numAllocations != null && { num_allocations: numAllocations }) }),
         },
         ...(headers ? { headers } : {}),
       },

--- a/x-pack/platform/plugins/shared/inference_endpoint/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/inference_endpoint/server/routes/index.ts
@@ -228,15 +228,22 @@ export const getInferenceServicesRoute = (
 
           const taskSettings = config?.headers ? { headers: config.headers } : undefined;
 
-          // currently update api only allows api_key and num_allocations
+          const adaptiveAllocations = config?.providerConfig?.adaptive_allocations;
+          const numAllocations = config?.providerConfig?.num_allocations;
+
+          let allocationSettings = {};
+          if (adaptiveAllocations) {
+            allocationSettings = { adaptive_allocations: adaptiveAllocations };
+          } else if (numAllocations) {
+            allocationSettings = { num_allocations: numAllocations };
+          }
+
           const body = {
             service_settings: {
               ...(secrets?.providerSecrets?.api_key && {
                 api_key: secrets.providerSecrets.api_key,
               }),
-              ...(config?.providerConfig?.num_allocations !== undefined && {
-                num_allocations: config.providerConfig.num_allocations,
-              }),
+              ...allocationSettings,
             },
             ...(taskSettings ? { task_settings: taskSettings } : {}),
           };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[AI Connector][Inference endpoint] Creation: adaptive allocations not set correctly on serverless (#251357)](https://github.com/elastic/kibana/pull/251357)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saikat Sarkar","email":"132922331+saikatsarkar056@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-23T19:04:49Z","message":"[AI Connector][Inference endpoint] Creation: adaptive allocations not set correctly on serverless (#251357)\n\n## Summary\n\nFixes AI Connector inference endpoint creation failing on serverless\nwhen using the 'elasticsearch' provider with adaptive allocations\nenabled.\n\nThe issue was that `num_threads` and `num_allocations` were being sent\nin the `providerConfig` alongside `adaptive_allocations`, which causes a\nconflict since these properties cannot be set when adaptive allocations\nis enabled.\n\nThis PR updates the form serializer to exclude `num_threads` and\n`num_allocations` from the payload when adaptive allocations is\nconfigured.\n\n\n\nhttps://github.com/user-attachments/assets/5d4b42ff-db33-4f3a-ab70-b32fcccbc445\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n### Release note\nFixes AI Connector creation on serverless failing when adaptive\nallocations is enabled with the ElasticSearch provider.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Melissa <melissa.alvarez@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82dc85e41b82908e61c9afc0f9ab18dc4a734172","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.3.0","v9.4.0"],"title":"[AI Connector][Inference endpoint] Creation: adaptive allocations not set correctly on serverless","number":251357,"url":"https://github.com/elastic/kibana/pull/251357","mergeCommit":{"message":"[AI Connector][Inference endpoint] Creation: adaptive allocations not set correctly on serverless (#251357)\n\n## Summary\n\nFixes AI Connector inference endpoint creation failing on serverless\nwhen using the 'elasticsearch' provider with adaptive allocations\nenabled.\n\nThe issue was that `num_threads` and `num_allocations` were being sent\nin the `providerConfig` alongside `adaptive_allocations`, which causes a\nconflict since these properties cannot be set when adaptive allocations\nis enabled.\n\nThis PR updates the form serializer to exclude `num_threads` and\n`num_allocations` from the payload when adaptive allocations is\nconfigured.\n\n\n\nhttps://github.com/user-attachments/assets/5d4b42ff-db33-4f3a-ab70-b32fcccbc445\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n### Release note\nFixes AI Connector creation on serverless failing when adaptive\nallocations is enabled with the ElasticSearch provider.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Melissa <melissa.alvarez@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82dc85e41b82908e61c9afc0f9ab18dc4a734172"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251357","number":251357,"mergeCommit":{"message":"[AI Connector][Inference endpoint] Creation: adaptive allocations not set correctly on serverless (#251357)\n\n## Summary\n\nFixes AI Connector inference endpoint creation failing on serverless\nwhen using the 'elasticsearch' provider with adaptive allocations\nenabled.\n\nThe issue was that `num_threads` and `num_allocations` were being sent\nin the `providerConfig` alongside `adaptive_allocations`, which causes a\nconflict since these properties cannot be set when adaptive allocations\nis enabled.\n\nThis PR updates the form serializer to exclude `num_threads` and\n`num_allocations` from the payload when adaptive allocations is\nconfigured.\n\n\n\nhttps://github.com/user-attachments/assets/5d4b42ff-db33-4f3a-ab70-b32fcccbc445\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n### Release note\nFixes AI Connector creation on serverless failing when adaptive\nallocations is enabled with the ElasticSearch provider.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Melissa <melissa.alvarez@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82dc85e41b82908e61c9afc0f9ab18dc4a734172"}}]}] BACKPORT-->