### PR TITLE
Stabilize breadcrumbs badges append extension content

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/state/breadcrumbs_state.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/breadcrumbs_state.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChromeBreadcrumbsAppendExtension } from '@kbn/core-chrome-browser';
+import { createBreadcrumbsState } from './breadcrumbs_state';
+
+const createExtension = (): ChromeBreadcrumbsAppendExtension => ({
+  content: () => () => undefined,
+});
+
+const getBadgesContent = (extensions: ChromeBreadcrumbsAppendExtension[]) => {
+  const badgesExtension = extensions[extensions.length - 1];
+  expect(badgesExtension).toBeDefined();
+  return badgesExtension.content;
+};
+
+describe('createBreadcrumbsState', () => {
+  it('keeps badges content stable when only non-badge extensions change', () => {
+    const state = createBreadcrumbsState();
+    const emissions: ChromeBreadcrumbsAppendExtension[][] = [];
+    const subscription = state.breadcrumbsAppendExtensionsWithBadges$.subscribe((extensions) => {
+      emissions.push(extensions);
+    });
+
+    try {
+      state.breadcrumbsAppendExtensions.set([createExtension()]);
+      state.breadcrumbsBadges.set([{ badgeText: 'Badge A' }]);
+      const initialBadgesContent = getBadgesContent(emissions[emissions.length - 1]);
+
+      state.breadcrumbsAppendExtensions.set([createExtension()]);
+      const updatedBadgesContent = getBadgesContent(emissions[emissions.length - 1]);
+
+      state.breadcrumbsAppendExtensions.set([createExtension(), createExtension()]);
+      const updatedBadgesContentWithMultipleExtensions = getBadgesContent(
+        emissions[emissions.length - 1]
+      );
+
+      expect(updatedBadgesContent).toBe(initialBadgesContent);
+      expect(updatedBadgesContentWithMultipleExtensions).toBe(initialBadgesContent);
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+
+  it('recreates badges content when badges change', () => {
+    const state = createBreadcrumbsState();
+    const emissions: ChromeBreadcrumbsAppendExtension[][] = [];
+    const subscription = state.breadcrumbsAppendExtensionsWithBadges$.subscribe((extensions) => {
+      emissions.push(extensions);
+    });
+
+    try {
+      state.breadcrumbsAppendExtensions.set([createExtension()]);
+      state.breadcrumbsBadges.set([{ badgeText: 'Badge A' }]);
+      const initialBadgesContent = getBadgesContent(emissions[emissions.length - 1]);
+
+      state.breadcrumbsBadges.set([{ badgeText: 'Badge B' }]);
+      const updatedBadgesContent = getBadgesContent(emissions[emissions.length - 1]);
+
+      expect(updatedBadgesContent).not.toBe(initialBadgesContent);
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+
+  it('recreates badges content when isFirst changes', () => {
+    const state = createBreadcrumbsState();
+    const emissions: ChromeBreadcrumbsAppendExtension[][] = [];
+    const subscription = state.breadcrumbsAppendExtensionsWithBadges$.subscribe((extensions) => {
+      emissions.push(extensions);
+    });
+
+    try {
+      state.breadcrumbsBadges.set([{ badgeText: 'Badge A' }]);
+      const contentWhenFirst = getBadgesContent(emissions[emissions.length - 1]);
+
+      state.breadcrumbsAppendExtensions.set([createExtension()]);
+      const contentWhenNotFirst = getBadgesContent(emissions[emissions.length - 1]);
+
+      expect(contentWhenNotFirst).not.toBe(contentWhenFirst);
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

@eokoneyo pointed our new error in console in Discover:

<img width="1688" height="1244" alt="image" src="https://github.com/user-attachments/assets/f6b734ef-2031-427e-b840-9b0c9a3e347b" />

I think the error appeared after https://github.com/elastic/kibana/pull/253954/

The change to functional components made React highlight an issue with the breadcrumb badge unmounting and remounting because of an unstable reference.

This PR is meant to short-fix this:

- Stabilize breadcrumbs badges append extension content identity so unrelated extension updates do not recreate the badges mount function.
- Refactor badges stream derivation into small helpers to keep the state pipeline easier to reason about while preserving behavior.
- Add focused unit tests for `createBreadcrumbsState` identity behavior on non-badge extension updates, badge updates, and `isFirst` transitions.

Longer term I hope we migrate to native react extension points - https://github.com/elastic/kibana/pull/221815

## Test plan
- [x] `yarn test:jest src/core/packages/chrome/browser-internal/src/state/breadcrumbs_state.test.ts`