### PR TITLE
[Discover][Metrics] Move E2E Metrics in Discover from discover_enhanced to discover

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1823,6 +1823,9 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 /src/platform/plugins/shared/discover/test/scout/ui/traces_experience_parallel.playwright.config.ts @elastic/obs-exploration-team
 /src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/ @elastic/obs-exploration-team
 /src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/ @elastic/obs-exploration-team
+/src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts @elastic/obs-exploration-team
+/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/ @elastic/obs-exploration-team
+/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/ @elastic/obs-exploration-team
 
 # obs-onboarding-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality @elastic/obs-onboarding-team
@@ -2004,8 +2007,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/common/ftr_provider_context.ts @elastic/appex-qa
 /x-pack/platform/plugins/shared/maps/test/scout @elastic/appex-qa # temporarily
 /x-pack/platform/plugins/private/discover_enhanced/test/scout/ @elastic/appex-qa # temporarily
-/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/page_objects/metrics_experience.ts @elastic/appex-qa @elastic/obs-exploration-team
-/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/metrics_experience/ @elastic/appex-qa @elastic/obs-exploration-team
 /x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/discover_cdp_perf.spec.ts @elastic/kibana-data-discovery # test tracks bundle size limits
 /x-pack/platform/plugins/private/painless_lab/test/scout @elastic/appex-qa # temporarily
 /x-pack/platform/test/functional/fixtures/kbn_archives/packaging.json @elastic/appex-qa # No usages found

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+
+export const TSDB_LOGS_DEFAULT_START_TIME = '2023-03-28T09:17:00.000Z';
+export const TSDB_LOGS_DEFAULT_END_TIME = '2023-06-28T09:17:00.000Z';
+
+export const METRICS_TEST_INDEX_NAME = 'test-metrics-experience';
+
+export const ESQL_QUERIES = {
+  TS_TSDB_LOGS: 'TS kibana_sample_data_logstsdb',
+  FROM_TSDB_LOGS: 'FROM kibana_sample_data_logstsdb',
+  TS_METRICS_TEST: `TS ${METRICS_TEST_INDEX_NAME}`,
+};
+
+export const DATA_VIEW_NAME = {
+  TSDB_LOGS: 'Kibana Sample Data Logs (TSDB)',
+};
+
+export const ES_ARCHIVES = {
+  TSDB_LOGS: 'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_logs_tsdb',
+};
+
+export const KBN_ARCHIVES = {
+  TSDB_LOGS: 'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_logs_tsdb.json',
+};
+
+export const METRICS_EXPERIENCE_TAGS = [
+  ...tags.stateful.all,
+  ...tags.serverless.observability.complete,
+];

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts
@@ -9,28 +9,17 @@
 
 import { tags } from '@kbn/scout';
 
-export const TSDB_LOGS_DEFAULT_START_TIME = '2023-03-28T09:17:00.000Z';
-export const TSDB_LOGS_DEFAULT_END_TIME = '2023-06-28T09:17:00.000Z';
-
 export const METRICS_TEST_INDEX_NAME = 'test-metrics-experience';
 
 export const ESQL_QUERIES = {
-  TS_TSDB_LOGS: 'TS kibana_sample_data_logstsdb',
-  FROM_TSDB_LOGS: 'FROM kibana_sample_data_logstsdb',
-  TS_METRICS_TEST: `TS ${METRICS_TEST_INDEX_NAME}`,
+  TS: `TS ${METRICS_TEST_INDEX_NAME}`,
+  FROM: `FROM ${METRICS_TEST_INDEX_NAME}`,
 };
 
-export const DATA_VIEW_NAME = {
-  TSDB_LOGS: 'Kibana Sample Data Logs (TSDB)',
-};
+export const DATA_VIEW_NAME = METRICS_TEST_INDEX_NAME;
 
