### PR TITLE
[Fleet] Implement missing filters setup methods|signals in new browse integration UX

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.test.tsx
@@ -58,12 +58,12 @@ describe('SearchAndFiltersBar', () => {
         status: ['deprecated'],
       });
 
-      const { getByTestId, container } = renderSearchAndFiltersBar();
+      const { getByTestId } = renderSearchAndFiltersBar();
       const button = getByTestId('browseIntegrations.searchBar.statusBtn');
 
       expect(button).toHaveClass('euiFilterButton-hasActiveFilters');
 
-      const badge = container.querySelector('.euiNotificationBadge');
+      const badge = button.querySelector('.euiNotificationBadge');
       expect(badge).toBeInTheDocument();
       expect(badge).toHaveTextContent('1');
     });
@@ -153,7 +153,7 @@ describe('SearchAndFiltersBar', () => {
         status: ['deprecated'],
       });
 
-      const { getByTestId, container } = renderSearchAndFiltersBar();
+      const { getByTestId } = renderSearchAndFiltersBar();
 
       // Search should show query
       const searchInput = getByTestId('browseIntegrations.searchBar.input') as HTMLInputElement;
@@ -162,7 +162,7 @@ describe('SearchAndFiltersBar', () => {
       // Status filter should show count
       const statusButton = getByTestId('browseIntegrations.searchBar.statusBtn');
       expect(statusButton).toHaveClass('euiFilterButton-hasActiveFilters');
-      const badge = container.querySelector('.euiNotificationBadge');
+      const badge = statusButton.querySelector('.euiNotificationBadge');
       expect(badge).toBeInTheDocument();
       expect(badge).toHaveTextContent('1');
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
@@ -30,13 +30,8 @@ import type {
   SetupMethodFilterType,
   SignalFilterType,
 } from '../types';
-import {
-  SETUP_METHOD_AGENTLESS,
-  SETUP_METHOD_ELASTIC_AGENT,
-  SETUP_METHOD_BEATS,
-  SIGNAL_LOGS,
-  SIGNAL_METRICS,
-} from '../types';
+import { SETUP_METHOD_AGENTLESS, SETUP_METHOD_ELASTIC_AGENT, SETUP_METHOD_BEATS } from '../types';
+import { dataTypes } from '../../../../../../../../common/constants';
 import { StatusFilter } from '../../../components/status_filter';
 
 const SEARCH_DEBOUNCE_MS = 150;
@@ -261,8 +256,8 @@ const SignalFilter: React.FC<{
           'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.signalLogsOption',
           { defaultMessage: 'Logs' }
         ),
-        key: SIGNAL_LOGS,
-        checked: selectedSignals.includes(SIGNAL_LOGS) ? 'on' : undefined,
+        key: dataTypes.Logs,
+        checked: selectedSignals.includes(dataTypes.Logs) ? 'on' : undefined,
         'data-test-subj': 'browseIntegrations.searchBar.signalLogsOption',
       },
       {
@@ -270,9 +265,18 @@ const SignalFilter: React.FC<{
           'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.signalMetricsOption',
           { defaultMessage: 'Metrics' }
         ),
-        key: SIGNAL_METRICS,
-        checked: selectedSignals.includes(SIGNAL_METRICS) ? 'on' : undefined,
+        key: dataTypes.Metrics,
+        checked: selectedSignals.includes(dataTypes.Metrics) ? 'on' : undefined,
         'data-test-subj': 'browseIntegrations.searchBar.signalMetricsOption',
+      },
+      {
+        label: i18n.translate(
+          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.signalTracesOption',
+          { defaultMessage: 'Traces' }
+        ),
+        key: dataTypes.Traces,
+        checked: selectedSignals.includes(dataTypes.Traces) ? 'on' : undefined,
+        'data-test-subj': 'browseIntegrations.searchBar.signalTracesOption',
       },
     ],
     [selectedSignals]

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
@@ -21,8 +21,22 @@ import styled from '@emotion/styled';
 import { FormattedMessage } from '@kbn/i18n-react';
 import useDebounce from 'react-use/lib/useDebounce';
 
