### PR TITLE
[Entity Store] Add store usage task

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
@@ -14,6 +14,7 @@ import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { EntityType } from '../../common';
 import { scheduleExtractEntityTask, stopExtractEntityTask } from '../tasks/extract_entity_task';
 import { scheduleEntityMaintainerTasks } from '../tasks/entity_maintainer';
+import { scheduleStoreUsageTask, stopStoreUsageTask } from '../tasks/store_usage_task';
 import { installElasticsearchAssets, uninstallElasticsearchAssets } from './assets/install_assets';
 import {
   EngineDescriptorTypeName,
@@ -107,6 +108,13 @@ export class AssetManager {
           request,
         }),
 
+        scheduleStoreUsageTask({
+          logger: this.logger,
+          taskManager: this.taskManager,
+          namespace: this.namespace,
+          request,
+        }),
+
         installEuidStoredScripts({
           esClient: this.esClient,
           logger: this.logger,
@@ -182,6 +190,11 @@ export class AssetManager {
         deleteEuidStoredScripts({
           esClient: this.esClient,
           logger: this.logger,
+        }),
+        stopStoreUsageTask({
+          taskManager: this.taskManager,
+          logger: this.logger,
+          namespace: this.namespace,
         }),
       ]);
       this.logger.get(type).debug(`Uninstalled definition: ${type}`);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
@@ -15,7 +15,7 @@ export interface EntityStoreTaskConfig extends TaskScheduleConfig {
   type: string;
 }
 
-export const TasksConfig: Record<EntityStoreTaskType, EntityStoreTaskConfig> = {
+export const TasksConfig = {
   [EntityStoreTaskType.Values.extractEntity]: {
     title: 'Entity Store - Execute Entity Task',
     type: 'entity_store:v2:extract_entity_task',
@@ -32,4 +32,4 @@ export const TasksConfig: Record<EntityStoreTaskType, EntityStoreTaskConfig> = {
     timeout: '25s',
     interval: '1h',
   },
-};
+} as const satisfies Record<EntityStoreTaskType, EntityStoreTaskConfig>;

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
@@ -26,4 +26,10 @@ export const TasksConfig: Record<EntityStoreTaskType, EntityStoreTaskConfig> = {
     title: 'Entity Store - Entity Maintainer Task',
     type: 'entity_store:v2:entity_maintainer_task',
   },
+  [EntityStoreTaskType.Values.storeUsage]: {
+    title: 'Entity Store - Store Usage Task',
+    type: 'entity_store:v2:store_usage_task',
+    timeout: '25s',
+    interval: '1h',
+  },
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/constants.ts
@@ -8,4 +8,4 @@
 import { z } from '@kbn/zod';
 
 export type EntityStoreTaskType = z.infer<typeof EntityStoreTaskType>;
-export const EntityStoreTaskType = z.enum(['extractEntity', 'entityMaintainer']);
+export const EntityStoreTaskType = z.enum(['extractEntity', 'entityMaintainer', 'storeUsage']);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
@@ -9,6 +9,7 @@ import type { Logger } from '@kbn/logging';
 import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
 
 import { registerExtractEntityTasks } from './extract_entity_task';
+import { registerStoreUsageTask } from './store_usage_task';
 import type { EntityStoreCoreSetup } from '../types';
 import { ALL_ENTITY_TYPES } from '../../common/domain/definitions/entity_schema';
 
@@ -18,4 +19,5 @@ export function registerTasks(
   core: EntityStoreCoreSetup
 ) {
   registerExtractEntityTasks({ taskManager, logger, entityTypes: ALL_ENTITY_TYPES, core });
+  registerStoreUsageTask({ taskManager, logger, core });
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/store_usage_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/store_usage_task.ts
@@ -122,7 +122,7 @@ export async function scheduleStoreUsageTask({
       {
         id: getStoreUsageTaskId(namespace),
         taskType: config.type,
-        schedule: { interval: config.interval! },
+        schedule: { interval: config.interval },
         state: { namespace },
         params: {},
       },

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/store_usage_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/store_usage_task.ts
@@ -9,7 +9,7 @@ import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
-import type { RunResult } from '@kbn/task-manager-plugin/server/task';
+import type { RunContext, RunResult } from '@kbn/task-manager-plugin/server/task';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
 import { TasksConfig } from './config';
@@ -40,22 +40,16 @@ async function runTask({
   logger,
   core,
   reportEvent,
-}: {
-  taskInstance: { state: Record<string, unknown> };
-  fakeRequest?: KibanaRequest;
+}: RunContext & {
   logger: Logger;
   core: EntityStoreCoreSetup;
-  reportEvent: TelemetryReporter;
+  reportEvent: TelemetryReporter['reportEvent'];
 }): Promise<RunResult> {
-  logger.info('Running store usage task');
-
-  const currentState = taskInstance.state;
-  const runs = (currentState.runs as number) || 0;
-  const namespace = currentState.namespace as string;
+  const namespace = taskInstance.state.namespace as string;
 
   if (!fakeRequest) {
     logger.error('No fake request found, skipping store usage task');
-    return { state: { ...currentState } };
+    return { state: { namespace } };
   }
 
   try {
@@ -63,33 +57,19 @@ async function runTask({
     const esClient = coreStart.elasticsearch.client.asScoped(fakeRequest).asCurrentUser;
     const index = getLatestEntitiesIndexName(namespace);
 
-    await Promise.all(
-      ALL_ENTITY_TYPES.map(async (entityType) => {
+    for (const entityType of ALL_ENTITY_TYPES) {
+      try {
         const { count: storeSize } = await getStoreSize(esClient, index, entityType);
         reportEvent(ENTITY_STORE_USAGE_EVENT, { storeSize, entityType, namespace });
-        logger.debug(`Reported store usage for ${entityType}: ${storeSize} entities`);
-      })
-    );
-
-    return {
-      state: {
-        namespace,
-        lastExecutionTimestamp: new Date().toISOString(),
-        runs: runs + 1,
-        status: 'success',
-      },
-    };
+      } catch (e) {
+        logger.error(`Error reporting store usage for ${entityType}: ${e.message}`);
+      }
+    }
   } catch (e) {
     logger.error(`Error running store usage task: ${e.message}`);
-    return {
-      state: {
-        ...currentState,
-        lastError: e.message,
-        lastErrorTimestamp: new Date().toISOString(),
-        status: 'error',
-      },
-    };
   }
+
+  return { state: { namespace } };
 }
 
 export function registerStoreUsageTask({
@@ -101,17 +81,18 @@ export function registerStoreUsageTask({
   taskManager: TaskManagerSetupContract;
   logger: Logger;
 }): void {
-  const reportEvent = createReportEvent(core.analytics);
   try {
+    const { reportEvent } = createReportEvent(core.analytics);
     taskManager.registerTaskDefinitions({
       [config.type]: {
         title: config.title,
         timeout: config.timeout,
-        createTaskRunner: ({ taskInstance, fakeRequest }) => ({
+        createTaskRunner: ({ taskInstance, fakeRequest, abortController }) => ({
           run: () =>
             runTask({
               taskInstance,
               fakeRequest,
+              abortController,
               logger: logger.get(taskInstance.id),
               core,
               reportEvent,
@@ -137,10 +118,9 @@ export async function scheduleStoreUsageTask({
   request: KibanaRequest;
 }): Promise<void> {
   try {
-    const taskId = getStoreUsageTaskId(namespace);
     await taskManager.ensureScheduled(
       {
-        id: taskId,
+        id: getStoreUsageTaskId(namespace),
         taskType: config.type,
         schedule: { interval: config.interval! },
         state: { namespace },

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/store_usage_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/store_usage_task.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { RunResult } from '@kbn/task-manager-plugin/server/task';
+import type { Logger } from '@kbn/logging';
+import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
+import { TasksConfig } from './config';
+import { EntityStoreTaskType } from './constants';
+import type { EntityStoreCoreSetup } from '../types';
+import type { EntityType } from '../../common/domain/definitions/entity_schema';
+import { ALL_ENTITY_TYPES } from '../../common/domain/definitions/entity_schema';
+import { getLatestEntitiesIndexName } from '../domain/assets/latest_index';
+import {
+  ENTITY_STORE_USAGE_EVENT,
+  createReportEvent,
+  type TelemetryReporter,
+} from '../telemetry/events';
+
+const config = TasksConfig[EntityStoreTaskType.Values.storeUsage];
+
+const getStoreUsageTaskId = (namespace: string): string => `${config.type}:${namespace}`;
+
+const getStoreSize = (esClient: ElasticsearchClient, index: string, entityType: EntityType) =>
+  esClient.count({
+    index,
+    query: { term: { 'entity.EngineMetadata.Type': entityType } },
+  });
+
+async function runTask({
+  taskInstance,
+  fakeRequest,
+  logger,
+  core,
+  reportEvent,
+}: {
+  taskInstance: { state: Record<string, unknown> };
+  fakeRequest?: KibanaRequest;
+  logger: Logger;
+  core: EntityStoreCoreSetup;
+  reportEvent: TelemetryReporter;
+}): Promise<RunResult> {
+  logger.info('Running store usage task');
+
+  const currentState = taskInstance.state;
+  const runs = (currentState.runs as number) || 0;
+  const namespace = currentState.namespace as string;
+
+  if (!fakeRequest) {
+    logger.error('No fake request found, skipping store usage task');
+    return { state: { ...currentState } };
+  }
+
+  try {
+    const [coreStart] = await core.getStartServices();
+    const esClient = coreStart.elasticsearch.client.asScoped(fakeRequest).asCurrentUser;
+    const index = getLatestEntitiesIndexName(namespace);
+
+    await Promise.all(
+      ALL_ENTITY_TYPES.map(async (entityType) => {
+        const { count: storeSize } = await getStoreSize(esClient, index, entityType);
+        reportEvent(ENTITY_STORE_USAGE_EVENT, { storeSize, entityType, namespace });
+        logger.debug(`Reported store usage for ${entityType}: ${storeSize} entities`);
+      })
+    );
+
+    return {
+      state: {
+        namespace,
+        lastExecutionTimestamp: new Date().toISOString(),
+        runs: runs + 1,
+        status: 'success',
+      },
+    };
+  } catch (e) {
+    logger.error(`Error running store usage task: ${e.message}`);
+    return {
+      state: {
+        ...currentState,
+        lastError: e.message,
+        lastErrorTimestamp: new Date().toISOString(),
+        status: 'error',
+      },
+    };
+  }
+}
+
+export function registerStoreUsageTask({
+  taskManager,
+  logger,
+  core,
+}: {
+  core: EntityStoreCoreSetup;
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+}): void {
+  const reportEvent = createReportEvent(core.analytics);
+  try {
+    taskManager.registerTaskDefinitions({
+      [config.type]: {
+        title: config.title,
+        timeout: config.timeout,
+        createTaskRunner: ({ taskInstance, fakeRequest }) => ({
+          run: () =>
+            runTask({
+              taskInstance,
+              fakeRequest,
+              logger: logger.get(taskInstance.id),
+              core,
+              reportEvent,
+            }),
+        }),
+      },
+    });
+  } catch (e) {
+    logger.error(`Error registering store usage task: ${e.message}`);
+    throw e;
+  }
+}
+
+export async function scheduleStoreUsageTask({
+  logger,
+  taskManager,
+  namespace,
+  request,
+}: {
+  logger: Logger;
+  taskManager: TaskManagerStartContract;
+  namespace: string;
+  request: KibanaRequest;
+}): Promise<void> {
+  try {
+    const taskId = getStoreUsageTaskId(namespace);
+    await taskManager.ensureScheduled(
+      {
+        id: taskId,
+        taskType: config.type,
+        schedule: { interval: config.interval! },
+        state: { namespace },
+        params: {},
+      },
+      { request }
+    );
+  } catch (e) {
+    logger.error(`Error scheduling store usage task: ${e.message}`);
+    throw e;
+  }
+}
+
+export async function stopStoreUsageTask({
+  taskManager,
+  logger,
+  namespace,
+}: {
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+  namespace: string;
+}): Promise<void> {
+  const taskId = getStoreUsageTaskId(namespace);
+  await taskManager.removeIfExists(taskId);
+  logger.debug(`Removed store usage task: ${taskId}`);
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/telemetry/events.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/telemetry/events.ts
@@ -27,6 +27,11 @@ interface DeletionEvent {
   namespace: string;
 }
 
+interface StoreUsageEventPayload {
+  storeSize: number;
+  entityType: string;
+  namespace: string;
+}
 // ------------------------------------
 // Event definitions
 // ------------------------------------
@@ -85,6 +90,30 @@ export const ENTITY_STORE_DELETION_EVENT = {
   },
 } as const satisfies EventTypeOpts<DeletionEvent>;
 
+export const ENTITY_STORE_USAGE_EVENT = {
+  eventType: 'entity_store_usage',
+  schema: {
+    storeSize: {
+      type: 'long',
+      _meta: {
+        description: 'Number of entities stored in the entity store by type and namespace',
+      },
+    },
+    entityType: {
+      type: 'keyword',
+      _meta: {
+        description: 'Type of entities stored (e.g. "host")',
+      },
+    },
+    namespace: {
+      type: 'keyword',
+      _meta: {
+        description: 'Namespace where the entities are stored (e.g. "default")',
+      },
+    },
+  },
+} as const satisfies EventTypeOpts<StoreUsageEventPayload>;
+
 // ------------------------------------
 // Registration
 // ------------------------------------
@@ -93,6 +122,7 @@ const events = [
   ENTITY_STORE_INITIALIZATION_EVENT,
   ENTITY_STORE_INITIALIZATION_FAILURE_EVENT,
   ENTITY_STORE_DELETION_EVENT,
+  ENTITY_STORE_USAGE_EVENT,
 ] as const;
 
 export const registerTelemetry = (analytics: AnalyticsServiceSetup) => {
@@ -109,6 +139,7 @@ interface TelemetryEventMap {
   [ENTITY_STORE_INITIALIZATION_EVENT.eventType]: InitializationEvent;
   [ENTITY_STORE_DELETION_EVENT.eventType]: DeletionEvent;
   [ENTITY_STORE_INITIALIZATION_FAILURE_EVENT.eventType]: InitializationFailureEvent;
+  [ENTITY_STORE_USAGE_EVENT.eventType]: StoreUsageEventPayload;
 }
 
 export type TelemetryReporter = ReturnType<typeof createReportEvent>;

--- a/x-pack/solutions/security/plugins/entity_store/server/telemetry/events.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/telemetry/events.ts
@@ -125,11 +125,8 @@ const events = [
   ENTITY_STORE_USAGE_EVENT,
 ] as const;
 
-export const registerTelemetry = (analytics: AnalyticsServiceSetup) => {
-  events.forEach((eventConfig: EventTypeOpts<{}>) => {
-    analytics.registerEventType(eventConfig);
-  });
-};
+export const registerTelemetry = (analytics: AnalyticsServiceSetup) =>
+  events.forEach((eventConfig: EventTypeOpts<{}>) => analytics.registerEventType(eventConfig));
 
 // ------------------------------------
 // Type-safe reporting

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/field_retention_enrichment/field_retention_enrichment_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/field_retention_enrichment/field_retention_enrichment_task.ts
@@ -30,11 +30,7 @@ import type { EntityAnalyticsRoutesDeps } from '../../../types';
 
 import { executeFieldRetentionEnrichPolicy } from '../../elasticsearch_assets';
 
-import { getEntitiesIndexName } from '../../utils';
-import {
-  FIELD_RETENTION_ENRICH_POLICY_EXECUTION_EVENT,
-  ENTITY_STORE_USAGE_EVENT,
-} from '../../../../telemetry/event_based/events';
+import { FIELD_RETENTION_ENRICH_POLICY_EXECUTION_EVENT } from '../../../../telemetry/event_based/events';
 import { VERSIONS_BY_ENTITY_TYPE } from '../../entity_definitions/constants';
 import { entityStoreTaskDebugLogFactory, entityStoreTaskLogFactory } from '../utils';
 import { getApiKeyManager } from '../../auth/api_key';
@@ -47,7 +43,6 @@ type ExecuteEnrichPolicy = (
   namespace: string,
   entityType: EntityType
 ) => ReturnType<typeof executeFieldRetentionEnrichPolicy>;
-type GetStoreSize = (index: string | string[]) => Promise<number>;
 
 export const registerEntityStoreFieldRetentionEnrichTask = ({
   getStartServices,
@@ -81,14 +76,6 @@ export const registerEntityStoreFieldRetentionEnrichTask = ({
       esClient,
       logger,
     });
-  };
-
-  const getStoreSize: GetStoreSize = async (index) => {
-    const [coreStart] = await getStartServices();
-    const esClient = coreStart.elasticsearch.client.asInternalUser;
-
-    const { count } = await esClient.count({ index });
-    return count;
   };
 
   const getEnabledEntityTypesForNamespace = async (namespace: string) => {
@@ -129,7 +116,6 @@ export const registerEntityStoreFieldRetentionEnrichTask = ({
       createTaskRunner: createEntityStoreFieldRetentionEnrichTaskRunnerFactory({
         logger,
         telemetry,
-        getStoreSize,
         executeEnrichPolicy,
         getEnabledEntityTypesForNamespace,
       }),
@@ -195,7 +181,6 @@ export const removeEntityStoreFieldRetentionEnrichTask = async ({
 
 export const runEntityStoreFieldRetentionEnrichTask = async ({
   executeEnrichPolicy,
-  getStoreSize,
   isCancelled,
   logger,
   taskInstance,
@@ -205,7 +190,6 @@ export const runEntityStoreFieldRetentionEnrichTask = async ({
   logger: Logger;
   isCancelled: () => boolean;
   executeEnrichPolicy: ExecuteEnrichPolicy;
-  getStoreSize: GetStoreSize;
   taskInstance: ConcreteTaskInstance;
   telemetry: AnalyticsServiceSetup;
   getEnabledEntityTypesForNamespace: (namespace: string) => Promise<EntityType[]>;
@@ -259,19 +243,6 @@ export const runEntityStoreFieldRetentionEnrichTask = async ({
       interval: taskInstance.schedule?.interval,
     });
 
-    // Track entity store usage per namespace & entity type
-    await Promise.all(
-      entityTypes.map(async (entityType) => {
-        const index = getEntitiesIndexName(entityType, state.namespace);
-        const storeSize = await getStoreSize(index);
-        telemetry.reportEvent(ENTITY_STORE_USAGE_EVENT.eventType, {
-          storeSize,
-          entityType,
-          namespace: state.namespace,
-        });
-      })
-    );
-
     return {
       state: updatedState,
     };
@@ -286,13 +257,11 @@ const createEntityStoreFieldRetentionEnrichTaskRunnerFactory =
     logger,
     telemetry,
     executeEnrichPolicy,
-    getStoreSize,
     getEnabledEntityTypesForNamespace,
   }: {
     logger: Logger;
     telemetry: AnalyticsServiceSetup;
     executeEnrichPolicy: ExecuteEnrichPolicy;
-    getStoreSize: GetStoreSize;
     getEnabledEntityTypesForNamespace: (namespace: string) => Promise<EntityType[]>;
   }) =>
   ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => {
@@ -302,7 +271,6 @@ const createEntityStoreFieldRetentionEnrichTaskRunnerFactory =
       run: async () =>
         runEntityStoreFieldRetentionEnrichTask({
           executeEnrichPolicy,
-          getStoreSize,
           isCancelled,
           logger,
           taskInstance,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -667,34 +667,6 @@ export const ENTITY_HIGHLIGHTS_USAGE_EVENT: EventTypeOpts<{
   },
 };
 
-export const ENTITY_STORE_USAGE_EVENT: EventTypeOpts<{
-  storeSize: number;
-  entityType: string;
-  namespace: string;
-}> = {
-  eventType: 'entity_store_usage',
-  schema: {
-    storeSize: {
-      type: 'long',
-      _meta: {
-        description: 'Number of entities stored in the entity store by type and namespace',
-      },
-    },
-    entityType: {
-      type: 'keyword',
-      _meta: {
-        description: 'Type of entities stored (e.g. "host")',
-      },
-    },
-    namespace: {
-      type: 'keyword',
-      _meta: {
-        description: 'Namespace where the entities are stored (e.g. "default")',
-      },
-    },
-  },
-};
-
 export const ENTITY_STORE_API_CALL_EVENT: EventTypeOpts<{
   endpoint: string;
   error?: string;
@@ -1736,7 +1708,6 @@ export const events = [
   ENTITY_ENGINE_RESOURCE_INIT_FAILURE_EVENT,
   ENTITY_ENGINE_INITIALIZATION_EVENT,
   ENTITY_ENGINE_DELETION_EVENT,
-  ENTITY_STORE_USAGE_EVENT,
   ENTITY_HIGHLIGHTS_USAGE_EVENT,
   PRIVMON_ENGINE_INITIALIZATION_EVENT,
   PRIVMON_ENGINE_RESOURCE_INIT_FAILURE_EVENT,


### PR DESCRIPTION
### Summary 

- removed `entity_store_usage` telemetry event from `v1`, added to `v2` (can only be registered once)
- task scheduled for every new namespace install, runs every 1hr, counts the store size and reports back: `storeSize, entityType, namespace`


- related https://github.com/elastic/security-portal/pull/228