### PR TITLE
[Scout] fix to the Rules Page failure on MKI

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/rules_page.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/rules_page.ts
@@ -603,6 +603,26 @@ export class RulesPage {
   }
 
   /**
+   * Ensures a rule is enabled before status-change tests run
+   */
+  async ensureRuleEnabled(ruleName: string) {
+    const ruleRow = this.getRuleRowByName(ruleName);
+    await expect(ruleRow).toBeVisible({ timeout: SHORTER_TIMEOUT });
+    const statusDropdown = this.getRuleStatusDropdown(ruleRow);
+    await expect(statusDropdown).toBeVisible({ timeout: SHORTER_TIMEOUT });
+
+    const statusTitle = await statusDropdown.getAttribute('title');
+    if (statusTitle === 'Disabled') {
+      await statusDropdown.click();
+      await this.clickEnableFromDropDownMenu();
+
+      await expect(this.confirmModalButton).toBeVisible({ timeout: SHORTER_TIMEOUT });
+      await this.confirmModalButton.click();
+      await expect(statusDropdown).toHaveAttribute('title', 'Enabled', { timeout: BIGGER_TIMEOUT });
+    }
+  }
+
+  /**
    * Verifies that a rule's status is "Disabled"
    */
   async expectRuleToBeDisabled(ruleName: string) {

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/rules/rules_page_rules_tab/rules_page_rules_tab.admin.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/rules/rules_page_rules_tab/rules_page_rules_tab.admin.spec.ts
@@ -64,15 +64,8 @@ test.describe(
 
     test('changes the rule status to "disabled"', async ({ pageObjects }) => {
       await expect(pageObjects.rulesPage.rulesTable).toBeVisible();
-
-      await pageObjects.rulesPage.clickRuleStatusDropDownMenu(RULE_NAMES.FIRST_RULE_TEST);
-      await pageObjects.rulesPage.clickDisableFromDropDownMenu();
-
-      await expect(pageObjects.rulesPage.confirmModalButton).toBeVisible();
-      await pageObjects.rulesPage.confirmModalButton.click();
-
-      // Wait for the rule status to change
-      await pageObjects.rulesPage.expectRuleToBeDisabled(RULE_NAMES.FIRST_RULE_TEST);
+      await pageObjects.rulesPage.ensureRuleEnabled(RULE_NAMES.FIRST_RULE_TEST);
+      await pageObjects.rulesPage.disableRule(RULE_NAMES.FIRST_RULE_TEST);
     });
   }
 );


### PR DESCRIPTION
[Buildkite failure ](https://buildkite.com/elastic/appex-qa-serverless-kibana-scout-tests/builds/303/steps/canvas?sid=019c6a38-5299-4333-822d-b625c4fa4255&tab=output)
