### PR TITLE
[Security Solution] Show only user-relevant events in the "Execution Events" tab

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/event_log_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/event_log_fields.ts
@@ -17,6 +17,7 @@ export const EVENT_CATEGORY = 'event.category' as const;
 export const EVENT_SEQUENCE = 'event.sequence' as const;
 
 export const LOG_LEVEL = 'log.level' as const;
+export const TAGS = 'tags' as const;
 
 // -------------------------------------------------------------------------------------------------
 // Custom fields of Alerting Framework and Security Solution

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -225,9 +225,9 @@ export const createRuleExecutionLogClientForExecutors = (
   };
 
   const writeStatusChangeToEventLog = (args: NormalizedStatusChangeArgs): void => {
-    const { newStatus, message, metrics } = args;
+    const { newStatus, message, metrics, isFinal } = args;
 
-    if (metrics) {
+    if (metrics && isFinal) {
       eventLog.logExecutionMetrics({
         ruleId,
         ruleUuid,
@@ -250,6 +250,7 @@ export const createRuleExecutionLogClientForExecutors = (
       executionId,
       newStatus,
       message,
+      isFinal,
     });
   };
 
@@ -261,6 +262,7 @@ interface NormalizedStatusChangeArgs {
   message: string;
   metrics?: RuleExecutionMetrics;
   userError?: boolean;
+  isFinal?: boolean;
 }
 
 const normalizeStatusChangeArgs = (args: StatusChangeArgs): NormalizedStatusChangeArgs => {
@@ -270,7 +272,7 @@ const normalizeStatusChangeArgs = (args: StatusChangeArgs): NormalizedStatusChan
       message: '',
     };
   }
-  const { newStatus, message, metrics, userError } = args;
+  const { newStatus, message, metrics, userError, isFinal } = args;
 
   return {
     newStatus,
@@ -286,6 +288,7 @@ const normalizeStatusChangeArgs = (args: StatusChangeArgs): NormalizedStatusChan
         }
       : undefined,
     userError,
+    isFinal,
   };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -129,6 +129,7 @@ export interface StatusChangeArgs {
   message?: string;
   metrics?: MetricsArgs;
   userError?: boolean;
+  isFinal?: boolean;
 }
 
 export interface MetricsArgs {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_reader.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_reader.ts
@@ -300,7 +300,11 @@ const buildEventLogKqlFilter = ({
   GetExecutionEventsArgs,
   'searchTerm' | 'eventTypes' | 'logLevels' | 'dateStart' | 'dateEnd'
 >) => {
-  const filters = [`${f.EVENT_PROVIDER}:${RULE_EXECUTION_LOG_PROVIDER}`];
+  const filters = [
+    `${f.EVENT_PROVIDER}:${RULE_EXECUTION_LOG_PROVIDER}`,
+    // Only extract events that are meaningful to the user: final status, "running" status, execution metrics, or message events with a log level of trace, debug, or info
+    `(${f.TAGS}:final OR ${f.RULE_EXECUTION_STATUS}:running OR ${f.EVENT_ACTION}:${RuleExecutionEventTypeEnum['execution-metrics']} OR (${f.EVENT_ACTION}:${RuleExecutionEventTypeEnum.message} AND ${f.LOG_LEVEL}:(trace OR debug OR info)))`,
+  ];
 
   if (searchTerm?.length) {
     filters.push(`${f.MESSAGE}:${prepareKQLStringParam(searchTerm)}`);
@@ -327,10 +331,6 @@ const buildEventLogKqlFilter = ({
   if (dateRangeFilter.length) {
     filters.push(kqlAnd(dateRangeFilter));
   }
-
-  filters.push(
-    `(${f.TAGS}:final OR ${f.RULE_EXECUTION_STATUS}:running OR ${f.EVENT_ACTION}:${RuleExecutionEventTypeEnum['execution-metrics']} OR (${f.EVENT_ACTION}:${RuleExecutionEventTypeEnum.message} AND ${f.LOG_LEVEL}:(trace OR debug OR info)))`
-  );
 
   return kqlAnd(filters);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_reader.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_reader.ts
@@ -328,6 +328,10 @@ const buildEventLogKqlFilter = ({
     filters.push(kqlAnd(dateRangeFilter));
   }
 
+  filters.push(
+    `(${f.TAGS}:final OR ${f.RULE_EXECUTION_STATUS}:running OR ${f.EVENT_ACTION}:${RuleExecutionEventTypeEnum['execution-metrics']} OR (${f.EVENT_ACTION}:${RuleExecutionEventTypeEnum.message} AND ${f.LOG_LEVEL}:(trace OR debug OR info)))`
+  );
+
   return kqlAnd(filters);
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
@@ -51,6 +51,7 @@ export interface MessageArgs extends BaseArgs {
 export interface StatusChangeArgs extends BaseArgs {
   newStatus: RuleExecutionStatus;
   message?: string;
+  isFinal?: boolean;
 }
 
 export interface ExecutionMetricsArgs extends BaseArgs {
@@ -111,6 +112,7 @@ export const createEventLogWriter = (eventLogService: IEventLogService): IEventL
       eventLogger.logEvent({
         '@timestamp': nowISO(),
         message: args.message,
+        ...(args.isFinal ? { tags: ['final'] } : {}),
         rule: {
           id: args.ruleId,
           uuid: args.ruleUuid,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -279,14 +279,14 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               if (SavedObjectsErrorHelpers.isNotFoundError(exc)) {
                 await ruleExecutionLogger.logStatusChange({
                   newStatus: RuleExecutionStatusEnum.failed,
-                  message: `Data view is not found.\nError: ${exc}`,
+                  message: `Data view is not found.\n${exc}`,
                   userError: true,
                   isFinal: true,
                 });
               } else {
                 await ruleExecutionLogger.logStatusChange({
                   newStatus: RuleExecutionStatusEnum.failed,
-                  message: `Check for indices to search failed.\nError: ${exc}`,
+                  message: `Check for indices to search failed.\n${exc}`,
                   isFinal: true,
                 });
               }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -513,14 +513,24 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
 
                 const createdSignals = result.createdSignals.concat(runResult.createdSignals);
                 const warningMessages = result.warningMessages.concat(runResult.warningMessages);
+
+                // Some executors (e.g. Threshold, New Terms) don't report `totalEventsFound`.
+                // When neither the accumulated result nor the current run has a value, we keep
+                // it undefined so the wrapper doesn't log a misleading "Found matching events: 0".
+                const executorTracksTotalEventsFound =
+                  typeof result.totalEventsFound === 'number' ||
+                  typeof runResult.totalEventsFound === 'number';
+                const totalEventsFound = executorTracksTotalEventsFound
+                  ? (result.totalEventsFound ?? 0) + (runResult.totalEventsFound ?? 0)
+                  : undefined;
+
                 result = {
                   bulkCreateTimes: result.bulkCreateTimes.concat(runResult.bulkCreateTimes),
                   enrichmentTimes: result.enrichmentTimes.concat(runResult.enrichmentTimes),
                   createdSignals,
                   createdSignalsCount: createdSignals.length,
                   suppressedAlertsCount: runResult.suppressedAlertsCount,
-                  totalEventsFound:
-                    (result.totalEventsFound ?? 0) + (runResult.totalEventsFound ?? 0),
+                  totalEventsFound,
                   errors: result.errors.concat(runResult.errors),
                   searchAfterTimes: result.searchAfterTimes.concat(runResult.searchAfterTimes),
                   state: runResult.state,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -281,11 +281,13 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   newStatus: RuleExecutionStatusEnum.failed,
                   message: `Data view is not found.\nError: ${exc}`,
                   userError: true,
+                  isFinal: true,
                 });
               } else {
                 await ruleExecutionLogger.logStatusChange({
                   newStatus: RuleExecutionStatusEnum.failed,
                   message: `Check for indices to search failed.\nError: ${exc}`,
+                  isFinal: true,
                 });
               }
 
@@ -380,6 +382,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             tuples,
             remainingGap,
             warningStatusMessage: rangeTuplesWarningMessage,
+            errorStatusMessage: rangeTuplesErrorMessage,
             gap,
             originalFrom,
             originalTo,
@@ -395,6 +398,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
           });
           if (rangeTuplesWarningMessage != null) {
             wrapperWarnings.push(rangeTuplesWarningMessage);
+          }
+          if (rangeTuplesErrorMessage != null) {
+            wrapperErrors.push(rangeTuplesErrorMessage);
           }
 
           agent.setCustomContext({ [SECURITY_NUM_RANGE_TUPLES]: tuples.length });
@@ -578,7 +584,10 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               wrapperWarnings.push(disabledActionsWarning);
             }
 
-            if (result.warningMessages.length > 0 || wrapperWarnings.length > 0) {
+            const hasWarnings = result.warningMessages.length > 0 || wrapperWarnings.length > 0;
+            const hasErrors = wrapperErrors.length > 0 || result.errors.length > 0;
+
+            if (hasWarnings) {
               // write warning messages first because if we have still have an error to write
               // we want to write the error messages last, so that the errors are set
               // as the current status of the rule.
@@ -591,9 +600,10 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   enrichmentDurations: result.enrichmentTimes,
                   frozenIndicesQueriedCount,
                 },
+                isFinal: !hasErrors,
               });
             }
-            if (wrapperErrors.length > 0 || result.errors.length > 0) {
+            if (hasErrors) {
               await ruleExecutionLogger.logStatusChange({
                 newStatus: RuleExecutionStatusEnum.failed,
                 message: truncateList(result.errors.concat(wrapperErrors)).join(', '),
@@ -608,8 +618,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 userError:
                   result.userError ||
                   result.errors.every((err) => checkErrorDetails(err).isUserError),
+                isFinal: true,
               });
-            } else if (!(result.warningMessages.length > 0) && !(wrapperWarnings.length > 0)) {
+            } else if (!hasWarnings) {
               ruleExecutionLogger.debug('Security Rule execution completed');
               ruleExecutionLogger.debug(
                 `Indexed ${createdSignalsCount} alerts into "${ruleDataClient.indexNameWithNamespace(
@@ -629,6 +640,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   enrichmentDurations: result.enrichmentTimes,
                   frozenIndicesQueriedCount,
                 },
+                isFinal: true,
               });
             }
           } catch (error) {
@@ -644,6 +656,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 enrichmentDurations: result.enrichmentTimes,
                 frozenIndicesQueriedCount,
               },
+              isFinal: true,
             });
           }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -40,6 +40,7 @@ import { formatAlertForNotificationActions } from '../rule_actions_legacy/logic/
 import { createResultObject } from './utils';
 import { RuleExecutionStatusEnum } from '../../../../common/api/detection_engine/rule_monitoring';
 import { truncateList } from '../rule_monitoring';
+import { logExecutionTotals } from './utils/log_execution_totals';
 import aadFieldConversion from '../routes/index/signal_aad_mapping.json';
 import { extractReferences, injectReferences } from './saved_object_references';
 import { withSecuritySpan } from '../../../utils/with_security_span';
@@ -562,27 +563,14 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               (action) => !actions.isActionTypeEnabled(action.actionTypeId)
             );
 
-            if (result.totalEventsFound != null) {
-              ruleExecutionLogger.info(`Found matching events: ${result.totalEventsFound}`);
-            }
-            const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
-            if (suppressedAlertsCount > 0) {
-              ruleExecutionLogger.info(`Alerts suppressed: ${suppressedAlertsCount}`);
-            }
-
             const createdSignalsCount = result.createdSignals.length;
 
-            if (result.totalEventsFound != null && result.totalEventsFound > 0) {
-              const unaccountedEvents =
-                result.totalEventsFound - createdSignalsCount - suppressedAlertsCount;
-              if (unaccountedEvents > 0) {
-                ruleExecutionLogger.info(
-                  `Events that did not result in alerts: ${unaccountedEvents}\nThis is typically because alerts for these events already exist from a previous rule execution, or events were excluded by value list exceptions. This number doesn't include suppressed alerts.`
-                );
-              }
-            }
-
-            ruleExecutionLogger.info(`Alerts created: ${createdSignalsCount}`);
+            logExecutionTotals(ruleExecutionLogger, {
+              ruleType: params.type,
+              totalEventsFound: result.totalEventsFound,
+              suppressedAlertsCount: result.suppressedAlertsCount,
+              createdSignalsCount,
+            });
 
             agent.setCustomContext({ [SECURITY_NUM_ALERTS_CREATED]: createdSignalsCount });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
@@ -156,7 +156,7 @@ export const createThreatSignals = async ({
     indexFields: threatIndexFields,
   });
 
-  ruleExecutionLogger.info(`Found threat indicators: ${threatListCount}`);
+  ruleExecutionLogger.debug(`Found threat indicators: ${threatListCount}`);
 
   const threatListConfig = {
     fields: threatMapping.map((mapping) => mapping.entries.map((item) => item.value)).flat(),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
@@ -126,7 +126,6 @@ export const createThreatSignals = async ({
   });
 
   ruleExecutionLogger.debug(`Total event count: ${eventCount}`);
-  results.totalEventsFound = eventCount;
 
   let threatPitId: OpenPointInTimeResponse['id'] = (
     await services.scopedClusterClient.asCurrentUser.openPointInTime({
@@ -389,9 +388,6 @@ export const createThreatSignals = async ({
     signalsCount: results.createdSignalsCount,
     responseActions: completeRule.ruleParams.responseActions,
   });
-  // Restore totalEventsFound since combineConcurrentResults doesn't carry it through
-  results.totalEventsFound = eventCount;
-
   ruleExecutionLogger.trace('Indicator matching rule has completed');
   return results;
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/log_execution_totals.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/log_execution_totals.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRuleExecutionLogForExecutors } from '../../rule_monitoring';
+
+export const logExecutionTotals = (
+  logger: IRuleExecutionLogForExecutors,
+  result: {
+    ruleType: string;
+    totalEventsFound?: number;
+    suppressedAlertsCount?: number;
+    createdSignalsCount: number;
+  }
+) => {
+  const { ruleType, totalEventsFound, suppressedAlertsCount = 0, createdSignalsCount } = result;
+
+  if (totalEventsFound != null) {
+    logger.info(`Found matching events: ${totalEventsFound}`);
+  }
+
+  // Indicator Match rules re-process the same source events across indicator
+  // pages, inflating suppression/unaccounted counts. Skipping these metrics for IM.
+  if (ruleType !== 'threat_match') {
+    if (suppressedAlertsCount > 0) {
+      logger.info(`Alerts suppressed: ${suppressedAlertsCount}`);
+    }
+
+    if (totalEventsFound != null && totalEventsFound > 0) {
+      const unaccountedEvents = totalEventsFound - createdSignalsCount - suppressedAlertsCount;
+      if (unaccountedEvents > 0) {
+        logger.info(
+          `Events that did not result in alerts: ${unaccountedEvents}\nThis is typically because alerts for these events already exist from a previous rule execution, or events were excluded by value list exceptions. This number doesn't include suppressed alerts.`
+        );
+      }
+    }
+  }
+
+  logger.info(`Alerts created: ${createdSignalsCount}`);
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -433,15 +433,15 @@ export const getRuleRangeTuples = async ({
 
   const intervalDuration = parseInterval(interval);
   if (intervalDuration == null) {
-    ruleExecutionLogger.error(
-      `Error computing gap between rule runs\nError: could not parse rule interval "${JSON.stringify(
-        interval
-      )}"`
-    );
+    const errorStatusMessage = `Error computing gap between rule runs: could not parse rule interval "${JSON.stringify(
+      interval
+    )}"`;
+    ruleExecutionLogger.error(errorStatusMessage);
     return {
       tuples,
       remainingGap: moment.duration(0),
       warningStatusMessage,
+      errorStatusMessage,
       originalFrom,
       originalTo,
     };


### PR DESCRIPTION
**Epic:** https://github.com/elastic/security-team/issues/15617

## Summary

This PR addresses some of the usability concerns for the "Execution events" tab on the rule details page. The tab is currently hidden behind a feature flag.

Goal of this PR is to avoid overburdening the user with the implementation details by default. However, writing debug and trace level events to event log can still be turned on using the `securitySolution:extendedRuleExecutionLoggingMinLevel` advanced setting.

## Feature behaviour by default (info/warn/error levels)
- Show a single final rule execution status to the user. The final status contains warnings or errors if rule execution had any.
- Show a single "metrics" event at the end of rule execution

## What this does NOT change
- All events at all levels are still written to the event log. Filtering is read-side only in the API.
- The "Execution results" tab and Detection Engine Health API are unaffected. They use their own aggregation queries.
- No schema changes to the event log.

## What info-level events are shown to user
All of these are logged from a shared rule wrapper. These were added in a previous [PR](https://github.com/elastic/kibana/pull/253992). Posting table here for context.

Event | Rule types | When shown
-- | -- | --
Found matching events: \<N\> | Query, EQL, ESQL, ML | Always (every execution)
Alerts created: \<N\> | All (incl. New Terms, Threshold) | Always (every execution)
Alerts suppressed: \<N\> | Query, EQL, ESQL (with suppression configured) | Only when suppressed count > 0
Events that did not result in alerts: \<N\> | Query, EQL, ESQL, Indicator Match, ML | Only when matched events > created + suppressed

## Screenshots

<details>
  <summary>🖼️ Click to see screenshots</summary>
  <h3>Various rule execution statuses - only "Running" and a single final status are shown</h3>
  <img width="1613" height="1151" alt="Screenshot 2026-02-24 at 22 04 40" src="https://github.com/user-attachments/assets/17b83089-28e8-4627-b605-e57e96f92cc7" />

  <h3>Paging through ES – no flood of execution events</h3>
<img width="1196" height="598" alt="Screenshot 2026-02-25 at 18 18 04" src="https://github.com/user-attachments/assets/ed0b5219-2097-4914-8b44-4c88f5eb055f" />

  <h3>More screenshots</h3>
<img width="1203" height="913" alt="Screenshot 2026-02-25 at 14 46 36" src="https://github.com/user-attachments/assets/f2731b7b-9fd4-4ec4-9635-769b0031aab1" />
<img width="1203" height="913" alt="Screenshot 2026-02-25 at 14 44 18" src="https://github.com/user-attachments/assets/f50754ce-aa94-4c79-a02d-f5364c3d78ef" />
<img width="1203" height="913" alt="Screenshot 2026-02-25 at 14 43 33" src="https://github.com/user-attachments/assets/a9373ca9-53fd-4374-9213-b412910fd4ef" />
<img width="760" height="908" alt="Screenshot 2026-02-25 at 14 56 56" src="https://github.com/user-attachments/assets/00f141aa-5a13-444e-b26d-5257f89637eb" />
<img width="883" height="981" alt="Screenshot 2026-02-25 at 14 58 35" src="https://github.com/user-attachments/assets/a7c4fddd-c9d8-44f3-b2b7-26117500407f" />


</details>

---

> ⚠️ **Pragmatic stopgap**: This PR takes a minimal-change approach to ship customer value now. A proper refactoring is planned for v9.5 in [#16022](https://github.com/elastic/security-team/issues/16022) which will consolidate to a single structured event per execution. This PR is designed to be fully replaceable by that work — no new public APIs or schema changes.