### PR TITLE
[8.19] [ResponseOps][Rules] Bug - "Copy Query" button for ES Query Rule type not working  (#253731)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/test_query_row.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/test_query_row.test.tsx
@@ -84,4 +84,119 @@ describe('TestQueryRow', () => {
     expect(localOnCopyQuery).toHaveBeenCalled();
     expect(copyToClipboard).toHaveBeenCalledWith(COPIED_QUERY);
   });
+
+  it('should display an error when copyQuery throws an error', async () => {
+    const errorMessage = 'Expected AND, OR, end of input but ":" found.';
+    const localOnCopyQuery = jest.fn(() => {
+      throw new Error(errorMessage);
+    });
+    const component = mountWithIntl(
+      <TestQueryRow fetch={onFetch} copyQuery={localOnCopyQuery} hasValidationErrors={false} />
+    );
+    await act(async () => {
+      findTestSubject(component, 'copyQuery').simulate('click');
+    });
+    component.update();
+    expect(localOnCopyQuery).toHaveBeenCalled();
+    expect(findTestSubject(component, 'copyQueryError').exists()).toBe(true);
+    expect(findTestSubject(component, 'copyQueryError').text()).toContain(errorMessage);
+  });
+
+  it('should clear copyQuery error when clicking copy query again', async () => {
+    const errorMessage = 'Expected AND, OR, end of input but ":" found.';
+    let shouldThrow = true;
+    const localOnCopyQuery = jest.fn(() => {
+      if (shouldThrow) {
+        throw new Error(errorMessage);
+      }
+      return COPIED_QUERY;
+    });
+    const component = mountWithIntl(
+      <TestQueryRow fetch={onFetch} copyQuery={localOnCopyQuery} hasValidationErrors={false} />
+    );
+
+    await act(async () => {
+      findTestSubject(component, 'copyQuery').simulate('click');
+    });
+    component.update();
+    expect(findTestSubject(component, 'copyQueryError').exists()).toBe(true);
+
+    shouldThrow = false;
+    await act(async () => {
+      findTestSubject(component, 'copyQuery').simulate('click');
+    });
+    component.update();
+    expect(findTestSubject(component, 'copyQueryError').exists()).toBe(false);
+  });
+
+  it('should clear copyQuery error when clicking test query', async () => {
+    const errorMessage = 'Expected AND, OR, end of input but ":" found.';
+    const localOnCopyQuery = jest.fn(() => {
+      throw new Error(errorMessage);
+    });
+    const component = mountWithIntl(
+      <TestQueryRow fetch={onFetch} copyQuery={localOnCopyQuery} hasValidationErrors={false} />
+    );
+
+    await act(async () => {
+      findTestSubject(component, 'copyQuery').simulate('click');
+    });
+    component.update();
+    expect(findTestSubject(component, 'copyQueryError').exists()).toBe(true);
+
+    await act(async () => {
+      findTestSubject(component, 'testQuery').simulate('click');
+    });
+    component.update();
+    expect(findTestSubject(component, 'copyQueryError').exists()).toBe(false);
+  });
+
+  it('should clear testQuery error when clicking copy query', async () => {
+    const localOnFetch = jest.fn(() => Promise.reject(new Error('Test query failed')));
+    const component = mountWithIntl(
+      <TestQueryRow fetch={localOnFetch} copyQuery={onCopyQuery} hasValidationErrors={false} />
+    );
+
+    await act(async () => {
+      findTestSubject(component, 'testQuery').simulate('click');
+    });
+    component.update();
+    expect(findTestSubject(component, 'testQueryError').exists()).toBe(true);
+
+    await act(async () => {
+      findTestSubject(component, 'copyQuery').simulate('click');
+    });
+    component.update();
+    expect(findTestSubject(component, 'testQueryError').exists()).toBe(false);
+  });
+
+  it('should clear copyQuery error when fetch prop changes', async () => {
+    const errorMessage = 'Expected AND, OR, end of input but ":" found.';
+    const localOnCopyQuery = jest.fn(() => {
+      throw new Error(errorMessage);
+    });
+    const component = mountWithIntl(
+      <TestQueryRow fetch={onFetch} copyQuery={localOnCopyQuery} hasValidationErrors={false} />
+    );
+
+    await act(async () => {
+      findTestSubject(component, 'copyQuery').simulate('click');
+    });
+    component.update();
+    expect(findTestSubject(component, 'copyQueryError').exists()).toBe(true);
+
+    const newFetch = () =>
+      Promise.resolve({
+        testResults: {
+          results: [{ group: 'all documents', hits: [], count: 10, sourceFields: [] }],
+          truncated: false,
+        },
+        isGrouped: false,
+        timeWindow: '10m',
+      });
+
+    component.setProps({ fetch: newFetch });
+    component.update();
+    expect(findTestSubject(component, 'copyQueryError').exists()).toBe(false);
+  });
 });

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/test_query_row.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/test_query_row.tsx
@@ -4,7 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { ReactNode, useState } from 'react';
+import type { ReactNode } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   copyToClipboard,
   EuiButton,
