### PR TITLE
force overflow hidden on sidebar panel

### DIFF
--- a/src/core/packages/chrome/sidebar/sidebar-components/src/components/sidebar_panel.tsx
+++ b/src/core/packages/chrome/sidebar/sidebar-components/src/components/sidebar_panel.tsx
@@ -33,6 +33,7 @@ const panelContainerStyles = (isProjectStyle: boolean) => (theme: UseEuiTheme) =
     flex-direction: column;
     flex-grow: 1;
     min-width: 0; // Allow panel to shrink
+    overflow: hidden; // Force children to respect border radius and shadow
 
     ${isProjectStyle &&
     css`


### PR DESCRIPTION
## Summary

Agent builder uses custom background on their children, so they cover our rounded borders and shadows. This fix should resolve this. 

### Before

<img width="1157" height="332" alt="Screenshot 2026-02-24 at 12 55 07" src="https://github.com/user-attachments/assets/05fbb5a6-d6e7-4841-a4c2-15f435727abb" />

### After

<img width="1163" height="298" alt="Screenshot 2026-02-24 at 12 55 02" src="https://github.com/user-attachments/assets/c8aca9b9-a3a0-41b6-b695-37631978e040" />



