### PR TITLE
[Discover tests] Fix flaky chart timespan and initial hits check

### DIFF
--- a/src/platform/test/functional/apps/discover/tabs/_duplication.ts
+++ b/src/platform/test/functional/apps/discover/tabs/_duplication.ts
@@ -80,9 +80,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should restore the previous app and global states', async () => {
-      const initialHitCount = await discover.getHitCount();
+      let initialHitCount: string;
+
+      await retry.try(async () => {
+        initialHitCount = await discover.getHitCount();
+        expect(initialHitCount).to.be('14,004');
+      });
+
       const updatedHitCount = '270';
-      expect(initialHitCount).to.be('14,004');
       await discover.chooseBreakdownField('geo.src');
       await queryBar.setQuery('geo.dest: "US"');
       await discover.waitUntilTabIsLoaded();

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -58,6 +58,13 @@ export class DiscoverPageObject extends FtrService {
   }
 
   public async getChartTimespan() {
+    await this.retry.waitFor('chart timespan to finish loading', async () => {
+      const timespan = await this.testSubjects.getAttribute(
+        'unifiedHistogramChart',
+        'data-time-range'
+      );
+      return !timespan?.includes('Loading');
+    });
     return await this.testSubjects.getAttribute('unifiedHistogramChart', 'data-time-range');
   }
 

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -58,14 +58,15 @@ export class DiscoverPageObject extends FtrService {
   }
 
   public async getChartTimespan() {
+    const getHistogramChartDataTimeRange = async () =>
+      await this.testSubjects.getAttribute('unifiedHistogramChart', 'data-time-range');
+
     await this.retry.waitFor('chart timespan to finish loading', async () => {
-      const timespan = await this.testSubjects.getAttribute(
-        'unifiedHistogramChart',
-        'data-time-range'
-      );
+      const timespan = await getHistogramChartDataTimeRange();
       return !timespan?.includes('Loading');
     });
-    return await this.testSubjects.getAttribute('unifiedHistogramChart', 'data-time-range');
+
+    return await getHistogramChartDataTimeRange();
   }
 
   public async saveSearch(


### PR DESCRIPTION
## Summary

- Adds a retry to the FTR helper `getChartTimespan()` in `src/platform/test/functional/page_objects/discover_page.ts` to wait for `Loading` to disappear. It replicates what the equivalent helper does in Scout (`src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts`).
- Also adds a retry to get `initialHitCount` for tabs tests (`src/platform/test/functional/apps/discover/tabs/_duplication.ts`).

Here's an [example](https://web.buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/0fda5127-f57f-42fb-8e5a-146b3d535916/019c9591-dbf0-4289-95f9-7476a86719d4/019c959c-a813-4136-8171-7cee1561aceb/target/test_failures/019c959c-a813-4136-8171-7cee1561aceb_e6aed5a5e57b21870680914bb7bf0b14.html?jwt=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI2MjM2NzoxMTMwNDciLCJhdWQiOiJ3ZWIuYnVpbGRraXRlYXJ0aWZhY3RzLmNvbSIsInBhdGgiOiJlMGYzOTcwZS0zYTc1LTQ2MjEtOTE5Zi1lNmM3NzNlMmJiMTIvMGZkYTUxMjctZjU3Zi00MmZiLThlNWEtMTQ2YjNkNTM1OTE2LzAxOWM5NTkxLWRiZjAtNDI4OS05NWY5LTc0NzZhODY3MTlkNC8wMTljOTU5Yy1hODEzLTQxMzYtODE3MS03Y2VlMTU2MWFjZWIiLCJpc3MiOiJidWlsZGtpdGUuY29tIiwiZXhwIjoxNzcyMDk4Mzk2LCJpYXQiOjE3NzIwOTc3OTZ9.XZoUN0ZJO-o4xkiVL3bV6ncjaFgkNdDMqtP742J89Pg5Wbgadb68kppacaImnmL1) where the test failed.

<img width="1300" height="861" alt="image" src="https://github.com/user-attachments/assets/7fb98f1b-e46e-4ac3-a733-7fa3a9466194" />
 
### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->