### PR TITLE
[9.3] [Write restricted dashboards] - Add auditing per object for change access control operations (#253952)

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/saved_objects/access_control_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/saved_objects/access_control_service.test.ts
@@ -558,7 +558,7 @@ describe('AccessControlService', () => {
         );
       });
 
-      it('calls addAuditEventFn with all unauthorized types when access control check fails', () => {
+      it('calls addAuditEventFn with custom error message and RBAC unauthorized types when access control check fails', () => {
         const addAuditEventFn = jest.fn();
         const authorizationResult = makeAuthResult('partially_authorized', {
           dashboard: {
@@ -585,8 +585,14 @@ describe('AccessControlService', () => {
           })
         ).toThrow(/Access denied/);
 
-        // Should be called with all unauthorized types (deduplicated and sorted)
-        expect(addAuditEventFn).toHaveBeenCalledWith(['dashboard']);
+        // Should be called with only RBAC unauthorized types (not access control types)
+        expect(addAuditEventFn).toHaveBeenCalledWith(
+          'Access denied: Unable to perform manage access control for types dashboard. ' +
+            'The "update" privilege is required to change access control of objects owned by the current user. ' +
+            'Unable to manage access control for objects dashboard:obj-2: ' +
+            'the "manage_access_control" privilege is required to change access control of objects owned by another user.',
+          ['dashboard']
+        );
       });
 
       it('filters unauthorized objects to only include types that failed manage_access_control check', () => {

--- a/x-pack/platform/plugins/shared/security/server/saved_objects/access_control_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/saved_objects/access_control_service.ts
@@ -141,7 +141,7 @@ export class AccessControlService {
     authorizationResult: CheckAuthorizationResult<A>;
     objectsRequiringPrivilegeCheck: ObjectRequiringPrivilegeCheckResult[];
     currentSpace: string;
-    addAuditEventFn?: (types: string[]) => void;
+    addAuditEventFn?: (errMessage: string, types: string[]) => void;
   }) {
     // Derive typesRequiringAccessControl and typesRequiringRbac from the objects array.
     // - typesRequiringAccessControl: types where objects are NOT owned by current user (need manage_access_control)
@@ -163,8 +163,8 @@ export class AccessControlService {
 
     if (authorizationResult.status === 'unauthorized') {
       const rbacTypeList = [...typesRequiringRbac].sort();
-      const allTypes = [...new Set([...typesRequiringRbac, ...typesRequiringAccessControl])].sort();
-      addAuditEventFn?.(allTypes);
+      const errorMsg = buildAccessDeniedMessage(rbacTypeList, objectsRequiringAccessControl);
+      addAuditEventFn?.(errorMsg, rbacTypeList);
       throw SavedObjectsErrorHelpers.decorateForbiddenError(
         new Error(buildAccessDeniedMessage(rbacTypeList, objectsRequiringAccessControl))
       );
@@ -212,15 +212,12 @@ export class AccessControlService {
 
     if (unauthorizedRbacTypes.size > 0 || unauthorizedAccessControlTypes.size > 0) {
       const rbacTypeList = [...unauthorizedRbacTypes].sort();
-      const accessControlTypeList = [...unauthorizedAccessControlTypes].sort();
-      const allUnauthorizedTypes = [...new Set([...rbacTypeList, ...accessControlTypeList])].sort();
       const unauthorizedObjects = objectsRequiringAccessControl.filter((obj) =>
         unauthorizedAccessControlTypes.has(obj.type)
       );
-      addAuditEventFn?.(allUnauthorizedTypes);
-      throw SavedObjectsErrorHelpers.decorateForbiddenError(
-        new Error(buildAccessDeniedMessage(rbacTypeList, unauthorizedObjects))
-      );
+      const errorMsg = buildAccessDeniedMessage(rbacTypeList, unauthorizedObjects);
+      addAuditEventFn?.(errorMsg, rbacTypeList);
+      throw SavedObjectsErrorHelpers.decorateForbiddenError(new Error(errorMsg));
     }
   }
 }

--- a/x-pack/platform/plugins/shared/security/server/saved_objects/saved_objects_security_extension.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/saved_objects/saved_objects_security_extension.test.ts
@@ -6563,12 +6563,40 @@ describe('#authorizeChangeAccessControl', () => {
       )
     ).rejects.toThrow();
 
-    expect(addAuditEventSpy).toHaveBeenCalledWith(
+    const expectedError = new Error(
+      'Access denied: Unable to perform manage access control for types visualization. ' +
+        'The "update" privilege is required to change access control of objects owned by the current user. ' +
+        'Unable to manage access control for objects dashboard:1: ' +
+        'the "manage_access_control" privilege is required to change access control of objects owned by another user.'
+    );
+
+    expect(auditHelperSpy).toHaveBeenCalledTimes(1);
+
+    expect(addAuditEventSpy).toHaveBeenCalledTimes(2);
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         action: AuditAction.UPDATE_OBJECTS_OWNER,
-        error: expect.any(Error),
-        unauthorizedTypes: ['dashboard', 'visualization'],
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
         unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[0].type,
+          id: objectsWithExistingNamespaces[0].id,
+        }),
+      })
+    );
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_OWNER,
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[1].type,
+          id: objectsWithExistingNamespaces[1].id,
+        }),
       })
     );
   });
