### PR TITLE
[Entity Store] Add usage collector

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/entity_store/kibana.jsonc
@@ -16,7 +16,8 @@
       "security"
   ],
     "optionalPlugins": [
-      "encryptedSavedObjects"
+      "encryptedSavedObjects",
+      "usageCollection"
     ]
   }
 }

--- a/x-pack/solutions/security/plugins/entity_store/moon.yml
+++ b/x-pack/solutions/security/plugins/entity_store/moon.yml
@@ -42,6 +42,7 @@ dependsOn:
   - '@kbn/std'
   - '@kbn/es-query'
   - '@kbn/security-plugin'
+  - '@kbn/usage-collection-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EngineDescriptor } from './definitions/saved_objects/engine_descriptor/constants';
+import { ENGINE_STATUS, ENTITY_STORE_STATUS } from './constants';
+import { getEntityStoreStatus } from './asset_manager';
+
+const engineWithStatus = (status: EngineDescriptor['status']): EngineDescriptor =>
+  ({
+    status,
+  } as EngineDescriptor);
+
+describe('getEntityStoreStatus', () => {
+  it('returns NOT_INSTALLED when there are no engines', () => {
+    expect(getEntityStoreStatus([])).toBe(ENTITY_STORE_STATUS.NOT_INSTALLED);
+  });
+
+  describe('single engine', () => {
+    it.each([
+      [ENGINE_STATUS.ERROR, ENTITY_STORE_STATUS.ERROR],
+      [ENGINE_STATUS.INSTALLING, ENTITY_STORE_STATUS.INSTALLING],
+      [ENGINE_STATUS.STOPPED, ENTITY_STORE_STATUS.STOPPED],
+      [ENGINE_STATUS.STARTED, ENTITY_STORE_STATUS.RUNNING],
+      [ENGINE_STATUS.UPDATING, ENTITY_STORE_STATUS.RUNNING],
+    ])(
+      'returns correct store status for engine status "%s"',
+      (engineStatus, expectedStoreStatus) => {
+        expect(getEntityStoreStatus([engineWithStatus(engineStatus)])).toBe(expectedStoreStatus);
+      }
+    );
+  });
+
+  describe('two unique engines', () => {
+    it.each([
+      // ERROR overrides everything
+      [ENGINE_STATUS.ERROR, ENGINE_STATUS.ERROR, ENTITY_STORE_STATUS.ERROR],
+      [ENGINE_STATUS.ERROR, ENGINE_STATUS.INSTALLING, ENTITY_STORE_STATUS.ERROR],
+      [ENGINE_STATUS.ERROR, ENGINE_STATUS.STOPPED, ENTITY_STORE_STATUS.ERROR],
+      [ENGINE_STATUS.ERROR, ENGINE_STATUS.STARTED, ENTITY_STORE_STATUS.ERROR],
+      [ENGINE_STATUS.ERROR, ENGINE_STATUS.UPDATING, ENTITY_STORE_STATUS.ERROR],
+      // INSTALLING overrides non-error
+      [ENGINE_STATUS.INSTALLING, ENGINE_STATUS.INSTALLING, ENTITY_STORE_STATUS.INSTALLING],
+      [ENGINE_STATUS.INSTALLING, ENGINE_STATUS.STOPPED, ENTITY_STORE_STATUS.INSTALLING],
+      [ENGINE_STATUS.INSTALLING, ENGINE_STATUS.STARTED, ENTITY_STORE_STATUS.INSTALLING],
+      [ENGINE_STATUS.INSTALLING, ENGINE_STATUS.UPDATING, ENTITY_STORE_STATUS.INSTALLING],
+      // STOPPED only when all engines are stopped
+      [ENGINE_STATUS.STOPPED, ENGINE_STATUS.STOPPED, ENTITY_STORE_STATUS.STOPPED],
+      // Everything else falls through to RUNNING
+      [ENGINE_STATUS.STOPPED, ENGINE_STATUS.STARTED, ENTITY_STORE_STATUS.RUNNING],
+      [ENGINE_STATUS.STOPPED, ENGINE_STATUS.UPDATING, ENTITY_STORE_STATUS.RUNNING],
+      [ENGINE_STATUS.STARTED, ENGINE_STATUS.STARTED, ENTITY_STORE_STATUS.RUNNING],
+      [ENGINE_STATUS.STARTED, ENGINE_STATUS.UPDATING, ENTITY_STORE_STATUS.RUNNING],
+      [ENGINE_STATUS.UPDATING, ENGINE_STATUS.UPDATING, ENTITY_STORE_STATUS.RUNNING],
+    ])('engines [%s, %s] = %s', (statusA, statusB, expected) => {
+      const engines = [engineWithStatus(statusA), engineWithStatus(statusB)];
+      expect(getEntityStoreStatus(engines)).toBe(expected);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
@@ -199,7 +199,7 @@ export class AssetManager {
   public async getStatus(withComponents: boolean = false): Promise<GetStatusResult> {
     try {
       const engines = await this.engineDescriptorClient.getAll();
-      const status = this.calculateEntityStoreStatus(engines);
+      const status = getEntityStoreStatus(engines);
 
       if (withComponents) {
         const enginesWithComponents = await Promise.all(
@@ -440,18 +440,21 @@ export class AssetManager {
       return false;
     }
   }
-
-  private calculateEntityStoreStatus(engines: EngineDescriptor[]): EntityStoreStatus {
-    if (engines.length === 0) {
-      return ENTITY_STORE_STATUS.NOT_INSTALLED;
-    } else if (engines.some((engine) => engine.status === ENGINE_STATUS.ERROR)) {
-      return ENTITY_STORE_STATUS.ERROR;
-    } else if (engines.every((engine) => engine.status === ENGINE_STATUS.STOPPED)) {
-      return ENTITY_STORE_STATUS.STOPPED;
-    } else if (engines.some((engine) => engine.status === ENGINE_STATUS.INSTALLING)) {
-      return ENTITY_STORE_STATUS.INSTALLING;
-    }
-
-    return ENTITY_STORE_STATUS.RUNNING;
-  }
 }
+
+export const getEntityStoreStatus = (engines: EngineDescriptor[]): EntityStoreStatus => {
+  if (engines.length === 0) {
+    return ENTITY_STORE_STATUS.NOT_INSTALLED;
+  }
+
+  const hasStatus = (s: EngineDescriptor['status']) => engines.some(({ status }) => status === s);
+  const allStatus = (s: EngineDescriptor['status']) => engines.every(({ status }) => status === s);
+
+  if (hasStatus(ENGINE_STATUS.ERROR)) return ENTITY_STORE_STATUS.ERROR;
+
+  if (hasStatus(ENGINE_STATUS.INSTALLING)) return ENTITY_STORE_STATUS.INSTALLING;
+
+  if (allStatus(ENGINE_STATUS.STOPPED)) return ENTITY_STORE_STATUS.STOPPED;
+
+  return ENTITY_STORE_STATUS.RUNNING;
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
@@ -443,9 +443,7 @@ export class AssetManager {
 }
 
 export const getEntityStoreStatus = (engines: EngineDescriptor[]): EntityStoreStatus => {
-  if (engines.length === 0) {
-    return ENTITY_STORE_STATUS.NOT_INSTALLED;
-  }
+  if (engines.length === 0) return ENTITY_STORE_STATUS.NOT_INSTALLED;
 
   const hasStatus = (s: EngineDescriptor['status']) => engines.some(({ status }) => status === s);
   const allStatus = (s: EngineDescriptor['status']) => engines.every(({ status }) => status === s);

--- a/x-pack/solutions/security/plugins/entity_store/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/plugin.ts
@@ -23,6 +23,7 @@ import { EngineDescriptorType } from './domain/definitions/saved_objects';
 import { registerEntityMaintainerTask } from './tasks/entity_maintainer';
 import type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainer/types';
 import { registerTelemetry, createReportEvent } from './telemetry/events';
+import { registerEntityStoreStatusCollector } from './telemetry/collectors/register';
 
 export class EntityStorePlugin
   implements
@@ -49,6 +50,7 @@ export class EntityStorePlugin
 
     this.logger.debug('Registering telemetry events');
     registerTelemetry(core.analytics);
+    registerEntityStoreStatusCollector(this.logger, plugins.usageCollection);
 
     const router = core.http.createRouter<EntityStoreRequestHandlerContext>();
     core.http.registerRouteHandlerContext<EntityStoreRequestHandlerContext, typeof PLUGIN_ID>(

--- a/x-pack/solutions/security/plugins/entity_store/server/telemetry/collectors/register.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/telemetry/collectors/register.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  Collector,
+  createCollectorFetchContextMock,
+  createUsageCollectionSetupMock,
+} from '@kbn/usage-collection-plugin/server/mocks';
+import type { EngineDescriptor } from '../../domain/definitions/saved_objects/engine_descriptor/constants';
+import { EngineDescriptorTypeName } from '../../domain/definitions/saved_objects/engine_descriptor/types';
+import { ENGINE_STATUS, ENTITY_STORE_STATUS } from '../../domain/constants';
+import { registerEntityStoreStatusCollector } from './register';
+
+const mockEngine = (overrides: Partial<EngineDescriptor> = {}): EngineDescriptor => ({
+  type: 'host',
+  status: ENGINE_STATUS.STARTED,
+  error: { message: '', action: 'init' },
+  versionState: { version: 2, state: 'running', isMigratedFromV1: false },
+  logExtractionState: {
+    filter: '',
+    additionalIndexPatterns: [],
+    fieldHistoryLength: 10,
+    lookbackPeriod: '3h',
+    delay: '1m',
+    docsLimit: 10000,
+    timeout: '25s',
+    frequency: '30s',
+    paginationTimestamp: undefined,
+    paginationId: undefined,
+    lastExecutionTimestamp: undefined,
+  },
+  ...overrides,
+});
+
+const mockSavedObject = (attrs: EngineDescriptor) => ({
+  id: `engine-${attrs.type}`,
+  type: EngineDescriptorTypeName,
+  attributes: attrs,
+  references: [],
+  score: 0,
+});
+
+describe('registerEntityStoreStatusCollector', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let collector: Collector<unknown>;
+  let usageCollectionMock: ReturnType<typeof createUsageCollectionSetupMock>;
+  const mockedFetchContext = createCollectorFetchContextMock();
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    usageCollectionMock = createUsageCollectionSetupMock();
+    usageCollectionMock.makeUsageCollector.mockImplementation((config) => {
+      collector = new Collector(logger, config);
+      return createUsageCollectionSetupMock().makeUsageCollector(config);
+    });
+
+    registerEntityStoreStatusCollector(logger, usageCollectionMock);
+  });
+
+  it('registers a collector', () => {
+    expect(collector).toBeDefined();
+    expect(usageCollectionMock.registerCollector).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register when usageCollection is undefined', () => {
+    const freshMock = createUsageCollectionSetupMock();
+    registerEntityStoreStatusCollector(logger, undefined);
+    expect(freshMock.registerCollector).not.toHaveBeenCalled();
+  });
+
+  describe('isReady', () => {
+    it('returns true', () => {
+      expect(collector.isReady()).toBe(true);
+    });
+  });
+
+  describe('fetch', () => {
+    it('calls soClient.find with the correct parameters', async () => {
+      mockedFetchContext.soClient.find.mockResolvedValue({
+        saved_objects: [],
+        total: 0,
+        per_page: 1000,
+        page: 1,
+      });
+
+      await collector.fetch(mockedFetchContext);
+
+      expect(mockedFetchContext.soClient.find).toHaveBeenCalledWith({
+        type: EngineDescriptorTypeName,
+        perPage: 1000,
+        namespaces: ['*'],
+      });
+    });
+
+    it('returns not_installed when no engines exist', async () => {
+      mockedFetchContext.soClient.find.mockResolvedValue({
+        saved_objects: [],
+        total: 0,
+        per_page: 1000,
+        page: 1,
+      });
+
+      const result = await collector.fetch(mockedFetchContext);
+
+      expect(result).toEqual({
+        status: ENTITY_STORE_STATUS.NOT_INSTALLED,
+        engines: [],
+      });
+    });
+
+    it('returns running status with engine data', async () => {
+      const engine = mockEngine();
+      mockedFetchContext.soClient.find.mockResolvedValue({
+        saved_objects: [mockSavedObject(engine)],
+        total: 1,
+        per_page: 1000,
+        page: 1,
+      });
+
+      const result = await collector.fetch(mockedFetchContext);
+
+      expect(result).toEqual({
+        status: ENTITY_STORE_STATUS.RUNNING,
+        engines: [
+          {
+            type: 'host',
+            status: ENGINE_STATUS.STARTED,
+            error: { message: '', action: 'init' },
+            versionState: { version: 2, state: 'running', isMigratedFromV1: false },
+            logExtractionState: {
+              filter: '',
+              additionalIndexPatterns: [],
+              fieldHistoryLength: 10,
+              lookbackPeriod: '3h',
+              delay: '1m',
+              docsLimit: 10000,
+              timeout: '25s',
+              frequency: '30s',
+            },
+          },
+        ],
+      });
+    });
+
+    it('strips pagination fields from logExtractionState', async () => {
+      const engine = mockEngine({
+        logExtractionState: {
+          filter: 'host.name: *',
+          additionalIndexPatterns: ['logs-*'],
+          fieldHistoryLength: 5,
+          lookbackPeriod: '6h',
+          delay: '2m',
+          docsLimit: 5000,
+          timeout: '30s',
+          frequency: '1m',
+          paginationTimestamp: '2026-01-01T00:00:00Z',
+          paginationId: 'some-id',
+          lastExecutionTimestamp: '2026-01-01T00:00:00Z',
+        },
+      });
+
+      mockedFetchContext.soClient.find.mockResolvedValue({
+        saved_objects: [mockSavedObject(engine)],
+        total: 1,
+        per_page: 1000,
+        page: 1,
+      });
+
+      const result = await collector.fetch(mockedFetchContext);
+      const engineResult = (result as { engines: Array<Record<string, unknown>> }).engines[0];
+      const { logExtractionState } = engineResult as {
+        logExtractionState: Record<string, unknown>;
+      };
+
+      expect(logExtractionState).not.toHaveProperty('paginationTimestamp');
+      expect(logExtractionState).not.toHaveProperty('paginationId');
+      expect(logExtractionState).not.toHaveProperty('lastExecutionTimestamp');
+      expect(logExtractionState).toEqual({
+        filter: 'host.name: *',
+        additionalIndexPatterns: ['logs-*'],
+        fieldHistoryLength: 5,
+        lookbackPeriod: '6h',
+        delay: '2m',
+        docsLimit: 5000,
+        timeout: '30s',
+        frequency: '1m',
+      });
+    });
+
+    it('returns not_installed and logs error when soClient.find throws', async () => {
+      mockedFetchContext.soClient.find.mockRejectedValue(new Error('SO client unavailable'));
+
+      const result = await collector.fetch(mockedFetchContext);
+
+      expect(result).toEqual({
+        status: ENTITY_STORE_STATUS.NOT_INSTALLED,
+        engines: [],
+      });
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to fetch entity store status telemetry: SO client unavailable'
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/telemetry/collectors/register.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/telemetry/collectors/register.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CollectorFetchContext,
+  UsageCollectionSetup,
+} from '@kbn/usage-collection-plugin/server';
+import type { Logger } from '@kbn/core/server';
+import type { EngineDescriptor } from '../../domain/definitions/saved_objects/engine_descriptor/constants';
+import { EngineDescriptorTypeName } from '../../domain/definitions/saved_objects/engine_descriptor/types';
+import { getEntityStoreStatus } from '../../domain/asset_manager';
+import { ENTITY_STORE_STATUS } from '../../domain/constants';
+import { entityStoreStatusSchema, type EntityStoreStatusUsage } from './schema';
+
+export const registerEntityStoreStatusCollector = (
+  logger: Logger,
+  usageCollection?: UsageCollectionSetup
+): void => {
+  if (!usageCollection) {
+    return;
+  }
+
+  const collector = usageCollection.makeUsageCollector<EntityStoreStatusUsage>({
+    type: 'entity_store_status',
+    isReady: () => true,
+    schema: entityStoreStatusSchema,
+    fetch: async ({ soClient }: CollectorFetchContext) => {
+      try {
+        const { saved_objects: engines } = await soClient.find<EngineDescriptor>({
+          type: EngineDescriptorTypeName,
+          perPage: 1000,
+          namespaces: ['*'],
+        });
+
+        const engineAttributes = engines.map((v) => v.attributes);
+
+        return {
+          status: getEntityStoreStatus(engineAttributes),
+          engines: engineAttributes.map(getEntityStoreStatusUsage),
+        };
+      } catch (error) {
+        logger.error(`Failed to fetch entity store status telemetry: ${error.message}`);
+        return { status: ENTITY_STORE_STATUS.NOT_INSTALLED, engines: [] };
+      }
+    },
+  });
+
+  usageCollection.registerCollector(collector);
+};
+
+const getEntityStoreStatusUsage = ({
+  type,
+  status,
+  error,
+  versionState,
+  logExtractionState: {
+    paginationTimestamp,
+    paginationId,
+    lastExecutionTimestamp,
+    ...logExtractionState
+  },
+}: EngineDescriptor) => ({
+  type,
+  status,
+  error,
+  versionState,
+  logExtractionState,
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/telemetry/collectors/schema.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/telemetry/collectors/schema.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MakeSchemaFrom } from '@kbn/usage-collection-plugin/server';
+import type {
+  EngineDescriptor,
+  LogExtractionState,
+} from '../../domain/definitions/saved_objects/engine_descriptor/constants';
+import type { EntityStoreStatus } from '../../domain/types';
+
+type EngineStatusUsage = Pick<EngineDescriptor, 'type' | 'status' | 'error' | 'versionState'> & {
+  logExtractionState: Omit<
+    LogExtractionState,
+    'paginationTimestamp' | 'paginationId' | 'lastExecutionTimestamp'
+  >;
+};
+
+export interface EntityStoreStatusUsage {
+  status: EntityStoreStatus;
+  engines: EngineStatusUsage[];
+}
+
+export const entityStoreStatusSchema: MakeSchemaFrom<EntityStoreStatusUsage> = {
+  status: {
+    type: 'keyword',
+    _meta: {
+      description:
+        'Overall entity store status ("running", "stopped", "installing", "not_installed", "error")',
+    },
+  },
+  engines: {
+    type: 'array',
+    items: {
+      type: {
+        type: 'keyword',
+        _meta: { description: 'Engine type (e.g. "host", "user", "generic")' },
+      },
+      status: {
+        type: 'keyword',
+        _meta: { description: 'Engine status (e.g. "started", "stopped", "error")' },
+      },
+      logExtractionState: {
+        delay: {
+          type: 'keyword',
+          _meta: { description: 'Initial data processing delay (e.g. "1m")' },
+        },
+        frequency: {
+          type: 'keyword',
+          _meta: { description: 'Run frequency (e.g. "30s", "1m")' },
+        },
+        lookbackPeriod: {
+          type: 'keyword',
+          _meta: { description: 'Lookback period used by the engine (e.g. "3h")' },
+        },
+        fieldHistoryLength: {
+          type: 'long',
+          _meta: { description: 'Number of historical field entries retained' },
+        },
+        filter: {
+          type: 'keyword',
+          _meta: { description: 'Filter applied to ingested documents' },
+        },
+        additionalIndexPatterns: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: { description: 'Additional index pattern ingested by the engine' },
+          },
+        },
+        docsLimit: {
+          type: 'long',
+          _meta: { description: 'Maximum documents per extraction run' },
+        },
+        timeout: {
+          type: 'keyword',
+          _meta: { description: 'Extraction timeout (e.g. "25s")' },
+        },
+      },
+      error: {
+        message: {
+          type: 'keyword',
+          _meta: { description: 'Error message when engine is in error state' },
+        },
+        action: {
+          type: 'keyword',
+          _meta: { description: 'Action that caused the error ("init" or "extractLogs")' },
+        },
+      },
+      versionState: {
+        version: {
+          type: 'long',
+          _meta: { description: 'Engine schema version (1 or 2)' },
+        },
+        state: {
+          type: 'keyword',
+          _meta: { description: 'Engine version state ("running" or "migrating")' },
+        },
+        isMigratedFromV1: {
+          type: 'boolean',
+          _meta: { description: 'Whether the engine was migrated from v1' },
+        },
+      },
+    },
+  },
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -15,6 +15,7 @@ import type {
   EncryptedSavedObjectsPluginSetup,
   EncryptedSavedObjectsPluginStart,
 } from '@kbn/encrypted-saved-objects-plugin/server';
+import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type {
   CoreRequestHandlerContext,
   CustomRequestHandlerContext,
@@ -33,6 +34,7 @@ export interface EntityStoreSetupPlugins {
   taskManager: TaskManagerSetupContract;
   spaces: SpacesPluginSetup;
   encryptedSavedObjects: EncryptedSavedObjectsPluginSetup;
+  usageCollection?: UsageCollectionSetup;
 }
 
 export interface EntityStoreStartPlugins {

--- a/x-pack/solutions/security/plugins/entity_store/tsconfig.json
+++ b/x-pack/solutions/security/plugins/entity_store/tsconfig.json
@@ -37,6 +37,7 @@
     "@kbn/core-saved-objects-server",
     "@kbn/std",
     "@kbn/es-query",
-    "@kbn/security-plugin"
+    "@kbn/security-plugin",
+    "@kbn/usage-collection-plugin"
   ]
 }


### PR DESCRIPTION
### Summary

WIP 


- adds a [snapshot telemetry](https://docs.elastic.dev/telemetry/collection/snapshot-telemetry) usage collector (`entity_store_status`) 
- replaces the previous approach of using an hourly EBT health task
- reports engine type, status, and logExtractionState config


### Test 

#### local
1. set `telemetry.localShipper: true` in `kibana.dev.yml`
2. enable entity store
3. force collection:
```
POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2
{ "unencrypted": true, "refreshCache": true }
```
4. response has `entity_store_status`


### dev env

WIP

