### PR TITLE
[9.2] [Deps] Upgrade markdown-it to 14.1.1 (#254563)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1313,7 +1313,7 @@
     "magic-bytes.js": "1.12.1",
     "mapbox-gl-draw-rectangle-mode": "1.0.4",
     "maplibre-gl": "5.3.0",
-    "markdown-it": "14.1.0",
+    "markdown-it": "14.1.1",
     "memoize-one": "6.0.0",
     "mime": "2.6.0",
     "mime-types": "2.1.35",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25281,10 +25281,10 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
   integrity sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=
 
-markdown-it@14.1.0:
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
-  integrity sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==
+markdown-it@14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.1.tgz#856f90b66fc39ae70affd25c1b18b581d7deee1f"
+  integrity sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==
   dependencies:
     argparse "^2.0.1"
     entities "^4.4.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Deps] Upgrade markdown-it to 14.1.1 (#254563)](https://github.com/elastic/kibana/pull/254563)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-25T17:10:01Z","message":"[Deps] Upgrade markdown-it to 14.1.1 (#254563)","sha":"52082b243365908eec0a509197de2dc873dba850","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","backport:9.2","backport:9.3","backport:8.19"],"title":"[Deps] Upgrade markdown-it to 14.1.1","number":254563,"url":"https://github.com/elastic/kibana/pull/254563","mergeCommit":{"message":"[Deps] Upgrade markdown-it to 14.1.1 (#254563)","sha":"52082b243365908eec0a509197de2dc873dba850"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254563","number":254563,"mergeCommit":{"message":"[Deps] Upgrade markdown-it to 14.1.1 (#254563)","sha":"52082b243365908eec0a509197de2dc873dba850"}}]}] BACKPORT-->