@@ -6770,15 +6798,42 @@ describe('#authorizeChangeAccessControl', () => {
       )
     ).rejects.toThrow();
 
-    expect(addAuditEventSpy).toHaveBeenCalledWith(
+    const expectedError = new Error(
+      'Access denied: Unable to perform manage access control for types visualization. ' +
+        'The "update" privilege is required to change access control of objects owned by the current user. ' +
+        'Unable to manage access control for objects dashboard:1: ' +
+        'the "manage_access_control" privilege is required to change access control of objects owned by another user.'
+    );
+
+    expect(auditHelperSpy).toHaveBeenCalledTimes(1);
+
+    expect(addAuditEventSpy).toHaveBeenCalledTimes(2);
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         action: AuditAction.UPDATE_OBJECTS_ACCESS_MODE,
-        error: expect.any(Error),
-        unauthorizedTypes: expect.arrayContaining(['dashboard']),
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
         unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[0].type,
+          id: objectsWithExistingNamespaces[0].id,
+        }),
       })
     );
-    expect(auditHelperSpy).not.toHaveBeenCalled();
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_ACCESS_MODE,
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[1].type,
+          id: objectsWithExistingNamespaces[1].id,
+        }),
+      })
+    );
   });
 
   test('audits failure event with multiple types when changeOwnership is unauthorized', async () => {
@@ -6817,15 +6872,55 @@ describe('#authorizeChangeAccessControl', () => {
       )
     ).rejects.toThrow();
 
-    expect(addAuditEventSpy).toHaveBeenCalledWith(
+    const expectedError = new Error(
+      'Access denied: Unable to perform manage access control for types map, visualization. ' +
+        'The "update" privilege is required to change access control of objects owned by the current user. ' +
+        'Unable to manage access control for objects dashboard:1: ' +
+        'the "manage_access_control" privilege is required to change access control of objects owned by another user.'
+    );
+
+    expect(auditHelperSpy).toHaveBeenCalledTimes(1);
+
+    expect(addAuditEventSpy).toHaveBeenCalledTimes(3);
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         action: AuditAction.UPDATE_OBJECTS_OWNER,
-        error: expect.any(Error),
-        unauthorizedTypes: expect.arrayContaining(['dashboard']),
+        error: expectedError,
+        unauthorizedTypes: ['map', 'visualization'],
         unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objects[0].type,
+          id: objects[0].id,
+        }),
       })
     );
-    expect(auditHelperSpy).not.toHaveBeenCalled();
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_OWNER,
+        error: expectedError,
+        unauthorizedTypes: ['map', 'visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objects[1].type,
+          id: objects[1].id,
+        }),
+      })
+    );
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_OWNER,
+        error: expectedError,
+        unauthorizedTypes: ['map', 'visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objects[2].type,
+          id: objects[2].id,
+        }),
+      })
+    );
   });
 
   test('audits failure event when partially authorized but not in current space', async () => {
@@ -6870,15 +6965,71 @@ describe('#authorizeChangeAccessControl', () => {
       )
     ).rejects.toThrow();
 
-    expect(addAuditEventSpy).toHaveBeenCalledWith(
+    const expectedError = new Error(
+      'Access denied: Unable to perform manage access control for types visualization. ' +
+        'The "update" privilege is required to change access control of objects owned by the current user. ' +
+        'Unable to manage access control for objects dashboard:1: ' +
+        'the "manage_access_control" privilege is required to change access control of objects owned by another user.'
+    );
+
+    expect(auditHelperSpy).toHaveBeenCalledTimes(1);
+    expect(auditHelperSpy).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         action: AuditAction.UPDATE_OBJECTS_OWNER,
-        error: expect.any(Error),
-        unauthorizedTypes: ['dashboard', 'visualization'],
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
         unauthorizedSpaces: [namespace],
+        objects: [
+          {
+            accessControl: {
+              accessMode: 'write_restricted',
+              owner: 'fake_owner_id',
+            },
+            existingNamespaces: [],
+            id: '1',
+            type: 'dashboard',
+          },
+          {
+            accessControl: {
+              accessMode: 'write_restricted',
+              owner: 'fake_owner_id',
+            },
+            existingNamespaces: [],
+            id: '2',
+            type: 'visualization',
+          },
+        ],
       })
     );
