### PR TITLE
[Agent Skills] Add SDH Investigation Skill

### DIFF
--- a/.agents/skills/sdh-investigation/SKILL.md
+++ b/.agents/skills/sdh-investigation/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: sdh-investigation
+description: Investigate Kibana SDH tickets. Analyzes GitHub issues, artifacts (HAR, logs, diagnostics), and Kibana source code to produce investigation reports that accelerate diagnosis.
+---
+
+# SDH Investigation
+
+Investigates SDH support tickets by cross-referencing GitHub issues, customer artifacts, and Kibana source code. Produces a structured debugging report with evidence-backed diagnosis.
+
+
+## 🎯 Role
+
+You are a **Senior Escalation Engineer** producing an **engineering acceleration artifact**.
+
+**Audience:** Engineers
+
+> **Core principle:** Evidence-only. Diagnosis must be traceable to artifacts, code, or known issues. When evidence is missing, say so and write the report — don't fill the gap with reasoning.
+
+---
+
+## Tool Strategy
+
+| Context | Tools | Why |
+|---------|-------|-----|
+| **Artifacts** (downloaded logs, HAR, JSON) | `rg`, `jq`, `grep` in terminal | Files on disk, not in codebase |
+| **Code** (Kibana source) | **SemanticSearch** to understand, **Grep/Read** only to confirm or quote | Avoids `grep`→`read`→`grep` spirals |
+
+These are different tools for different jobs. Don't carry terminal grep habits into code search.
+
+## Constraints
+
+❌ Never write code, suggest implementations, or workarounds
+❌ Never open PRs or comment on issues
+✅ One hypothesis at a time — search for evidence, confirm or mark "Plausible", move to the next step
+✅ "Plausible" and "Insufficient" are valid final results — do NOT keep searching to upgrade them. Note what's missing in Next Steps and write the report
+✅ When you identify missing evidence, stop searching and write the report. The report captures what you found, not what you wish you'd found
+✅ Quote evidence with source (file:line, issue URL, PR number)
+✅ Redact customer PII before writing any file (see [PII Redaction](#pii-redaction))
+
+## Extract Parameters
+
+From the issue URL `https://github.com/{owner}/{repo}/issues/{number}`, extract:
+- **REPO** → `{owner}/{repo}` (e.g., `elastic/sdh-kibana`)
+- **ISSUE** → the number (e.g., `6052`)
+- **ARTIFACTS_DIR** → `.cursor/sdh/ISSUE/` (relative to workspace root)
+
+
+## Prerequisites
+
+- **`jq`** — Required for HAR and JSON artifact analysis (`brew install jq`)
+- **`rg`** (ripgrep) — Used for searching downloaded artifacts (logs, diagnostics). If unavailable, substitute `grep` directly — flags like `-i`, `-c`, `-A`, `-B` work the same. (`brew install ripgrep`)
+
+---
+
+## Confidence Levels
+
+Each gate requires a confidence assessment. These are the levels — learn them before starting:
+
+| Level | Meaning | Example |
+|-------|---------|---------|
+| **Proven** | An engineer, a PR, or an issue confirms it | "Engineer confirmed bug, PR #1234 fixes it" |
+| **Strongly supported** | Evidence aligns across artifacts, code, or history | "HAR shows 500 on /api/foo, code throws on null input" |
+| **Plausible** | Hypothesis only — code suggests cause but nothing confirms | "Likely a race condition in the fetch handler" |
+| **Insufficient** | Can't diagnose — issue lacks information | "No artifacts, no error message, no repro steps" |
+
+**Confidence carries forward.** Each gate inherits the confidence from the previous gate. Later gates can only upgrade confidence (e.g. Plausible → Strongly supported), never downgrade it.
+
+## Flow
+
+**Do NOT skip steps. Complete each before proceeding. Do NOT run Steps 3 and 4 in parallel — finish Step 3's gate before starting Step 4.**
+
+### Step 0: Setup & Prior Context
+
+Ensure `.cursor/sdh/` is gitignored. Check for a prior report — if one exists, build upon it, don't restart. See [commands.md](./references/commands.md) for setup commands.
+
+### Step 1: Gather Info from GitHub Issue
+
+Read the issue filtering out bot comments (see [commands.md](./references/commands.md)). **Start from the last human comment** — that's the current state.
+
+Extract:
+- **Version**, **Symptoms**, **Labels** (`pending_on_support` vs `pending_on_dev`)
+- **Questions**: Track unanswered questions from anyone in the thread
+
+Download artifacts from `upload.elastic.co` URLs to `.cursor/sdh/ISSUE/` — skip files already downloaded. Extract archives.
+
+**Bailout conditions** (stop and explain why):
+- Issue is closed or resolved
+- Prior report exists AND no new comments since it was generated
+- No artifacts, no error messages, and no reproduction steps — set confidence to "Insufficient", generate a short report requesting the missing info
+
+**Gate — write this out literally:**
+> GATE 1: [one-sentence confidence]. → Step [2 or 5].
+
+Proven → Step 5 (your report organizes findings, it doesn't re-discover them). Otherwise → Step 2.
+
+### Step 2: Analyze Artifacts
+
+List artifacts with sizes (see [commands.md](./references/commands.md)). **Sniff file format** — some `.log`/`.txt` files are actually JSON (`head -c 1` — if `{` or `[`, use `jq`).
+
+**Start narrow, drill down.** For every artifact:
+1. Get a **summary** first (counts, status codes, error types)
+2. Identify the **high-signal items** (failures, errors, anomalies)
+3. Drill into **specific items** only when needed
+
+Do not skip any artifact. See [artifact-analysis.md](./references/artifact-analysis.md) for per-format querying patterns.
+
+### Step 3: Historical Analysis & Similar Issues
+
+**Deliverable:** A short list of related issues/PRs (possibly empty). Nothing more.
+
+Search GitHub for known issues, related SDHs and fix PRs from the **last 12 months**. Do NOT read PR diffs or issue artifacts — just collect titles, URLs, labels, versions and affected files. Deep reading is Step 4 work.
+
+Search angles (try in order, stop as soon as one hits):
+1. **Prior SDH cases** — search the SDH repo for the same symptom
+2. **Component or endpoint** — feature names, plugin names, endpoint paths
+3. **Fix PRs** — search `elastic/kibana` for PRs that fix the component
+4. **Regressions** — only if the issue appeared after an upgrade
+
+**A hit** = any issue or PR whose title or description mentions the same endpoint, error message, or component. When you get a hit, note it and go to the gate. You do not need to verify it solves the problem — that's Step 4.
+
+An empty list is a valid result. Do not rephrase the same query hoping for different results.
+
+**Gate — write this out literally:**
+> GATE 3: [one-sentence confidence]. Found: [list of issue/PR numbers, or "none"]. → Step [4 or 5].
+
+Proven/Strongly supported → Step 5. Otherwise → Step 4.
+
+### Step 4: Code Search
+
+**Deliverable:** The file path and function where the issue lives, plus a few quoted lines for the report. That's it — you're locating, not explaining.
+
+1. **SemanticSearch** to discover (1–2 queries from different angles: endpoint, error, component)
+2. **SemanticSearch** to follow up if needed (narrow `target_directories` to the area found above)
+3. **Read** to quote specific lines for the report (small ranges only)
+4. **Grep** only to confirm a symbol exists (not to explore)
+
+**You're done when you can name the file and function.** You don't need to understand the full call chain, trace every import, or read adjacent utility functions. If you found the handler that produces the error, that's enough.
+
+> Quote `file:lines` for any code referenced in the report.
+
+**Gate — write this out literally:**
+> GATE 4: [one-sentence confidence]. Key file: [path:function]. → Step 5.
+
+### Step 5: Verify & Generate Report
+
+**Pre-report checklist:**
+- [ ] Claims you include have a quote from logs, JSON, or code
+- [ ] Cause → Effect chain is logical
+- [ ] Timestamps support the causality
+- [ ] Unproven claims moved to Next Steps as hypotheses
+- [ ] Unanswered questions listed in Next Steps
+- [ ] Customer PII redacted (see [PII Redaction](#pii-redaction))
+
+**Report structure** (full template in [report-template.md](./references/report-template.md)):
+
+Summary → Discussion (timeline) → Artifact Analysis → Code Analysis → Similar Issues → Related PRs → Conclusion (diagnosis, confidence, evidence summary, next steps)
+
+Archive any prior report before saving (see [commands.md](./references/commands.md)). Save to `.cursor/sdh/ISSUE/sdh_report_ISSUE.md`.
+
+---
+
+## PII Redaction
+
+Redact all PII before writing the report. Replace **entire values** — no partial redaction. See the detailed checklist in [report-template.md](./references/report-template.md).

--- a/.agents/skills/sdh-investigation/references/artifact-analysis.md
+++ b/.agents/skills/sdh-investigation/references/artifact-analysis.md
@@ -1,0 +1,253 @@
+# Artifact Analysis Patterns
+
+Querying patterns for common SDH artifact types.
+
+**Approach:** Start narrow, widen only if needed. Get counts and summaries first, then drill into specific items. Never dump an entire file.
+
+**Before choosing a strategy**, sniff the file content — some `.log` or `.txt` files are actually JSON:
+
+```bash
+head -c 1 file.log  # { or [ → treat as JSON, use jq
+```
+
+**Always filter first, never read an entire file.** Artifacts may contain credentials, tokens, and sensitive config — filtering reduces the risk of exposing them. Size determines how aggressively you filter:
+
+| Size     | Approach                                               |
+| -------- | ------------------------------------------------------ |
+| < 1MB    | `rg`/`jq` with targeted queries                        |
+| 1-10MB   | `rg`/`jq` with filters, pipe through `head`            |
+| 10-100MB | Targeted `rg`/`grep` searches only                     |
+| > 100MB  | `find`/`du` to explore, search specific subdirectories |
+
+---
+
+## HAR Files
+
+HAR files capture browser network traffic. They can be large (10-100MB).
+
+### Step 1: Counts (always start here)
+
+Get the shape of the data before reading any content:
+
+```bash
+# How many API calls? What status codes?
+jq -r '[.log.entries[] | select(._resourceType == "fetch" or ._resourceType == "xhr") | .response.status] | group_by(.) | map({status: .[0], count: length}) | sort_by(-.count)' file.har
+
+# How many entries total?
+jq '.log.entries | length' file.har
+```
+
+### Step 2: Failed and slow requests
+
+Focus on anomalies — don't read successful responses:
+
+```bash
+# Failed requests (4xx/5xx) — URLs only, no bodies yet
+jq -r '.log.entries[] | select(._resourceType == "fetch" or ._resourceType == "xhr") | select(.response.status >= 400) | "\(.response.status) \(.request.method) \(.request.url)"' file.har
+
+# Slow requests (>5s) — timing only
+jq -r '.log.entries[] | select(.time > 5000) | "\(.time | round)ms \(.response.status) \(.request.url)"' file.har
+```
+
+### Step 3: Drill into specific entries
+
+Only after identifying which entries matter, read their content — truncated:
+
+```bash
+# Response body for a specific URL (first 500 chars only)
+jq '.log.entries[] | select(.request.url | contains("PATTERN")) | {url: .request.url, status: .response.status, body: (.response.content.text | if . then .[0:500] else null end)}' file.har
+
+# If you need more, increase the truncation or request the full body for one entry
+jq '.log.entries[] | select(.request.url | contains("SPECIFIC_ENDPOINT")) | .response.content.text' file.har | head -100
+```
+
+### Kibana-specific endpoints (high signal)
+
+| Endpoint pattern   | What it contains                                  |
+| ------------------ | ------------------------------------------------- |
+| `_inspect`         | Raw ES query DSL, index patterns, timing          |
+| `internal/bsearch` | Batch search requests/responses, often compressed |
+| `internal/search`  | Single search requests                            |
+| `_msearch`         | Multi-search ES queries                           |
+| `_async_search`    | Async search queries and results                  |
+
+### Interesting queries (highest signal)
+
+```bash
+# Responses with 0 hits (queries that matched nothing)
+jq -r '.log.entries[] | select(.response.content.text != null) | select(.response.content.text | test("\"hits\":\\{\"total\":\\{\"value\":0")) | .request.url' file.har 2>/dev/null
+
+# Shard failures
+jq -r '.log.entries[] | select(.response.content.text != null) | select(.response.content.text | test("shard.*fail|failed_shards")) | .request.url' file.har 2>/dev/null
+```
+
+### ES queries from \_inspect responses
+
+The `_inspect` object exposes the raw Elasticsearch query — critical for query-level debugging:
+
+```bash
+# Extract _inspect data from bsearch responses
+jq -r '.log.entries[] | select(.request.url | contains("bsearch")) | .response.content.text' file.har \
+  | jq -r 'fromjson? | .. | objects | select(has("_inspect")) | ._inspect | {index: (.requestParams.index // .requestParams.path), dsl: .dsl}' 2>/dev/null
+
+# ES query DSL from _inspect endpoints
+jq -r '.log.entries[] | select(.request.url | contains("_inspect")) | .response.content.text' file.har \
+  | jq -r 'fromjson? | .dsl // .inspect.dsl // empty' 2>/dev/null
+```
+
+### Compressed bsearch responses
+
+Kibana's bsearch API often uses `compress=true` (zlib + base64). Decompress:
+
+```bash
+# Check if compression is in use first
+jq -r '.log.entries[] | select(.request.url | contains("compress=true")) | .request.url' file.har | head -3
+
+# Decompress a single response
+jq -r '.log.entries[] | select(.request.url | contains("bsearch")) | .response.content.text' file.har \
+  | head -1 \
+  | base64 -d \
+  | python3 -c "import sys,zlib; sys.stdout.buffer.write(zlib.decompress(sys.stdin.buffer.read()))" \
+  | jq . | head -50
+```
+
+---
+
+## Log Files
+
+Kibana logs, ECK diagnostics, server logs. Use `rg` (ripgrep), fall back to `grep`.
+
+### Step 1: Shape of the data
+
+```bash
+# Time range and size
+wc -l file.log
+head -1 file.log | cut -c1-100
+tail -1 file.log | cut -c1-100
+```
+
+### Step 2: Error counts (deduplicated)
+
+Get unique error patterns before reading individual errors:
+
+```bash
+# Strip timestamps, truncate, count unique patterns — most common first
+rg -i "error" file.log | sed 's/^[0-9T:.,+Z\[\]-]*//' | cut -c1-150 | sort | uniq -c | sort -rn | head -20
+```
+
+This is usually more useful than reading errors chronologically.
+
+### Step 3: Drill into specific errors
+
+Once you know which error pattern matters, get context:
+
+```bash
+# Search with context (5 lines after match), truncate long lines
+rg -A5 "specific error pattern" file.log | cut -c1-300 | head -30
+
+# Stack traces for a specific error
+rg -A10 "specific error" file.log | rg -A10 "at .*\.(ts|js):" | head -30
+```
+
+### Step 4: Time-bounded search (if timestamps are known)
+
+```bash
+rg "2026-01-15T1[0-2]:" file.log | rg -i "error" | cut -c1-300 | head -20
+```
+
+---
+
+## JSON Files
+
+Config dumps, diagnostic output, API responses.
+
+### Step 1: Structure overview
+
+```bash
+# Top-level keys only
+jq 'keys' file.json
+
+# For nested objects, get keys at depth 2
+jq 'to_entries | map({key, value_type: (.value | type), child_keys: (if .value | type == "object" then (.value | keys) else null end)})' file.json
+```
+
+### Step 2: Targeted extraction
+
+```bash
+# Extract specific paths
+jq '.elasticsearch.hosts' file.json
+jq '.kibana.version' file.json
+
+# Search for error objects anywhere in the tree
+jq '.. | objects | select(has("error"))' file.json 2>/dev/null | head -30
+```
+
+### NDJSON (newline-delimited JSON)
+
+```bash
+# Count lines and peek at structure
+wc -l file.ndjson
+head -1 file.ndjson | jq 'keys'
+
+# Search for specific content
+rg "error" file.ndjson | jq . | head -30
+```
+
+---
+
+## YAML Files
+
+YAML is human-readable — use `rg` (or `grep` if unavailable) to search directly, don't convert to JSON.
+
+### Step 1: Identify the file's purpose
+
+```bash
+# First few lines usually reveal the kind/type
+head -5 file.yml
+```
+
+### Step 2: Search for relevant content
+
+Search based on what you learned from the issue — symptoms, component names, config keys:
+
+```bash
+# Search for keywords from the issue (error messages, component names)
+rg -i "SYMPTOM_KEYWORD" file.yml | head -20
+
+# Common high-signal searches
+rg -i "error|warn|fail" file.yml | head -20
+rg "image:|version:" file.yml | head -10
+rg "resources:|limits:|requests:" file.yml | head -10
+```
+
+### Step 3: Read specific sections with context
+
+Once you find a relevant line, grab surrounding context:
+
+```bash
+# Show 5 lines before and after a match to see the full YAML block
+rg -B5 -A5 "PATTERN" file.yml
+```
+
+---
+
+## ECK Diagnostics Bundles
+
+These extract to directories with Kubernetes resources and logs.
+
+```bash
+# Explore structure first
+find .cursor/sdh/ISSUE/eck-diagnostics-*/ -type f | head -30
+
+# Kibana pod logs — error counts
+rg -c -i "error|warn" .cursor/sdh/ISSUE/eck-diagnostics-*/kibana-*/logs/*.log
+
+# Then drill into the noisiest log
+rg -i "error|warn" .cursor/sdh/ISSUE/eck-diagnostics-*/kibana-*/logs/SPECIFIC.log | cut -c1-300 | head -30
+
+# Elasticsearch cluster health — status and key indicators only
+jq '{status, number_of_nodes, active_shards, unassigned_shards, relocating_shards}' .cursor/sdh/ISSUE/eck-diagnostics-*/elasticsearch-*/*cluster-health* 2>/dev/null
+
+# Pod status
+jq '.items[] | {name: .metadata.name, phase: .status.phase, restarts: (.status.containerStatuses[]?.restartCount // 0)}' .cursor/sdh/ISSUE/eck-diagnostics-*/pods.json 2>/dev/null
+```

--- a/.agents/skills/sdh-investigation/references/commands.md
+++ b/.agents/skills/sdh-investigation/references/commands.md
@@ -1,0 +1,88 @@
+# SDH Investigation Commands
+
+Reference commands for each investigation step. Replace `ISSUE`, `REPO`, `TOKEN`, `URL` with actual values.
+
+## Step 0: Setup
+
+```bash
+# Ensure artifacts dir is gitignored
+grep -qxF '.cursor/sdh/' .gitignore 2>/dev/null || echo '.cursor/sdh/' >> .gitignore
+
+# Check for prior report
+ls -la .cursor/sdh/ISSUE/sdh_report_* 2>/dev/null
+```
+
+## Step 1: Read Issue & Download Artifacts
+
+```bash
+# Read issue — filter out bots, get human comments
+gh issue view ISSUE --repo REPO --json title,state,labels,body,comments \
+  | jq '{
+    title: .title,
+    state: .state,
+    labels: [.labels[].name],
+    body: .body,
+    comments: [.comments[] | select(.author.login | test("bot|elasticmachine|kibanamachine") | not) | {author: .author.login, date: .createdAt, body: .body}]
+  }'
+```
+
+```bash
+# Download artifacts
+mkdir -p .cursor/sdh/ISSUE
+cd .cursor/sdh/ISSUE
+```
+
+Artifacts in SDH issues appear in two formats. Parse the issue body and comments, then download each artifact.
+
+**Format A — curl command (run as-is from the artifacts directory):**
+
+```
+curl -L -H 'Authorization: TOKEN' -o 'filename.har' https://upload.elastic.co/d/HASH
+```
+
+**Format B — structured text (construct the curl command):**
+
+```
+File name: example.har
+You can download the file here: https://upload.elastic.co/d/HASH
+Use this Authorization Token: TOKEN
+```
+
+→ `curl -L -H 'Authorization: TOKEN' -o 'example.har' https://upload.elastic.co/d/HASH`
+
+**Rules:**
+- Skip files already present in the artifacts directory
+- Extract archives after downloading:
+
+```bash
+unzip -q -o archive.zip -d extracted_name 2>/dev/null
+tar -xzf archive.tar.gz -C extracted_name 2>/dev/null
+```
+
+## Step 2: List Artifacts
+
+```bash
+find .cursor/sdh/ISSUE/ -type f -exec du -sh {} \; | sort -rh
+```
+
+## Step 3: Search GitHub
+
+```bash
+# Limit searches to the last 12 months
+gh search issues "symptom keywords" --repo REPO --limit 10 --created ">$(date -v-1y +%Y-%m-%d)"
+gh search issues "error message" --repo elastic/kibana --limit 10 --created ">$(date -v-1y +%Y-%m-%d)"
+gh search prs "component-name fix" --repo elastic/kibana --state closed --limit 10 --created ">$(date -v-1y +%Y-%m-%d)"
+```
+
+## Step 4: Code Search
+
+```bash
+# Read PR diff for a specific file
+gh pr diff NUMBER --repo elastic/kibana -- path/to/file.ts
+```
+
+## Step 5: Archive Prior Report
+
+```bash
+mv .cursor/sdh/ISSUE/sdh_report_ISSUE.md .cursor/sdh/ISSUE/sdh_report_ISSUE_$(date +%Y-%m-%d_%H%M).md 2>/dev/null
+```

--- a/.agents/skills/sdh-investigation/references/report-template.md
+++ b/.agents/skills/sdh-investigation/references/report-template.md
@@ -1,0 +1,107 @@
+# SDH Report Template
+
+Use this template when writing the investigation report. Omit empty sections.
+
+**Save to:** `.cursor/sdh/ISSUE/sdh_report_ISSUE.md`
+
+⚠️ **Before saving**: Redact customer PII. Replace the **entire value** with a placeholder — no partial redaction (e.g., `smtp.<redacted>.com` is wrong, `[HOSTNAME]` is correct).
+
+Watch for:
+- **Tokens & keys**: JWTs (`eyJ...`), GitHub (`ghp_*`, `gho_*`), Slack (`xox*-`), AWS (`AKIA...`), Stripe (`sk_live_*`), Bearer/Basic auth headers
+- **Connection strings**: DB URLs (`mongodb://`, `postgres://`), Azure (`DefaultEndpointsProtocol=`), URLs with credentials (`user:pass@`)
+- **Crypto**: private keys (`-----BEGIN`), certificates, Session-ID, Master-Key
+- **PII**: emails, IPv4 addresses, all hostnames/FQDNs, Elastic Cloud URLs
+- **Fields by name**: `password`, `secret`, `api_key`, `token`, `user_id`, `author`, `username`, `created_by`, `license_key`
+- **Infrastructure**: K8s namespaces, node names, container IDs, service names, cluster/deployment IDs
+- **SDH fields**: customer name, case ID, Slack channel links, deployment URLs
+
+---
+
+```markdown
+# Debugging Report: Issue #ISSUE
+
+## Summary
+
+- **Issue:** [REPO #ISSUE](https://github.com/REPO/issues/ISSUE)
+- **Problem:** One-sentence description
+- **Version:** X.Y.Z
+- **Status:** pending_on_dev | pending_on_support | closed
+
+## Discussion
+
+Max 5 bullets showing the most recent key developments. Summarize older history in a single TL;DR line at the top. One line per event — who, what, and outcome.
+
+- **TL;DR:** One-sentence summary of older thread history (if any)
+- **YYYY-MM-DD (@user):** One-sentence summary of what happened or was discovered
+- **YYYY-MM-DD (@user):** Next key development
+
+## Artifact Analysis
+
+### filename (lines X-Y)
+
+```[file extension|content type]
+[quoted evidence from artifact]
+```
+
+Interpretation of what this evidence shows.
+
+## Code Analysis
+
+### filepath (lines X-Y)
+
+```ts
+[quoted code snippet]
+```
+
+Explanation of how this code relates to the reported issue.
+
+## Similar Issues
+
+- [#NUMBER](URL): Why this issue is similar
+- [#NUMBER](URL): Why this issue is similar
+
+## Related PRs
+
+- [PR title](URL): How this PR relates — "fixes", "may address", "similar symptoms"
+
+## Conclusion
+
+**Confidence:** Proven | Strongly supported | Plausible | Insufficient
+
+### Diagnosis
+
+The root cause finding in 1-2 paragraphs. Must be provable with specific evidence quoted above.
+If confidence is "Insufficient": "Insufficient evidence to form hypothesis."
+
+### Fixed In
+
+(Only if a fix exists. Omit "Next Steps" if this section is present.)
+
+PR #NUMBER (version X.Y.Z+)
+
+### Evidence Summary
+
+In 2-3 sentences, explain *how you know* — connect the evidence that supports the diagnosis. Reference findings by section (e.g. "the HAR analysis shows...") but don't re-quote them. Don't re-explain the diagnosis.
+
+### Missing Information
+
+(Required when confidence is "Insufficient")
+
+- What information is missing and why it prevents diagnosis
+- What would increase confidence
+
+### Unanswered Questions
+
+(Include questions from the thread that remain unanswered — from support agents, customers, or engineers.)
+
+- @support_agent asked about X on YYYY-MM-DD — no response yet
+- Customer mentioned Y but didn't clarify Z
+
+### Next Steps
+
+(Omit if "Fixed In" is present. Only information-gathering actions — no fixes.)
+
+- Request Kibana server logs from the time of the error
+- Verify if PR #12345 (8.12.1+) addresses this issue
+- Clarify with customer whether SAML auth is enabled — asked in thread but unanswered
+```


### PR DESCRIPTION
## Summary

> [!NOTE]
>  This work isa collaboration between @kpatticha, @crespocarlos and @rmyz, our teams (@elastic/obs-exploration-team and @elastic/obs-presentation-team) have been using this tool, and it helped a lot during our regular SDH duty rotations. 
> We recommend everyone try it out!

This PR adds an agent skill that accelerates the diagnosis of SDH tickets. 

Given a GitHub issue URL, the skill guides the agent through a structured investigation workflow: gathering issue context, analyzing customer artifacts (HAR files, logs, diagnostics bundles), searching for related issues/PRs, and pinpointing relevant Kibana source code. 

It produces a structured investigation report with evidence-backed diagnosis and confidence levels, helping engineers quickly triage and resolve escalated support cases without manual artifact wrangling.

## Suggestions to use it
- [Semantic Code Search MCP](https://github.com/elastic/semantic-code-search-mcp-server), Cursor has SemanticSearch built in, but for SDH investigation Semantic Code Search MCP will give better results.
- [Github MCP](https://github.com/github/github-mcp-server) or gh cli.

## Demo

Short demo just to highlight the functionality, we don't want to expose customer information

https://github.com/user-attachments/assets/196a4b29-83ce-4397-9597-fbdcaa6ab532
