### PR TITLE
[Discover tests] Extend discover_sidebar_responsive slowest tests timeout

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -667,16 +667,20 @@ describe('discover responsive sidebar', function () {
     EXTENDED_TIMEOUT
   );
 
-  it('should not render Add/Edit field buttons in viewer mode', async () => {
-    const services = createMockServices();
-    services.dataViewFieldEditor.userPermissions.editIndexPattern = jest.fn(() => false);
-    const { user } = await renderComponent(props, {}, services);
-    expect(screen.queryAllByTestId('dataView-add-field_btn')).toHaveLength(0);
-    const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
-    await user.click(within(availableFields).getByTestId('field-bytes'));
-    expect(screen.queryByTestId('discoverFieldListPanelEdit-bytes')).not.toBeInTheDocument();
-    expect(services.dataViewEditor.userPermissions.editDataView).toHaveBeenCalled();
-  });
+  it(
+    'should not render Add/Edit field buttons in viewer mode',
+    async () => {
+      const services = createMockServices();
+      services.dataViewFieldEditor.userPermissions.editIndexPattern = jest.fn(() => false);
+      const { user } = await renderComponent(props, {}, services);
+      expect(screen.queryAllByTestId('dataView-add-field_btn')).toHaveLength(0);
+      const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
+      await user.click(within(availableFields).getByTestId('field-bytes'));
+      expect(screen.queryByTestId('discoverFieldListPanelEdit-bytes')).not.toBeInTheDocument();
+      expect(services.dataViewEditor.userPermissions.editDataView).toHaveBeenCalled();
+    },
+    EXTENDED_TIMEOUT
+  );
 
   it(
     'should render buttons in data view picker correctly',

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -34,6 +34,9 @@ import type { UnifiedFieldListRestorableState } from '@kbn/unified-field-list';
 import { internalStateActions } from '../../state_management/redux';
 import { nextTick } from '@kbn/test-jest-helpers';
 
+// There are some flaky tests in this file because they render a big DOM tree, which can take some time to run the tests.
+const EXTENDED_TIMEOUT = 10_000;
+
 type TestWrapperProps = DiscoverSidebarResponsiveProps & { selectedDataView: DataView };
 
 const mockSearchBarCustomization: SearchBarCustomization = {
@@ -255,8 +258,7 @@ async function renderComponent(
   };
 }
 
-// Failing: See https://github.com/elastic/kibana/issues/225126
-describe.skip('discover responsive sidebar', function () {
+describe('discover responsive sidebar', function () {
   let props: TestWrapperProps;
 
   beforeEach(async () => {
@@ -400,16 +402,20 @@ describe.skip('discover responsive sidebar', function () {
     expect(ExistingFieldsServiceApi.loadFieldExisting).not.toHaveBeenCalled();
   });
 
-  it('should allow adding breakdown field', async function () {
-    const { user } = await renderComponent(props);
-    const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
-    await user.click(within(availableFields).getByTestId('field-extension-showDetails'));
-    const addBreakdownButton = await screen.findByTestId(
-      'fieldPopoverHeader_addBreakdownField-extension'
-    );
-    await user.click(addBreakdownButton);
-    expect(props.onAddBreakdownField).toHaveBeenCalled();
-  });
+  it(
+    'should allow adding breakdown field',
+    async function () {
+      const { user } = await renderComponent(props);
+      const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
+      await user.click(within(availableFields).getByTestId('field-extension-showDetails'));
+      const addBreakdownButton = await screen.findByTestId(
+        'fieldPopoverHeader_addBreakdownField-extension'
+      );
+      await user.click(addBreakdownButton);
+      expect(props.onAddBreakdownField).toHaveBeenCalled();
+    },
+    EXTENDED_TIMEOUT
+  );
   it('should allow selecting fields', async function () {
     const { user } = await renderComponent(props);
     const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
@@ -422,20 +428,28 @@ describe.skip('discover responsive sidebar', function () {
     await user.click(within(selectedFields).getByTestId('fieldToggle-extension'));
     expect(props.onRemoveField).toHaveBeenCalledWith('extension');
   });
-  it('should allow adding filters', async function () {
-    const { user } = await renderComponent(props);
-    const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
-    await user.click(within(availableFields).getByTestId('field-extension-showDetails'));
-    await user.click(await screen.findByTestId('plus-extension-gif'));
-    expect(props.onAddFilter).toHaveBeenCalled();
-  });
-  it('should allow adding "exist" filter', async function () {
-    const { user } = await renderComponent(props);
-    const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
-    await user.click(within(availableFields).getByTestId('field-extension-showDetails'));
-    await user.click(await screen.findByTestId('discoverFieldListPanelAddExistFilter-extension'));
-    expect(props.onAddFilter).toHaveBeenCalledWith('_exists_', 'extension', '+');
-  });
+  it(
+    'should allow adding filters',
+    async function () {
+      const { user } = await renderComponent(props);
+      const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
+      await user.click(within(availableFields).getByTestId('field-extension-showDetails'));
+      await user.click(await screen.findByTestId('plus-extension-gif'));
+      expect(props.onAddFilter).toHaveBeenCalled();
+    },
+    EXTENDED_TIMEOUT
+  );
+  it(
+    'should allow adding "exist" filter',
+    async function () {
+      const { user } = await renderComponent(props);
+      const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
+      await user.click(within(availableFields).getByTestId('field-extension-showDetails'));
+      await user.click(await screen.findByTestId('discoverFieldListPanelAddExistFilter-extension'));
+      expect(props.onAddFilter).toHaveBeenCalledWith('_exists_', 'extension', '+');
+    },
+    EXTENDED_TIMEOUT
+  );
 
   it('should allow searching by string, and calcFieldCount should just be executed once', async function () {
     const { user } = await renderComponent(props);
@@ -456,24 +470,28 @@ describe.skip('discover responsive sidebar', function () {
     expect(mockCalcFieldCounts.mock.calls.length).toBe(1);
   });
 
-  it('should allow filtering by field type', async function () {
-    const { user } = await renderComponent(props);
+  it(
+    'should allow filtering by field type',
+    async function () {
+      const { user } = await renderComponent(props);
 
-    expect(screen.getByTestId('fieldListGroupedAvailableFields-count')).toHaveTextContent('3');
-    expect(screen.getByTestId('fieldListGrouped__ariaDescription')).toHaveTextContent(
-      '1 selected field. 4 popular fields. 3 available fields. 20 empty fields. 2 meta fields.'
-    );
+      expect(screen.getByTestId('fieldListGroupedAvailableFields-count')).toHaveTextContent('3');
+      expect(screen.getByTestId('fieldListGrouped__ariaDescription')).toHaveTextContent(
+        '1 selected field. 4 popular fields. 3 available fields. 20 empty fields. 2 meta fields.'
+      );
 
-    await user.click(screen.getByTestId('fieldListFiltersFieldTypeFilterToggle'));
-    await user.click(await screen.findByTestId('typeFilter-number'));
+      await user.click(screen.getByTestId('fieldListFiltersFieldTypeFilterToggle'));
+      await user.click(await screen.findByTestId('typeFilter-number'));
 
-    expect(screen.getByTestId('fieldListGroupedAvailableFields-count')).toHaveTextContent('2');
-    expect(screen.getByTestId('fieldListGrouped__ariaDescription')).toHaveTextContent(
-      '1 popular field. 2 available fields. 1 empty field. 0 meta fields.'
-    );
+      expect(screen.getByTestId('fieldListGroupedAvailableFields-count')).toHaveTextContent('2');
+      expect(screen.getByTestId('fieldListGrouped__ariaDescription')).toHaveTextContent(
+        '1 popular field. 2 available fields. 1 empty field. 0 meta fields.'
+      );
 
-    expect(mockCalcFieldCounts.mock.calls.length).toBe(1);
-  });
+      expect(mockCalcFieldCounts.mock.calls.length).toBe(1);
+    },
+    EXTENDED_TIMEOUT
+  );
 
   it('should restore sidebar state after switching tabs', async function () {
     await renderComponent(props, {
@@ -635,15 +653,19 @@ describe.skip('discover responsive sidebar', function () {
     expect(services.dataViewFieldEditor.openEditor).toHaveBeenCalledTimes(1);
   });
 
-  it('should render "Edit field" button', async () => {
-    const services = createMockServices();
-    const { user } = await renderComponent(props, {}, services);
-    const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
-    await user.click(within(availableFields).getByTestId('field-bytes'));
-    const editFieldButton = await screen.findByTestId('discoverFieldListPanelEdit-bytes');
-    await user.click(editFieldButton);
-    expect(services.dataViewFieldEditor.openEditor).toHaveBeenCalledTimes(1);
-  });
+  it(
+    'should render "Edit field" button',
+    async () => {
+      const services = createMockServices();
+      const { user } = await renderComponent(props, {}, services);
+      const availableFields = screen.getByTestId('fieldListGroupedAvailableFields');
+      await user.click(within(availableFields).getByTestId('field-bytes'));
+      const editFieldButton = await screen.findByTestId('discoverFieldListPanelEdit-bytes');
+      await user.click(editFieldButton);
+      expect(services.dataViewFieldEditor.openEditor).toHaveBeenCalledTimes(1);
+    },
+    EXTENDED_TIMEOUT
+  );
 
   it('should not render Add/Edit field buttons in viewer mode', async () => {
     const services = createMockServices();
@@ -656,96 +678,110 @@ describe.skip('discover responsive sidebar', function () {
     expect(services.dataViewEditor.userPermissions.editDataView).toHaveBeenCalled();
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/217005
-  it.skip('should render buttons in data view picker correctly', async () => {
-    const services = createMockServices();
-    const propsWithPicker: TestWrapperProps = {
-      ...props,
-      fieldListVariant: 'button-and-flyout-always',
-      documents$: new BehaviorSubject({
-        fetchStatus: FetchStatus.UNINITIALIZED,
-      }) as DataDocuments$,
-    };
-    const { user } = await renderComponent(propsWithPicker, {}, services);
-    // open flyout
-    await user.click(screen.getByTestId('discover-sidebar-fields-button'));
+  it(
+    'should render buttons in data view picker correctly',
+    async () => {
+      const services = createMockServices();
+      const propsWithPicker: TestWrapperProps = {
+        ...props,
+        fieldListVariant: 'button-and-flyout-always',
+        documents$: new BehaviorSubject({
+          fetchStatus: FetchStatus.UNINITIALIZED,
+        }) as DataDocuments$,
+      };
+      const { user } = await renderComponent(propsWithPicker, {}, services);
+      // open flyout
+      await user.click(screen.getByTestId('discover-sidebar-fields-button'));
 
-    // open data view picker
-    await user.click(await screen.findByTestId('dataView-switch-link'));
-    expect(await screen.findByTestId('changeDataViewPopover')).toBeInTheDocument();
+      // open data view picker
+      await user.click(await screen.findByTestId('dataView-switch-link'));
+      expect(await screen.findByTestId('changeDataViewPopover')).toBeInTheDocument();
 
-    // check "Add a field"
-    expect(screen.getAllByTestId('indexPattern-add-field')).toHaveLength(1);
+      // check "Add a field"
+      expect(screen.getAllByTestId('indexPattern-add-field')).toHaveLength(1);
 
-    // click "Create a data view"
-    const createDataViewButton = screen.getByTestId('dataview-create-new');
-    await user.click(createDataViewButton);
-    expect(services.dataViewEditor.openEditor).toHaveBeenCalled();
-  }, 5000);
+      // click "Create a data view"
+      const createDataViewButton = screen.getByTestId('dataview-create-new');
+      await user.click(createDataViewButton);
+      expect(services.dataViewEditor.openEditor).toHaveBeenCalled();
+    },
+    EXTENDED_TIMEOUT
+  );
 
-  // FLAKY: https://github.com/elastic/kibana/issues/254625
-  it.skip('should not render buttons in data view picker when in viewer mode', async () => {
-    const services = createMockServices();
-    services.dataViewEditor.userPermissions.editDataView = jest.fn(() => false);
-    services.dataViewFieldEditor.userPermissions.editIndexPattern = jest.fn(() => false);
-    const propsWithPicker: TestWrapperProps = {
-      ...props,
-      fieldListVariant: 'button-and-flyout-always',
-      documents$: new BehaviorSubject({
-        fetchStatus: FetchStatus.UNINITIALIZED,
-      }) as DataDocuments$,
-    };
-    const { user } = await renderComponent(propsWithPicker, {}, services);
-    // open flyout
-    await user.click(screen.getByTestId('discover-sidebar-fields-button'));
+  it(
+    'should not render buttons in data view picker when in viewer mode',
+    async () => {
+      const services = createMockServices();
+      services.dataViewEditor.userPermissions.editDataView = jest.fn(() => false);
+      services.dataViewFieldEditor.userPermissions.editIndexPattern = jest.fn(() => false);
+      const propsWithPicker: TestWrapperProps = {
+        ...props,
+        fieldListVariant: 'button-and-flyout-always',
+        documents$: new BehaviorSubject({
+          fetchStatus: FetchStatus.UNINITIALIZED,
+        }) as DataDocuments$,
+      };
+      const { user } = await renderComponent(propsWithPicker, {}, services);
+      // open flyout
+      await user.click(screen.getByTestId('discover-sidebar-fields-button'));
 
-    // open data view picker
-    await user.click(await screen.findByTestId('dataView-switch-link'));
-    expect(await screen.findByTestId('changeDataViewPopover')).toBeInTheDocument();
+      // open data view picker
+      await user.click(await screen.findByTestId('dataView-switch-link'));
+      expect(await screen.findByTestId('changeDataViewPopover')).toBeInTheDocument();
 
-    // check that buttons are not present
-    expect(screen.queryAllByTestId('dataView-add-field')).toHaveLength(0);
-    expect(screen.queryAllByTestId('dataview-create-new')).toHaveLength(0);
-  });
+      // check that buttons are not present
+      expect(screen.queryAllByTestId('dataView-add-field')).toHaveLength(0);
+      expect(screen.queryAllByTestId('dataview-create-new')).toHaveLength(0);
+    },
+    EXTENDED_TIMEOUT
+  );
 
   describe('search bar customization', () => {
-    it('should not render CustomDataViewPicker', async () => {
-      mockUseCustomizations = false;
-      const { user } = await renderComponent(
-        {
-          ...props,
-          fieldListVariant: 'button-and-flyout-always',
-          documents$: new BehaviorSubject({
-            fetchStatus: FetchStatus.UNINITIALIZED,
-          }) as DataDocuments$,
-        },
-        {},
-        undefined
-      );
+    it(
+      'should not render CustomDataViewPicker',
+      async () => {
+        mockUseCustomizations = false;
+        const { user } = await renderComponent(
+          {
+            ...props,
+            fieldListVariant: 'button-and-flyout-always',
+            documents$: new BehaviorSubject({
+              fetchStatus: FetchStatus.UNINITIALIZED,
+            }) as DataDocuments$,
+          },
+          {},
+          undefined
+        );
 
-      await user.click(screen.getByTestId('discover-sidebar-fields-button'));
+        await user.click(screen.getByTestId('discover-sidebar-fields-button'));
 
-      expect(screen.queryByTestId('custom-data-view-picker')).not.toBeInTheDocument();
-    });
+        expect(screen.queryByTestId('custom-data-view-picker')).not.toBeInTheDocument();
+      },
+      EXTENDED_TIMEOUT
+    );
 
-    it('should render CustomDataViewPicker', async () => {
-      mockUseCustomizations = true;
-      const { user } = await renderComponent(
-        {
-          ...props,
-          fieldListVariant: 'button-and-flyout-always',
-          documents$: new BehaviorSubject({
-            fetchStatus: FetchStatus.UNINITIALIZED,
-          }) as DataDocuments$,
-        },
-        {},
-        undefined
-      );
+    it(
+      'should render CustomDataViewPicker',
+      async () => {
+        mockUseCustomizations = true;
+        const { user } = await renderComponent(
+          {
+            ...props,
+            fieldListVariant: 'button-and-flyout-always',
+            documents$: new BehaviorSubject({
+              fetchStatus: FetchStatus.UNINITIALIZED,
+            }) as DataDocuments$,
+          },
+          {},
+          undefined
+        );
 
-      await user.click(screen.getByTestId('discover-sidebar-fields-button'));
+        await user.click(screen.getByTestId('discover-sidebar-fields-button'));
 
-      expect(await screen.findByTestId('custom-data-view-picker')).toBeInTheDocument();
-    });
+        expect(await screen.findByTestId('custom-data-view-picker')).toBeInTheDocument();
+      },
+      EXTENDED_TIMEOUT
+    );
 
     it('should allow to toggle sidebar', async function () {
       const { user } = await renderComponent(props);
@@ -788,24 +824,28 @@ describe.skip('discover responsive sidebar', function () {
       expect(mockAccessorFn).toHaveBeenCalled();
     });
 
-    it('should use fallback function when profile accessor returns fallback', async () => {
-      mockGetRecommendedFieldsAccessor.mockImplementation((fallback) => {
-        expect(typeof fallback).toBe('function');
-        return fallback;
-      });
+    it(
+      'should use fallback function when profile accessor returns fallback',
+      async () => {
+        mockGetRecommendedFieldsAccessor.mockImplementation((fallback) => {
+          expect(typeof fallback).toBe('function');
+          return fallback;
+        });
 
-      await renderComponent({
-        ...props,
-        documents$: new BehaviorSubject({
-          fetchStatus: FetchStatus.UNINITIALIZED,
-        }) as DataDocuments$,
-      });
+        await renderComponent({
+          ...props,
+          documents$: new BehaviorSubject({
+            fetchStatus: FetchStatus.UNINITIALIZED,
+          }) as DataDocuments$,
+        });
 
-      expect(mockGetRecommendedFieldsAccessor).toHaveBeenCalled();
-      // Verify the fallback function was called with the expected structure
-      const fallbackCall = mockGetRecommendedFieldsAccessor.mock.calls[0];
-      expect(typeof fallbackCall[0]).toBe('function');
-      expect(fallbackCall[0]()).toEqual({ recommendedFields: [] });
-    });
+        expect(mockGetRecommendedFieldsAccessor).toHaveBeenCalled();
+        // Verify the fallback function was called with the expected structure
+        const fallbackCall = mockGetRecommendedFieldsAccessor.mock.calls[0];
+        expect(typeof fallbackCall[0]).toBe('function');
+        expect(fallbackCall[0]()).toEqual({ recommendedFields: [] });
+      },
+      EXTENDED_TIMEOUT
+    );
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/217005
Closes https://github.com/elastic/kibana/issues/225126
Closes https://github.com/elastic/kibana/issues/253317
Closes https://github.com/elastic/kibana/issues/254229
Closes https://github.com/elastic/kibana/issues/254625


The tests in [discover_sidebar_responsive.test.tsx](https://github.com/elastic/kibana/blob/07289d3710a34df94e970ebe20a816d0d7876826/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx) are pretty flaky because the DOM tree is pretty big. I'm updating not only the tests that have already failed but the ones that are in the list of the slowest ones to have an increased timeout.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

