### PR TITLE
[9.2] [SharedUX][A11y] Add announcement for table list view selection (#254509)

### DIFF
--- a/src/platform/packages/shared/content-management/table_list_view_table/src/components/table.tsx
+++ b/src/platform/packages/shared/content-management/table_list_view_table/src/components/table.tsx
@@ -25,6 +25,7 @@ import {
   useEuiTheme,
   EuiCode,
   EuiText,
+  EuiLiveAnnouncer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
@@ -170,6 +171,17 @@ export function Table<T extends UserContentCommonSchema>({
       };
     }
   }, [deleteItems, dispatch, tableItemsRowActions]);
+
+  const selectionAnnouncement = useMemo(() => {
+    if (selectedIds.length === 0) return '';
+    return i18n.translate('contentManagement.tableList.listing.selectionAnnouncement', {
+      defaultMessage: '{count} {entityName} selected. Delete button is now available.',
+      values: {
+        count: selectedIds.length,
+        entityName: selectedIds.length === 1 ? entityName : entityNamePlural,
+      },
+    });
+  }, [selectedIds.length, entityName, entityNamePlural]);
 
   const {
     isPopoverOpen,
@@ -363,6 +375,7 @@ export function Table<T extends UserContentCommonSchema>({
         totalActiveFilters={totalActiveFilters}
         clearTagSelection={clearTagSelection}
       >
+        <EuiLiveAnnouncer>{selectionAnnouncement}</EuiLiveAnnouncer>
         <EuiInMemoryTable<T>
           itemId="id"
           items={visibleItems}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[SharedUX][A11y] Add announcement for table list view selection (#254509)](https://github.com/elastic/kibana/pull/254509)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ángeles Martínez Barrio","email":"angeles.martinezbarrio@elastic.co"},"sourceCommit":{"committedDate":"2026-02-24T09:30:55Z","message":"[SharedUX][A11y] Add announcement for table list view selection (#254509)\n\nCloses https://github.com/elastic/kibana/issues/236107\n\n## Summary\n\n- Added\n[EuiLiveAnnouncer](https://eui.elastic.co/docs/utilities/accessibility/#live-announcer-region-)\nto announce the table list view 'delete' button which renders\nconditionally.\n\n### Testing\n\nChrome + VO + Maps (reported combination)\n<img width=\"1201\" height=\"459\" alt=\"Screenshot 2026-02-23 at 15 41 56\"\nsrc=\"https://github.com/user-attachments/assets/1847d61d-5817-4dbc-b688-22de8f0ac19a\"\n/>\n\nSafari + VO + Dashboards\n<img width=\"1265\" height=\"644\" alt=\"Screenshot 2026-02-23 at 15 42 29\"\nsrc=\"https://github.com/user-attachments/assets/a5bdef7f-dbc9-46cf-8b58-882d3e72e6bc\"\n/>\n\nVMWareFusion + Chrome + NVDA + Dashboards\n<img width=\"1728\" height=\"623\" alt=\"Screenshot 2026-02-23 at 15 50 55\"\nsrc=\"https://github.com/user-attachments/assets/19b29841-babd-410b-9f23-82ce9b40c8f9\"\n/>","sha":"afc39da41e535cbfae55b559409b327dc0c63e86","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:version","a11y","v9.2.0","v9.3.0","v9.4.0"],"title":"[SharedUX][A11y] Add announcement for table list view selection","number":254509,"url":"https://github.com/elastic/kibana/pull/254509","mergeCommit":{"message":"[SharedUX][A11y] Add announcement for table list view selection (#254509)\n\nCloses https://github.com/elastic/kibana/issues/236107\n\n## Summary\n\n- Added\n[EuiLiveAnnouncer](https://eui.elastic.co/docs/utilities/accessibility/#live-announcer-region-)\nto announce the table list view 'delete' button which renders\nconditionally.\n\n### Testing\n\nChrome + VO + Maps (reported combination)\n<img width=\"1201\" height=\"459\" alt=\"Screenshot 2026-02-23 at 15 41 56\"\nsrc=\"https://github.com/user-attachments/assets/1847d61d-5817-4dbc-b688-22de8f0ac19a\"\n/>\n\nSafari + VO + Dashboards\n<img width=\"1265\" height=\"644\" alt=\"Screenshot 2026-02-23 at 15 42 29\"\nsrc=\"https://github.com/user-attachments/assets/a5bdef7f-dbc9-46cf-8b58-882d3e72e6bc\"\n/>\n\nVMWareFusion + Chrome + NVDA + Dashboards\n<img width=\"1728\" height=\"623\" alt=\"Screenshot 2026-02-23 at 15 50 55\"\nsrc=\"https://github.com/user-attachments/assets/19b29841-babd-410b-9f23-82ce9b40c8f9\"\n/>","sha":"afc39da41e535cbfae55b559409b327dc0c63e86"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254509","number":254509,"mergeCommit":{"message":"[SharedUX][A11y] Add announcement for table list view selection (#254509)\n\nCloses https://github.com/elastic/kibana/issues/236107\n\n## Summary\n\n- Added\n[EuiLiveAnnouncer](https://eui.elastic.co/docs/utilities/accessibility/#live-announcer-region-)\nto announce the table list view 'delete' button which renders\nconditionally.\n\n### Testing\n\nChrome + VO + Maps (reported combination)\n<img width=\"1201\" height=\"459\" alt=\"Screenshot 2026-02-23 at 15 41 56\"\nsrc=\"https://github.com/user-attachments/assets/1847d61d-5817-4dbc-b688-22de8f0ac19a\"\n/>\n\nSafari + VO + Dashboards\n<img width=\"1265\" height=\"644\" alt=\"Screenshot 2026-02-23 at 15 42 29\"\nsrc=\"https://github.com/user-attachments/assets/a5bdef7f-dbc9-46cf-8b58-882d3e72e6bc\"\n/>\n\nVMWareFusion + Chrome + NVDA + Dashboards\n<img width=\"1728\" height=\"623\" alt=\"Screenshot 2026-02-23 at 15 50 55\"\nsrc=\"https://github.com/user-attachments/assets/19b29841-babd-410b-9f23-82ce9b40c8f9\"\n/>","sha":"afc39da41e535cbfae55b559409b327dc0c63e86"}}]}] BACKPORT-->