### PR TITLE
[Search] Refetch sample docs on index refresh

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
@@ -147,7 +147,7 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
   );
 
   const onIndexRefresh = useCallback(() => {
-    resendDocumentsSampleRequest();
+    return resendDocumentsSampleRequest();
   }, [resendDocumentsSampleRequest]);
 
   const headerTabs = useMemo<EuiPageHeaderProps['tabs']>(() => {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_content_v2.tsx
@@ -18,6 +18,7 @@ import { openWiredConnectionDetails } from '@kbn/cloud/connection_details';
 import { useIndexErrors } from '../../../../hooks/use_index_errors';
 import { resetIndexUrlParams } from './reset_index_url_params';
 import { renderBadges } from '../../../../lib/render_badges';
+import { useLoadIndexDocumentsSample } from '../../../../services/api';
 import type { Index } from '../../../../../../common';
 import type { IndexDetailsTab, IndexDetailsTabId } from '../../../../../../common/constants';
 import { INDEX_OPEN, IndexDetailsSection } from '../../../../../../common/constants';
@@ -33,14 +34,7 @@ import { IndexErrorCallout } from './index_error_callout';
 import { DetailsPageOverviewV2 } from './details_page_overview/details_page_overview_v2';
 
 const defaultTabs: IndexDetailsTab[] = [
-  {
-    id: IndexDetailsSection.Overview,
-    name: i18n.translate('xpack.idxMgmt.indexDetails.overviewTitle', {
-      defaultMessage: 'Overview',
-    }),
-    renderTabContent: ({ index }) => <DetailsPageOverviewV2 indexDetails={index} />,
-    order: 10,
-  },
+  // Overview tab is injected in component to pass live docs sample data.
   {
     id: IndexDetailsSection.Mappings,
     name: i18n.translate('xpack.idxMgmt.indexDetails.mappingsTitle', {
@@ -97,9 +91,32 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
   const hasMLPermissions = capabilities?.ml?.canGetTrainedModels ? true : false;
 
   const indexErrors = useIndexErrors(index, ml, hasMLPermissions);
+  const {
+    data: documentsSampleData,
+    isLoading: isDocumentsSampleLoading,
+    error: documentsSampleError,
+    resendRequest: resendDocumentsSampleRequest,
+  } = useLoadIndexDocumentsSample(index.name);
 
   const tabs = useMemo(() => {
-    const sortedTabs = [...defaultTabs];
+    const sortedTabs: IndexDetailsTab[] = [
+      {
+        id: IndexDetailsSection.Overview,
+        name: i18n.translate('xpack.idxMgmt.indexDetails.overviewTitle', {
+          defaultMessage: 'Overview',
+        }),
+        renderTabContent: ({ index: selectedIndex }) => (
+          <DetailsPageOverviewV2
+            indexDetails={selectedIndex}
+            sampleDocuments={documentsSampleData?.results ?? []}
+            isDocumentsLoading={isDocumentsSampleLoading}
+            documentsError={documentsSampleError}
+          />
+        ),
+        order: 10,
+      },
+      ...defaultTabs,
+    ];
     if (enableIndexStats) {
       sortedTabs.push(statsTab);
     }
@@ -113,7 +130,14 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
       return tabA.order - tabB.order;
     });
     return sortedTabs;
-  }, [enableIndexStats, extensionsService.indexDetailsTabs, index]);
+  }, [
+    documentsSampleData,
+    isDocumentsSampleLoading,
+    documentsSampleError,
+    enableIndexStats,
+    extensionsService.indexDetailsTabs,
+    index,
+  ]);
 
   const onSectionChange = useCallback(
     (newSection: IndexDetailsTabId) => {
@@ -121,6 +145,10 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
     },
     [history, index.name, search]
   );
+
+  const onIndexRefresh = useCallback(() => {
+    resendDocumentsSampleRequest();
+  }, [resendDocumentsSampleRequest]);
 
   const headerTabs = useMemo<EuiPageHeaderProps['tabs']>(() => {
     return tabs.map((tabConfig) => ({
@@ -151,6 +179,7 @@ export const DetailsPageContentV2: FunctionComponent<Props> = ({
             index={index}
             reloadIndexDetails={fetchIndexDetails}
             navigateToIndicesList={navigateToIndicesList}
+            onIndexRefresh={onIndexRefresh}
             fill={true}
           />,
           <DiscoverLink indexName={index.name} asButton={true} fill={false} />,

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview_v2.tsx
@@ -31,6 +31,7 @@ import {
   EisUpdateCallout,
 } from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { type Index } from '../../../../../../../common';
 import { formatBytes } from '../../../../../lib/format_bytes';
 import { useAppContext } from '../../../../../app_context';
@@ -53,9 +54,17 @@ import { IndexDocuments } from '../index_documents/index_documents';
 
 interface Props {
   indexDetails: Index;
+  sampleDocuments: SearchHit[];
+  isDocumentsLoading: boolean;
+  documentsError: unknown;
 }
 
-export const DetailsPageOverviewV2: React.FunctionComponent<Props> = ({ indexDetails }) => {
+export const DetailsPageOverviewV2: React.FunctionComponent<Props> = ({
+  indexDetails,
+  sampleDocuments,
+  isDocumentsLoading,
+  documentsError,
+}) => {
   const {
     name,
     status,
@@ -225,7 +234,12 @@ export const DetailsPageOverviewV2: React.FunctionComponent<Props> = ({ indexDet
               consoleRequest={getConsoleRequest('ingestDataIndex', codeSnippetArguments)}
             />
           </EuiFlexItem>
-          <IndexDocuments indexName={name} mappings={mappingsData ?? undefined} />
+          <IndexDocuments
+            documents={sampleDocuments}
+            isLoading={isDocumentsLoading}
+            error={documentsError}
+            mappings={mappingsData ?? undefined}
+          />
         </EuiFlexGroup>
       )}
     </>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/index_documents/index_documents.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/index_documents/index_documents.tsx
@@ -8,18 +8,23 @@
 import React from 'react';
 import { EuiTitle, EuiSpacer, EuiHorizontalRule, EuiFlexItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { DocumentList } from './document_list';
-import { useLoadIndexDocumentsSample } from '../../../../../services/api';
 import type { MappingsResponse } from '../../../../../../../common';
 
 interface IndexDocumentsProps {
-  indexName: string;
+  documents: SearchHit[];
+  isLoading: boolean;
+  error: unknown;
   mappings?: MappingsResponse;
 }
 
-export const IndexDocuments: React.FC<IndexDocumentsProps> = ({ indexName, mappings }) => {
-  const { data, isLoading, error } = useLoadIndexDocumentsSample(indexName);
-  const documents = data?.results ?? [];
+export const IndexDocuments: React.FC<IndexDocumentsProps> = ({
+  documents,
+  isLoading,
+  error,
+  mappings,
+}) => {
   const mappingProperties = mappings?.mappings?.properties;
 
   if (isLoading || error || documents.length === 0) {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/manage_index_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/manage_index_button.tsx
@@ -42,6 +42,7 @@ interface Props {
   index: Index;
   reloadIndexDetails: () => Promise<void>;
   navigateToIndicesList: () => void;
+  onIndexRefresh?: () => Promise<void> | void;
   fill?: boolean;
 }
 
@@ -55,6 +56,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
   index,
   reloadIndexDetails,
   navigateToIndicesList,
+  onIndexRefresh,
   fill = false,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -131,6 +133,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
     try {
       await refreshIndicesRequest(indexNames);
       await reloadIndices();
+      await onIndexRefresh?.();
       setIsLoading(false);
       notificationService.showSuccessToast(
         i18n.translate('xpack.idxMgmt.refreshIndicesAction.indexRefreshedMessage', {
@@ -142,7 +145,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       setIsLoading(false);
       notificationService.showDangerToast(error.body.message);
     }
-  }, [reloadIndices, indexNames]);
+  }, [reloadIndices, indexNames, onIndexRefresh]);
 
   const clearCacheIndices = useCallback(async () => {
     setIsLoading(true);

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.test.ts
@@ -42,7 +42,13 @@ describe('Documents sample API', () => {
       expect(searchMock).toHaveBeenCalledWith({
         index: 'my-index',
         size: DEFAULT_DOCUMENT_PAGE_SIZE,
-        sort: ['_doc'],
+        sort: [
+          {
+            _doc: {
+              order: 'desc',
+            },
+          },
+        ],
         track_total_hits: false,
       });
 

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/indices/register_documents_sample_route.ts
@@ -39,7 +39,13 @@ export function registerDocumentsSampleRoute({
           index: indexName,
           size: DEFAULT_DOCUMENT_PAGE_SIZE,
           track_total_hits: false,
-          sort: ['_doc'],
+          sort: [
+            {
+              _doc: {
+                order: 'desc',
+              },
+            },
+          ],
         });
 
         return response.ok({


### PR DESCRIPTION
## Summary

This PR allows the sample documents in the Data Preview section to be re-requested as part of an index refresh. It moves sample document fetching up to `DetailsPageContentV2` so `resendDocumentsSampleRequest` can be passed to `ManageIndexButton` through the `onIndexRefresh` callback. 

That callback is invoked in `refreshIndices`, which runs when the `Refresh index` action is triggered.

On the server side, this change also makes the `DocumentsSample` sort explicit as `_doc desc` so the latest sample set is returned, or at least more likely to.

### Screenshots
<img width="700" height="694" alt="Screenshot 2026-02-25 at 14 01 26" src="https://github.com/user-attachments/assets/5f873a2c-7a19-4ecf-8c7a-eaba3da04aa6" />


### Testing

- [ ] Create an index with documents. The `Intro to Semantic Search` tutorial on the Getting Started page is a quick and easy way to do this.
- [ ] Visit the platform index details page for your created index
- [ ] Using the console, add more documents to the index
- [ ] Click the `Manage Index` button and then the `Refresh index` button
- [ ] Confirm that the new sample documents appear in the Data Preview section

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

