### PR TITLE
[One Workflow] refactor: extract shared getStepExecutionsByWorkflowExecution to @kbn/workflows

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/server/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/index.ts
@@ -8,3 +8,7 @@
  */
 
 export { ExecutionError } from './errors/execution_error';
+export {
+  getStepExecutionsByIds,
+  getStepExecutionsByWorkflowExecution,
+} from './repositories/step_execution_repository';

--- a/src/platform/packages/shared/kbn-workflows/server/repositories/step_execution_repository.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/repositories/step_execution_repository.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EsWorkflowStepExecution } from '../../types/v1';
+import { getStepExecutionsByIds, getStepExecutionsByWorkflowExecution } from './step_execution_repository';
+
+const INDEX = '.workflows-step-executions';
+
+const createStepExecution = (overrides: Partial<EsWorkflowStepExecution> = {}): EsWorkflowStepExecution =>
+  ({
+    id: 'step-1',
+    stepId: 'test-step',
+    workflowRunId: 'exec-1',
+    status: 'completed',
+    startedAt: '2025-01-01T00:00:00Z',
+    globalExecutionIndex: 0,
+    ...overrides,
+  } as EsWorkflowStepExecution);
+
+describe('getStepExecutionsByIds', () => {
+  let esClient: { mget: jest.Mock };
+
+  beforeEach(() => {
+    esClient = { mget: jest.fn() };
+  });
+
+  it('should return empty array for empty stepExecutionIds', async () => {
+    const result = await getStepExecutionsByIds(esClient as any, INDEX, []);
+
+    expect(result).toEqual([]);
+    expect(esClient.mget).not.toHaveBeenCalled();
+  });
+
+  it('should fetch step executions using mget', async () => {
+    const step1 = createStepExecution({ id: 'step-1' });
+    const step2 = createStepExecution({ id: 'step-2', stepId: 'test-step-2' });
+
+    esClient.mget.mockResolvedValue({
+      docs: [
+        { found: true, _id: 'step-1', _source: step1 },
+        { found: true, _id: 'step-2', _source: step2 },
+      ],
+    });
+
+    const result = await getStepExecutionsByIds(esClient as any, INDEX, ['step-1', 'step-2']);
+
+    expect(result).toEqual([step1, step2]);
+    expect(esClient.mget).toHaveBeenCalledWith({
+      index: INDEX,
+      ids: ['step-1', 'step-2'],
+    });
+  });
+
+  it('should skip documents that are not found', async () => {
+    const step1 = createStepExecution({ id: 'step-1' });
+
+    esClient.mget.mockResolvedValue({
+      docs: [
+        { found: true, _id: 'step-1', _source: step1 },
+        { found: false, _id: 'step-2' },
+      ],
+    });
+
+    const result = await getStepExecutionsByIds(esClient as any, INDEX, ['step-1', 'step-2']);
+
+    expect(result).toEqual([step1]);
+  });
+
+  it('should skip documents with missing _source', async () => {
+    esClient.mget.mockResolvedValue({
+      docs: [{ found: true, _id: 'step-1', _source: null }],
+    });
+
+    const result = await getStepExecutionsByIds(esClient as any, INDEX, ['step-1']);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should pass sourceExcludes when provided', async () => {
+    esClient.mget.mockResolvedValue({ docs: [] });
+
+    await getStepExecutionsByIds(esClient as any, INDEX, ['step-1'], ['input', 'output']);
+
+    expect(esClient.mget).toHaveBeenCalledWith({
+      index: INDEX,
+      ids: ['step-1'],
+      _source_excludes: ['input', 'output'],
+    });
+  });
+
+  it('should not pass _source_excludes when sourceExcludes is empty', async () => {
+    esClient.mget.mockResolvedValue({ docs: [] });
+
+    await getStepExecutionsByIds(esClient as any, INDEX, ['step-1'], []);
+
+    expect(esClient.mget).toHaveBeenCalledWith({
+      index: INDEX,
+      ids: ['step-1'],
+    });
+  });
+});
+
+describe('getStepExecutionsByWorkflowExecution', () => {
+  let esClient: { mget: jest.Mock; search: jest.Mock };
+
+  beforeEach(() => {
+    esClient = { mget: jest.fn(), search: jest.fn() };
+  });
+
+  it('should use mget when stepExecutionIds are provided', async () => {
+    const step1 = createStepExecution({ id: 'step-1' });
+
+    esClient.mget.mockResolvedValue({
+      docs: [{ found: true, _id: 'step-1', _source: step1 }],
+    });
+
+    const result = await getStepExecutionsByWorkflowExecution({
+      esClient: esClient as any,
+      stepsExecutionIndex: INDEX,
+      workflowExecutionId: 'exec-1',
+      stepExecutionIds: ['step-1'],
+    });
+
+    expect(result).toEqual([step1]);
+    expect(esClient.mget).toHaveBeenCalled();
+    expect(esClient.search).not.toHaveBeenCalled();
+  });
+
+  it('should pass sourceExcludes to mget when stepExecutionIds are provided', async () => {
+    esClient.mget.mockResolvedValue({ docs: [] });
+
+    await getStepExecutionsByWorkflowExecution({
+      esClient: esClient as any,
+      stepsExecutionIndex: INDEX,
+      workflowExecutionId: 'exec-1',
+      stepExecutionIds: ['step-1'],
+      sourceExcludes: ['input'],
+    });
+
+    expect(esClient.mget).toHaveBeenCalledWith(
+      expect.objectContaining({ _source_excludes: ['input'] })
+    );
+  });
+
+  it('should fall back to search when stepExecutionIds is undefined', async () => {
+    const step1 = createStepExecution({ id: 'step-1' });
+
+    esClient.search.mockResolvedValue({
+      hits: { hits: [{ _id: 'step-1', _source: step1 }] },
+    });
+
+    const result = await getStepExecutionsByWorkflowExecution({
+      esClient: esClient as any,
+      stepsExecutionIndex: INDEX,
+      workflowExecutionId: 'exec-1',
+    });
+
+    expect(result).toEqual([step1]);
+    expect(esClient.search).toHaveBeenCalledWith({
+      index: INDEX,
+      query: { match: { workflowRunId: 'exec-1' } },
+      sort: 'startedAt:desc',
+      size: 10000,
+    });
+    expect(esClient.mget).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to search when stepExecutionIds is empty', async () => {
+    esClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+    await getStepExecutionsByWorkflowExecution({
+      esClient: esClient as any,
+      stepsExecutionIndex: INDEX,
+      workflowExecutionId: 'exec-1',
+      stepExecutionIds: [],
+    });
+
+    expect(esClient.search).toHaveBeenCalled();
+    expect(esClient.mget).not.toHaveBeenCalled();
+  });
+
+  it('should pass sourceExcludes to search fallback', async () => {
+    esClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+    await getStepExecutionsByWorkflowExecution({
+      esClient: esClient as any,
+      stepsExecutionIndex: INDEX,
+      workflowExecutionId: 'exec-1',
+      sourceExcludes: ['input', 'output'],
+    });
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _source: { excludes: ['input', 'output'] },
+      })
+    );
+  });
+
+  it('should not pass _source when sourceExcludes is empty on search fallback', async () => {
+    esClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+    await getStepExecutionsByWorkflowExecution({
+      esClient: esClient as any,
+      stepsExecutionIndex: INDEX,
+      workflowExecutionId: 'exec-1',
+      sourceExcludes: [],
+    });
+
+    const searchCall = esClient.search.mock.calls[0][0];
+    expect(searchCall).not.toHaveProperty('_source');
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows/server/repositories/step_execution_repository.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/repositories/step_execution_repository.test.ts
@@ -7,12 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import {
+  getStepExecutionsByIds,
+  getStepExecutionsByWorkflowExecution,
+} from './step_execution_repository';
 import type { EsWorkflowStepExecution } from '../../types/v1';
-import { getStepExecutionsByIds, getStepExecutionsByWorkflowExecution } from './step_execution_repository';
 
 const INDEX = '.workflows-step-executions';
 
-const createStepExecution = (overrides: Partial<EsWorkflowStepExecution> = {}): EsWorkflowStepExecution =>
+const createStepExecution = (
+  overrides: Partial<EsWorkflowStepExecution> = {}
+): EsWorkflowStepExecution =>
   ({
     id: 'step-1',
     stepId: 'test-step',

--- a/src/platform/packages/shared/kbn-workflows/server/repositories/step_execution_repository.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/repositories/step_execution_repository.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { EsWorkflowStepExecution } from '../../types/v1';
+
+/**
+ * Fetches step executions by their IDs using mget (O(1) operation).
+ * This is real-time (reads from translog) and doesn't require index refresh.
+ */
+export const getStepExecutionsByIds = async (
+  esClient: ElasticsearchClient,
+  stepsExecutionIndex: string,
+  stepExecutionIds: string[],
+  sourceExcludes?: string[]
+): Promise<EsWorkflowStepExecution[]> => {
+  if (stepExecutionIds.length === 0) {
+    return [];
+  }
+
+  const mgetResponse = await esClient.mget<EsWorkflowStepExecution>({
+    index: stepsExecutionIndex,
+    ids: stepExecutionIds,
+    ...(sourceExcludes?.length ? { _source_excludes: sourceExcludes } : {}),
+  });
+
+  const steps: EsWorkflowStepExecution[] = [];
+  for (const doc of mgetResponse.docs) {
+    if ('found' in doc && doc.found && doc._source) {
+      steps.push(doc._source);
+    }
+  }
+  return steps;
+};
+
+interface GetStepExecutionsByWorkflowExecutionParams {
+  esClient: ElasticsearchClient;
+  stepsExecutionIndex: string;
+  workflowExecutionId: string;
+  stepExecutionIds?: string[];
+  sourceExcludes?: string[];
+}
+
+/**
+ * Fetches all step executions for a workflow execution.
+ * Uses mget (real-time, O(1)) when stepExecutionIds are available,
+ * falls back to search for backward compatibility with older executions.
+ */
+export const getStepExecutionsByWorkflowExecution = async ({
+  esClient,
+  stepsExecutionIndex,
+  workflowExecutionId,
+  stepExecutionIds,
+  sourceExcludes,
+}: GetStepExecutionsByWorkflowExecutionParams): Promise<EsWorkflowStepExecution[]> => {
+  if (stepExecutionIds && stepExecutionIds.length > 0) {
+    return getStepExecutionsByIds(esClient, stepsExecutionIndex, stepExecutionIds, sourceExcludes);
+  }
+
+  const response = await esClient.search<EsWorkflowStepExecution>({
+    index: stepsExecutionIndex,
+    query: {
+      match: { workflowRunId: workflowExecutionId },
+    },
+    ...(sourceExcludes?.length ? { _source: { excludes: sourceExcludes } } : {}),
+    sort: 'startedAt:desc',
+    size: 10000,
+  });
+
+  return response.hits.hits.map((hit) => hit._source as EsWorkflowStepExecution);
+};


### PR DESCRIPTION
## Summary

- Extracts `getStepExecutionsByIds` and `getStepExecutionsByWorkflowExecution` into `@kbn/workflows/server` as shared utilities, replacing the duplicated mget logic in `workflows_management`.
- `getStepExecutionsByWorkflowExecution` encapsulates the pattern of using mget (real-time, O(1)) when `stepExecutionIds` are available, falling back to search for backward compatibility with older executions.
- Adds `getStepExecutionsByWorkflowExecution` to `StepExecutionRepository` in `workflows_execution_engine` — this will be consumed by the `workflow.execute` step (sync strategy).

## Test plan

- [x] Unit tests added for both shared functions (12 tests)
- [ ] Verify `get_workflow_execution` in workflows_management still works correctly
- [ ] Verify the `workflow.execute` step integration when merged with its branch