### PR TITLE
[Discover][Metrics]: Fix focus management when entering fullscreen mode in metrics grid

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/charts_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/charts_grid.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { EuiFocusTrap } from '@elastic/eui';
 import { cx } from '@emotion/css';
 import { css } from '@emotion/react';
@@ -39,6 +39,7 @@ export const ChartsGrid = ({
   onKeyDown,
 }: React.PropsWithChildren<ChartsGridProps>) => {
   const { metricsGridId, setMetricsGridWrapper, styles } = useMetricsGridFullScreen({ prefix: id });
+  const metricsGridRef = useRef<HTMLDivElement>(null);
 
   const restrictBodyClass = styles[METRICS_GRID_RESTRICT_BODY_CLASS];
   const metricsGridFullScreenClass = styles[METRICS_GRID_FULL_SCREEN_CLASS];
@@ -61,6 +62,8 @@ export const ChartsGrid = ({
   return (
     <EuiFocusTrap
       disabled={!isFullscreen}
+      // Using callback because useGeneratedHtmlId produces IDs with ':' which breaks CSS selectors
+      initialFocus={() => metricsGridRef.current as HTMLElement}
       css={css`
         height: ${isComponentVisible ? '100%' : 0};
         visibility: ${isComponentVisible ? 'visible' : 'hidden'};
@@ -76,7 +79,9 @@ export const ChartsGrid = ({
         css={fullHeightCss}
       >
         <div
+          ref={metricsGridRef}
           id={metricsGridId}
+          tabIndex={-1}
           data-test-subj="metricsExperienceGrid"
           className={cx(METRICS_GRID_CLASS, {
             [METRICS_GRID_FULL_SCREEN_CLASS]: isFullscreen,

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
@@ -84,7 +84,6 @@ export const useMetricsGridFullScreen = ({ prefix }: { prefix: string }) => {
         background-color: ${euiTheme.colors.backgroundBasePlain};
       `,
       [METRICS_GRID_RESTRICT_BODY_CLASS]: css`
-        ${logicalCSS('height', '100vh')}
         overflow: hidden;
 
         .euiHeader[data-fixed-header] {


### PR DESCRIPTION
Closes: #249512

## Summary

Fixes focus management when entering fullscreen mode in the Metrics Experience grid. Previously, when activating fullscreen, focus was not properly directed to the grid container, which could cause accessibility issues and unexpected keyboard navigation behavior.

### Changes

- **`charts_grid.tsx`**: Added `initialFocus` prop to `EuiFocusTrap` to properly focus the metrics grid container when entering fullscreen mode
  - Uses a ref callback instead of a CSS selector because `useGeneratedHtmlId` produces IDs containing `:` which breaks `querySelector`
  - Added `tabIndex={-1}` to make the grid container programmatically focusable without adding it to the natural tab order

- **`use_metrics_grid_fullscreen.ts`**: Removed redundant `height: 100vh` from body restriction styles that was causing layout issues

### Demo

https://github.com/user-attachments/assets/31386332-fd6f-49f5-a9a9-c99676a1d3a7

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



