### PR TITLE
[Streams] Update EditPolicyModal copies

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.test.tsx
@@ -31,7 +31,7 @@ describe('EditPolicyModal', () => {
     );
 
     expect(screen.getByTestId('editPolicyModalTitle')).toHaveTextContent(
-      '3 streams and 2 indices will be affected'
+      'This update affects 3 streams and 2 indices'
     );
     expect(screen.getByTestId('editPolicyModal-affectedResourcesList-index-1')).toBeInTheDocument();
     expect(screen.getByTestId('editPolicyModal-affectedResourcesList-index-2')).toBeInTheDocument();
@@ -60,7 +60,7 @@ describe('EditPolicyModal', () => {
     );
 
     expect(screen.getByTestId('editPolicyModalTitle')).toHaveTextContent(
-      '2 streams will be affected'
+      'This update affects 2 streams'
     );
   });
 
@@ -78,7 +78,7 @@ describe('EditPolicyModal', () => {
     );
 
     expect(screen.getByTestId('editPolicyModalTitle')).toHaveTextContent(
-      '2 indices will be affected'
+      'This update affects 2 indices'
     );
   });
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_policy_modal/edit_policy_modal.tsx
@@ -50,6 +50,7 @@ export function EditPolicyModal({
 }: EditPolicyModalProps) {
   const modalTitleId = useGeneratedHtmlId();
   const isInUse = affectedResources.length > 0;
+  const affectedResourcesCount = affectedResources.length;
   const streamsCount = isInUse
     ? affectedResources.filter((resource) => resource.type === 'stream').length
     : 0;
@@ -83,7 +84,7 @@ export function EditPolicyModal({
 
   const modalTitle = isInUse
     ? i18n.translate('xpack.streams.editPolicyModal.title', {
-        defaultMessage: '{affectedResourcesLabel} will be affected',
+        defaultMessage: 'This update affects {affectedResourcesLabel}',
         values: {
           affectedResourcesLabel,
         },
@@ -128,7 +129,7 @@ export function EditPolicyModal({
               <p>
                 {i18n.translate('xpack.streams.editPolicyModal.managedWarningDescription', {
                   defaultMessage:
-                    'This policy is managed by Elasticsearch. Modifying it may cause unexpected behavior. Consider saving as a new policy instead.',
+                    'This policy is managed by Elasticsearch. Modifying it can cause unexpected behavior. To avoid unintended changes, save as a new policy instead.',
                 })}
               </p>
             </EuiCallOut>
@@ -140,9 +141,10 @@ export function EditPolicyModal({
             <EuiText size="s">
               {i18n.translate('xpack.streams.editPolicyModal.description', {
                 defaultMessage:
-                  'The ILM policy you are updating is currently used in {affectedResourcesLabel}. If you would like your updates to only affect this stream, you may save as a new ILM policy.',
+                  "{affectedResourcesLabel} {affectedResourcesCount, plural, one {uses} other {use}} the ILM policy you're updating. To apply your changes to only this stream, save as a new policy.",
                 values: {
                   affectedResourcesLabel,
+                  affectedResourcesCount,
                 },
               })}
             </EuiText>
@@ -207,7 +209,7 @@ export function EditPolicyModal({
                   isLoading={isProcessing}
                 >
                   {i18n.translate('xpack.streams.editPolicyModal.overwriteButton', {
-                    defaultMessage: 'Overwrite',
+                    defaultMessage: 'Update current policy',
                   })}
                 </EuiButton>
               </EuiFlexItem>
@@ -219,7 +221,7 @@ export function EditPolicyModal({
                   disabled={isProcessing}
                 >
                   {i18n.translate('xpack.streams.editPolicyModal.saveAsNewButton', {
-                    defaultMessage: 'Save as new',
+                    defaultMessage: 'Save as new policy',
                   })}
                 </EuiButton>
               </EuiFlexItem>


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/254852

## Summary

From the analysis @mdbirnstiehl did:

> For the title, how about "This update affects 6 streams and 4 indices"
> 
> For the managed policy warning, how about the following to maybe suggest saving as a new policy:
> 
> Modifying a managed policy
> This policy is managed by Elasticsearch. Modifying it can cause unexpected behavior. To avoid unintended changes, save as a new policy instead.
> 
> For the body text:
> 7 streams and 5 indices use the ILM policy you're updating. To apply your changes to only this stream, save as a new policy. 
> 
> For the CTA:
> 
> How about [Update current policy][Save as new policy]? Maybe these are too long and might not look quite right, but if they fit, I think this is more explicit.


### How to test
View the component in Storybook:

```bash
yarn storybook streams_app
```