-export const ES_ARCHIVES = {
-  TSDB_LOGS: 'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_logs_tsdb',
-};
-
-export const KBN_ARCHIVES = {
-  TSDB_LOGS: 'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_logs_tsdb.json',
-};
+export const KBN_ARCHIVE =
+  'src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/kbn_archives/metrics_data_view.json';
 
 export const METRICS_EXPERIENCE_TAGS = [
   ...tags.stateful.all,

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export * from './metrics_tsdb_index';

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/metrics_tsdb_index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/metrics_tsdb_index.ts
@@ -1,8 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 import type { EsClient } from '@kbn/scout';
@@ -182,7 +184,6 @@ export async function cleanMetricsTestIndex(
  * Includes a defensive catch for `resource_already_exists_exception` to handle the race
  * condition where parallel Playwright setup projects may attempt to create the same index
  * concurrently.
- *
  */
 export async function createMetricsTestIndexIfNeeded(
   esClient: EsClient,

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/metrics_tsdb_index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/metrics_tsdb_index.ts
@@ -46,12 +46,8 @@ const INDEX_TIME_RANGE = {
   documentsBaseTime: '2025-01-01T00:30:00.000Z',
 } as const;
 
-/**
- * Time range for UI tests. Covers both TSDB_LOGS (2023) and metrics test data (2025).
- * This wide range is needed because selectTextBaseLang() requires visible data.
- */
 export const DEFAULT_TIME_RANGE = {
-  from: '2023-01-01T00:00:00.000Z',
+  from: '2025-01-01T00:00:00.000Z',
   to: '2025-12-31T23:59:59.000Z',
 } as const;
 

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
@@ -37,7 +37,7 @@ export const spaceTest = spaceBaseTest.extend<
   ) => {
     const extendedPageObjects = {
       ...pageObjects,
-      metricsExperience: createLazyPageObject(MetricsExperiencePage, page, pageObjects.discover),
+      metricsExperience: createLazyPageObject(MetricsExperiencePage, page),
     };
 
     await use(extendedPageObjects);

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/index.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  PageObjects,
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
+} from '@kbn/scout';
+import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+import { MetricsExperiencePage } from './page_objects';
+
+export interface MetricsExperienceTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: PageObjects & {
+    metricsExperience: MetricsExperiencePage;
+  };
+}
+
+export const spaceTest = spaceBaseTest.extend<
+  MetricsExperienceTestFixtures,
+  ScoutParallelWorkerFixtures
+>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: MetricsExperienceTestFixtures['pageObjects'];
+      page: MetricsExperienceTestFixtures['page'];
+    },
+    use: (pageObjects: MetricsExperienceTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    const extendedPageObjects = {
+      ...pageObjects,
+      metricsExperience: createLazyPageObject(MetricsExperiencePage, page, pageObjects.discover),
+    };
+
+    await use(extendedPageObjects);
+  },
+});
+
+export * as testData from './constants';
+export * from './generators';

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/kbn_archives/metrics_data_view.json
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/kbn_archives/metrics_data_view.json
@@ -1,0 +1,15 @@
+{
+    "attributes": {
+        "name": "test-metrics-experience",
+        "timeFieldName": "@timestamp",
+        "title": "test-metrics-experience"
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2025-01-01T00:00:00.000Z",
+    "id": "metrics-experience-data-view",
+    "managed": false,
+    "references": [],
+    "type": "index-pattern",
+    "typeMigrationVersion": "7.11.0",
+    "updated_at": "2025-01-01T00:00:00.000Z"
+}

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { MetricsExperiencePage } from './metrics_experience';

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/metrics_experience.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/metrics_experience.ts
@@ -7,8 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Locator, PageObjects, ScoutPage } from '@kbn/scout';
-import { KibanaCodeEditorWrapper } from '@kbn/scout';
+import type { Locator, ScoutPage } from '@kbn/scout';
 
 interface MetricsPagination {
   readonly container: Locator;
@@ -29,7 +28,7 @@ function createPagination(parentContainer: Locator): MetricsPagination {
 }
 
 export class MetricsExperiencePage {
-  private readonly codeEditor: KibanaCodeEditorWrapper;
+  // metricsExperienceRendered is the outer wrapper containing header, grid, and pagination
   public readonly container: Locator;
   public readonly grid: Locator;
   public readonly cards: Locator;
@@ -38,12 +37,7 @@ export class MetricsExperiencePage {
   public readonly searchInput: Locator;
   public readonly emptyState: Locator;
 
-  constructor(
-    private readonly page: ScoutPage,
-    private readonly discover: PageObjects['discover']
-  ) {
-    this.codeEditor = new KibanaCodeEditorWrapper(page);
-    // metricsExperienceRendered is the outer wrapper containing header, grid, and pagination
+  constructor(page: ScoutPage) {
     this.container = page.testSubj.locator('metricsExperienceRendered');
     this.grid = page.testSubj.locator('unifiedMetricsExperienceGrid');
     this.cards = this.grid.locator('[data-chart-index]');
@@ -51,16 +45,6 @@ export class MetricsExperiencePage {
     this.searchButton = page.testSubj.locator('metricsExperienceToolbarSearch');
     this.searchInput = page.testSubj.locator('metricsExperienceGridToolbarSearch');
     this.emptyState = page.testSubj.locator('metricsExperienceNoData');
-  }
-
-  /**
-   * Runs an ES|QL query and waits for results.
-   */
-  public async runEsqlQuery(query: string): Promise<void> {
-    await this.discover.selectTextBaseLang();
-    await this.codeEditor.setCodeEditorValue(query);
-    await this.page.testSubj.click('querySubmitButton');
-    await this.discover.waitUntilSearchingHasFinished();
   }
 
   public getCardByIndex(index: number): Locator {

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/metrics_experience.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/page_objects/metrics_experience.ts
@@ -1,8 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 import type { Locator, PageObjects, ScoutPage } from '@kbn/scout';

--- a/src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './parallel_tests/metrics_experience',
+  workers: 2,
+  runGlobalSetup: true,
+});

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/global.setup.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/global.setup.ts
@@ -8,20 +8,14 @@
  */
 
 import { globalSetupHook } from '@kbn/scout';
-import { testData, createMetricsTestIndexIfNeeded } from '../../fixtures/metrics_experience';
+import { createMetricsTestIndexIfNeeded } from '../../fixtures/metrics_experience';
 
-globalSetupHook(
-  'Ingest metrics data to Elasticsearch',
-  async ({ esArchiver, esClient, log }) => {
-    log.debug('[setup] loading TSDB_LOGS ES archive (only if index does not exist)...');
-    await esArchiver.loadIfNeeded(testData.ES_ARCHIVES.TSDB_LOGS);
-
-    log.debug('[setup] loading metrics test index (only if it does not exist)...');
-    const created = await createMetricsTestIndexIfNeeded(esClient);
-    log.debug(
-      created
-        ? '[setup] metrics test index created successfully'
-        : '[setup] metrics test index already exists, skipping'
-    );
-  }
-);
+globalSetupHook('Ingest metrics data to Elasticsearch', async ({ esClient, log }) => {
+  log.debug('[setup] creating metrics test index (only if it does not exist)...');
+  const created = await createMetricsTestIndexIfNeeded(esClient);
+  log.debug(
+    created
+      ? '[setup] metrics test index created successfully'
+      : '[setup] metrics test index already exists, skipping'
+  );
+});

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/global.setup.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/global.setup.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { globalSetupHook } from '@kbn/scout';
+import { testData, createMetricsTestIndexIfNeeded } from '../../fixtures/metrics_experience';
+
+globalSetupHook(
+  'Ingest metrics data to Elasticsearch',
+  async ({ esArchiver, esClient, log }) => {
+    log.debug('[setup] loading TSDB_LOGS ES archive (only if index does not exist)...');
+    await esArchiver.loadIfNeeded(testData.ES_ARCHIVES.TSDB_LOGS);
+
+    log.debug('[setup] loading metrics test index (only if it does not exist)...');
+    const created = await createMetricsTestIndexIfNeeded(esClient);
+    log.debug(
+      created
+        ? '[setup] metrics test index created successfully'
+        : '[setup] metrics test index already exists, skipping'
+    );
+  }
+);

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
@@ -11,8 +11,8 @@
  * Grid Navigation tests: pagination and search.
  *
  * These tests use a dynamically created TSDB index (test-metrics-experience)
- * with 45 metric fields (23 gauge + 22 counter) to exercise scenarios that
- * require more metrics than the static TSDB_LOGS archive provides.
+ * with 45 metric fields (23 gauge + 22 counter) to exercise pagination
+ * and search scenarios.
  */
 
 import { expect } from '@kbn/scout/ui';
@@ -28,7 +28,6 @@ const { PAGE_SIZE, TOTAL_PAGES, LAST_PAGE_CARDS } = PAGINATION;
 
 const SEARCH_METRIC_NAME = DEFAULT_CONFIG.metrics[0].name;
 
-// Sort metrics alphabetically to match UI display order
 const SORTED_METRICS = [...DEFAULT_CONFIG.metrics].sort((a, b) => a.name.localeCompare(b.name));
 const FIRST_CARD_PAGE_1 = `${SORTED_METRICS[0].name}-0`;
 const FIRST_CARD_PAGE_2 = `${SORTED_METRICS[PAGE_SIZE].name}-0`;
@@ -41,8 +40,8 @@ spaceTest.describe(
   },
   () => {
     spaceTest.beforeAll(async ({ scoutSpace }) => {
-      await scoutSpace.savedObjects.load(testData.KBN_ARCHIVES.TSDB_LOGS);
-      await scoutSpace.uiSettings.setDefaultIndex(testData.DATA_VIEW_NAME.TSDB_LOGS);
+      await scoutSpace.savedObjects.load(testData.KBN_ARCHIVE);
+      await scoutSpace.uiSettings.setDefaultIndex(testData.DATA_VIEW_NAME);
       await scoutSpace.uiSettings.setDefaultTime(DEFAULT_TIME_RANGE);
     });
 
@@ -58,7 +57,7 @@ spaceTest.describe(
 
     spaceTest('should paginate through metrics', async ({ pageObjects }) => {
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS_METRICS_TEST);
+      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
 
       await spaceTest.step('pagination is visible', async () => {
         await expect(metricsExperience.grid).toBeVisible();
@@ -96,7 +95,7 @@ spaceTest.describe(
 
     spaceTest('should filter metrics using search', async ({ pageObjects }) => {
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS_METRICS_TEST);
+      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
       await expect(metricsExperience.grid).toBeVisible();
 
       await spaceTest.step('search filters results across all pages', async () => {

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
@@ -1,8 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 /**
@@ -20,13 +22,12 @@ import {
   PAGINATION,
   DEFAULT_TIME_RANGE,
   DEFAULT_CONFIG,
-} from '../../fixtures';
+} from '../../fixtures/metrics_experience';
 
 const { PAGE_SIZE, TOTAL_PAGES, LAST_PAGE_CARDS } = PAGINATION;
 
 const SEARCH_METRIC_NAME = DEFAULT_CONFIG.metrics[0].name;
 
-// Sort metrics alphabetically to match UI display order
 const SORTED_METRICS = [...DEFAULT_CONFIG.metrics].sort((a, b) => a.name.localeCompare(b.name));
 const FIRST_CARD_PAGE_1 = `${SORTED_METRICS[0].name}-0`;
 const FIRST_CARD_PAGE_2 = `${SORTED_METRICS[PAGE_SIZE].name}-0`;
@@ -39,7 +40,6 @@ spaceTest.describe(
   },
   () => {
     spaceTest.beforeAll(async ({ scoutSpace }) => {
-      // Load TSDB_LOGS for the data view (required by selectTextBaseLang)
       await scoutSpace.savedObjects.load(testData.KBN_ARCHIVES.TSDB_LOGS);
       await scoutSpace.uiSettings.setDefaultIndex(testData.DATA_VIEW_NAME.TSDB_LOGS);
       await scoutSpace.uiSettings.setDefaultTime(DEFAULT_TIME_RANGE);

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
@@ -56,8 +56,8 @@ spaceTest.describe(
     });
 
     spaceTest('should paginate through metrics', async ({ pageObjects }) => {
+      await pageObjects.discover.writeEsqlQuery(testData.ESQL_QUERIES.TS);
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
 
       await spaceTest.step('pagination is visible', async () => {
         await expect(metricsExperience.grid).toBeVisible();
@@ -94,8 +94,8 @@ spaceTest.describe(
     });
 
     spaceTest('should filter metrics using search', async ({ pageObjects }) => {
+      await pageObjects.discover.writeEsqlQuery(testData.ESQL_QUERIES.TS);
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
       await expect(metricsExperience.grid).toBeVisible();
 
       await spaceTest.step('search filters results across all pages', async () => {

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.navigation.spec.ts
@@ -28,6 +28,7 @@ const { PAGE_SIZE, TOTAL_PAGES, LAST_PAGE_CARDS } = PAGINATION;
 
 const SEARCH_METRIC_NAME = DEFAULT_CONFIG.metrics[0].name;
 
+// Sort metrics alphabetically to match UI display order
 const SORTED_METRICS = [...DEFAULT_CONFIG.metrics].sort((a, b) => a.name.localeCompare(b.name));
 const FIRST_CARD_PAGE_1 = `${SORTED_METRICS[0].name}-0`;
 const FIRST_CARD_PAGE_2 = `${SORTED_METRICS[PAGE_SIZE].name}-0`;

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.spec.ts
@@ -11,12 +11,11 @@
  * Grid activation and ES|QL command compatibility tests.
  *
  * These tests validate when the metrics grid activates (or does not) based on
- * different ES|QL commands, using static TSDB_LOGS data.
- * For pagination and search tests see grid.navigation.spec.ts.
+ * different ES|QL commands. For pagination and search tests see grid.navigation.spec.ts.
  */
 
 import { expect } from '@kbn/scout/ui';
-import { spaceTest, testData } from '../../fixtures/metrics_experience';
+import { spaceTest, testData, DEFAULT_TIME_RANGE } from '../../fixtures/metrics_experience';
 
 spaceTest.describe(
   'Metrics in Discover - Grid',
@@ -25,12 +24,9 @@ spaceTest.describe(
   },
   () => {
     spaceTest.beforeAll(async ({ scoutSpace }) => {
-      await scoutSpace.savedObjects.load(testData.KBN_ARCHIVES.TSDB_LOGS);
-      await scoutSpace.uiSettings.setDefaultIndex(testData.DATA_VIEW_NAME.TSDB_LOGS);
-      await scoutSpace.uiSettings.setDefaultTime({
-        from: testData.TSDB_LOGS_DEFAULT_START_TIME,
-        to: testData.TSDB_LOGS_DEFAULT_END_TIME,
-      });
+      await scoutSpace.savedObjects.load(testData.KBN_ARCHIVE);
+      await scoutSpace.uiSettings.setDefaultIndex(testData.DATA_VIEW_NAME);
+      await scoutSpace.uiSettings.setDefaultTime(DEFAULT_TIME_RANGE);
     });
 
     spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
@@ -45,47 +41,47 @@ spaceTest.describe(
 
     spaceTest('should render metrics grid with cards', async ({ pageObjects }) => {
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS_TSDB_LOGS);
+      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
       await expect(metricsExperience.grid).toBeVisible();
       await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
     });
 
     spaceTest('should render grid with WHERE filter', async ({ pageObjects }) => {
       await pageObjects.metricsExperience.runEsqlQuery(
-        `${testData.ESQL_QUERIES.TS_TSDB_LOGS} | WHERE @timestamp > "${testData.TSDB_LOGS_DEFAULT_END_TIME}" - 100 DAYS`
+        `${testData.ESQL_QUERIES.TS} | WHERE @timestamp > "${DEFAULT_TIME_RANGE.from}" - 100 DAYS`
       );
       await expect(pageObjects.metricsExperience.grid).toBeVisible();
     });
 
     spaceTest('should render grid with LIMIT', async ({ pageObjects }) => {
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(`${testData.ESQL_QUERIES.TS_TSDB_LOGS} | LIMIT 5`);
+      await metricsExperience.runEsqlQuery(`${testData.ESQL_QUERIES.TS} | LIMIT 5`);
       await expect(metricsExperience.grid).toBeVisible();
     });
 
     spaceTest('should render grid with SORT', async ({ pageObjects }) => {
       const { metricsExperience } = pageObjects;
       await metricsExperience.runEsqlQuery(
-        `${testData.ESQL_QUERIES.TS_TSDB_LOGS} | SORT @timestamp DESC`
+        `${testData.ESQL_QUERIES.TS} | SORT @timestamp DESC`
       );
       await expect(metricsExperience.grid).toBeVisible();
     });
 
     spaceTest('should not render grid with FROM command', async ({ pageObjects }) => {
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.FROM_TSDB_LOGS);
+      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.FROM);
       await expect(metricsExperience.grid).toBeHidden();
     });
 
     spaceTest('should not render grid with STATS command', async ({ pageObjects }) => {
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(`${testData.ESQL_QUERIES.TS_TSDB_LOGS} | STATS count()`);
+      await metricsExperience.runEsqlQuery(`${testData.ESQL_QUERIES.TS} | STATS count()`);
       await expect(metricsExperience.grid).toBeHidden();
     });
 
     spaceTest('should persist grid when changing time range', async ({ pageObjects }) => {
       const { metricsExperience, datePicker } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS_TSDB_LOGS);
+      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
       await expect(metricsExperience.grid).toBeVisible();
 
       await datePicker.setCommonlyUsedTime('Last_30 days');

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.spec.ts
@@ -40,48 +40,44 @@ spaceTest.describe(
     });
 
     spaceTest('should render metrics grid with cards', async ({ pageObjects }) => {
+      await pageObjects.discover.writeEsqlQuery(testData.ESQL_QUERIES.TS);
       const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
       await expect(metricsExperience.grid).toBeVisible();
       await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
     });
 
     spaceTest('should render grid with WHERE filter', async ({ pageObjects }) => {
-      await pageObjects.metricsExperience.runEsqlQuery(
+      await pageObjects.discover.writeEsqlQuery(
         `${testData.ESQL_QUERIES.TS} | WHERE @timestamp > "${DEFAULT_TIME_RANGE.from}" - 100 DAYS`
       );
       await expect(pageObjects.metricsExperience.grid).toBeVisible();
     });
 
     spaceTest('should render grid with LIMIT', async ({ pageObjects }) => {
-      const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(`${testData.ESQL_QUERIES.TS} | LIMIT 5`);
-      await expect(metricsExperience.grid).toBeVisible();
+      await pageObjects.discover.writeEsqlQuery(`${testData.ESQL_QUERIES.TS} | LIMIT 5`);
+      await expect(pageObjects.metricsExperience.grid).toBeVisible();
     });
 
     spaceTest('should render grid with SORT', async ({ pageObjects }) => {
-      const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(
+      await pageObjects.discover.writeEsqlQuery(
         `${testData.ESQL_QUERIES.TS} | SORT @timestamp DESC`
       );
-      await expect(metricsExperience.grid).toBeVisible();
+      await expect(pageObjects.metricsExperience.grid).toBeVisible();
     });
 
     spaceTest('should not render grid with FROM command', async ({ pageObjects }) => {
-      const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.FROM);
-      await expect(metricsExperience.grid).toBeHidden();
+      await pageObjects.discover.writeEsqlQuery(testData.ESQL_QUERIES.FROM);
+      await expect(pageObjects.metricsExperience.grid).toBeHidden();
     });
 
     spaceTest('should not render grid with STATS command', async ({ pageObjects }) => {
-      const { metricsExperience } = pageObjects;
-      await metricsExperience.runEsqlQuery(`${testData.ESQL_QUERIES.TS} | STATS count()`);
-      await expect(metricsExperience.grid).toBeHidden();
+      await pageObjects.discover.writeEsqlQuery(`${testData.ESQL_QUERIES.TS} | STATS count()`);
+      await expect(pageObjects.metricsExperience.grid).toBeHidden();
     });
 
     spaceTest('should persist grid when changing time range', async ({ pageObjects }) => {
+      await pageObjects.discover.writeEsqlQuery(testData.ESQL_QUERIES.TS);
       const { metricsExperience, datePicker } = pageObjects;
-      await metricsExperience.runEsqlQuery(testData.ESQL_QUERIES.TS);
       await expect(metricsExperience.grid).toBeVisible();
 
       await datePicker.setCommonlyUsedTime('Last_30 days');

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/grid.spec.ts
@@ -1,8 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 /**
@@ -14,7 +16,7 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { spaceTest, testData } from '../../fixtures';
+import { spaceTest, testData } from '../../fixtures/metrics_experience';
 
 spaceTest.describe(
   'Metrics in Discover - Grid',

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
@@ -7,18 +7,21 @@ We follow Scout Best Practices for test structure and conventions.
 ## Folder structure
 
 ```
-discover_enhanced/test/scout/ui/
-├── fixtures/                        # Shared across all discover_enhanced tests
-│   ├── constants.ts                 # Time ranges, queries, data views, tags
-│   ├── page_objects/
-│   │   └── metrics_experience.ts    # Page object for metrics UI
-│   └── generators/
-│       └── metrics_tsdb_index.ts    # Dynamic TSDB index creation
-├── parallel_tests/
-│   ├── global.setup.ts              # Loads archives + creates test index
-│   └── metrics_experience/          # Feature subfolder (you are here)
-│       ├── grid.spec.ts             # Grid activation/command compatibility
-│       └── grid.navigation.spec.ts  # Pagination and search
+discover/test/scout/ui/
+├── metrics_experience_parallel.playwright.config.ts
+├── fixtures/
+│   └── metrics_experience/
+│       ├── index.ts                     # spaceTest extension with MetricsExperiencePage
+│       ├── constants.ts                 # Time ranges, queries, data views, tags
+│       ├── page_objects/
+│       │   └── metrics_experience.ts    # Page object for metrics UI
+│       └── generators/
+│           └── metrics_tsdb_index.ts    # Dynamic TSDB index creation
+└── parallel_tests/
+    └── metrics_experience/              # Feature subfolder (you are here)
+        ├── global.setup.ts              # Loads archives + creates test index
+        ├── grid.spec.ts                 # Grid activation/command compatibility
+        └── grid.navigation.spec.ts      # Pagination and search
 ```
 
 ## Data strategy
@@ -48,7 +51,7 @@ When adding or modifying tests, run the flaky test runner to verify stability be
 For the metrics experience tests:
 
 ```
-/flaky scoutConfig:x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel.playwright.config.ts:30
+/flaky scoutConfig:src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts:30
 ```
 
 25-30 runs is considered safe to call tests "stable". See [example in PR #253076](https://github.com/elastic/kibana/pull/253076#issuecomment-3913203928) where 30/30 runs passed.
@@ -69,7 +72,7 @@ Then, in another terminal, run the tests:
 
 ```bash
 npx playwright test \
-  x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/metrics_experience/ \
-  --config x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel.playwright.config.ts \
+  src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/ \
+  --config src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts \
   --project local --trace on
 ```

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
@@ -2,80 +2,32 @@
 
 Scout UI tests for the Metrics in Discover feature.
 
-We follow Scout Best Practices for test structure and conventions.
-
-## Folder structure
-
-```
-discover/test/scout/ui/
-├── metrics_experience_parallel.playwright.config.ts
-├── fixtures/
-│   └── metrics_experience/
-│       ├── index.ts                     # spaceTest extension with MetricsExperiencePage
-│       ├── constants.ts                 # Queries, data view name, tags
-│       ├── kbn_archives/
-│       │   └── metrics_data_view.json   # Data view pointing to dynamic index
-│       ├── page_objects/
-│       │   └── metrics_experience.ts    # Page object for metrics UI
-│       └── generators/
-│           └── metrics_tsdb_index.ts    # Dynamic TSDB index creation
-└── parallel_tests/
-    └── metrics_experience/              # Feature subfolder (you are here)
-        ├── global.setup.ts              # Creates dynamic test index
-        ├── grid.spec.ts                 # Grid activation/command compatibility
-        └── grid.navigation.spec.ts      # Pagination and search
-```
-
 ## Data strategy
 
-All tests use a single dynamically created TSDB index (`test-metrics-experience`) with 45 metric fields (23 gauge + 22 counter) and 30 dimensions. The index is created in `global.setup.ts` via `createMetricsTestIndexIfNeeded` and is reused across all specs.
+All tests use a single dynamically created TSDB index (`test-metrics-experience`) with 45 metric fields (23 gauge + 22 counter) and 30 dimensions. The index is created once in `global.setup.ts` via `createMetricsTestIndexIfNeeded` and reused across all specs.
 
-A matching data view is loaded from `kbn_archives/metrics_data_view.json` in each spec's `beforeAll` hook, pointing Discover to the dynamic index.
+A matching data view is loaded from `kbn_archives/metrics_data_view.json` in each spec's `beforeAll` hook. This keeps the suite fully self-contained with no dependency on external ES archives.
 
-This approach keeps the test suite fully self-contained with no dependency on external ES archives.
+## Running locally
 
-## How to add a new test
-
-1. Decide if it fits in an existing spec or needs a new one
-2. Use the page object (`MetricsExperiencePage`) for locators. Add new ones there if needed.
-3. Add constants to `constants.ts`
-4. If custom data is needed, extend the generator or create a new one
-5. Use `spaceTest.step()` for multi-step journeys within a single test
-6. Tag your test with `testData.METRICS_EXPERIENCE_TAGS` to ensure it runs in the correct environments
-
-## Detecting flaky tests
-
-When adding or modifying tests, run the flaky test runner to verify stability before merging. Trigger it via a PR comment:
-
-```
-/flaky scoutConfig:<scout config path>:<retry count>
-```
-
-For the metrics experience tests:
-
-```
-/flaky scoutConfig:src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts:30
-```
-
-25-30 runs is considered safe to call tests "stable". See [example in PR #253076](https://github.com/elastic/kibana/pull/253076#issuecomment-3913203928) where 30/30 runs passed.
-
-## Running tests locally
-
-First, start a server in a separate terminal. Use stateful OR serverless depending on which environment you want to test:
+Start a server, then run the tests:
 
 ```bash
-# For stateful tests
+# Stateful
 node scripts/scout start-server --arch stateful --domain classic
 
-# For serverless observability tests
+# Serverless observability
 node scripts/scout start-server --arch serverless --domain observability_complete
 ```
 
-Then, in another terminal, run the tests:
-
 ```bash
 npx playwright test \
-  src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/ \
   --config src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts \
   --project local --trace on
+```
+
+To check stability before merging, trigger the flaky test runner from a PR comment:
+
+```
+/flaky scoutConfig:src/platform/plugins/shared/discover/test/scout/ui/metrics_experience_parallel.playwright.config.ts:30
 ```

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
@@ -12,24 +12,27 @@ discover/test/scout/ui/
 ├── fixtures/
 │   └── metrics_experience/
 │       ├── index.ts                     # spaceTest extension with MetricsExperiencePage
-│       ├── constants.ts                 # Time ranges, queries, data views, tags
+│       ├── constants.ts                 # Queries, data view name, tags
+│       ├── kbn_archives/
+│       │   └── metrics_data_view.json   # Data view pointing to dynamic index
 │       ├── page_objects/
 │       │   └── metrics_experience.ts    # Page object for metrics UI
 │       └── generators/
 │           └── metrics_tsdb_index.ts    # Dynamic TSDB index creation
 └── parallel_tests/
     └── metrics_experience/              # Feature subfolder (you are here)
-        ├── global.setup.ts              # Loads archives + creates test index
+        ├── global.setup.ts              # Creates dynamic test index
         ├── grid.spec.ts                 # Grid activation/command compatibility
         └── grid.navigation.spec.ts      # Pagination and search
 ```
 
 ## Data strategy
 
-Two approaches are used:
+All tests use a single dynamically created TSDB index (`test-metrics-experience`) with 45 metric fields (23 gauge + 22 counter) and 30 dimensions. The index is created in `global.setup.ts` via `createMetricsTestIndexIfNeeded` and is reused across all specs.
 
-- **Static data** (`TSDB_LOGS` archive): For `grid.spec.ts`. Enough for grid activation tests. No dynamic data generation needed, uses the shared archive loaded in global setup.
-- **Dynamic data** (`test-metrics-experience` index): For `grid.navigation.spec.ts`. Contains enough metrics to fill multiple pages. Created via `metrics_tsdb_index.ts` generator. Handles parallel creation races with `resource_already_exists_exception`.
+A matching data view is loaded from `kbn_archives/metrics_data_view.json` in each spec's `beforeAll` hook, pointing Discover to the dynamic index.
+
+This approach keeps the test suite fully self-contained with no dependency on external ES archives.
 
 ## How to add a new test
 

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/constants.ts
@@ -5,21 +5,8 @@
  * 2.0.
  */
 
-import { tags } from '@kbn/scout';
-
 export const LOGSTASH_DEFAULT_START_TIME = '2015-09-19T06:31:44.000Z';
 export const LOGSTASH_DEFAULT_END_TIME = '2015-09-23T18:31:44.000Z';
-
-export const TSDB_LOGS_DEFAULT_START_TIME = '2023-03-28T09:17:00.000Z';
-export const TSDB_LOGS_DEFAULT_END_TIME = '2023-06-28T09:17:00.000Z';
-
-export const METRICS_TEST_INDEX_NAME = 'test-metrics-experience';
-
-export const ESQL_QUERIES = {
-  TS_TSDB_LOGS: 'TS kibana_sample_data_logstsdb',
-  FROM_TSDB_LOGS: 'FROM kibana_sample_data_logstsdb',
-  TS_METRICS_TEST: `TS ${METRICS_TEST_INDEX_NAME}`,
-};
 
 /**
  * Should be used in "single thread" tests to set default Data View
@@ -39,7 +26,6 @@ export const DATA_VIEW_NAME = {
   ECOMMERCE: 'ecommerce',
   LOGSTASH: 'logstash-*',
   NO_TIME_FIELD: 'without-timefield',
-  TSDB_LOGS: 'Kibana Sample Data Logs (TSDB)',
 };
 
 export const LOGSTASH_OUT_OF_RANGE_DATES = {
@@ -57,7 +43,6 @@ export const ES_ARCHIVES = {
   NO_TIME_FIELD:
     'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield',
   ECOMMERCE: 'x-pack/platform/test/fixtures/es_archives/reporting/ecommerce',
-  TSDB_LOGS: 'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_logs_tsdb',
 };
 
 export const KBN_ARCHIVES = {
@@ -69,10 +54,4 @@ export const KBN_ARCHIVES = {
     'x-pack/platform/test/functional/fixtures/kbn_archives/dashboard_drilldowns/drilldowns',
   DISCOVER: 'src/platform/test/functional/fixtures/kbn_archiver/discover',
   ECOMMERCE: 'x-pack/platform/test/functional/fixtures/kbn_archives/reporting/ecommerce.json',
-  TSDB_LOGS: 'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_logs_tsdb.json',
 };
-
-export const METRICS_EXPERIENCE_TAGS = [
-  ...tags.stateful.all,
-  ...tags.serverless.observability.complete,
-];

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/generators/index.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/generators/index.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export * from './metrics_tsdb_index';

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/index.ts
@@ -13,12 +13,11 @@ import type {
   ScoutParallelWorkerFixtures,
 } from '@kbn/scout';
 import { test as baseTest, spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
-import { DemoPage, MetricsExperiencePage } from './page_objects';
+import { DemoPage } from './page_objects';
 
 export interface ExtScoutTestFixtures extends ScoutTestFixtures {
   pageObjects: PageObjects & {
     demo: DemoPage;
-    metricsExperience: MetricsExperiencePage;
   };
 }
 
@@ -36,7 +35,6 @@ export const test = baseTest.extend<ExtScoutTestFixtures, ScoutWorkerFixtures>({
     const extendedPageObjects = {
       ...pageObjects,
       demo: createLazyPageObject(DemoPage, page),
-      metricsExperience: createLazyPageObject(MetricsExperiencePage, page, pageObjects.discover),
     };
 
     await use(extendedPageObjects);
@@ -46,7 +44,6 @@ export const test = baseTest.extend<ExtScoutTestFixtures, ScoutWorkerFixtures>({
 export interface ExtParallelRunTestFixtures extends ScoutParallelTestFixtures {
   pageObjects: PageObjects & {
     demo: DemoPage;
-    metricsExperience: MetricsExperiencePage;
   };
 }
 
@@ -67,7 +64,6 @@ export const spaceTest = spaceBaseTest.extend<
     const extendedPageObjects = {
       ...pageObjects,
       demo: createLazyPageObject(DemoPage, page),
-      metricsExperience: createLazyPageObject(MetricsExperiencePage, page, pageObjects.discover),
     };
 
     await use(extendedPageObjects);
@@ -76,4 +72,3 @@ export const spaceTest = spaceBaseTest.extend<
 
 export * as testData from './constants';
 export * as assertionMessages from './assertion_messages';
-export * from './generators';

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/fixtures/page_objects/index.ts
@@ -6,4 +6,3 @@
  */
 
 export { DemoPage } from './demo';
-export { MetricsExperiencePage } from './metrics_experience';

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/global.setup.ts
@@ -6,27 +6,18 @@
  */
 
 import { globalSetupHook } from '@kbn/scout';
-import { testData, createMetricsTestIndexIfNeeded } from '../fixtures';
+import { testData } from '../fixtures';
 
-globalSetupHook('Ingest data to Elasticsearch', async ({ esArchiver, esClient, log }) => {
+globalSetupHook('Ingest data to Elasticsearch', async ({ esArchiver, log }) => {
   // add archives to load, if needed
   const archives = [
     testData.ES_ARCHIVES.LOGSTASH,
     testData.ES_ARCHIVES.NO_TIME_FIELD,
     testData.ES_ARCHIVES.ECOMMERCE,
-    testData.ES_ARCHIVES.TSDB_LOGS,
   ];
 
   log.debug('[setup] loading ES archives (only if indices do not exist)...');
   for (const archive of archives) {
     await esArchiver.loadIfNeeded(archive);
   }
-
-  log.debug('[setup] loading metrics test index (only if it does not exist)...');
-  const created = await createMetricsTestIndexIfNeeded(esClient);
-  log.debug(
-    created
-      ? '[setup] metrics test index created successfully'
-      : '[setup] metrics test index already exists, skipping'
-  );
 });


### PR DESCRIPTION
## Summary

Migrates the metrics experience Scout e2e tests from `discover_enhanced/test/scout/ui/` to `discover/test/scout/ui/`, following the isolated pattern established by the traces experience PR (#253960) (thanks @iblancof for this really cool structure).

- Metrics tests now live under `discover/test/scout/ui/` with their own Playwright config, global setup, fixtures, and spec files
- Unified data strategy: removed the ES archiver dependency (`TSDB_LOGS`) and now all tests use a single dynamically created TSDB index (`test-metrics-experience`) with a matching KBN archive data view
- Removed duplicate `runEsqlQuery` from `MetricsExperiencePage` -- specs now use the shared `DiscoverApp.writeEsqlQuery()` from `kbn-scout`, following the same feedback applied in the traces PR
- Cleaned up `discover_enhanced`: removed all metrics-specific constants, page objects, generators, and global setup references
- Updated `CODEOWNERS` to reflect the new paths under `@elastic/obs-exploration-team`
- Simplified README: removed stale folder structure diagram and generic guidance, kept only data strategy and run commands

### Dashboard img

<img width="1067" height="502" alt="image" src="https://github.com/user-attachments/assets/52e16e87-beac-4836-b8be-3ed79c972411" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