-    expect(auditHelperSpy).not.toHaveBeenCalled();
+
+    expect(addAuditEventSpy).toHaveBeenCalledTimes(2);
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_OWNER,
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[0].type,
+          id: objectsWithExistingNamespaces[0].id,
+        }),
+      })
+    );
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_OWNER,
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[1].type,
+          id: objectsWithExistingNamespaces[1].id,
+        }),
+      })
+    );
   });
 
   test('audits failure event when partially authorized but not in current space for changeAccessMode', async () => {
@@ -6922,15 +7073,71 @@ describe('#authorizeChangeAccessControl', () => {
       )
     ).rejects.toThrow();
 
-    expect(addAuditEventSpy).toHaveBeenCalledWith(
+    const expectedError = new Error(
+      'Access denied: Unable to perform manage access control for types visualization. ' +
+        'The "update" privilege is required to change access control of objects owned by the current user. ' +
+        'Unable to manage access control for objects dashboard:1: ' +
+        'the "manage_access_control" privilege is required to change access control of objects owned by another user.'
+    );
+
+    expect(auditHelperSpy).toHaveBeenCalledTimes(1);
+    expect(auditHelperSpy).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
-        action: AuditAction.UPDATE_OBJECTS_ACCESS_MODE,
-        error: expect.any(Error),
-        unauthorizedTypes: expect.arrayContaining(['visualization']),
-        unauthorizedSpaces: [namespace],
+        action: 'saved_object_update_objects_access_mode',
+        error: expectedError,
+        objects: [
+          {
+            accessControl: {
+              accessMode: 'write_restricted',
+              owner: 'fake_owner_id',
+            },
+            existingNamespaces: [],
+            id: '1',
+            type: 'dashboard',
+          },
+          {
+            accessControl: {
+              accessMode: 'write_restricted',
+              owner: 'fake_owner_id',
+            },
+            existingNamespaces: [],
+            id: '2',
+            type: 'visualization',
+          },
+        ],
+        unauthorizedSpaces: ['x'],
+        unauthorizedTypes: ['visualization'],
       })
     );
-    expect(auditHelperSpy).not.toHaveBeenCalled();
+
+    expect(addAuditEventSpy).toHaveBeenCalledTimes(2);
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_ACCESS_MODE,
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[0].type,
+          id: objectsWithExistingNamespaces[0].id,
+        }),
+      })
+    );
+    expect(addAuditEventSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: AuditAction.UPDATE_OBJECTS_ACCESS_MODE,
+        error: expectedError,
+        unauthorizedTypes: ['visualization'],
+        unauthorizedSpaces: [namespace],
+        savedObject: expect.objectContaining({
+          type: objectsWithExistingNamespaces[1].type,
+          id: objectsWithExistingNamespaces[1].id,
+        }),
+      })
+    );
   });
 
   test('does not audit success when operation fails', async () => {
@@ -6959,7 +7166,7 @@ describe('#authorizeChangeAccessControl', () => {
       )
     ).rejects.toThrow();
 
-    expect(addAuditEventSpy).toHaveBeenCalledTimes(1);
-    expect(auditHelperSpy).not.toHaveBeenCalled();
+    expect(addAuditEventSpy).toHaveBeenCalledTimes(objectsWithExistingNamespaces.length);
+    expect(auditHelperSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/saved_objects/saved_objects_security_extension.ts
+++ b/x-pack/platform/plugins/shared/security/server/saved_objects/saved_objects_security_extension.ts
@@ -1270,11 +1270,11 @@ export class SavedObjectsSecurityExtension implements ISavedObjectsSecurityExten
         objectsRequiringPrivilegeCheck,
         authorizationResult,
         currentSpace: namespaceString,
-        addAuditEventFn: (types: string[]) => {
-          const errMessage = `Unable to ${authzAction} for types ${types.join(', ')}`;
+        addAuditEventFn: (errMessage: string, types: string[]) => {
           const err = new Error(errMessage);
-          this.addAuditEvent({
+          this.auditHelper({
             action: auditAction!,
+            objects,
             error: err,
             unauthorizedTypes: types,
             unauthorizedSpaces: [...spacesToAuthorize],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Write restricted dashboards] - Add auditing per object for change access control operations (#253952)](https://github.com/elastic/kibana/pull/253952)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-02-20T15:30:27Z","message":"[Write restricted dashboards] - Add auditing per object for change access control operations (#253952)\n\nCloses https://github.com/elastic/kibana/issues/249212\n\n## Summary\n\nAdds auditing per object with custom error message to access control\noperations (i.e. change access mode, change owner).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9394bf21d7ac4a75f02d5b999eb476025d25a479","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","Feature:Saved Objects","release_note:skip","backport missing","Feature:Security/Audit","backport:version","v9.3.0","v9.4.0"],"title":"[Write restricted dashboards] - Add auditing per object for change access control operations","number":253952,"url":"https://github.com/elastic/kibana/pull/253952","mergeCommit":{"message":"[Write restricted dashboards] - Add auditing per object for change access control operations (#253952)\n\nCloses https://github.com/elastic/kibana/issues/249212\n\n## Summary\n\nAdds auditing per object with custom error message to access control\noperations (i.e. change access mode, change owner).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9394bf21d7ac4a75f02d5b999eb476025d25a479"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253952","number":253952,"mergeCommit":{"message":"[Write restricted dashboards] - Add auditing per object for change access control operations (#253952)\n\nCloses https://github.com/elastic/kibana/issues/249212\n\n## Summary\n\nAdds auditing per object with custom error message to access control\noperations (i.e. change access mode, change owner).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9394bf21d7ac4a75f02d5b999eb476025d25a479"}}]}] BACKPORT-->