+import type { EuiSelectableOption } from '@elastic/eui';
+
 import { useUrlFilters, useAddUrlFilters } from '../hooks/url_filters';
-import type { BrowseIntegrationSortType, IntegrationStatusFilterType } from '../types';
+import type {
+  BrowseIntegrationSortType,
+  IntegrationStatusFilterType,
+  SetupMethodFilterType,
+  SignalFilterType,
+} from '../types';
+import {
+  SETUP_METHOD_AGENTLESS,
+  SETUP_METHOD_ELASTIC_AGENT,
+  SETUP_METHOD_BEATS,
+  SIGNAL_LOGS,
+  SIGNAL_METRICS,
+} from '../types';
 import { StatusFilter } from '../../../components/status_filter';
 
 const SEARCH_DEBOUNCE_MS = 150;
@@ -136,6 +150,189 @@ const SortFilter: React.FC = () => {
   );
 };
 
+const SetupMethodFilter: React.FC<{
+  selectedMethods?: SetupMethodFilterType[];
+  onChange: (methods: SetupMethodFilterType[]) => void;
+}> = ({ selectedMethods = [], onChange }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const togglePopover = useCallback(() => setIsOpen((prevIsOpen) => !prevIsOpen), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
+
+  const options: EuiSelectableOption[] = useMemo(
+    () => [
+      {
+        label: i18n.translate(
+          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.setupMethodAgentlessOption',
+          { defaultMessage: 'Agentless' }
+        ),
+        key: SETUP_METHOD_AGENTLESS,
+        checked: selectedMethods.includes(SETUP_METHOD_AGENTLESS) ? 'on' : undefined,
+        'data-test-subj': 'browseIntegrations.searchBar.setupMethodAgentlessOption',
+      },
+      {
+        label: i18n.translate(
+          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.setupMethodElasticAgentOption',
+          { defaultMessage: 'Elastic Agent' }
+        ),
+        key: SETUP_METHOD_ELASTIC_AGENT,
+        checked: selectedMethods.includes(SETUP_METHOD_ELASTIC_AGENT) ? 'on' : undefined,
+        'data-test-subj': 'browseIntegrations.searchBar.setupMethodElasticAgentOption',
+      },
+      {
+        label: i18n.translate(
+          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.setupMethodBeatsOption',
+          { defaultMessage: 'Beats' }
+        ),
+        key: SETUP_METHOD_BEATS,
+        checked: selectedMethods.includes(SETUP_METHOD_BEATS) ? 'on' : undefined,
+        'data-test-subj': 'browseIntegrations.searchBar.setupMethodBeatsOption',
+      },
+    ],
+    [selectedMethods]
+  );
+
+  const activeCount = selectedMethods.length;
+
+  const onSelectionChange = useCallback(
+    (newOptions: EuiSelectableOption[]) => {
+      const newMethods: SetupMethodFilterType[] = [];
+      newOptions.forEach((option) => {
+        if (option.checked === 'on' && option.key) {
+          newMethods.push(option.key as SetupMethodFilterType);
+        }
+      });
+      onChange(newMethods);
+    },
+    [onChange]
+  );
+
+  return (
+    <EuiPopover
+      id="browseIntegrationsSetupMethodPopover"
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      button={
+        <EuiFilterButton
+          data-test-subj="browseIntegrations.searchBar.setupMethodBtn"
+          iconType="arrowDown"
+          onClick={togglePopover}
+          isSelected={isOpen}
+          numFilters={activeCount}
+          hasActiveFilters={activeCount > 0}
+          numActiveFilters={activeCount}
+        >
+          <FormattedMessage
+            id="xpack.fleet.epm.browseIntegrations.searchAndFilterBar.setupMethodLabel"
+            defaultMessage="Setup method"
+          />
+        </EuiFilterButton>
+      }
+    >
+      <EuiSelectable
+        data-test-subj="browseIntegrations.searchBar.setupMethodSelectableList"
+        searchable={false}
+        options={options}
+        onChange={onSelectionChange}
+        listProps={{
+          paddingSize: 's',
+          showIcons: true,
+          style: { minWidth: 250 },
+        }}
+      >
+        {(list) => list}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};
+
+const SignalFilter: React.FC<{
+  selectedSignals?: SignalFilterType[];
+  onChange: (signals: SignalFilterType[]) => void;
+}> = ({ selectedSignals = [], onChange }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const togglePopover = useCallback(() => setIsOpen((prevIsOpen) => !prevIsOpen), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
+
+  const options: EuiSelectableOption[] = useMemo(
+    () => [
+      {
+        label: i18n.translate(
+          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.signalLogsOption',
+          { defaultMessage: 'Logs' }
+        ),
+        key: SIGNAL_LOGS,
+        checked: selectedSignals.includes(SIGNAL_LOGS) ? 'on' : undefined,
+        'data-test-subj': 'browseIntegrations.searchBar.signalLogsOption',
+      },
+      {
+        label: i18n.translate(
+          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.signalMetricsOption',
+          { defaultMessage: 'Metrics' }
+        ),
+        key: SIGNAL_METRICS,
+        checked: selectedSignals.includes(SIGNAL_METRICS) ? 'on' : undefined,
+        'data-test-subj': 'browseIntegrations.searchBar.signalMetricsOption',
+      },
+    ],
+    [selectedSignals]
+  );
+
+  const activeCount = selectedSignals.length;
+
+  const onSelectionChange = useCallback(
+    (newOptions: EuiSelectableOption[]) => {
+      const newSignals: SignalFilterType[] = [];
+      newOptions.forEach((option) => {
+        if (option.checked === 'on' && option.key) {
+          newSignals.push(option.key as SignalFilterType);
+        }
+      });
+      onChange(newSignals);
+    },
+    [onChange]
+  );
+
+  return (
+    <EuiPopover
+      id="browseIntegrationsSignalPopover"
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      button={
+        <EuiFilterButton
+          data-test-subj="browseIntegrations.searchBar.signalBtn"
+          iconType="arrowDown"
+          onClick={togglePopover}
+          isSelected={isOpen}
+          numFilters={activeCount}
+          hasActiveFilters={activeCount > 0}
+          numActiveFilters={activeCount}
+        >
+          <FormattedMessage
+            id="xpack.fleet.epm.browseIntegrations.searchAndFilterBar.allSignalsLabel"
+            defaultMessage="All signals"
+          />
+        </EuiFilterButton>
+      }
+    >
+      <EuiSelectable
+        data-test-subj="browseIntegrations.searchBar.signalSelectableList"
+        searchable={false}
+        options={options}
+        onChange={onSelectionChange}
+        listProps={{
+          paddingSize: 's',
+          showIcons: true,
+          style: { minWidth: 250 },
+        }}
+      >
+        {(list) => list}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};
+
 const SearchBar: React.FC = () => {
   const urlFilters = useUrlFilters();
   const addUrlFilters = useAddUrlFilters();
@@ -182,6 +379,21 @@ export const SearchAndFiltersBar: React.FC = ({}) => {
     },
     [addUrlFilters]
   );
+
+  const handleSetupMethodChange = useCallback(
+    (methods: SetupMethodFilterType[]) => {
+      addUrlFilters({ setupMethod: methods.length > 0 ? methods : undefined });
+    },
+    [addUrlFilters]
+  );
+
+  const handleSignalChange = useCallback(
+    (signals: SignalFilterType[]) => {
+      addUrlFilters({ signal: signals.length > 0 ? signals : undefined });
+    },
+    [addUrlFilters]
+  );
+
   return (
     <StickyFlexItem>
       <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
@@ -190,18 +402,11 @@ export const SearchAndFiltersBar: React.FC = ({}) => {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFilterGroup compressed>
-            <EuiFilterButton>
-              <FormattedMessage
-                id="xpack.fleet.epm.browseIntegrations.searchAndFilterBar.setupMethodLabel"
-                defaultMessage="Setup method"
-              />
-            </EuiFilterButton>
-            <EuiFilterButton>
-              <FormattedMessage
-                id="xpack.fleet.epm.browseIntegrations.searchAndFilterBar.allSignalsLabel"
-                defaultMessage="All signals"
-              />
-            </EuiFilterButton>
+            <SetupMethodFilter
+              selectedMethods={urlFilters.setupMethod}
+              onChange={handleSetupMethodChange}
+            />
+            <SignalFilter selectedSignals={urlFilters.signal} onChange={handleSignalChange} />
 
             <StatusFilter
               selectedStatuses={urlFilters.status}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
@@ -30,7 +30,7 @@ import type {
   SetupMethodFilterType,
   SignalFilterType,
 } from '../types';
-import { SETUP_METHOD_AGENTLESS, SETUP_METHOD_ELASTIC_AGENT, SETUP_METHOD_BEATS } from '../types';
+import { SETUP_METHOD_AGENTLESS, SETUP_METHOD_ELASTIC_AGENT } from '../types';
 import { dataTypes } from '../../../../../../../../common/constants';
 import { StatusFilter } from '../../../components/status_filter';
 
@@ -172,15 +172,6 @@ const SetupMethodFilter: React.FC<{
         key: SETUP_METHOD_ELASTIC_AGENT,
         checked: selectedMethods.includes(SETUP_METHOD_ELASTIC_AGENT) ? 'on' : undefined,
         'data-test-subj': 'browseIntegrations.searchBar.setupMethodElasticAgentOption',
-      },
-      {
-        label: i18n.translate(
-          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.setupMethodBeatsOption',
-          { defaultMessage: 'Beats' }
-        ),
-        key: SETUP_METHOD_BEATS,
-        checked: selectedMethods.includes(SETUP_METHOD_BEATS) ? 'on' : undefined,
-        'data-test-subj': 'browseIntegrations.searchBar.setupMethodBeatsOption',
       },
     ],
     [selectedMethods]

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
@@ -88,8 +88,40 @@ export function useBrowseIntegrationHook({
       }
     }
 
+    // Apply setup method filters (union: show cards matching ANY selected method)
+    const setupMethodFilters = urlFilters.setupMethod;
+    if (setupMethodFilters && setupMethodFilters.length > 0) {
+      cards = cards.filter((card) => {
+        return setupMethodFilters.some((method) => {
+          switch (method) {
+            case 'agentless':
+              return card.supportsAgentless === true;
+            case 'elastic_agent':
+              return card.type !== 'ui_link';
+            case 'beats':
+              return card.type === 'ui_link';
+            default:
+              return false;
+          }
+        });
+      });
+    }
+
+    // Apply signal filters (union: show cards matching ANY selected signal)
+    const signalFilters = urlFilters.signal;
+    if (signalFilters && signalFilters.length > 0) {
+      cards = cards.filter((card) => signalFilters.some((s) => card.signalTypes?.includes(s)));
+    }
+
     return cards;
-  }, [localSearch, searchTerm, sortedCards, urlFilters.status]);
+  }, [
+    localSearch,
+    searchTerm,
+    sortedCards,
+    urlFilters.status,
+    urlFilters.setupMethod,
+    urlFilters.signal,
+  ]);
 
   const onCategoryChange = useCallback(
     ({ id }: { id: string }) => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
@@ -97,9 +97,7 @@ export function useBrowseIntegrationHook({
             case 'agentless':
               return card.supportsAgentless === true;
             case 'elastic_agent':
-              return card.type !== 'ui_link';
-            case 'beats':
-              return card.type === 'ui_link';
+              return card.type === 'integration' || card.type === 'input';
             default:
               return false;
           }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.test.tsx
@@ -10,13 +10,8 @@ import { useHistory } from 'react-router-dom';
 
 import { useUrlParams } from '../../../../../../../hooks';
 
-import {
-  STATUS_DEPRECATED,
-  SETUP_METHOD_AGENTLESS,
-  SETUP_METHOD_ELASTIC_AGENT,
-  SIGNAL_LOGS,
-  SIGNAL_METRICS,
-} from '../types';
+import { STATUS_DEPRECATED, SETUP_METHOD_AGENTLESS, SETUP_METHOD_ELASTIC_AGENT } from '../types';
+import { dataTypes } from '../../../../../../../../common/constants';
 
 import { useAddUrlFilters, useUrlFilters } from './url_filters';
 
@@ -176,7 +171,7 @@ describe('useUrlFilters', () => {
 
     const { result } = renderHook(() => useUrlFilters());
 
-    expect(result.current.signal).toEqual([SIGNAL_LOGS]);
+    expect(result.current.signal).toEqual([dataTypes.Logs]);
   });
 
   it('parses signal array from URL', () => {
@@ -187,7 +182,7 @@ describe('useUrlFilters', () => {
 
     const { result } = renderHook(() => useUrlFilters());
 
-    expect(result.current.signal).toEqual([SIGNAL_LOGS, SIGNAL_METRICS]);
+    expect(result.current.signal).toEqual([dataTypes.Logs, dataTypes.Metrics]);
   });
 
   it('ignores invalid signal values', () => {
@@ -209,7 +204,29 @@ describe('useUrlFilters', () => {
 
     const { result } = renderHook(() => useUrlFilters());
 
-    expect(result.current.signal).toEqual([SIGNAL_LOGS]);
+    expect(result.current.signal).toEqual([dataTypes.Logs]);
+  });
+
+  it('parses single traces signal from URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: 'traces' },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.signal).toEqual([dataTypes.Traces]);
+  });
+
+  it('parses signal array with traces from URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: ['logs', 'metrics', 'traces'] },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.signal).toEqual([dataTypes.Logs, dataTypes.Metrics, dataTypes.Traces]);
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.test.tsx
@@ -10,7 +10,13 @@ import { useHistory } from 'react-router-dom';
 
 import { useUrlParams } from '../../../../../../../hooks';
 
-import { STATUS_DEPRECATED } from '../types';
+import {
+  STATUS_DEPRECATED,
+  SETUP_METHOD_AGENTLESS,
+  SETUP_METHOD_ELASTIC_AGENT,
+  SIGNAL_LOGS,
+  SIGNAL_METRICS,
+} from '../types';
 
 import { useAddUrlFilters, useUrlFilters } from './url_filters';
 
@@ -91,6 +97,119 @@ describe('useUrlFilters', () => {
     const { result } = renderHook(() => useUrlFilters());
 
     expect(result.current.sort).toBe('a-z');
+  });
+
+  it('returns undefined for setupMethod when not in URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: {},
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.setupMethod).toBeUndefined();
+  });
+
+  it('parses single setupMethod from URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { setupMethod: 'agentless' },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.setupMethod).toEqual([SETUP_METHOD_AGENTLESS]);
+  });
+
+  it('parses setupMethod array from URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { setupMethod: ['agentless', 'elastic_agent'] },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.setupMethod).toEqual([
+      SETUP_METHOD_AGENTLESS,
+      SETUP_METHOD_ELASTIC_AGENT,
+    ]);
+  });
+
+  it('ignores invalid setupMethod values', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { setupMethod: 'invalid' },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.setupMethod).toBeUndefined();
+  });
+
+  it('filters out invalid setupMethod values from array', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { setupMethod: ['invalid', 'agentless'] },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.setupMethod).toEqual([SETUP_METHOD_AGENTLESS]);
+  });
+
+  it('returns undefined for signal when not in URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: {},
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.signal).toBeUndefined();
+  });
+
+  it('parses single signal from URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: 'logs' },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.signal).toEqual([SIGNAL_LOGS]);
+  });
+
+  it('parses signal array from URL', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: ['logs', 'metrics'] },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.signal).toEqual([SIGNAL_LOGS, SIGNAL_METRICS]);
+  });
+
+  it('ignores invalid signal values', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: 'invalid' },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.signal).toBeUndefined();
+  });
+
+  it('filters out invalid signal values from array', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: ['invalid', 'logs'] },
+      toUrlParams: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useUrlFilters());
+
+    expect(result.current.signal).toEqual([SIGNAL_LOGS]);
   });
 });
 
