### PR TITLE
Endpoint policy advanced settings redesign

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -7,6 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 
+export type AdvancedSettingCategory =
+  | 'performance'
+  | 'product_features'
+  | 'logs'
+  | 'configs'
+  | 'others';
+
 interface AdvancedPolicySchemaType {
   key: string;
   first_supported_version: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/get_advanced_setting_category.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/get_advanced_setting_category.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getCategory } from './get_advanced_setting_category';
+
+describe('getCategory', () => {
+  describe('logs', () => {
+    it('returns logs for keys containing .logging.', () => {
+      expect(getCategory('linux.advanced.logging.file')).toBe('logs');
+      expect(getCategory('mac.advanced.logging.syslog')).toBe('logs');
+      expect(getCategory('windows.advanced.logging.debugview')).toBe('logs');
+    });
+  });
+
+  describe('configs', () => {
+    it('returns configs for artifacts, elasticsearch, agent, event_filter, flags', () => {
+      expect(getCategory('linux.advanced.artifacts.global.base_url')).toBe('configs');
+      expect(getCategory('windows.advanced.elasticsearch.delay')).toBe('configs');
+      expect(getCategory('mac.advanced.agent.connection_delay')).toBe('configs');
+      expect(getCategory('linux.advanced.event_filter.default')).toBe('configs');
+      expect(getCategory('windows.advanced.flags')).toBe('configs');
+    });
+  });
+
+  describe('performance', () => {
+    it('returns performance for utilization_limits, tty_io, file_cache, deduplicate, aggregate_', () => {
+      expect(getCategory('linux.advanced.utilization_limits.cpu')).toBe('performance');
+      expect(getCategory('linux.advanced.tty_io.max_kilobytes_per_process')).toBe('performance');
+      expect(getCategory('windows.advanced.file_cache.file_object_cache_size')).toBe('performance');
+      expect(getCategory('mac.advanced.events.deduplicate_network_events')).toBe('performance');
+      expect(getCategory('windows.advanced.events.aggregate_process')).toBe('performance');
+    });
+  });
+
+  describe('product_features', () => {
+    it('returns product_features for malware, ransomware, memory_protection, kernel, etc.', () => {
+      expect(getCategory('windows.advanced.malware.quarantine')).toBe('product_features');
+      expect(getCategory('windows.advanced.ransomware.mbr')).toBe('product_features');
+      expect(getCategory('linux.advanced.memory_protection.memory_scan')).toBe('product_features');
+      expect(getCategory('windows.advanced.kernel.process')).toBe('product_features');
+      expect(getCategory('mac.advanced.alerts.cloud_lookup')).toBe('product_features');
+      expect(getCategory('windows.advanced.diagnostic.enabled')).toBe('product_features');
+      expect(getCategory('mac.advanced.device_control.filter_images')).toBe('product_features');
+      expect(getCategory('mac.advanced.harden.self_protect')).toBe('product_features');
+      expect(getCategory('linux.advanced.fanotify.ignored_filesystems')).toBe('product_features');
+      expect(getCategory('linux.advanced.host_isolation.allowed')).toBe('product_features');
+      expect(getCategory('windows.advanced.mitigations.policies.redirection_guard')).toBe(
+        'product_features'
+      );
+    });
+  });
+
+  describe('others', () => {
+    it('returns others for keys that do not match other categories', () => {
+      expect(getCategory('linux.advanced.capture_command_line')).toBe('others');
+      expect(getCategory('linux.advanced.network_events_exclude_local')).toBe('others');
+      expect(getCategory('windows.advanced.set_extended_host_information')).toBe('others');
+      expect(getCategory('linux.advanced.capture_env_vars')).toBe('others');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/get_advanced_setting_category.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/get_advanced_setting_category.ts
@@ -13,59 +13,45 @@ import type { AdvancedSettingCategory } from './advanced_policy_schema';
  * Uses key path patterns; can be replaced later with explicit category per schema entry.
  */
 export function getCategory(key: string): AdvancedSettingCategory {
-  const k = key;
-
-  // Logs: logging configuration
-  if (k.includes('.logging.')) {
-    return 'logs';
+  const advancedIndex = key.indexOf('.advanced.');
+  if (advancedIndex === -1) {
+    return 'others';
   }
+  const afterAdvanced = key.slice(advancedIndex + '.advanced.'.length);
+  const segment = afterAdvanced.split('.')[0];
 
-  // Configs: artifacts, elasticsearch, agent, event_filter, flags, proxy
-  if (
-    k.includes('.artifacts.') ||
-    k.includes('.elasticsearch.') ||
-    k.includes('.agent.') ||
-    k.includes('.event_filter.') ||
-    k.endsWith('.flags')
-  ) {
-    return 'configs';
+  switch (segment) {
+    case 'logging':
+      return 'logs';
+    case 'artifacts':
+    case 'elasticsearch':
+    case 'agent':
+    case 'event_filter':
+    case 'flags':
+      return 'configs';
+    case 'utilization_limits':
+    case 'tty_io':
+    case 'file_cache':
+      return 'performance';
+    case 'events':
+      return key.includes('deduplicate') || key.includes('aggregate_')
+        ? 'performance'
+        : 'product_features';
+    case 'malware':
+    case 'ransomware':
+    case 'memory_protection':
+    case 'kernel':
+    case 'alerts':
+    case 'diagnostic':
+    case 'device_control':
+    case 'harden':
+    case 'fanotify':
+    case 'host_isolation':
+    case 'mitigations':
+    case 'document_enrichment':
+    case 'firewall_anti_tamper':
+      return 'product_features';
+    default:
+      return 'others';
   }
-
-  // Performance: utilization, tty_io, file_cache, deduplicate, aggregate
-  if (
-    k.includes('.utilization_limits.') ||
-    k.includes('.tty_io.') ||
-    k.includes('.file_cache.') ||
-    k.includes('deduplicate') ||
-    k.includes('aggregate_')
-  ) {
-    return 'performance';
-  }
-
-  // Product Features: malware, ransomware, memory_protection, kernel, alerts, diagnostic,
-  // device_control, harden, fanotify, host_isolation, mitigations, document_enrichment,
-  // firewall, etc.
-  if (
-    k.includes('.malware.') ||
-    k.includes('.ransomware.') ||
-    k.includes('.memory_protection.') ||
-    k.includes('.kernel.') ||
-    k.includes('.alerts.') ||
-    k.includes('.diagnostic.') ||
-    k.includes('.device_control.') ||
-    k.includes('.harden.') ||
-    k.includes('.fanotify.') ||
-    k.includes('.host_isolation.') ||
-    k.includes('.mitigations.') ||
-    k.includes('.document_enrichment.') ||
-    k.includes('firewall_anti_tamper') ||
-    k.includes('.events.') ||
-    k.includes('.kernel.') ||
-    k.includes('.ppl.') ||
-    k.includes('dev_drives.')
-  ) {
-    return 'product_features';
-  }
-
-  return 'others';
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/get_advanced_setting_category.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/get_advanced_setting_category.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AdvancedSettingCategory } from './advanced_policy_schema';
+
+/**
+ * Maps an advanced policy setting key to one of the PM-proposed categories
+ * (Performance, Product Features, Logs, Configs, Others) for discoverability.
+ * Uses key path patterns; can be replaced later with explicit category per schema entry.
+ */
+export function getCategory(key: string): AdvancedSettingCategory {
+  const k = key;
+
+  // Logs: logging configuration
+  if (k.includes('.logging.')) {
+    return 'logs';
+  }
+
+  // Configs: artifacts, elasticsearch, agent, event_filter, flags, proxy
+  if (
+    k.includes('.artifacts.') ||
+    k.includes('.elasticsearch.') ||
+    k.includes('.agent.') ||
+    k.includes('.event_filter.') ||
+    k.endsWith('.flags')
+  ) {
+    return 'configs';
+  }
+
+  // Performance: utilization, tty_io, file_cache, deduplicate, aggregate
+  if (
+    k.includes('.utilization_limits.') ||
+    k.includes('.tty_io.') ||
+    k.includes('.file_cache.') ||
+    k.includes('deduplicate') ||
+    k.includes('aggregate_')
+  ) {
+    return 'performance';
+  }
+
+  // Product Features: malware, ransomware, memory_protection, kernel, alerts, diagnostic,
+  // device_control, harden, fanotify, host_isolation, mitigations, document_enrichment,
+  // firewall, etc.
+  if (
+    k.includes('.malware.') ||
+    k.includes('.ransomware.') ||
+    k.includes('.memory_protection.') ||
+    k.includes('.kernel.') ||
+    k.includes('.alerts.') ||
+    k.includes('.diagnostic.') ||
+    k.includes('.device_control.') ||
+    k.includes('.harden.') ||
+    k.includes('.fanotify.') ||
+    k.includes('.host_isolation.') ||
+    k.includes('.mitigations.') ||
+    k.includes('.document_enrichment.') ||
+    k.includes('firewall_anti_tamper') ||
+    k.includes('.events.') ||
+    k.includes('.kernel.') ||
+    k.includes('.ppl.') ||
+    k.includes('dev_drives.')
+  ) {
+    return 'product_features';
+  }
+
+  return 'others';
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.test.tsx
@@ -86,7 +86,6 @@ describe('Policy Advanced Settings section', () => {
 
     expect(getByTestId(testSubj.search)).toBeInTheDocument();
     expect(getByTestId(testSubj.osFilter)).toBeInTheDocument();
-    expect(getByTestId(testSubj.categoryFilter)).toBeInTheDocument();
   });
 
   it('should filter settings when search query is entered', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.test.tsx
@@ -81,6 +81,41 @@ describe('Policy Advanced Settings section', () => {
     expect(getByTestId(testSubj.warningCallout));
   });
 
+  it('should show search and filters when expanded', async () => {
+    const { getByTestId } = await render(true);
+
+    expect(getByTestId(testSubj.search)).toBeInTheDocument();
+    expect(getByTestId(testSubj.osFilter)).toBeInTheDocument();
+    expect(getByTestId(testSubj.categoryFilter)).toBeInTheDocument();
+  });
+
+  it('should filter settings when search query is entered', async () => {
+    await render(true);
+
+    const searchInput = renderResult.getByTestId(testSubj.search);
+    await userEvent.type(searchInput, 'logging.file');
+
+    const linuxLoggingRow = renderResult.queryByTestId(
+      testSubj.settingRowTestSubjects('linux.advanced.logging.file').container
+    );
+    expect(linuxLoggingRow).toBeInTheDocument();
+
+    const unrelatedRow = renderResult.queryByTestId(
+      testSubj.settingRowTestSubjects('linux.advanced.agent.connection_delay').container
+    );
+    expect(unrelatedRow).not.toBeInTheDocument();
+  });
+
+  it('should show empty state when filters match no settings', async () => {
+    await render(true);
+
+    const searchInput = renderResult.getByTestId(testSubj.search);
+    await userEvent.type(searchInput, 'nonexistentSettingKey12345');
+
+    expect(renderResult.getByTestId(testSubj.emptyState)).toBeInTheDocument();
+    expect(renderResult.getByText('No settings match your filters.')).toBeInTheDocument();
+  });
+
   it('should render all advanced options', async () => {
     const fieldsWithDefaultValues = [
       'mac.advanced.capture_env_vars',

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiFieldTextProps } from '@elastic/eui';
@@ -21,7 +21,6 @@ import {
   EuiFormRow,
   EuiIconTip,
   EuiPanel,
-  EuiSelect,
   EuiSpacer,
   EuiText,
   useEuiBackgroundColorCSS,
@@ -177,7 +176,6 @@ const CATEGORY_LABELS: Record<AdvancedSettingCategory, string> = {
 };
 
 type OSFilterValue = 'all' | 'linux' | 'mac' | 'windows';
-type CategoryFilterValue = 'all' | AdvancedSettingCategory;
 
 export type AdvancedSectionProps = PolicyFormComponentCommonProps;
 
@@ -187,7 +185,8 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
     const [showAdvancedPolicy, setShowAdvancedPolicy] = useState<boolean>(false);
     const [searchQuery, setSearchQuery] = useState('');
     const [selectedOS, setSelectedOS] = useState<OSFilterValue>('all');
-    const [selectedCategory, setSelectedCategory] = useState<CategoryFilterValue>('all');
+    const openCategoriesRef = useRef<Set<AdvancedSettingCategory>>(new Set());
+    const [, setAccordionUpdateCounter] = useState(0);
     const isPlatinumPlus = useLicense().isPlatinumPlus();
     const euiBackgroundColorCSS = useEuiBackgroundColorCSS();
 
@@ -195,6 +194,16 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
 
     const handleAdvancedSettingsButtonClick = useCallback(() => {
       setShowAdvancedPolicy((prevState) => !prevState);
+    }, []);
+
+    const handleCategoryToggle = useCallback((category: AdvancedSettingCategory) => {
+      const next = openCategoriesRef.current;
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      setAccordionUpdateCounter((c) => c + 1);
     }, []);
 
     const handleAdvancedSettingUpdate = useCallback<NonNullable<EuiFieldTextProps['onChange']>>(
@@ -226,9 +235,6 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
               : 'windows.advanced.';
           if (!entry.key.startsWith(prefix)) return false;
         }
-        if (selectedCategory !== 'all' && getCategory(entry.key) !== selectedCategory) {
-          return false;
-        }
         if (query) {
           const keyMatch = entry.key.toLowerCase().includes(query);
           const docMatch = entry.documentation.toLowerCase().includes(query);
@@ -246,7 +252,7 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
         byCategory.get(cat)!.push(entry);
       }
       return byCategory;
-    }, [policy, isPlatinumPlus, selectedOS, selectedCategory, searchQuery]);
+    }, [policy, isPlatinumPlus, selectedOS, searchQuery]);
 
     const totalFilteredCount = useMemo(() => {
       let count = 0;
@@ -385,24 +391,6 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
                   data-test-subj={getTestId('osFilter')}
                 />
               </EuiFlexItem>
-              <EuiFlexItem grow={false} style={{ minWidth: 180 }}>
-                <EuiSelect
-                  id={getTestId('categoryFilter')}
-                  options={[
-                    { value: 'all', text: FILTER_ALL },
-                    { value: 'performance', text: CATEGORY_PERFORMANCE },
-                    { value: 'product_features', text: CATEGORY_PRODUCT_FEATURES },
-                    { value: 'logs', text: CATEGORY_LOGS },
-                    { value: 'configs', text: CATEGORY_CONFIGS },
-                    { value: 'others', text: CATEGORY_OTHERS },
-                  ]}
-                  value={selectedCategory}
-                  onChange={(e) => setSelectedCategory(e.target.value as CategoryFilterValue)}
-                  fullWidth
-                  compressed
-                  data-test-subj={getTestId('categoryFilter')}
-                />
-              </EuiFlexItem>
             </EuiFlexGroup>
 
             <EuiSpacer size="m" />
@@ -454,7 +442,8 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
                           arrowProps={{
                             style: { marginLeft: 16 },
                           }}
-                          initialIsOpen={true}
+                          forceState={openCategoriesRef.current.has(category) ? 'open' : 'closed'}
+                          onToggle={() => handleCategoryToggle(category)}
                         >
                           <div css={euiBackgroundColorCSS.subdued} style={{ padding: 12 }}>
                             {entries.map((entry) => renderSettingRow(entry))}

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.tsx
@@ -120,10 +120,9 @@ const SEARCH_PLACEHOLDER = i18n.translate(
   { defaultMessage: 'Search by setting name or description' }
 );
 
-const FILTER_ALL = i18n.translate(
-  'xpack.securitySolution.endpoint.policy.advanced.filterAll',
-  { defaultMessage: 'All' }
-);
+const FILTER_ALL = i18n.translate('xpack.securitySolution.endpoint.policy.advanced.filterAll', {
+  defaultMessage: 'All',
+});
 
 const OS_LINUX = i18n.translate('xpack.securitySolution.endpoint.policy.advanced.osLinux', {
   defaultMessage: 'Linux',
@@ -216,15 +215,15 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
     const filteredAndGroupedSettings = useMemo(() => {
       const query = searchQuery.trim().toLowerCase();
 
-      let items = AdvancedPolicySchema.filter((entry) => {
+      const items = AdvancedPolicySchema.filter((entry) => {
         if (!isPlatinumPlus && entry.license === 'platinum') return false;
         if (selectedOS !== 'all') {
           const prefix =
             selectedOS === 'linux'
               ? 'linux.advanced.'
               : selectedOS === 'mac'
-                ? 'mac.advanced.'
-                : 'windows.advanced.';
+              ? 'mac.advanced.'
+              : 'windows.advanced.';
           if (!entry.key.startsWith(prefix)) return false;
         }
         if (selectedCategory !== 'all' && getCategory(entry.key) !== selectedCategory) {
@@ -259,7 +258,12 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
 
     const renderSettingRow = useCallback(
       (entry: (typeof AdvancedPolicySchema)[number]) => {
-        const { key, documentation, first_supported_version: firstVersion, last_supported_version: lastVersion } = entry;
+        const {
+          key,
+          documentation,
+          first_supported_version: firstVersion,
+          last_supported_version: lastVersion,
+        } = entry;
         const configPath = key.split('.');
         const value = getValue(policy as unknown as Record<string, unknown>, configPath);
         return (
@@ -410,7 +414,11 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
                 </EuiText>
               </EuiPanel>
             ) : (
-              <EuiFlexGroup gutterSize="m" direction="column" data-test-subj={getTestId('settings')}>
+              <EuiFlexGroup
+                gutterSize="m"
+                direction="column"
+                data-test-subj={getTestId('settings')}
+              >
                 {CATEGORY_ORDER.map((category) => {
                   const entries = filteredAndGroupedSettings.get(category)!;
                   if (entries.length === 0) return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/advanced_section.tsx
@@ -5,20 +5,26 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiFieldTextProps } from '@elastic/eui';
 import {
+  EuiAccordion,
+  EuiButtonEmpty,
+  EuiButtonGroup,
   EuiCallOut,
+  EuiFieldSearch,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
   EuiIconTip,
   EuiPanel,
+  EuiSelect,
   EuiSpacer,
   EuiText,
-  EuiButtonEmpty,
+  useEuiBackgroundColorCSS,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { cloneDeep } from 'lodash';
@@ -26,7 +32,9 @@ import { getEmptyValue } from '../../../../../../common/components/empty_value';
 import { useLicense } from '../../../../../../common/hooks/use_license';
 import { useTestIdGenerator } from '../../../../../hooks/use_test_id_generator';
 import type { PolicyFormComponentCommonProps } from '../types';
+import type { AdvancedSettingCategory } from '../../../models/advanced_policy_schema';
 import { AdvancedPolicySchema } from '../../../models/advanced_policy_schema';
+import { getCategory } from '../../../models/get_advanced_setting_category';
 
 function setValue(obj: Record<string, unknown>, value: string, path: string[]) {
   let newPolicyConfig = obj;
@@ -107,13 +115,82 @@ const SHOW = i18n.translate('xpack.securitySolution.endpoint.policy.advanced.sho
   defaultMessage: 'Show',
 });
 
+const SEARCH_PLACEHOLDER = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.searchPlaceholder',
+  { defaultMessage: 'Search by setting name or description' }
+);
+
+const FILTER_ALL = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.filterAll',
+  { defaultMessage: 'All' }
+);
+
+const OS_LINUX = i18n.translate('xpack.securitySolution.endpoint.policy.advanced.osLinux', {
+  defaultMessage: 'Linux',
+});
+const OS_MAC = i18n.translate('xpack.securitySolution.endpoint.policy.advanced.osMac', {
+  defaultMessage: 'macOS',
+});
+const OS_WINDOWS = i18n.translate('xpack.securitySolution.endpoint.policy.advanced.osWindows', {
+  defaultMessage: 'Windows',
+});
+
+const CATEGORY_PERFORMANCE = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.categoryPerformance',
+  { defaultMessage: 'Performance' }
+);
+const CATEGORY_PRODUCT_FEATURES = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.categoryProductFeatures',
+  { defaultMessage: 'Product Features' }
+);
+const CATEGORY_LOGS = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.categoryLogs',
+  { defaultMessage: 'Logs' }
+);
+const CATEGORY_CONFIGS = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.categoryConfigs',
+  { defaultMessage: 'Configs' }
+);
+const CATEGORY_OTHERS = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.categoryOthers',
+  { defaultMessage: 'Others' }
+);
+
+const EMPTY_STATE_MESSAGE = i18n.translate(
+  'xpack.securitySolution.endpoint.policy.advanced.emptyStateMessage',
+  { defaultMessage: 'No settings match your filters.' }
+);
+
+const CATEGORY_ORDER: AdvancedSettingCategory[] = [
+  'performance',
+  'product_features',
+  'logs',
+  'configs',
+  'others',
+];
+
+const CATEGORY_LABELS: Record<AdvancedSettingCategory, string> = {
+  performance: CATEGORY_PERFORMANCE,
+  product_features: CATEGORY_PRODUCT_FEATURES,
+  logs: CATEGORY_LOGS,
+  configs: CATEGORY_CONFIGS,
+  others: CATEGORY_OTHERS,
+};
+
+type OSFilterValue = 'all' | 'linux' | 'mac' | 'windows';
+type CategoryFilterValue = 'all' | AdvancedSettingCategory;
+
 export type AdvancedSectionProps = PolicyFormComponentCommonProps;
 
 export const AdvancedSection = memo<AdvancedSectionProps>(
   ({ policy, mode, onChange, 'data-test-subj': dataTestSubj }) => {
     const getTestId = useTestIdGenerator(dataTestSubj);
     const [showAdvancedPolicy, setShowAdvancedPolicy] = useState<boolean>(false);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [selectedOS, setSelectedOS] = useState<OSFilterValue>('all');
+    const [selectedCategory, setSelectedCategory] = useState<CategoryFilterValue>('all');
     const isPlatinumPlus = useLicense().isPlatinumPlus();
+    const euiBackgroundColorCSS = useEuiBackgroundColorCSS();
 
     const isEditMode = mode === 'edit';
 
@@ -134,6 +211,102 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
         onChange({ isValid: true, updatedPolicy });
       },
       [onChange, policy]
+    );
+
+    const filteredAndGroupedSettings = useMemo(() => {
+      const query = searchQuery.trim().toLowerCase();
+
+      let items = AdvancedPolicySchema.filter((entry) => {
+        if (!isPlatinumPlus && entry.license === 'platinum') return false;
+        if (selectedOS !== 'all') {
+          const prefix =
+            selectedOS === 'linux'
+              ? 'linux.advanced.'
+              : selectedOS === 'mac'
+                ? 'mac.advanced.'
+                : 'windows.advanced.';
+          if (!entry.key.startsWith(prefix)) return false;
+        }
+        if (selectedCategory !== 'all' && getCategory(entry.key) !== selectedCategory) {
+          return false;
+        }
+        if (query) {
+          const keyMatch = entry.key.toLowerCase().includes(query);
+          const docMatch = entry.documentation.toLowerCase().includes(query);
+          if (!keyMatch && !docMatch) return false;
+        }
+        return true;
+      });
+
+      const byCategory = new Map<AdvancedSettingCategory, typeof items>();
+      for (const cat of CATEGORY_ORDER) {
+        byCategory.set(cat, []);
+      }
+      for (const entry of items) {
+        const cat = getCategory(entry.key);
+        byCategory.get(cat)!.push(entry);
+      }
+      return byCategory;
+    }, [policy, isPlatinumPlus, selectedOS, selectedCategory, searchQuery]);
+
+    const totalFilteredCount = useMemo(() => {
+      let count = 0;
+      filteredAndGroupedSettings.forEach((arr) => {
+        count += arr.length;
+      });
+      return count;
+    }, [filteredAndGroupedSettings]);
+
+    const renderSettingRow = useCallback(
+      (entry: (typeof AdvancedPolicySchema)[number]) => {
+        const { key, documentation, first_supported_version: firstVersion, last_supported_version: lastVersion } = entry;
+        const configPath = key.split('.');
+        const value = getValue(policy as unknown as Record<string, unknown>, configPath);
+        return (
+          <EuiFormRow
+            key={key}
+            fullWidth
+            data-test-subj={getTestId(`${key}-container`)}
+            label={
+              <EuiFlexGroup responsive={false}>
+                <EuiFlexItem grow={true} data-test-subj={getTestId(`${key}-label`)}>
+                  {key}
+                </EuiFlexItem>
+                {documentation && (
+                  <EuiFlexItem grow={false}>
+                    <EuiIconTip
+                      type="info"
+                      content={documentation}
+                      position="right"
+                      anchorProps={{ 'data-test-subj': getTestId(`${key}-tooltipIcon`) }}
+                    />
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+            }
+            labelAppend={
+              <EuiText size="xs" data-test-subj={getTestId(`${key}-versionInfo`)}>
+                {lastVersion ? `${firstVersion}-${lastVersion}` : `${firstVersion}+`}
+              </EuiText>
+            }
+          >
+            {isEditMode ? (
+              <EuiFieldText
+                data-test-subj={key}
+                fullWidth
+                name={key}
+                value={value as string}
+                onChange={handleAdvancedSettingUpdate}
+              />
+            ) : (
+              <EuiText size="xs" data-test-subj={getTestId(`${key}-viewValue`)}>
+                {value || getEmptyValue()}
+              </EuiText>
+            )}
+          </EuiFormRow>
+        );
+      },
+      [policy, isEditMode, getTestId, handleAdvancedSettingUpdate]
     );
 
     return (
@@ -176,70 +349,115 @@ export const AdvancedSection = memo<AdvancedSectionProps>(
               </h4>
             </EuiText>
 
-            <EuiPanel data-test-subj={getTestId('settings')} paddingSize="s">
-              {AdvancedPolicySchema.map(
-                (
-                  {
-                    key,
-                    documentation,
-                    first_supported_version: firstVersion,
-                    last_supported_version: lastVersion,
-                    license,
-                  },
-                  index
-                ) => {
-                  if (!isPlatinumPlus && license === 'platinum') {
-                    return <React.Fragment key={key} />;
-                  }
+            <EuiSpacer size="s" />
 
-                  const configPath = key.split('.');
-                  const value = getValue(policy as unknown as Record<string, unknown>, configPath);
+            <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false} wrap={false}>
+              <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
+                <EuiFieldSearch
+                  fullWidth
+                  placeholder={SEARCH_PLACEHOLDER}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  data-test-subj={getTestId('search')}
+                  compressed
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonGroup
+                  legend={i18n.translate(
+                    'xpack.securitySolution.endpoint.policy.advanced.osFilterLegend',
+                    { defaultMessage: 'Filter by operating system' }
+                  )}
+                  options={[
+                    { id: 'all', label: FILTER_ALL },
+                    { id: 'linux', label: OS_LINUX },
+                    { id: 'mac', label: OS_MAC },
+                    { id: 'windows', label: OS_WINDOWS },
+                  ]}
+                  idSelected={selectedOS}
+                  onChange={(id) => setSelectedOS(id as OSFilterValue)}
+                  buttonSize="compressed"
+                  type="single"
+                  data-test-subj={getTestId('osFilter')}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false} style={{ minWidth: 180 }}>
+                <EuiSelect
+                  id={getTestId('categoryFilter')}
+                  options={[
+                    { value: 'all', text: FILTER_ALL },
+                    { value: 'performance', text: CATEGORY_PERFORMANCE },
+                    { value: 'product_features', text: CATEGORY_PRODUCT_FEATURES },
+                    { value: 'logs', text: CATEGORY_LOGS },
+                    { value: 'configs', text: CATEGORY_CONFIGS },
+                    { value: 'others', text: CATEGORY_OTHERS },
+                  ]}
+                  value={selectedCategory}
+                  onChange={(e) => setSelectedCategory(e.target.value as CategoryFilterValue)}
+                  fullWidth
+                  compressed
+                  data-test-subj={getTestId('categoryFilter')}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
 
+            <EuiSpacer size="m" />
+
+            {totalFilteredCount === 0 ? (
+              <EuiPanel data-test-subj={getTestId('settings')} paddingSize="l">
+                <EuiText size="s" color="subdued" data-test-subj={getTestId('emptyState')}>
+                  {EMPTY_STATE_MESSAGE}
+                </EuiText>
+              </EuiPanel>
+            ) : (
+              <EuiFlexGroup gutterSize="m" direction="column" data-test-subj={getTestId('settings')}>
+                {CATEGORY_ORDER.map((category) => {
+                  const entries = filteredAndGroupedSettings.get(category)!;
+                  if (entries.length === 0) return null;
                   return (
-                    <EuiFormRow
-                      key={key}
-                      fullWidth
-                      data-test-subj={getTestId(`${key}-container`)}
-                      label={
-                        <EuiFlexGroup responsive={false}>
-                          <EuiFlexItem grow={true} data-test-subj={getTestId(`${key}-label`)}>
-                            {key}
-                          </EuiFlexItem>
-                          {documentation && (
-                            <EuiFlexItem grow={false}>
-                              <EuiIconTip
-                                content={documentation}
-                                position="right"
-                                anchorProps={{ 'data-test-subj': getTestId(`${key}-tooltipIcon`) }}
-                              />
-                            </EuiFlexItem>
-                          )}
-                        </EuiFlexGroup>
-                      }
-                      labelAppend={
-                        <EuiText size="xs" data-test-subj={getTestId(`${key}-versionInfo`)}>
-                          {lastVersion ? `${firstVersion}-${lastVersion}` : `${firstVersion}+`}
-                        </EuiText>
-                      }
-                    >
-                      {isEditMode ? (
-                        <EuiFieldText
-                          data-test-subj={key}
-                          fullWidth
-                          name={key}
-                          value={value as string}
-                          onChange={handleAdvancedSettingUpdate}
-                        />
-                      ) : (
-                        <EuiText size="xs" data-test-subj={getTestId(`${key}-viewValue`)}>
-                          {value || getEmptyValue()}
-                        </EuiText>
-                      )}
-                    </EuiFormRow>
+                    <EuiFlexItem key={category}>
+                      <EuiPanel
+                        hasBorder
+                        paddingSize="none"
+                        data-test-subj={getTestId(`category-${category}`)}
+                      >
+                        <EuiAccordion
+                          id={`advanced-settings-category-${category}`}
+                          className="advancedSettingsCategoryAccordion"
+                          css={css`
+                            &.euiAccordion-isOpen .euiAccordion__triggerWrapper {
+                              border-bottom: 1px solid #d3dae6;
+                            }
+                          `}
+                          buttonContent={
+                            <span style={{ fontWeight: 600 }}>
+                              {CATEGORY_LABELS[category]} ({entries.length})
+                            </span>
+                          }
+                          buttonProps={{
+                            style: {
+                              padding: 12,
+                              width: '100%',
+                              textAlign: 'left',
+                              display: 'flex',
+                              alignItems: 'center',
+                            },
+                          }}
+                          arrowProps={{
+                            style: { marginLeft: 16 },
+                          }}
+                          initialIsOpen={true}
+                        >
+                          <div css={euiBackgroundColorCSS.subdued} style={{ padding: 12 }}>
+                            {entries.map((entry) => renderSettingRow(entry))}
+                          </div>
+                        </EuiAccordion>
+                      </EuiPanel>
+                    </EuiFlexItem>
                   );
-                }
-              )}
-            </EuiPanel>
+                })}
+              </EuiFlexGroup>
+            )}
           </div>
         )}
       </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/mocks.ts
@@ -151,7 +151,6 @@ export const getPolicySettingsFormTestSubjects = (
       warningCallout: advancedSectionTestSubj('warning'),
       search: advancedSectionTestSubj('search'),
       osFilter: advancedSectionTestSubj('osFilter'),
-      categoryFilter: advancedSectionTestSubj('categoryFilter'),
       emptyState: advancedSectionTestSubj('emptyState'),
       settingRowTestSubjects: (settingKeyPath: string) => {
         const testSubjForSetting = advancedSectionTestSubj.withPrefix(settingKeyPath);

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/mocks.ts
@@ -149,6 +149,10 @@ export const getPolicySettingsFormTestSubjects = (
       showHideButton: advancedSectionTestSubj('showButton'),
       settingsContainer: advancedSectionTestSubj('settings'),
       warningCallout: advancedSectionTestSubj('warning'),
+      search: advancedSectionTestSubj('search'),
+      osFilter: advancedSectionTestSubj('osFilter'),
+      categoryFilter: advancedSectionTestSubj('categoryFilter'),
+      emptyState: advancedSectionTestSubj('emptyState'),
       settingRowTestSubjects: (settingKeyPath: string) => {
         const testSubjForSetting = advancedSectionTestSubj.withPrefix(settingKeyPath);
 


### PR DESCRIPTION
## Summary

Improvements to the endpoint policy advanced settings section in Security. 
1. A search bar has been added that will search through the text field labels and tooltip content.
2. A filter group has been added to filter by OS
3. a category filter has been added to filter by category
4. Fields are now grouped within 5 categories that will collapse and expand on request.

<img width="1251" height="605" alt="image" src="https://github.com/user-attachments/assets/53ece5e6-8098-4fb4-af3b-d9195e79e7de" />

## POC todos
- [ ] Refactor if needed
- [ ] Get rid of useRef (see https://github.com/elastic/kibana/pull/255143#discussion_r2897038291)
- [ ] This PR is a good occasion to improve performance: every keystroke causes a 120ms long re-render, both when typing in an advanced option input (this is an old issue) and in the new search bar

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



