### PR TITLE
[APM] Add kibana.alert.grouping to latency threshold alerts

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/register_apm_rule_types.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/register_apm_rule_types.ts
@@ -90,7 +90,6 @@ export const apmRuleTypeAlertFieldMap = {
   },
 };
 
-// Defines which alerts-as-data index alerts will use
 export const ApmRuleTypeAlertDefinition: IRuleTypeAlerts<ObservabilityApmAlert> = {
   context: APM_RULE_TYPE_ALERT_CONTEXT,
   mappings: {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
@@ -86,6 +86,7 @@ describe('registerTransactionDurationRuleType', () => {
       payload: {
         'kibana.alert.evaluation.threshold': 3000000,
         'kibana.alert.evaluation.value': 5500000,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: development, type: request. Alert when > 3.0 s.',
         'processor.event': 'transaction',
@@ -176,6 +177,7 @@ describe('registerTransactionDurationRuleType', () => {
       payload: {
         'kibana.alert.evaluation.threshold': 3000000,
         'kibana.alert.evaluation.value': 5500000,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: development, type: request, name: GET /products. Alert when > 3.0 s.',
         'processor.event': 'transaction',
@@ -266,6 +268,7 @@ describe('registerTransactionDurationRuleType', () => {
       payload: {
         'kibana.alert.evaluation.threshold': 3000000,
         'kibana.alert.evaluation.value': 5500000,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: development, type: request. Alert when > 3.0 s.',
         'processor.event': 'transaction',
@@ -356,6 +359,7 @@ describe('registerTransactionDurationRuleType', () => {
       payload: {
         'kibana.alert.evaluation.threshold': 3000000,
         'kibana.alert.evaluation.value': 5500000,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: Not defined, type: request, name: tx-java. Alert when > 3.0 s.',
         'processor.event': 'transaction',
@@ -445,6 +449,7 @@ describe('registerTransactionDurationRuleType', () => {
       payload: {
         'kibana.alert.evaluation.threshold': 3000000,
         'kibana.alert.evaluation.value': 5500000,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: All, type: request, name: tx-java. Alert when > 3.0 s.',
         'processor.event': 'transaction',
@@ -541,6 +546,7 @@ describe('registerTransactionDurationRuleType', () => {
       payload: {
         'kibana.alert.evaluation.threshold': 3000000,
         'kibana.alert.evaluation.value': 5500000,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: development, type: request. Alert when > 3.0 s.',
         'processor.event': 'transaction',
@@ -596,6 +602,16 @@ describe('registerTransactionDurationRuleType', () => {
           'processor.event': 'transaction',
           'kibana.alert.evaluation.value': 1000000,
           'kibana.alert.evaluation.threshold': 149000,
+          'kibana.alert.grouping': {
+            service: {
+              environment: 'Synthtrace: many_errors',
+              name: 'synthtrace-high-cardinality-0',
+            },
+            transaction: {
+              name: 'from-recovered-hit',
+              type: 'request',
+            },
+          },
           'kibana.alert.reason':
             'Avg. latency is 1,000 ms in the last 5 days for service: synthtrace-high-cardinality-0, env: Synthtrace: many_errors, type: request. Alert when > 149 ms.',
           'agent.name': 'java',
@@ -667,6 +683,7 @@ describe('registerTransactionDurationRuleType', () => {
             name: 'synthtrace-high-cardinality-0',
           },
           transaction: {
+            name: 'from-recovered-hit',
             type: 'request',
           },
         },

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
@@ -29,6 +29,7 @@ import { getParsedFilterQuery, termQuery } from '@kbn/observability-plugin/serve
 import {
   ALERT_EVALUATION_THRESHOLD,
   ALERT_EVALUATION_VALUE,
+  ALERT_GROUPING,
   ALERT_INDEX_PATTERN,
   ALERT_REASON,
   ALERT_RULE_PARAMETERS,
@@ -319,6 +320,7 @@ export function registerTransactionDurationRuleType({
           [PROCESSOR_EVENT]: ProcessorEvent.transaction,
           [ALERT_EVALUATION_VALUE]: transactionDuration,
           [ALERT_EVALUATION_THRESHOLD]: thresholdMicroseconds,
+          [ALERT_GROUPING]: groupingObject,
           [ALERT_REASON]: reason,
           [ALERT_INDEX_PATTERN]: index,
           ...sourceFields,
@@ -369,7 +371,8 @@ export function registerTransactionDurationRuleType({
           alertHits?.[ALERT_EVALUATION_VALUE]
         ).formatted;
         const groupByActionVariables = getGroupByActionVariables(groupByFields);
-        const groupingObject = unflattenObject(groupByFields);
+        const groupingObjectFromRecoveredAlert =
+          alertHits?.[ALERT_GROUPING] ?? unflattenObject(groupByFields);
 
         const recoveredContext = {
           alertDetailsUrl,
@@ -383,7 +386,7 @@ export function registerTransactionDurationRuleType({
           threshold: ruleParams.threshold,
           triggerValue: transactionDurationFormatted,
           viewInAppUrl,
-          grouping: groupingObject,
+          grouping: groupingObjectFromRecoveredAlert,
           ...groupByActionVariables,
         };
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
@@ -204,22 +204,23 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
 
       it('indexes alert document with all group-by fields', async () => {
-        expect(alerts[0]).property('service.name', 'opbeans-java');
-        expect(alerts[0]).property('service.environment', 'production');
-        expect(alerts[0]).property('transaction.type', 'request');
-        expect(alerts[0]).property('transaction.name', 'tx-java');
-        expect(alerts[0])
-          .property('kibana.alert.grouping')
-          .eql({
-            service: {
-              name: 'opbeans-java',
-              environment: 'production',
-            },
-            transaction: {
-              type: 'request',
-              name: 'tx-java',
-            },
-          });
+        const alert = alerts[0];
+        expect({
+          'service.name': alert['service.name'],
+          'service.environment': alert['service.environment'],
+          'transaction.type': alert['transaction.type'],
+          'transaction.name': alert['transaction.name'],
+          'kibana.alert.grouping': alert['kibana.alert.grouping'],
+        }).to.eql({
+          'service.name': 'opbeans-java',
+          'service.environment': 'production',
+          'transaction.type': 'request',
+          'transaction.name': 'tx-java',
+          'kibana.alert.grouping': {
+            service: { name: 'opbeans-java', environment: 'production' },
+            transaction: { type: 'request', name: 'tx-java' },
+          },
+        });
       });
 
       it('shows the correct alert count for each service on service inventory', async () => {
@@ -316,22 +317,23 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
 
       it('indexes alert document with all group-by fields', async () => {
-        expect(alerts[0]).property('service.name', 'opbeans-node');
-        expect(alerts[0]).property('service.environment', 'production');
-        expect(alerts[0]).property('transaction.type', 'request');
-        expect(alerts[0]).property('transaction.name', 'tx-node');
-        expect(alerts[0])
-          .property('kibana.alert.grouping')
-          .eql({
-            service: {
-              name: 'opbeans-node',
-              environment: 'production',
-            },
-            transaction: {
-              type: 'request',
-              name: 'tx-node',
-            },
-          });
+        const alert = alerts[0];
+        expect({
+          'service.name': alert['service.name'],
+          'service.environment': alert['service.environment'],
+          'transaction.type': alert['transaction.type'],
+          'transaction.name': alert['transaction.name'],
+          'kibana.alert.grouping': alert['kibana.alert.grouping'],
+        }).to.eql({
+          'service.name': 'opbeans-node',
+          'service.environment': 'production',
+          'transaction.type': 'request',
+          'transaction.name': 'tx-node',
+          'kibana.alert.grouping': {
+            service: { name: 'opbeans-node', environment: 'production' },
+            transaction: { type: 'request', name: 'tx-node' },
+          },
+        });
       });
 
       it('shows alert count=1 for opbeans-node on service inventory', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
@@ -9,7 +9,7 @@ import { AggregationType } from '@kbn/apm-plugin/common/rules/apm_rule_types';
 import { ApmRuleType } from '@kbn/rule-data-utils';
 import { transactionDurationActionVariables } from '@kbn/apm-plugin/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type';
 import { apm, timerange } from '@kbn/synthtrace-client';
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import { omit } from 'lodash';
 import type { ApmSynthtraceEsClient } from '@kbn/synthtrace';
 import type { RoleCredentials } from '../../../services';
@@ -208,6 +208,18 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         expect(alerts[0]).property('service.environment', 'production');
         expect(alerts[0]).property('transaction.type', 'request');
         expect(alerts[0]).property('transaction.name', 'tx-java');
+        expect(alerts[0])
+          .property('kibana.alert.grouping')
+          .eql({
+            service: {
+              name: 'opbeans-java',
+              environment: 'production',
+            },
+            transaction: {
+              type: 'request',
+              name: 'tx-java',
+            },
+          });
       });
 
       it('shows the correct alert count for each service on service inventory', async () => {
@@ -308,6 +320,18 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         expect(alerts[0]).property('service.environment', 'production');
         expect(alerts[0]).property('transaction.type', 'request');
         expect(alerts[0]).property('transaction.name', 'tx-node');
+        expect(alerts[0])
+          .property('kibana.alert.grouping')
+          .eql({
+            service: {
+              name: 'opbeans-node',
+              environment: 'production',
+            },
+            transaction: {
+              type: 'request',
+              name: 'tx-node',
+            },
+          });
       });
 
       it('shows alert count=1 for opbeans-node on service inventory', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/transaction_duration.spec.ts
@@ -9,7 +9,7 @@ import { AggregationType } from '@kbn/apm-plugin/common/rules/apm_rule_types';
 import { ApmRuleType } from '@kbn/rule-data-utils';
 import { transactionDurationActionVariables } from '@kbn/apm-plugin/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type';
 import { apm, timerange } from '@kbn/synthtrace-client';
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import { omit } from 'lodash';
 import type { ApmSynthtraceEsClient } from '@kbn/synthtrace';
 import type { RoleCredentials } from '../../../services';


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/224898
Implements `kibana.alert.grouping` for the APM Latency threshold rule (`apm.transaction_duration`) in line with the Observability grouping initiative.

### What changed

- Added `kibana.alert.grouping` to active alert payloads in the transaction duration executor.
- Updated recovered alert context to prefer `kibana.alert.grouping` from the recovered alert document, with a backward-compatible fallback to reconstructed grouping for older alerts.
- Updated latency rule unit tests to validate payload/context behavior.
- Updated deployment-agnostic APM API integration tests to assert `kibana.alert.grouping` is indexed with the expected nested structure.
<img width="1550" height="1504" alt="Screenshot 2026-02-25 at 12 57 53" src="https://github.com/user-attachments/assets/d7fd2fc6-788b-4d4a-8c02-6b3a25d1d635" />

## Why

This ensures grouping is first-class in alert documents for filtering/searching and keeps recovered `context.grouping` aligned with the alert document source of truth.

## Test plan

- `yarn test:jest x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts`
- `yarn test:ftr --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts --grep "transaction duration alert"`

## Validation results

- Unit tests: **PASS** (7/7)
- Deployment-agnostic stateful APM suite (filtered to transaction duration alert): **PASS** (22 passing, exit code 0)

## Notes

- No saved object migration is required.
- Shared APM mapping support for `kibana.alert.grouping.*` is additive.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->