@@ -196,5 +315,176 @@ describe('useAddUrlFilters', () => {
 
     expect(mockReplace).toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('adds setupMethod to URL when set', () => {
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ setupMethod: ['agentless'] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: 'setupMethod=agentless',
+    });
+  });
+
+  it('adds multiple setupMethod values to URL', () => {
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ setupMethod: ['agentless', 'elastic_agent'] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('setupMethod=agentless'),
+    });
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('setupMethod=elastic_agent'),
+    });
+  });
+
+  it('removes setupMethod from URL when set to undefined', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { setupMethod: 'agentless' },
+      toUrlParams: mockToUrlParams,
+    });
+
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ setupMethod: undefined });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: '',
+    });
+  });
+
+  it('removes setupMethod from URL when set to empty array', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { setupMethod: 'agentless' },
+      toUrlParams: mockToUrlParams,
+    });
+
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ setupMethod: [] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: '',
+    });
+  });
+
+  it('preserves other filters when updating setupMethod', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { q: 'apache', status: 'deprecated' },
+      toUrlParams: mockToUrlParams,
+    });
+
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ setupMethod: ['agentless'] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('q=apache'),
+    });
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('status=deprecated'),
+    });
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('setupMethod=agentless'),
+    });
+  });
+
+  it('adds signal to URL when set', () => {
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ signal: ['logs'] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: 'signal=logs',
+    });
+  });
+
+  it('adds multiple signal values to URL', () => {
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ signal: ['logs', 'metrics'] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('signal=logs'),
+    });
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('signal=metrics'),
+    });
+  });
+
+  it('removes signal from URL when set to undefined', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: 'logs' },
+      toUrlParams: mockToUrlParams,
+    });
+
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ signal: undefined });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: '',
+    });
+  });
+
+  it('removes signal from URL when set to empty array', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { signal: 'logs' },
+      toUrlParams: mockToUrlParams,
+    });
+
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ signal: [] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: '',
+    });
+  });
+
+  it('preserves other filters when updating signal', () => {
+    (useUrlParams as jest.Mock).mockReturnValue({
+      urlParams: { q: 'apache', status: 'deprecated', setupMethod: 'agentless' },
+      toUrlParams: mockToUrlParams,
+    });
+
+    const { result } = renderHook(() => useAddUrlFilters());
+
+    act(() => {
+      result.current({ signal: ['logs'] });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('q=apache'),
+    });
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('status=deprecated'),
+    });
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('setupMethod=agentless'),
+    });
+    expect(mockPush).toHaveBeenCalledWith({
+      search: expect.stringContaining('signal=logs'),
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.tsx
@@ -15,15 +15,29 @@ import type {
   BrowseIntegrationsFilter,
   BrowseIntegrationSortType,
   IntegrationStatusFilterType,
+  SetupMethodFilterType,
+  SignalFilterType,
 } from '../types';
 
 const VALID_STATUSES: IntegrationStatusFilterType[] = ['deprecated'];
+const VALID_SETUP_METHODS: SetupMethodFilterType[] = ['agentless', 'elastic_agent', 'beats'];
+const VALID_SIGNALS: SignalFilterType[] = ['logs', 'metrics'];
 const INTEGRATIONS_QUERYPARAM_Q = 'q';
 const INTEGRATIONS_QUERYPARAM_SORT = 'sort';
 const INTEGRATIONS_QUERYPARAM_STATUS = 'status';
+const INTEGRATIONS_QUERYPARAM_SETUP_METHOD = 'setupMethod';
+const INTEGRATIONS_QUERYPARAM_SIGNAL = 'signal';
 
 function isValidStatus(value: string): value is IntegrationStatusFilterType {
   return (VALID_STATUSES as string[]).includes(value);
+}
+
+function isValidSetupMethod(value: string): value is SetupMethodFilterType {
+  return (VALID_SETUP_METHODS as string[]).includes(value);
+}
+
+function isValidSignal(value: string): value is SignalFilterType {
+  return (VALID_SIGNALS as string[]).includes(value);
 }
 
 export function useAddUrlFilters() {
@@ -44,12 +58,20 @@ export function useAddUrlFilters() {
               urlParams,
               INTEGRATIONS_QUERYPARAM_Q,
               INTEGRATIONS_QUERYPARAM_SORT,
-              INTEGRATIONS_QUERYPARAM_STATUS
+              INTEGRATIONS_QUERYPARAM_STATUS,
+              INTEGRATIONS_QUERYPARAM_SETUP_METHOD,
+              INTEGRATIONS_QUERYPARAM_SIGNAL
             ),
             ...(newFilters.q ? { q: newFilters.q } : {}),
             ...(newFilters.sort ? { sort: newFilters.sort } : {}),
             ...(newFilters.status && newFilters.status.length > 0
               ? { status: newFilters.status }
+              : {}),
+            ...(newFilters.setupMethod && newFilters.setupMethod.length > 0
+              ? { setupMethod: newFilters.setupMethod }
+              : {}),
+            ...(newFilters.signal && newFilters.signal.length > 0
+              ? { signal: newFilters.signal }
               : {}),
           },
           {
@@ -93,10 +115,42 @@ export function useUrlFilters(): BrowseIntegrationsFilter {
       }
     }
 
+    let setupMethod: BrowseIntegrationsFilter[typeof INTEGRATIONS_QUERYPARAM_SETUP_METHOD];
+    const rawSetupMethod = urlParams[INTEGRATIONS_QUERYPARAM_SETUP_METHOD];
+    if (typeof rawSetupMethod === 'string') {
+      if (isValidSetupMethod(rawSetupMethod)) {
+        setupMethod = [rawSetupMethod];
+      }
+    } else if (Array.isArray(rawSetupMethod)) {
+      const validMethods = rawSetupMethod.filter(
+        (s): s is SetupMethodFilterType => typeof s === 'string' && isValidSetupMethod(s)
+      );
+      if (validMethods.length > 0) {
+        setupMethod = validMethods;
+      }
+    }
+
+    let signal: BrowseIntegrationsFilter[typeof INTEGRATIONS_QUERYPARAM_SIGNAL];
+    const rawSignal = urlParams[INTEGRATIONS_QUERYPARAM_SIGNAL];
+    if (typeof rawSignal === 'string') {
+      if (isValidSignal(rawSignal)) {
+        signal = [rawSignal];
+      }
+    } else if (Array.isArray(rawSignal)) {
+      const validSignals = rawSignal.filter(
+        (s): s is SignalFilterType => typeof s === 'string' && isValidSignal(s)
+      );
+      if (validSignals.length > 0) {
+        signal = validSignals;
+      }
+    }
+
     return {
       q,
       sort,
       status,
+      setupMethod,
+      signal,
     };
   }, [urlParams]);
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.tsx
@@ -10,6 +10,7 @@ import { useHistory } from 'react-router-dom';
 import { omit } from 'lodash';
 
 import { useUrlParams } from '../../../../../../../hooks';
