### PR TITLE
[Agent Builder] Propagate inference errors

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/errors.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/errors.ts
@@ -25,6 +25,8 @@ const recoverableErrorCodes = [
 
 /** Matches "Status code: xxx" in connector error messages */
 const CONNECTOR_STATUS_CODE_REGEXP = /Status code: ([0-9]{3})/i;
+/** Matches "status [xxx]" in ES inference API error messages */
+const INFERENCE_STATUS_CODE_REGEXP = /status \[([0-9]{3})\]/i;
 
 /**
  * Parses connector error messages and returns the HTTP status code when present
@@ -34,7 +36,8 @@ const parseConnectorStatusCode = (message: string): number | null => {
   if (!message.includes('Error calling connector:')) {
     return null;
   }
-  const match = CONNECTOR_STATUS_CODE_REGEXP.exec(message);
+  const match =
+    CONNECTOR_STATUS_CODE_REGEXP.exec(message) ?? INFERENCE_STATUS_CODE_REGEXP.exec(message);
   if (!match) {
     return null;
   }


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/252372 where Inference errors are now also caught and propagated to the Agent Builder API, rather than returning a 500 for these requests. Unfortunately these match a different pattern than Connector errors. 

This should help with some of the 500 errors we've been seeing in Serverless for Agent Builder API errors. 

Written using Cursor/Opus 4.6.