### PR TITLE
Update alerting-v2 owner to new rna project team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1880,7 +1880,7 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 
 
 # Alerting alerting_v2
-/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2 @elastic/response-ops
+/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2 @elastic/rna-project-team
 
 ### END Observability Plugins
 

--- a/x-pack/platform/plugins/shared/alerting_v2/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/alerting_v2/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/alerting-v2-plugin",
-  "owner": ["@elastic/response-ops"],
+  "owner": ["@elastic/rna-project-team"],
   "group": "platform",
   "visibility": "shared",
   "plugin": {


### PR DESCRIPTION
While we are working as a unified, collaborative team for RnA, we should share ownership, review approvals, etc. across the team, with all of the standard caveats around making sure the right people are looped in that we would always have even within a single team.
