### PR TITLE
[Entity Analytics] Add FTR test for reset to zero

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/index.ts
@@ -13,6 +13,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./risk_engine_cleanup_api'));
     loadTestFile(require.resolve('./risk_score_preview'));
     loadTestFile(require.resolve('./risk_scoring_task/task_execution'));
+    loadTestFile(require.resolve('./risk_scoring_task/reset_to_zero'));
     loadTestFile(require.resolve('./risk_scoring_task/task_execution_nondefault_spaces'));
     loadTestFile(require.resolve('./telemetry_usage'));
     loadTestFile(require.resolve('./risk_engine_privileges'));

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/reset_to_zero.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/reset_to_zero.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { v4 as uuidv4 } from 'uuid';
+import { deleteAllRules, deleteAllAlerts } from '@kbn/detections-response-ftr-services';
+import { dataGeneratorFactory } from '../../../../detections_response/utils';
+import {
+  buildDocument,
+  createAndSyncRuleAndAlertsFactory,
+  deleteAllRiskScores,
+  normalizeScores,
+  readRiskScores,
+  riskEngineRouteHelpersFactory,
+  waitForRiskScoresToBePresent,
+  disableEntityStoreV2,
+} from '../../../utils';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default ({ getService }: FtrProviderContext): void => {
+  const supertest = getService('supertest');
+  const esArchiver = getService('esArchiver');
+  const es = getService('es');
+  const log = getService('log');
+  const kibanaServer = getService('kibanaServer');
+
+  const createAndSyncRuleAndAlerts = createAndSyncRuleAndAlertsFactory({ supertest, log });
+  const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
+  const { indexListOfDocuments } = dataGeneratorFactory({
+    es,
+    index: 'ecs_compliant',
+    log,
+  });
+
+  describe('@ess @serverless @serverlessQA Risk Scoring Task Reset To Zero', () => {
+    const hostsWithDeletedAlerts = Array(5)
+      .fill(0)
+      .map((_, index) => `host-${index + 5}`);
+
+    before(async () => {
+      await esArchiver.load(
+        'x-pack/solutions/security/test/fixtures/es_archives/security_solution/ecs_compliant'
+      );
+    });
+
+    after(async () => {
+      await esArchiver.unload(
+        'x-pack/solutions/security/test/fixtures/es_archives/security_solution/ecs_compliant'
+      );
+    });
+
+    beforeEach(async () => {
+      await disableEntityStoreV2(kibanaServer);
+      await riskEngineRoutes.cleanUp();
+      await deleteAllRiskScores(log, es, undefined, true);
+      await deleteAllAlerts(supertest, log, es);
+      await deleteAllRules(supertest, log);
+
+      const documentId = uuidv4();
+      await indexListOfDocuments(
+        Array(10)
+          .fill(0)
+          .map((_, index) => buildDocument({ host: { name: `host-${index}` } }, documentId))
+      );
+
+      await createAndSyncRuleAndAlerts({
+        query: `id: ${documentId}`,
+        alerts: 10,
+        riskScore: 40,
+      });
+
+      await riskEngineRoutes.init();
+      await waitForRiskScoresToBePresent({ es, log, scoreCount: 10 });
+    });
+
+    afterEach(async () => {
+      await riskEngineRoutes.cleanUp();
+      await deleteAllRiskScores(log, es, undefined, true);
+      await deleteAllAlerts(supertest, log, es);
+      await deleteAllRules(supertest, log);
+      await disableEntityStoreV2(kibanaServer);
+    });
+
+    it('@skipInServerlessMKI resets risk scores to zero for entities whose alerts were deleted', async () => {
+      const initialScores = normalizeScores(await readRiskScores(es));
+      expect(initialScores.length).to.eql(10);
+      expect(initialScores.every((score) => score.id_field === 'host.name')).to.eql(true);
+      expect(initialScores.every((score) => (score.calculated_score_norm ?? 0) > 0)).to.eql(true);
+
+      await es.deleteByQuery({
+        index: '.alerts-security.alerts-*',
+        query: {
+          bool: {
+            filter: [{ terms: { 'host.name': hostsWithDeletedAlerts } }],
+          },
+        },
+        refresh: true,
+      });
+
+      await riskEngineRoutes.disable();
+      await riskEngineRoutes.enable();
+      await waitForRiskScoresToBePresent({ es, log, scoreCount: 20 });
+
+      const allScores = normalizeScores(await readRiskScores(es));
+
+      const zeroScoreIds = allScores
+        .filter((score) => score.calculated_score_norm === 0)
+        .map((score) => score.id_value)
+        .sort();
+
+      expect(zeroScoreIds).to.eql(hostsWithDeletedAlerts.sort());
+
+      const nonZeroCountByEntity = allScores
+        .filter((score) => (score.calculated_score_norm ?? 0) > 0)
+        .reduce<Record<string, number>>((acc, score) => {
+          const id = score.id_value;
+          if (typeof id === 'string') {
+            acc[id] = (acc[id] ?? 0) + 1;
+          }
+          return acc;
+        }, {});
+
+      const expectedNonZeroIds = Array(5)
+        .fill(0)
+        .map((_, index) => `host-${index}`);
+
+      expectedNonZeroIds.forEach((id) => {
+        expect(nonZeroCountByEntity[id]).to.eql(2);
+      });
+    });
+  });
+};


### PR DESCRIPTION
## Summary

We didn't have any test coverage for reset to zero behaviour, in moving to v2 I have added this so I asked AI to create a v1 version. I am going to backport this to 9.3.

The structure of the test is:

- create risk scores for 10 entities
- delete the alerts for a subset of those entities
- re-run the engine
- those entities with no alerts should have a zero score document