### PR TITLE
[ObsAI] Add `logs_search` tool (POC)

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/index.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/index.ts
@@ -24,3 +24,4 @@ export * from './tools/get_service_topology/topology';
 export * from './tools/get_service_topology/topology_trace_isolation';
 export * from './tools/get_service_topology/topology_cycle';
 export * from './tools/get_runtime_metrics/runtime_metrics';
+export * from './tools/logs_search/logs_search';

--- a/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/tools/logs_search/logs_search.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/tools/logs_search/logs_search.ts
@@ -1,0 +1,294 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * SCENARIO: Logs Search — Noise + Error Spike
+ *
+ * Story: Generates realistic log data for testing the `logs_search` agentic tool.
+ * The data simulates a production environment where:
+ *
+ * - Background noise: health checks, cron jobs, routine access logs (high volume)
+ * - Normal service logs: info-level application messages from checkout, user, payment services
+ * - Error spike: a burst of OOM and connection timeout errors from the checkout service
+ *   concentrated in a ~10 minute window within the time range
+ *
+ * The agent should be able to:
+ * 1. See the high volume of noise in the initial peek
+ * 2. Filter out health checks and cron jobs
+ * 3. Notice the error spike in the histogram
+ * 4. Drill down to the checkout service OOM errors
+ * 5. Identify the root cause (memory exhaustion in checkout pods)
+ *
+ * Services:
+ * - checkout-service (production): The failing service with OOM errors
+ * - payment-service (production): Normal operation, some routine warnings
+ * - user-service (production): Normal operation
+ * - fluent-bit (kube-system): Log collector noise
+ *
+ * Validate via:
+ *
+ * ```
+ * POST kbn:///api/agent_builder/tools/_execute
+ * {
+ *   "tool_id": "observability.logs_search",
+ *   "tool_params": {
+ *     "prompt": "Why are there errors in the checkout service?",
+ *     "start": "now-1h",
+ *     "end": "now"
+ *   }
+ * }
+ * ```
+ */
+
+import type { LogDocument, Timerange } from '@kbn/synthtrace-client';
+import { log } from '@kbn/synthtrace-client';
+import { createCliScenario } from '../../../../lib/utils/create_scenario';
+import { withClient, type ScenarioReturnType } from '../../../../lib/utils/with_client';
+import type { LogsSynthtraceEsClient } from '../../../../lib/logs/logs_synthtrace_es_client';
+
+export function generateLogsSearchData({
+  range,
+  logsEsClient,
+}: {
+  range: Timerange;
+  logsEsClient: LogsSynthtraceEsClient;
+}): ScenarioReturnType<LogDocument>[] {
+  const healthCheckLogs = range
+    .interval('10s')
+    .rate(8)
+    .generator((timestamp) =>
+      log
+        .create()
+        .message('GET /health 200 OK')
+        .logLevel('info')
+        .service('checkout-service')
+        .defaults({
+          'service.environment': 'production',
+          'host.name': 'checkout-pod-1',
+          'kubernetes.namespace': 'default',
+          'kubernetes.pod.name': 'checkout-7f8b9c4d5-xk2m9',
+          'container.name': 'checkout',
+        })
+        .timestamp(timestamp)
+    );
+
+  const cronLogs = range
+    .interval('1m')
+    .rate(3)
+    .generator((timestamp) =>
+      log
+        .create()
+        .message('CRON: Running scheduled cleanup task')
+        .logLevel('info')
+        .service('task-scheduler')
+        .defaults({
+          'service.environment': 'production',
+          'host.name': 'scheduler-host-1',
+          'kubernetes.namespace': 'kube-system',
+          'kubernetes.pod.name': 'scheduler-5c8f7d-9xmn4',
+          'container.name': 'scheduler',
+        })
+        .timestamp(timestamp)
+    );
+
+  const fluentBitLogs = range
+    .interval('15s')
+    .rate(5)
+    .generator((timestamp) =>
+      log
+        .create()
+        .message('[filter:kubernetes:kubernetes.0] Merged new pod metadata')
+        .logLevel('info')
+        .service('fluent-bit')
+        .defaults({
+          'service.environment': 'production',
+          'host.name': 'fluent-bit-node-1',
+          'kubernetes.namespace': 'kube-system',
+          'kubernetes.pod.name': 'fluent-bit-ds-7k2x9',
+          'container.name': 'fluent-bit',
+        })
+        .timestamp(timestamp)
+    );
+
+  const checkoutNormalLogs = range
+    .interval('30s')
+    .rate(3)
+    .generator((timestamp, index) =>
+      log
+        .create()
+        .message(`Processing order #${50000 + index} for customer`)
+        .logLevel('info')
+        .service('checkout-service')
+        .defaults({
+          'service.environment': 'production',
+          'host.name': 'checkout-pod-1',
+          'kubernetes.namespace': 'default',
+          'kubernetes.pod.name': 'checkout-7f8b9c4d5-xk2m9',
+          'container.name': 'checkout',
+        })
+        .timestamp(timestamp)
+    );
+
+  const paymentNormalLogs = range
+    .interval('30s')
+    .rate(2)
+    .generator((timestamp) =>
+      log
+        .create()
+        .message('Payment processed successfully')
+        .logLevel('info')
+        .service('payment-service')
+        .defaults({
+          'service.environment': 'production',
+          'host.name': 'payment-pod-1',
+          'kubernetes.namespace': 'default',
+          'kubernetes.pod.name': 'payment-6c9d8e5f7-abc12',
+          'container.name': 'payment',
+        })
+        .timestamp(timestamp)
+    );
+
+  const userServiceLogs = range
+    .interval('20s')
+    .rate(2)
+    .generator((timestamp) =>
+      log
+        .create()
+        .message('User session validated')
+        .logLevel('info')
+        .service('user-service')
+        .defaults({
+          'service.environment': 'production',
+          'host.name': 'user-pod-1',
+          'kubernetes.namespace': 'default',
+          'kubernetes.pod.name': 'user-4b7c6d5e-qrs89',
+          'container.name': 'user',
+        })
+        .timestamp(timestamp)
+    );
+
+  const paymentWarnings = range
+    .interval('5m')
+    .rate(1)
+    .generator((timestamp) =>
+      log
+        .create()
+        .message('Payment gateway response time exceeded 2s threshold')
+        .logLevel('warn')
+        .service('payment-service')
+        .defaults({
+          'service.environment': 'production',
+          'host.name': 'payment-pod-1',
+          'kubernetes.namespace': 'default',
+          'kubernetes.pod.name': 'payment-6c9d8e5f7-abc12',
+          'container.name': 'payment',
+        })
+        .timestamp(timestamp)
+    );
+
+  const oomErrors = range
+    .interval('15s')
+    .rate(1)
+    .generator((timestamp) => {
+      const rangeMs = range.end.getTime() - range.start.getTime();
+      const spikeStart = range.start.getTime() + rangeMs * 0.5;
+      const spikeEnd = spikeStart + 10 * 60 * 1000;
+
+      if (timestamp < spikeStart || timestamp > spikeEnd) {
+        return [];
+      }
+
+      return [
+        log
+          .create()
+          .message(
+            'java.lang.OutOfMemoryError: Java heap space at com.checkout.CartService.loadCart(CartService.java:142)'
+          )
+          .logLevel('error')
+          .service('checkout-service')
+          .defaults({
+            'service.environment': 'production',
+            'error.message': 'Java heap space',
+            'host.name': 'checkout-pod-2',
+            'kubernetes.namespace': 'default',
+            'kubernetes.pod.name': 'checkout-7f8b9c4d5-yz789',
+            'container.name': 'checkout',
+            'container.id': 'abc123def456',
+          })
+          .timestamp(timestamp),
+        log
+          .create()
+          .message(
+            'java.lang.OutOfMemoryError: Java heap space at com.checkout.CartService.loadCart(CartService.java:142)'
+          )
+          .logLevel('error')
+          .service('checkout-service')
+          .defaults({
+            'service.environment': 'production',
+            'error.message': 'Java heap space',
+            'host.name': 'checkout-pod-1',
+            'kubernetes.namespace': 'default',
+            'kubernetes.pod.name': 'checkout-7f8b9c4d5-xk2m9',
+            'container.name': 'checkout',
+            'container.id': 'def789ghi012',
+          })
+          .timestamp(timestamp + 2000),
+      ];
+    });
+
+  const connectionTimeouts = range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) => {
+      const rangeMs = range.end.getTime() - range.start.getTime();
+      const spikeStart = range.start.getTime() + rangeMs * 0.5;
+      const spikeEnd = spikeStart + 10 * 60 * 1000;
+
+      if (timestamp < spikeStart || timestamp > spikeEnd) {
+        return [];
+      }
+
+      return log
+        .create()
+        .message(
+          'Connection to redis-master:6379 timed out after 5000ms - circuit breaker OPEN'
+        )
+        .logLevel('error')
+        .service('checkout-service')
+        .defaults({
+          'service.environment': 'production',
+          'error.message': 'Connection timed out after 5000ms',
+          'host.name': 'checkout-pod-2',
+          'kubernetes.namespace': 'default',
+          'kubernetes.pod.name': 'checkout-7f8b9c4d5-yz789',
+          'container.name': 'checkout',
+          'container.id': 'abc123def456',
+        })
+        .timestamp(timestamp);
+    });
+
+  return [
+    withClient(logsEsClient, healthCheckLogs),
+    withClient(logsEsClient, cronLogs),
+    withClient(logsEsClient, fluentBitLogs),
+    withClient(logsEsClient, checkoutNormalLogs),
+    withClient(logsEsClient, paymentNormalLogs),
+    withClient(logsEsClient, userServiceLogs),
+    withClient(logsEsClient, paymentWarnings),
+    withClient(logsEsClient, oomErrors),
+    withClient(logsEsClient, connectionTimeouts),
+  ];
+}
+
+export default createCliScenario<LogDocument>(
+  ({ range, clients: { logsEsClient } }) => {
+    const results = generateLogsSearchData({ range, logsEsClient });
+    return results;
+  }
+);

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -31,6 +31,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.observability}.get_service_topology`,
   `${internalNamespaces.observability}.get_traces`,
   `${internalNamespaces.observability}.get_runtime_metrics`,
+  `${internalNamespaces.observability}.logs_search`,
 
   // Security Solution
   `${internalNamespaces.security}.entity_risk_score`,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_service_topology/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_service_topology/tool.ts
@@ -76,7 +76,7 @@ When NOT to use:
 
 After reviewing topology results, consider:
 - Use \`observability.get_trace_metrics\` with timeseries to check latency/error trends over time
-- Use \`observability.get_correlated_logs\` to find error patterns in failing dependencies`,
+- Use \`observability.get_traces\` to find error patterns in failing dependencies`,
     schema: getServiceTopologyToolSchema,
     tags: ['observability', 'apm', 'service-map', 'topology'],
     availability: {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/index.ts
@@ -16,3 +16,4 @@ export { OBSERVABILITY_GET_TRACES_TOOL_ID } from './get_traces/tool';
 export { OBSERVABILITY_GET_RUNTIME_METRICS_TOOL_ID } from './get_runtime_metrics/tool';
 export { OBSERVABILITY_GET_INDEX_INFO_TOOL_ID } from './get_index_info';
 export { OBSERVABILITY_GET_SERVICE_TOPOLOGY_TOOL_ID } from './get_service_topology/tool';
+export { OBSERVABILITY_LOGS_SEARCH_TOOL_ID } from './logs_search/tool';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/constants.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const OBSERVABILITY_LOGS_SEARCH_TOOL_ID = 'observability.logs_search';
+
+export const MAX_ITERATIONS = 10;
+export const MAX_OBSERVATION_CHARS = 15_000;
+export const MAX_ANSWER_CHARS = 3_000;
+export const MAX_SAMPLE_LOGS = 10;
+export const MAX_CATEGORIES = 10;
+export const MAX_CELL_VALUE_LENGTH = 500;
+export const MAX_CONTEXT_LOGS = 50;
+export const DEFAULT_CONTEXT_WINDOW = '5m';
+
+export const DEFAULT_KEEP_FIELDS = [
+  'message',
+  'error.message',
+  'service.name',
+  'container.name',
+  'host.name',
+  'container.id',
+  'trace.id',
+  'agent.name',
+  'kubernetes.container.name',
+  'kubernetes.node.name',
+  'kubernetes.namespace',
+  'kubernetes.pod.name',
+  'log.level',
+];

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/handler.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/handler.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/core/server';
+import { MessageRole, ToolChoiceType } from '@kbn/inference-common';
+import type { Message, BoundInferenceClient } from '@kbn/inference-common';
+import { buildSystemPrompt } from './system_prompt';
+import { INNER_TOOL_DEFINITIONS, executeInnerTool } from './inner_tools';
+import { MAX_ITERATIONS, MAX_ANSWER_CHARS } from './constants';
+
+export interface LogsSearchParams {
+  prompt: string;
+  start: string;
+  end: string;
+  index: string;
+}
+
+export interface LogsSearchResult {
+  answer: string;
+  evidence: string;
+  queryTrace: string[];
+  finalQuery: string;
+  iterations: number;
+  totalLogsExamined: number;
+  finalMatchCount: number;
+  error?: string;
+}
+
+export async function logsSearchHandler({
+  params,
+  inferenceClient,
+  esClient,
+  logger,
+}: {
+  params: LogsSearchParams;
+  inferenceClient: BoundInferenceClient;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<LogsSearchResult> {
+  const systemPrompt = buildSystemPrompt({
+    index: params.index,
+    start: params.start,
+    end: params.end,
+  });
+
+  const messages: Message[] = [{ role: MessageRole.User, content: params.prompt }];
+
+  const queryTrace: string[] = [];
+  let finalQuery = '';
+  let totalLogsExamined = 0;
+  let finalMatchCount = 0;
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    logger.debug(
+      `[logs_search] Iteration ${i + 1}/${MAX_ITERATIONS} — sending ${messages.length} messages`
+    );
+
+    const response = await inferenceClient.chatComplete({
+      system: systemPrompt,
+      messages,
+      tools: INNER_TOOL_DEFINITIONS,
+      toolChoice: ToolChoiceType.auto,
+    });
+
+    const assistantMessage: Message = {
+      role: MessageRole.Assistant,
+      content: response.content,
+      toolCalls: response.toolCalls,
+    };
+    messages.push(assistantMessage);
+
+    if (!response.toolCalls?.length) {
+      logger.debug(`[logs_search] No tool calls at iteration ${i + 1} — returning text response`);
+      return buildResult({
+        answer: response.content || 'No answer provided.',
+        evidence: '',
+        queryTrace,
+        finalQuery,
+        iterations: i + 1,
+        totalLogsExamined,
+        finalMatchCount,
+      });
+    }
+
+    for (const toolCall of response.toolCalls) {
+      if (toolCall.function.name === 'answer') {
+        const answerArgs = toolCall.function.arguments as Record<string, unknown>;
+        logger.debug(`[logs_search] Answer provided at iteration ${i + 1}`);
+        return buildResult({
+          answer: String(answerArgs.answer ?? ''),
+          evidence: String(answerArgs.evidence ?? ''),
+          queryTrace,
+          finalQuery,
+          iterations: i + 1,
+          totalLogsExamined,
+          finalMatchCount,
+        });
+      }
+
+      if (toolCall.function.name === 'search_logs') {
+        const searchArgs = toolCall.function.arguments as Record<string, unknown>;
+        const qs = String(searchArgs.query_string ?? '*');
+        queryTrace.push(qs);
+        finalQuery = qs;
+      }
+
+      const observation = await executeInnerTool(
+        {
+          toolCallId: toolCall.toolCallId,
+          function: {
+            name: toolCall.function.name,
+            arguments: toolCall.function.arguments as Record<string, unknown>,
+          },
+        },
+        {
+          esClient,
+          index: params.index,
+          start: params.start,
+          end: params.end,
+          logger,
+        }
+      );
+
+      logger.debug(
+        `[logs_search] Tool "${toolCall.function.name}" returned ${observation.length} chars`
+      );
+
+      const totalMatch = observation.match(/Total matching logs:\s*([\d,]+)/);
+      if (totalMatch) {
+        const count = parseInt(totalMatch[1].replace(/,/g, ''), 10);
+        if (i === 0) {
+          totalLogsExamined = count;
+        }
+        finalMatchCount = count;
+      }
+
+      const toolMessage: Message = {
+        role: MessageRole.Tool,
+        toolCallId: toolCall.toolCallId,
+        response: observation,
+        name: toolCall.function.name,
+      };
+      messages.push(toolMessage);
+    }
+  }
+
+  logger.debug(`[logs_search] Reached max iterations (${MAX_ITERATIONS})`);
+
+  return buildResult({
+    answer: 'Investigation reached maximum iterations without a definitive conclusion.',
+    evidence: '',
+    queryTrace,
+    finalQuery,
+    iterations: MAX_ITERATIONS,
+    totalLogsExamined,
+    finalMatchCount,
+    error: 'max_iterations_reached',
+  });
+}
+
+function buildResult(result: LogsSearchResult): LogsSearchResult {
+  return {
+    ...result,
+    answer: result.answer.slice(0, MAX_ANSWER_CHARS),
+    evidence: result.evidence.slice(0, MAX_ANSWER_CHARS),
+  };
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/inner_tools.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/inner_tools.ts
@@ -1,0 +1,558 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/core/server';
+import type { ToolDefinition } from '@kbn/inference-common';
+import {
+  MAX_SAMPLE_LOGS,
+  MAX_CATEGORIES,
+  MAX_CONTEXT_LOGS,
+  DEFAULT_CONTEXT_WINDOW,
+  DEFAULT_KEEP_FIELDS,
+} from './constants';
+import { truncateObservation, truncateCellValue, formatTabular } from './truncation';
+
+export const INNER_TOOL_DEFINITIONS: Record<string, ToolDefinition> = {
+  search_logs: {
+    description:
+      'Search logs using the funnel approach. Returns a histogram (trend), total count, and up to 10 log samples in one query. This is your PRIMARY tool — use it iteratively to filter noise and drill down.',
+    schema: {
+      type: 'object' as const,
+      properties: {
+        query_string: {
+          type: 'string' as const,
+          description:
+            'KQL query string. Use NOT clauses to filter noise. Examples: "*", "error.message: *", "NOT message: \\"GET /health\\" AND NOT kubernetes.namespace: \\"kube-system\\""',
+        },
+        t_start: {
+          type: 'string' as const,
+          description: 'Start of time range. Elasticsearch date math, e.g. "now-1h"',
+        },
+        t_end: {
+          type: 'string' as const,
+          description: 'End of time range. Elasticsearch date math, e.g. "now"',
+        },
+        t_bucket_size: {
+          type: 'string' as const,
+          description: 'Histogram bucket size. Examples: "5m", "1m", "30s", "1h"',
+        },
+        breakdown_field: {
+          type: 'string' as const,
+          description:
+            'Optional field to break down the histogram by (e.g. "log.level", "service.name"). Adds a second dimension to the histogram for richer trend analysis.',
+        },
+      },
+      required: ['query_string', 't_start', 't_end', 't_bucket_size'] as const,
+    },
+  },
+  categorize_logs: {
+    description:
+      'Find common and rare log message patterns using ES|QL CATEGORIZE. Use "common" to find noise patterns to exclude, "rare" to find unusual messages worth investigating.',
+    schema: {
+      type: 'object' as const,
+      properties: {
+        query_string: {
+          type: 'string' as const,
+          description: 'KQL query string to scope the categorization',
+        },
+        t_start: {
+          type: 'string' as const,
+          description: 'Start of time range',
+        },
+        t_end: {
+          type: 'string' as const,
+          description: 'End of time range',
+        },
+        mode: {
+          type: 'string' as const,
+          enum: ['common', 'rare', 'both'] as const,
+          description:
+            'Which patterns to return: "common" (high-count, likely noise), "rare" (low-count, likely interesting), or "both"',
+        },
+      },
+      required: ['query_string', 't_start', 't_end', 'mode'] as const,
+    },
+  },
+  get_log_document: {
+    description:
+      'Fetch a single full log document by its _id for deep inspection. Use when a log sample looks interesting and you need the complete fields.',
+    schema: {
+      type: 'object' as const,
+      properties: {
+        document_id: {
+          type: 'string' as const,
+          description: 'The _id of the document to fetch',
+        },
+        index: {
+          type: 'string' as const,
+          description: 'The specific index containing the document',
+        },
+      },
+      required: ['document_id', 'index'] as const,
+    },
+  },
+  execute_esql: {
+    description:
+      'Execute an arbitrary ES|QL query. Use as an escape hatch when the structured tools cannot express what you need (e.g., complex aggregations, joins, CHANGE_POINT).',
+    schema: {
+      type: 'object' as const,
+      properties: {
+        query: {
+          type: 'string' as const,
+          description: 'The full ES|QL query to execute',
+        },
+      },
+      required: ['query'] as const,
+    },
+  },
+  get_logs_in_context: {
+    description:
+      'Fetch a chronological timeline of logs around a specific log entry, pivoting on a shared entity. Use after finding a suspicious log to see what happened before and after on the same trace, container, host, service, or pod.',
+    schema: {
+      type: 'object' as const,
+      properties: {
+        timestamp: {
+          type: 'string' as const,
+          description:
+            'ISO 8601 anchor timestamp of the log being investigated, e.g. "2026-02-25T14:05:23.000Z"',
+        },
+        context_field: {
+          type: 'string' as const,
+          enum: [
+            'trace.id',
+            'container.id',
+            'host.name',
+            'service.name',
+            'kubernetes.pod.name',
+          ] as const,
+          description:
+            'Field to pivot on. Use trace.id for distributed request tracing, or container.id/host.name/service.name/kubernetes.pod.name for co-located events.',
+        },
+        context_value: {
+          type: 'string' as const,
+          description: 'The value of the context field to filter on',
+        },
+        window: {
+          type: 'string' as const,
+          description:
+            'Time window around the anchor timestamp, e.g. "5m", "2m", "30s". Defaults to "5m".',
+        },
+      },
+      required: ['timestamp', 'context_field', 'context_value'] as const,
+    },
+  },
+  answer: {
+    description:
+      'Provide your final root cause analysis. Call this when you have enough evidence to answer the original question.',
+    schema: {
+      type: 'object' as const,
+      properties: {
+        answer: {
+          type: 'string' as const,
+          description:
+            'Clear root cause statement or investigation summary answering the original question',
+        },
+        evidence: {
+          type: 'string' as const,
+          description: 'Key log lines, timestamps, and entities that support the conclusion',
+        },
+        root_cause: {
+          type: 'string' as const,
+          description: 'One-line root cause if identified',
+        },
+        affected_entities: {
+          type: 'string' as const,
+          description: 'Comma-separated list of affected services, hosts, pods, etc.',
+        },
+      },
+      required: ['answer', 'evidence'] as const,
+    },
+  },
+};
+
+interface InnerToolContext {
+  esClient: ElasticsearchClient;
+  index: string;
+  start: string;
+  end: string;
+  logger: Logger;
+}
+
+interface ToolCallPayload {
+  toolCallId: string;
+  function: {
+    name: string;
+    arguments: Record<string, unknown>;
+  };
+}
+
+export async function executeInnerTool(
+  toolCall: ToolCallPayload,
+  ctx: InnerToolContext
+): Promise<string> {
+  const { name, arguments: args } = toolCall.function;
+
+  try {
+    switch (name) {
+      case 'search_logs':
+        return await executeSearchLogs(args, ctx);
+      case 'categorize_logs':
+        return await executeCategorizeLogs(args, ctx);
+      case 'get_log_document':
+        return await executeGetLogDocument(args, ctx);
+      case 'get_logs_in_context':
+        return await executeGetLogsInContext(args, ctx);
+      case 'execute_esql':
+        return await executeEsql(args, ctx);
+      default:
+        return `Unknown tool: ${name}`;
+    }
+  } catch (error) {
+    ctx.logger.error(`Inner tool "${name}" failed: ${error.message}`);
+    return `Error executing ${name}: ${error.message}`;
+  }
+}
+
+async function executeSearchLogs(
+  args: Record<string, unknown>,
+  ctx: InnerToolContext
+): Promise<string> {
+  const queryString = (args.query_string as string) || '*';
+  const tStart = (args.t_start as string) || ctx.start;
+  const tEnd = (args.t_end as string) || ctx.end;
+  const tBucketSize = (args.t_bucket_size as string) || '5m';
+  const breakdownField = args.breakdown_field as string | undefined;
+  const keepFields = DEFAULT_KEEP_FIELDS.join(', ');
+
+  const histogramGroupBy = breakdownField
+    ? `bucket = BUCKET(@timestamp, ${tBucketSize}), ${breakdownField}`
+    : `bucket = BUCKET(@timestamp, ${tBucketSize})`;
+
+  const query = [
+    `SET approximation = true`,
+    `FROM ${ctx.index} METADATA _id, _index`,
+    `| WHERE @timestamp >= TO_DATETIME("${tStart}") AND @timestamp <= TO_DATETIME("${tEnd}")`,
+    `| WHERE KQL("${escapeQueryString(queryString)}")`,
+    `| FORK`,
+    `  (STATS count = COUNT(*) BY ${histogramGroupBy} | SORT bucket)`,
+    `  (STATS total = COUNT(*))`,
+    `  (SORT @timestamp DESC | LIMIT ${MAX_SAMPLE_LOGS} | KEEP _id, _index, @timestamp, ${keepFields})`,
+  ].join('\n');
+
+  const result = await runEsqlQuery(ctx.esClient, query);
+  return truncateObservation(formatSearchLogsResult(result, tBucketSize));
+}
+
+async function executeCategorizeLogs(
+  args: Record<string, unknown>,
+  ctx: InnerToolContext
+): Promise<string> {
+  const queryString = (args.query_string as string) || '*';
+  const tStart = (args.t_start as string) || ctx.start;
+  const tEnd = (args.t_end as string) || ctx.end;
+  const mode = (args.mode as string) || 'both';
+
+  const forks: string[] = [];
+
+  if (mode === 'common' || mode === 'both') {
+    forks.push(
+      `(STATS count = COUNT(*) BY category = CATEGORIZE(message) | SORT count DESC | LIMIT ${MAX_CATEGORIES})`
+    );
+  }
+  if (mode === 'rare' || mode === 'both') {
+    forks.push(
+      `(STATS count = COUNT(*) BY category = CATEGORIZE(message) | SORT count ASC | LIMIT ${MAX_CATEGORIES})`
+    );
+  }
+
+  const query = [
+    `SET approximation = true`,
+    `FROM ${ctx.index}`,
+    `| WHERE @timestamp >= TO_DATETIME("${tStart}") AND @timestamp <= TO_DATETIME("${tEnd}")`,
+    `| WHERE KQL("${escapeQueryString(queryString)}")`,
+    `| FORK`,
+    ...forks.map((f) => `  ${f}`),
+  ].join('\n');
+
+  const result = await runEsqlQuery(ctx.esClient, query);
+  return truncateObservation(formatCategorizeResult(result, mode));
+}
+
+async function executeGetLogDocument(
+  args: Record<string, unknown>,
+  ctx: InnerToolContext
+): Promise<string> {
+  const documentId = args.document_id as string;
+  const index = (args.index as string) || ctx.index;
+
+  const response = await ctx.esClient.get({ index, id: documentId });
+  const source = response._source as Record<string, unknown> | undefined;
+
+  if (!source) {
+    return 'Document not found or has no _source.';
+  }
+
+  const lines = flattenObject(source).map(
+    ([key, value]) => `${key}: ${truncateCellValue(value)}`
+  );
+
+  return truncateObservation(lines.join('\n'));
+}
+
+async function executeGetLogsInContext(
+  args: Record<string, unknown>,
+  ctx: InnerToolContext
+): Promise<string> {
+  const timestamp = args.timestamp as string;
+  const contextField = args.context_field as string;
+  const contextValue = args.context_value as string;
+  const window = (args.window as string) || DEFAULT_CONTEXT_WINDOW;
+
+  const anchorMs = new Date(timestamp).getTime();
+  const windowMs = parseWindowToMs(window);
+  const windowStart = new Date(anchorMs - windowMs).toISOString();
+  const windowEnd = new Date(anchorMs + windowMs).toISOString();
+  const keepFields = DEFAULT_KEEP_FIELDS.join(', ');
+
+  const query = [
+    `FROM ${ctx.index}`,
+    `| WHERE @timestamp >= TO_DATETIME("${windowStart}") AND @timestamp <= TO_DATETIME("${windowEnd}")`,
+    `| WHERE KQL("${contextField}: \\"${escapeQueryString(contextValue)}\\"")`,
+    `| SORT @timestamp`,
+    `| LIMIT ${MAX_CONTEXT_LOGS}`,
+    `| KEEP @timestamp, ${keepFields}`,
+  ].join('\n');
+
+  const result = await runEsqlQuery(ctx.esClient, query);
+
+  if (!result.columns?.length || !result.values?.length) {
+    return `No logs found for ${contextField}="${contextValue}" within ±${window} of ${timestamp}.`;
+  }
+
+  const header = `## Logs in context (${result.values.length} logs for ${contextField}="${contextValue}", ±${window} around ${timestamp})`;
+  const table = formatTabular(result.columns, result.values);
+  return truncateObservation(`${header}\n${table}`);
+}
+
+async function executeEsql(
+  args: Record<string, unknown>,
+  ctx: InnerToolContext
+): Promise<string> {
+  const query = args.query as string;
+
+  const result = await runEsqlQuery(ctx.esClient, query);
+
+  if (!result.columns?.length || !result.values?.length) {
+    return '(no results)';
+  }
+
+  const maxRows = 50;
+  const truncatedValues =
+    result.values.length > maxRows ? result.values.slice(0, maxRows) : result.values;
+  const table = formatTabular(result.columns, truncatedValues);
+  const suffix =
+    result.values.length > maxRows
+      ? `\n[... showing ${maxRows} of ${result.values.length} rows]`
+      : '';
+
+  return truncateObservation(table + suffix);
+}
+
+interface EsqlResult {
+  columns: Array<{ name: string; type: string }>;
+  values: unknown[][];
+}
+
+async function runEsqlQuery(esClient: ElasticsearchClient, query: string): Promise<EsqlResult> {
+  const response = await esClient.transport.request<EsqlResult>({
+    method: 'POST',
+    path: '/_query',
+    body: {
+      query,
+      format: 'json',
+      drop_null_columns: true,
+    },
+  });
+
+  return {
+    columns: response.columns ?? [],
+    values: response.values ?? [],
+  };
+}
+
+function formatSearchLogsResult(result: EsqlResult, _bucketSize: string): string {
+  if (!result.columns?.length || !result.values?.length) {
+    return 'No matching logs found.';
+  }
+
+  const forkColIdx = result.columns.findIndex((c) => c.name === '_fork');
+  const sections: string[] = [];
+
+  if (forkColIdx >= 0) {
+    const grouped = groupByFork(result, forkColIdx);
+
+    if (grouped['fork1']?.values.length) {
+      sections.push(formatHistogramFork(grouped['fork1']));
+    }
+    if (grouped['fork2']?.values.length) {
+      sections.push(formatTotalCountFork(grouped['fork2']));
+    }
+    if (grouped['fork3']?.values.length) {
+      sections.push(formatSamplesFork(grouped['fork3']));
+    }
+  } else {
+    sections.push(formatTabular(result.columns, result.values));
+  }
+
+  return sections.join('\n\n');
+}
+
+function formatCategorizeResult(result: EsqlResult, mode: string): string {
+  if (!result.columns?.length || !result.values?.length) {
+    return 'No log patterns found.';
+  }
+
+  const forkColIdx = result.columns.findIndex((c) => c.name === '_fork');
+
+  if (forkColIdx >= 0) {
+    const grouped = groupByFork(result, forkColIdx);
+    const sections: string[] = [];
+
+    if (grouped['fork1']?.values.length) {
+      const label = mode === 'both' ? 'Common patterns (noise candidates)' : 'Patterns';
+      sections.push(`## ${label}\n${formatCategoryRows(grouped['fork1'])}`);
+    }
+    if (grouped['fork2']?.values.length) {
+      const label = mode === 'both' ? 'Rare patterns (investigation candidates)' : 'Patterns';
+      sections.push(`## ${label}\n${formatCategoryRows(grouped['fork2'])}`);
+    }
+
+    return sections.join('\n\n');
+  }
+
+  return formatCategoryRows(result);
+}
+
+function formatCategoryRows(result: EsqlResult): string {
+  const countIdx = result.columns.findIndex((c) => c.name === 'count');
+  const catIdx = result.columns.findIndex((c) => c.name === 'category');
+
+  if (countIdx < 0 || catIdx < 0) {
+    return formatTabular(result.columns, result.values);
+  }
+
+  return result.values
+    .map((row) => `[${row[countIdx]}] ${truncateCellValue(row[catIdx])}`)
+    .join('\n');
+}
+
+function formatHistogramFork(fork: EsqlResult): string {
+  const bucketIdx = fork.columns.findIndex((c) => c.name === 'bucket');
+  const countIdx = fork.columns.findIndex((c) => c.name === 'count');
+
+  if (bucketIdx < 0 || countIdx < 0) {
+    return formatTabular(fork.columns, fork.values);
+  }
+
+  const breakdownIdx = fork.columns.findIndex(
+    (c) => c.name !== 'bucket' && c.name !== 'count'
+  );
+  const hasBreakdown = breakdownIdx >= 0;
+
+  const maxCount = Math.max(...fork.values.map((r) => Number(r[countIdx]) || 0), 1);
+
+  const lines = fork.values.map((row) => {
+    const bucket = String(row[bucketIdx] ?? '');
+    const count = Number(row[countIdx]) || 0;
+    const barLen = Math.round((count / maxCount) * 30);
+    const bar = '='.repeat(barLen);
+    const breakdownLabel = hasBreakdown ? ` (${String(row[breakdownIdx] ?? 'unknown')})` : '';
+    return `${bucket}${breakdownLabel} [${bar} ${count}]`;
+  });
+
+  const breakdownNote = hasBreakdown
+    ? ` by ${fork.columns[breakdownIdx].name}`
+    : '';
+  return `## Histogram (trend${breakdownNote})\n${lines.join('\n')}`;
+}
+
+function formatTotalCountFork(fork: EsqlResult): string {
+  const countIdx = fork.columns.findIndex((c) => c.name === 'total');
+  if (countIdx >= 0 && fork.values.length > 0) {
+    return `## Total matching logs: ${fork.values[0][countIdx]}`;
+  }
+  return `## Total matching logs: ${formatTabular(fork.columns, fork.values)}`;
+}
+
+function formatSamplesFork(fork: EsqlResult): string {
+  const header = `## Log samples (${fork.values.length})`;
+  const table = formatTabular(fork.columns, fork.values);
+  return `${header}\n${table}`;
+}
+
+interface GroupedForkResult {
+  [forkId: string]: EsqlResult;
+}
+
+function groupByFork(result: EsqlResult, forkColIdx: number): GroupedForkResult {
+  const grouped: GroupedForkResult = {};
+
+  for (const row of result.values) {
+    const forkId = String(row[forkColIdx] ?? 'unknown');
+    if (!grouped[forkId]) {
+      grouped[forkId] = {
+        columns: result.columns.filter((_, i) => i !== forkColIdx),
+        values: [],
+      };
+    }
+    grouped[forkId].values.push(row.filter((_, i) => i !== forkColIdx));
+  }
+
+  return grouped;
+}
+
+function parseWindowToMs(window: string): number {
+  const match = window.match(/^(\d+)(s|m|h)$/);
+  if (!match) {
+    return 5 * 60 * 1000;
+  }
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  switch (unit) {
+    case 's':
+      return value * 1000;
+    case 'm':
+      return value * 60 * 1000;
+    case 'h':
+      return value * 60 * 60 * 1000;
+    default:
+      return 5 * 60 * 1000;
+  }
+}
+
+function escapeQueryString(qs: string): string {
+  return qs.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function flattenObject(
+  obj: Record<string, unknown>,
+  prefix = ''
+): Array<[string, unknown]> {
+  const result: Array<[string, unknown]> = [];
+
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      result.push(...flattenObject(value as Record<string, unknown>, fullKey));
+    } else {
+      result.push([fullKey, value]);
+    }
+  }
+
+  return result;
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/system_prompt.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/system_prompt.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import dedent from 'dedent';
+
+export function buildSystemPrompt({
+  index,
+  start,
+  end,
+}: {
+  index: string;
+  start: string;
+  end: string;
+}): string {
+  return dedent`You are an expert SRE investigating log data in Elasticsearch.
+    Your job is to find root causes by iteratively filtering logs, just like a human
+    uses Kibana Discover. Think step-by-step. Show your reasoning before each action.
+
+    ## Your Tools
+
+    - search_logs: Your PRIMARY tool. Returns 3 signals in one query:
+      - Trend (histogram by time bucket) — spot spikes and drops
+      - Total count — gauge how broad/narrow your filter is
+      - Up to 10 log samples (compact: _id, _index, message, service, host, k8s metadata, trace.id)
+      - Optional: pass breakdown_field (e.g. "log.level", "service.name") to slice the histogram by a dimension
+    - categorize_logs: Find common patterns (noise) and rare patterns (needles)
+    - get_log_document: Fetch one full document by _id for deep inspection.
+      Use the _id and _index returned in search_logs samples.
+    - get_logs_in_context: Fetch a timeline of logs around a specific event,
+      pivoting on a shared entity (trace.id, container, host, service, pod).
+      Use after finding a suspicious log to see what happened before and after.
+    - execute_esql: Escape hatch for arbitrary ES|QL queries
+    - answer: Provide your final root cause analysis
+
+    ## The Funnel Workflow (Standard Operating Procedure)
+
+    ### Step 1: Initial Peek
+    Call search_logs with a broad query_string (e.g. "*" or "service.name: target").
+    Set t_bucket_size to "5m" for a reasonable histogram resolution.
+    - Look at the total count. Is it huge? You have lots of noise to filter.
+    - Look at the histogram trend. Is there a spike at a specific time? Narrow t_start/t_end.
+    - Look at the 10 samples. What do you see? Health checks? Cron jobs? Real errors?
+
+    ### Step 2: Filter Noise (repeat 3-5 times)
+    Call search_logs again with KQL NOT clauses added to query_string:
+    - Exclude routine messages: NOT message: "GET /health"
+    - Exclude noisy containers: NOT kubernetes.container.name: "fluent-bit"
+    - Focus on errors: error.message: * AND NOT message: "Known benign warning"
+    - ALWAYS accumulate your filters — do not drop previous NOT clauses
+    - Watch the total count drop as you carve away junk
+
+    ### Step 3: Drill Down
+    Once samples show the failing component:
+    - Narrow the time window around the spike
+    - Filter to the specific entity: container.id: "abc-123" or kubernetes.pod.name: "..."
+    - Use get_log_document to inspect a specific log entry in full
+
+    ### Step 4: Categorize (optional)
+    If filtering alone is not enough, use categorize_logs to find:
+    - Common patterns (mode: "common") — these are the noise to exclude
+    - Rare patterns (mode: "rare") — these may be the needle in the haystack
+
+    ### Step 5: Logs in Context (optional)
+    When you find a suspicious log and want to understand what happened around it:
+    - If the log has a trace.id: call get_logs_in_context with context_field="trace.id"
+      to see all logs for that distributed request across services
+    - If no trace.id: call get_logs_in_context with context_field set to container.id,
+      host.name, or kubernetes.pod.name to see co-located events within a time window
+    - Default window is 5m; narrow to 30s-2m for dense environments
+    - This is especially useful for understanding cascading failures:
+      e.g. OOM on one container may cause connection timeouts on another
+
+    ### Step 6: Answer
+    Call the answer tool with:
+    - A clear root cause statement
+    - Key evidence (specific log lines, timestamps, entities)
+    - The progression of your investigation
+
+    ## Critical Rules
+
+    1. ALWAYS accumulate KQL query_string filters. Never "zoom out" by dropping previous NOT clauses.
+    2. Call search_logs at least 3 times before answering. One query is never enough.
+    3. Keep your reasoning visible — explain what you see and why you are filtering.
+    4. If the total count is > 10,000, you have too much noise. Filter more aggressively.
+    5. If the total count is < 100, you may be ready to draw conclusions from the samples.
+
+    ## Log Field Priority
+
+    For the message field, look for (in order): message, error.message, body.text, event.original
+    For resource metadata:
+    - Service: service.name
+    - Container: kubernetes.container.name → container.name
+    - Host/Node: kubernetes.node.name → host.name
+    - Namespace: kubernetes.namespace → k8s.namespace.name
+    - Pod: kubernetes.pod.name → k8s.pod.name
+
+    ## Example Investigation
+
+    User: "Why are there errors in the checkout service?"
+
+    Thought: I'll start with a broad search to understand the overall log landscape and spot any spikes.
+    Action: search_logs(query_string="*", t_start="now-1h", t_end="now", t_bucket_size="5m")
+    Observation: Total 42,000 logs. Histogram shows a spike at 14:05-14:10. Samples dominated by "GET /health 200 OK" and fluent-bit noise.
+
+    Thought: 42,000 logs is too much noise. The samples are all health checks. I need to exclude health checks and fluent-bit, then zoom into the 14:05 spike.
+    Action: search_logs(query_string="NOT message: \\"GET /health\\" AND NOT kubernetes.container.name: \\"fluent-bit\\"", t_start="2026-02-25T14:00:00Z", t_end="2026-02-25T14:15:00Z", t_bucket_size="1m")
+    Observation: Total 3,200 logs. Spike confirmed at 14:07. Samples show "OOMKilled" from checkout-pod-abc, container.id: "xyz-123".
+
+    Thought: The spike is OOM errors on a specific container. Let me see surrounding logs on that container to understand the cascade.
+    Action: get_logs_in_context(timestamp="2026-02-25T14:07:30.000Z", context_field="container.id", context_value="xyz-123", window="2m")
+    Observation: Timeline shows memory warnings starting at 14:05, escalating to OOMKilled at 14:07, followed by connection timeouts from payment-service.
+
+    Action: answer(answer="Checkout service crashed due to OOMKilled on container xyz-123. Memory warnings began at 14:05 and the container was killed at 14:07, causing cascading connection timeouts in payment-service.", evidence="14:05 memory warning, 14:07 OOMKilled, 14:07+ connection timeouts from payment-service")
+
+    ## Context
+
+    - Index: ${index}
+    - Time range: ${start} to ${end}
+  `;
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/tool.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition, StaticToolRegistration } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/core/server';
+import type { ObservabilityAgentBuilderCoreSetup } from '../../types';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import { OBSERVABILITY_LOGS_SEARCH_TOOL_ID } from './constants';
+import { logsSearchHandler } from './handler';
+
+const logsSearchSchema = z.object({
+  prompt: z
+    .string()
+    .describe(
+      'Natural language question about log data. Examples: ' +
+        '"Why did checkout errors spike at 6pm yesterday?", ' +
+        '"Find OOM errors in production kubernetes pods in the last 2 hours", ' +
+        '"What happened to the payment service between 14:00 and 14:30?"'
+    ),
+  start: z
+    .string()
+    .default('now-1h')
+    .describe(
+      'Start of time range. Elasticsearch date math, e.g. "now-1h", "2026-02-25T14:00:00Z". Defaults to "now-1h".'
+    ),
+  end: z
+    .string()
+    .default('now')
+    .describe(
+      'End of time range. Elasticsearch date math, e.g. "now", "2026-02-25T14:30:00Z". Defaults to "now".'
+    ),
+  index: z
+    .string()
+    .default('logs-*')
+    .describe('Log index pattern. Defaults to "logs-*".'),
+});
+
+export function createLogsSearchTool({
+  core,
+  logger,
+}: {
+  core: ObservabilityAgentBuilderCoreSetup;
+  logger: Logger;
+}): StaticToolRegistration<typeof logsSearchSchema> {
+  const toolDefinition: BuiltinToolDefinition<typeof logsSearchSchema> = {
+    id: OBSERVABILITY_LOGS_SEARCH_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Autonomous log investigation agent that iteratively searches and filters logs to find root causes.
+
+When to use:
+- Investigating error spikes, outages, or performance degradations in log data
+- Finding the root cause of incidents by analyzing log patterns
+- Answering "what happened?" or "why did X fail?" questions about services
+
+How it works:
+- Runs an internal reasoning loop that mimics an SRE using Kibana Discover
+- Starts broad, filters noise (health checks, cron jobs), and drills down to the root cause
+- Returns a structured analysis with evidence and the investigation trail
+
+Do NOT use for:
+- Querying metrics or traces (use dedicated tools)
+- Simple log count or volume questions (use execute_esql directly)`,
+    schema: logsSearchSchema,
+    tags: ['observability', 'logs', 'investigation'],
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) => {
+        return getAgentBuilderResourceAvailability({ core, request, logger });
+      },
+    },
+    handler: async (toolParams, { esClient, modelProvider }) => {
+      try {
+        const { inferenceClient } = await modelProvider.getDefaultModel();
+
+        const result = await logsSearchHandler({
+          params: {
+            prompt: toolParams.prompt,
+            start: toolParams.start,
+            end: toolParams.end,
+            index: toolParams.index,
+          },
+          inferenceClient,
+          esClient: esClient.asCurrentUser,
+          logger,
+        });
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: result,
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(`Logs search agent failed: ${error.message}`);
+        logger.debug(error);
+
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Logs search investigation failed: ${error.message}`,
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+
+  return toolDefinition;
+}
+
+export { OBSERVABILITY_LOGS_SEARCH_TOOL_ID };

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/truncation.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/logs_search/truncation.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  MAX_OBSERVATION_CHARS,
+  MAX_CELL_VALUE_LENGTH,
+} from './constants';
+
+export function truncateObservation(content: string, maxChars = MAX_OBSERVATION_CHARS): string {
+  if (content.length <= maxChars) {
+    return content;
+  }
+  const startSize = Math.floor(maxChars * 0.8);
+  const endSize = Math.floor(maxChars * 0.2);
+  return [
+    content.slice(0, startSize),
+    `\n[... truncated: ${content.length} total chars ...]\n`,
+    content.slice(-endSize),
+  ].join('');
+}
+
+export function truncateCellValue(value: unknown): string {
+  const str = typeof value === 'string' ? value : JSON.stringify(value ?? '');
+  if (str.length <= MAX_CELL_VALUE_LENGTH) {
+    return str;
+  }
+  return str.slice(0, MAX_CELL_VALUE_LENGTH) + '…';
+}
+
+export function formatTabular(columns: Array<{ name: string }>, values: unknown[][]): string {
+  if (!columns.length || !values.length) {
+    return '(no results)';
+  }
+
+  const header = columns.map((c) => c.name).join(' | ');
+  const rows = values.map((row) => row.map((cell) => truncateCellValue(cell)).join(' | '));
+  return [header, '-'.repeat(header.length), ...rows].join('\n');
+}
+

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/register_tools.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/register_tools.ts
@@ -54,6 +54,10 @@ import {
   createGetServiceTopologyTool,
 } from './get_service_topology/tool';
 import { OBSERVABILITY_GET_TRACES_TOOL_ID, createGetTracesTool } from './get_traces/tool';
+import {
+  OBSERVABILITY_LOGS_SEARCH_TOOL_ID,
+  createLogsSearchTool,
+} from './logs_search/tool';
 
 const PLATFORM_TOOL_IDS = [
   platformCoreTools.listIndices,
@@ -77,6 +81,7 @@ const OBSERVABILITY_TOOL_IDS = [
   OBSERVABILITY_GET_TRACE_CHANGE_POINTS_TOOL_ID,
   OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
   OBSERVABILITY_GET_SERVICE_TOPOLOGY_TOOL_ID,
+  OBSERVABILITY_LOGS_SEARCH_TOOL_ID,
 ];
 
 export const OBSERVABILITY_AGENT_TOOL_IDS = [...PLATFORM_TOOL_IDS, ...OBSERVABILITY_TOOL_IDS];
@@ -107,6 +112,7 @@ export async function registerTools({
     createGetTraceChangePointsTool({ core, plugins, logger }),
     createGetIndexInfoTool({ core, plugins, logger }),
     createGetServiceTopologyTool({ core, plugins, dataRegistry, logger }),
+    createLogsSearchTool({ core, logger }),
   ];
 
   for (const tool of observabilityTools) {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/index.ts
@@ -24,6 +24,7 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./tools/get_index_info.spec.ts'));
     loadTestFile(require.resolve('./tools/get_service_topology.spec.ts'));
     loadTestFile(require.resolve('./tools/get_traces.spec.ts'));
+    loadTestFile(require.resolve('./tools/logs_search.spec.ts'));
 
     // ai insights
     loadTestFile(require.resolve('./ai_insights/error.spec.ts'));

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/logs_search.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/logs_search.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { timerange } from '@kbn/synthtrace-client';
+import { type LogsSynthtraceEsClient, generateLogsSearchData } from '@kbn/synthtrace';
+import { OBSERVABILITY_LOGS_SEARCH_TOOL_ID } from '@kbn/observability-agent-builder-plugin/server/tools';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
+import type { SynthtraceProvider } from '../../../services/synthtrace';
+import { createAgentBuilderApiClient } from '../utils/agent_builder_client';
+
+const START = 'now-15m';
+const END = 'now';
+
+async function setupSynthtraceData(synthtrace: ReturnType<typeof SynthtraceProvider>) {
+  const logsEsClient = synthtrace.createLogsSynthtraceEsClient();
+  await logsEsClient.clean();
+
+  const range = timerange(START, END);
+
+  const scenarios = generateLogsSearchData({ range, logsEsClient });
+
+  for (const scenario of scenarios) {
+    await scenario.client.index(scenario.generator);
+  }
+
+  return { logsEsClient };
+}
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const roleScopedSupertest = getService('roleScopedSupertest');
+  const synthtrace = getService('synthtrace');
+
+  // This tool requires an LLM connector to be configured.
+  // Skipped in CI — run manually with a connector:
+  //
+  //   node scripts/synthtrace src/platform/packages/shared/kbn-synthtrace/src/scenarios/agent_builder/tools/logs_search/logs_search \
+  //     --from "now-1h" --to "now" --clean --workers=1
+  //
+  //   curl -X POST http://localhost:5601/api/agent_builder/tools/_execute \
+  //     -u elastic:changeme -H 'kbn-xsrf: true' -H 'Content-Type: application/json' \
+  //     -d '{ "tool_id": "observability.logs_search", "tool_params": { "prompt": "Why are there errors in the checkout service?", "start": "now-1h", "end": "now" } }'
+  describe.skip(`tool: ${OBSERVABILITY_LOGS_SEARCH_TOOL_ID}`, function () {
+    let agentBuilderApiClient: ReturnType<typeof createAgentBuilderApiClient>;
+    let logsSynthtraceEsClient: LogsSynthtraceEsClient;
+
+    before(async () => {
+      const scoped = await roleScopedSupertest.getSupertestWithRoleScope('editor');
+      agentBuilderApiClient = createAgentBuilderApiClient(scoped);
+      const clients = await setupSynthtraceData(synthtrace);
+      logsSynthtraceEsClient = clients.logsEsClient;
+    });
+
+    after(async () => {
+      await logsSynthtraceEsClient.clean();
+    });
+
+    it('returns a structured investigation result', async () => {
+      const results = await agentBuilderApiClient.executeTool({
+        id: OBSERVABILITY_LOGS_SEARCH_TOOL_ID,
+        params: {
+          prompt: 'Why are there errors in the checkout service?',
+          start: START,
+          end: END,
+          index: 'logs-*',
+        },
+      });
+
+      const data = results[0].data as Record<string, unknown>;
+
+      // Verify the result has the expected structure
+      expect(data).to.have.property('answer');
+      expect(data).to.have.property('evidence');
+      expect(data).to.have.property('queryTrace');
+      expect(data).to.have.property('iterations');
+      expect(data).to.have.property('totalLogsExamined');
+      expect(data).to.have.property('finalMatchCount');
+
+      // The agent should have performed multiple iterations
+      expect(data.iterations).to.be.greaterThan(1);
+
+      // The query trace should show the funnel progression
+      const queryTrace = data.queryTrace as string[];
+      expect(queryTrace.length).to.be.greaterThan(1);
+    });
+  });
+}


### PR DESCRIPTION
Related to https://github.com/elastic/obs-ai-team/issues/520

Adds an agentic log investigation tool that accepts a natural language prompt and autonomously searches log data to find root causes. The tool runs an internal ReAct-style reasoning loop where the LLM iteratively queries Elasticsearch, filters out noise, and drills down to the relevant logs -- mimicking how an SRE uses Kibana Discover.

Highly guided by cursor and not yet fully validated