### PR TITLE
[Dashboards as Code] Register control schemas

### DIFF
--- a/src/platform/packages/shared/controls/controls-schemas/index.ts
+++ b/src/platform/packages/shared/controls/controls-schemas/index.ts
@@ -39,3 +39,10 @@ export type {
   LegacyStoredRangeSliderExplicitInput,
   LegacyStoredTimeSliderExplicitInput,
 } from './src/legacy_types';
+
+export {
+  optionsListESQLControlSchema,
+  optionsListDSLControlSchema,
+} from './src/options_list_schema';
+export { rangeSliderControlSchema } from './src/range_slider_schema';
+export { timeSliderControlSchema } from './src/time_slider_schema';

--- a/src/platform/plugins/shared/controls/server/transforms/esql_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/esql_control_transforms.ts
@@ -8,15 +8,17 @@
  */
 
 import { ESQL_CONTROL } from '@kbn/controls-constants';
-import type {
-  LegacyStoredESQLControlExplicitInput,
-  OptionsListESQLControlState,
+import {
+  type LegacyStoredESQLControlExplicitInput,
+  type OptionsListESQLControlState,
+  optionsListESQLControlSchema,
 } from '@kbn/controls-schemas';
 import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
 import { convertCamelCasedKeysToSnakeCase } from '@kbn/presentation-publishing';
 
 export const registerESQLControlTransforms = (embeddable: EmbeddableSetup) => {
   embeddable.registerTransforms(ESQL_CONTROL, {
+    getSchema: () => optionsListESQLControlSchema,
     getTransforms: () => ({
       transformOut: <
         StoredStateType extends Partial<

--- a/src/platform/plugins/shared/controls/server/transforms/options_list_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/options_list_control_transforms.ts
@@ -7,15 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { omitBy } from 'lodash';
+
 import type { Reference } from '@kbn/content-management-utils';
 import { OPTIONS_LIST_CONTROL } from '@kbn/controls-constants';
 import {
+  optionsListDSLControlSchema,
   type LegacyStoredOptionsListExplicitInput,
   type OptionsListDSLControlState,
 } from '@kbn/controls-schemas';
 import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
 import { convertCamelCasedKeysToSnakeCase } from '@kbn/presentation-publishing';
-import { omitBy } from 'lodash';
+
 import { transformDataControlIn, transformDataControlOut } from './data_control_transforms';
 
 const OPTIONS_LIST_REF_NAME = 'optionsListDataView' as const;
@@ -26,6 +29,7 @@ const OPTIONS_LIST_LEGACY_REF_NAMES = [
 
 export const registerOptionsListControlTransforms = (embeddable: EmbeddableSetup) => {
   embeddable.registerTransforms(OPTIONS_LIST_CONTROL, {
+    getSchema: () => optionsListDSLControlSchema,
     getTransforms: () => ({
       transformIn: (state: OptionsListDSLControlState) => {
         const { state: dataControlState, references } = transformDataControlIn(

--- a/src/platform/plugins/shared/controls/server/transforms/range_slider_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/range_slider_control_transforms.ts
@@ -9,9 +9,10 @@
 
 import type { Reference } from '@kbn/content-management-utils';
 import { RANGE_SLIDER_CONTROL } from '@kbn/controls-constants';
-import type {
-  LegacyStoredRangeSliderExplicitInput,
-  RangeSliderControlState,
+import {
+  rangeSliderControlSchema,
+  type LegacyStoredRangeSliderExplicitInput,
+  type RangeSliderControlState,
 } from '@kbn/controls-schemas';
 import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
 import { transformDataControlIn, transformDataControlOut } from './data_control_transforms';
@@ -24,6 +25,7 @@ const RANGE_SLIDER_LEGACY_REF_NAMES = [
 
 export const registerRangeSliderControlTransforms = (embeddable: EmbeddableSetup) => {
   embeddable.registerTransforms(RANGE_SLIDER_CONTROL, {
+    getSchema: () => rangeSliderControlSchema,
     getTransforms: () => ({
       transformIn: (state: RangeSliderControlState) => {
         const { state: dataControlState, references } = transformDataControlIn(

--- a/src/platform/plugins/shared/controls/server/transforms/time_slider_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/time_slider_control_transforms.ts
@@ -8,15 +8,17 @@
  */
 
 import { TIME_SLIDER_CONTROL } from '@kbn/controls-constants';
-import type {
-  LegacyStoredTimeSliderExplicitInput,
-  TimeSliderControlState,
+import {
+  type LegacyStoredTimeSliderExplicitInput,
+  type TimeSliderControlState,
+  timeSliderControlSchema,
 } from '@kbn/controls-schemas';
 import type { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
 import { convertCamelCasedKeysToSnakeCase } from '@kbn/presentation-publishing';
 
 export const registerTimeSliderControlTransforms = (embeddable: EmbeddableSetup) => {
   embeddable.registerTransforms(TIME_SLIDER_CONTROL, {
+    getSchema: () => timeSliderControlSchema,
     getTransforms: () => ({
       transformOut: <
         StoredStateType extends Partial<

--- a/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/fixtures/schema_snapshot.json
+++ b/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/fixtures/schema_snapshot.json
@@ -1,6 +1,208 @@
 [
   {
     "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "description": "A human-readable title for the control"
+      },
+      "display_settings": {
+        "type": "object",
+        "properties": {
+          "placeholder": {
+            "type": "string"
+          },
+          "hide_action_bar": {
+            "type": "boolean"
+          },
+          "hide_exclude": {
+            "type": "boolean"
+          },
+          "hide_exists": {
+            "type": "boolean"
+          },
+          "hide_sort": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "single_select": {
+        "type": "boolean"
+      },
+      "selected_options": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "variable_name": {
+        "type": "string"
+      },
+      "variable_type": {
+        "type": "string",
+        "enum": ["fields", "values", "functions", "time_literal", "multi_values"]
+      },
+      "esql_query": {
+        "type": "string"
+      },
+      "control_type": {
+        "type": "string",
+        "enum": ["STATIC_VALUES", "VALUES_FROM_QUERY"]
+      },
+      "available_options": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": true,
+    "required": ["selected_options", "variable_name", "variable_type", "esql_query", "control_type"]
+  },
+  {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "description": "A human-readable title for the control"
+      },
+      "data_view_id": {
+        "type": "string",
+        "description": "The ID of the data view that the control is tied to"
+      },
+      "field_name": {
+        "type": "string",
+        "description": "The name of the field in the data view that the control is tied to"
+      },
+      "use_global_filters": {
+        "type": "boolean"
+      },
+      "ignore_validations": {
+        "type": "boolean"
+      },
+      "display_settings": {
+        "type": "object",
+        "properties": {
+          "placeholder": {
+            "type": "string"
+          },
+          "hide_action_bar": {
+            "type": "boolean"
+          },
+          "hide_exclude": {
+            "type": "boolean"
+          },
+          "hide_exists": {
+            "type": "boolean"
+          },
+          "hide_sort": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "single_select": {
+        "type": "boolean"
+      },
+      "exclude": {
+        "type": "boolean"
+      },
+      "exists_selected": {
+        "type": "boolean"
+      },
+      "run_past_timeout": {
+        "type": "boolean"
+      },
+      "search_technique": {
+        "type": "string",
+        "enum": ["prefix", "wildcard", "exact"]
+      },
+      "selected_options": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
+      },
+      "sort": {
+        "type": "object",
+        "properties": {
+          "by": {
+            "type": "string",
+            "enum": ["_count", "_key"]
+          },
+          "direction": {
+            "type": "string",
+            "enum": ["asc", "desc"]
+          }
+        },
+        "additionalProperties": false,
+        "required": ["by", "direction"]
+      }
+    },
+    "additionalProperties": true,
+    "required": ["data_view_id", "field_name"]
+  },
+  {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "description": "A human-readable title for the control"
+      },
+      "data_view_id": {
+        "type": "string",
+        "description": "The ID of the data view that the control is tied to"
+      },
+      "field_name": {
+        "type": "string",
+        "description": "The name of the field in the data view that the control is tied to"
+      },
+      "use_global_filters": {
+        "type": "boolean"
+      },
+      "ignore_validations": {
+        "type": "boolean"
+      },
+      "value": {
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 2,
+        "items": {
+          "type": "string"
+        }
+      },
+      "step": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": true,
+    "required": ["data_view_id", "field_name"]
+  },
+  {
+    "type": "object",
+    "properties": {
+      "start_percentage_of_time_range": {
+        "type": "number"
+      },
+      "end_percentage_of_time_range": {
+        "type": "number"
+      },
+      "is_anchored": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  },
+  {
+    "type": "object",
     "description": "Markdown embeddable schema",
     "properties": {
       "content": {

--- a/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
@@ -71,6 +71,13 @@ apiTest.describe('dashboard REST schema', { tag: tags.stateful.all }, () => {
     expect(panelSchema).toBeDefined();
 
     const configSchema = panelSchema.properties.config;
+    // API integration tests do not support jest expect
+    // so we had to roll our own toMatchSnapshot
+    // To update snapshot:
+    // 1) uncomment console.log
+    // 2) run test
+    // 3) replace snapshot file contents with copy of consoled output
+    // console.log(JSON.stringify(configSchema.anyOf, null, ' '));
     expect(configSchema.anyOf).toHaveLength(8);
     expect(configSchema.anyOf).toStrictEqual(snapshot);
   });

--- a/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
@@ -71,14 +71,7 @@ apiTest.describe('dashboard REST schema', { tag: tags.stateful.all }, () => {
     expect(panelSchema).toBeDefined();
 
     const configSchema = panelSchema.properties.config;
-    // API integration tests do not support jest expect
-    // so we had to roll our own toMatchSnapshot
-    // To update snapshot:
-    // 1) uncomment console.log
-    // 2) run test
-    // 3) replace snapshot file contents with copy of consoled output
-    // console.log(JSON.stringify(configSchema.anyOf, null, ' '));
-    expect(configSchema.anyOf).toHaveLength(4);
+    expect(configSchema.anyOf).toHaveLength(8);
     expect(configSchema.anyOf).toStrictEqual(snapshot);
   });
 });


### PR DESCRIPTION
## Summary

This PR registers the controls schemas so that they are available in the dashboard API.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



