### PR TITLE
[Dashboard Drilldown] fix Selected destination dashboard value vanishes from dropdown after selection

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
@@ -22,7 +22,7 @@ import { DashboardNavigationOptionsEditor } from '../dashboard_navigation/option
 export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDrilldownState>) => {
   const [options, setOptions] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
   const [isLoadingOptions, setIsLoadingOptions] = useState(false);
-  const [initialDashboardOption, setInitialDashboardOption] = useState<
+  const [selectedDashboardOption, setSelectedDashboardOption] = useState<
     EuiComboBoxOptionOption<string> | undefined
   >();
   const [isLoadingInitialDashboard, setIsLoadingInitialDashboard] = useState(false);
@@ -96,7 +96,7 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
         return;
       }
 
-      setInitialDashboardOption({
+      setSelectedDashboardOption({
         value: initialDashboardId,
         label: result.attributes.title,
       });
@@ -110,14 +110,16 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // options contains dashboard search results (which may not include the selected dashboard)
+  // mergedOptions = options + selectedDashboardOption
   const mergedOptions = useMemo(() => {
-    if (!initialDashboardOption || initialDashboardOption.value !== props.state.dashboard_id) {
+    if (!selectedDashboardOption) {
       return options;
     }
 
-    const hasInitialDashboard = options.some(({ value }) => value === initialDashboardOption.value);
-    return hasInitialDashboard ? options : [initialDashboardOption, ...options];
-  }, [initialDashboardOption, options, props.state]);
+    const hasSelectedDashboard = options.some(({ value }) => value === selectedDashboardOption.value);
+    return hasSelectedDashboard ? options : [selectedDashboardOption, ...options];
+  }, [selectedDashboardOption, options, props.state]);
 
   const selectedOptions = useMemo(() => {
     if (!props.state.dashboard_id) {
@@ -152,6 +154,7 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
           selectedOptions={selectedOptions}
           options={mergedOptions}
           onChange={(nextSelectedOptions) => {
+            setSelectedDashboardOption(nextSelectedOptions?.[0]);
             props.onChange({ ...props.state, dashboard_id: nextSelectedOptions?.[0]?.value });
             if (error) {
               setError(undefined);

--- a/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
@@ -117,17 +117,11 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
       return options;
     }
 
-    const hasSelectedDashboard = options.some(({ value }) => value === selectedDashboardOption.value);
+    const hasSelectedDashboard = options.some(
+      ({ value }) => value === selectedDashboardOption.value
+    );
     return hasSelectedDashboard ? options : [selectedDashboardOption, ...options];
-  }, [selectedDashboardOption, options, props.state]);
-
-  const selectedOptions = useMemo(() => {
-    if (!props.state.dashboard_id) {
-      return undefined;
-    }
-    const selectedOption = mergedOptions.find(({ value }) => value === props.state.dashboard_id);
-    return selectedOption ? [selectedOption] : undefined;
-  }, [mergedOptions, props.state.dashboard_id]);
+  }, [selectedDashboardOption, options]);
 
   const navigationOptions = useMemo(() => {
     return {
@@ -151,7 +145,7 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
       >
         <EuiComboBox<string>
           async
-          selectedOptions={selectedOptions}
+          selectedOptions={selectedDashboardOption ? [selectedDashboardOption] : undefined}
           options={mergedOptions}
           onChange={(nextSelectedOptions) => {
             setSelectedDashboardOption(nextSelectedOptions?.[0]);

--- a/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
@@ -22,7 +22,7 @@ import { DashboardNavigationOptionsEditor } from '../dashboard_navigation/option
 export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDrilldownState>) => {
   const [options, setOptions] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
   const [isLoadingOptions, setIsLoadingOptions] = useState(false);
-  const [selectedDashboardOption, setSelectedDashboardOption] = useState<
+  const [selectedOption, setSelectedOption] = useState<
     EuiComboBoxOptionOption<string> | undefined
   >();
   const [isLoadingInitialDashboard, setIsLoadingInitialDashboard] = useState(false);
@@ -96,7 +96,7 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
         return;
       }
 
-      setSelectedDashboardOption({
+      setSelectedOption({
         value: initialDashboardId,
         label: result.attributes.title,
       });
@@ -111,17 +111,15 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
   }, []);
 
   // options contains dashboard search results (which may not include the selected dashboard)
-  // mergedOptions = options + selectedDashboardOption
+  // mergedOptions = options + selectedOption
   const mergedOptions = useMemo(() => {
-    if (!selectedDashboardOption) {
+    if (!selectedOption) {
       return options;
     }
 
-    const hasSelectedDashboard = options.some(
-      ({ value }) => value === selectedDashboardOption.value
-    );
-    return hasSelectedDashboard ? options : [selectedDashboardOption, ...options];
-  }, [selectedDashboardOption, options]);
+    const hasSelectedDashboard = options.some(({ value }) => value === selectedOption.value);
+    return hasSelectedDashboard ? options : [selectedOption, ...options];
+  }, [selectedOption, options]);
 
   const navigationOptions = useMemo(() => {
     return {
@@ -145,10 +143,10 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
       >
         <EuiComboBox<string>
           async
-          selectedOptions={selectedDashboardOption ? [selectedDashboardOption] : undefined}
+          selectedOptions={selectedOption ? [selectedOption] : undefined}
           options={mergedOptions}
           onChange={(nextSelectedOptions) => {
-            setSelectedDashboardOption(nextSelectedOptions?.[0]);
+            setSelectedOption(nextSelectedOptions?.[0]);
             props.onChange({ ...props.state, dashboard_id: nextSelectedOptions?.[0]?.value });
             if (error) {
               setError(undefined);

--- a/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx
@@ -110,17 +110,6 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // options contains dashboard search results (which may not include the selected dashboard)
-  // mergedOptions = options + selectedOption
-  const mergedOptions = useMemo(() => {
-    if (!selectedOption) {
-      return options;
-    }
-
-    const hasSelectedDashboard = options.some(({ value }) => value === selectedOption.value);
-    return hasSelectedDashboard ? options : [selectedOption, ...options];
-  }, [selectedOption, options]);
-
   const navigationOptions = useMemo(() => {
     return {
       ...DEFAULT_DASHBOARD_NAVIGATION_OPTIONS,
@@ -144,7 +133,7 @@ export const DashboardDrilldownEditor = (props: DrilldownEditorProps<DashboardDr
         <EuiComboBox<string>
           async
           selectedOptions={selectedOption ? [selectedOption] : undefined}
-          options={mergedOptions}
+          options={options}
           onChange={(nextSelectedOptions) => {
             setSelectedOption(nextSelectedOptions?.[0]);
             props.onChange({ ...props.state, dashboard_id: nextSelectedOptions?.[0]?.value });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/254608

Regression caused by https://github.com/elastic/kibana/pull/252976

### Testing
* install sample web logs
* Change search limit to "1" at https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/dashboard/public/dashboard_drilldown/editor.tsx#L48
* Create a new dashboard and save as "empty"
* Create another new dashboard
* Add a panel that supports dashboard drilldowns, like lens or maps
* add a dashboard drilldown.
* In dashboard select drop down, type "empty" and selected "empty" dashboard
* verify dashboard does not disappear when selected.