### PR TITLE
[ES|QL] Prevents the visor being focusable when hidden

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -166,6 +166,7 @@ export function QuickSearchVisor({
       responsive={false}
       css={styles.visorContainer}
       data-test-subj="ESQLEditor-quick-search-visor"
+      {...(!isVisible && { inert: '' })}
     >
       <EuiFlexItem grow={false} css={styles.visorWrapper}>
         <EuiFlexGroup


### PR DESCRIPTION
## Summary

When the visor is hidden, the elements remain focusable via keyboard Tab navigation. (we have the visor hidden because we want the visibility animation)

The fix adds the inert attribute to the outer EuiFlexGroup container when isVisible is false. The inert attribute:
- Removes all child elements from the tab order so they can't receive keyboard focus
- Makes the subtree invisible to assistive technology (equivalent to aria-hidden="true")
- Prevents all user interaction (clicks, focus, selection)



