### PR TITLE
[Search Profiler] Fix flaky test

### DIFF
--- a/x-pack/platform/test/functional/apps/dev_tools/searchprofiler_editor.ts
+++ b/x-pack/platform/test/functional/apps/dev_tools/searchprofiler_editor.ts
@@ -21,6 +21,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const security = getService('security');
   const es = getService('es');
   const log = getService('log');
+  const testSubjects = getService('testSubjects');
 
   describe('Search Profiler Editor', () => {
     before(async () => {
@@ -34,6 +35,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           test: 'sample value',
         },
       });
+      await es.indices.refresh({ index: testIndex });
 
       expect(await PageObjects.searchProfiler.editorExists()).to.be(true);
     });
@@ -98,16 +100,26 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/241358
-    describe.skip('With a test index', () => {
+    describe('With a test index', () => {
       it('profiles a simple query', async () => {
+        // Reset to the base app URL, as other tests in this suite navigate with query params.
+        await PageObjects.common.navigateToApp('searchProfiler');
+        await retry.waitForWithTimeout('profile button to be enabled', 20_000, async () => {
+          return await testSubjects.exists('profileButton');
+        });
+
         await PageObjects.searchProfiler.setIndexName(testIndex);
+        await retry.waitForWithTimeout('index input to update', 5_000, async () => {
+          return (await PageObjects.searchProfiler.getIndexName()) === testIndex;
+        });
         await PageObjects.searchProfiler.setQuery(testQuery);
 
         await PageObjects.searchProfiler.clickProfileButton();
 
-        const content = await PageObjects.searchProfiler.getProfileContent();
-        expect(content).to.contain(testIndex);
+        await retry.waitForWithTimeout('profile results to render', 30_000, async () => {
+          const content = await PageObjects.searchProfiler.getProfileContent();
+          return content.includes(testIndex);
+        });
       });
     });
 

--- a/x-pack/platform/test/functional/page_objects/search_profiler_page.ts
+++ b/x-pack/platform/test/functional/page_objects/search_profiler_page.ts
@@ -27,7 +27,7 @@ export function SearchProfilerPageProvider({ getService }: FtrProviderContext) {
       return JSON.parse(await monacoEditor.getCodeEditorValue(0));
     },
     async setIndexName(indexName: string) {
-      await testSubjects.setValue('indexName', indexName);
+      await testSubjects.setValue('indexName', indexName, { clearWithKeyboard: true });
     },
     async getIndexName() {
       const indexInput = await testSubjects.find('indexName');
@@ -37,7 +37,7 @@ export function SearchProfilerPageProvider({ getService }: FtrProviderContext) {
       await testSubjects.click('profileButton');
     },
     async getProfileContent() {
-      const profileTree = await testSubjects.find('profileTree');
+      const profileTree = await testSubjects.find('profileTree', 30_000);
       return profileTree.getVisibleText();
     },
     getUrlWithIndexAndQuery({ indexName, query }: { indexName: string; query: any }) {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/241358

## Summary

This PR fixes and unskips a flaky Search Profiler test.

### What was going wrong
In the Buildkite runs linked from the issue, the test times out waiting for `profileTree` because profiling never succeeds. The artifact evidence from the builds shows the UI submitting with "No such index [my_index]" toast, which matches the suite’s earlier test that navigates to Search Profiler with `index=my_index` in the URL. The “profile a simple query” test was racing UI re-renders and sometimes didn’t actually override the index input before clicking Profile.

### Fix
- Reset navigation to the base Search Profiler URL before profiling (so previous URL params don’t “win”).
- Wait until the Profile button is enabled (ensures the initial `has_indices` request finished, avoiding a late re-render resetting the input).
- Clear + set the index input reliably, then assert it updated before clicking Profile.
- Wait longer for `profileTree` in CI-slower environments.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10844