### PR TITLE
[Cloud Security] Fix 3P integrations missing icon in cloud account grouping

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
@@ -209,6 +209,9 @@ export interface FindingsGroupingAggregation {
   accountName?: {
     buckets?: GenericBuckets[];
   };
+  cloudProvider?: {
+    buckets?: GenericBuckets[];
+  };
   clusterName?: {
     buckets?: GenericBuckets[];
   };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.test.tsx
@@ -140,7 +140,9 @@ describe('groupPanelRenderer - CLOUD_ACCOUNT_ID', () => {
     } as unknown as RawBucket<FindingsGroupingAggregation>;
 
     const { getByTestId, queryByTestId } = render(
-      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+      <>
+        {groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}
+      </>
     );
 
     expect(getByTestId('cis-benchmark-icon')).toBeInTheDocument();
@@ -160,7 +162,9 @@ describe('groupPanelRenderer - CLOUD_ACCOUNT_ID', () => {
     } as unknown as RawBucket<FindingsGroupingAggregation>;
 
     const { getByTestId, queryByTestId } = render(
-      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+      <>
+        {groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}
+      </>
     );
 
     expect(getByTestId('cloud-provider-icon')).toBeInTheDocument();
@@ -180,7 +184,9 @@ describe('groupPanelRenderer - CLOUD_ACCOUNT_ID', () => {
     } as unknown as RawBucket<FindingsGroupingAggregation>;
 
     const { getByText } = render(
-      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+      <>
+        {groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}
+      </>
     );
 
     expect(getByText('Google Cloud Platform')).toBeInTheDocument();
@@ -195,7 +201,9 @@ describe('groupPanelRenderer - CLOUD_ACCOUNT_ID', () => {
     } as unknown as RawBucket<FindingsGroupingAggregation>;
 
     const { getByText, queryByText } = render(
-      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+      <>
+        {groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}
+      </>
     );
 
     expect(getByText('CIS Azure')).toBeInTheDocument();
@@ -211,7 +219,9 @@ describe('groupPanelRenderer - CLOUD_ACCOUNT_ID', () => {
     } as unknown as RawBucket<FindingsGroupingAggregation>;
 
     const { queryByTestId } = render(
-      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+      <>
+        {groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}
+      </>
     );
 
     expect(queryByTestId('cis-benchmark-icon')).not.toBeInTheDocument();
@@ -220,7 +230,14 @@ describe('groupPanelRenderer - CLOUD_ACCOUNT_ID', () => {
 
   it('renders NullGroup when nullGroupMessage is provided', () => {
     const { getByTestId } = render(
-      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, baseBucket, 'No data', false)}</>
+      <>
+        {groupPanelRenderer(
+          FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID,
+          baseBucket,
+          'No data',
+          false
+        )}
+      </>
     );
 
     expect(getByTestId('null-group')).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.test.tsx
@@ -10,8 +10,11 @@ import { render } from '@testing-library/react';
 import { useEuiTheme } from '@elastic/eui';
 import type { RawBucket } from '@kbn/grouping/src';
 import type { FindingsGroupingAggregation } from '@kbn/cloud-security-posture';
-import { ComplianceBarComponent } from './latest_findings_group_renderer';
+import { ComplianceBarComponent, groupPanelRenderer } from './latest_findings_group_renderer';
 import { ComplianceScoreBar } from '../../../components/compliance_score_bar';
+import { CISBenchmarkIcon } from '../../../components/cis_benchmark_icon';
+import { CloudProviderIcon } from '../../../components/cloud_provider_icon';
+import { FINDINGS_GROUPING_OPTIONS } from '../../../common/constants';
 
 jest.mock('@elastic/eui', () => {
   const actual = jest.requireActual('@elastic/eui');
@@ -25,7 +28,20 @@ jest.mock('../../../components/compliance_score_bar', () => ({
   ComplianceScoreBar: jest.fn(() => null),
 }));
 
-jest.mock('../../../components/cloud_security_grouping');
+jest.mock('../../../components/cloud_security_grouping', () => ({
+  firstNonNullValue: jest.requireActual('../../../components/cloud_security_grouping')
+    .firstNonNullValue,
+  LoadingGroup: () => <div data-test-subj="loading-group">Loading</div>,
+  NullGroup: ({ title }: { title: string }) => <div data-test-subj="null-group">{title}</div>,
+}));
+
+jest.mock('../../../components/cis_benchmark_icon', () => ({
+  CISBenchmarkIcon: jest.fn(() => <div data-test-subj="cis-benchmark-icon" />),
+}));
+
+jest.mock('../../../components/cloud_provider_icon', () => ({
+  CloudProviderIcon: jest.fn(() => <div data-test-subj="cloud-provider-icon" />),
+}));
 
 describe('<ComplianceBarComponent />', () => {
   beforeEach(() => {
@@ -97,5 +113,116 @@ describe('<ComplianceBarComponent />', () => {
       }),
       {}
     );
+  });
+});
+
+describe('groupPanelRenderer - CLOUD_ACCOUNT_ID', () => {
+  const baseBucket = {
+    key: 'account-123',
+    key_as_string: 'account-123',
+    doc_count: 10,
+    failedFindings: { doc_count: 4 },
+    passedFindings: { doc_count: 6 },
+    accountName: { buckets: [{ key: 'My Account', doc_count: 10 }] },
+  } as unknown as RawBucket<FindingsGroupingAggregation>;
+
+  beforeEach(() => {
+    (CISBenchmarkIcon as jest.Mock).mockClear();
+    (CloudProviderIcon as jest.Mock).mockClear();
+  });
+
+  it('renders CISBenchmarkIcon when benchmarkId is present (native integration)', () => {
+    const bucket = {
+      ...baseBucket,
+      benchmarkId: { buckets: [{ key: 'cis_aws', doc_count: 10 }] },
+      benchmarkName: { buckets: [{ key: 'CIS AWS', doc_count: 10 }] },
+      cloudProvider: { buckets: [{ key: 'aws', doc_count: 10 }] },
+    } as unknown as RawBucket<FindingsGroupingAggregation>;
+
+    const { getByTestId, queryByTestId } = render(
+      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+    );
+
+    expect(getByTestId('cis-benchmark-icon')).toBeInTheDocument();
+    expect(queryByTestId('cloud-provider-icon')).not.toBeInTheDocument();
+    expect(CISBenchmarkIcon).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'cis_aws', name: 'CIS AWS' }),
+      expect.anything()
+    );
+  });
+
+  it('renders CloudProviderIcon when benchmarkId is absent but cloudProvider is present (3P integration)', () => {
+    const bucket = {
+      ...baseBucket,
+      benchmarkId: { buckets: [] },
+      benchmarkName: { buckets: [] },
+      cloudProvider: { buckets: [{ key: 'aws', doc_count: 10 }] },
+    } as unknown as RawBucket<FindingsGroupingAggregation>;
+
+    const { getByTestId, queryByTestId } = render(
+      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+    );
+
+    expect(getByTestId('cloud-provider-icon')).toBeInTheDocument();
+    expect(queryByTestId('cis-benchmark-icon')).not.toBeInTheDocument();
+    expect(CloudProviderIcon).toHaveBeenCalledWith(
+      expect.objectContaining({ cloudProvider: 'aws' }),
+      expect.anything()
+    );
+  });
+
+  it('shows cloud provider full name as subtitle when benchmark name is absent', () => {
+    const bucket = {
+      ...baseBucket,
+      benchmarkId: { buckets: [] },
+      benchmarkName: { buckets: [] },
+      cloudProvider: { buckets: [{ key: 'gcp', doc_count: 10 }] },
+    } as unknown as RawBucket<FindingsGroupingAggregation>;
+
+    const { getByText } = render(
+      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+    );
+
+    expect(getByText('Google Cloud Platform')).toBeInTheDocument();
+  });
+
+  it('shows benchmark name as subtitle when both benchmarkName and cloudProvider are present', () => {
+    const bucket = {
+      ...baseBucket,
+      benchmarkId: { buckets: [{ key: 'cis_azure', doc_count: 10 }] },
+      benchmarkName: { buckets: [{ key: 'CIS Azure', doc_count: 10 }] },
+      cloudProvider: { buckets: [{ key: 'azure', doc_count: 10 }] },
+    } as unknown as RawBucket<FindingsGroupingAggregation>;
+
+    const { getByText, queryByText } = render(
+      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+    );
+
+    expect(getByText('CIS Azure')).toBeInTheDocument();
+    expect(queryByText('Microsoft Azure')).not.toBeInTheDocument();
+  });
+
+  it('renders no icon and no subtitle when both benchmarkId and cloudProvider are absent', () => {
+    const bucket = {
+      ...baseBucket,
+      benchmarkId: { buckets: [] },
+      benchmarkName: { buckets: [] },
+      cloudProvider: { buckets: [] },
+    } as unknown as RawBucket<FindingsGroupingAggregation>;
+
+    const { queryByTestId } = render(
+      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, bucket, undefined, false)}</>
+    );
+
+    expect(queryByTestId('cis-benchmark-icon')).not.toBeInTheDocument();
+    expect(queryByTestId('cloud-provider-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders NullGroup when nullGroupMessage is provided', () => {
+    const { getByTestId } = render(
+      <>{groupPanelRenderer(FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID, baseBucket, 'No data', false)}</>
+    );
+
+    expect(getByTestId('null-group')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.test.tsx
@@ -85,6 +85,30 @@ describe('useLatestFindingsGrouping', () => {
     );
   });
 
+  it('includes cloudProvider aggregation for cloud.account.id grouping', () => {
+    renderHook(() =>
+      useLatestFindingsGrouping({
+        groupPanelRenderer: mockGroupPanelRenderer,
+        getGroupStats: mockGetGroupStats,
+        groupingLevel: 0,
+        groupFilters: [],
+        selectedGroup: 'cloud.account.id',
+      })
+    );
+
+    expect(getGroupingQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statsAggregations: expect.arrayContaining([
+          expect.objectContaining({
+            cloudProvider: {
+              terms: { field: 'cloud.provider', size: 1 },
+            },
+          }),
+        ]),
+      })
+    );
+  });
+
   it('calls getGroupingQuery without nullGroupItems when selectedGroup is "none"', () => {
     renderHook(() =>
       useLatestFindingsGrouping({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -99,6 +99,7 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
     case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID:
       return [
         ...aggMetrics,
+        getTermAggregation('cloudProvider', 'cloud.provider'),
         getTermAggregation('benchmarkName', 'rule.benchmark.name'),
         getTermAggregation('benchmarkId', 'rule.benchmark.id'),
         getTermAggregation('accountName', 'cloud.account.name'),


### PR DESCRIPTION
## Summary

When grouping misconfigurations by Cloud Account, 3rd party integrations (Wiz, AWS Security Hub) showed no icon or subtitle because the renderer relied on rule.benchmark.id which only exists for native CIS benchmarks.

Use CISBenchmarkIcon when benchmark data is available (native), fall back to CloudProviderIcon via cloud.provider for 3P integrations. Subtitle falls back from benchmark name to cloud provider name.

Closes #202908

<img width="1723" height="440" alt="Screenshot 2026-02-24 at 11 23 14" src="https://github.com/user-attachments/assets/dbe60473-1456-4a4a-9738-b5d22125e61a" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


