### PR TITLE
[CSP] Fix grouping control right-alignment in Findings toolbar

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/use_styles.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/use_styles.ts
@@ -66,6 +66,16 @@ export const useStyles = () => {
     }
     & .euiDataGrid__leftControls {
       flex-grow: 1;
+
+      > .euiFlexGroup {
+        flex-grow: 1;
+
+        > .euiFlexItem {
+          flex-grow: 1;
+          flex-direction: row;
+          align-items: center;
+        }
+      }
     }
   `;
 


### PR DESCRIPTION
## Summary

Fixes the "Group findings by" control alignment in the Findings page (Misconfigurations/Vulnerabilities) toolbar. The control was left-aligned instead of right-aligned due to a regression in UnifiedDataTable (commit 618d62c21cc6) that wrapped `externalAdditionalControls` in a non-growing `EuiFlexItem`, breaking the `margin-left: auto` alignment.

The fix adds CSS overrides in `use_styles.ts` to make the intermediary flex containers (EuiFlexGroup and EuiFlexItem from UnifiedDataTable) grow and use row direction, restoring the right-alignment.

Fixes #254691

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk — CSS-only change scoped to the CSP data table toolbar. No functional changes.