@@ -18,7 +19,8 @@ import {
   EuiCallOut,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { ParsedAggregationResults } from '@kbn/triggers-actions-ui-plugin/common';
+import { i18n } from '@kbn/i18n';
+import type { ParsedAggregationResults } from '@kbn/triggers-actions-ui-plugin/common';
 import { useTestQuery } from './use_test_query';
 import { TestQueryRowTable } from './test_query_row_table';
 
@@ -41,6 +43,7 @@ export const TestQueryRow: React.FC<TestQueryRowProps> = ({
 }) => {
   const {
     onTestQuery,
+    resetTestQueryResponse,
     testQueryResult,
     testQueryError,
     testQueryWarning,
@@ -49,6 +52,11 @@ export const TestQueryRow: React.FC<TestQueryRowProps> = ({
   } = useTestQuery(fetch);
 
   const [copiedMessage, setCopiedMessage] = useState<ReactNode | null>(null);
+  const [copyQueryError, setCopyQueryError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCopyQueryError(null);
+  }, [fetch]);
 
   return (
     <>
@@ -61,6 +69,7 @@ export const TestQueryRow: React.FC<TestQueryRowProps> = ({
               iconSide="left"
               iconType="playFilled"
               onClick={() => {
+                setCopyQueryError(null);
                 onTestQuery();
               }}
               disabled={hasValidationErrors}
@@ -87,13 +96,24 @@ export const TestQueryRow: React.FC<TestQueryRowProps> = ({
                   iconSide="left"
                   iconType="copyClipboard"
                   onClick={() => {
-                    const copied = copyToClipboard(copyQuery());
-                    if (copied) {
-                      setCopiedMessage(
-                        <FormattedMessage
-                          id="xpack.stackAlerts.esQuery.ui.queryCopiedToClipboard"
-                          defaultMessage="Copied"
-                        />
+                    setCopyQueryError(null);
+                    resetTestQueryResponse();
+                    try {
+                      const copied = copyToClipboard(copyQuery());
+                      if (copied) {
+                        setCopiedMessage(
+                          <FormattedMessage
+                            id="xpack.stackAlerts.esQuery.ui.queryCopiedToClipboard"
+                            defaultMessage="Copied"
+                          />
+                        );
+                      }
+                    } catch (err) {
+                      setCopyQueryError(
+                        i18n.translate('xpack.stackAlerts.esQuery.ui.copyQueryError', {
+                          defaultMessage: 'Error copying query: {message}',
+                          values: { message: err.message },
+                        })
                       );
                     }
                   }}
@@ -134,6 +154,13 @@ export const TestQueryRow: React.FC<TestQueryRowProps> = ({
         <EuiFormRow>
           <EuiText data-test-subj="testQueryError" color="danger" size="s">
             <p>{testQueryError}</p>
+          </EuiText>
+        </EuiFormRow>
+      )}
+      {copyQueryError && (
+        <EuiFormRow>
+          <EuiText data-test-subj="copyQueryError" color="danger" size="s">
+            <p>{copyQueryError}</p>
           </EuiText>
         </EuiFormRow>
       )}

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/use_test_query.test.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/use_test_query.test.ts
@@ -160,4 +160,26 @@ describe('useTestQuery', () => {
       rows: [{ grouped: 'test' }],
     });
   });
+
+  test('resetTestQueryResponse clears all state', async () => {
+    const errorMsg = 'How dare you writing such a query';
+    const { result } = renderHook(useTestQuery, {
+      initialProps: () => Promise.reject({ message: errorMsg }),
+    });
+
+    await act(async () => {
+      await result.current.onTestQuery();
+    });
+    expect(result.current.testQueryError).toContain(errorMsg);
+
+    act(() => {
+      result.current.resetTestQueryResponse();
+    });
+
+    expect(result.current.testQueryLoading).toBe(false);
+    expect(result.current.testQueryError).toBe(null);
+    expect(result.current.testQueryWarning).toBe(null);
+    expect(result.current.testQueryResult).toBe(null);
+    expect(result.current.testQueryPreview).toBe(null);
+  });
 });

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/use_test_query.test.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/use_test_query.test.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react';
-import { act } from 'react-test-renderer';
+import { renderHook, act } from '@testing-library/react';
 import { useTestQuery } from './use_test_query';
 
 describe('useTestQuery', () => {
@@ -172,7 +171,7 @@ describe('useTestQuery', () => {
     });
     expect(result.current.testQueryError).toContain(errorMsg);
 
-    act(() => {
+    await act(async () => {
       result.current.resetTestQueryResponse();
     });
 

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/use_test_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/test_query_row/use_test_query.ts
@@ -126,8 +126,13 @@ export function useTestQuery(fetch: () => Promise<TestQueryFetchResponse>) {
     }
   }, [fetch]);
 
+  const resetTestQueryResponse = useCallback(() => {
+    setTestQueryResponse(TEST_QUERY_INITIAL_RESPONSE);
+  }, []);
+
   return {
     onTestQuery,
+    resetTestQueryResponse,
     testQueryResult: testQueryResponse.result,
     testQueryError: testQueryResponse.error,
     testQueryWarning: testQueryResponse.warning,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Rules] Bug - "Copy Query" button for ES Query Rule type not working  (#253731)](https://github.com/elastic/kibana/pull/253731)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2026-02-23T15:15:16Z","message":"[ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type not working  (#253731)\n\nCloses https://github.com/elastic/response-ops-team/issues/512\n\n## Summary\n\n- fixed `Copy query` button to handle invalid queries. Previously,\nclicking `Copy query` with an invalid KQL query (e.g., syntax errors)\nwould throw an uncaught exception to the console. Now it displays an\nerror message in the UI, consistent with how `Test query` handles\nerrors.\n- Additionally, only one error is shown at a time - clicking either\nbutton clears the other's error state.","sha":"eaa38eefa3e0fecf1c4ccee1eeffb3650276ed2f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.4.0","v9.3.1","v9.2.6","v8.19.13","v9.2.7","v9.3.2"],"title":"[ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type not working ","number":253731,"url":"https://github.com/elastic/kibana/pull/253731","mergeCommit":{"message":"[ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type not working  (#253731)\n\nCloses https://github.com/elastic/response-ops-team/issues/512\n\n## Summary\n\n- fixed `Copy query` button to handle invalid queries. Previously,\nclicking `Copy query` with an invalid KQL query (e.g., syntax errors)\nwould throw an uncaught exception to the console. Now it displays an\nerror message in the UI, consistent with how `Test query` handles\nerrors.\n- Additionally, only one error is shown at a time - clicking either\nbutton clears the other's error state.","sha":"eaa38eefa3e0fecf1c4ccee1eeffb3650276ed2f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253731","number":253731,"mergeCommit":{"message":"[ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type not working  (#253731)\n\nCloses https://github.com/elastic/response-ops-team/issues/512\n\n## Summary\n\n- fixed `Copy query` button to handle invalid queries. Previously,\nclicking `Copy query` with an invalid KQL query (e.g., syntax errors)\nwould throw an uncaught exception to the console. Now it displays an\nerror message in the UI, consistent with how `Test query` handles\nerrors.\n- Additionally, only one error is shown at a time - clicking either\nbutton clears the other's error state.","sha":"eaa38eefa3e0fecf1c4ccee1eeffb3650276ed2f"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/254526","number":254526,"state":"MERGED","mergeCommit":{"sha":"a45cc5f6b290404565c17c122e0d8d661d7ba882","message":"[9.3] [ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type not working  (#253731) (#254526)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type\nnot working (#253731)](https://github.com/elastic/kibana/pull/253731)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Georgiana-Andreea Onoleață <georgiana.onoleata@elastic.co>"}},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/254525","number":254525,"state":"MERGED","mergeCommit":{"sha":"517e575e9f28e6ae441af4bb3d0929f2629d5035","message":"[9.2] [ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type not working  (#253731) (#254525)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[ResponseOps][Rules] Bug - \"Copy Query\" button for ES Query Rule type\nnot working (#253731)](https://github.com/elastic/kibana/pull/253731)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Georgiana-Andreea Onoleață <georgiana.onoleata@elastic.co>"}},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->