### PR TITLE
[ES|QL] Fixes the detail in the TS autocomplete

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/context_fixtures.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/context_fixtures.ts
@@ -18,17 +18,17 @@ import { getFieldNamesByType } from './autocomplete';
 export const joinIndices: IndexAutocompleteItem[] = [
   {
     name: 'join_index',
-    mode: 'lookup',
+    mode: 'Lookup',
     aliases: [],
   },
   {
     name: 'join_index_with_alias',
-    mode: 'lookup',
+    mode: 'Lookup',
     aliases: ['join_index_alias_1', 'join_index_alias_2'],
   },
   {
     name: 'lookup_index',
-    mode: 'lookup',
+    mode: 'Lookup',
     aliases: [],
   },
 ];
@@ -42,17 +42,17 @@ export const lookupIndexFields = [
 export const timeseriesIndices: IndexAutocompleteItem[] = [
   {
     name: 'timeseries_index',
-    mode: 'time_series',
+    mode: 'Timeseries',
     aliases: [],
   },
   {
     name: 'timeseries_index_with_alias',
-    mode: 'time_series',
+    mode: 'Timeseries',
     aliases: ['timeseries_index_alias_1', 'timeseries_index_alias_2'],
   },
   {
     name: 'time_series_index',
-    mode: 'time_series',
+    mode: 'Timeseries',
     aliases: [],
   },
 ];

--- a/src/platform/packages/shared/kbn-esql-language/src/__tests__/language/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/__tests__/language/helpers.ts
@@ -71,17 +71,17 @@ export const policies = [
 export const joinIndices: IndexAutocompleteItem[] = [
   {
     name: 'join_index',
-    mode: 'lookup',
+    mode: 'Lookup',
     aliases: [],
   },
   {
     name: 'join_index_with_alias',
-    mode: 'lookup',
+    mode: 'Lookup',
     aliases: ['join_index_alias_1', 'join_index_alias_2'],
   },
   {
     name: 'lookup_index',
-    mode: 'lookup',
+    mode: 'Lookup',
     aliases: [],
   },
 ];
@@ -89,17 +89,17 @@ export const joinIndices: IndexAutocompleteItem[] = [
 export const timeseriesIndices: IndexAutocompleteItem[] = [
   {
     name: 'timeseries_index',
-    mode: 'time_series',
+    mode: 'Timeseries',
     aliases: [],
   },
   {
     name: 'timeseries_index_with_alias',
-    mode: 'time_series',
+    mode: 'Timeseries',
     aliases: ['timeseries_index_alias_1', 'timeseries_index_alias_2'],
   },
   {
     name: 'time_series_index',
-    mode: 'time_series',
+    mode: 'Timeseries',
     aliases: [],
   },
 ];

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/sources.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/sources.ts
@@ -255,12 +255,12 @@ export const specialIndicesToSuggestions = (
         label: index.name,
         text: index.name + ' ',
         kind: 'Issue',
-        detail: i18n.translate(
-          'kbn-esql-language.esql.autocomplete.specialIndexes.indexType.index',
-          {
-            defaultMessage: 'Index',
-          }
-        ),
+        detail: i18n.translate('kbn-esql-language.esql.autocomplete.sourceDefinition', {
+          defaultMessage: '{type}',
+          values: {
+            type: index.mode ?? SOURCES_TYPES.INDEX,
+          },
+        }),
         sortText: '0-INDEX-' + index.name,
       })
     );

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/join/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/join/autocomplete.test.ts
@@ -214,7 +214,7 @@ describe('JOIN Autocomplete', () => {
         autocomplete
       );
       const indices: string[] = suggestions
-        .filter((s) => s.detail === 'Index')
+        .filter((s) => s.detail === 'Lookup')
         .map(({ label }) => label)
         .sort();
       const aliases: string[] = suggestions

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/autocomplete.test.ts
@@ -877,8 +877,8 @@ describe('index= suggestions', () => {
   const contextWithSources: ICommandContext = {
     ...mockContext,
     timeSeriesSources: [
-      { name: 'metrics', mode: 'time_series', aliases: [] },
-      { name: 'logs-tsdb', mode: 'time_series', aliases: [] },
+      { name: 'metrics', mode: 'Timeseries', aliases: [] },
+      { name: 'logs-tsdb', mode: 'Timeseries', aliases: [] },
     ],
   };
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/autocomplete.test.ts
@@ -102,7 +102,7 @@ describe('TS Autocomplete', () => {
     test('discriminates between indices and aliases', async () => {
       const suggestions = await suggest('TS ');
       const indices: string[] = suggestions
-        .filter((s) => s.detail === 'Index')
+        .filter((s) => s.detail === 'Timeseries')
         .map((s) => s.label)
         .sort();
       const aliases: string[] = suggestions

--- a/src/platform/plugins/shared/esql/server/integration_tests/esql_routes.test.ts
+++ b/src/platform/plugins/shared/esql/server/integration_tests/esql_routes.test.ts
@@ -32,7 +32,7 @@ describe('ESQL routes', () => {
 
     expect(item1).toMatchObject({
       name: 'lookup_index1',
-      mode: 'lookup',
+      mode: 'Lookup',
       aliases: [],
     });
 
@@ -40,7 +40,7 @@ describe('ESQL routes', () => {
 
     expect(item2).toMatchObject({
       name: 'lookup_index2',
-      mode: 'lookup',
+      mode: 'Lookup',
       aliases: ['lookup_index2_alias1', 'lookup_index2_alias2'],
     });
   });
@@ -54,7 +54,7 @@ describe('ESQL routes', () => {
 
     expect(item1).toMatchObject({
       name: 'ts_index1',
-      mode: 'time_series',
+      mode: 'Timeseries',
       aliases: [],
     });
 
@@ -62,7 +62,7 @@ describe('ESQL routes', () => {
 
     expect(item2).toMatchObject({
       name: 'ts_index2',
-      mode: 'time_series',
+      mode: 'Timeseries',
       aliases: ['ts_index2_alias1', 'ts_index2_alias2'],
     });
   });

--- a/src/platform/plugins/shared/esql/server/services/esql_service.ts
+++ b/src/platform/plugins/shared/esql/server/services/esql_service.ts
@@ -55,12 +55,14 @@ export class EsqlService {
       mode,
     })) as ResolveIndexResponse;
 
+    const mappedMode = this.getIndexSourceType(mode);
+
     sources.indices?.forEach((index) => {
-      indices.push({ name: index.name, mode, aliases: index.aliases ?? [] });
+      indices.push({ name: index.name, mode: mappedMode, aliases: index.aliases ?? [] });
     });
 
     sources.data_streams?.forEach((dataStream) => {
-      indices.push({ name: dataStream.name, mode, aliases: dataStream.aliases ?? [] });
+      indices.push({ name: dataStream.name, mode: mappedMode, aliases: dataStream.aliases ?? [] });
     });
 
     const crossClusterCommonIndices = remoteClusters


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/251080

While in FROM the detail is correct, in TS and Lookup join it was Index which can be confusing

<img width="760" height="380" alt="image" src="https://github.com/user-attachments/assets/21fffbe4-a9fd-45e3-88c6-7ae3c18b11ed" />




