### PR TITLE
[Agent Builder] add research skill

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/prompts/research_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/prompts/research_agent.ts
@@ -30,10 +30,11 @@ type ResearchAgentPromptParams = PromptFactoryParams & ResearchAgentPromptRuntim
 export const getResearchAgentPrompt = async (
   params: ResearchAgentPromptParams
 ): Promise<BaseMessageLike[]> => {
-  const { actions, processedConversation, resultTransformer } = params;
+  const { actions, processedConversation, resultTransformer, experimentalFeatures } = params;
   const clearSystemMessage = params.configuration.research.replace_default_instructions;
 
-  // Generate messages from the conversation's rounds
+  const useBaseMessage = clearSystemMessage || experimentalFeatures.skills;
+
   const previousRoundsAsMessages = await convertPreviousRounds({
     conversation: processedConversation,
     resultTransformer,
@@ -42,9 +43,7 @@ export const getResearchAgentPrompt = async (
   return [
     [
       'system',
-      clearSystemMessage
-        ? await getBaseSystemMessage(params)
-        : await getResearchSystemMessage(params),
+      useBaseMessage ? await getBaseSystemMessage(params) : await getResearchSystemMessage(params),
     ],
     ...getConversationAttachmentsSystemMessages(
       params.processedConversation.versionedAttachmentPresentation

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
@@ -27,7 +27,6 @@ export class AgentBuilderPlatformPlugin
       PluginStartDependencies
     >
 {
-  // @ts-expect-error unused for now
   private logger: Logger;
   // @ts-expect-error unused for now
   private config: AgentBuilderConfig;
@@ -49,7 +48,9 @@ export class AgentBuilderPlatformPlugin
       coreSetup,
       setupDeps,
     });
-    registerSkills(setupDeps.agentBuilder);
+    registerSkills(setupDeps.agentBuilder).catch((e) => {
+      this.logger.warn(`Failed to register skills: ${e.message}`);
+    });
 
     return {};
   }

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
@@ -16,6 +16,7 @@ import type {
 } from './types';
 import { registerTools } from './tools';
 import { registerAttachmentTypes } from './attachment_types';
+import { registerSkills } from './skills/register_skills';
 
 export class AgentBuilderPlatformPlugin
   implements
@@ -48,6 +49,7 @@ export class AgentBuilderPlatformPlugin
       coreSetup,
       setupDeps,
     });
+    registerSkills(setupDeps.agentBuilder);
 
     return {};
   }

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/register_skills.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/register_skills.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import { researchSkill } from './research_skill';
+
+export const registerSkills = async (agentBuilder: AgentBuilderPluginSetup): Promise<void> => {
+  await agentBuilder.skills.register(researchSkill);
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/research_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/research_skill.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sanitizeToolId } from '@kbn/agent-builder-genai-utils/langchain';
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+
+const tools = {
+  indexExplorer: sanitizeToolId(platformCoreTools.indexExplorer),
+  listIndices: sanitizeToolId(platformCoreTools.listIndices),
+  search: sanitizeToolId(platformCoreTools.search),
+};
+
+export const researchSkill = defineSkillType({
+  id: 'research',
+  name: 'research',
+  basePath: 'skills/platform',
+  description: 'Core research methodology for conducting data research and information gathering',
+  content: `## PRIORITY ORDER (read first)
+1) NON-NEGOTIABLE RULES (highest priority)
+2) CUSTOM INSTRUCTIONS (when not conflicting)
+3) OPERATING PROTOCOL
+
+## CORE MISSION
+- Your goal is to conduct research to gather all necessary information to answer the user's query.
+- You will execute a series of tool calls to find the required data.
+
+## NON-NEGOTIABLE RULES
+1) Tool-first: For any factual / procedural / troubleshooting / product / platform / integration / config / pricing / version / feature / support / policy question you MUST call at least one available tool before answering.
+2) Grounding: Every claim must come from tool output or user-provided content. If not present, omit it.
+3) Scope discipline: Focus your research ONLY on what was asked.
+4) No speculation or capability disclaimers. Do not deflect, over-explain limitations, guess, or fabricate links, data, or tool behavior.
+5) Clarify **only if a mandatory tool parameter is missing** and cannot be defaulted or omitted; otherwise run a tool first.
+6) One tool call at a time: You must only call one tool per turn. Never call multiple tools, or multiple times the same tool, at the same time (no parallel tool call).
+7) Use only currently available tools. Never invent tool names or capabilities.
+8) Bias to action: When uncertain about an information-seeking query, default to calling tools to gather information. This rule does not apply to conversational interactions identified during Triage.
+
+## TRIAGE: WHEN TO BYPASS RESEARCH
+
+Your first step is ALWAYS to determine the user's intent. Before planning any research, you MUST check if the query falls into one of these categories.
+If it does, your ONLY action is to immediately respond in plain text with a brief note (e.g., "Ready to answer, no tools needed.") to hand over to the answering agent.
+- Conversational Interaction: The user provides a greeting, an acknowledgment, feedback, or other social chat that does not ask for information.
+- Public, universally known general facts (not about products / vendors / policies / features / versions / pricing / support).
+- Pure math / logic.
+- Transformations (summarize, rewrite, classify user-supplied content) without adding new external facts.
+- Mandatory parameter clarifications (1 - 2 targeted questions).
+- Acknowledgments or user explicitly says not to use tools.
+- Reporting tool errors / unavailability (offer retry).
+NOT public (thus require grounding): any vendor / platform / product / integration / policy / config / pricing / feature / version / support / security / limits / SLA details.
+If plausible organizational or product-specific knowledge is involved, default to tools.
+
+## TOOL SELECTION POLICY (authoritative)
+
+Precedence sequence (stop at first applicable):
+  1. User-specified tool: If the user explicitly requests or has previously instructed you (for this session or similar queries) to use a specific tool and it is not clearly unsafe or irrelevant, use it first. If unsuitable or unavailable, skip and continue.
+  2. Specialized tool: Use a domain-targeted tool that directly produces the needed answer more precisely than a general search.
+      Examples of specialized categories (illustrative, only use if available and relevant):
+        • Custom domain / vertical analyzers (e.g., detection engineering, incident triage, attack pattern classifiers).
+        • External system connectors (e.g., SaaS platform search) or federated knowledge base connectors (e.g., Confluence / wiki / code repo / ticketing / CRM / knowledge store), when required data resides outside Elasticsearch.
+        • Structured analytics & aggregation tools (metrics, time-series rollups, statistical or anomaly detection utilities).
+        • Log or event pattern mining, clustering, summarization, correlation, causality, or root-cause analytic utilities.
+  3. General search fallback: If no user-specified or specialized tool applies, call \`${tools.search}\` (if available). **It can discover indices itself—do NOT call index tools just to find an index**.
+  4. Index inspection fallback: Use \`${tools.indexExplorer}\` or \`${tools.listIndices}\` ONLY if (a) the user explicitly asks to list / inspect indices / fields / metadata, OR (b) \`${tools.search}\` is unavailable and structural discovery is necessary.
+  5. Additional calls: If initial results do not fully answer all explicit sub-parts, issue targeted follow-up tool calls before asking the user for more info.
+Constraints:
+  - Do not delay an initial eligible search for non-mandatory clarifications.
+  - **Ask 1-2 focused questions only if a mandatory parameter is missing and blocks any tool call.**
+  - Adapt gracefully if some tools are disabled; re-run the precedence with remaining tools.
+  - Never expose internal tool selection reasoning unless the user asks.
+
+## OPERATING PROTOCOL
+  Step 1 — Triage Intent
+    - First, analyze the user's latest query and the conversation history.
+    - Apply the rules in the "TRIAGE: WHEN TO BYPASS RESEARCH" section.
+    - If the query matches a category for bypassing research, your decision is made. Your only task is to respond in plain text to initiate the handover. Do not proceed to the next steps.
+  Step 2 — Plan Research (if necessary)
+    - If the query is informational and requires research, formulate a step-by-step plan to find the answer.
+    - Parse user intent, sub-questions, entities, constraints, etc.
+    - Check the SKILLS section: if any skill matches the query, your first action MUST be to load it via \`filestore.read\`.
+  Step 3 — Execute & Iterate
+    - Apply the Tool Selection Policy to execute the first step of your plan (skill loading takes priority).
+    - After each tool call, review the gathered information.
+    - If more information is needed, update your plan and execute the next tool call.
+  Step 4 — Conclude Research
+    - Once your plan is complete and you have gathered sufficient information, respond in plain text. This response will serve as your handover notes for the answering agent.
+    - Your plain text handover note is for meta-commentary ONLY.
+      - **DO NOT** summarize the tool outputs or repeat facts from the tool call history. The answering agent has full access to this information.
+      - Keep the note concise and focused on insights that are not obvious from the data.`,
+  getRegistryTools: () => [
+    platformCoreTools.search,
+    platformCoreTools.listIndices,
+    platformCoreTools.indexExplorer,
+  ],
+});


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/13206

Note: this is gated behind the `agentBuilder:experimentalFeatures` FF.

Extract the researcher prompt's research instructions into a `research` skill, and always use the "base" agent prompt instead of the researcher one.

This is meant to be used for deep agent evals, to see how much this impact the efficiency of our agent for research tasks.


