### PR TITLE
[CI] Guard ingest meta-data against empty string

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -32,7 +32,7 @@ if [[ "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" != "" ]]; then # if we're in a P
   # GITHUB_PR_DRAFT is set by our pr build trigger bot
   buildkite-agent meta-data set "ingest:is_draft_pr" "${GITHUB_PR_DRAFT:-false}"
   # GITHUB_PR_LABELS is set by our pr build trigger bot, and is a comma-separated list of labels on the PR
-  if [[ -n "${GITHUB_PR_LABELS:-}" ]]; then
+  if [[ "${GITHUB_PR_LABELS:-}" =~ [^[:space:]] ]]; then
     buildkite-agent meta-data set "ingest:pr_labels" "$GITHUB_PR_LABELS"
   fi
 fi


### PR DESCRIPTION
## Summary

`buildkite-agent meta-data set` does not support empty strings and we're trying to set `GITHUB_PR_LABELS=""` so make sure that this value has at least one non-whitespace character in it.

https://buildkite.com/elastic/kibana-pull-request/builds/400404#019c9200-a56d-4617-b838-37db8c166f0b/L204

### Testing
Run with no labels: https://buildkite.com/elastic/kibana-pull-request/builds/401077

### Follow Up
There are likely two more follow up PRs here:
- The PR bot shouldn't be sending empty string in this example, because labels were actually on the PR
- `Dynamic Pipeline` should be erroring when this happens instead of passing.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->