### PR TITLE
[8.19] [APM] Fix Otel missing fields undefined errors (#254271)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/missing_service_environment.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/missing_service_environment.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Generates OTel traces with no service.environment (namespace omitted).
+ * Use to verify UI does not crash when opening error samples, transaction/span
+ * flyouts, or agent config links for data without environment.
+ */
+
+import type { ApmOtelFields, OtelInstance } from '@kbn/synthtrace-client';
+import { apm, ApmSynthtracePipelineSchema } from '@kbn/synthtrace-client';
+import { withClient } from '../lib/utils/with_client';
+import type { Scenario } from '../cli/scenario';
+
+const scenario: Scenario<ApmOtelFields> = async (runOptions) => {
+  return {
+    generate: ({ range, clients: { apmEsClient } }) => {
+      const transactionName = 'oteldemo.AdServiceSynth/GetAds';
+
+      const { logger } = runOptions;
+
+      const edotInstance = apm
+        .otelService({
+          name: 'adservice-edot-synth',
+          sdkLanguage: 'java',
+          sdkName: 'opentelemetry',
+          distro: 'elastic',
+        })
+        .instance('edot-instance');
+
+      const otelNativeInstance = apm
+        .otelService({
+          name: 'sendotlp-otel-native-synth',
+          sdkName: 'otlp',
+          sdkLanguage: 'nodejs',
+        })
+        .instance('otel-native-instance');
+
+      const successfulTimestamps = range.interval('1m').rate(180);
+      const failedTimestamps = range.interval('1m').rate(40);
+
+      const instanceSpans = (instance: OtelInstance) => {
+        const successfulTraceEvents = successfulTimestamps.generator((timestamp) =>
+          instance
+            .span({
+              name: transactionName,
+              kind: 'Server',
+            })
+            .timestamp(timestamp)
+            .duration(1000)
+            .success()
+            .children(
+              instance
+                .dbExitSpan({
+                  name: 'GET apm-*/_search',
+                  type: 'elasticsearch',
+                })
+                .duration(1000)
+                .success()
+                .timestamp(timestamp),
+              instance
+                .span({
+                  name: 'custom_operation',
+                  kind: 'Internal',
+                })
+                .duration(100)
+                .success()
+                .timestamp(timestamp)
+            )
+        );
+
+        const failedTraceEvents = failedTimestamps.generator((timestamp) =>
+          instance
+            .span({ name: transactionName, kind: 'Server' })
+            .timestamp(timestamp)
+            .duration(1000)
+            .failure()
+            .errors(
+              instance
+                .error({
+                  message: '[ResponseError] index_not_found_exception',
+                  type: 'ResponseError',
+                })
+                .timestamp(timestamp + 50)
+            )
+        );
+
+        return [successfulTraceEvents, failedTraceEvents];
+      };
+
+      return [
+        withClient(
+          apmEsClient,
+          logger.perf('generating_otel_trace', () =>
+            [otelNativeInstance, edotInstance].flatMap((instance) => instanceSpans(instance))
+          )
+        ),
+      ];
+    },
+    setupPipeline: ({ apmEsClient }) => {
+      apmEsClient.setPipeline(apmEsClient.resolvePipelineType(ApmSynthtracePipelineSchema.Otel));
+    },
+  };
+};
+
+export default scenario;

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/missing_service_environment.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/missing_service_environment.ts
@@ -13,8 +13,8 @@
  * flyouts, or agent config links for data without environment.
  */
 
-import type { ApmOtelFields, OtelInstance } from '@kbn/synthtrace-client';
-import { apm, ApmSynthtracePipelineSchema } from '@kbn/synthtrace-client';
+import type { ApmOtelFields, OtelInstance } from '@kbn/apm-synthtrace-client';
+import { apm, ApmSynthtracePipelineSchema } from '@kbn/apm-synthtrace-client';
 import { withClient } from '../lib/utils/with_client';
 import type { Scenario } from '../cli/scenario';
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_contextual_insight.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_contextual_insight.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ErrorSampleContextualInsight } from './error_sample_contextual_insight';
+import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
+
+jest.mock('../../../../context/apm_plugin/use_apm_plugin_context');
+
+const mockUseApmPluginContext = useApmPluginContext as jest.MockedFunction<
+  typeof useApmPluginContext
+>;
+
+describe('ErrorSampleContextualInsight', () => {
+  beforeEach(() => {
+    mockUseApmPluginContext.mockReturnValue({
+      observabilityAIAssistant: undefined,
+    } as any);
+  });
+
+  it('renders null when error is undefined (OTel / incomplete data)', () => {
+    const { container } = render(
+      <ErrorSampleContextualInsight transaction={{ transaction: { name: 'GET /api' } }} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders null when error has no service (missing service.environment case)', () => {
+    const { container } = render(
+      <ErrorSampleContextualInsight
+        error={
+          {
+            error: { exception: [{ message: 'err' }] },
+            service: undefined,
+          } as any
+        }
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not throw when error.service is missing', () => {
+    expect(() => {
+      render(
+        <ErrorSampleContextualInsight
+          error={
+            {
+              error: { exception: [{ message: 'err' }] },
+            } as any
+          }
+        />
+      );
+    }).not.toThrow();
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_contextual_insight.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_contextual_insight.tsx
@@ -18,10 +18,10 @@ export function ErrorSampleContextualInsight({
   error,
   transaction,
 }: {
-  error: {
+  error?: {
     [AT_TIMESTAMP]: string;
     error: Pick<APMError['error'], 'log' | 'exception' | 'id'>;
-    service: {
+    service?: {
       name: string;
       environment?: string;
       language?: {
@@ -45,11 +45,11 @@ export function ErrorSampleContextualInsight({
   const [exceptionStacktrace, setExceptionStacktrace] = useState('');
 
   const messages = useMemo<Message[] | undefined>(() => {
-    const serviceName = error.service.name;
-    const languageName = error.service.language?.name ?? '';
-    const runtimeName = error.service.runtime?.name ?? '';
-    const runtimeVersion = error.service.runtime?.version ?? '';
-    const transactionName = transaction?.transaction.name ?? '';
+    const serviceName = error?.service?.name ?? '';
+    const languageName = error?.service?.language?.name ?? '';
+    const runtimeName = error?.service?.runtime?.name ?? '';
+    const runtimeVersion = error?.service?.runtime?.version ?? '';
+    const transactionName = transaction?.transaction?.name ?? '';
 
     return observabilityAIAssistant?.getContextualInsightMessages({
       message: `I'm looking at an exception and trying to understand what it means`,
@@ -78,6 +78,10 @@ export function ErrorSampleContextualInsight({
     });
   }, [error, transaction, logStacktrace, exceptionStacktrace, observabilityAIAssistant]);
 
+  if (!error?.service) {
+    return null;
+  }
+
   return observabilityAIAssistant?.ObservabilityAIAssistantContextualInsight && messages ? (
     <>
       <EuiFlexItem>
@@ -95,7 +99,7 @@ export function ErrorSampleContextualInsight({
         }}
         style={{ display: 'none' }}
       >
-        {error.error.log?.message && (
+        {error?.error?.log?.message && (
           <ErrorSampleDetailTabContent error={error} currentTab={logStacktraceTab} />
         )}
       </div>
@@ -105,7 +109,7 @@ export function ErrorSampleContextualInsight({
         }}
         style={{ display: 'none' }}
       >
-        {error.error.exception?.length && (
+        {error?.error?.exception?.length && (
           <ErrorSampleDetailTabContent error={error} currentTab={exceptionStacktraceTab} />
         )}
       </div>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -53,6 +53,10 @@ import { SampleSummary } from './sample_summary';
 import { ErrorSampleContextualInsight } from './error_sample_contextual_insight';
 import { getComparisonEnabled } from '../../../shared/time_comparison/get_comparison_enabled';
 import { buildUrl } from '../../../../utils/build_url';
+import {
+  ENVIRONMENT_NOT_DEFINED,
+  getEnvironmentLabel,
+} from '../../../../../common/environment_filter_values';
 
 const TransactionLinkName = euiStyled.div`
   margin-left: ${({ theme }) => theme.eui.euiSizeS};
@@ -98,7 +102,7 @@ export function ErrorSampleDetails({
     '/mobile-services/{serviceName}/errors-and-crashes/crashes/{groupId}'
   );
 
-  const { kuery } = query;
+  const { kuery, environment } = query;
 
   const loadingErrorSamplesData = isPending(errorSamplesFetchStatus);
   const loadingErrorData = isPending(errorFetchStatus);
@@ -151,7 +155,7 @@ export function ErrorSampleDetails({
 
   const tabs = getTabs(error);
   const currentTab = getCurrentTab(tabs, detailTab) as ErrorTab;
-  const urlFromError = error.error.page?.url || error.url?.full;
+  const urlFromError = error?.error?.page?.url || error?.url?.full;
   const urlFromTransaction = transaction?.transaction?.page?.url || transaction?.url?.full;
   const errorOrTransactionUrl = error?.url ? error : transaction;
   const errorOrTransactionHttp = error?.http ? error : transaction;
@@ -167,9 +171,13 @@ export function ErrorSampleDetails({
   const method = errorOrTransactionHttp?.http?.request?.method;
   const status = errorOrTransactionHttp?.http?.response?.status_code;
   const userAgent = errorOrTransactionUserAgent;
-  const environment = error.service.environment;
-  const serviceVersion = error.service.version;
-  const isUnhandled = error.error.exception?.[0]?.handled === false;
+  const errorEnvironment =
+    error?.service?.environment ??
+    transaction?.service?.environment ??
+    environment ??
+    ENVIRONMENT_NOT_DEFINED.value;
+  const serviceVersion = error?.service?.version ?? transaction?.service?.version ?? undefined;
+  const isUnhandled = error?.error?.exception?.[0]?.handled === false;
 
   return (
     <EuiPanel hasBorder={true}>
@@ -258,15 +266,15 @@ export function ErrorSampleDetails({
                 </TransactionDetailLink>
               </EuiToolTip>
             ),
-            environment ? (
-              <EuiToolTip
-                content={i18n.translate('xpack.apm.errorSampleDetails.serviceEnvironment', {
-                  defaultMessage: 'Environment',
-                })}
-              >
-                <EuiBadge color="hollow">{environment}</EuiBadge>
-              </EuiToolTip>
-            ) : null,
+            <EuiToolTip
+              content={i18n.translate('xpack.apm.errorSampleDetails.serviceEnvironment', {
+                defaultMessage: 'Environment',
+              })}
+            >
+              <EuiBadge color="hollow" tabIndex={0}>
+                {getEnvironmentLabel(errorEnvironment)}
+              </EuiBadge>
+            </EuiToolTip>,
             serviceVersion ? (
               <EuiToolTip
                 content={i18n.translate('xpack.apm.errorSampleDetails.serviceVersion', {
@@ -335,7 +343,7 @@ export function ErrorSampleDetailTabContent({
   currentTab,
 }: {
   error: {
-    service: {
+    service?: {
       language?: {
         name?: string;
       };
@@ -345,13 +353,13 @@ export function ErrorSampleDetailTabContent({
   };
   currentTab: ErrorTab;
 }) {
-  const codeLanguage = error?.service.language?.name;
-  const exceptions = error?.error.exception || [];
+  const codeLanguage = error?.service?.language?.name;
+  const exceptions = error?.error?.exception || [];
   const hasExceptions = exceptions.length > 0;
-  const logStackframes = error?.error.log?.stacktrace;
+  const logStackframes = error?.error?.log?.stacktrace;
   const isPlaintextException = hasExceptions
-    ? !!error.error.stack_trace && exceptions.length === 1 && !exceptions[0].stacktrace
-    : !!error.error.stack_trace;
+    ? !!error?.error?.stack_trace && exceptions.length === 1 && !exceptions[0].stacktrace
+    : !!error?.error?.stack_trace;
 
   switch (currentTab.key) {
     case ErrorTabKey.LogStackTrace:
@@ -359,9 +367,9 @@ export function ErrorSampleDetailTabContent({
     case ErrorTabKey.ExceptionStacktrace:
       return isPlaintextException ? (
         <PlaintextStacktrace
-          message={hasExceptions ? exceptions[0].message : undefined}
-          type={hasExceptions ? exceptions[0].type : undefined}
-          stacktrace={error?.error.stack_trace}
+          message={hasExceptions ? exceptions[0]?.message : undefined}
+          type={hasExceptions ? exceptions[0]?.type : undefined}
+          stacktrace={error?.error?.stack_trace}
           codeLanguage={codeLanguage}
         />
       ) : (

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SampleSummary } from './sample_summary';
+
+describe('SampleSummary (missing service / OTel incomplete data)', () => {
+  it('renders nothing when error is undefined', () => {
+    const { container } = render(<SampleSummary />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when error.error is undefined', () => {
+    const { container } = render(<SampleSummary error={{ error: undefined as any }} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_details/error_sampler/sample_summary.tsx
@@ -18,14 +18,18 @@ const Label = euiStyled.div`
 `;
 
 interface Props {
-  error: {
+  error?: {
     error: Pick<APMError['error'], 'log' | 'exception' | 'culprit' | 'message'>;
   };
 }
 export function SampleSummary({ error }: Props) {
-  const logMessage = error.error.log?.message;
-  const excMessage = error.error.exception?.[0].message || error.error.message;
-  const culprit = error.error.culprit;
+  const logMessage = error?.error?.log?.message;
+  const excMessage = error?.error?.exception?.[0]?.message || error?.error?.message;
+  const culprit = error?.error?.culprit;
+
+  if (!error?.error) {
+    return null;
+  }
 
   return (
     <>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/maybe_view_trace_link.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/maybe_view_trace_link.tsx
@@ -10,7 +10,10 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useApmRouter } from '../../../../hooks/use_apm_router';
-import { getNextEnvironmentUrlParam } from '../../../../../common/environment_filter_values';
+import {
+  ENVIRONMENT_NOT_DEFINED,
+  getNextEnvironmentUrlParam,
+} from '../../../../../common/environment_filter_values';
 import type { Transaction as ITransaction } from '../../../../../typings/es_schemas/ui/transaction';
 import { TransactionDetailLink } from '../../../shared/links/apm/transaction_detail_link';
 import type { IWaterfall } from './waterfall_container/waterfall/waterfall_helpers/waterfall_helpers';
@@ -89,7 +92,7 @@ export function MaybeViewTraceLink({
   const rootTransaction = rootWaterfallTransaction.doc;
   const isRoot = transaction.transaction.id === rootWaterfallTransaction.id;
   const nextEnvironment = getNextEnvironmentUrlParam({
-    requestedEnvironment: rootTransaction.service.environment,
+    requestedEnvironment: rootTransaction.service?.environment ?? ENVIRONMENT_NOT_DEFINED.value,
     currentEnvironmentUrlParam: environment,
   });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.tsx
@@ -9,7 +9,11 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useApmRouter } from '../../../../../../hooks/use_apm_router';
 import { SERVICE_NAME, TRANSACTION_NAME } from '../../../../../../../common/es_fields/apm';
-import { getNextEnvironmentUrlParam } from '../../../../../../../common/environment_filter_values';
+import {
+  ENVIRONMENT_ALL,
+  ENVIRONMENT_NOT_DEFINED,
+  getNextEnvironmentUrlParam,
+} from '../../../../../../../common/environment_filter_values';
 import { LatencyAggregationType } from '../../../../../../../common/latency_aggregation_types';
 import type { Transaction } from '../../../../../../../typings/es_schemas/ui/transaction';
 import { useAnyOfApmParams } from '../../../../../../hooks/use_apm_params';
@@ -40,8 +44,8 @@ export function FlyoutTopLevelProperties({ transaction }: Props) {
   }
 
   const nextEnvironment = getNextEnvironmentUrlParam({
-    requestedEnvironment: transaction.service.environment,
-    currentEnvironmentUrlParam: query.environment,
+    requestedEnvironment: transaction.service?.environment ?? ENVIRONMENT_NOT_DEFINED.value,
+    currentEnvironmentUrlParam: query?.environment ?? ENVIRONMENT_ALL.value,
   });
 
   const stickyProperties = [

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.tsx
@@ -15,7 +15,10 @@ import {
   SPAN_NAME,
   TRANSACTION_NAME,
 } from '../../../../../../../../common/es_fields/apm';
-import { getNextEnvironmentUrlParam } from '../../../../../../../../common/environment_filter_values';
+import {
+  ENVIRONMENT_NOT_DEFINED,
+  getNextEnvironmentUrlParam,
+} from '../../../../../../../../common/environment_filter_values';
 import { NOT_AVAILABLE_LABEL } from '../../../../../../../../common/i18n';
 import type { Span } from '../../../../../../../../typings/es_schemas/ui/span';
 import type { Transaction } from '../../../../../../../../typings/es_schemas/ui/transaction';
@@ -51,7 +54,7 @@ export function StickySpanProperties({ span, transaction }: Props) {
   const trackEvent = useUiTracker();
 
   const nextEnvironment = getNextEnvironmentUrlParam({
-    requestedEnvironment: transaction?.service.environment,
+    requestedEnvironment: transaction?.service?.environment ?? ENVIRONMENT_NOT_DEFINED.value,
     currentEnvironmentUrlParam: environment,
   });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/apm/agent_configuration_links.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/apm/agent_configuration_links.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use it except in compliance with the Elastic License 2.0.
+ */
+
+import { editAgentConfigurationHref } from './agent_configuration_links';
+import { ENVIRONMENT_NOT_DEFINED } from '../../../../../common/environment_filter_values';
+
+const mockBasePath = {
+  prepend: (path: string) => `/base${path}`,
+} as any;
+
+describe('editAgentConfigurationHref', () => {
+  it('uses ENVIRONMENT_NOT_DEFINED when configService is undefined', () => {
+    const href = editAgentConfigurationHref(undefined as any, '', mockBasePath);
+    expect(href).toContain(`environment=${encodeURIComponent(ENVIRONMENT_NOT_DEFINED.value)}`);
+  });
+
+  it('uses ENVIRONMENT_NOT_DEFINED when configService.environment is missing', () => {
+    const href = editAgentConfigurationHref({ name: 'my-service' }, '', mockBasePath);
+    expect(href).toContain(`environment=${encodeURIComponent(ENVIRONMENT_NOT_DEFINED.value)}`);
+  });
+
+  it('uses configService.environment when present', () => {
+    const href = editAgentConfigurationHref(
+      { name: 'my-service', environment: 'production' },
+      '',
+      mockBasePath
+    );
+    expect(href).toContain('environment=production');
+  });
+
+  it('does not throw when configService is undefined and returns valid path', () => {
+    const href = editAgentConfigurationHref(undefined as any, '', mockBasePath);
+    expect(href).toContain('/app/apm/settings/agent-configuration/edit');
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/apm/agent_configuration_links.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/apm/agent_configuration_links.tsx
@@ -7,6 +7,7 @@
 
 import type { IBasePath } from '@kbn/core/public';
 import type { AgentConfigurationIntake } from '../../../../../common/agent_configuration/configuration_types';
+import { ENVIRONMENT_NOT_DEFINED } from '../../../../../common/environment_filter_values';
 import { getLegacyApmHref } from './apm_link_hooks';
 
 export function editAgentConfigurationHref(
@@ -21,8 +22,8 @@ export function editAgentConfigurationHref(
     query: {
       // ignoring because `name` has not been added to url params. Related: https://github.com/elastic/kibana/issues/51963
       // @ts-expect-error
-      name: configService.name,
-      environment: configService.environment,
+      name: configService?.name,
+      environment: configService?.environment ?? ENVIRONMENT_NOT_DEFINED.value,
     },
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Fix Otel missing fields undefined errors (#254271)](https://github.com/elastic/kibana/pull/254271)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2026-02-24T10:04:27Z","message":"[APM] Fix Otel missing fields undefined errors (#254271)\n\nCloses #254222\n\n## Summary\n\nThis PR fixes uncaught errors when APM data has missing `service` or\n`service.environment` (e.g. OpenTelemetry or incomplete documents). The\nUI was reading `error.service.environment`,\n`transaction.service.environment`, and similar properties without\noptional chaining, causing \"Cannot read properties of undefined (reading\n'environment')\" and error boundary crashes.\n\nThis PR:\n\n- Adds optional chaining and fallbacks to `ENVIRONMENT_NOT_DEFINED` /\n`getEnvironmentLabel` where service or environment may be missing\n- Updates **error group details**: error sample detail, contextual\ninsight, and sample summary (optional `error`/`service`, safe access to\n`error.error`)\n- Updates **transaction/span flyouts**: transaction flyout, view full\ntrace link, span flyout sticky properties\n- Updates **agent configuration link**: safe access to\n`configService?.name` and `configService?.environment`\n\n## How to test\n\n- Use APM with data that has no `service` or no `service.environment`\n(e.g. OTel or incomplete documents): If using synthtrace I added a\nscenario:\n- Run `node scripts/synthtrace missing_service_environment --from=now-1h\n--to=now+1h`\n- Confirm that the service.environment is not in the document and there\nis no error in the flyout:\n<img width=\"3446\" height=\"1962\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/04867ef0-f89b-4601-b0bf-381a795ab2a6\"\n/>\n- Open error group details and an error sample, transaction flyout, span\nflyout, or a view that uses agent config service\n- Confirm the UI no longer crashes and shows \"Not defined\" (or\nequivalent) for missing environment where appropriate:\n<img width=\"3456\" height=\"1994\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/21fb7684-2c40-4eb5-b83d-063d9b2437be\"\n/>\n\n\nhttps://github.com/user-attachments/assets/19c46cb3-ff2e-4938-8cf3-2316f7a1a4ae\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f0e605f119e7adfbae1969e32dfe77ce104baa52","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"[APM] Fix Otel missing fields undefined errors","number":254271,"url":"https://github.com/elastic/kibana/pull/254271","mergeCommit":{"message":"[APM] Fix Otel missing fields undefined errors (#254271)\n\nCloses #254222\n\n## Summary\n\nThis PR fixes uncaught errors when APM data has missing `service` or\n`service.environment` (e.g. OpenTelemetry or incomplete documents). The\nUI was reading `error.service.environment`,\n`transaction.service.environment`, and similar properties without\noptional chaining, causing \"Cannot read properties of undefined (reading\n'environment')\" and error boundary crashes.\n\nThis PR:\n\n- Adds optional chaining and fallbacks to `ENVIRONMENT_NOT_DEFINED` /\n`getEnvironmentLabel` where service or environment may be missing\n- Updates **error group details**: error sample detail, contextual\ninsight, and sample summary (optional `error`/`service`, safe access to\n`error.error`)\n- Updates **transaction/span flyouts**: transaction flyout, view full\ntrace link, span flyout sticky properties\n- Updates **agent configuration link**: safe access to\n`configService?.name` and `configService?.environment`\n\n## How to test\n\n- Use APM with data that has no `service` or no `service.environment`\n(e.g. OTel or incomplete documents): If using synthtrace I added a\nscenario:\n- Run `node scripts/synthtrace missing_service_environment --from=now-1h\n--to=now+1h`\n- Confirm that the service.environment is not in the document and there\nis no error in the flyout:\n<img width=\"3446\" height=\"1962\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/04867ef0-f89b-4601-b0bf-381a795ab2a6\"\n/>\n- Open error group details and an error sample, transaction flyout, span\nflyout, or a view that uses agent config service\n- Confirm the UI no longer crashes and shows \"Not defined\" (or\nequivalent) for missing environment where appropriate:\n<img width=\"3456\" height=\"1994\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/21fb7684-2c40-4eb5-b83d-063d9b2437be\"\n/>\n\n\nhttps://github.com/user-attachments/assets/19c46cb3-ff2e-4938-8cf3-2316f7a1a4ae\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f0e605f119e7adfbae1969e32dfe77ce104baa52"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254271","number":254271,"mergeCommit":{"message":"[APM] Fix Otel missing fields undefined errors (#254271)\n\nCloses #254222\n\n## Summary\n\nThis PR fixes uncaught errors when APM data has missing `service` or\n`service.environment` (e.g. OpenTelemetry or incomplete documents). The\nUI was reading `error.service.environment`,\n`transaction.service.environment`, and similar properties without\noptional chaining, causing \"Cannot read properties of undefined (reading\n'environment')\" and error boundary crashes.\n\nThis PR:\n\n- Adds optional chaining and fallbacks to `ENVIRONMENT_NOT_DEFINED` /\n`getEnvironmentLabel` where service or environment may be missing\n- Updates **error group details**: error sample detail, contextual\ninsight, and sample summary (optional `error`/`service`, safe access to\n`error.error`)\n- Updates **transaction/span flyouts**: transaction flyout, view full\ntrace link, span flyout sticky properties\n- Updates **agent configuration link**: safe access to\n`configService?.name` and `configService?.environment`\n\n## How to test\n\n- Use APM with data that has no `service` or no `service.environment`\n(e.g. OTel or incomplete documents): If using synthtrace I added a\nscenario:\n- Run `node scripts/synthtrace missing_service_environment --from=now-1h\n--to=now+1h`\n- Confirm that the service.environment is not in the document and there\nis no error in the flyout:\n<img width=\"3446\" height=\"1962\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/04867ef0-f89b-4601-b0bf-381a795ab2a6\"\n/>\n- Open error group details and an error sample, transaction flyout, span\nflyout, or a view that uses agent config service\n- Confirm the UI no longer crashes and shows \"Not defined\" (or\nequivalent) for missing environment where appropriate:\n<img width=\"3456\" height=\"1994\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/21fb7684-2c40-4eb5-b83d-063d9b2437be\"\n/>\n\n\nhttps://github.com/user-attachments/assets/19c46cb3-ff2e-4938-8cf3-2316f7a1a4ae\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f0e605f119e7adfbae1969e32dfe77ce104baa52"}}]}] BACKPORT-->