### PR TITLE
[Dashboard] Fix flaky ES|QL value control test by waiting for flyout to close

### DIFF
--- a/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
+++ b/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
@@ -83,7 +83,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('saveEsqlControlsFlyoutButton');
       // Wait for the control flyout to close before checking panel count,
       // otherwise waitForRenderComplete may complete based on the old panel count
-      await testSubjects.waitForHidden('create_esql_control_flyout');
+      await testSubjects.waitForEnabled('applyFlyoutButton');
       await dashboard.waitForRenderComplete();
       await retry.try(async () => {
         expect(await dashboard.getPanelCount()).to.be(panelCountBefore + 1);

--- a/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
+++ b/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
@@ -81,7 +81,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // create the control
       await testSubjects.waitForEnabled('saveEsqlControlsFlyoutButton');
       await testSubjects.click('saveEsqlControlsFlyoutButton');
+      // Wait for the control flyout to close before checking panel count,
+      // otherwise waitForRenderComplete may complete based on the old panel count
+      await testSubjects.waitForHidden('create_esql_control_flyout');
       await dashboard.waitForRenderComplete();
+      expect(await testSubjects.exists('esqlValuesPreview')).to.be(true);
       await retry.try(async () => {
         expect(await dashboard.getPanelCount()).to.be(panelCountBefore + 1);
       });

--- a/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
+++ b/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
@@ -85,7 +85,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // otherwise waitForRenderComplete may complete based on the old panel count
       await testSubjects.waitForHidden('create_esql_control_flyout');
       await dashboard.waitForRenderComplete();
-      expect(await testSubjects.exists('esqlValuesPreview')).to.be(true);
       await retry.try(async () => {
         expect(await dashboard.getPanelCount()).to.be(panelCountBefore + 1);
       });

--- a/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
+++ b/src/platform/test/functional/apps/dashboard/esql_controls/value_control.ts
@@ -83,7 +83,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('saveEsqlControlsFlyoutButton');
       // Wait for the control flyout to close before checking panel count,
       // otherwise waitForRenderComplete may complete based on the old panel count
-      await testSubjects.waitForEnabled('applyFlyoutButton');
+      await testSubjects.waitForDeleted('saveEsqlControlsFlyoutButton');
       await dashboard.waitForRenderComplete();
       await retry.try(async () => {
         expect(await dashboard.getPanelCount()).to.be(panelCountBefore + 1);


### PR DESCRIPTION
Resolves #251388

FTR - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10840

After clicking the save button in the ES|QL control flyout, waitForRenderComplete was probably called too early — before the flyout closed and the new panel was added to the DOM. As a result, it completed based on the old panel count, causing getPanelCount to intermittently return the wrong value.     
                                                                                                                                                     
The fix adds waitForHidden('create_esql_control_flyout') before waitForRenderComplete, ensuring the flyout has fully closed and the panel has been added before the render check runs.