### PR TITLE
skills: align Scout skill docs with current CLI flags and constants

### DIFF
--- a/.agents/skills/scout-api-testing/SKILL.md
+++ b/.agents/skills/scout-api-testing/SKILL.md
@@ -91,12 +91,11 @@ Tests then import `apiTest` from the local fixtures: `import { apiTest } from '.
 ## Run / debug quickly
 
 - Use either `--config` or `--testFiles` (they are mutually exclusive).
-- Run by config: `node scripts/scout.js run-tests --stateful --config <module-root>/test/scout*/api/playwright.config.ts` (or `.../api/parallel.playwright.config.ts` for parallel API runs)
-- Run by file/dir (Scout derives the right `playwright.config.ts` vs `parallel.playwright.config.ts`): `node scripts/scout.js run-tests --stateful --testFiles <module-root>/test/scout*/api/tests/my.spec.ts`
-- For faster iteration, start servers once in another terminal: `node scripts/scout.js start-server --stateful [--config-dir <configSet>]`, then run Playwright directly: `npx playwright test --config <...> --project local --grep <tag>`.
-- `--config-dir` notes:
-- `run-tests` auto-detects the custom config dir from `.../test/scout_<name>/...` paths (override with `--config-dir <name>` if needed).
-- `start-server` has no Playwright config to inspect, so pass `--config-dir <name>` when your tests require a custom server config.
+- Run by config: `node scripts/scout.js run-tests --arch stateful --domain classic --config <module-root>/test/scout*/api/playwright.config.ts` (or `.../api/parallel.playwright.config.ts` for parallel API runs)
+- Run by file/dir (Scout derives the right `playwright.config.ts` vs `parallel.playwright.config.ts`): `node scripts/scout.js run-tests --arch stateful --domain classic --testFiles <module-root>/test/scout*/api/tests/my.spec.ts`
+- For faster iteration, start servers once in another terminal: `node scripts/scout.js start-server --arch stateful --domain classic [--serverConfigSet <configSet>]`, then run Playwright directly: `npx playwright test --config <...> --project local --grep <tag>`.
+- `run-tests` auto-detects custom config sets from `.../test/scout_<name>/...` paths.
+- `start-server` has no Playwright config to inspect, so pass `--serverConfigSet <name>` when your tests require a custom config set.
 - Debug: `SCOUT_LOG_LEVEL=debug`
 
 ## CI enablement

--- a/.agents/skills/scout-api-testing/references/scout-api-auth.md
+++ b/.agents/skills/scout-api-testing/references/scout-api-auth.md
@@ -25,7 +25,7 @@ const COMMON_HEADERS = {
   'elastic-api-version': '2023-10-31', // include for versioned public APIs
 };
 
-apiTest.describe('GET /api/my_plugin/foo', { tag: tags.DEPLOYMENT_AGNOSTIC }, () => {
+apiTest.describe('GET /api/my_plugin/foo', { tag: tags.deploymentAgnostic }, () => {
   let viewer: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ requestAuth }) => {
@@ -55,7 +55,7 @@ const INTERNAL_HEADERS = {
   'x-elastic-internal-origin': 'kibana',
 };
 
-apiTest.describe('GET /internal/my_plugin/foo', { tag: tags.DEPLOYMENT_AGNOSTIC }, () => {
+apiTest.describe('GET /internal/my_plugin/foo', { tag: tags.deploymentAgnostic }, () => {
   apiTest('calls internal endpoint', async ({ apiClient, samlAuth }) => {
     const { cookieHeader } = await samlAuth.asInteractiveUser('viewer');
 

--- a/.agents/skills/scout-create-scaffold/SKILL.md
+++ b/.agents/skills/scout-create-scaffold/SKILL.md
@@ -64,8 +64,8 @@ Notes:
 - Update `.meta` manifests when adding/moving configs or tests:
   - `node scripts/scout.js update-test-config-manifests`
 - Custom server config sets:
-  - If you create/use `test/scout_<configSet>`, you typically also need a matching server config under `src/platform/packages/shared/kbn-scout/src/servers/configs/custom/<configSet>`.
-  - `start-server` requires `--config-dir <configSet>` when using a custom server config set.
+  - If you create/use `test/scout_<configSet>`, you typically also need a matching server config under `src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/<configSet>`.
+  - `start-server` requires `--serverConfigSet <configSet>` when using a custom server config set.
 
 ## Path Conventions (Specs)
 

--- a/.agents/skills/scout-migrate-from-ftr/SKILL.md
+++ b/.agents/skills/scout-migrate-from-ftr/SKILL.md
@@ -48,9 +48,10 @@ Migrate FTR tests to Scout by deciding whether a test should be UI or API, mappi
 9. Update Scout manifests (discovery/CI).
    - Run `node scripts/scout.js update-test-config-manifests` so `.meta` manifests reflect the new/changed tests and configs.
 10. Verify in both stateful and serverless when applicable.
-   - Use `node scripts/scout.js run-tests --stateful --testFiles <path>` and
-     `node scripts/scout.js run-tests --serverless=oblt --testFiles <path>` (adjust serverless target).
-   - If the tests are under `test/scout_<configSet>/...`, `run-tests` auto-detects the server config dir from the Playwright config path (use `--config-dir <configSet>` only to override, or when using `start-server`).
+   - Use `node scripts/scout.js run-tests --arch stateful --domain classic --testFiles <path>` and
+     `node scripts/scout.js run-tests --arch serverless --domain observability_complete --testFiles <path>` (adjust the serverless domain).
+   - If tests are under `test/scout_<configSet>/...`, `run-tests` auto-detects the config set from the Playwright config path.
+   - If you start servers separately, pass `--serverConfigSet <configSet>` to `node scripts/scout.js start-server ...`.
 
 ## Common patterns
 

--- a/.agents/skills/scout-ui-testing/SKILL.md
+++ b/.agents/skills/scout-ui-testing/SKILL.md
@@ -104,12 +104,11 @@ test('creates and verifies a dashboard', async ({ pageObjects, page }) => {
 ## Run / debug quickly
 
 - Use either `--config` or `--testFiles` (they are mutually exclusive).
-- Run by config: `node scripts/scout.js run-tests --stateful --config <module-root>/test/scout*/ui/playwright.config.ts` (or `.../ui/parallel.playwright.config.ts` for parallel UI)
-- Run by file/dir (Scout derives the right `playwright.config.ts` vs `parallel.playwright.config.ts`): `node scripts/scout.js run-tests --stateful --testFiles <module-root>/test/scout*/ui/tests/my.spec.ts`
-- For faster iteration, start servers once in another terminal: `node scripts/scout.js start-server --stateful [--config-dir <configSet>]`, then run Playwright directly: `npx playwright test --config <...> --project local --grep <tag> --headed`.
-- `--config-dir` notes:
-- `run-tests` auto-detects the custom config dir from `.../test/scout_<name>/...` paths (override with `--config-dir <name>` if needed).
-- `start-server` has no Playwright config to inspect, so pass `--config-dir <name>` when your tests require a custom server config.
+- Run by config: `node scripts/scout.js run-tests --arch stateful --domain classic --config <module-root>/test/scout*/ui/playwright.config.ts` (or `.../ui/parallel.playwright.config.ts` for parallel UI)
+- Run by file/dir (Scout derives the right `playwright.config.ts` vs `parallel.playwright.config.ts`): `node scripts/scout.js run-tests --arch stateful --domain classic --testFiles <module-root>/test/scout*/ui/tests/my.spec.ts`
+- For faster iteration, start servers once in another terminal: `node scripts/scout.js start-server --arch stateful --domain classic [--serverConfigSet <configSet>]`, then run Playwright directly: `npx playwright test --config <...> --project local --grep <tag> --headed`.
+- `run-tests` auto-detects custom config sets from `.../test/scout_<name>/...` paths.
+- `start-server` has no Playwright config to inspect, so pass `--serverConfigSet <name>` when your tests require a custom config set.
 - Debug: `SCOUT_LOG_LEVEL=debug`, or `npx playwright test --config <...> --project local --ui`
 
 ## CI enablement

--- a/.agents/skills/scout-ui-testing/references/scout-browser-auth.md
+++ b/.agents/skills/scout-ui-testing/references/scout-browser-auth.md
@@ -19,7 +19,7 @@ import { tags } from '@kbn/scout'; // or the module's Scout package (e.g. @kbn/s
 import { expect } from '@kbn/scout/ui'; // or '@kbn/scout-search/ui', etc.
 import { test } from '../fixtures';
 
-test.describe('my suite', { tag: tags.DEPLOYMENT_AGNOSTIC }, () => {
+test.describe('my suite', { tag: tags.deploymentAgnostic }, () => {
   test.beforeEach(async ({ browserAuth }) => {
     await browserAuth.loginAsViewer();
   });

--- a/.agents/skills/scout-ui-testing/references/scout-ui-parallelism.md
+++ b/.agents/skills/scout-ui-testing/references/scout-ui-parallelism.md
@@ -21,7 +21,7 @@ Use this when working under `.../test/scout*/ui/parallel_tests/` or a `parallel.
 import { spaceTest, tags } from '@kbn/scout'; // or the module's Scout package
 import { expect } from '@kbn/scout/ui'; // or '@kbn/scout-oblt/ui', etc.
 
-spaceTest.describe('my feature', { tag: tags.DEPLOYMENT_AGNOSTIC }, () => {
+spaceTest.describe('my feature', { tag: tags.deploymentAgnostic }, () => {
   spaceTest.beforeAll(async ({ scoutSpace }) => {
     // Worker-scoped setup in the isolated space.
     await scoutSpace.savedObjects.cleanStandardList();


### PR DESCRIPTION
Replace stale Scout command examples (`--stateful`, `--serverless=...`, `--config-dir`) with the current flag model (`--arch`, `--domain`, `--serverConfigSet`), update the custom config-set path, and fix `tags.DEPLOYMENT_AGNOSTIC` examples to `tags.deploymentAgnostic`.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->