### PR TITLE
Assign server annotations CODEOWNERS to @elastic/actionable-obs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1592,6 +1592,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/observability/server/features/cases_v1.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/features/cases_v2.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/features/cases_v3.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/observability/server/lib/annotations @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/lib/rules @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/routes/alerts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/server/routes/rules @elastic/actionable-obs-team


### PR DESCRIPTION
## Summary

The server-side annotations directory (`x-pack/solutions/observability/plugins/observability/server/lib/annotations`) was missing an explicit CODEOWNERS entry, causing it to fall through to the broad `@elastic/observability-ui` catch-all. The public-side directories and common file already have `@elastic/actionable-obs-team` ownership.

This adds the missing override so all annotation code is consistently owned by `@elastic/actionable-obs-team`.

Context: https://github.com/elastic/kibana/pull/254285

## Test plan

- Verify CODEOWNERS validation passes in CI
- Confirm `server/lib/annotations` files resolve to `@elastic/actionable-obs-team` ownership


Made with [Cursor](https://cursor.com)