### PR TITLE
[Streams] Flyout guidance

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_dsl_steps_flyout/sections/dsl_steps_flyout_array_view.tsx
@@ -25,7 +25,7 @@ import {
   type DslStepsFlyoutFormInternal,
   type PreservedTimeUnit,
 } from '../form';
-import { getDoubledDurationFromPrevious, toMilliseconds } from '../../shared';
+import { downsamplingHelpText, getDoubledDurationFromPrevious, toMilliseconds } from '../../shared';
 import { TIME_UNIT_OPTIONS } from '../constants';
 import { useStyles } from '../use_styles';
 import { StepPanel } from './step_panel';
@@ -326,6 +326,11 @@ export const DslStepsFlyoutArrayView = ({
                 })}
               </h2>
             </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s" color="subdued">
+              {downsamplingHelpText}
+            </EuiText>
           </EuiFlexItem>
 
           {items.length > 0 && (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/edit_ilm_phases_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/edit_ilm_phases_flyout.tsx
@@ -57,7 +57,7 @@ export const EditIlmPhasesFlyout = ({
 }: EditIlmPhasesFlyoutProps) => {
   const flyoutTitleId = useGeneratedHtmlId({ prefix: 'streamsEditIlmPhasesFlyoutTitle' });
   const dataTestSubj = dataTestSubjProp ?? 'streamsEditIlmPhasesFlyout';
-  const { footerStyles, headerStyles, sectionStyles } = useStyles();
+  const { footerStyles, headerStyles, sectionStyles, phaseDescriptionStyles } = useStyles();
 
   const initialPhasesRef = useRef<IlmPolicyPhases>(initialPhases);
 
@@ -377,6 +377,7 @@ export const EditIlmPhasesFlyout = ({
                 onRefreshSearchableSnapshotRepositories={onRefreshSearchableSnapshotRepositories}
                 onCreateSnapshotRepository={onCreateSnapshotRepository}
                 isMetricsStream={isMetricsStream}
+                phaseDescriptionStyles={phaseDescriptionStyles}
               />
             ))}
           </OnFieldErrorsChangeProvider>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/sections/downsample_field_section.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/sections/downsample_field_section.tsx
@@ -24,7 +24,11 @@ import {
 import type { DownsamplePhase, IlmPhasesFlyoutFormInternal } from '../form';
 import { DOWNSAMPLE_PHASES } from '../form';
 import { DownsampleIntervalField } from '../form';
-import { getDoubledDurationFromPrevious, type PreservedTimeUnit } from '../../shared';
+import {
+  downsamplingHelpText,
+  getDoubledDurationFromPrevious,
+  type PreservedTimeUnit,
+} from '../../shared';
 import { TIME_UNIT_OPTIONS } from '../constants';
 import { useKibana } from '../../../../../../hooks/use_kibana';
 
@@ -91,11 +95,7 @@ export const DownsampleFieldSection = ({
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIconTip
-                content={i18n.translate('xpack.streams.editIlmPhasesFlyout.downsamplingHelp', {
-                  defaultMessage: 'Configure downsampling for this phase.',
-                })}
-              />
+              <EuiIconTip content={downsamplingHelpText} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/sections/phase_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/sections/phase_panel.tsx
@@ -10,8 +10,9 @@ import type { SerializedStyles } from '@emotion/react';
 import type { IlmPolicyPhases, PhaseName } from '@kbn/streams-schema';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { useFormData } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
-import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiText } from '@elastic/eui';
 
+import { useIlmPhasesColorAndDescription } from '../../../hooks/use_ilm_phases_color_and_description';
 import type { IlmPhasesFlyoutFormInternal } from '../form';
 import { DeleteSearchableSnapshotToggleField, MinAgeField, ReadOnlyToggleField } from '../form';
 import { READONLY_ALLOWED_PHASES, TIME_UNIT_OPTIONS } from '../constants';
@@ -34,6 +35,7 @@ export interface PhasePanelProps {
   onRefreshSearchableSnapshotRepositories?: () => void;
   onCreateSnapshotRepository?: () => void;
   isMetricsStream: boolean;
+  phaseDescriptionStyles: SerializedStyles;
 }
 
 export const PhasePanel = ({
@@ -50,8 +52,11 @@ export const PhasePanel = ({
   onRefreshSearchableSnapshotRepositories,
   onCreateSnapshotRepository,
   isMetricsStream,
+  phaseDescriptionStyles,
 }: PhasePanelProps) => {
   const isHidden = selectedPhase !== phase;
+
+  const { ilmPhases } = useIlmPhasesColorAndDescription();
 
   const isHotPhase = phase === 'hot';
   const isWarmPhase = phase === 'warm';
@@ -71,7 +76,9 @@ export const PhasePanel = ({
   return (
     <div hidden={isHidden} data-test-subj={`${dataTestSubj}Panel-${phase}`}>
       <PhaseFieldsMount phase={phase} />
-
+      <EuiText size="s" color="subdued" css={phaseDescriptionStyles}>
+        {ilmPhases[phase].description}
+      </EuiText>
       {(!isHotPhase || !isDownsampleEnabled) && (
         <EuiFlexGroup direction="column" gutterSize="m" responsive={false} css={sectionStyles}>
           {!isHotPhase && (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/use_styles.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/edit_ilm_phases_flyout/use_styles.ts
@@ -31,6 +31,16 @@ export const useStyles = () => {
       }
     `;
 
-    return { sectionStyles, headerStyles, footerStyles, tabsErrorSelectedUnderlineStyles };
+    const phaseDescriptionStyles = css`
+      padding: ${euiTheme.size.m} ${euiTheme.size.l} 0 ${euiTheme.size.l};
+    `;
+
+    return {
+      sectionStyles,
+      headerStyles,
+      footerStyles,
+      tabsErrorSelectedUnderlineStyles,
+      phaseDescriptionStyles,
+    };
   }, [euiTheme.colors.danger, euiTheme.size.l, euiTheme.size.m]);
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/shared/i18n.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/shared/i18n.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const downsamplingHelpText = i18n.translate('xpack.streams.downsamplingHelpText', {
+  defaultMessage:
+    'Aggregate time series data into fixed intervals to reduce index size and granularity.',
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/shared/index.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/downsampling/shared/index.ts
@@ -18,3 +18,4 @@ export {
 export { getBoundsHelpTextValues } from './bounds_help_text';
 export { getUnitSelectOptions, isPreservedNonDefaultUnit } from './unit_select_options';
 export type { TimeUnitSelectOption } from './unit_select_options';
+export { downsamplingHelpText } from './i18n';


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/255081

## Summary
Addresses some improvements requested in https://github.com/elastic/kibana/pull/254668#issuecomment-3960844507


1. Change ILM tooltip to `Aggregate time series data into fixed intervals to reduce index size and granularity`

<img width="352" height="228" alt="Screenshot 2026-02-26 at 12 46 46" src="https://github.com/user-attachments/assets/6a2260b1-87f6-4323-8eb6-5311e0de3bfe" />


2. Include the same descriptive text as a subheader to the DLM downsampling flyout.
<img width="375" height="415" alt="Screenshot 2026-02-26 at 12 46 32" src="https://github.com/user-attachments/assets/9ba576e5-3599-436a-a972-e57297913781" />


3. Include phase description under each data phase tab in the configuration flyout.


<img width="380" height="114" alt="Screenshot 2026-02-26 at 12 46 59" src="https://github.com/user-attachments/assets/5daf9afe-17b8-4f29-b02a-20d4b7a18b94" />

<img width="359" height="104" alt="Screenshot 2026-02-26 at 12 46 52" src="https://github.com/user-attachments/assets/31d8a7a5-739b-4262-9ac5-5d04827f9c10" />


### How to test

View and test the component in Storybook:

```bash
yarn storybook streams_app
```
