### PR TITLE
[8.19] Feature/infra tab otel update (#252188)

### DIFF
--- a/src/dev/storybook/aliases.ts
+++ b/src/dev/storybook/aliases.ts
@@ -45,6 +45,7 @@ export const storybookAliases = {
   lists: 'x-pack/solutions/security/plugins/lists/.storybook',
   logs_explorer: 'x-pack/solutions/observability/plugins/logs_explorer/.storybook',
   management: 'src/platform/packages/shared/kbn-management/storybook/config',
+  metrics_data_access: 'x-pack/solutions/observability/plugins/metrics_data_access/.storybook',
   observability_ai_assistant_app:
     'x-pack/solutions/observability/plugins/observability_ai_assistant_app/.storybook',
   observability_ai_assistant:

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
@@ -162,6 +162,7 @@ export const CONTAINER_IMAGE = 'container.image.name';
 
 export const KUBERNETES = 'kubernetes';
 export const KUBERNETES_POD_NAME = 'kubernetes.pod.name';
+export const KUBERNETES_POD_NAME_OTEL = 'k8s.pod.name';
 export const KUBERNETES_POD_UID = 'kubernetes.pod.uid';
 export const KUBERNETES_NAMESPACE = 'kubernetes.namespace';
 export const KUBERNETES_NODE_NAME = 'kubernetes.node.name';

--- a/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
@@ -174,6 +174,8 @@ exports[`Error KUBERNETES_NODE_NAME 1`] = `undefined`;
 
 exports[`Error KUBERNETES_POD_NAME 1`] = `undefined`;
 
+exports[`Error KUBERNETES_POD_NAME_OTEL 1`] = `undefined`;
+
 exports[`Error KUBERNETES_POD_UID 1`] = `undefined`;
 
 exports[`Error KUBERNETES_REPLICASET 1`] = `undefined`;
@@ -570,6 +572,8 @@ exports[`Span KUBERNETES_NAMESPACE_NAME 1`] = `undefined`;
 exports[`Span KUBERNETES_NODE_NAME 1`] = `undefined`;
 
 exports[`Span KUBERNETES_POD_NAME 1`] = `undefined`;
+
+exports[`Span KUBERNETES_POD_NAME_OTEL 1`] = `undefined`;
 
 exports[`Span KUBERNETES_POD_UID 1`] = `undefined`;
 
@@ -977,6 +981,8 @@ exports[`Transaction KUBERNETES_NAMESPACE_NAME 1`] = `undefined`;
 exports[`Transaction KUBERNETES_NODE_NAME 1`] = `undefined`;
 
 exports[`Transaction KUBERNETES_POD_NAME 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_POD_NAME_OTEL 1`] = `undefined`;
 
 exports[`Transaction KUBERNETES_POD_UID 1`] = `"pod1234567890abcdef"`;
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/index.tsx
@@ -24,7 +24,7 @@ const INITIAL_STATE = {
 };
 
 export function InfraTabs() {
-  const { serviceName } = useApmServiceContext();
+  const { serviceName, agentName } = useApmServiceContext();
   const history = useHistory();
   const {
     query: { environment, kuery, rangeFrom, rangeTo, detailTab },
@@ -42,12 +42,13 @@ export function InfraTabs() {
               kuery,
               start,
               end,
+              agentName,
             },
           },
         });
       }
     },
-    [environment, kuery, serviceName, start, end]
+    [environment, kuery, agentName, serviceName, start, end]
   );
 
   const { containerIds, podNames, hostNames } = data;
@@ -56,6 +57,7 @@ export function InfraTabs() {
     containerIds,
     podNames,
     hostNames,
+    agentName,
     start,
     end,
   });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
@@ -83,7 +83,7 @@ export function useTabs({
         filter: [{ terms: { [k8sFilterFields]: podNames } }],
       },
     }),
