### PR TITLE
[One Workflow] Fix url param of http step to render templates

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/http.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/http.ts
@@ -17,7 +17,7 @@ import { z } from '@kbn/zod/v4';
 // HTTP connector parameter schema
 export const HttpParamsSchema = z.object({
   url: z
-    .url()
+    .string()
     .optional()
     .describe(
       'The base URL to send the request to. If `connector-id` is provided the configured URL will be used and this value will be ignored.'


### PR DESCRIPTION
## Summary

follow-up for https://github.com/elastic/kibana/pull/249004

Fix template rendering in `url` field:

<img width="591" height="108" alt="Captura de pantalla 2026-02-24 a les 14 51 13" src="https://github.com/user-attachments/assets/5a4b7f0d-00c8-4b88-a777-54392a802299" />

### Before

<img width="503" height="47" alt="Captura de pantalla 2026-02-24 a les 14 54 27" src="https://github.com/user-attachments/assets/1a9853ab-c0b0-4e28-b43a-f6d1090b4623" />

### After

<img width="503" height="47" alt="Captura de pantalla 2026-02-24 a les 14 52 42" src="https://github.com/user-attachments/assets/01947497-360a-4d31-9937-60efa316da47" />

