### PR TITLE
chore(NA): make sure build api docs starts without dependencies

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -168,8 +168,6 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
       diskSizeGb: 105
     key: build_api_docs
-    depends_on:
-      - build
     timeout_in_minutes: 60
     retry:
       automatic:


### PR DESCRIPTION
The Build API Docs step doesnt need to wait on dependencies before starting as it runs from source.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->