### PR TITLE
Unskip search bar test

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
@@ -127,8 +127,7 @@ function wrapSearchBarInContext(
   );
 }
 
-// FLAKY: https://github.com/elastic/kibana/issues/253342
-describe.skip('SearchBar', () => {
+describe('SearchBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/253342

I ran the jest suite 100 times locally and had all passes - this PR unskips the test