### PR TITLE
Troubleshooting flaky jest tests

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -138,7 +138,7 @@ function createMockServices() {
   return mockServices;
 }
 
-const mockfieldCounts: Record<string, number> = {};
+let mockfieldCounts: Record<string, number> = {};
 const mockCalcFieldCounts = jest.fn(() => {
   return mockfieldCounts;
 });
@@ -255,9 +255,12 @@ async function renderComponent(
   };
 }
 
-// Failing: See https://github.com/elastic/kibana/issues/225126
-describe.skip('discover responsive sidebar', function () {
+describe.each(new Array(10).fill('test'))('discover responsive sidebar', function () {
   let props: TestWrapperProps;
+
+  beforeAll(() => {
+    mockfieldCounts = {};
+  });
 
   beforeEach(async () => {
     (ExistingFieldsServiceApi.loadFieldExisting as jest.Mock).mockImplementation(async () => ({
@@ -656,8 +659,7 @@ describe.skip('discover responsive sidebar', function () {
     expect(services.dataViewEditor.userPermissions.editDataView).toHaveBeenCalled();
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/217005
-  it.skip('should render buttons in data view picker correctly', async () => {
+  it('should render buttons in data view picker correctly', async () => {
     const services = createMockServices();
     const propsWithPicker: TestWrapperProps = {
       ...props,
@@ -683,8 +685,7 @@ describe.skip('discover responsive sidebar', function () {
     expect(services.dataViewEditor.openEditor).toHaveBeenCalled();
   }, 5000);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/254625
-  it.skip('should not render buttons in data view picker when in viewer mode', async () => {
+  it('should not render buttons in data view picker when in viewer mode', async () => {
     const services = createMockServices();
     services.dataViewEditor.userPermissions.editDataView = jest.fn(() => false);
     services.dataViewFieldEditor.userPermissions.editIndexPattern = jest.fn(() => false);


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.