### PR TITLE
[9.2] [CI] Add parallelism and timeout to security_solution/investigations

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -10,6 +10,8 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
       - build
+    timeout_in_minutes: 60
+    parallelism: 24
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -8,6 +8,8 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
       - build
+    timeout_in_minutes: 60
+    parallelism: 9
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
This is the setting on main/9.3, but for some reason not on this branch and is causing 3hour+ CI times for the 9.2 branch.
