### PR TITLE
Fix Observability Functional UI Tests - data shows Wafflemap

### DIFF
--- a/x-pack/solutions/observability/test/functional/apps/infra/feature_controls/infrastructure_security.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/feature_controls/infrastructure_security.ts
@@ -111,6 +111,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             await testSubjects.existOrFail('waffleDatePicker');
           });
 
+          expect(await testSubjects.exists('waffleMap')).to.be(false);
+
           await retry.tryForTime(60000, async () => {
             await PageObjects.infraHome.goToTime(DATE_WITH_DATA);
             await PageObjects.infraHome.getWaffleMap();
@@ -226,6 +228,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           await retry.tryForTime(30000, async () => {
             await testSubjects.existOrFail('waffleDatePicker');
           });
+
+          expect(await testSubjects.exists('waffleMap')).to.be(false);
 
           await retry.tryForTime(60000, async () => {
             await PageObjects.infraHome.goToTime(DATE_WITH_DATA);

--- a/x-pack/solutions/observability/test/functional/apps/infra/feature_controls/infrastructure_security.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/feature_controls/infrastructure_security.ts
@@ -95,16 +95,25 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
 
         it(`shows Wafflemap`, async () => {
-          await PageObjects.common.navigateToUrlWithBrowserHistory('infraOps', '', undefined, {
-            ensureCurrentUrl: true,
-            shouldLoginIfPrompted: false,
-          });
+          await PageObjects.common.navigateToUrlWithBrowserHistory(
+            'infraOps',
+            '/inventory',
+            undefined,
+            {
+              ensureCurrentUrl: true,
+              shouldLoginIfPrompted: false,
+            }
+          );
 
           await PageObjects.header.waitUntilLoadingHasFinished();
 
-          await retry.tryForTime(5000, async () => {
+          await retry.tryForTime(30000, async () => {
+            await testSubjects.existOrFail('waffleDatePicker');
+          });
+
+          await retry.tryForTime(60000, async () => {
             await PageObjects.infraHome.goToTime(DATE_WITH_DATA);
-            await testSubjects.existOrFail('~waffleMap');
+            await PageObjects.infraHome.getWaffleMap();
           });
         });
 
@@ -202,16 +211,25 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
 
         it(`shows Wafflemap`, async () => {
-          await PageObjects.common.navigateToUrlWithBrowserHistory('infraOps', '', undefined, {
-            ensureCurrentUrl: true,
-            shouldLoginIfPrompted: false,
-          });
+          await PageObjects.common.navigateToUrlWithBrowserHistory(
+            'infraOps',
+            '/inventory',
+            undefined,
+            {
+              ensureCurrentUrl: true,
+              shouldLoginIfPrompted: false,
+            }
+          );
 
           await PageObjects.header.waitUntilLoadingHasFinished();
 
-          await retry.tryForTime(5000, async () => {
+          await retry.tryForTime(30000, async () => {
+            await testSubjects.existOrFail('waffleDatePicker');
+          });
+
+          await retry.tryForTime(60000, async () => {
             await PageObjects.infraHome.goToTime(DATE_WITH_DATA);
-            await testSubjects.existOrFail('~waffleMap');
+            await PageObjects.infraHome.getWaffleMap();
           });
         });
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/230824

## Summary

Fix flaky tests about Wafflemap (ran 30 times locally and now works, before it would always crash at least once)


### How to run tests

#### Server

`node scripts/functional_tests_server --config x-pack/solutions/observability/test/functional/apps/infra/config.ts`

#### Client

`node scripts/functional_test_runner.js --config x-pack/solutions/observability/test/functional/apps/infra/config.ts --grep "infrastructure security"`

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->