+import { dataTypes } from '../../../../../../../../common/constants';
 
 import type {
   BrowseIntegrationsFilter,
@@ -21,7 +22,7 @@ import type {
 
 const VALID_STATUSES: IntegrationStatusFilterType[] = ['deprecated'];
 const VALID_SETUP_METHODS: SetupMethodFilterType[] = ['agentless', 'elastic_agent', 'beats'];
-const VALID_SIGNALS: SignalFilterType[] = ['logs', 'metrics'];
+const VALID_SIGNALS: SignalFilterType[] = Object.values(dataTypes);
 const INTEGRATIONS_QUERYPARAM_Q = 'q';
 const INTEGRATIONS_QUERYPARAM_SORT = 'sort';
 const INTEGRATIONS_QUERYPARAM_STATUS = 'status';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/url_filters.tsx
@@ -21,7 +21,7 @@ import type {
 } from '../types';
 
 const VALID_STATUSES: IntegrationStatusFilterType[] = ['deprecated'];
-const VALID_SETUP_METHODS: SetupMethodFilterType[] = ['agentless', 'elastic_agent', 'beats'];
+const VALID_SETUP_METHODS: SetupMethodFilterType[] = ['agentless', 'elastic_agent'];
 const VALID_SIGNALS: SignalFilterType[] = Object.values(dataTypes);
 const INTEGRATIONS_QUERYPARAM_Q = 'q';
 const INTEGRATIONS_QUERYPARAM_SORT = 'sort';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/types.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/types.tsx
@@ -10,11 +10,9 @@ export type IntegrationStatusFilterType = typeof STATUS_DEPRECATED;
 
 export const SETUP_METHOD_AGENTLESS = 'agentless';
 export const SETUP_METHOD_ELASTIC_AGENT = 'elastic_agent';
-export const SETUP_METHOD_BEATS = 'beats';
 export type SetupMethodFilterType =
   | typeof SETUP_METHOD_AGENTLESS
-  | typeof SETUP_METHOD_ELASTIC_AGENT
-  | typeof SETUP_METHOD_BEATS;
+  | typeof SETUP_METHOD_ELASTIC_AGENT;
 
 import type { dataTypes } from '../../../../../../../common/constants';
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/types.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/types.tsx
@@ -8,10 +8,24 @@
 export const STATUS_DEPRECATED = 'deprecated';
 export type IntegrationStatusFilterType = typeof STATUS_DEPRECATED;
 
+export const SETUP_METHOD_AGENTLESS = 'agentless';
+export const SETUP_METHOD_ELASTIC_AGENT = 'elastic_agent';
+export const SETUP_METHOD_BEATS = 'beats';
+export type SetupMethodFilterType =
+  | typeof SETUP_METHOD_AGENTLESS
+  | typeof SETUP_METHOD_ELASTIC_AGENT
+  | typeof SETUP_METHOD_BEATS;
+
+export const SIGNAL_LOGS = 'logs';
+export const SIGNAL_METRICS = 'metrics';
+export type SignalFilterType = typeof SIGNAL_LOGS | typeof SIGNAL_METRICS;
+
 export interface BrowseIntegrationsFilter {
   q?: string;
   sort?: BrowseIntegrationSortType;
   status?: IntegrationStatusFilterType[];
+  setupMethod?: SetupMethodFilterType[];
+  signal?: SignalFilterType[];
 }
 
 export type BrowseIntegrationSortType = 'recent-old' | 'old-recent' | 'a-z' | 'z-a';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/types.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/types.tsx
@@ -16,9 +16,9 @@ export type SetupMethodFilterType =
   | typeof SETUP_METHOD_ELASTIC_AGENT
   | typeof SETUP_METHOD_BEATS;
 
-export const SIGNAL_LOGS = 'logs';
-export const SIGNAL_METRICS = 'metrics';
-export type SignalFilterType = typeof SIGNAL_LOGS | typeof SIGNAL_METRICS;
+import type { dataTypes } from '../../../../../../../common/constants';
+
+export type SignalFilterType = (typeof dataTypes)[keyof typeof dataTypes];
 
 export interface BrowseIntegrationsFilter {
   q?: string;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx
@@ -76,6 +76,8 @@ export interface IntegrationCardItem {
   url: string;
   version: string;
   type?: string;
+  supportsAgentless?: boolean;
+  signalTypes?: string[];
 }
 
 export const mapToCard = ({
@@ -161,6 +163,17 @@ export const mapToCard = ({
 
   if (item.type === 'integration') {
     cardResult.installStatus = item.installationInfo?.install_status;
+  }
+
+  if ('supportsAgentless' in item && item.supportsAgentless) {
+    cardResult.supportsAgentless = true;
+  }
+
+  if ('data_streams' in item && Array.isArray(item.data_streams)) {
+    const types = [...new Set(item.data_streams.map((ds) => ds.type))];
+    if (types.length > 0) {
+      cardResult.signalTypes = types;
+    }
   }
 
   return cardResult;


### PR DESCRIPTION
## Description 

Implement missing filters in new browse integration UX: 
* setup methods
* signals

New filters are persisted in url, as all the filters in that new browse integration UX.

## UI Changes

<img width="900" alt="Screenshot 2026-02-26 at 10 29 55 AM" src="https://github.com/user-attachments/assets/a38f6411-2c30-44a3-bea4-4c8ca96e8718" />
<img width="900"  alt="Screenshot 2026-02-26 at 10 29 50 AM" src="https://github.com/user-attachments/assets/a9bcb261-1d4a-40d3-bc92-6af41b0da901" />