-    [podNames]
+    [podNames, k8sFilterFields]
   );
   const containersFilter = useMemo(
     () => ({

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
@@ -11,8 +11,10 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { hasOpenTelemetryPrefix } from '@kbn/elastic-agent-utils';
 import type { ApmPluginStartDeps } from '../../../../plugin';
 import { KUBERNETES_POD_NAME, HOST_NAME, CONTAINER_ID } from '../../../../../common/es_fields/apm';
+
 type Tab = NonNullable<EuiTabbedContentProps['tabs']>[0] & {
   id: 'containers' | 'pods' | 'hosts';
   hidden?: boolean;
@@ -28,12 +30,14 @@ export function useTabs({
   containerIds,
   podNames,
   hostNames,
+  agentName,
   start,
   end,
 }: {
   containerIds: string[];
   podNames: string[];
   hostNames: string[];
+  agentName?: string;
   start: string;
   end: string;
 }) {
@@ -43,6 +47,11 @@ export function useTabs({
   const ContainerMetricsTable = metricsDataAccess?.ContainerMetricsTable;
   const PodMetricsTable = metricsDataAccess?.PodMetricsTable;
 
+  const isOtel = useMemo(
+    () => Boolean(agentName && hasOpenTelemetryPrefix(agentName)),
+    [agentName]
+  );
+
   const timerange = useMemo(
     () => ({
       from: start,
@@ -51,6 +60,11 @@ export function useTabs({
     [start, end]
   );
 
+  const k8sFilterFields = useMemo(
+    () => (isOtel ? 'k8s.pod.name' : KUBERNETES_POD_NAME),
+    [isOtel]
+  );
+  
   const hostsFilter = useMemo(
     (): QueryDslQueryContainer => ({
       bool: {
@@ -69,10 +83,11 @@ export function useTabs({
   const podsFilter = useMemo(
     () => ({
       bool: {
-        filter: [{ terms: { [KUBERNETES_POD_NAME]: podNames } }],
+        filter: [{ terms: { [k8sFilterFields]: podNames } }],
       },
     }),
     [podNames]
+
   );
   const containersFilter = useMemo(
     () => ({
@@ -90,6 +105,8 @@ export function useTabs({
         ContainerMetricsTable({
           timerange,
           filterClauseDsl: containersFilter,
+          isOtel,
+          isK8sContainer: podNames.length > 0,
         })}
     </>
   );
@@ -101,6 +118,7 @@ export function useTabs({
         PodMetricsTable({
           timerange,
           filterClauseDsl: podsFilter,
+          isOtel,
         })}
     </>
   );
@@ -112,6 +130,7 @@ export function useTabs({
         HostMetricsTable({
           timerange,
           filterClauseDsl: hostsFilter,
+          isOtel,
         })}
     </>
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
@@ -60,11 +60,8 @@ export function useTabs({
     [start, end]
   );
 
-  const k8sFilterFields = useMemo(
-    () => (isOtel ? 'k8s.pod.name' : KUBERNETES_POD_NAME),
-    [isOtel]
-  );
-  
+  const k8sFilterFields = useMemo(() => (isOtel ? 'k8s.pod.name' : KUBERNETES_POD_NAME), [isOtel]);
+
   const hostsFilter = useMemo(
     (): QueryDslQueryContainer => ({
       bool: {
@@ -87,7 +84,6 @@ export function useTabs({
       },
     }),
     [podNames]
-
   );
   const containersFilter = useMemo(
     () => ({

--- a/x-pack/solutions/observability/plugins/apm/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/plugin.ts
@@ -76,8 +76,6 @@ import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/publ
 import type { SharePublicStart } from '@kbn/share-plugin/public/plugin';
 import type { ApmSourceAccessPluginStart } from '@kbn/apm-sources-access-plugin/public';
 import type { ConfigSchema } from '.';
-import { registerApmRuleTypes } from './components/alerting/rule_types/register_apm_rule_types';
-import { registerEmbeddables } from './embeddable/register_embeddables';
 import {
   getApmEnrollmentFlyoutData,
   LazyApmCustomAssetsExtension,
@@ -85,8 +83,8 @@ import {
 import { getLazyApmAgentsTabExtension } from './components/fleet_integration/lazy_apm_agents_tab_extension';
 import { getLazyAPMPolicyCreateExtension } from './components/fleet_integration/lazy_apm_policy_create_extension';
 import { getLazyAPMPolicyEditExtension } from './components/fleet_integration/lazy_apm_policy_edit_extension';
-import { featureCatalogueEntry } from './feature_catalogue_entry';
 import { APMServiceDetailLocator } from './locator/service_detail_locator';
+import { featureCatalogueEntry } from './feature_catalogue_entry';
 import type { ITelemetryClient } from './services/telemetry';
 import { TelemetryService } from './services/telemetry';
 
@@ -420,13 +418,19 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       },
     });
 
-    registerApmRuleTypes(observabilityRuleTypeRegistry);
-    registerEmbeddables({
-      coreSetup: core,
-      pluginsSetup: plugins,
-      config,
-      kibanaEnvironment,
-      observabilityRuleTypeRegistry,
+    import('./components/alerting/rule_types/register_apm_rule_types').then(
+      ({ registerApmRuleTypes }) => {
+        registerApmRuleTypes(observabilityRuleTypeRegistry);
+      }
+    );
+    import('./embeddable/register_embeddables').then(({ registerEmbeddables }) => {
+      registerEmbeddables({
+        coreSetup: core,
+        pluginsSetup: plugins,
+        config,
+        kibanaEnvironment,
+        observabilityRuleTypeRegistry,
+      });
     });
 
     const locator = plugins.share.url.locators.create(new APMServiceDetailLocator(core.uiSettings));

--- a/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
@@ -36,7 +36,6 @@ export const getInfrastructureData = async ({
   start: number;
   end: number;
 }) => {
-
   const isOtel = Boolean(agentName && hasOpenTelemetryPrefix(agentName));
   const k8sFilterField = isOtel ? KUBERNETES_POD_NAME_OTEL : KUBERNETES_POD_NAME;
 
@@ -46,42 +45,42 @@ export const getInfrastructureData = async ({
       apm: {
         events: [ProcessorEvent.metric],
       },
-      body :{
-      track_total_hits: false,
-      size: 0,
-      query: {
-        bool: {
-          filter: [
-            ...termQuery(SERVICE_NAME, serviceName),
-            ...rangeQuery(start, end),
-            ...environmentQuery(environment),
-            ...kqlQuery(kuery),
-          ],
-        },
-      },
-      aggs: {
-        containerIds: {
-          terms: {
-            field: CONTAINER_ID,
-            size: 500,
+      body: {
+        track_total_hits: false,
+        size: 0,
+        query: {
+          bool: {
+            filter: [
+              ...termQuery(SERVICE_NAME, serviceName),
+              ...rangeQuery(start, end),
+              ...environmentQuery(environment),
+              ...kqlQuery(kuery),
+            ],
           },
         },
-        hostNames: {
-          terms: {
-            field: HOST_NAME,
-            size: 500,
+        aggs: {
+          containerIds: {
+            terms: {
+              field: CONTAINER_ID,
+              size: 500,
+            },
           },
-        },
-        podNames: {
-          terms: {
-            field: k8sFilterField,
-            size: 500,
+          hostNames: {
+            terms: {
+              field: HOST_NAME,
+              size: 500,
+            },
+          },
+          podNames: {
+            terms: {
+              field: k8sFilterField,
+              size: 500,
+            },
           },
         },
       },
     },
-  },
-  { skipProcessorEventFilter: true }
+    { skipProcessorEventFilter: true }
   );
 
   let containerIds: string[] =
@@ -120,7 +119,7 @@ export const getInfrastructureData = async ({
           },
         },
       },
-    { skipProcessorEventFilter: true }
+      { skipProcessorEventFilter: true }
     );
     containerIds =
       containersByPodResponse.aggregations?.containerIds?.buckets.map(

--- a/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
@@ -7,41 +7,52 @@
 
 import { rangeQuery, kqlQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
+import { termQuery, termsQuery } from '@kbn/observability-plugin/server';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import {
   SERVICE_NAME,
   CONTAINER_ID,
   KUBERNETES_POD_NAME,
+  KUBERNETES_POD_NAME_OTEL,
   HOST_NAME,
 } from '../../../common/es_fields/apm';
 import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import { hasOpenTelemetryPrefix } from '../../../common/agent_name';
 
 export const getInfrastructureData = async ({
   kuery,
   serviceName,
+  agentName,
   environment,
   apmEventClient,
   start,
   end,
 }: {
   kuery: string;
+  agentName: string | undefined;
   serviceName: string;
   environment: string;
   apmEventClient: APMEventClient;
   start: number;
   end: number;
 }) => {
-  const response = await apmEventClient.search('get_service_infrastructure', {
-    apm: {
-      events: [ProcessorEvent.metric],
-    },
-    body: {
+
+  const isOtel = Boolean(agentName && hasOpenTelemetryPrefix(agentName));
+  const k8sFilterField = isOtel ? KUBERNETES_POD_NAME_OTEL : KUBERNETES_POD_NAME;
+
+  const response = await apmEventClient.search(
+    'get_service_infrastructure',
+    {
+      apm: {
+        events: [ProcessorEvent.metric],
+      },
+      body :{
       track_total_hits: false,
       size: 0,
       query: {
         bool: {
           filter: [
-            { term: { [SERVICE_NAME]: serviceName } },
+            ...termQuery(SERVICE_NAME, serviceName),
             ...rangeQuery(start, end),
             ...environmentQuery(environment),
             ...kqlQuery(kuery),
@@ -63,19 +74,63 @@ export const getInfrastructureData = async ({
         },
         podNames: {
           terms: {
-            field: KUBERNETES_POD_NAME,
+            field: k8sFilterField,
             size: 500,
           },
         },
       },
     },
-  });
+  },
+  { skipProcessorEventFilter: true }
+  );
+
+  let containerIds: string[] =
+    response.aggregations?.containerIds?.buckets.map((bucket) => bucket.key as string) ?? [];
+  const hostNames =
+    response.aggregations?.hostNames?.buckets.map((bucket) => bucket.key as string) ?? [];
+  const podNames =
+    response.aggregations?.podNames?.buckets.map((bucket) => bucket.key as string) ?? [];
+
+  if (podNames.length > 0 && isOtel) {
+    const containersByPodResponse = await apmEventClient.search(
+      'get_container_ids_by_pod_names',
+      {
+        apm: {
+          events: [ProcessorEvent.metric],
+        },
+        body: {
+          track_total_hits: false,
+          size: 0,
+          query: {
+            bool: {
+              filter: [
+                ...rangeQuery(start, end),
+                ...kqlQuery(kuery),
+                ...termsQuery(k8sFilterField, ...podNames),
+              ],
+            },
+          },
+          aggs: {
+            containerIds: {
+              terms: {
+                field: CONTAINER_ID,
+                size: 500,
+              },
+            },
+          },
+        },
+      },
+    { skipProcessorEventFilter: true }
+    );
+    containerIds =
+      containersByPodResponse.aggregations?.containerIds?.buckets.map(
+        (bucket) => bucket.key as string
+      ) ?? [];
+  }
 
   return {
-    containerIds:
-      response.aggregations?.containerIds?.buckets.map((bucket) => bucket.key as string) ?? [],
-    hostNames:
-      response.aggregations?.hostNames?.buckets.map((bucket) => bucket.key as string) ?? [],
-    podNames: response.aggregations?.podNames?.buckets.map((bucket) => bucket.key as string) ?? [],
+    containerIds,
+    hostNames,
+    podNames,
   };
 };

--- a/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/route.ts
@@ -18,7 +18,7 @@ const infrastructureRoute = createApmServerRoute({
     path: t.type({
       serviceName: t.string,
     }),
-    query: t.intersection([kueryRt, rangeRt, environmentRt]),
+    query: t.intersection([kueryRt, rangeRt, environmentRt, t.partial({ agentName: t.string })]),
   }),
   security: { authz: { requiredPrivileges: ['apm'] } },
   handler: async (
@@ -34,13 +34,14 @@ const infrastructureRoute = createApmServerRoute({
 
     const {
       path: { serviceName },
-      query: { environment, kuery, start, end },
+      query: { environment, kuery, start, end, agentName },
     } = params;
 
     const infrastructureData = await getInfrastructureData({
       apmEventClient,
       serviceName,
       environment,
+      agentName,
       kuery,
       start,
       end,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/.storybook/main.js
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/.storybook/main.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = require('@kbn/storybook').defaultConfig;

--- a/x-pack/solutions/observability/plugins/metrics_data_access/.storybook/preview.js
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/.storybook/preview.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { BehaviorSubject } from 'rxjs';
+import { CoreProviders } from '../public/apps/common_providers';
+import { createStartServicesAccessorMock } from '../public/components/infrastructure_node_metrics_tables/test_helpers';
+
+export const parameters = {
+  docs: {
+    source: {
+      type: 'code', // without this, stories in mdx documents freeze the browser
+    },
+  },
+};
+
+// Add a global decorator that wraps all stories with Router context and CoreProviders
+// This ensures hooks like useLocation have the necessary context
+export const decorators = [
+  (StoryFn) => {
+    const { coreProvidersPropsMock } = createStartServicesAccessorMock();
+
+    // Ensure the CoreStart mock includes proper Observable mocks for RxJS subscriptions
+    coreProvidersPropsMock.core.application.currentAppId$ = new BehaviorSubject('metrics');
+
+    // Ensure the CoreStart mock includes a share.locators.get implementation
+    const MOCK_HREF = '/app/r?l=ASSET_DETAILS_LOCATOR&v=8.15.0&lz=MoCkLoCaToRvAlUe';
+    const mockLocator = {
+      getRedirectUrl: () => MOCK_HREF,
+      navigate: () => {},
+    };
+
+    if (!coreProvidersPropsMock.core.share) {
+      coreProvidersPropsMock.core.share = {};
+    }
+    if (!coreProvidersPropsMock.core.share.url) {
+      coreProvidersPropsMock.core.share.url = {};
+    }
+    coreProvidersPropsMock.core.share.url.locators = {
+      get: () => mockLocator,
+    };
+
+    return (
+      <MemoryRouter>
+        <CoreProviders {...coreProvidersPropsMock}>
+          <StoryFn />
+        </CoreProviders>
+      </MemoryRouter>
+    );
+  },
+];

--- a/x-pack/solutions/observability/plugins/metrics_data_access/moon.yml
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/moon.yml
@@ -49,6 +49,7 @@ dependsOn:
   - '@kbn/react-kibana-context-theme'
   - '@kbn/router-utils'
   - '@kbn/observability-utils-common'
+  - '@kbn/esql-ast'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/metrics_data_access/moon.yml
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/moon.yml
@@ -49,7 +49,7 @@ dependsOn:
   - '@kbn/react-kibana-context-theme'
   - '@kbn/router-utils'
   - '@kbn/observability-utils-common'
-  - '@kbn/esql-ast'
+  - '@kbn/esql-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
@@ -97,7 +97,7 @@ describe('container_metrics_configs', () => {
         bool: {
           filter: [{ term: { 'container.id': 'abc-123' } }],
         },
-      }
+      };
 
       const filterClauseWithEventModuleFilter = {
         bool: {
@@ -115,11 +115,14 @@ describe('container_metrics_configs', () => {
         bool: {
           filter: [{ term: { 'container.id': 'abc-123' } }],
         },
-      }
+      };
 
       const filterClauseWithEventModuleFilter = {
         bool: {
-          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }, { ...filterClauseDsl }],
+          filter: [
+            { term: { 'event.dataset': 'dockerstatsreceiver.otel' } },
+            { ...filterClauseDsl },
+          ],
         },
       };
 
@@ -136,10 +139,13 @@ describe('container_metrics_configs', () => {
       };
       const filterClauseWithEventModuleFilter = {
         bool: {
-          filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }, { ...filterClauseDsl }],
+          filter: [
+            { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
+            { ...filterClauseDsl },
+          ],
         },
       };
-      
+
       const { options } = getOptionsForSchema(true, true, filterClauseDsl);
 
       expect(options.filterQuery).toBe(JSON.stringify(filterClauseWithEventModuleFilter));

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
+  ECS_CONTAINER_MEMORY_USAGE_BYTES,
+  SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
+  SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
+  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+} from '../shared/constants';
+import { getOptionsForSchema } from './container_metrics_configs';
+
+describe('container_metrics_configs', () => {
+  describe('getOptionsForSchema', () => {
+    it('returns ECS options when isOtel is false', () => {
+      const { options } = getOptionsForSchema(false);
+
+      const filterClauseDsl = {
+        bool: {
+          filter: [{ term: { 'event.dataset': 'kubernetes.container' } }],
+        },
+      };
+
+      expect(options.groupBy).toBe('container.id');
+      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.metrics).toEqual(
+        expect.arrayContaining([
+          { field: ECS_CONTAINER_CPU_USAGE_LIMIT_PCT, aggregation: 'avg' },
+          { field: ECS_CONTAINER_MEMORY_USAGE_BYTES, aggregation: 'avg' },
+        ])
+      );
+      expect(options.metrics).toHaveLength(2);
+    });
+
+    it('returns SemConv Docker options when isOtel is true and isK8sContainer is false', () => {
+      const { options } = getOptionsForSchema(true, false);
+      const filterClauseDsl = {
+        bool: {
+          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }],
+        },
+      };
+
+      expect(options.groupBy).toBe('container.id');
+      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.metrics).toEqual(
+        expect.arrayContaining([
+          { field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION, aggregation: 'avg' },
+          { field: SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT, aggregation: 'avg' },
+        ])
+      );
+      expect(options.metrics).toHaveLength(2);
+    });
+
+    it('returns SemConv Docker options when isOtel is true and isK8sContainer is undefined', () => {
+      const { options } = getOptionsForSchema(true);
+      const filterClauseDsl = {
+        bool: {
+          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }],
+        },
+      };
+      expect(options.groupBy).toBe('container.id');
+      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.metrics).toEqual(
+        expect.arrayContaining([
+          { field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION, aggregation: 'avg' },
+          { field: SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT, aggregation: 'avg' },
+        ])
+      );
+      expect(options.metrics).toHaveLength(2);
+    });
+
+    it('returns SemConv K8s options when isOtel is true and isK8sContainer is true', () => {
+      const { options } = getOptionsForSchema(true, true);
+      const filterClauseDsl = {
+        bool: {
+          filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }],
+        },
+      };
+      expect(options.groupBy).toBe('container.id');
+      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.metrics).toEqual(
+        expect.arrayContaining([
+          { field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION, aggregation: 'avg' },
+          { field: SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION, aggregation: 'avg' },
+        ])
+      );
+      expect(options.metrics).toHaveLength(2);
+    });
+
+    it('combines kuery with ECS source filter when isOtel is false and kuery is provided', () => {
+      const filterClauseDsl = {
+        bool: {
+          filter: [{ term: { 'container.id': 'abc-123' } }],
+        },
+      }
+
+      const filterClauseWithEventModuleFilter = {
+        bool: {
+          filter: [{ term: { 'event.dataset': 'kubernetes.container' } }, { ...filterClauseDsl }],
+        },
+      };
+
+      const { options } = getOptionsForSchema(false, undefined, filterClauseDsl);
+
+      expect(options.filterQuery).toBe(JSON.stringify(filterClauseWithEventModuleFilter));
+    });
+
+    it('combines kuery with SemConv Docker when isOtel is true, isK8sContainer false, and kuery is provided', () => {
+      const filterClauseDsl = {
+        bool: {
+          filter: [{ term: { 'container.id': 'abc-123' } }],
+        },
+      }
+
+      const filterClauseWithEventModuleFilter = {
+        bool: {
+          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }, { ...filterClauseDsl }],
+        },
+      };
+
+      const { options } = getOptionsForSchema(true, false, filterClauseDsl);
+
+      expect(options.filterQuery).toBe(JSON.stringify(filterClauseWithEventModuleFilter));
+    });
+
+    it('combines kuery with SemConv K8s when isOtel is true, isK8sContainer true, and kuery is provided', () => {
+      const filterClauseDsl = {
+        bool: {
+          filter: [{ term: { 'container.id': 'abc-123' } }],
+        },
+      };
+      const filterClauseWithEventModuleFilter = {
+        bool: {
+          filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }, { ...filterClauseDsl }],
+        },
+      };
+      
+      const { options } = getOptionsForSchema(true, true, filterClauseDsl);
+
+      expect(options.filterQuery).toBe(JSON.stringify(filterClauseWithEventModuleFilter));
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
+import type { MetricsQueryOptions } from '../shared';
+import { createMetricByFieldLookup, makeUnpackMetric, metricsToApiOptions } from '../shared';
+import {
+  ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
+  ECS_CONTAINER_MEMORY_USAGE_BYTES,
+  SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
+  SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
+  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+} from '../shared/constants';
+
+// --- ECS (Elastic Common Schema) ---
+type ContainerMetricsFieldEcs =
+  | typeof ECS_CONTAINER_CPU_USAGE_LIMIT_PCT
+  | typeof ECS_CONTAINER_MEMORY_USAGE_BYTES;
+
+const containerMetricsQueryConfigEcs: MetricsQueryOptions<ContainerMetricsFieldEcs> = {
+  sourceFilter: { 
+    term: { 
+      'event.dataset': 'kubernetes.container'
+    },
+  },
+  groupByField: 'container.id',
+  metricsMap: {
+    [ECS_CONTAINER_CPU_USAGE_LIMIT_PCT]: {
+      aggregation: 'avg',
+      field: ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
+    },
+    [ECS_CONTAINER_MEMORY_USAGE_BYTES]: {
+      aggregation: 'avg',
+      field: ECS_CONTAINER_MEMORY_USAGE_BYTES,
+    },
+  },
+};
+
+// --- SemConv Docker (generic container metrics) ---
+type ContainerMetricsFieldSemconvDocker =
+  | typeof SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION
+  | typeof SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT;
+
+const containerMetricsQueryConfigSemconvDocker: MetricsQueryOptions<ContainerMetricsFieldSemconvDocker> =
+  {
+    sourceFilter: { 
+      term: { 
+        'event.dataset': 'dockerstatsreceiver.otel'
+      },
+    },
+    groupByField: 'container.id',
+    metricsMap: {
+      [SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION]: {
+        aggregation: 'avg',
+        field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
+      },
+      [SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT]: {
+        aggregation: 'avg',
+        field: SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
+      },
+    },
+  };
+
+// --- SemConv K8s (Kubernetes container metrics) ---
+type ContainerMetricsFieldSemconvK8s =
+  | typeof SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION
+  | typeof SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION;
+
+const containerMetricsQueryConfigSemconvK8s: MetricsQueryOptions<ContainerMetricsFieldSemconvK8s> =
+  {
+    sourceFilter: { 
+      term: { 
+        'event.dataset': 'kubeletstatsreceiver.otel',
+      },
+    },
+    groupByField: 'container.id',
+    metricsMap: {
+      [SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION]: {
+        aggregation: 'avg',
+        field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+      },
+      [SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION]: {
+        aggregation: 'avg',
+        field: SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+      },
+    },
+  };
+
+export const metricByFieldEcs = createMetricByFieldLookup(
+  containerMetricsQueryConfigEcs.metricsMap
+);
+export const unpackMetricEcs = makeUnpackMetric(metricByFieldEcs);
+
+const metricByFieldSemconvDocker = createMetricByFieldLookup(
+  containerMetricsQueryConfigSemconvDocker.metricsMap
+);
+export const unpackMetricSemconvDocker = makeUnpackMetric(metricByFieldSemconvDocker);
+
+const metricByFieldSemconvK8s = createMetricByFieldLookup(
+  containerMetricsQueryConfigSemconvK8s.metricsMap
+);
+export const unpackMetricSemconvK8s = makeUnpackMetric(metricByFieldSemconvK8s);
+
+/** @deprecated Use metricByFieldEcs for ECS; use unpack from getUnpackMetricsForSchema for transform */
+export const metricByField = metricByFieldEcs;
+
+export function getOptionsForSchema(isOtel: boolean, isK8sContainer?: boolean, filterClauseDsl?: QueryDslQueryContainer) {
+  if (isOtel) {
+    return isK8sContainer
+      ? metricsToApiOptions(containerMetricsQueryConfigSemconvK8s, filterClauseDsl)
+      : metricsToApiOptions(containerMetricsQueryConfigSemconvDocker, filterClauseDsl);
+  }
+  return metricsToApiOptions(containerMetricsQueryConfigEcs, filterClauseDsl);
+}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
+import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { MetricsQueryOptions } from '../shared';
 import { createMetricByFieldLookup, makeUnpackMetric, metricsToApiOptions } from '../shared';
 import {
@@ -23,9 +23,9 @@ type ContainerMetricsFieldEcs =
   | typeof ECS_CONTAINER_MEMORY_USAGE_BYTES;
 
 const containerMetricsQueryConfigEcs: MetricsQueryOptions<ContainerMetricsFieldEcs> = {
-  sourceFilter: { 
-    term: { 
-      'event.dataset': 'kubernetes.container'
+  sourceFilter: {
+    term: {
+      'event.dataset': 'kubernetes.container',
     },
   },
   groupByField: 'container.id',
@@ -48,9 +48,9 @@ type ContainerMetricsFieldSemconvDocker =
 
 const containerMetricsQueryConfigSemconvDocker: MetricsQueryOptions<ContainerMetricsFieldSemconvDocker> =
   {
-    sourceFilter: { 
-      term: { 
-        'event.dataset': 'dockerstatsreceiver.otel'
+    sourceFilter: {
+      term: {
+        'event.dataset': 'dockerstatsreceiver.otel',
       },
     },
     groupByField: 'container.id',
@@ -73,8 +73,8 @@ type ContainerMetricsFieldSemconvK8s =
 
 const containerMetricsQueryConfigSemconvK8s: MetricsQueryOptions<ContainerMetricsFieldSemconvK8s> =
   {
-    sourceFilter: { 
-      term: { 
+    sourceFilter: {
+      term: {
         'event.dataset': 'kubeletstatsreceiver.otel',
       },
     },
@@ -109,7 +109,11 @@ export const unpackMetricSemconvK8s = makeUnpackMetric(metricByFieldSemconvK8s);
 /** @deprecated Use metricByFieldEcs for ECS; use unpack from getUnpackMetricsForSchema for transform */
 export const metricByField = metricByFieldEcs;
 
-export function getOptionsForSchema(isOtel: boolean, isK8sContainer?: boolean, filterClauseDsl?: QueryDslQueryContainer) {
+export function getOptionsForSchema(
+  isOtel: boolean,
+  isK8sContainer?: boolean,
+  filterClauseDsl?: QueryDslQueryContainer
+) {
   if (isOtel) {
     return isK8sContainer
       ? metricsToApiOptions(containerMetricsQueryConfigSemconvK8s, filterClauseDsl)

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.stories.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.stories.tsx
@@ -17,12 +17,18 @@ import type { ContainerNodeMetricsRow } from './use_container_metrics_table';
 
 const mockServices = {
   application: {
+    currentAppId$: {
+      subscribe: (callback: (appId: string) => void) => {
+        callback('mock-app-id');
+        return { unsubscribe: () => {} };
+      },
+    },
     getUrlForApp: (app: string, { path }: { path: string }) => `your-kibana/app/${app}/${path}`,
   },
 };
 
 export default {
-  title: 'infra/Node Metrics Tables/Container',
+  title: 'metrics_data_access/Node Metrics Tables/Container',
   decorators: [
     (wrappedStory) => <EuiCard title="Container metrics">{wrappedStory()}</EuiCard>,
     (wrappedStory) => (
@@ -60,28 +66,28 @@ export default {
 const loadedContainers: ContainerNodeMetricsRow[] = [
   {
     id: 'gke-edge-oblt-pool-1-9a60016d-lgg1',
-    averageCpuUsagePercent: 99,
-    averageMemoryUsageMegabytes: 34,
+    averageCpuUsage: 99,
+    averageMemoryUsage: 34,
   },
   {
     id: 'gke-edge-oblt-pool-1-9a60016d-lgg2',
-    averageCpuUsagePercent: 72,
-    averageMemoryUsageMegabytes: 68,
+    averageCpuUsage: 72,
+    averageMemoryUsage: 68,
   },
   {
     id: 'gke-edge-oblt-pool-1-9a60016d-lgg3',
-    averageCpuUsagePercent: 54,
-    averageMemoryUsageMegabytes: 132,
+    averageCpuUsage: 54,
+    averageMemoryUsage: 132,
   },
   {
     id: 'gke-edge-oblt-pool-1-9a60016d-lgg4',
-    averageCpuUsagePercent: 34,
-    averageMemoryUsageMegabytes: 264,
+    averageCpuUsage: 34,
+    averageMemoryUsage: 264,
   },
   {
     id: 'gke-edge-oblt-pool-1-9a60016d-lgg5',
-    averageCpuUsagePercent: 13,
-    averageMemoryUsageMegabytes: 512,
+    averageCpuUsage: 13,
+    averageMemoryUsage: 512,
   },
 ];
 
@@ -163,5 +169,28 @@ export const FailedToLoadMetrics = {
       state: 'error',
       errors: [new Error('Failed to load metrics')],
     },
+  },
+};
+
+export const BasicWithSemconv = {
+  render: Template,
+
+  args: {
+    data: {
+      state: 'data',
+      currentPageIndex: 1,
+      pageCount: 10,
+      rows: loadedContainers,
+    },
+    isOtel: true,
+  },
+};
+
+export const LoadingWithSemconv = {
+  render: Template,
+
+  args: {
+    isLoading: true,
+    isOtel: true,
   },
 };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
@@ -13,6 +13,10 @@ import { createStartServicesAccessorMock, createMetricsClientMock } from '../tes
 import { ContainerMetricsTable } from './container_metrics_table';
 import { createLazyContainerMetricsTable } from './create_lazy_container_metrics_table';
 import IntegratedContainerMetricsTable from './integrated_container_metrics_table';
+import {
+  ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
+  ECS_CONTAINER_MEMORY_USAGE_BYTES,
+} from '../shared/constants';
 import { metricByField } from './use_container_metrics_table';
 
 jest.mock('../../../pages/link_to/use_asset_details_redirect', () => ({
@@ -157,8 +161,8 @@ function createContainer(
     id: name,
     rows: [
       {
-        [metricByField['kubernetes.container.cpu.usage.limit.pct']]: cpuUsagePct,
-        [metricByField['kubernetes.container.memory.usage.bytes']]: memoryUsageBytes,
+        [metricByField[ECS_CONTAINER_CPU_USAGE_LIMIT_PCT]]: cpuUsagePct,
+        [metricByField[ECS_CONTAINER_MEMORY_USAGE_BYTES]]: memoryUsageBytes,
       } as MetricsExplorerSeries['rows'][number],
     ],
   };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.tsx
@@ -23,6 +23,7 @@ import {
   NumberCell,
   StepwisePagination,
 } from '../shared';
+
 import type { ContainerNodeMetricsRow } from './use_container_metrics_table';
 
 export interface ContainerMetricsTableProps {
@@ -35,12 +36,28 @@ export interface ContainerMetricsTableProps {
     from: string;
     to: string;
   };
+  isOtel?: boolean;
+  metricsIndices?: string;
+  isK8sContainer?: boolean;
 }
 
 export const ContainerMetricsTable = (props: ContainerMetricsTableProps) => {
-  const { data, isLoading, setCurrentPageIndex, setSortState, sortState, timerange } = props;
+  const {
+    data,
+    isLoading,
+    setCurrentPageIndex,
+    setSortState,
+    sortState,
+    timerange,
+    isOtel,
+    metricsIndices,
+    isK8sContainer,
+  } = props;
 
-  const columns = useMemo(() => containerNodeColumns(timerange), [timerange]);
+  const columns = useMemo(
+    () => containerNodeColumns({ timerange, isOtel, metricsIndices, isK8sContainer }),
+    [timerange, isOtel, metricsIndices, isK8sContainer]
+  );
 
   const sortSettings: EuiTableSortingType<ContainerNodeMetricsRow> = {
     enableAllColumns: true,
@@ -112,9 +129,16 @@ export const ContainerMetricsTable = (props: ContainerMetricsTableProps) => {
   }
 };
 
-function containerNodeColumns(
-  timerange: ContainerMetricsTableProps['timerange']
-): Array<EuiBasicTableColumn<ContainerNodeMetricsRow>> {
+function containerNodeColumns({
+  timerange,
+  isOtel,
+  metricsIndices,
+  isK8sContainer,
+}: Pick<
+  ContainerMetricsTableProps,
+  'timerange' | 'isOtel' | 'metricsIndices' | 'isK8sContainer'
+>): Array<EuiBasicTableColumn<ContainerNodeMetricsRow>> {
+  const memoryUnit = isOtel ? '%' : ' MB';
   return [
     {
       name: i18n.translate('xpack.metricsData.metricsTable.container.idColumnHeader', {
@@ -125,34 +149,51 @@ function containerNodeColumns(
       textOnly: true,
       render: (id: string) => {
         return (
-          <MetricsNodeDetailsLink id={id} label={id} nodeType={'container'} timerange={timerange} />
+          <MetricsNodeDetailsLink
+            id={id}
+            label={id}
+            nodeType={'container'}
+            timerange={timerange}
+            isOtel={isOtel}
+            metricsIndices={metricsIndices}
+          />
         );
       },
     },
     {
-      name: i18n.translate(
-        'xpack.metricsData.metricsTable.container.averageCpuUsagePercentColumnHeader',
-        {
-          defaultMessage: 'CPU usage (avg.)',
-        }
+      name: (
+        <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} wrap={false}>
+          <EuiFlexItem grow={false}>
+            {i18n.translate(
+              'xpack.metricsData.metricsTable.container.averageCpuUsagePercentColumnHeader',
+              {
+                defaultMessage: 'CPU usage (avg.)',
+              }
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
       ),
-      field: 'averageCpuUsagePercent',
+      field: 'averageCpuUsage',
       align: 'right',
-      render: (averageCpuUsagePercent: number) => (
-        <NumberCell value={averageCpuUsagePercent} unit="%" />
-      ),
+      render: (averageCpuUsage: number) => <NumberCell value={averageCpuUsage} unit="%" />,
     },
     {
-      name: i18n.translate(
-        'xpack.metricsData.metricsTable.container.averageMemoryUsageMegabytesColumnHeader',
-        {
-          defaultMessage: 'Memory usage(avg.)',
-        }
+      name: (
+        <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} wrap={false}>
+          <EuiFlexItem grow={false}>
+            {i18n.translate(
+              'xpack.metricsData.metricsTable.container.averageMemoryUsageColumnHeader',
+              {
+                defaultMessage: 'Memory usage(avg.)',
+              }
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
       ),
-      field: 'averageMemoryUsageMegabytes',
+      field: 'averageMemoryUsage',
       align: 'right',
-      render: (averageMemoryUsageMegabytes: number) => (
-        <NumberCell value={averageMemoryUsageMegabytes} unit=" MB" />
+      render: (averageMemoryUsage: number) => (
+        <NumberCell value={averageMemoryUsage} unit={memoryUnit} />
       ),
     },
   ];

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
@@ -29,7 +29,7 @@ export function createLazyContainerMetricsTable(core: CoreStart, metricsClient: 
           core={core}
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
-          timerange={timerange} 
+          timerange={timerange}
           filterClauseDsl={filterClauseDsl}
           isOtel={isOtel}
           isK8sContainer={isK8sContainer}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
@@ -9,21 +9,30 @@ import type { CoreStart } from '@kbn/core/public';
 import React, { lazy, Suspense } from 'react';
 import type { MetricsDataClient } from '../../../lib/metrics_client';
 import type { NodeMetricsTableProps } from '../shared';
-
 const LazyIntegratedContainerMetricsTable = lazy(
   () => import('./integrated_container_metrics_table')
 );
 
 export function createLazyContainerMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId }: NodeMetricsTableProps) => {
+  return ({
+    timerange,
+    filterClauseDsl,
+    sourceId,
+    isOtel,
+    isK8sContainer,
+  }: NodeMetricsTableProps & {
+    isK8sContainer?: boolean;
+  }) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedContainerMetricsTable
           core={core}
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
-          timerange={timerange}
+          timerange={timerange} 
           filterClauseDsl={filterClauseDsl}
+          isOtel={isOtel}
+          isK8sContainer={isK8sContainer}
         />
       </Suspense>
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/integrated_container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/integrated_container_metrics_table.tsx
@@ -7,36 +7,59 @@
 
 import React from 'react';
 import { CoreProviders } from '../../../apps/common_providers';
-import type { IntegratedNodeMetricsTableProps, UseNodeMetricsTableOptions } from '../shared';
+import type { IntegratedNodeMetricsTableProps } from '../shared';
 import { ContainerMetricsTable } from './container_metrics_table';
 import { useContainerMetricsTable } from './use_container_metrics_table';
+type ContainerIntegratedProps = IntegratedNodeMetricsTableProps & {
+  isK8sContainer?: boolean;
+};
+
+type HookedContainerMetricsTableProps = Pick<
+  ContainerIntegratedProps,
+  'timerange' | 'filterClauseDsl' | 'isOtel' | 'isK8sContainer' | 'metricsClient'
+>;
 
 function HookedContainerMetricsTable({
   timerange,
   filterClauseDsl,
+  isOtel,
+  isK8sContainer,
   metricsClient,
-}: UseNodeMetricsTableOptions) {
+}: HookedContainerMetricsTableProps) {
   const containerMetricsTableProps = useContainerMetricsTable({
     timerange,
     filterClauseDsl,
+    isOtel,
+    isK8sContainer,
     metricsClient,
   });
-  return <ContainerMetricsTable {...containerMetricsTableProps} />;
+  return (
+    <ContainerMetricsTable
+      {...containerMetricsTableProps}
+      isOtel={isOtel}
+      metricsIndices={containerMetricsTableProps.metricIndices}
+      isK8sContainer={isK8sContainer}
+    />
+  );
 }
 
 function ContainerMetricsTableWithProviders({
   timerange,
   filterClauseDsl,
   sourceId,
+  isOtel,
+  isK8sContainer,
   metricsClient,
   ...coreProvidersProps
-}: IntegratedNodeMetricsTableProps) {
+}: ContainerIntegratedProps) {
   return (
     <CoreProviders {...coreProvidersProps}>
       <HookedContainerMetricsTable
         timerange={timerange}
         filterClauseDsl={filterClauseDsl}
+        isOtel={isOtel}
         metricsClient={metricsClient}
+        isK8sContainer={isK8sContainer}
       />
     </CoreProviders>
   );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -5,6 +5,14 @@
  * 2.0.
  */
 
+import {
+  ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
+  ECS_CONTAINER_MEMORY_USAGE_BYTES,
+  SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
+  SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
+  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+} from '../shared/constants';
 import { useContainerMetricsTable } from './use_container_metrics_table';
 import { useInfrastructureNodeMetrics } from '../shared';
 import { renderHook } from '@testing-library/react';
@@ -23,7 +31,7 @@ describe('useContainerMetricsTable hook', () => {
   it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
     const filterClauseDsl = {
       bool: {
-        filter: [{ terms: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
       },
     };
 
@@ -37,6 +45,7 @@ describe('useContainerMetricsTable hook', () => {
     useInfrastructureNodeMetricsMock.mockReturnValue({
       isLoading: true,
       data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
     });
 
     renderHook(() =>
@@ -51,6 +60,138 @@ describe('useContainerMetricsTable hook', () => {
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
           filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+        }),
+      })
+    );
+  });
+
+  it('should call useInfrastructureNodeMetrics with SemConv Docker metrics when isOtel is true (default)', () => {
+    const filterClauseDsl = {
+      bool: {
+        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+      },
+    };
+
+    const filterClauseWithEventModuleFilter = {
+      bool: {
+        filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }, { ...filterClauseDsl }],
+      },
+    };
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      useContainerMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        filterClauseDsl,
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+      })
+    );
+
+    expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricsExplorerOptions: expect.objectContaining({
+          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          metrics: expect.arrayContaining([
+            expect.objectContaining({ field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION }),
+            expect.objectContaining({ field: SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('should call useInfrastructureNodeMetrics with SemConv K8s metrics when isOtel is true and isK8s is true', () => {
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    const filterClauseDsl = {
+      bool: {
+        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+      },
+    };
+
+    const filterClauseWithEventModuleFilter = {
+      bool: {
+        filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }, { ...filterClauseDsl }],
+      },
+    };
+
+    renderHook(() =>
+      useContainerMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        filterClauseDsl,
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+        isK8sContainer: true,
+      })
+    );
+
+    expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricsExplorerOptions: expect.objectContaining({
+          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          metrics: expect.arrayContaining([
+            expect.objectContaining({
+              field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+            }),
+            expect.objectContaining({
+              field: SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+            }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    const filterClauseDsl = {
+      bool: {
+        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+      },
+    };
+
+    const filterClauseWithEventModuleFilter = {
+      bool: {
+        filter: [{ term: { 'event.dataset': 'kubernetes.container' } }, { ...filterClauseDsl }],
+      },
+    };
+
+    renderHook(() =>
+      useContainerMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        filterClauseDsl,
+        metricsClient: createMetricsClientMock({}),
+        isOtel: false,
+      })
+    );
+
+
+    expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricsExplorerOptions: expect.objectContaining({
+          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          metrics: expect.arrayContaining([
+            expect.objectContaining({
+              field: ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
+            }),
+            expect.objectContaining({
+              field: ECS_CONTAINER_MEMORY_USAGE_BYTES,
+            }),
+          ]),
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -120,7 +120,10 @@ describe('useContainerMetricsTable hook', () => {
 
     const filterClauseWithEventModuleFilter = {
       bool: {
-        filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }, { ...filterClauseDsl }],
+        filter: [
+          { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
+          { ...filterClauseDsl },
+        ],
       },
     };
 
@@ -178,7 +181,6 @@ describe('useContainerMetricsTable hook', () => {
         isOtel: false,
       })
     );
-
 
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
@@ -10,76 +10,115 @@ import type {
   MetricsExplorerRow,
   MetricsExplorerSeries,
 } from '../../../../common/http_api/metrics_explorer';
-import type { MetricsQueryOptions, SortState, UseNodeMetricsTableOptions } from '../shared';
+import type { SortState, UseNodeMetricsTableOptions } from '../shared';
+import { averageOfValues, scaleUpPercentage, useInfrastructureNodeMetrics } from '../shared';
 import {
-  averageOfValues,
-  createMetricByFieldLookup,
-  makeUnpackMetric,
-  metricsToApiOptions,
-  scaleUpPercentage,
-  useInfrastructureNodeMetrics,
-} from '../shared';
+  getOptionsForSchema,
+  unpackMetricEcs,
+  unpackMetricSemconvDocker,
+  unpackMetricSemconvK8s,
+} from './container_metrics_configs';
+import {
+  ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
+  ECS_CONTAINER_MEMORY_USAGE_BYTES,
+  SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
+  SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
+  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+} from '../shared/constants';
 
-type ContainerMetricsField =
-  | 'kubernetes.container.cpu.usage.limit.pct'
-  | 'kubernetes.container.memory.usage.bytes';
+export { metricByFieldEcs, metricByField } from './container_metrics_configs';
 
-const containerMetricsQueryConfig: MetricsQueryOptions<ContainerMetricsField> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'kubernetes.container',
-    },
-  },
-  groupByField: 'container.id',
-  metricsMap: {
-    'kubernetes.container.cpu.usage.limit.pct': {
-      aggregation: 'avg',
-      field: 'kubernetes.container.cpu.usage.limit.pct',
-    },
-    'kubernetes.container.memory.usage.bytes': {
-      aggregation: 'avg',
-      field: 'kubernetes.container.memory.usage.bytes',
-    },
-  },
-};
-
-export const metricByField = createMetricByFieldLookup(containerMetricsQueryConfig.metricsMap);
-const unpackMetric = makeUnpackMetric(metricByField);
+export interface UseContainerMetricsTableOptions extends UseNodeMetricsTableOptions {
+  isK8sContainer?: boolean;
+}
 
 export interface ContainerNodeMetricsRow {
   id: string;
-  averageCpuUsagePercent: number | null;
-  averageMemoryUsageMegabytes: number | null;
+  averageCpuUsage: number | null;
+  averageMemoryUsage: number | null;
+}
+
+type UnpackMetricsFn = (row: MetricsExplorerRow) => Omit<ContainerNodeMetricsRow, 'id'>;
+
+const semconvDockerUnpackMetrics = (row: MetricsExplorerRow) => {
+  // semconv docker unpack metrics
+  const cpuUtilization = unpackMetricSemconvDocker(row, SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION);
+  const memoryUtilization = unpackMetricSemconvDocker(row, SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT);
+  return {
+    averageCpuUsage: cpuUtilization !== null ? scaleUpPercentage(cpuUtilization) : null,
+    averageMemoryUsage: memoryUtilization !== null ? memoryUtilization : null,
+  };
+};
+
+const semconvK8sUnpackMetrics = (row: MetricsExplorerRow) => {
+  // semconv k8s unpack metrics
+  const cpuUtilization = unpackMetricSemconvK8s(row, SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION);
+  const memoryUsage = unpackMetricSemconvK8s(row, SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION);
+  return {
+    averageCpuUsage: cpuUtilization !== null ? scaleUpPercentage(cpuUtilization) : null,
+    averageMemoryUsage: memoryUsage !== null ? scaleUpPercentage(memoryUsage) : null,
+  };
+};
+
+const ecsUnpackMetrics = (row: MetricsExplorerRow) => {
+  const rawCpu = unpackMetricEcs(row, ECS_CONTAINER_CPU_USAGE_LIMIT_PCT);
+  const memoryBytes = unpackMetricEcs(row, ECS_CONTAINER_MEMORY_USAGE_BYTES);
+  return {
+    averageCpuUsage: rawCpu !== null ? scaleUpPercentage(rawCpu) : null,
+    averageMemoryUsage: memoryBytes !== null ? Math.floor(memoryBytes / 1_000_000) : null,
+  };
+};
+
+function getUnpackMetricsForSchema(isOtel: boolean, isK8sContainer?: boolean): UnpackMetricsFn {
+  if (isOtel) {
+    if (isK8sContainer) {
+      // semconv k8s metrics unpacking
+      return semconvK8sUnpackMetrics;
+    }
+    // semconv docker metrics unpacking
+    return semconvDockerUnpackMetrics;
+  }
+  // ecs metrics unpacking
+  return ecsUnpackMetrics;
 }
 
 export function useContainerMetricsTable({
   timerange,
   filterClauseDsl,
   metricsClient,
-}: UseNodeMetricsTableOptions) {
+  isOtel,
+  isK8sContainer,
+}: UseContainerMetricsTableOptions) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [sortState, setSortState] = useState<SortState<ContainerNodeMetricsRow>>({
-    field: 'averageCpuUsagePercent',
+    field: 'averageCpuUsage',
     direction: 'desc',
   });
 
-  const { options: containerMetricsOptions } = useMemo(
-    () => metricsToApiOptions(containerMetricsQueryConfig, filterClauseDsl),
-    [filterClauseDsl]
+  const metricsExplorerOptions = useMemo(
+    () => getOptionsForSchema(isOtel ?? false, isK8sContainer, filterClauseDsl).options,
+    [isOtel, isK8sContainer, filterClauseDsl]
   );
 
-  const { data, isLoading } = useInfrastructureNodeMetrics<ContainerNodeMetricsRow>({
-    metricsExplorerOptions: containerMetricsOptions,
+  const transform = useMemo(() => {
+    const unpackMetrics = getUnpackMetricsForSchema(isOtel ?? false, isK8sContainer);
+    return (series: MetricsExplorerSeries): ContainerNodeMetricsRow =>
+      seriesToContainerNodeMetricsRow(series, unpackMetrics);
+  }, [isOtel, isK8sContainer]);
+
+  const { data, isLoading, metricIndices } = useInfrastructureNodeMetrics<ContainerNodeMetricsRow>({
+    metricsExplorerOptions,
     timerange,
-    transform: seriesToContainerNodeMetricsRow,
+    transform,
     sortState,
     currentPageIndex,
     metricsClient,
   });
-
   return {
     data,
     isLoading,
+    metricIndices,
     setCurrentPageIndex,
     setSortState,
     sortState,
@@ -87,72 +126,67 @@ export function useContainerMetricsTable({
   };
 }
 
-function seriesToContainerNodeMetricsRow(series: MetricsExplorerSeries): ContainerNodeMetricsRow {
+function seriesToContainerNodeMetricsRow(
+  series: MetricsExplorerSeries,
+  unpackMetrics: UnpackMetricsFn
+): ContainerNodeMetricsRow {
   if (series.rows.length === 0) {
     return rowWithoutMetrics(series.id);
   }
 
   return {
     id: series.id,
-    ...calculateMetricAverages(series.rows),
+    ...calculateMetricAverages(series.rows, unpackMetrics),
   };
 }
 
-function rowWithoutMetrics(id: string) {
+function rowWithoutMetrics(id: string): ContainerNodeMetricsRow {
   return {
     id,
-    averageCpuUsagePercent: null,
-    averageMemoryUsageMegabytes: null,
+    averageCpuUsage: null,
+    averageMemoryUsage: null,
   };
 }
 
-function calculateMetricAverages(rows: MetricsExplorerRow[]) {
-  const { averageCpuUsagePercentValues, averageMemoryUsageMegabytesValues } =
-    collectMetricValues(rows);
+function calculateMetricAverages(rows: MetricsExplorerRow[], unpackMetrics: UnpackMetricsFn) {
+  const { averageCpuUsageValues, averageMemoryUsageValues } = collectMetricValues(
+    rows,
+    unpackMetrics
+  );
 
-  let averageCpuUsagePercent = null;
-  if (averageCpuUsagePercentValues.length !== 0) {
-    averageCpuUsagePercent = scaleUpPercentage(averageOfValues(averageCpuUsagePercentValues));
+  let averageCpuUsage: number | null = null;
+  if (averageCpuUsageValues.length !== 0) {
+    averageCpuUsage = averageOfValues(averageCpuUsageValues);
   }
 
-  let averageMemoryUsageMegabytes = null;
-  if (averageMemoryUsageMegabytesValues.length !== 0) {
-    const averageInBytes = averageOfValues(averageMemoryUsageMegabytesValues);
-    const bytesPerMegabyte = 1000000;
-    averageMemoryUsageMegabytes = Math.floor(averageInBytes / bytesPerMegabyte);
+  let averageMemoryUsage: number | null = null;
+  if (averageMemoryUsageValues.length !== 0) {
+    averageMemoryUsage = Math.floor(averageOfValues(averageMemoryUsageValues));
   }
 
   return {
-    averageCpuUsagePercent,
-    averageMemoryUsageMegabytes,
+    averageCpuUsage,
+    averageMemoryUsage,
   };
 }
 
-function collectMetricValues(rows: MetricsExplorerRow[]) {
-  const averageCpuUsagePercentValues: number[] = [];
-  const averageMemoryUsageMegabytesValues: number[] = [];
-
+function collectMetricValues(rows: MetricsExplorerRow[], unpackMetrics: UnpackMetricsFn) {
+  const averageCpuUsageValues: number[] = [];
+  const averageMemoryUsageValues: number[] = [];
   rows.forEach((row) => {
-    const { averageCpuUsagePercent, averageMemoryUsageMegabytes } = unpackMetrics(row);
+    const { averageCpuUsage, averageMemoryUsage } = unpackMetrics(row);
 
-    if (averageCpuUsagePercent !== null) {
-      averageCpuUsagePercentValues.push(averageCpuUsagePercent);
+    if (averageCpuUsage !== null) {
+      averageCpuUsageValues.push(averageCpuUsage);
     }
 
-    if (averageMemoryUsageMegabytes !== null) {
-      averageMemoryUsageMegabytesValues.push(averageMemoryUsageMegabytes);
+    if (averageMemoryUsage !== null) {
+      averageMemoryUsageValues.push(averageMemoryUsage);
     }
   });
 
   return {
-    averageCpuUsagePercentValues,
-    averageMemoryUsageMegabytesValues,
-  };
-}
-
-function unpackMetrics(row: MetricsExplorerRow): Omit<ContainerNodeMetricsRow, 'id'> {
-  return {
-    averageCpuUsagePercent: unpackMetric(row, 'kubernetes.container.cpu.usage.limit.pct'),
-    averageMemoryUsageMegabytes: unpackMetric(row, 'kubernetes.container.memory.usage.bytes'),
+    averageCpuUsageValues,
+    averageMemoryUsageValues,
   };
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
@@ -13,7 +13,6 @@ import type { NodeMetricsTableProps } from '../shared';
 const LazyIntegratedHostMetricsTable = lazy(() => import('./integrated_host_metrics_table'));
 
 export function createLazyHostMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-
   return ({ timerange, filterClauseDsl, sourceId, isOtel }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
@@ -13,13 +13,15 @@ import type { NodeMetricsTableProps } from '../shared';
 const LazyIntegratedHostMetricsTable = lazy(() => import('./integrated_host_metrics_table'));
 
 export function createLazyHostMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId }: NodeMetricsTableProps) => {
+
+  return ({ timerange, filterClauseDsl, sourceId, isOtel }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedHostMetricsTable
           core={core}
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
+          isOtel={isOtel}
           timerange={timerange}
           filterClauseDsl={filterClauseDsl}
         />

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.stories.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.stories.tsx
@@ -17,12 +17,18 @@ import type { HostNodeMetricsRow } from './use_host_metrics_table';
 
 const mockServices = {
   application: {
+    currentAppId$: {
+      subscribe: (callback: (appId: string) => void) => {
+        callback('mock-app-id');
+        return { unsubscribe: () => {} };
+      },
+    },
     getUrlForApp: (app: string, { path }: { path: string }) => `your-kibana/app/${app}/${path}`,
   },
 };
 
 export default {
-  title: 'infra/Node Metrics Tables/Host',
+  title: 'metrics_data_access/Node Metrics Tables/Host',
   decorators: [
     (wrappedStory) => <EuiCard title="Host metrics">{wrappedStory()}</EuiCard>,
     (wrappedStory) => (
@@ -173,5 +179,28 @@ export const FailedToLoadMetrics = {
       state: 'error',
       errors: [new Error('Failed to load metrics')],
     },
+  },
+};
+
+export const BasicWithSemconv = {
+  render: Template,
+
+  args: {
+    data: {
+      state: 'data',
+      currentPageIndex: 1,
+      pageCount: 10,
+      rows: loadedHosts,
+    },
+    isOtel: true,
+  },
+};
+
+export const LoadingWithSemconv = {
+  render: Template,
+
+  args: {
+    isLoading: true,
+    isOtel: true,
   },
 };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
@@ -13,6 +13,12 @@ import { createStartServicesAccessorMock, createMetricsClientMock } from '../tes
 import { createLazyHostMetricsTable } from './create_lazy_host_metrics_table';
 import { HostMetricsTable } from './host_metrics_table';
 import IntegratedHostMetricsTable from './integrated_host_metrics_table';
+import {
+  SYSTEM_CPU_CORES,
+  SYSTEM_CPU_TOTAL_NORM_PCT,
+  SYSTEM_MEMORY_TOTAL,
+  SYSTEM_MEMORY_USED_PCT,
+} from '../shared/constants';
 import { metricByField } from './use_host_metrics_table';
 
 jest.mock('../../../pages/link_to/use_asset_details_redirect', () => ({
@@ -156,10 +162,10 @@ function createHost(
     id: name,
     rows: [
       {
-        [metricByField['system.cpu.cores']]: coreCount,
-        [metricByField['system.cpu.total.norm.pct']]: cpuUsagePct,
-        [metricByField['system.memory.total']]: memoryBytes,
-        [metricByField['system.memory.used.pct']]: memoryUsagePct,
+        [metricByField[SYSTEM_CPU_CORES]]: coreCount,
+        [metricByField[SYSTEM_CPU_TOTAL_NORM_PCT]]: cpuUsagePct,
+        [metricByField[SYSTEM_MEMORY_TOTAL]]: memoryBytes,
+        [metricByField[SYSTEM_MEMORY_USED_PCT]]: memoryUsagePct,
       } as MetricsExplorerSeries['rows'][number],
     ],
   };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.tsx
@@ -35,12 +35,26 @@ export interface HostMetricsTableProps {
     from: string;
     to: string;
   };
+  isOtel?: boolean;
+  metricIndices?: string;
 }
 
 export const HostMetricsTable = (props: HostMetricsTableProps) => {
-  const { data, isLoading, setCurrentPageIndex, setSortState, sortState, timerange } = props;
+  const {
+    data,
+    isLoading,
+    setCurrentPageIndex,
+    setSortState,
+    sortState,
+    timerange,
+    isOtel,
+    metricIndices,
+  } = props;
 
-  const columns = useMemo(() => hostMetricsColumns(timerange), [timerange]);
+  const columns = useMemo(
+    () => hostMetricsColumns(timerange, isOtel, metricIndices),
+    [timerange, isOtel, metricIndices]
+  );
 
   const sortSettings: EuiTableSortingType<HostNodeMetricsRow> = {
     enableAllColumns: true,
@@ -110,7 +124,9 @@ export const HostMetricsTable = (props: HostMetricsTableProps) => {
 };
 
 function hostMetricsColumns(
-  timerange: HostMetricsTableProps['timerange']
+  timerange: HostMetricsTableProps['timerange'],
+  isOtel?: HostMetricsTableProps['isOtel'],
+  metricIndices?: HostMetricsTableProps['metricIndices']
 ): Array<EuiBasicTableColumn<HostNodeMetricsRow>> {
   return [
     {
@@ -121,7 +137,14 @@ function hostMetricsColumns(
       truncateText: true,
       textOnly: true,
       render: (name: string) => (
-        <MetricsNodeDetailsLink id={name} label={name} nodeType={'host'} timerange={timerange} />
+        <MetricsNodeDetailsLink
+          id={name}
+          label={name}
+          nodeType="host"
+          timerange={timerange}
+          isOtel={isOtel}
+          metricsIndices={metricIndices}
+        />
       ),
     },
     {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
@@ -11,7 +11,6 @@ import { HostMetricsTable } from './host_metrics_table';
 import { useHostMetricsTable } from './use_host_metrics_table';
 import type { IntegratedNodeMetricsTableProps } from '../shared';
 
-
 type HookedHostMetricsTableProps = Pick<
   IntegratedNodeMetricsTableProps,
   'timerange' | 'filterClauseDsl' | 'isOtel' | 'metricsClient'
@@ -23,7 +22,12 @@ function HookedHostMetricsTable({
   metricsClient,
   isOtel,
 }: HookedHostMetricsTableProps) {
-  const hostMetricsTableProps = useHostMetricsTable({ timerange, filterClauseDsl, metricsClient, isOtel });
+  const hostMetricsTableProps = useHostMetricsTable({
+    timerange,
+    filterClauseDsl,
+    metricsClient,
+    isOtel,
+  });
   return (
     <HostMetricsTable
       {...hostMetricsTableProps}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
@@ -7,17 +7,30 @@
 
 import React from 'react';
 import { CoreProviders } from '../../../apps/common_providers';
-import type { IntegratedNodeMetricsTableProps, UseNodeMetricsTableOptions } from '../shared';
 import { HostMetricsTable } from './host_metrics_table';
 import { useHostMetricsTable } from './use_host_metrics_table';
+import type { IntegratedNodeMetricsTableProps } from '../shared';
+
+
+type HookedHostMetricsTableProps = Pick<
+  IntegratedNodeMetricsTableProps,
+  'timerange' | 'filterClauseDsl' | 'isOtel' | 'metricsClient'
+>;
 
 function HookedHostMetricsTable({
   timerange,
   filterClauseDsl,
   metricsClient,
-}: UseNodeMetricsTableOptions) {
-  const hostMetricsTableProps = useHostMetricsTable({ timerange, filterClauseDsl, metricsClient });
-  return <HostMetricsTable {...hostMetricsTableProps} />;
+  isOtel,
+}: HookedHostMetricsTableProps) {
+  const hostMetricsTableProps = useHostMetricsTable({ timerange, filterClauseDsl, metricsClient, isOtel });
+  return (
+    <HostMetricsTable
+      {...hostMetricsTableProps}
+      isOtel={isOtel}
+      metricIndices={hostMetricsTableProps.metricIndices}
+    />
+  );
 }
 
 function HostMetricsTableWithProviders({
@@ -25,6 +38,7 @@ function HostMetricsTableWithProviders({
   filterClauseDsl,
   sourceId,
   metricsClient,
+  isOtel,
   ...coreProvidersProps
 }: IntegratedNodeMetricsTableProps) {
   return (
@@ -33,6 +47,7 @@ function HostMetricsTableWithProviders({
         timerange={timerange}
         filterClauseDsl={filterClauseDsl}
         metricsClient={metricsClient}
+        isOtel={isOtel}
       />
     </CoreProviders>
   );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
@@ -75,7 +75,6 @@ describe('useHostMetricsTable hook', () => {
   });
 
   it('should call useInfrastructureNodeMetrics with OTEL/semconv metrics when isOtel is true', () => {
-
     const filterClauseDsl = {
       bool: {
         filter: [{ term: { 'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
@@ -5,6 +5,16 @@
  * 2.0.
  */
 
+import {
+  SEMCONV_SYSTEM_CPU_LOGICAL_COUNT,
+  SEMCONV_SYSTEM_CPU_UTILIZATION,
+  SEMCONV_SYSTEM_MEMORY_LIMIT,
+  SEMCONV_SYSTEM_MEMORY_UTILIZATION,
+  SYSTEM_CPU_CORES,
+  SYSTEM_CPU_TOTAL_NORM_PCT,
+  SYSTEM_MEMORY_TOTAL,
+  SYSTEM_MEMORY_USED_PCT,
+} from '../shared/constants';
 import { useHostMetricsTable } from './use_host_metrics_table';
 import { useInfrastructureNodeMetrics } from '../shared';
 import { renderHook } from '@testing-library/react';
@@ -44,6 +54,7 @@ describe('useHostMetricsTable hook', () => {
     useInfrastructureNodeMetricsMock.mockReturnValue({
       isLoading: true,
       data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
     });
 
     renderHook(() =>
@@ -58,6 +69,95 @@ describe('useHostMetricsTable hook', () => {
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
           filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+        }),
+      })
+    );
+  });
+
+  it('should call useInfrastructureNodeMetrics with OTEL/semconv metrics when isOtel is true', () => {
+
+    const filterClauseDsl = {
+      bool: {
+        filter: [{ term: { 'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+      },
+    };
+
+    const filterClauseWithEventModuleFilter = {
+      bool: {
+        filter: [{ term: { 'event.dataset': 'hostmetricsreceiver.otel' } }, { ...filterClauseDsl }],
+      },
+    };
+
+    // include this to prevent rendering error in test
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      useHostMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        filterClauseDsl,
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+      })
+    );
+
+    expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricsExplorerOptions: expect.objectContaining({
+          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          metrics: expect.arrayContaining([
+            expect.objectContaining({ field: SEMCONV_SYSTEM_CPU_LOGICAL_COUNT }),
+            expect.objectContaining({ field: SEMCONV_SYSTEM_CPU_UTILIZATION }),
+            expect.objectContaining({ field: SEMCONV_SYSTEM_MEMORY_LIMIT }),
+            expect.objectContaining({ field: SEMCONV_SYSTEM_MEMORY_UTILIZATION }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {
+    const filterClauseDsl = {
+      bool: {
+        filter: [{ term: { 'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+      },
+    };
+
+    const filterClauseWithEventModuleFilter = {
+      bool: {
+        filter: [{ term: { 'event.module': 'system' } }, { ...filterClauseDsl }],
+      },
+    };
+
+    // include this to prevent rendering error in test
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      useHostMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        filterClauseDsl,
+        metricsClient: createMetricsClientMock({}),
+        isOtel: false,
+      })
+    );
+
+    expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricsExplorerOptions: expect.objectContaining({
+          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          metrics: expect.arrayContaining([
+            expect.objectContaining({ field: SYSTEM_CPU_CORES }),
+            expect.objectContaining({ field: SYSTEM_CPU_TOTAL_NORM_PCT }),
+            expect.objectContaining({ field: SYSTEM_MEMORY_TOTAL }),
+            expect.objectContaining({ field: SYSTEM_MEMORY_USED_PCT }),
+          ]),
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
@@ -64,11 +64,11 @@ type HostMetricsFieldsOtel =
   | typeof SEMCONV_SYSTEM_MEMORY_UTILIZATION;
 
 const hostsMetricsQueryConfigOtel: MetricsQueryOptions<HostMetricsFieldsOtel> = {
-  sourceFilter:  { 
-    term: { 
+  sourceFilter: {
+    term: {
       'event.dataset': 'hostmetricsreceiver.otel',
-     },
     },
+  },
   groupByField: 'host.name',
   metricsMap: {
     [SEMCONV_SYSTEM_CPU_LOGICAL_COUNT]: {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
@@ -19,12 +19,22 @@ import {
   scaleUpPercentage,
   useInfrastructureNodeMetrics,
 } from '../shared';
+import {
+  SEMCONV_SYSTEM_CPU_LOGICAL_COUNT,
+  SEMCONV_SYSTEM_CPU_UTILIZATION,
+  SEMCONV_SYSTEM_MEMORY_LIMIT,
+  SEMCONV_SYSTEM_MEMORY_UTILIZATION,
+  SYSTEM_CPU_CORES,
+  SYSTEM_CPU_TOTAL_NORM_PCT,
+  SYSTEM_MEMORY_TOTAL,
+  SYSTEM_MEMORY_USED_PCT,
+} from '../shared/constants';
 
 type HostMetricsField =
-  | 'system.cpu.cores'
-  | 'system.cpu.total.norm.pct'
-  | 'system.memory.total'
-  | 'system.memory.used.pct';
+  | typeof SYSTEM_CPU_CORES
+  | typeof SYSTEM_CPU_TOTAL_NORM_PCT
+  | typeof SYSTEM_MEMORY_TOTAL
+  | typeof SYSTEM_MEMORY_USED_PCT;
 
 const hostsMetricsQueryConfig: MetricsQueryOptions<HostMetricsField> = {
   sourceFilter: {
@@ -34,19 +44,51 @@ const hostsMetricsQueryConfig: MetricsQueryOptions<HostMetricsField> = {
   },
   groupByField: 'host.name',
   metricsMap: {
-    'system.cpu.cores': { aggregation: 'max', field: 'system.cpu.cores' },
-    'system.cpu.total.norm.pct': {
+    [SYSTEM_CPU_CORES]: { aggregation: 'max', field: SYSTEM_CPU_CORES },
+    [SYSTEM_CPU_TOTAL_NORM_PCT]: {
       aggregation: 'avg',
-      field: 'system.cpu.total.norm.pct',
+      field: SYSTEM_CPU_TOTAL_NORM_PCT,
     },
-    'system.memory.total': { aggregation: 'max', field: 'system.memory.total' },
-    'system.memory.used.pct': {
+    [SYSTEM_MEMORY_TOTAL]: { aggregation: 'max', field: SYSTEM_MEMORY_TOTAL },
+    [SYSTEM_MEMORY_USED_PCT]: {
       aggregation: 'avg',
-      field: 'system.memory.used.pct',
+      field: SYSTEM_MEMORY_USED_PCT,
     },
   },
 };
 
+type HostMetricsFieldsOtel =
+  | typeof SEMCONV_SYSTEM_CPU_LOGICAL_COUNT
+  | typeof SEMCONV_SYSTEM_CPU_UTILIZATION
+  | typeof SEMCONV_SYSTEM_MEMORY_LIMIT
+  | typeof SEMCONV_SYSTEM_MEMORY_UTILIZATION;
+
+const hostsMetricsQueryConfigOtel: MetricsQueryOptions<HostMetricsFieldsOtel> = {
+  sourceFilter:  { 
+    term: { 
+      'event.dataset': 'hostmetricsreceiver.otel',
+     },
+    },
+  groupByField: 'host.name',
+  metricsMap: {
+    [SEMCONV_SYSTEM_CPU_LOGICAL_COUNT]: {
+      aggregation: 'max',
+      field: SEMCONV_SYSTEM_CPU_LOGICAL_COUNT,
+    },
+    [SEMCONV_SYSTEM_CPU_UTILIZATION]: {
+      aggregation: 'avg',
+      field: SEMCONV_SYSTEM_CPU_UTILIZATION,
+    },
+    [SEMCONV_SYSTEM_MEMORY_LIMIT]: {
+      aggregation: 'max',
+      field: SEMCONV_SYSTEM_MEMORY_LIMIT,
+    },
+    [SEMCONV_SYSTEM_MEMORY_UTILIZATION]: {
+      aggregation: 'avg',
+      field: SEMCONV_SYSTEM_MEMORY_UTILIZATION,
+    },
+  },
+};
 export const metricByField = createMetricByFieldLookup(hostsMetricsQueryConfig.metricsMap);
 const unpackMetric = makeUnpackMetric(metricByField);
 
@@ -62,6 +104,7 @@ export function useHostMetricsTable({
   timerange,
   filterClauseDsl,
   metricsClient,
+  isOtel,
 }: UseNodeMetricsTableOptions) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [sortState, setSortState] = useState<SortState<HostNodeMetricsRow>>({
@@ -74,8 +117,12 @@ export function useHostMetricsTable({
     [filterClauseDsl]
   );
 
-  const { data, isLoading } = useInfrastructureNodeMetrics<HostNodeMetricsRow>({
-    metricsExplorerOptions: hostMetricsOptions,
+  const { options: hostMetricsOptionsOtel } = useMemo(
+    () => metricsToApiOptions(hostsMetricsQueryConfigOtel, filterClauseDsl),
+    [filterClauseDsl]
+  );
+  const { data, isLoading, metricIndices } = useInfrastructureNodeMetrics<HostNodeMetricsRow>({
+    metricsExplorerOptions: isOtel ? hostMetricsOptionsOtel : hostMetricsOptions,
     timerange,
     transform: seriesToHostNodeMetricsRow,
     sortState,
@@ -86,6 +133,7 @@ export function useHostMetricsTable({
   return {
     data,
     isLoading,
+    metricIndices,
     setCurrentPageIndex,
     setSortState,
     sortState,
@@ -189,9 +237,9 @@ function collectMetricValues(rows: MetricsExplorerRow[]) {
 
 function unpackMetrics(row: MetricsExplorerRow): Omit<HostNodeMetricsRow, 'name'> {
   return {
-    cpuCount: unpackMetric(row, 'system.cpu.cores'),
-    averageCpuUsagePercent: unpackMetric(row, 'system.cpu.total.norm.pct'),
-    totalMemoryMegabytes: unpackMetric(row, 'system.memory.total'),
-    averageMemoryUsagePercent: unpackMetric(row, 'system.memory.used.pct'),
+    cpuCount: unpackMetric(row, SYSTEM_CPU_CORES),
+    averageCpuUsagePercent: unpackMetric(row, SYSTEM_CPU_TOTAL_NORM_PCT),
+    totalMemoryMegabytes: unpackMetric(row, SYSTEM_MEMORY_TOTAL),
+    averageMemoryUsagePercent: unpackMetric(row, SYSTEM_MEMORY_USED_PCT),
   };
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/create_lazy_pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/create_lazy_pod_metrics_table.tsx
@@ -13,7 +13,7 @@ import type { NodeMetricsTableProps } from '../shared';
 const LazyIntegratedPodMetricsTable = lazy(() => import('./integrated_pod_metrics_table'));
 
 export function createLazyPodMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId }: NodeMetricsTableProps) => {
+  return ({ timerange, filterClauseDsl, sourceId, isOtel }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedPodMetricsTable
@@ -22,6 +22,7 @@ export function createLazyPodMetricsTable(core: CoreStart, metricsClient: Metric
           sourceId={sourceId || 'default'}
           timerange={timerange}
           filterClauseDsl={filterClauseDsl}
+          isOtel={isOtel}
         />
       </Suspense>
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
@@ -13,11 +13,16 @@ import { usePodMetricsTable } from './use_pod_metrics_table';
 
 function HookedPodMetricsTable({
   timerange,
-filterClauseDsl,
+  filterClauseDsl,
   metricsClient,
   isOtel,
 }: UseNodeMetricsTableOptions) {
-  const podMetricsTableProps = usePodMetricsTable({ timerange, filterClauseDsl, metricsClient, isOtel });
+  const podMetricsTableProps = usePodMetricsTable({
+    timerange,
+    filterClauseDsl,
+    metricsClient,
+    isOtel,
+  });
   return (
     <PodMetricsTable
       {...podMetricsTableProps}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
@@ -13,11 +13,18 @@ import { usePodMetricsTable } from './use_pod_metrics_table';
 
 function HookedPodMetricsTable({
   timerange,
-  filterClauseDsl,
+filterClauseDsl,
   metricsClient,
+  isOtel,
 }: UseNodeMetricsTableOptions) {
-  const podMetricsTableProps = usePodMetricsTable({ timerange, filterClauseDsl, metricsClient });
-  return <PodMetricsTable {...podMetricsTableProps} />;
+  const podMetricsTableProps = usePodMetricsTable({ timerange, filterClauseDsl, metricsClient, isOtel });
+  return (
+    <PodMetricsTable
+      {...podMetricsTableProps}
+      isOtel={isOtel}
+      metricIndices={podMetricsTableProps.metricIndices}
+    />
+  );
 }
 
 function PodMetricsTableWithProviders({
@@ -25,6 +32,7 @@ function PodMetricsTableWithProviders({
   filterClauseDsl,
   sourceId,
   metricsClient,
+  isOtel,
   ...coreProvidersProps
 }: IntegratedNodeMetricsTableProps) {
   return (
@@ -33,6 +41,7 @@ function PodMetricsTableWithProviders({
         timerange={timerange}
         filterClauseDsl={filterClauseDsl}
         metricsClient={metricsClient}
+        isOtel={isOtel}
       />
     </CoreProviders>
   );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.stories.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.stories.tsx
@@ -17,12 +17,18 @@ import type { PodNodeMetricsRow } from './use_pod_metrics_table';
 
 const mockServices = {
   application: {
+    currentAppId$: {
+      subscribe: (callback: (appId: string) => void) => {
+        callback('mock-app-id');
+        return { unsubscribe: () => {} };
+      },
+    },
     getUrlForApp: (app: string, { path }: { path: string }) => `your-kibana/app/${app}/${path}`,
   },
 };
 
 export default {
-  title: 'infra/Node Metrics Tables/Pod',
+  title: 'metrics_data_access/Node Metrics Tables/Pod',
   decorators: [
     (wrappedStory) => <EuiCard title="Pod metrics">{wrappedStory()}</EuiCard>,
     (wrappedStory) => (
@@ -62,31 +68,31 @@ const loadedPods: PodNodeMetricsRow[] = [
     id: '358d96e3-026f-4440-a487-f6c2301884c0',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg1',
     averageCpuUsagePercent: 99,
-    averageMemoryUsageMegabytes: 34,
+    averageMemoryUsagePercent: 34,
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c1',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg2',
     averageCpuUsagePercent: 72,
-    averageMemoryUsageMegabytes: 68,
+    averageMemoryUsagePercent: 68,
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c0',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg3',
     averageCpuUsagePercent: 54,
-    averageMemoryUsageMegabytes: 132,
+    averageMemoryUsagePercent: 132,
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c0',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg4',
     averageCpuUsagePercent: 34,
-    averageMemoryUsageMegabytes: 264,
+    averageMemoryUsagePercent: 264,
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c0',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg5',
     averageCpuUsagePercent: 13,
-    averageMemoryUsageMegabytes: 512,
+    averageMemoryUsagePercent: 512,
   },
 ];
 
@@ -101,7 +107,7 @@ export const Basic = {
     data: {
       state: 'data',
       currentPageIndex: 1,
-      pageCount: 10,
+      pageCount: 1,
       rows: loadedPods,
     },
   },
@@ -168,5 +174,28 @@ export const FailedToLoadMetrics = {
       state: 'error',
       errors: [new Error('Failed to load metrics')],
     },
+  },
+};
+
+export const BasicWithSemconv = {
+  render: Template,
+
+  args: {
+    data: {
+      state: 'data',
+      currentPageIndex: 1,
+      pageCount: 10,
+      rows: loadedPods,
+    },
+    isOtel: true,
+  },
+};
+
+export const LoadingWithSemconv = {
+  render: Template,
+
+  args: {
+    isLoading: true,
+    isOtel: true,
   },
 };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
@@ -13,6 +13,7 @@ import { createStartServicesAccessorMock, createMetricsClientMock } from '../tes
 import { createLazyPodMetricsTable } from './create_lazy_pod_metrics_table';
 import IntegratedPodMetricsTable from './integrated_pod_metrics_table';
 import { PodMetricsTable } from './pod_metrics_table';
+import { ECS_POD_CPU_USAGE_LIMIT_PCT, MEMORY_LIMIT_UTILIZATION } from '../shared/constants';
 import { metricByField } from './use_pod_metrics_table';
 
 jest.mock('../../../pages/link_to/use_asset_details_redirect', () => ({
@@ -156,8 +157,8 @@ function createPod(
     keys: [id, name],
     rows: [
       {
-        [metricByField['kubernetes.pod.cpu.usage.limit.pct']]: cpuUsagePct,
-        [metricByField['kubernetes.pod.memory.usage.bytes']]: memoryUsageBytes,
+        [metricByField[ECS_POD_CPU_USAGE_LIMIT_PCT]]: cpuUsagePct,
+        [metricByField[MEMORY_LIMIT_UTILIZATION]]: memoryUsageBytes,
       } as MetricsExplorerSeries['rows'][number],
     ],
   };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -68,10 +68,13 @@ describe('usePodMetricsTable hook', () => {
         filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
       },
     };
-    
+
     const filterClauseWithEventModuleFilter = {
       bool: {
-        filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }, { ...filterClauseDsl }],
+        filter: [
+          { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
+          { ...filterClauseDsl },
+        ],
       },
     };
 
@@ -110,13 +113,12 @@ describe('usePodMetricsTable hook', () => {
         filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
       },
     };
-    
+
     const filterClauseWithEventModuleFilter = {
       bool: {
         filter: [{ term: { 'event.dataset': 'kubernetes.pod' } }, { ...filterClauseDsl }],
       },
     };
-
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -5,6 +5,11 @@
  * 2.0.
  */
 
+import {
+  ECS_POD_CPU_USAGE_LIMIT_PCT,
+  MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION,
+} from '../shared/constants';
 import { usePodMetricsTable } from './use_pod_metrics_table';
 import { useInfrastructureNodeMetrics } from '../shared';
 import { renderHook } from '@testing-library/react';
@@ -23,7 +28,7 @@ describe('usePodMetricsTable hook', () => {
   it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
     const filterClauseDsl = {
       bool: {
-        filter: [{ terms: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
       },
     };
 
@@ -37,6 +42,7 @@ describe('usePodMetricsTable hook', () => {
     useInfrastructureNodeMetricsMock.mockReturnValue({
       isLoading: true,
       data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
     });
 
     renderHook(() =>
@@ -51,6 +57,91 @@ describe('usePodMetricsTable hook', () => {
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
           filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+        }),
+      })
+    );
+  });
+
+  it('should call useInfrastructureNodeMetrics with OTEL/semconv metrics when isOtel is true', () => {
+    const filterClauseDsl = {
+      bool: {
+        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+      },
+    };
+    
+    const filterClauseWithEventModuleFilter = {
+      bool: {
+        filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }, { ...filterClauseDsl }],
+      },
+    };
+
+    // include this to prevent rendering error in test
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      usePodMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        filterClauseDsl,
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+      })
+    );
+
+    expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricsExplorerOptions: expect.objectContaining({
+          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          metrics: expect.arrayContaining([
+            expect.objectContaining({ field: SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION }),
+            expect.objectContaining({ field: MEMORY_LIMIT_UTILIZATION }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {
+    const filterClauseDsl = {
+      bool: {
+        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
+      },
+    };
+    
+    const filterClauseWithEventModuleFilter = {
+      bool: {
+        filter: [{ term: { 'event.dataset': 'kubernetes.pod' } }, { ...filterClauseDsl }],
+      },
+    };
+
+
+    // include this to prevent rendering error in test
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      usePodMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        filterClauseDsl,
+        metricsClient: createMetricsClientMock({}),
+        isOtel: false,
+      })
+    );
+
+    expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricsExplorerOptions: expect.objectContaining({
+          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          metrics: expect.arrayContaining([
+            expect.objectContaining({ field: ECS_POD_CPU_USAGE_LIMIT_PCT }),
+            expect.objectContaining({ field: MEMORY_LIMIT_UTILIZATION }),
+          ]),
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
@@ -19,8 +19,16 @@ import {
   scaleUpPercentage,
   useInfrastructureNodeMetrics,
 } from '../shared';
+import {
+  ECS_POD_CPU_USAGE_LIMIT_PCT,
+  KUBERNETES_NODE_MEMORY_ALLOCATABLE_BYTES,
+  KUBERNETES_NODE_MEMORY_USAGE_BYTES,
+  MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION,
+  SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+} from '../shared/constants';
 
-type PodMetricsField = 'kubernetes.pod.cpu.usage.limit.pct' | 'kubernetes.pod.memory.usage.bytes';
+type PodMetricsField = typeof ECS_POD_CPU_USAGE_LIMIT_PCT | typeof MEMORY_LIMIT_UTILIZATION;
 
 const podMetricsQueryConfig: MetricsQueryOptions<PodMetricsField> = {
   sourceFilter: {
@@ -30,13 +38,59 @@ const podMetricsQueryConfig: MetricsQueryOptions<PodMetricsField> = {
   },
   groupByField: ['kubernetes.pod.uid', 'kubernetes.pod.name'],
   metricsMap: {
-    'kubernetes.pod.cpu.usage.limit.pct': {
+    [ECS_POD_CPU_USAGE_LIMIT_PCT]: {
       aggregation: 'avg',
-      field: 'kubernetes.pod.cpu.usage.limit.pct',
+      field: ECS_POD_CPU_USAGE_LIMIT_PCT,
     },
-    'kubernetes.pod.memory.usage.bytes': {
+    [MEMORY_LIMIT_UTILIZATION]: {
+      aggregation: 'custom',
+      field: MEMORY_LIMIT_UTILIZATION,
+      custom_metrics: [
+        {
+          name: 'A',
+          aggregation: 'max',
+          field: KUBERNETES_NODE_MEMORY_ALLOCATABLE_BYTES,
+        },
+        {
+          name: 'B',
+          aggregation: 'avg',
+          field: KUBERNETES_NODE_MEMORY_USAGE_BYTES,
+        },
+      ],
+      equation: 'B / A',
+    },
+  },
+};
+
+type PodMetricsFieldsOtel =
+  | typeof SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION
+  | typeof MEMORY_LIMIT_UTILIZATION;
+
+const podMetricsQueryConfigOtel: MetricsQueryOptions<PodMetricsFieldsOtel> = {
+  sourceFilter: {
+    term: {
+      'event.dataset': 'kubeletstatsreceiver.otel',
+    },
+  },
+  groupByField: ['k8s.pod.uid', 'k8s.pod.name'],
+  metricsMap: {
+    // this is an optional field and wont populate unless specifically enabled in kubeletstatreceiver.
+    // There are not pod metrics that can derive this value.
+    [SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION]: {
       aggregation: 'avg',
-      field: 'kubernetes.pod.memory.usage.bytes',
+      field: SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION, // this is an opt-in field.
+    },
+    [MEMORY_LIMIT_UTILIZATION]: {
+      field: MEMORY_LIMIT_UTILIZATION,
+      aggregation: 'custom',
+      custom_metrics: [
+        {
+          name: 'A',
+          aggregation: 'avg',
+          field: SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+        },
+      ],
+      equation: 'A',
     },
   },
 };
@@ -48,13 +102,14 @@ export interface PodNodeMetricsRow {
   id: string;
   name: string;
   averageCpuUsagePercent: number | null;
-  averageMemoryUsageMegabytes: number | null;
+  averageMemoryUsagePercent: number | null;
 }
 
 export function usePodMetricsTable({
   timerange,
   filterClauseDsl,
   metricsClient,
+  isOtel,
 }: UseNodeMetricsTableOptions) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [sortState, setSortState] = useState<SortState<PodNodeMetricsRow>>({
@@ -67,8 +122,13 @@ export function usePodMetricsTable({
     [filterClauseDsl]
   );
 
-  const { data, isLoading } = useInfrastructureNodeMetrics<PodNodeMetricsRow>({
-    metricsExplorerOptions: podMetricsOptions,
+  const { options: podMetricsOptionsOtel } = useMemo(
+    () => metricsToApiOptions(podMetricsQueryConfigOtel, filterClauseDsl),
+    [filterClauseDsl]
+  );
+
+  const { data, isLoading, metricIndices } = useInfrastructureNodeMetrics<PodNodeMetricsRow>({
+    metricsExplorerOptions: isOtel ? podMetricsOptionsOtel : podMetricsOptions,
     timerange,
     transform: seriesToPodNodeMetricsRow,
     sortState,
@@ -80,6 +140,7 @@ export function usePodMetricsTable({
     currentPageIndex,
     data,
     isLoading,
+    metricIndices,
     setCurrentPageIndex,
     setSortState,
     sortState,
@@ -105,12 +166,12 @@ function rowWithoutMetrics(id: string, name: string) {
     id,
     name,
     averageCpuUsagePercent: null,
-    averageMemoryUsageMegabytes: null,
+    averageMemoryUsagePercent: null,
   };
 }
 
 function calculateMetricAverages(rows: MetricsExplorerRow[]) {
-  const { averageCpuUsagePercentValues, averageMemoryUsageMegabytesValues } =
+  const { averageCpuUsagePercentValues, averageMemoryUsagePercentValues } =
     collectMetricValues(rows);
 
   let averageCpuUsagePercent = null;
@@ -118,44 +179,41 @@ function calculateMetricAverages(rows: MetricsExplorerRow[]) {
     averageCpuUsagePercent = scaleUpPercentage(averageOfValues(averageCpuUsagePercentValues));
   }
 
-  let averageMemoryUsageMegabytes = null;
-  if (averageMemoryUsageMegabytesValues.length !== 0) {
-    const averageInBytes = averageOfValues(averageMemoryUsageMegabytesValues);
-    const bytesPerMegabyte = 1000000;
-    averageMemoryUsageMegabytes = Math.floor(averageInBytes / bytesPerMegabyte);
+  let averageMemoryUsagePercent = null;
+  if (averageMemoryUsagePercentValues.length !== 0) {
+    averageMemoryUsagePercent = scaleUpPercentage(averageOfValues(averageMemoryUsagePercentValues));
   }
-
   return {
     averageCpuUsagePercent,
-    averageMemoryUsageMegabytes,
+    averageMemoryUsagePercent,
   };
 }
 
 function collectMetricValues(rows: MetricsExplorerRow[]) {
   const averageCpuUsagePercentValues: number[] = [];
-  const averageMemoryUsageMegabytesValues: number[] = [];
+  const averageMemoryUsagePercentValues: number[] = [];
 
   rows.forEach((row) => {
-    const { averageCpuUsagePercent, averageMemoryUsageMegabytes } = unpackMetrics(row);
+    const { averageCpuUsagePercent, averageMemoryUsagePercent } = unpackMetrics(row);
 
     if (averageCpuUsagePercent !== null) {
       averageCpuUsagePercentValues.push(averageCpuUsagePercent);
     }
 
-    if (averageMemoryUsageMegabytes !== null) {
-      averageMemoryUsageMegabytesValues.push(averageMemoryUsageMegabytes);
+    if (averageMemoryUsagePercent !== null) {
+      averageMemoryUsagePercentValues.push(averageMemoryUsagePercent);
     }
   });
 
   return {
     averageCpuUsagePercentValues,
-    averageMemoryUsageMegabytesValues,
+    averageMemoryUsagePercentValues,
   };
 }
 
 function unpackMetrics(row: MetricsExplorerRow): Omit<PodNodeMetricsRow, 'id' | 'name'> {
   return {
-    averageCpuUsagePercent: unpackMetric(row, 'kubernetes.pod.cpu.usage.limit.pct'),
-    averageMemoryUsageMegabytes: unpackMetric(row, 'kubernetes.pod.memory.usage.bytes'),
+    averageCpuUsagePercent: unpackMetric(row, ECS_POD_CPU_USAGE_LIMIT_PCT),
+    averageMemoryUsagePercent: unpackMetric(row, MEMORY_LIMIT_UTILIZATION),
   };
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.test.tsx
@@ -1,0 +1,296 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { coreMock } from '@kbn/core/public/mocks';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { createKibanaContextForPlugin } from '../../../../hooks/use_kibana';
+import { MetricsNodeDetailsLink } from './metrics_node_details_link';
+
+const DISCOVER_APP_LOCATOR_ID = 'DISCOVER_APP_LOCATOR';
+const ASSET_HREF = '/app/metrics/link-to/asset-detail';
+const DISCOVER_HREF = '/app/discover#/';
+
+const mockGetAssetDetailUrl = jest.fn(() => ({
+  href: ASSET_HREF,
+  onClick: jest.fn(),
+}));
+
+jest.mock('../../../../pages/link_to/use_asset_details_redirect', () => ({
+  useAssetDetailsRedirect: () => ({
+    getAssetDetailUrl: mockGetAssetDetailUrl,
+  }),
+}));
+
+function createDiscoverLocatorMock() {
+  const getRedirectUrl = jest.fn((params: { query?: { esql?: string }; timeRange?: unknown }) => {
+    return params?.query?.esql ? DISCOVER_HREF : '#';
+  });
+  const navigate = jest.fn();
+  return { getRedirectUrl, navigate };
+}
+
+function createWrapper(discoverLocator = createDiscoverLocatorMock()) {
+  const core = coreMock.createStart();
+  core.i18n.Context.mockImplementation(I18nProvider as () => JSX.Element);
+
+  const share = {
+    url: {
+      locators: {
+        get: (id: string) => (id === DISCOVER_APP_LOCATOR_ID ? discoverLocator : undefined),
+      },
+    },
+  };
+
+  const services = { ...core, share: share as any };
+  const { Provider: KibanaContextProviderForPlugin } = createKibanaContextForPlugin(services);
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <KibanaRenderContextProvider {...core}>
+        <KibanaContextProviderForPlugin services={services}>
+          {children}
+        </KibanaContextProviderForPlugin>
+      </KibanaRenderContextProvider>
+    );
+  };
+}
+
+const defaultProps = {
+  id: 'my-container-id',
+  label: 'my-container',
+  nodeType: 'container' as const,
+  timerange: { from: 'now-15m', to: 'now' },
+};
+
+describe('MetricsNodeDetailsLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when isOtel is true and nodeType is not host', () => {
+    it('navigates to Discover with ES|QL query for container', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink
+          {...defaultProps}
+          isOtel={true}
+          nodeType="container"
+          id="abc-123"
+        />,
+        { wrapper: Wrapper }
+      );
+
+      expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            esql: 'TS "metrics-*"\n| WHERE `container.id`=="abc-123"',
+          },
+          timeRange: { from: 'now-15m', to: 'now' },
+        })
+      );
+      expect(mockGetAssetDetailUrl).not.toHaveBeenCalled();
+    });
+
+    it('navigates to Discover with ES|QL query for pod', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink {...defaultProps} isOtel={true} nodeType="pod" id="pod-uid-456" />,
+        { wrapper: Wrapper }
+      );
+
+      expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            esql: 'TS "metrics-*"\n| WHERE `k8s.pod.uid`=="pod-uid-456"',
+          },
+          timeRange: { from: 'now-15m', to: 'now' },
+        })
+      );
+      expect(mockGetAssetDetailUrl).not.toHaveBeenCalled();
+    });
+
+    it('uses metricIndices in ES|QL when provided', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink
+          {...defaultProps}
+          isOtel={true}
+          nodeType="container"
+          id="abc-123"
+          metricsIndices="my-metrics-*"
+        />,
+        { wrapper: Wrapper }
+      );
+
+      expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            esql: 'TS "my-metrics-*"\n| WHERE `container.id`=="abc-123"',
+          },
+          timeRange: { from: 'now-15m', to: 'now' },
+        })
+      );
+    });
+
+    it('falls back to metrics-* when metricIndices is not provided', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink {...defaultProps} isOtel={true} nodeType="container" id="x" />,
+        { wrapper: Wrapper }
+      );
+
+      expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            esql: 'TS "metrics-*"\n| WHERE `container.id`=="x"',
+          },
+          timeRange: { from: 'now-15m', to: 'now' },
+        })
+      );
+    });
+
+    it('escapes double quotes in entity id in ES|QL', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink
+          {...defaultProps}
+          isOtel={true}
+          nodeType="container"
+          id='id-with-"quote"'
+        />,
+        { wrapper: Wrapper }
+      );
+
+      expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            esql: 'TS "metrics-*"\n| WHERE `container.id`=="id-with-\\"quote\\""',
+          },
+          timeRange: { from: 'now-15m', to: 'now' },
+        })
+      );
+    });
+  });
+
+  describe('when isOtel is true and nodeType is host', () => {
+    it('uses asset details redirect, not Discover', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink
+          {...defaultProps}
+          isOtel={true}
+          nodeType="host"
+          id="host-01"
+          label="host-01"
+        />,
+        { wrapper: Wrapper }
+      );
+
+      expect(mockGetAssetDetailUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetType: 'host',
+          assetId: 'host-01',
+          search: expect.objectContaining({ name: 'host-01' }),
+        })
+      );
+      expect(discoverLocator.getRedirectUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when isOtel is false or undefined', () => {
+    it('uses asset details redirect for container when isOtel is false', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink
+          {...defaultProps}
+          isOtel={false}
+          nodeType="container"
+          id="abc-123"
+          label="my-container"
+        />,
+        { wrapper: Wrapper }
+      );
+
+      expect(mockGetAssetDetailUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetType: 'container',
+          assetId: 'abc-123',
+          search: expect.objectContaining({ name: 'my-container' }),
+        })
+      );
+      expect(discoverLocator.getRedirectUrl).not.toHaveBeenCalled();
+    });
+
+    it('uses asset details redirect when isOtel is undefined', () => {
+      const discoverLocator = createDiscoverLocatorMock();
+      const Wrapper = createWrapper(discoverLocator);
+
+      render(
+        <MetricsNodeDetailsLink {...defaultProps} nodeType="pod" id="pod-1" label="my-pod" />,
+        { wrapper: Wrapper }
+      );
+
+      expect(mockGetAssetDetailUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetType: 'pod',
+          assetId: 'pod-1',
+        })
+      );
+      expect(discoverLocator.getRedirectUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('render', () => {
+    it('renders link with label', () => {
+      const Wrapper = createWrapper();
+
+      render(<MetricsNodeDetailsLink {...defaultProps} label="My Container Label" />, {
+        wrapper: Wrapper,
+      });
+
+      const link = screen.getByTestId('infraMetricsNodeDetailsLinkLink');
+      expect(link).toHaveTextContent('My Container Label');
+    });
+
+    it('uses Discover href when redirecting to Discover', () => {
+      const Wrapper = createWrapper();
+
+      render(<MetricsNodeDetailsLink {...defaultProps} isOtel={true} nodeType="container" />, {
+        wrapper: Wrapper,
+      });
+
+      const link = screen.getByRole('link', { name: defaultProps.label });
+      expect(link).toHaveAttribute('href', DISCOVER_HREF);
+    });
+
+    it('uses asset details href when not redirecting to Discover', () => {
+      const Wrapper = createWrapper();
+
+      render(<MetricsNodeDetailsLink {...defaultProps} />, { wrapper: Wrapper });
+
+      const link = screen.getByRole('link', { name: defaultProps.label });
+      expect(link).toHaveAttribute('href', ASSET_HREF);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.test.tsx
@@ -92,7 +92,7 @@ describe('MetricsNodeDetailsLink', () => {
       expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
-            esql: 'TS "metrics-*"\n| WHERE `container.id`=="abc-123"',
+            esql: 'FROM "metrics-*"\n| WHERE `container.id`=="abc-123"',
           },
           timeRange: { from: 'now-15m', to: 'now' },
         })
@@ -112,7 +112,7 @@ describe('MetricsNodeDetailsLink', () => {
       expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
-            esql: 'TS "metrics-*"\n| WHERE `k8s.pod.uid`=="pod-uid-456"',
+            esql: 'FROM "metrics-*"\n| WHERE `k8s.pod.uid`=="pod-uid-456"',
           },
           timeRange: { from: 'now-15m', to: 'now' },
         })
@@ -138,7 +138,7 @@ describe('MetricsNodeDetailsLink', () => {
       expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
-            esql: 'TS "my-metrics-*"\n| WHERE `container.id`=="abc-123"',
+            esql: 'FROM "my-metrics-*"\n| WHERE `container.id`=="abc-123"',
           },
           timeRange: { from: 'now-15m', to: 'now' },
         })
@@ -157,7 +157,7 @@ describe('MetricsNodeDetailsLink', () => {
       expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
-            esql: 'TS "metrics-*"\n| WHERE `container.id`=="x"',
+            esql: 'FROM "metrics-*"\n| WHERE `container.id`=="x"',
           },
           timeRange: { from: 'now-15m', to: 'now' },
         })
@@ -181,7 +181,7 @@ describe('MetricsNodeDetailsLink', () => {
       expect(discoverLocator.getRedirectUrl).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {
-            esql: 'TS "metrics-*"\n| WHERE `container.id`=="id-with-\\"quote\\""',
+            esql: 'FROM "metrics-*"\n| WHERE `container.id`=="id-with-\\"quote\\""',
           },
           timeRange: { from: 'now-15m', to: 'now' },
         })

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
@@ -5,19 +5,73 @@
  * 2.0.
  */
 
+import React, { useMemo } from 'react';
 import { parse } from '@kbn/datemath';
 import { EuiLink } from '@elastic/eui';
-import React from 'react';
+import { appendWhereClauseToESQLQuery } from '@kbn/esql-utils';
 import type { InventoryItemType } from '../../../../../common/inventory_models/types';
+import { useKibanaContextForPlugin } from '../../../../hooks/use_kibana';
 import { useAssetDetailsRedirect } from '../../../../pages/link_to/use_asset_details_redirect';
 
+const DISCOVER_APP_LOCATOR_ID = 'DISCOVER_APP_LOCATOR';
+
+/** Fallback index pattern when infrastructure metric indices are not available. */
+const DEFAULT_METRICS_INDEX = 'metrics-*';
+
 type ExtractStrict<T, U extends T> = Extract<T, U>;
+type NodeTypeForLink = ExtractStrict<InventoryItemType, 'host' | 'container' | 'pod'>;
 
 interface MetricsNodeDetailsLinkProps {
   id: string;
   label: string;
-  nodeType: ExtractStrict<InventoryItemType, 'host' | 'container' | 'pod'>;
+  nodeType: NodeTypeForLink;
   timerange: { from: string; to: string };
+  isOtel?: boolean;
+  /** Infrastructure/metrics index pattern from settings; used for Discover ES|QL when isOtel is true. */
+  metricsIndices?: string;
+}
+
+/** Escape index pattern for use inside an ES|QL double-quoted string. */
+function escapeEsqlStringLiteral(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Build an ES|QL query string that filters by the given node type and entity id.
+ * Uses @kbn/esql-utils for safe WHERE clause appending (escaping and parsing).
+ */
+function getDiscoverEsqlQueryForNode(
+  nodeType: NodeTypeForLink,
+  entityId: string,
+  indexPattern: string
+): string {
+  const from = indexPattern || DEFAULT_METRICS_INDEX;
+  const baseQuery = `TS "${escapeEsqlStringLiteral(from)}"`;
+
+  switch (nodeType) {
+    case 'container': {
+      const withWhere = appendWhereClauseToESQLQuery(
+        baseQuery,
+        'container.id',
+        entityId,
+        '+',
+        'string'
+      );
+      return withWhere ?? baseQuery;
+    }
+    case 'pod': {
+      const withWhere = appendWhereClauseToESQLQuery(
+        baseQuery,
+        'k8s.pod.uid',
+        entityId,
+        '+',
+        'string'
+      );
+      return withWhere ?? baseQuery;
+    }
+    default:
+      return baseQuery;
+  }
 }
 
 export const MetricsNodeDetailsLink = ({
@@ -25,20 +79,71 @@ export const MetricsNodeDetailsLink = ({
   label,
   nodeType,
   timerange,
+  isOtel,
+  metricsIndices,
 }: MetricsNodeDetailsLinkProps) => {
+  const { share } = useKibanaContextForPlugin().services;
   const { getAssetDetailUrl } = useAssetDetailsRedirect();
-  const linkProps = getAssetDetailUrl({
-    assetType: nodeType,
-    assetId: id,
-    search: {
-      name: label,
-      from: parse(timerange.from)?.valueOf(),
-      to: parse(timerange.to)?.valueOf(),
-    },
-  });
+
+
+  const redirectToDiscover = isOtel && nodeType !== 'host';
+
+  const linkProps = useMemo(() => {
+    if (redirectToDiscover) {
+      const discoverLocator = share?.url?.locators?.get(DISCOVER_APP_LOCATOR_ID);
+      const esqlQuery = getDiscoverEsqlQueryForNode(
+        nodeType,
+        id,
+        metricsIndices ?? DEFAULT_METRICS_INDEX
+      );
+      const discoverParams = {
+        timeRange: { from: timerange.from, to: timerange.to },
+        query: {
+          esql: esqlQuery,
+        },
+      };
+      const href = discoverLocator?.getRedirectUrl(discoverParams) ?? '#';
+      return {
+        href,
+        onClick: (e: React.MouseEvent) => {
+          if (discoverLocator) {
+            e.preventDefault();
+            discoverLocator.navigate(discoverParams);
+          }
+        },
+      };
+    }
+
+    const assetDetails = getAssetDetailUrl({
+      assetType: nodeType,
+      assetId: id,
+      search: {
+        name: label,
+        from: parse(timerange.from)?.valueOf(),
+        to: parse(timerange.to)?.valueOf(),
+      },
+    });
+    return { href: assetDetails.href, onClick: assetDetails.onClick };
+  }, [
+    redirectToDiscover,
+    share?.url?.locators,
+    timerange.from,
+    timerange.to,
+    nodeType,
+    id,
+    label,
+    isOtel,
+    metricsIndices,
+    getAssetDetailUrl,
+  ]);
 
   return (
-    <EuiLink data-test-subj="infraMetricsNodeDetailsLinkLink" href={linkProps.href}>
+    // eslint-disable-next-line @elastic/eui/href-or-on-click -- onClick for programmatic navigation; href for "Open in new tab" and fallback
+    <EuiLink
+      data-test-subj="infraMetricsNodeDetailsLinkLink"
+      href={linkProps.href}
+      onClick={linkProps.onClick}
+    >
       {label}
     </EuiLink>
   );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
@@ -85,7 +85,6 @@ export const MetricsNodeDetailsLink = ({
   const { share } = useKibanaContextForPlugin().services;
   const { getAssetDetailUrl } = useAssetDetailsRedirect();
 
-
   const redirectToDiscover = isOtel && nodeType !== 'host';
 
   const linkProps = useMemo(() => {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
@@ -46,7 +46,7 @@ function getDiscoverEsqlQueryForNode(
   indexPattern: string
 ): string {
   const from = indexPattern || DEFAULT_METRICS_INDEX;
-  const baseQuery = `TS "${escapeEsqlStringLiteral(from)}"`;
+  const baseQuery = `FROM "${escapeEsqlStringLiteral(from)}"`;
 
   switch (nodeType) {
     case 'container': {
@@ -131,7 +131,6 @@ export const MetricsNodeDetailsLink = ({
     nodeType,
     id,
     label,
-    isOtel,
     metricsIndices,
     getAssetDetailUrl,
   ]);

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/constants.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/constants.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// --- Container metric field names ---
+
+/** ECS (Elastic Common Schema) container metric field names */
+export const ECS_CONTAINER_CPU_USAGE_LIMIT_PCT = 'kubernetes.container.cpu.usage.limit.pct';
+export const ECS_CONTAINER_MEMORY_USAGE_BYTES = 'kubernetes.container.memory.usage.bytes';
+
+/** SemConv K8s (Kubernetes container) metric field names */
+export const SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION =
+  'metrics.k8s.container.cpu_limit_utilization';
+export const SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION =
+  'metrics.k8s.container.memory_limit_utilization';
+
+/** SemConv container metric names used in UI tooltips (generic / display) */
+export const SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION = 'metrics.container.cpu.utilization';
+export const SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT = 'metrics.container.memory.percent';
+
+// --- Host metric field names ---
+
+/** ECS / system host metric field names */
+export const SYSTEM_CPU_CORES = 'system.cpu.cores';
+export const SYSTEM_CPU_TOTAL_NORM_PCT = 'system.cpu.total.norm.pct';
+export const SYSTEM_MEMORY_TOTAL = 'system.memory.total';
+export const SYSTEM_MEMORY_USED_PCT = 'system.memory.used.pct';
+
+/** SemConv (OpenTelemetry) host metric field names */
+export const SEMCONV_SYSTEM_CPU_LOGICAL_COUNT = 'metrics.system.cpu.logical.count';
+export const SEMCONV_SYSTEM_CPU_UTILIZATION = 'metrics.system.cpu.utilization';
+export const SEMCONV_SYSTEM_MEMORY_LIMIT = 'metrics.system.memory.limit';
+export const SEMCONV_SYSTEM_MEMORY_UTILIZATION = 'metrics.system.memory.utilization';
+
+// --- Pod metric field names ---
+
+/** ECS (Elastic Common Schema) pod metric field names */
+export const ECS_POD_CPU_USAGE_LIMIT_PCT = 'kubernetes.pod.cpu.usage.limit.pct';
+
+/** Derived/custom metric name used in both ECS and SemConv */
+export const MEMORY_LIMIT_UTILIZATION = 'memory_limit_utilization';
+
+/** ECS custom metric sub-fields (node memory for equation) */
+export const KUBERNETES_NODE_MEMORY_ALLOCATABLE_BYTES = 'kubernetes.node.memory.allocatable.bytes';
+export const KUBERNETES_NODE_MEMORY_USAGE_BYTES = 'kubernetes.node.memory.usage.bytes';
+
+/** SemConv K8s pod metric field names */
+export const SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION = 'metrics.k8s.pod.cpu_limit_utilization';
+export const SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION = 'metrics.k8s.pod.memory_limit_utilization';

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
+import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { ObjectValues } from '../../../../../common/utility_types';
 import type {
   MetricsExplorerOptions,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { ObjectValues } from '../../../../../common/utility_types';
 import type {
   MetricsExplorerOptions,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
@@ -177,6 +177,7 @@ export const useInfrastructureNodeMetrics = <T>(
   return {
     isLoading,
     data,
+    metricIndices,
   };
 };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { CoreProvidersProps } from '../../../apps/common_providers';
 import type { MetricsDataClient } from '../../../lib/metrics_client';
 
@@ -13,6 +13,7 @@ export interface UseNodeMetricsTableOptions {
   timerange: { from: string; to: string };
   filterClauseDsl?: QueryDslQueryContainer;
   metricsClient: MetricsDataClient;
+  isOtel?: boolean;
 }
 
 export interface SourceProviderProps {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
+import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { CoreProvidersProps } from '../../../apps/common_providers';
 import type { MetricsDataClient } from '../../../lib/metrics_client';
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/types.ts
@@ -8,7 +8,6 @@ import type { Search } from 'history';
 import type { Plugin as PluginClass } from '@kbn/core/public';
 import type { MetricsDataClient } from './lib/metrics_client';
 import type { NodeMetricsTableProps } from './components/infrastructure_node_metrics_tables/shared';
-
 export interface MetricsDataPluginSetup {
   metricsClient: MetricsDataClient;
 }
@@ -17,7 +16,9 @@ export interface MetricsDataPluginStart {
   metricsClient: MetricsDataClient;
   HostMetricsTable: (props: NodeMetricsTableProps) => JSX.Element;
   PodMetricsTable: (props: NodeMetricsTableProps) => JSX.Element;
-  ContainerMetricsTable: (props: NodeMetricsTableProps) => JSX.Element;
+  ContainerMetricsTable: (
+    props: NodeMetricsTableProps & { isK8sContainer?: boolean }
+  ) => JSX.Element;
 }
 
 export type MetricsDataPluginClass = PluginClass<MetricsDataPluginSetup, MetricsDataPluginStart>;

--- a/x-pack/solutions/observability/plugins/metrics_data_access/server/routes/metrics_explorer/index.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/server/routes/metrics_explorer/index.ts
@@ -23,6 +23,7 @@ import type { KibanaFramework } from '../../lib/adapters/framework/kibana_framew
 
 export const initMetricExplorerRoute = (framework: KibanaFramework) => {
   const validateBody = createRouteValidationFunction(metricsExplorerRequestBodyRT);
+
   framework.registerRoute(
     {
       method: 'post',

--- a/x-pack/solutions/observability/plugins/metrics_data_access/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/tsconfig.json
@@ -36,9 +36,7 @@
     "@kbn/react-kibana-context-render",
     "@kbn/react-kibana-context-theme",
     "@kbn/router-utils",
-    "@kbn/chart-expressions-common",
     "@kbn/observability-utils-common",
-    "@kbn/esql-ast",
     "@kbn/esql-utils"
   ]
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/tsconfig.json
@@ -36,6 +36,9 @@
     "@kbn/react-kibana-context-render",
     "@kbn/react-kibana-context-theme",
     "@kbn/router-utils",
-    "@kbn/observability-utils-common"
+    "@kbn/chart-expressions-common",
+    "@kbn/observability-utils-common",
+    "@kbn/esql-ast",
+    "@kbn/esql-utils"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Feature/infra tab otel update (#252188)](https://github.com/elastic/kibana/pull/252188)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bryce Buchanan","email":"75274611+bryce-b@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-19T23:14:16Z","message":"Feature/infra tab otel update (#252188)\n\n## Summary\nresolves https://github.com/elastic/observability-dev/issues/4976 &\nhttps://github.com/elastic/observability-dev/issues/5153\n\nThis PR adds support for Otel based entities in the APM infrastructure\ntab. It updates the queries to populate the tables for k8s pods, k8s\ncontainers, and docker containers (hosts already worked). It also\nupdates table metrics queries to provide metric details for each type of\nentity, including hosts.\n\n#### Semconv Docker container infra-tab\n\nhttps://github.com/user-attachments/assets/555dfc77-cdda-4033-abe7-1ae5db54b856\n\n#### Semconv k8s infra tab\n\nhttps://github.com/user-attachments/assets/378ad8f6-b9cb-474d-ace1-a00bae787c91\n\n## Details \n\nThe root change is the differentiation of data scheme based off the\n`agentName` using either `semconv` to denote the otel scheme, or `ecs`\nto denote the Elastic's schema. This is propagated to various portions\nof the UI and server routes.\nHere are some notes regarding some of the more \n###\n[get_infrastructure_data.ts](https://github.com/elastic/kibana/pull/252188/changes#diff-277565e622c87b4a66d4ac85ac8ffa5c7465ffa25f412e8ca0fac16d60963a50)\nSchema information is required for querying containers and k8s data\ncorrectly. Semconv k8s pod ids is unique to esc, while container and\nhost ids are the same. Additionally, k8s containers entities do not\ncarry an association with `service.id` and must be queried using\n`k8s.pod.id`. Unfortunately, this needs to be done serially. I'm open to\nrecommendations to better options.\n\nThe addition parameter added to the get_infrastructure_data API is\noptional, and will behave in the original manner when left undefined.\n\n### infrastructure_node_metrics_tables\nThere are three sub-folders here: containers, hosts, and pods.\nContainers is the most complicated, as there are three different metrics\ndefinitions depending on two factors, `ECS` has one set of metrics, and\n`semconv` has a set of container metrics for both docker containers and\nk8s containers, this is defined in\n[container_metrics_configs.ts](https://github.com/elastic/kibana/pull/252188/changes#diff-6b68e529bfd6e595f8290c830615b08dcb5ed1874044a86ed095974b54483afd).\nThe others utilize the `use_*_metrics_table.ts` to define the metrics\nused.\n\nFor both pod and k8s container metrics the cpu & memory utilization\nmetrics are opt-in, so by default they will populate as N/A. I added a\n`EUITipIcon` to inform users why `N/A` may be appearing.\n<img width=\"1140\" height=\"280\" alt=\"Screenshot 2026-02-11 at 15 25 04\"\nsrc=\"https://github.com/user-attachments/assets/a01d319c-7afe-4119-8ac9-54066912e510\"\n/>\n\n### Linking\nLinks for semconv containers and pods tab now go to discover metrics\nscoped to the pod/container id, providing the table of all relevant\nmetrics using the index pattern set in the infrastructure settings. This\nuses ES|QL.\nexample: \n<img width=\"1683\" height=\"1099\" alt=\"Screenshot 2026-02-11 at 15 29 09\"\nsrc=\"https://github.com/user-attachments/assets/a9161e4f-0b46-4bda-a7bd-5b4fe09d2831\"\n/>\n\n### Testing\n\n* Kubernetes: k8s data can be acquired for testing by using the\n`edge-edot` cluster.\n* Docker: I'll add some directions below on how to create a local demo\ncluster that runs docker for testing the docker aspect of this PR.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e722222b2b2cb403527ee5ece8a92dcea8080825","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"Feature/infra tab otel update","number":252188,"url":"https://github.com/elastic/kibana/pull/252188","mergeCommit":{"message":"Feature/infra tab otel update (#252188)\n\n## Summary\nresolves https://github.com/elastic/observability-dev/issues/4976 &\nhttps://github.com/elastic/observability-dev/issues/5153\n\nThis PR adds support for Otel based entities in the APM infrastructure\ntab. It updates the queries to populate the tables for k8s pods, k8s\ncontainers, and docker containers (hosts already worked). It also\nupdates table metrics queries to provide metric details for each type of\nentity, including hosts.\n\n#### Semconv Docker container infra-tab\n\nhttps://github.com/user-attachments/assets/555dfc77-cdda-4033-abe7-1ae5db54b856\n\n#### Semconv k8s infra tab\n\nhttps://github.com/user-attachments/assets/378ad8f6-b9cb-474d-ace1-a00bae787c91\n\n## Details \n\nThe root change is the differentiation of data scheme based off the\n`agentName` using either `semconv` to denote the otel scheme, or `ecs`\nto denote the Elastic's schema. This is propagated to various portions\nof the UI and server routes.\nHere are some notes regarding some of the more \n###\n[get_infrastructure_data.ts](https://github.com/elastic/kibana/pull/252188/changes#diff-277565e622c87b4a66d4ac85ac8ffa5c7465ffa25f412e8ca0fac16d60963a50)\nSchema information is required for querying containers and k8s data\ncorrectly. Semconv k8s pod ids is unique to esc, while container and\nhost ids are the same. Additionally, k8s containers entities do not\ncarry an association with `service.id` and must be queried using\n`k8s.pod.id`. Unfortunately, this needs to be done serially. I'm open to\nrecommendations to better options.\n\nThe addition parameter added to the get_infrastructure_data API is\noptional, and will behave in the original manner when left undefined.\n\n### infrastructure_node_metrics_tables\nThere are three sub-folders here: containers, hosts, and pods.\nContainers is the most complicated, as there are three different metrics\ndefinitions depending on two factors, `ECS` has one set of metrics, and\n`semconv` has a set of container metrics for both docker containers and\nk8s containers, this is defined in\n[container_metrics_configs.ts](https://github.com/elastic/kibana/pull/252188/changes#diff-6b68e529bfd6e595f8290c830615b08dcb5ed1874044a86ed095974b54483afd).\nThe others utilize the `use_*_metrics_table.ts` to define the metrics\nused.\n\nFor both pod and k8s container metrics the cpu & memory utilization\nmetrics are opt-in, so by default they will populate as N/A. I added a\n`EUITipIcon` to inform users why `N/A` may be appearing.\n<img width=\"1140\" height=\"280\" alt=\"Screenshot 2026-02-11 at 15 25 04\"\nsrc=\"https://github.com/user-attachments/assets/a01d319c-7afe-4119-8ac9-54066912e510\"\n/>\n\n### Linking\nLinks for semconv containers and pods tab now go to discover metrics\nscoped to the pod/container id, providing the table of all relevant\nmetrics using the index pattern set in the infrastructure settings. This\nuses ES|QL.\nexample: \n<img width=\"1683\" height=\"1099\" alt=\"Screenshot 2026-02-11 at 15 29 09\"\nsrc=\"https://github.com/user-attachments/assets/a9161e4f-0b46-4bda-a7bd-5b4fe09d2831\"\n/>\n\n### Testing\n\n* Kubernetes: k8s data can be acquired for testing by using the\n`edge-edot` cluster.\n* Docker: I'll add some directions below on how to create a local demo\ncluster that runs docker for testing the docker aspect of this PR.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e722222b2b2cb403527ee5ece8a92dcea8080825"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252188","number":252188,"mergeCommit":{"message":"Feature/infra tab otel update (#252188)\n\n## Summary\nresolves https://github.com/elastic/observability-dev/issues/4976 &\nhttps://github.com/elastic/observability-dev/issues/5153\n\nThis PR adds support for Otel based entities in the APM infrastructure\ntab. It updates the queries to populate the tables for k8s pods, k8s\ncontainers, and docker containers (hosts already worked). It also\nupdates table metrics queries to provide metric details for each type of\nentity, including hosts.\n\n#### Semconv Docker container infra-tab\n\nhttps://github.com/user-attachments/assets/555dfc77-cdda-4033-abe7-1ae5db54b856\n\n#### Semconv k8s infra tab\n\nhttps://github.com/user-attachments/assets/378ad8f6-b9cb-474d-ace1-a00bae787c91\n\n## Details \n\nThe root change is the differentiation of data scheme based off the\n`agentName` using either `semconv` to denote the otel scheme, or `ecs`\nto denote the Elastic's schema. This is propagated to various portions\nof the UI and server routes.\nHere are some notes regarding some of the more \n###\n[get_infrastructure_data.ts](https://github.com/elastic/kibana/pull/252188/changes#diff-277565e622c87b4a66d4ac85ac8ffa5c7465ffa25f412e8ca0fac16d60963a50)\nSchema information is required for querying containers and k8s data\ncorrectly. Semconv k8s pod ids is unique to esc, while container and\nhost ids are the same. Additionally, k8s containers entities do not\ncarry an association with `service.id` and must be queried using\n`k8s.pod.id`. Unfortunately, this needs to be done serially. I'm open to\nrecommendations to better options.\n\nThe addition parameter added to the get_infrastructure_data API is\noptional, and will behave in the original manner when left undefined.\n\n### infrastructure_node_metrics_tables\nThere are three sub-folders here: containers, hosts, and pods.\nContainers is the most complicated, as there are three different metrics\ndefinitions depending on two factors, `ECS` has one set of metrics, and\n`semconv` has a set of container metrics for both docker containers and\nk8s containers, this is defined in\n[container_metrics_configs.ts](https://github.com/elastic/kibana/pull/252188/changes#diff-6b68e529bfd6e595f8290c830615b08dcb5ed1874044a86ed095974b54483afd).\nThe others utilize the `use_*_metrics_table.ts` to define the metrics\nused.\n\nFor both pod and k8s container metrics the cpu & memory utilization\nmetrics are opt-in, so by default they will populate as N/A. I added a\n`EUITipIcon` to inform users why `N/A` may be appearing.\n<img width=\"1140\" height=\"280\" alt=\"Screenshot 2026-02-11 at 15 25 04\"\nsrc=\"https://github.com/user-attachments/assets/a01d319c-7afe-4119-8ac9-54066912e510\"\n/>\n\n### Linking\nLinks for semconv containers and pods tab now go to discover metrics\nscoped to the pod/container id, providing the table of all relevant\nmetrics using the index pattern set in the infrastructure settings. This\nuses ES|QL.\nexample: \n<img width=\"1683\" height=\"1099\" alt=\"Screenshot 2026-02-11 at 15 29 09\"\nsrc=\"https://github.com/user-attachments/assets/a9161e4f-0b46-4bda-a7bd-5b4fe09d2831\"\n/>\n\n### Testing\n\n* Kubernetes: k8s data can be acquired for testing by using the\n`edge-edot` cluster.\n* Docker: I'll add some directions below on how to create a local demo\ncluster that runs docker for testing the docker aspect of this PR.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e722222b2b2cb403527ee5ece8a92dcea8080825"}},{"url":"https://github.com/elastic/kibana/pull/254523","number":254523,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->