### PR TITLE
[streams][background tasks] gracefully handle non existing stream

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification.ts
@@ -24,6 +24,7 @@ import type { TaskParams } from '../types';
 import { PromptsConfigService } from '../../saved_objects/significant_events/prompts_config_service';
 import { cancellableTask } from '../cancellable_task';
 import { MAX_FEATURE_AGE_MS } from '../../streams/feature/feature_client';
+import { isDefinitionNotFoundError } from '../../streams/errors/definition_not_found_error';
 
 export interface FeaturesIdentificationTaskParams {
   connectorId: string;
@@ -115,8 +116,7 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                   });
                   if (existing) {
                     taskContext.logger.debug(
-                      `Overwriting feature with id [${
-                        feature.id
+                      `Overwriting feature with id [${feature.id
                       }] since it already exists.\nExisting feature: ${JSON.stringify(
                         existing
                       )}\nNew feature: ${JSON.stringify(feature)}`
@@ -144,6 +144,11 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                   { features }
                 );
               } catch (error) {
+                if (isDefinitionNotFoundError(error)) {
+                  taskContext.logger.debug(`Stream ${streamName} was deleted before features identification task started, skipping`);
+                  return getDeleteTaskRunResult();
+                }
+
                 // Get connector info for error enrichment
                 const connector = await inferenceClient.getConnectorById(connectorId);
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification.ts
@@ -116,7 +116,8 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                   });
                   if (existing) {
                     taskContext.logger.debug(
-                      `Overwriting feature with id [${feature.id
+                      `Overwriting feature with id [${
+                        feature.id
                       }] since it already exists.\nExisting feature: ${JSON.stringify(
                         existing
                       )}\nNew feature: ${JSON.stringify(feature)}`
@@ -145,7 +146,9 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                 );
               } catch (error) {
                 if (isDefinitionNotFoundError(error)) {
-                  taskContext.logger.debug(`Stream ${streamName} was deleted before features identification task started, skipping`);
+                  taskContext.logger.debug(
+                    `Stream ${streamName} was deleted before features identification task started, skipping`
+                  );
                   return getDeleteTaskRunResult();
                 }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
@@ -22,6 +22,7 @@ import type { TaskParams } from '../types';
 import { PromptsConfigService } from '../../saved_objects/significant_events/prompts_config_service';
 import { cancellableTask } from '../cancellable_task';
 import { generateSignificantEventDefinitions } from '../../significant_events/generate_significant_events';
+import { isDefinitionNotFoundError } from '../../streams/errors/definition_not_found_error';
 
 export interface SignificantEventsQueriesGenerationTaskParams {
   connectorId: string;
@@ -153,6 +154,11 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                   combinedResults
                 );
               } catch (error) {
+                if (isDefinitionNotFoundError(error)) {
+                  taskContext.logger.debug(`Stream ${streamName} was deleted before significant events queries generation task started, skipping`);
+                  return getDeleteTaskRunResult();
+                }
+
                 // Get connector info for error enrichment
                 const connector = await inferenceClient.getConnectorById(connectorId);
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
@@ -155,7 +155,9 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                 );
               } catch (error) {
                 if (isDefinitionNotFoundError(error)) {
-                  taskContext.logger.debug(`Stream ${streamName} was deleted before significant events queries generation task started, skipping`);
+                  taskContext.logger.debug(
+                    `Stream ${streamName} was deleted before significant events queries generation task started, skipping`
+                  );
                   return getDeleteTaskRunResult();
                 }
 


### PR DESCRIPTION
## Summary

It is possible for a stream to be deleted before a registered background task starts (eg query generation).
This change gracefully handles this case to prevent throwing an error.

