### PR TITLE
[OTel Tracing] Enrich http spans

### DIFF
--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -500,13 +500,13 @@ export class HttpServer {
     const { enabled, referrerWhitelist: list } = config.compression;
     if (!enabled) {
       this.log.debug('HTTP compression is disabled');
-      this.server.ext('onRequest', (request, h) => {
+      this.server.ext('onRequest', function conditionalCompression(request, h) {
         request.info.acceptEncoding = '';
         return h.continue;
       });
     } else if (list) {
       this.log.debug(`HTTP compression is only enabled for any referrer in the following: ${list}`);
-      this.server.ext('onRequest', (request, h) => {
+      this.server.ext('onRequest', function conditionalCompression(request, h) {
         const { referrer } = request.info;
         if (referrer !== '') {
           const { hostname } = url.parse(referrer);
@@ -544,7 +544,9 @@ export class HttpServer {
     executionContext?: InternalExecutionContextSetup,
     userActivity?: InternalUserActivityServiceSetup
   ) {
-    this.server!.ext('onPreResponse', (request, responseToolkit) => {
+    const _self = this;
+
+    this.server!.ext('onPreResponse', function requestStateAssignment(request, responseToolkit) {
       const stop = (request.app as KibanaRequestState).measureElu;
 
       if (!stop) {
@@ -562,8 +564,8 @@ export class HttpServer {
       return responseToolkit.continue;
     });
 
-    this.server!.ext('onRequest', (request, responseToolkit) => {
-      const stop = startEluMeasurement(request.path, this.log, this.config?.eluMonitor);
+    this.server!.ext('onRequest', function requestStateAssignment(request, responseToolkit) {
+      const stop = startEluMeasurement(request.path, _self.log, _self.config?.eluMonitor);
 
       const requestId = getRequestId(request, config.requestId);
 
@@ -601,15 +603,15 @@ export class HttpServer {
       return responseToolkit.continue;
     });
 
-    this.server!.ext('onPostAuth', async (request, responseToolkit) => {
-      if (this.redactedSessionIdGetter) {
+    this.server!.ext('onPostAuth', async function requestStateAssignment(request, responseToolkit) {
+      if (_self.redactedSessionIdGetter) {
         // Store the redacted session ID on the request state so the user
         // activity service can read it later. We cannot call the service
         // directly here because this handler is async and would use its
         // own user-activity
         try {
           const kibanaRequest = CoreKibanaRequest.from(request);
-          const redactedSessionId = await this.redactedSessionIdGetter(kibanaRequest);
+          const redactedSessionId = await _self.redactedSessionIdGetter(kibanaRequest);
           (request.app as KibanaRequestState).redactedSessionId = redactedSessionId;
         } catch {
           // just leave the session id as undefined
@@ -618,11 +620,11 @@ export class HttpServer {
       return responseToolkit.continue;
     });
 
-    this.server!.ext('onPreHandler', (request, responseToolkit) => {
+    this.server!.ext('onPreHandler', function requestStateAssignment(request, responseToolkit) {
       (request.app as KibanaRequestState).span?.end();
       (request.app as KibanaRequestState).span = null;
 
-      const user = this.authState.get<AuthenticatedUser>(request).state ?? null;
+      const user = _self.authState.get<AuthenticatedUser>(request).state ?? null;
       const { redactedSessionId } = request.app as KibanaRequestState;
       const remoteAddress = request.info.remoteAddress;
       userActivity?.setInjectedContext({
@@ -703,7 +705,7 @@ export class HttpServer {
     }
 
     // Using onPreAuth instead of onRequest because we want the request.route.path
-    this.server!.ext('onPreAuth', (request, responseToolkit) => {
+    this.server!.ext('onPreAuth', function instrumentMetrics(request, responseToolkit) {
       const attributes = getBaseAttributes(request);
 
       requestTotalServed.add(1, attributes);
@@ -725,7 +727,7 @@ export class HttpServer {
       return responseToolkit.continue;
     });
 
-    this.server!.ext('onPostResponse', (request, responseToolkit) => {
+    this.server!.ext('onPostResponse', function instrumentMetrics(request, responseToolkit) {
       const startTime = (request.app as KibanaRequestState).startTime;
       const stopTime = performance.now();
 

--- a/src/core/packages/http/server-internal/src/https_redirect_server.ts
+++ b/src/core/packages/http/server-internal/src/https_redirect_server.ts
@@ -37,19 +37,22 @@ export class HttpsRedirectServer {
       port: config.ssl.redirectHttpFromPort,
     });
 
-    this.server.ext('onRequest', (request: Request, responseToolkit: ResponseToolkit) => {
-      return responseToolkit
-        .redirect(
-          formatUrl({
-            hostname: request.url.hostname,
-            pathname: request.url.pathname,
-            port: config.port,
-            protocol: 'https',
-            search: request.url.search,
-          })
-        )
-        .takeover();
-    });
+    this.server.ext(
+      'onRequest',
+      function httpsRedirect(request: Request, responseToolkit: ResponseToolkit) {
+        return responseToolkit
+          .redirect(
+            formatUrl({
+              hostname: request.url.hostname,
+              pathname: request.url.pathname,
+              port: config.port,
+              protocol: 'https',
+              search: request.url.search,
+            })
+          )
+          .takeover();
+      }
+    );
 
     try {
       await this.server.start();

--- a/src/core/packages/http/server-internal/src/lifecycle/auth.ts
+++ b/src/core/packages/http/server-internal/src/lifecycle/auth.ts
@@ -26,6 +26,7 @@ import {
   CoreKibanaRequest,
   lifecycleResponseFactory,
 } from '@kbn/core-http-router-server-internal';
+import { context, trace } from '@opentelemetry/api';
 
 const authResult = {
   authenticated(data: AuthResultParams = {}): AuthResult {
@@ -74,6 +75,9 @@ export function adoptToHapiAuthFormat(
     request: Request,
     responseToolkit: ResponseToolkit
   ): Promise<Lifecycle.ReturnValue> {
+    if (fn.name) {
+      trace.getSpan(context.active())?.updateName(`ext - auth - ${fn.name}`);
+    }
     const hapiResponseAdapter = new HapiResponseAdapter(responseToolkit);
     const kibanaRequest = CoreKibanaRequest.from(request, undefined, false);
 

--- a/src/core/packages/http/server-internal/src/lifecycle/on_post_auth.ts
+++ b/src/core/packages/http/server-internal/src/lifecycle/on_post_auth.ts
@@ -24,6 +24,7 @@ import {
   lifecycleResponseFactory,
 } from '@kbn/core-http-router-server-internal';
 import { deepFreeze } from '@kbn/std';
+import { context, trace } from '@opentelemetry/api';
 
 const postAuthResult = {
   next(): OnPostAuthResult {
@@ -54,6 +55,9 @@ export function adoptToHapiOnPostAuthFormat(fn: OnPostAuthHandler, log: Logger) 
     request: Request,
     responseToolkit: HapiResponseToolkit
   ): Promise<Lifecycle.ReturnValue> {
+    if (fn.name) {
+      trace.getSpan(context.active())?.updateName(`ext - onPostAuth - ${fn.name}`);
+    }
     const hapiResponseAdapter = new HapiResponseAdapter(responseToolkit);
     try {
       const result = await fn(CoreKibanaRequest.from(request), lifecycleResponseFactory, toolkit);

--- a/src/core/packages/http/server-internal/src/lifecycle/on_pre_auth.ts
+++ b/src/core/packages/http/server-internal/src/lifecycle/on_pre_auth.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { trace, context } from '@opentelemetry/api';
 import type { Lifecycle, Request, ResponseToolkit as HapiResponseToolkit } from '@hapi/hapi';
 import type { Logger } from '@kbn/logging';
 import type {
@@ -46,6 +47,9 @@ export function adoptToHapiOnPreAuth(fn: OnPreAuthHandler, log: Logger) {
     request: Request,
     responseToolkit: HapiResponseToolkit
   ): Promise<Lifecycle.ReturnValue> {
+    if (fn.name) {
+      trace.getSpan(context.active())?.updateName(`ext - onPreAuth - ${fn.name}`);
+    }
     const hapiResponseAdapter = new HapiResponseAdapter(responseToolkit);
 
     try {

--- a/src/core/packages/http/server-internal/src/lifecycle/on_pre_response.ts
+++ b/src/core/packages/http/server-internal/src/lifecycle/on_pre_response.ts
@@ -27,6 +27,7 @@ import type {
 } from '@kbn/core-http-server';
 import { OnPreResponseResultType } from '@kbn/core-http-server';
 import { HapiResponseAdapter, CoreKibanaRequest } from '@kbn/core-http-router-server-internal';
+import { context, trace } from '@opentelemetry/api';
 
 const preResponseResult = {
   render(responseRender: OnPreResponseRender): OnPreResponseResult {
@@ -63,6 +64,9 @@ export function adoptToHapiOnPreResponseFormat(fn: OnPreResponseHandler, log: Lo
     responseToolkit: HapiResponseToolkit
   ): Promise<Lifecycle.ReturnValue> {
     const response = request.response;
+    if (fn.name) {
+      trace.getSpan(context.active())?.updateName(`ext - onPreResponse - ${fn.name}`);
+    }
 
     try {
       if (response) {

--- a/src/core/packages/http/server-internal/src/lifecycle/on_pre_routing.ts
+++ b/src/core/packages/http/server-internal/src/lifecycle/on_pre_routing.ts
@@ -24,6 +24,7 @@ import {
   CoreKibanaRequest,
   lifecycleResponseFactory,
 } from '@kbn/core-http-router-server-internal';
+import { context, trace } from '@opentelemetry/api';
 
 const preRoutingResult = {
   next(): OnPreRoutingResult {
@@ -55,6 +56,9 @@ export function adoptToHapiOnRequest(fn: OnPreRoutingHandler, log: Logger) {
     request: Request,
     responseToolkit: HapiResponseToolkit
   ): Promise<Lifecycle.ReturnValue> {
+    if (fn.name) {
+      trace.getSpan(context.active())?.updateName(`ext - onPreRouting - ${fn.name}`);
+    }
     const hapiResponseAdapter = new HapiResponseAdapter(responseToolkit);
 
     try {

--- a/src/core/packages/metrics/collectors-server-internal/src/server.ts
+++ b/src/core/packages/metrics/collectors-server-internal/src/server.ts
@@ -29,10 +29,11 @@ export class ServerMetricsCollector implements MetricsCollector<OpsServerMetrics
   };
 
   constructor(private readonly server: HapiServer) {
-    this.server.ext('onRequest', (request, h) => {
-      this.requests.total++;
+    const _self = this;
+    this.server.ext('onRequest', function metricsCollector(request, h) {
+      _self.requests.total++;
       request.events.once('disconnect', () => {
-        this.requests.disconnects++;
+        _self.requests.disconnects++;
       });
       return h.continue;
     });


### PR DESCRIPTION
## Summary

Potential solution to knowing to which functions the `ext` spans reported by the HAPI instrumentation belong.

<img width="1442" height="905" alt="image" src="https://github.com/user-attachments/assets/304beec9-77a5-44cc-a09a-fcf645064fa4" />

This compares to the default behavior shown below

<img width="1433" height="988" alt="image" src="https://github.com/user-attachments/assets/a7f716f3-20a2-4c0f-8a03-7ce2458ed4fb" />

**Alternative**: We might want to remove the [`hapi` auto-instrumentation](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-telemetry/src/init_autoinstrumentations.ts#L31-L33) and instrument the `ext` methods ourselves.

Related to https://github.com/elastic/kibana/issues/254480

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



