### PR TITLE
Escape regex metacharacters in get-field-values wildcard patterns

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_index_info/get_field_values_handler.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_index_info/get_field_values_handler.ts
@@ -212,9 +212,15 @@ async function getTextFieldSampleValues(
   );
 }
 
+/** Escapes regex metacharacters in a string */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** Converts a wildcard pattern to a regex */
 function wildcardToRegex(pattern: string): RegExp {
-  return new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
+  const escapedSegments = pattern.split('*').map(escapeRegExp);
+  return new RegExp(`^${escapedSegments.join('.*')}$`);
 }
 
 /** Determines the category for a field type */

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_index_info.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_index_info.spec.ts
@@ -440,6 +440,24 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         }
       });
 
+      it('handles regex metacharacters in wildcard patterns without throwing', async () => {
+        const results = await agentBuilderApiClient.executeTool({
+          id: OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
+          params: {
+            operation: 'get-field-values',
+            index: 'metrics-*',
+            fields: ['[abc*'],
+          },
+        });
+        const data = results[0].data as unknown as FieldValuesRecordResult;
+
+        const result = data.fields['[abc*'];
+        expect(result.type).to.be('error');
+        if (result.type === 'error') {
+          expect(result.message).to.contain('No fields match pattern');
+        }
+      });
+
       it('does not return parent object fields when querying a specific field', async () => {
         // This tests that fieldCaps parent objects (from passthrough types) are filtered out
         // When querying "host.name", we should NOT get "host" as an error


### PR DESCRIPTION
Prevent invalid regex construction when wildcard field patterns include regex metacharacters (e.g. [), by escaping non-wildcard segments before building the RegExp.
