### PR TITLE
[Console] Filter-out empty Serverless doc links

### DIFF
--- a/packages/kbn-generate-console-definitions/src/generate_console_definitions.ts
+++ b/packages/kbn-generate-console-definitions/src/generate_console_definitions.ts
@@ -48,7 +48,8 @@ const generateDocumentation = (endpoint: SpecificationTypes.Endpoint): string =>
 const generateServerlessDocumentation = (
   endpoint: SpecificationTypes.Endpoint
 ): string | undefined => {
-  return endpoint.docUrlServerless;
+  const url = endpoint.docUrlServerless?.trim();
+  return url ? url : undefined;
 };
 
 interface GeneratedParameters {

--- a/src/platform/plugins/shared/console/packaging/scripts/console_definitions/generate_aggregated_definitions.ts
+++ b/src/platform/plugins/shared/console/packaging/scripts/console_definitions/generate_aggregated_definitions.ts
@@ -120,8 +120,15 @@ class StandaloneSpecDefinitionsService {
     }
 
     if (isServerless) {
-      description.documentation =
-        description.documentation_serverless || 'https://www.elastic.co/docs/api';
+      const serverlessDocUrl =
+        typeof description.documentation_serverless === 'string'
+          ? description.documentation_serverless.trim()
+          : undefined;
+      description.documentation = serverlessDocUrl || 'https://www.elastic.co/docs/api';
+
+      if (!serverlessDocUrl) {
+        delete description.documentation_serverless;
+      }
     }
 
     Object.assign(copiedDescription, description);

--- a/src/platform/plugins/shared/console/server/services/spec_definitions_service.ts
+++ b/src/platform/plugins/shared/console/server/services/spec_definitions_service.ts
@@ -75,7 +75,15 @@ export class SpecDefinitionsService {
     }
 
     if (isServerless) {
-      description.documentation = description.documentation_serverless || API_DOCS_LINK;
+      const serverlessDocUrl =
+        typeof description.documentation_serverless === 'string'
+          ? description.documentation_serverless.trim()
+          : undefined;
+      description.documentation = serverlessDocUrl || API_DOCS_LINK;
+
+      if (!serverlessDocUrl) {
+        delete description.documentation_serverless;
+      }
     }
 
     _.assign(copiedDescription, description);


### PR DESCRIPTION
## Summary

This PR fixes an issue where empty `"docUrlServerless": ""` from `schema.json` were passed to generated definitions.

1. Download `schema.json` and run the script to generate definitions
```bash
mkdir -p src/tmp/output/schema

curl -L "https://raw.githubusercontent.com/elastic/elasticsearch-specification/refs/heads/main/output/schema/schema.json" \
  -o src/tmp/output/schema/schema.json

node scripts/generate_console_definitions.js \
  --source "src/tmp" \
  --dest "src/platform/plugins/shared/console/server/lib/spec_definitions/json/generated" \
  --emptyDest
```
2. Check generated definitions for empty strings (`"documentation_serverless": "",`)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.