### PR TITLE
[SigEvents][Evals] Add snapshot replay data generators for evals

### DIFF
--- a/x-pack/platform/packages/shared/kbn-es-snapshot-loader/src/types.ts
+++ b/x-pack/platform/packages/shared/kbn-es-snapshot-loader/src/types.ts
@@ -30,6 +30,19 @@ interface BaseConfig {
 // Restore configuration
 export interface RestoreConfig extends BaseConfig {
   indices?: string[];
+  /**
+   * Optional index rename during restore. This is useful to restore into a
+   * temporary location to avoid clobbering existing indices.
+   *
+   * Both values must be provided to enable renaming.
+   */
+  renamePattern?: string;
+  renameReplacement?: string;
+  /**
+   * When true, a restore that matches no indices is treated as a successful
+   * no-op (restoring nothing) instead of an error.
+   */
+  allowNoMatches?: boolean;
 }
 
 // Replay configuration

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/moon.yml
@@ -38,6 +38,7 @@ dependsOn:
   - '@kbn/es-query'
   - '@kbn/inference-common'
   - '@kbn/es-snapshot-loader'
+  - '@kbn/es-errors'
 tags:
   - functional-tests
   - package

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/moon.yml
@@ -37,6 +37,7 @@ dependsOn:
   - '@kbn/dissect-heuristics'
   - '@kbn/es-query'
   - '@kbn/inference-common'
+  - '@kbn/es-snapshot-loader'
 tags:
   - functional-tests
   - package

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/capture_otel_demo_snapshots.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/capture_otel_demo_snapshots.ts
@@ -13,11 +13,13 @@ import { GCS_BUCKET, BASELINE_WAIT_MS, FAILURE_WAIT_MS, SCENARIOS } from './lib/
 import { getConnectionConfig, type ConnectionConfig } from './lib/get_connection_config';
 import { createSnapshot, generateGcsBasePath, registerGcsRepository } from './lib/gcs';
 import { sleep } from './lib/sleep';
+import { ensureLogsIndexTemplate } from '../../src/data_generators/logs_index_template';
 import {
   cleanupSigEventsExtractedFeaturesData,
   disableStreams,
   enableSignificantEvents,
   logSigEventsExtractedFeatures,
+  persistSigEventsExtractedFeaturesForSnapshot,
   triggerSigEventsFeatureExtraction,
   waitForSigEventsFeatureExtraction,
 } from './lib/significant_events_workflow';
@@ -99,7 +101,9 @@ run(
     log.info('');
     log.info('Each snapshot contains:');
     log.info('  logs*                        - OTel Demo log data');
-    log.info('  .kibana_streams_features     - LLM-extracted features');
+    log.info(
+      '  sigevents-streams-features-* - LLM-extracted features (copied out of system indices)'
+    );
     log.info('');
     log.info(`To use in evals, update SIGEVENTS_SNAPSHOT_RUN in replay.ts to "${runId}"`);
   },
@@ -166,7 +170,11 @@ async function processScenario(
   log.info(`SCENARIO: ${scenario.id}${scenario.isFailure ? ' (failure)' : ' (baseline)'}`);
   log.info('='.repeat(70));
 
-  // Step 1 — Deploy OTel Demo (this will also enabled streams)
+  // Step 0 — Ensure the `logs` data stream exists so Streams feature extraction can run.
+  // (Streams' /internal/streams/{name}/features/_task requires a concrete data stream to exist.)
+  await ensureLogsDataStream(esClient, log);
+
+  // Step 1 — Deploy OTel Demo (this will stream logs into `logs`)
   log.info('[1/7] Deploying OTel Demo...');
   const { child, deployedPromise } = deployOtelDemo(log);
 
@@ -198,10 +206,11 @@ async function processScenario(
     await triggerSigEventsFeatureExtraction(config, log, connectorId);
     await waitForSigEventsFeatureExtraction(config, log);
     await logSigEventsExtractedFeatures(config, log);
+    await persistSigEventsExtractedFeaturesForSnapshot(config, esClient, log, scenario.id, 'logs');
 
     // Step 6 — Create a snapshot of the logs and extracted features
     log.info('[6/7] Creating GCS snapshot...');
-    await createSnapshot(esClient, log, scenario.id, runId);
+    await createSnapshot({ esClient, log, snapshotName: scenario.id, runId });
   } finally {
     // Kill the Otel Demo background process (log streamer)
     if (!child.killed) {
@@ -216,4 +225,37 @@ async function processScenario(
   await teardownOtelDemo(log);
 
   log.info(`Scenario "${scenario.id}" — done`);
+}
+
+async function ensureLogsDataStream(esClient: Client, log: ToolingLog): Promise<void> {
+  try {
+    await esClient.indices.getDataStream({ name: 'logs' });
+    return;
+  } catch (err) {
+    const statusCode = (err as { meta?: { statusCode?: number } })?.meta?.statusCode;
+    if (statusCode !== 404) {
+      throw err;
+    }
+  }
+
+  log.info('logs data stream not found — creating it for snapshot capture');
+  await ensureLogsIndexTemplate(esClient, log);
+
+  try {
+    await esClient.indices.createDataStream({ name: 'logs' });
+  } catch (err) {
+    // If something already exists at "logs" (e.g. a plain index), try to remove it and retry.
+    log.warning(
+      `Failed to create logs data stream (will attempt cleanup and retry): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    try {
+      await esClient.indices.deleteDataStream({ name: 'logs' });
+    } catch {
+      // ignore
+    }
+    await esClient.indices.delete({ index: 'logs', ignore_unavailable: true });
+    await esClient.indices.createDataStream({ name: 'logs' });
+  }
 }

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/capture_otel_demo_snapshots.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/capture_otel_demo_snapshots.ts
@@ -170,7 +170,7 @@ async function processScenario(
   log.info(`SCENARIO: ${scenario.id}${scenario.isFailure ? ' (failure)' : ' (baseline)'}`);
   log.info('='.repeat(70));
 
-  // Step 0 — Ensure the `logs` data stream exists so Streams feature extraction can run.
+  // Step 0 — Ensure the `logs` data stream exists so that feature extraction can run.
   // (Streams' /internal/streams/{name}/features/_task requires a concrete data stream to exist.)
   await ensureLogsDataStream(esClient, log);
 

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/gcs.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/gcs.ts
@@ -8,6 +8,7 @@
 import type { Client } from '@elastic/elasticsearch';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { GCS_BUCKET, GCS_BUCKET_FOLDER, OTEL_DEMO_NAMESPACE } from './constants';
+import { getSigeventsSnapshotFeaturesIndex } from '../../../src/data_generators/sigevents_features_index';
 
 export function generateGcsBasePath({
   runId,
@@ -45,14 +46,20 @@ export async function registerGcsRepository(
   log.info('GCS repository registered');
 }
 
-export async function createSnapshot(
-  esClient: Client,
-  log: ToolingLog,
-  snapshotName: string,
-  runId: string
-): Promise<void> {
+export async function createSnapshot({
+  esClient,
+  log,
+  snapshotName,
+  runId,
+}: {
+  esClient: Client;
+  log: ToolingLog;
+  snapshotName: string;
+  runId: string;
+}): Promise<void> {
   const repoName = generateGcsRepoName({ runId });
-  const indices = 'logs*,.kibana_streams_features';
+  const featuresIndex = getSigeventsSnapshotFeaturesIndex(snapshotName);
+  const indices = `logs*,${featuresIndex}`;
   log.info(`Creating snapshot "${repoName}/${snapshotName}" (indices: ${indices})`);
 
   const result = await esClient.snapshot.create({

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/otel_demo.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/otel_demo.ts
@@ -21,7 +21,9 @@ interface OtelDemoHandle {
 export function deployOtelDemo(log: ToolingLog): OtelDemoHandle {
   log.info('Deploying OTel Demo (will stream in background)...');
 
-  const child = execa('node', [otelDemoScript], {
+  // Force the demo to write logs into the `logs` data stream (not the default `logs.otel`)
+  // so it matches Streams' classic `logs` stream and our Significant Events dataset conventions.
+  const child = execa('node', [otelDemoScript, '--logs-index', 'logs'], {
     stdio: ['ignore', 'pipe', 'pipe'],
     reject: false,
     env: { ...process.env, FORCE_COLOR: '0' },

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/otel_demo.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/otel_demo.ts
@@ -22,7 +22,7 @@ export function deployOtelDemo(log: ToolingLog): OtelDemoHandle {
   log.info('Deploying OTel Demo (will stream in background)...');
 
   // Force the demo to write logs into the `logs` data stream (not the default `logs.otel`)
-  // so it matches Streams' classic `logs` stream and our Significant Events dataset conventions.
+  // so it matches `logs` stream and dataset conventions.
   const child = execa('node', [otelDemoScript, '--logs-index', 'logs'], {
     stdio: ['ignore', 'pipe', 'pipe'],
     reject: false,

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/significant_events_workflow.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/significant_events_workflow.ts
@@ -163,7 +163,15 @@ export async function persistSigEventsExtractedFeaturesForSnapshot(
 
     await esClient.bulk({ refresh: true, operations });
   } else {
-    await esClient.indices.refresh({ index });
+    try {
+      await esClient.indices.refresh({ index });
+    } catch (error) {
+      throw new Error(
+        `Failed to refresh features index "${index}" before snapshotting: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
   }
 
   log.info(`Persisted ${features.length} features to "${index}" for snapshotting`);

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/significant_events_workflow.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/significant_events_workflow.ts
@@ -7,9 +7,14 @@
 
 import type { Client } from '@elastic/elasticsearch';
 import type { ToolingLog } from '@kbn/tooling-log';
+import type { Feature } from '@kbn/streams-schema';
 import type { ConnectionConfig } from './get_connection_config';
 import { kibanaRequest } from './kibana';
 import { FEATURE_EXTRACTION_POLL_INTERVAL_MS, FEATURE_EXTRACTION_TIMEOUT_MS } from './constants';
+import {
+  getSigeventsSnapshotFeaturesIndex,
+  SIGEVENTS_FEATURES_INDEX_PATTERN,
+} from '../../../src/data_generators/sigevents_features_index';
 
 export async function enableSignificantEvents(
   config: ConnectionConfig,
@@ -95,17 +100,74 @@ export async function logSigEventsExtractedFeatures(
   config: ConnectionConfig,
   log: ToolingLog
 ): Promise<void> {
-  const { data } = await kibanaRequest(config, 'GET', '/internal/streams/logs/features');
-  const features = (data as Record<string, unknown>)?.features;
-  if (Array.isArray(features)) {
-    log.info(`Extracted ${features.length} features:`);
-    for (const f of features) {
-      const feat = f as Record<string, unknown>;
-      log.info(`  - ${feat.title || feat.description} (${feat.type})`);
-    }
-  } else {
-    log.warning('Could not retrieve features after extraction');
+  const features = await fetchSigEventsExtractedFeatures(config, log, 'logs');
+  log.info(`Extracted ${features.length} features:`);
+  for (const f of features) {
+    log.info(`  - ${f.title || f.description} (${f.type})`);
   }
+}
+
+async function fetchSigEventsExtractedFeatures(
+  config: ConnectionConfig,
+  log: ToolingLog,
+  streamName: string
+): Promise<Feature[]> {
+  const { data } = await kibanaRequest(config, 'GET', `/internal/streams/${streamName}/features`);
+  const features = (data as Record<string, unknown>)?.features;
+  if (!Array.isArray(features)) {
+    throw new Error(`Expected "features" array from Kibana, got: ${JSON.stringify(data)}`);
+  }
+  return features.filter(Boolean) as Feature[];
+}
+
+export async function persistSigEventsExtractedFeaturesForSnapshot(
+  config: ConnectionConfig,
+  esClient: Client,
+  log: ToolingLog,
+  snapshotName: string,
+  streamName: string = 'logs'
+): Promise<{ index: string; count: number }> {
+  const features = await fetchSigEventsExtractedFeatures(config, log, streamName);
+  const index = getSigeventsSnapshotFeaturesIndex(snapshotName);
+
+  await esClient.indices.delete({ index, ignore_unavailable: true });
+  await esClient.indices.create({
+    index,
+    mappings: {
+      dynamic: false,
+      properties: {
+        uuid: { type: 'keyword' },
+        id: { type: 'keyword' },
+        stream_name: { type: 'keyword' },
+        type: { type: 'keyword' },
+        subtype: { type: 'keyword' },
+        title: { type: 'keyword' },
+        description: { type: 'text' },
+        properties: { type: 'object', enabled: false },
+        confidence: { type: 'float' },
+        evidence: { type: 'keyword' },
+        tags: { type: 'keyword' },
+        meta: { type: 'object', enabled: false },
+        status: { type: 'keyword' },
+        last_seen: { type: 'date' },
+        expires_at: { type: 'date' },
+      },
+    },
+  });
+
+  if (features.length > 0) {
+    const operations = features.flatMap((feature) => [
+      { index: { _index: index, _id: feature.uuid } },
+      feature,
+    ]);
+
+    await esClient.bulk({ refresh: true, operations });
+  } else {
+    await esClient.indices.refresh({ index });
+  }
+
+  log.info(`Persisted ${features.length} features to "${index}" for snapshotting`);
+  return { index, count: features.length };
 }
 
 export async function cleanupSigEventsExtractedFeaturesData(
@@ -114,7 +176,7 @@ export async function cleanupSigEventsExtractedFeaturesData(
 ): Promise<void> {
   log.info('Cleaning up ES data...');
 
-  for (const target of ['logs*', '.kibana_streams_features']) {
+  for (const target of ['logs*', '.kibana_streams_features', SIGEVENTS_FEATURES_INDEX_PATTERN]) {
     try {
       await esClient.indices.deleteDataStream({ name: target });
     } catch {

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Feature } from '@kbn/streams-schema';
+import { canonicalFeaturesFromExpectedGroundTruth } from './canonical_features';
+import { CANONICAL_LAST_SEEN } from './canonical_features';
+
+const getFeatureById = (features: Feature[], id: string) =>
+  features.find((feature) => feature.id === id);
+
+describe('canonical_features', () => {
+  it('creates deterministic entity/dependency/infra features from expected_ground_truth', () => {
+    const features = canonicalFeaturesFromExpectedGroundTruth({
+      streamName: 'logs',
+      scenarioId: 'payment-unreachable',
+      expectedGroundTruth:
+        'entities=[frontend, checkout, payment], deps=[frontend->checkout (gRPC), checkout->payment (gRPC)], infra=[kubernetes]',
+    });
+
+    expect(getFeatureById(features, 'entity-frontend')?.type).toBe('entity');
+    expect(getFeatureById(features, 'entity-frontend')?.properties).toEqual({ name: 'frontend' });
+
+    expect(getFeatureById(features, 'dep-frontend-checkout')?.type).toBe('dependency');
+    expect(getFeatureById(features, 'dep-frontend-checkout')?.properties).toEqual({
+      from: 'frontend',
+      to: 'checkout',
+    });
+    expect(getFeatureById(features, 'dep-frontend-checkout')?.title).toBe('frontend → checkout');
+
+    expect(getFeatureById(features, 'infra-kubernetes')?.type).toBe('infrastructure');
+    expect(getFeatureById(features, 'infra-kubernetes')?.properties).toEqual({
+      name: 'kubernetes',
+    });
+
+    // Deterministic uuid prefix
+    expect(getFeatureById(features, 'entity-frontend')?.uuid).toBe(
+      'canonical-payment-unreachable-entity-frontend'
+    );
+    // Stable last_seen for canonical features
+    expect(getFeatureById(features, 'entity-frontend')?.last_seen).toBe(CANONICAL_LAST_SEEN);
+  });
+
+  it('filters ellipsis and “multiple services” items', () => {
+    const features = canonicalFeaturesFromExpectedGroundTruth({
+      streamName: 'logs',
+      scenarioId: 'healthy-baseline',
+      expectedGroundTruth:
+        'entities=[frontend, ..., multiple services], deps=[frontend->checkout], infra=[kubernetes]',
+    });
+
+    expect(features.some((feature) => feature.id === 'entity-frontend')).toBe(true);
+    expect(features.some((feature) => feature.id.includes('multiple-services'))).toBe(false);
+  });
+
+  it('skips malformed deps without ->', () => {
+    const features = canonicalFeaturesFromExpectedGroundTruth({
+      streamName: 'logs',
+      scenarioId: 'healthy-baseline',
+      expectedGroundTruth: 'deps=[frontend checkout, checkout->payment]',
+    });
+
+    expect(features.some((feature) => feature.id === 'dep-checkout-payment')).toBe(true);
+    expect(features.some((feature) => feature.description.includes('frontend checkout'))).toBe(
+      false
+    );
+  });
+
+  it('drops text within parentheses from ids', () => {
+    const features = canonicalFeaturesFromExpectedGroundTruth({
+      streamName: 'logs',
+      scenarioId: 'scenario',
+      expectedGroundTruth: 'entities=[payment (nodejs)], deps=[frontend->checkout (gRPC)]',
+    });
+
+    expect(features.some((feature) => feature.id === 'entity-payment')).toBe(true);
+    expect(features.some((feature) => feature.id.includes('nodejs'))).toBe(false);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.test.ts
@@ -36,9 +36,8 @@ describe('canonical_features', () => {
       name: 'kubernetes',
     });
 
-    // Deterministic uuid prefix
-    expect(getFeatureById(features, 'entity-frontend')?.uuid).toBe(
-      'canonical-payment-unreachable-entity-frontend'
+    expect(getFeatureById(features, 'entity-frontend')?.uuid).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-a[0-9a-f]{3}-[0-9a-f]{12}$/
     );
     // Stable last_seen for canonical features
     expect(getFeatureById(features, 'entity-frontend')?.last_seen).toBe(CANONICAL_LAST_SEEN);
@@ -78,5 +77,22 @@ describe('canonical_features', () => {
 
     expect(features.some((feature) => feature.id === 'entity-payment')).toBe(true);
     expect(features.some((feature) => feature.id.includes('nodejs'))).toBe(false);
+  });
+
+  it('generates stable uuids for the same scenario and feature id', () => {
+    const firstRun = canonicalFeaturesFromExpectedGroundTruth({
+      streamName: 'logs',
+      scenarioId: 'payment-unreachable',
+      expectedGroundTruth: 'entities=[frontend]',
+    });
+    const secondRun = canonicalFeaturesFromExpectedGroundTruth({
+      streamName: 'logs',
+      scenarioId: 'payment-unreachable',
+      expectedGroundTruth: 'entities=[frontend]',
+    });
+
+    expect(getFeatureById(firstRun, 'entity-frontend')?.uuid).toBe(
+      getFeatureById(secondRun, 'entity-frontend')?.uuid
+    );
   });
 });

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Feature } from '@kbn/streams-schema';
+
+const CANONICAL_LAST_SEEN = '2026-01-01T00:00:00.000Z';
+
+const normalizeIdPart = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const parseBracketList = (raw: string): string[] =>
+  raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => s.replace(/\([^)]*\)/g, '').trim())
+    .filter((s) => s.length > 0)
+    .filter((s) => !s.includes('...'))
+    .filter((s) => !s.toLowerCase().includes('multiple services'));
+
+const parseGroundTruthBlocks = (expectedGroundTruth: string): Record<string, string[]> => {
+  const blocks: Record<string, string[]> = {};
+  const re = /([a-zA-Z_]+)\s*=\s*\[([^\]]*)\]/g;
+  for (const match of expectedGroundTruth.matchAll(re)) {
+    const key = match[1];
+    const list = match[2];
+    if (!key || list == null) continue;
+    blocks[key] = parseBracketList(list);
+  }
+  return blocks;
+};
+
+const makeFeature = ({
+  streamName,
+  scenarioId,
+  id,
+  type,
+  title,
+  description,
+  properties,
+}: {
+  streamName: string;
+  scenarioId: string;
+  id: string;
+  type: string;
+  title?: string;
+  description: string;
+  properties: Record<string, unknown>;
+}): Feature => ({
+  id,
+  uuid: `canonical-${normalizeIdPart(scenarioId)}-${normalizeIdPart(id)}`,
+  status: 'active',
+  last_seen: CANONICAL_LAST_SEEN,
+  stream_name: streamName,
+  type,
+  title,
+  description,
+  properties,
+  confidence: 100,
+});
+
+/**
+ * Builds a deterministic "canonical" feature set from the dataset's
+ * `expected_ground_truth` string (e.g. `entities=[...], deps=[...], infra=[...]`).
+ *
+ * This is intended to decouple query-generation evals from snapshot-extracted
+ * features so query-generation regressions can be distinguished from feature
+ * identification regressions.
+ */
+export const canonicalFeaturesFromExpectedGroundTruth = ({
+  streamName,
+  scenarioId,
+  expectedGroundTruth,
+}: {
+  streamName: string;
+  scenarioId: string;
+  expectedGroundTruth: string;
+}): Feature[] => {
+  const blocks = parseGroundTruthBlocks(expectedGroundTruth);
+
+  const entities = blocks.entities ?? [];
+  const deps = blocks.deps ?? [];
+  const infra = blocks.infra ?? [];
+
+  const features: Feature[] = [];
+
+  for (const entity of entities) {
+    const name = entity.trim();
+    const id = `entity-${normalizeIdPart(name)}`;
+    features.push(
+      makeFeature({
+        streamName,
+        scenarioId,
+        id,
+        type: 'entity',
+        title: name,
+        description: `Service/entity: ${name}`,
+        properties: { name },
+      })
+    );
+  }
+
+  for (const dep of deps) {
+    const arrowIdx = dep.indexOf('->');
+    if (arrowIdx === -1) continue;
+    const from = dep.slice(0, arrowIdx).trim();
+    const to =
+      dep
+        .slice(arrowIdx + 2)
+        .trim()
+        .split(/\s+/)[0] ?? '';
+    if (!from || !to) continue;
+
+    const id = `dep-${normalizeIdPart(from)}-${normalizeIdPart(to)}`;
+    features.push(
+      makeFeature({
+        streamName,
+        scenarioId,
+        id,
+        type: 'dependency',
+        title: `${from} → ${to}`,
+        description: `Dependency: ${from} → ${to}`,
+        properties: { from, to },
+      })
+    );
+  }
+
+  for (const item of infra) {
+    const name = item.trim();
+    const id = `infra-${normalizeIdPart(name)}`;
+    features.push(
+      makeFeature({
+        streamName,
+        scenarioId,
+        id,
+        type: 'infrastructure',
+        title: name,
+        description: `Infrastructure: ${name}`,
+        properties: { name },
+      })
+    );
+  }
+
+  return features;
+};

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/canonical_features.ts
@@ -7,7 +7,7 @@
 
 import type { Feature } from '@kbn/streams-schema';
 
-const CANONICAL_LAST_SEEN = '2026-01-01T00:00:00.000Z';
+export const CANONICAL_LAST_SEEN = '2026-01-01T00:00:00.000Z';
 
 const normalizeIdPart = (value: string): string =>
   value

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/list_snapshots.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/list_snapshots.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import { createGcsRepository } from '@kbn/es-snapshot-loader';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { GcsConfig } from './snapshot_run_config';
+import { resolveBasePath, SIGEVENTS_SNAPSHOT_RUN } from './snapshot_run_config';
+
+/**
+ * Lists all snapshot names available in the current {@link SIGEVENTS_SNAPSHOT_RUN}.
+ * Registers a temporary GCS repository, queries the snapshot API, then cleans up.
+ */
+export async function listAvailableSnapshots(
+  esClient: Client,
+  log: ToolingLog,
+  gcs: GcsConfig
+): Promise<string[]> {
+  const basePath = resolveBasePath(gcs);
+  const repoName = `sigevents-list-${Date.now()}`;
+  const repository = createGcsRepository({ bucket: gcs.bucket, basePath });
+
+  try {
+    repository.validate();
+    await repository.register({ esClient, log, repoName });
+
+    const result = await esClient.snapshot.get({
+      repository: repoName,
+      snapshot: '_all',
+    });
+
+    const names = (result.snapshots ?? []).map((s) => s.snapshot).filter(Boolean) as string[];
+    log.info(
+      `Found ${names.length} snapshot(s) in run "${SIGEVENTS_SNAPSHOT_RUN}": ${names.join(', ')}`
+    );
+    return names;
+  } finally {
+    try {
+      await esClient.snapshot.deleteRepository({ name: repoName });
+    } catch {
+      log.debug('Failed to delete listing repository');
+    }
+  }
+}

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import {
+  GCS_BUCKET,
+  OTEL_DEMO_GCS_BASE_PATH_PREFIX,
+} from '../../scripts/significant_events_snapshots/lib/constants';
+
+const mockCreateGcsRepository = jest.fn(() => ({ mocked: true }));
+const mockRestoreSnapshot = jest.fn();
+
+jest.mock('@kbn/es-snapshot-loader', () => ({
+  createGcsRepository: mockCreateGcsRepository,
+  restoreSnapshot: mockRestoreSnapshot,
+}));
+
+describe('load_features_from_snapshot', () => {
+  const log = {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+  } as any;
+
+  const gcs = { bucket: GCS_BUCKET, basePathPrefix: OTEL_DEMO_GCS_BASE_PATH_PREFIX };
+
+  const makeEsClient = (): Client =>
+    ({
+      indices: {
+        delete: jest.fn().mockResolvedValue({}),
+      },
+      search: jest.fn().mockResolvedValue({
+        hits: { hits: [] },
+      }),
+    } as any);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SIGEVENTS_SNAPSHOT_RUN = '2026-02-26-test';
+    jest.resetModules();
+  });
+
+  it('returns an empty array when allowNoMatches results in zero restored indices', async () => {
+    mockRestoreSnapshot.mockResolvedValue({
+      success: true,
+      snapshotName: 'payment-unreachable',
+      restoredIndices: [],
+      errors: [],
+    });
+
+    const esClient = makeEsClient();
+    const { loadFeaturesFromSnapshot } = await import('./load_features_from_snapshot');
+    const features = await loadFeaturesFromSnapshot(
+      esClient,
+      log,
+      'payment-unreachable',
+      gcs,
+      'logs'
+    );
+
+    expect(features).toEqual([]);
+    expect(esClient.search).not.toHaveBeenCalled();
+  });
+
+  it('restores into temp index and returns matching Feature docs', async () => {
+    mockRestoreSnapshot.mockResolvedValue({
+      success: true,
+      snapshotName: 'payment-unreachable',
+      restoredIndices: ['sigevents-replay-temp-features'],
+      errors: [],
+    });
+
+    const esClient = makeEsClient();
+    (esClient.search as any).mockResolvedValue({
+      hits: {
+        hits: [
+          { _source: { uuid: 'u1', id: 'f1', stream_name: 'logs', type: 'entity' } },
+          { _source: { uuid: 'u2', id: 'f2', stream_name: 'logs', type: 'dependency' } },
+        ],
+      },
+    });
+
+    const { loadFeaturesFromSnapshot, FEATURES_TEMP_INDEX } = await import(
+      './load_features_from_snapshot'
+    );
+    const features = await loadFeaturesFromSnapshot(
+      esClient,
+      log,
+      'payment-unreachable',
+      gcs,
+      'logs'
+    );
+
+    expect(features).toHaveLength(2);
+
+    expect(mockCreateGcsRepository).toHaveBeenCalledWith({
+      bucket: GCS_BUCKET,
+      basePath: `${OTEL_DEMO_GCS_BASE_PATH_PREFIX}/2026-02-26-test`,
+    });
+
+    expect(mockRestoreSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotName: 'payment-unreachable',
+        renamePattern: '(.+)',
+        renameReplacement: FEATURES_TEMP_INDEX,
+        allowNoMatches: true,
+      })
+    );
+  });
+
+  it('throws if restore succeeds but did not produce the expected temp index', async () => {
+    mockRestoreSnapshot.mockResolvedValue({
+      success: true,
+      snapshotName: 'healthy-baseline',
+      restoredIndices: ['some-other-index'],
+      errors: [],
+    });
+
+    const esClient = makeEsClient();
+    const { loadFeaturesFromSnapshot } = await import('./load_features_from_snapshot');
+
+    await expect(
+      loadFeaturesFromSnapshot(esClient, log, 'healthy-baseline', gcs, 'logs')
+    ).rejects.toThrow(/did not produce expected temp index/i);
+  });
+
+  it('cleans up the temp index at the end even if search throws', async () => {
+    const { loadFeaturesFromSnapshot, FEATURES_TEMP_INDEX } = await import(
+      './load_features_from_snapshot'
+    );
+    mockRestoreSnapshot.mockResolvedValue({
+      success: true,
+      snapshotName: 'payment-unreachable',
+      restoredIndices: [FEATURES_TEMP_INDEX],
+      errors: [],
+    });
+
+    const esClient = makeEsClient();
+    (esClient.search as any).mockRejectedValue(new Error('boom'));
+
+    await expect(
+      loadFeaturesFromSnapshot(esClient, log, 'payment-unreachable', gcs, 'logs')
+    ).rejects.toThrow('boom');
+
+    expect((esClient.indices.delete as any).mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(esClient.indices.delete).toHaveBeenCalledWith({
+      index: FEATURES_TEMP_INDEX,
+      ignore_unavailable: true,
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.ts
@@ -13,7 +13,7 @@ import type { GcsConfig } from './snapshot_run_config';
 import { resolveBasePath } from './snapshot_run_config';
 import { getSigeventsSnapshotFeaturesIndex } from './sigevents_features_index';
 
-const FEATURES_TEMP_INDEX = 'sigevents-replay-temp-features';
+export const FEATURES_TEMP_INDEX = 'sigevents-replay-temp-features';
 
 /**
  * Restores sigevents-captured features from a snapshot and returns all

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { createGcsRepository, restoreSnapshot } from '@kbn/es-snapshot-loader';
+import type { Feature } from '@kbn/streams-schema';
+import type { GcsConfig } from './snapshot_run_config';
+import { resolveBasePath } from './snapshot_run_config';
+import { getSigeventsSnapshotFeaturesIndex } from './sigevents_features_index';
+
+const FEATURES_TEMP_INDEX = 'sigevents-replay-temp-features';
+
+/**
+ * Restores sigevents-captured features from a snapshot and returns all
+ * {@link Feature} documents for the given stream. The temp index is cleaned
+ * up before returning.
+ */
+export async function loadFeaturesFromSnapshot(
+  esClient: Client,
+  log: ToolingLog,
+  snapshotName: string,
+  gcs: GcsConfig,
+  streamName: string = 'logs'
+): Promise<Feature[]> {
+  const basePath = resolveBasePath(gcs);
+  const repository = createGcsRepository({ bucket: gcs.bucket, basePath });
+  const featuresIndex = getSigeventsSnapshotFeaturesIndex(snapshotName);
+
+  try {
+    await esClient.indices.delete({ index: FEATURES_TEMP_INDEX, ignore_unavailable: true });
+
+    const restoreResult = await restoreSnapshot({
+      esClient,
+      log,
+      repository,
+      snapshotName,
+      indices: [featuresIndex],
+      renamePattern: '(.+)',
+      renameReplacement: FEATURES_TEMP_INDEX,
+      allowNoMatches: true,
+    });
+
+    if (!restoreResult.success) {
+      throw new Error(
+        `Failed to restore snapshot "${snapshotName}": ${restoreResult.errors.join('; ')}`
+      );
+    }
+
+    if (restoreResult.restoredIndices.length === 0) {
+      return [];
+    }
+
+    if (!restoreResult.restoredIndices.includes(FEATURES_TEMP_INDEX)) {
+      throw new Error(
+        `Snapshot "${snapshotName}" restore did not produce expected temp index "${FEATURES_TEMP_INDEX}". ` +
+          `Restored indices: ${restoreResult.restoredIndices.join(', ')}`
+      );
+    }
+
+    const searchResult = await esClient.search<Record<string, unknown>>({
+      index: FEATURES_TEMP_INDEX,
+      size: 1000,
+      query: { term: { stream_name: streamName } },
+    });
+
+    const features: Feature[] = searchResult.hits.hits
+      .map((hit) => hit._source as Feature)
+      .filter(Boolean);
+
+    log.info(`Loaded ${features.length} features from snapshot "${snapshotName}"`);
+    return features;
+  } finally {
+    try {
+      await esClient.indices.delete({ index: FEATURES_TEMP_INDEX, ignore_unavailable: true });
+    } catch {
+      log.debug(`Failed to delete temp features index`);
+    }
+  }
+}

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/load_features_from_snapshot.ts
@@ -14,6 +14,7 @@ import { resolveBasePath } from './snapshot_run_config';
 import { getSigeventsSnapshotFeaturesIndex } from './sigevents_features_index';
 
 export const FEATURES_TEMP_INDEX = 'sigevents-replay-temp-features';
+const FEATURES_SEARCH_LIMIT = 1000;
 
 /**
  * Restores sigevents-captured features from a snapshot and returns all
@@ -64,7 +65,7 @@ export async function loadFeaturesFromSnapshot(
 
     const searchResult = await esClient.search<Record<string, unknown>>({
       index: FEATURES_TEMP_INDEX,
-      size: 1000,
+      size: FEATURES_SEARCH_LIMIT,
       query: { term: { stream_name: streamName } },
     });
 
@@ -72,7 +73,9 @@ export async function loadFeaturesFromSnapshot(
       .map((hit) => hit._source as Feature)
       .filter(Boolean);
 
-    log.info(`Loaded ${features.length} features from snapshot "${snapshotName}"`);
+    log.info(
+      `Loaded ${features.length} features from snapshot "${snapshotName}" (search limit: ${FEATURES_SEARCH_LIMIT})`
+    );
     return features;
   } finally {
     try {

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/logs_index_template.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/logs_index_template.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
+
+const SIGEVENTS_INDEX_TEMPLATE = 'sigevents-otel-logs';
+
+/**
+ * OTel Demo data requires two mapping workarounds for clean reindexing:
+ *
+ * 1. `subobjects: false` -- Different services emit `resource.attributes.app`
+ *    as a flat string or a nested object. Flattening all fields to leaves
+ *    eliminates the structural mapping conflict.
+ *
+ * 2. `ignore_malformed: true` -- Fields like `attributes.log.timestamp`
+ *    contain epoch millis in scientific notation (e.g. `1.771443280796E12`)
+ *    which ES's date parser rejects. Ignoring malformed values lets the
+ *    document index successfully while silently dropping the unparseable field.
+ */
+export async function ensureLogsIndexTemplate(esClient: Client, log: ToolingLog): Promise<void> {
+  log.debug(`Creating index template "${SIGEVENTS_INDEX_TEMPLATE}"`);
+
+  await esClient.indices.putIndexTemplate({
+    name: SIGEVENTS_INDEX_TEMPLATE,
+    index_patterns: ['logs'],
+    data_stream: {},
+    template: {
+      settings: {
+        index: {
+          mapping: {
+            ignore_malformed: true,
+          },
+        },
+      },
+      mappings: {
+        subobjects: false,
+      },
+    },
+    priority: 500,
+  });
+}
+
+export async function deleteLogsIndexTemplate(esClient: Client, log: ToolingLog): Promise<void> {
+  try {
+    await esClient.indices.deleteIndexTemplate({ name: SIGEVENTS_INDEX_TEMPLATE });
+  } catch {
+    log.debug(`Failed to delete index template "${SIGEVENTS_INDEX_TEMPLATE}" (may not exist)`);
+  }
+}

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { GcsConfig } from './snapshot_run_config';
+export { SIGEVENTS_SNAPSHOT_RUN, resolveBasePath } from './snapshot_run_config';
+
+export { listAvailableSnapshots } from './list_snapshots';
+
+export { ensureLogsIndexTemplate, deleteLogsIndexTemplate } from './logs_index_template';
+
+export {
+  replaySignificantEventsSnapshot,
+  cleanSignificantEventsDataStreams,
+} from './replay_logs_snapshot';
+
+export type { ReplayStats } from './replay_into_managed_stream';
+export { replayIntoManagedStream } from './replay_into_managed_stream';
+
+export { loadFeaturesFromSnapshot } from './load_features_from_snapshot';
+
+export { canonicalFeaturesFromExpectedGroundTruth } from './canonical_features';

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay_into_managed_stream.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay_into_managed_stream.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { createGcsRepository } from '@kbn/es-snapshot-loader';
+import type { GcsConfig } from './snapshot_run_config';
+import { resolveBasePath } from './snapshot_run_config';
+import { ensureLogsIndexTemplate } from './logs_index_template';
+
+const REPLAY_TEMP_PREFIX = 'sigevents-replay-temp-';
+
+const TIMESTAMP_TRANSFORM_SCRIPT = `
+  // Reset the _id field to null to avoid conflicts with subsequent reindex operations
+  ctx._id = null;
+  if (ctx.containsKey('@timestamp') && ctx['@timestamp'] != null) {
+    Instant maxTime = Instant.parse(params.max_timestamp);
+    Instant originalTime = Instant.parse(ctx['@timestamp'].toString());
+    long deltaMillis = maxTime.toEpochMilli() - originalTime.toEpochMilli();
+    Instant now = Instant.ofEpochMilli(System.currentTimeMillis());
+    ctx['@timestamp'] = now.minusMillis(deltaMillis).toString();
+  }
+`;
+
+export interface ReplayStats {
+  total: number;
+  created: number;
+  skipped: number;
+}
+
+/**
+ * Replays a snapshot into the managed `logs` ES stream by setting a
+ * `default_pipeline` on the write index rather than specifying a per-request
+ * pipeline. ES streams reject per-request pipelines but honour the
+ * `default_pipeline` index setting — the same mechanism the Streams plugin
+ * itself uses for its own processing pipelines.
+ *
+ * Documents that fail due to mapping conflicts (e.g. `resource.attributes.app`
+ * typed as string in one service and object in another) are skipped.  The
+ * returned {@link ReplayStats} reports how many documents were indexed vs
+ * skipped so callers can decide whether the drop rate is acceptable.
+ */
+export async function replayIntoManagedStream(
+  esClient: Client,
+  log: ToolingLog,
+  snapshotName: string,
+  gcs: GcsConfig
+): Promise<ReplayStats> {
+  log.debug(`Replaying snapshot "${snapshotName}" into managed logs stream`);
+
+  const basePath = resolveBasePath(gcs);
+  const repoName = `sigevents-replay-${Date.now()}`;
+  const repository = createGcsRepository({ bucket: gcs.bucket, basePath });
+  const pipelineName = `sigevents-ts-transform-${Date.now()}`;
+  const tempIndices: string[] = [];
+  let previousDefaultPipeline: string | null = null;
+  let writeIndexName: string | null = null;
+
+  try {
+    repository.validate();
+    await repository.register({ esClient, log, repoName });
+
+    const snapshotInfo = await esClient.snapshot.get({
+      repository: repoName,
+      snapshot: snapshotName,
+    });
+
+    const snap = snapshotInfo.snapshots?.[0];
+    if (!snap) {
+      throw new Error(`Snapshot "${snapshotName}" not found in repository "${repoName}"`);
+    }
+
+    const logsIndices = (snap.indices ?? []).filter(
+      (idx) => idx.startsWith('.ds-logs') || idx === 'logs'
+    );
+    if (logsIndices.length === 0) {
+      throw new Error(`No logs indices found in snapshot "${snapshotName}"`);
+    }
+
+    log.debug(`Restoring ${logsIndices.length} indices to temp location`);
+    await esClient.snapshot.restore({
+      repository: repoName,
+      snapshot: snapshotName,
+      wait_for_completion: true,
+      indices: logsIndices.join(','),
+      include_global_state: false,
+      rename_pattern: '(.+)',
+      rename_replacement: `${REPLAY_TEMP_PREFIX}$1`,
+    });
+    tempIndices.push(...logsIndices.map((idx) => `${REPLAY_TEMP_PREFIX}${idx}`));
+
+    const maxTsResult = await esClient.search({
+      index: tempIndices.join(','),
+      size: 0,
+      aggs: { max_ts: { max: { field: '@timestamp' } } },
+    });
+
+    const maxTsValue = (maxTsResult.aggregations?.max_ts as { value_as_string?: string })
+      ?.value_as_string;
+
+    if (!maxTsValue) {
+      throw new Error('No @timestamp found in restored snapshot indices');
+    }
+    log.debug(`Max timestamp from snapshot data: ${maxTsValue}`);
+
+    let logsDs:
+      | {
+          name: string;
+          indices: Array<{ index_name: string }>;
+        }
+      | undefined;
+
+    try {
+      const dataStreams = await esClient.indices.getDataStream({ name: 'logs' });
+      logsDs = dataStreams.data_streams[0] as typeof logsDs;
+    } catch (err) {
+      const statusCode = (err as { meta?: { statusCode?: number } })?.meta?.statusCode;
+      if (statusCode !== 404) {
+        throw err;
+      }
+
+      log.debug('logs data stream not found — creating it for replay');
+      await ensureLogsIndexTemplate(esClient, log);
+      await esClient.indices.createDataStream({ name: 'logs' });
+
+      const dataStreams = await esClient.indices.getDataStream({ name: 'logs' });
+      logsDs = dataStreams.data_streams[0] as typeof logsDs;
+    }
+
+    if (!logsDs) {
+      throw new Error('logs data stream not found');
+    }
+    const writeIndex = logsDs.indices.at(-1);
+    if (!writeIndex) {
+      throw new Error('logs data stream has no write index');
+    }
+    writeIndexName = writeIndex.index_name;
+
+    const settings = await esClient.indices.getSettings({ index: writeIndexName });
+    previousDefaultPipeline =
+      ((settings[writeIndexName]?.settings?.index as Record<string, unknown>)?.default_pipeline as
+        | string
+        | undefined) ?? '_none';
+
+    let chainedPipelineName: string | undefined =
+      previousDefaultPipeline !== '_none' ? previousDefaultPipeline : undefined;
+
+    if (chainedPipelineName) {
+      try {
+        await esClient.ingest.getPipeline({ id: chainedPipelineName });
+        log.debug(`Chaining existing default_pipeline: ${chainedPipelineName}`);
+      } catch {
+        log.warning(
+          `Write index default_pipeline "${chainedPipelineName}" not found; replay will run without it`
+        );
+        chainedPipelineName = undefined;
+      }
+    } else {
+      log.debug('Write index has no default_pipeline; replay will use timestamp transform only');
+    }
+
+    await esClient.ingest.putPipeline({
+      id: pipelineName,
+      processors: [
+        {
+          script: {
+            lang: 'painless',
+            params: { max_timestamp: maxTsValue },
+            source: TIMESTAMP_TRANSFORM_SCRIPT,
+          },
+        },
+        ...(chainedPipelineName
+          ? [
+              {
+                pipeline: {
+                  name: chainedPipelineName,
+                  ignore_missing_pipeline: true,
+                },
+              },
+            ]
+          : []),
+      ],
+    });
+
+    log.debug(`Setting default_pipeline on ${writeIndexName} to ${pipelineName}`);
+    await esClient.indices.putSettings({
+      index: writeIndexName,
+      settings: { 'index.default_pipeline': pipelineName },
+    });
+
+    log.debug('Reindexing into managed logs stream via default_pipeline');
+    const reindexResult = await esClient.reindex(
+      {
+        wait_for_completion: true,
+        source: { index: tempIndices.join(',') },
+        dest: { index: 'logs', op_type: 'create' },
+      },
+      { requestTimeout: 30 * 60 * 1000 }
+    );
+
+    const total = reindexResult.total ?? 0;
+    const created = reindexResult.created ?? 0;
+    const failures = reindexResult.failures ?? [];
+    const skipped = total - created;
+
+    if (failures.length > 0) {
+      log.warning(`Reindex: ${skipped} docs skipped due to mapping conflicts`);
+      for (const failure of failures.slice(0, 5)) {
+        const reason = failure.cause?.reason?.split('\n')[0]?.slice(0, 150) ?? 'unknown';
+        log.debug(`  - ${failure.cause?.type ?? 'error'}: ${reason}`);
+      }
+      if (failures.length > 5) {
+        log.debug(`  ... and ${failures.length - 5} more`);
+      }
+    }
+
+    log.info(`Replay complete: ${created}/${total} docs indexed, ${skipped} skipped`);
+    return { total, created, skipped };
+  } finally {
+    if (writeIndexName && previousDefaultPipeline !== null) {
+      try {
+        await esClient.indices.putSettings({
+          index: writeIndexName,
+          settings: { 'index.default_pipeline': previousDefaultPipeline },
+        });
+      } catch {
+        log.debug('Failed to restore default_pipeline');
+      }
+    }
+
+    for (const index of tempIndices) {
+      try {
+        await esClient.indices.delete({ index, ignore_unavailable: true });
+      } catch {
+        log.debug(`Failed to delete temp index: ${index}`);
+      }
+    }
+    try {
+      await esClient.ingest.deletePipeline({ id: pipelineName });
+    } catch {
+      log.debug('Failed to delete timestamp pipeline');
+    }
+    try {
+      await esClient.snapshot.deleteRepository({ name: repoName });
+    } catch {
+      log.debug('Failed to delete snapshot repository');
+    }
+  }
+}

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay_into_managed_stream.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay_into_managed_stream.ts
@@ -6,13 +6,17 @@
  */
 
 import type { Client } from '@elastic/elasticsearch';
+import { isNotFoundError } from '@kbn/es-errors';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { createGcsRepository } from '@kbn/es-snapshot-loader';
 import type { GcsConfig } from './snapshot_run_config';
 import { resolveBasePath } from './snapshot_run_config';
 import { ensureLogsIndexTemplate } from './logs_index_template';
 
+const LOGS_STREAM_NAME = 'logs';
 const REPLAY_TEMP_PREFIX = 'sigevents-replay-temp-';
+const REINDEX_REQUEST_TIMEOUT_MS = 30 * 60 * 1000;
+const MAX_LOGGED_REINDEX_FAILURES = 5;
 
 const TIMESTAMP_TRANSFORM_SCRIPT = `
   // Reset the _id field to null to avoid conflicts with subsequent reindex operations
@@ -31,6 +35,343 @@ export interface ReplayStats {
   created: number;
   skipped: number;
 }
+
+interface ReplayArtifacts {
+  repoName: string;
+  pipelineName: string;
+  tempIndices: string[];
+  writeIndexName?: string;
+  previousDefaultPipeline?: string;
+}
+
+interface LogsDataStream {
+  indices: Array<{ index_name: string }>;
+}
+
+const createReplayArtifacts = (): ReplayArtifacts => {
+  const runId = Date.now();
+  return {
+    repoName: `sigevents-replay-${runId}`,
+    pipelineName: `sigevents-ts-transform-${runId}`,
+    tempIndices: [],
+  };
+};
+
+const getLogsIndicesFromSnapshot = async ({
+  esClient,
+  repoName,
+  snapshotName,
+}: {
+  esClient: Client;
+  repoName: string;
+  snapshotName: string;
+}): Promise<string[]> => {
+  const snapshotInfo = await esClient.snapshot.get({
+    repository: repoName,
+    snapshot: snapshotName,
+  });
+
+  const snapshot = snapshotInfo.snapshots?.[0];
+  if (!snapshot) {
+    throw new Error(`Snapshot "${snapshotName}" not found in repository "${repoName}"`);
+  }
+
+  const logsIndices = (snapshot.indices ?? []).filter(
+    (indexName) => indexName.startsWith('.ds-logs') || indexName === LOGS_STREAM_NAME
+  );
+  if (logsIndices.length === 0) {
+    throw new Error(`No logs indices found in snapshot "${snapshotName}"`);
+  }
+
+  return logsIndices;
+};
+
+const restoreLogsIndicesToTemp = async ({
+  esClient,
+  repoName,
+  snapshotName,
+  logsIndices,
+  log,
+}: {
+  esClient: Client;
+  repoName: string;
+  snapshotName: string;
+  logsIndices: string[];
+  log: ToolingLog;
+}): Promise<string[]> => {
+  log.debug(`Restoring ${logsIndices.length} indices to temp location`);
+
+  await esClient.snapshot.restore({
+    repository: repoName,
+    snapshot: snapshotName,
+    wait_for_completion: true,
+    indices: logsIndices.join(','),
+    include_global_state: false,
+    rename_pattern: '(.+)',
+    rename_replacement: `${REPLAY_TEMP_PREFIX}$1`,
+  });
+
+  return logsIndices.map((indexName) => `${REPLAY_TEMP_PREFIX}${indexName}`);
+};
+
+const getMaxTimestampFromTempIndices = async ({
+  esClient,
+  tempIndices,
+  log,
+}: {
+  esClient: Client;
+  tempIndices: string[];
+  log: ToolingLog;
+}): Promise<string> => {
+  const maxTsResult = await esClient.search({
+    index: tempIndices.join(','),
+    size: 0,
+    aggs: { max_ts: { max: { field: '@timestamp' } } },
+  });
+
+  const maxTsValue = (maxTsResult.aggregations?.max_ts as { value_as_string?: string })
+    ?.value_as_string;
+
+  if (!maxTsValue) {
+    throw new Error('No @timestamp found in restored snapshot indices');
+  }
+
+  log.debug(`Max timestamp from snapshot data: ${maxTsValue}`);
+  return maxTsValue;
+};
+
+const getLogsDataStream = async (esClient: Client): Promise<LogsDataStream | undefined> => {
+  const dataStreams = await esClient.indices.getDataStream({ name: LOGS_STREAM_NAME });
+  return dataStreams.data_streams[0] as LogsDataStream | undefined;
+};
+
+const ensureLogsDataStream = async ({
+  esClient,
+  log,
+}: {
+  esClient: Client;
+  log: ToolingLog;
+}): Promise<LogsDataStream> => {
+  try {
+    const logsDataStream = await getLogsDataStream(esClient);
+    if (!logsDataStream) {
+      throw new Error(`${LOGS_STREAM_NAME} data stream not found`);
+    }
+    return logsDataStream;
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+
+    log.debug(`${LOGS_STREAM_NAME} data stream not found - creating it for replay`);
+    await ensureLogsIndexTemplate(esClient, log);
+    await esClient.indices.createDataStream({ name: LOGS_STREAM_NAME });
+
+    const logsDataStream = await getLogsDataStream(esClient);
+    if (!logsDataStream) {
+      throw new Error(`${LOGS_STREAM_NAME} data stream not found after creation`);
+    }
+    return logsDataStream;
+  }
+};
+
+const getWriteIndexInfo = async ({
+  esClient,
+  log,
+}: {
+  esClient: Client;
+  log: ToolingLog;
+}): Promise<{ writeIndexName: string; previousDefaultPipeline: string }> => {
+  const logsDataStream = await ensureLogsDataStream({ esClient, log });
+  const writeIndex = logsDataStream.indices.at(-1);
+  if (!writeIndex?.index_name) {
+    throw new Error(`${LOGS_STREAM_NAME} data stream has no write index`);
+  }
+
+  const writeIndexName = writeIndex.index_name;
+  const settings = await esClient.indices.getSettings({ index: writeIndexName });
+  const previousDefaultPipeline =
+    ((settings[writeIndexName]?.settings?.index as Record<string, unknown>)?.default_pipeline as
+      | string
+      | undefined) ?? '_none';
+
+  return { writeIndexName, previousDefaultPipeline };
+};
+
+const getReplayChainPipeline = async ({
+  esClient,
+  log,
+  previousDefaultPipeline,
+}: {
+  esClient: Client;
+  log: ToolingLog;
+  previousDefaultPipeline: string;
+}): Promise<string | undefined> => {
+  if (previousDefaultPipeline === '_none') {
+    log.debug('Write index has no default_pipeline; replay will use timestamp transform only');
+    return undefined;
+  }
+
+  try {
+    await esClient.ingest.getPipeline({ id: previousDefaultPipeline });
+    log.debug(`Chaining existing default_pipeline: ${previousDefaultPipeline}`);
+    return previousDefaultPipeline;
+  } catch {
+    log.warning(
+      `Write index default_pipeline "${previousDefaultPipeline}" not found; replay will run without it`
+    );
+    return undefined;
+  }
+};
+
+const createReplayPipeline = async ({
+  esClient,
+  pipelineName,
+  maxTimestamp,
+  chainedPipelineName,
+}: {
+  esClient: Client;
+  pipelineName: string;
+  maxTimestamp: string;
+  chainedPipelineName?: string;
+}): Promise<void> => {
+  await esClient.ingest.putPipeline({
+    id: pipelineName,
+    processors: [
+      {
+        script: {
+          lang: 'painless',
+          params: { max_timestamp: maxTimestamp },
+          source: TIMESTAMP_TRANSFORM_SCRIPT,
+        },
+      },
+      ...(chainedPipelineName
+        ? [
+            {
+              pipeline: {
+                name: chainedPipelineName,
+                ignore_missing_pipeline: true,
+              },
+            },
+          ]
+        : []),
+    ],
+  });
+};
+
+const setWriteIndexDefaultPipeline = async ({
+  esClient,
+  writeIndexName,
+  pipelineName,
+  log,
+}: {
+  esClient: Client;
+  writeIndexName: string;
+  pipelineName: string;
+  log: ToolingLog;
+}): Promise<void> => {
+  log.debug(`Setting default_pipeline on ${writeIndexName} to ${pipelineName}`);
+  await esClient.indices.putSettings({
+    index: writeIndexName,
+    settings: { 'index.default_pipeline': pipelineName },
+  });
+};
+
+const logReindexFailures = ({
+  log,
+  failures,
+  skipped,
+}: {
+  log: ToolingLog;
+  failures: Array<{ cause?: { reason?: string; type?: string } }>;
+  skipped: number;
+}): void => {
+  log.warning(`Reindex: ${skipped} docs skipped due to mapping conflicts`);
+  for (const failure of failures.slice(0, MAX_LOGGED_REINDEX_FAILURES)) {
+    const reason = failure.cause?.reason?.split('\n')[0]?.slice(0, 150) ?? 'unknown';
+    log.debug(`  - ${failure.cause?.type ?? 'error'}: ${reason}`);
+  }
+  if (failures.length > MAX_LOGGED_REINDEX_FAILURES) {
+    log.debug(`  ... and ${failures.length - MAX_LOGGED_REINDEX_FAILURES} more`);
+  }
+};
+
+const reindexTempIndicesIntoManagedStream = async ({
+  esClient,
+  tempIndices,
+  log,
+}: {
+  esClient: Client;
+  tempIndices: string[];
+  log: ToolingLog;
+}): Promise<ReplayStats> => {
+  log.debug('Reindexing into managed logs stream via default_pipeline');
+  const reindexResult = await esClient.reindex(
+    {
+      wait_for_completion: true,
+      source: { index: tempIndices.join(',') },
+      dest: { index: LOGS_STREAM_NAME, op_type: 'create' },
+    },
+    { requestTimeout: REINDEX_REQUEST_TIMEOUT_MS }
+  );
+
+  const total = reindexResult.total ?? 0;
+  const created = reindexResult.created ?? 0;
+  const failures = (reindexResult.failures ?? []) as Array<{
+    cause?: { reason?: string; type?: string };
+  }>;
+  const skipped = total - created;
+
+  if (failures.length > 0) {
+    logReindexFailures({ log, failures, skipped });
+  }
+
+  return { total, created, skipped };
+};
+
+const cleanupReplayArtifacts = async ({
+  esClient,
+  log,
+  artifacts,
+}: {
+  esClient: Client;
+  log: ToolingLog;
+  artifacts: ReplayArtifacts;
+}): Promise<void> => {
+  const { writeIndexName, previousDefaultPipeline, tempIndices, pipelineName, repoName } =
+    artifacts;
+
+  if (writeIndexName && previousDefaultPipeline !== undefined) {
+    try {
+      await esClient.indices.putSettings({
+        index: writeIndexName,
+        settings: { 'index.default_pipeline': previousDefaultPipeline },
+      });
+    } catch {
+      log.debug('Failed to restore default_pipeline');
+    }
+  }
+
+  for (const indexName of tempIndices) {
+    try {
+      await esClient.indices.delete({ index: indexName, ignore_unavailable: true });
+    } catch {
+      log.debug(`Failed to delete temp index: ${indexName}`);
+    }
+  }
+
+  try {
+    await esClient.ingest.deletePipeline({ id: pipelineName });
+  } catch {
+    log.debug('Failed to delete timestamp pipeline');
+  }
+
+  try {
+    await esClient.snapshot.deleteRepository({ name: repoName });
+  } catch {
+    log.debug('Failed to delete snapshot repository');
+  }
+};
 
 /**
  * Replays a snapshot into the managed `logs` ES stream by setting a
@@ -53,201 +394,70 @@ export async function replayIntoManagedStream(
   log.debug(`Replaying snapshot "${snapshotName}" into managed logs stream`);
 
   const basePath = resolveBasePath(gcs);
-  const repoName = `sigevents-replay-${Date.now()}`;
   const repository = createGcsRepository({ bucket: gcs.bucket, basePath });
-  const pipelineName = `sigevents-ts-transform-${Date.now()}`;
-  const tempIndices: string[] = [];
-  let previousDefaultPipeline: string | null = null;
-  let writeIndexName: string | null = null;
+  const artifacts = createReplayArtifacts();
 
   try {
+    log.info('Step 1/4: Registering snapshot repository...');
     repository.validate();
-    await repository.register({ esClient, log, repoName });
+    await repository.register({ esClient, log, repoName: artifacts.repoName });
 
-    const snapshotInfo = await esClient.snapshot.get({
-      repository: repoName,
-      snapshot: snapshotName,
+    log.info('Step 2/4: Restoring logs snapshot indices into temporary indices...');
+    const logsIndices = await getLogsIndicesFromSnapshot({
+      esClient,
+      repoName: artifacts.repoName,
+      snapshotName,
+    });
+    artifacts.tempIndices = await restoreLogsIndicesToTemp({
+      esClient,
+      repoName: artifacts.repoName,
+      snapshotName,
+      logsIndices,
+      log,
     });
 
-    const snap = snapshotInfo.snapshots?.[0];
-    if (!snap) {
-      throw new Error(`Snapshot "${snapshotName}" not found in repository "${repoName}"`);
-    }
+    log.info('Step 3/4: Preparing replay pipeline and managed stream write index...');
+    const maxTimestamp = await getMaxTimestampFromTempIndices({
+      esClient,
+      tempIndices: artifacts.tempIndices,
+      log,
+    });
+    const { writeIndexName, previousDefaultPipeline } = await getWriteIndexInfo({ esClient, log });
+    artifacts.writeIndexName = writeIndexName;
+    artifacts.previousDefaultPipeline = previousDefaultPipeline;
 
-    const logsIndices = (snap.indices ?? []).filter(
-      (idx) => idx.startsWith('.ds-logs') || idx === 'logs'
+    const chainedPipelineName = await getReplayChainPipeline({
+      esClient,
+      log,
+      previousDefaultPipeline,
+    });
+
+    await createReplayPipeline({
+      esClient,
+      pipelineName: artifacts.pipelineName,
+      maxTimestamp,
+      chainedPipelineName,
+    });
+
+    await setWriteIndexDefaultPipeline({
+      esClient,
+      writeIndexName,
+      pipelineName: artifacts.pipelineName,
+      log,
+    });
+
+    log.info('Step 4/4: Reindexing restored documents into managed logs stream...');
+    const stats = await reindexTempIndicesIntoManagedStream({
+      esClient,
+      tempIndices: artifacts.tempIndices,
+      log,
+    });
+
+    log.info(
+      `Replay complete: ${stats.created}/${stats.total} docs indexed, ${stats.skipped} skipped`
     );
-    if (logsIndices.length === 0) {
-      throw new Error(`No logs indices found in snapshot "${snapshotName}"`);
-    }
-
-    log.debug(`Restoring ${logsIndices.length} indices to temp location`);
-    await esClient.snapshot.restore({
-      repository: repoName,
-      snapshot: snapshotName,
-      wait_for_completion: true,
-      indices: logsIndices.join(','),
-      include_global_state: false,
-      rename_pattern: '(.+)',
-      rename_replacement: `${REPLAY_TEMP_PREFIX}$1`,
-    });
-    tempIndices.push(...logsIndices.map((idx) => `${REPLAY_TEMP_PREFIX}${idx}`));
-
-    const maxTsResult = await esClient.search({
-      index: tempIndices.join(','),
-      size: 0,
-      aggs: { max_ts: { max: { field: '@timestamp' } } },
-    });
-
-    const maxTsValue = (maxTsResult.aggregations?.max_ts as { value_as_string?: string })
-      ?.value_as_string;
-
-    if (!maxTsValue) {
-      throw new Error('No @timestamp found in restored snapshot indices');
-    }
-    log.debug(`Max timestamp from snapshot data: ${maxTsValue}`);
-
-    let logsDs:
-      | {
-          name: string;
-          indices: Array<{ index_name: string }>;
-        }
-      | undefined;
-
-    try {
-      const dataStreams = await esClient.indices.getDataStream({ name: 'logs' });
-      logsDs = dataStreams.data_streams[0] as typeof logsDs;
-    } catch (err) {
-      const statusCode = (err as { meta?: { statusCode?: number } })?.meta?.statusCode;
-      if (statusCode !== 404) {
-        throw err;
-      }
-
-      log.debug('logs data stream not found — creating it for replay');
-      await ensureLogsIndexTemplate(esClient, log);
-      await esClient.indices.createDataStream({ name: 'logs' });
-
-      const dataStreams = await esClient.indices.getDataStream({ name: 'logs' });
-      logsDs = dataStreams.data_streams[0] as typeof logsDs;
-    }
-
-    if (!logsDs) {
-      throw new Error('logs data stream not found');
-    }
-    const writeIndex = logsDs.indices.at(-1);
-    if (!writeIndex) {
-      throw new Error('logs data stream has no write index');
-    }
-    writeIndexName = writeIndex.index_name;
-
-    const settings = await esClient.indices.getSettings({ index: writeIndexName });
-    previousDefaultPipeline =
-      ((settings[writeIndexName]?.settings?.index as Record<string, unknown>)?.default_pipeline as
-        | string
-        | undefined) ?? '_none';
-
-    let chainedPipelineName: string | undefined =
-      previousDefaultPipeline !== '_none' ? previousDefaultPipeline : undefined;
-
-    if (chainedPipelineName) {
-      try {
-        await esClient.ingest.getPipeline({ id: chainedPipelineName });
-        log.debug(`Chaining existing default_pipeline: ${chainedPipelineName}`);
-      } catch {
-        log.warning(
-          `Write index default_pipeline "${chainedPipelineName}" not found; replay will run without it`
-        );
-        chainedPipelineName = undefined;
-      }
-    } else {
-      log.debug('Write index has no default_pipeline; replay will use timestamp transform only');
-    }
-
-    await esClient.ingest.putPipeline({
-      id: pipelineName,
-      processors: [
-        {
-          script: {
-            lang: 'painless',
-            params: { max_timestamp: maxTsValue },
-            source: TIMESTAMP_TRANSFORM_SCRIPT,
-          },
-        },
-        ...(chainedPipelineName
-          ? [
-              {
-                pipeline: {
-                  name: chainedPipelineName,
-                  ignore_missing_pipeline: true,
-                },
-              },
-            ]
-          : []),
-      ],
-    });
-
-    log.debug(`Setting default_pipeline on ${writeIndexName} to ${pipelineName}`);
-    await esClient.indices.putSettings({
-      index: writeIndexName,
-      settings: { 'index.default_pipeline': pipelineName },
-    });
-
-    log.debug('Reindexing into managed logs stream via default_pipeline');
-    const reindexResult = await esClient.reindex(
-      {
-        wait_for_completion: true,
-        source: { index: tempIndices.join(',') },
-        dest: { index: 'logs', op_type: 'create' },
-      },
-      { requestTimeout: 30 * 60 * 1000 }
-    );
-
-    const total = reindexResult.total ?? 0;
-    const created = reindexResult.created ?? 0;
-    const failures = reindexResult.failures ?? [];
-    const skipped = total - created;
-
-    if (failures.length > 0) {
-      log.warning(`Reindex: ${skipped} docs skipped due to mapping conflicts`);
-      for (const failure of failures.slice(0, 5)) {
-        const reason = failure.cause?.reason?.split('\n')[0]?.slice(0, 150) ?? 'unknown';
-        log.debug(`  - ${failure.cause?.type ?? 'error'}: ${reason}`);
-      }
-      if (failures.length > 5) {
-        log.debug(`  ... and ${failures.length - 5} more`);
-      }
-    }
-
-    log.info(`Replay complete: ${created}/${total} docs indexed, ${skipped} skipped`);
-    return { total, created, skipped };
+    return stats;
   } finally {
-    if (writeIndexName && previousDefaultPipeline !== null) {
-      try {
-        await esClient.indices.putSettings({
-          index: writeIndexName,
-          settings: { 'index.default_pipeline': previousDefaultPipeline },
-        });
-      } catch {
-        log.debug('Failed to restore default_pipeline');
-      }
-    }
-
-    for (const index of tempIndices) {
-      try {
-        await esClient.indices.delete({ index, ignore_unavailable: true });
-      } catch {
-        log.debug(`Failed to delete temp index: ${index}`);
-      }
-    }
-    try {
-      await esClient.ingest.deletePipeline({ id: pipelineName });
-    } catch {
-      log.debug('Failed to delete timestamp pipeline');
-    }
-    try {
-      await esClient.snapshot.deleteRepository({ name: repoName });
-    } catch {
-      log.debug('Failed to delete snapshot repository');
-    }
+    await cleanupReplayArtifacts({ esClient, log, artifacts });
   }
 }

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay_logs_snapshot.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/replay_logs_snapshot.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { createGcsRepository, replaySnapshot } from '@kbn/es-snapshot-loader';
+import { deleteLogsIndexTemplate, ensureLogsIndexTemplate } from './logs_index_template';
+import type { GcsConfig } from './snapshot_run_config';
+import { resolveBasePath } from './snapshot_run_config';
+
+export async function replaySignificantEventsSnapshot(
+  esClient: Client,
+  log: ToolingLog,
+  snapshotName: string,
+  gcs: GcsConfig
+) {
+  log.debug(`Replaying significant events data from snapshot: ${snapshotName}`);
+
+  await cleanSignificantEventsDataStreams(esClient, log);
+  await ensureLogsIndexTemplate(esClient, log);
+
+  const basePath = resolveBasePath(gcs);
+  await replaySnapshot({
+    esClient,
+    log,
+    repository: createGcsRepository({ bucket: gcs.bucket, basePath }),
+    snapshotName,
+    patterns: ['logs'],
+  });
+}
+
+export async function cleanSignificantEventsDataStreams(
+  esClient: Client,
+  log: ToolingLog
+): Promise<void> {
+  try {
+    await esClient.indices.deleteDataStream({ name: 'logs' });
+  } catch {
+    log.debug('No logs data stream to delete');
+  }
+
+  try {
+    await esClient.indices.delete({ index: 'logs', ignore_unavailable: true });
+  } catch {
+    log.debug('Failed to delete logs index (may be a data stream or not exist)');
+  }
+
+  await deleteLogsIndexTemplate(esClient, log);
+}

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getSigeventsSnapshotFeaturesIndex,
+  SIGEVENTS_FEATURES_INDEX_PATTERN,
+} from './sigevents_features_index';
+
+describe('sigevents_features_index', () => {
+  it('exports the expected index pattern', () => {
+    expect(SIGEVENTS_FEATURES_INDEX_PATTERN).toBe('sigevents-streams-features-*');
+  });
+
+  it('prefixes with sigevents-streams-features-', () => {
+    expect(getSigeventsSnapshotFeaturesIndex('healthy-baseline')).toBe(
+      'sigevents-streams-features-healthy-baseline'
+    );
+  });
+
+  it('lowercases and replaces invalid characters with dashes', () => {
+    expect(getSigeventsSnapshotFeaturesIndex('Payment Unreachable')).toBe(
+      'sigevents-streams-features-payment-unreachable'
+    );
+
+    expect(getSigeventsSnapshotFeaturesIndex('A/B\\C*D?E"F<G>H|I,J#K')).toBe(
+      'sigevents-streams-features-a-b-c-d-e-f-g-h-i-j-k'
+    );
+  });
+
+  it('collapses multiple dashes and trims leading/trailing dashes', () => {
+    expect(getSigeventsSnapshotFeaturesIndex('---Payment---Unreachable---')).toBe(
+      'sigevents-streams-features-payment-unreachable'
+    );
+  });
+
+  it('falls back to unknown if sanitized name is empty', () => {
+    expect(getSigeventsSnapshotFeaturesIndex('   ')).toBe('sigevents-streams-features-unknown');
+    expect(getSigeventsSnapshotFeaturesIndex('###')).toBe('sigevents-streams-features-unknown');
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.ts
@@ -10,7 +10,6 @@ const SIGEVENTS_FEATURES_INDEX_PREFIX = 'sigevents-streams-features-';
 export const SIGEVENTS_FEATURES_INDEX_PATTERN = `${SIGEVENTS_FEATURES_INDEX_PREFIX}*`;
 
 function sanitizeIndexComponent(value: string): string {
-  // Elasticsearch index names must be lowercase and must not contain: \ / * ? " < > | space , #
   return value
     .toLowerCase()
     .replace(/[^a-z0-9-_]+/g, '-')

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.ts
@@ -20,7 +20,7 @@ function sanitizeIndexComponent(value: string): string {
 }
 
 /**
- * Name of the non-system index that stores Streams-extracted features for a
+ * Name of the non-system index that stores extracted features for a
  * given snapshot scenario.
  *
  * We intentionally keep this as a **regular** index (no leading `.`) so it can

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/sigevents_features_index.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const SIGEVENTS_FEATURES_INDEX_PREFIX = 'sigevents-streams-features-';
+
+export const SIGEVENTS_FEATURES_INDEX_PATTERN = `${SIGEVENTS_FEATURES_INDEX_PREFIX}*`;
+
+function sanitizeIndexComponent(value: string): string {
+  // Elasticsearch index names must be lowercase and must not contain: \ / * ? " < > | space , #
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+}
+
+/**
+ * Name of the non-system index that stores Streams-extracted features for a
+ * given snapshot scenario.
+ *
+ * We intentionally keep this as a **regular** index (no leading `.`) so it can
+ * be included in snapshots via the `indices` parameter.
+ */
+export function getSigeventsSnapshotFeaturesIndex(snapshotName: string): string {
+  const component = sanitizeIndexComponent(snapshotName) || 'unknown';
+  return `${SIGEVENTS_FEATURES_INDEX_PREFIX}${component}`;
+}

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.test.ts
@@ -18,7 +18,7 @@ describe('snapshot_run_config', () => {
     jest.resetModules();
   });
 
-  it('defaults SIGEVENTS_SNAPSHOT_RUN to current date when env is unset', async () => {
+  it('defaults SIGEVENTS_SNAPSHOT_RUN to pinned date when env is unset', async () => {
     delete process.env.SIGEVENTS_SNAPSHOT_RUN;
     jest.resetModules();
 

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  GCS_BUCKET,
+  OTEL_DEMO_GCS_BASE_PATH_PREFIX,
+} from '../../scripts/significant_events_snapshots/lib/constants';
+
+describe('snapshot_run_config', () => {
+  const ORIGINAL = process.env.SIGEVENTS_SNAPSHOT_RUN;
+
+  afterEach(() => {
+    process.env.SIGEVENTS_SNAPSHOT_RUN = ORIGINAL;
+    jest.resetModules();
+  });
+
+  it('defaults SIGEVENTS_SNAPSHOT_RUN to current date when env is unset', async () => {
+    delete process.env.SIGEVENTS_SNAPSHOT_RUN;
+    jest.resetModules();
+
+    const mod = await import('./snapshot_run_config');
+    expect(mod.SIGEVENTS_SNAPSHOT_RUN).toBe('2026-02-25');
+  });
+
+  it('uses SIGEVENTS_SNAPSHOT_RUN from env when set', async () => {
+    process.env.SIGEVENTS_SNAPSHOT_RUN = '2026-02-26-test';
+    jest.resetModules();
+
+    const mod = await import('./snapshot_run_config');
+    expect(mod.SIGEVENTS_SNAPSHOT_RUN).toBe('2026-02-26-test');
+  });
+
+  it('resolveBasePath appends run id to basePathPrefix when SIGEVENTS_SNAPSHOT_RUN is set', async () => {
+    process.env.SIGEVENTS_SNAPSHOT_RUN = '2026-02-26-test';
+    jest.resetModules();
+
+    const { resolveBasePath } = await import('./snapshot_run_config');
+    expect(
+      resolveBasePath({ bucket: GCS_BUCKET, basePathPrefix: OTEL_DEMO_GCS_BASE_PATH_PREFIX })
+    ).toBe('sigevents/otel-demo/2026-02-26-test');
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface GcsConfig {
+  bucket: string;
+  basePathPrefix: string;
+}
+
+/**
+ * Identifies which snapshot run to replay. Each run is stored in its own
+ * GCS subfolder: `<basePathPrefix>/<run-id>/`.
+ *
+ * Override at runtime with:
+ *   SIGEVENTS_SNAPSHOT_RUN=2026-02-25 node scripts/scout ...
+ */
+export const SIGEVENTS_SNAPSHOT_RUN = process.env.SIGEVENTS_SNAPSHOT_RUN || '2026-02-25';
+
+export const resolveBasePath = (gcs: GcsConfig) =>
+  `${gcs.basePathPrefix}/${SIGEVENTS_SNAPSHOT_RUN}`;

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/dissect-heuristics",
     "@kbn/es-query",
     "@kbn/inference-common",
-    "@kbn/es-snapshot-loader"
+    "@kbn/es-snapshot-loader",
+    "@kbn/es-errors"
   ]
 }

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
@@ -26,5 +26,6 @@
     "@kbn/dissect-heuristics",
     "@kbn/es-query",
     "@kbn/inference-common",
+    "@kbn/es-snapshot-loader"
   ]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/255159

## Summary

- **Snapshot capture script:** Updates the existing OTel Demo Significant Events snapshot capture workflow to copy extracted features out of the system index and snapshot them as a regular index (`sigevents-streams-features-<scenario>`), since system indices can’t be reliably included via the snapshot indices parameter.
- Introduces data generators for listing/replaying snapshots and loading snapshot features, and canonical feature generation for query generation eval runs.
- **Snapshot loader restore behavior:** Adds and implements `allowNoMatches` (and optional renaming configs) in `@kbn/es-snapshot-loader`’s `restoreSnapshot` function so that restoring specific indices into a temp name can succeed as a no-op when nothing matches, rather than failing the caller.

**Note:** The data generators are not wired into the significant events evaluations yet. This will be done in a follow up PR to make sure we have fully-refined criteria before wiring snapshot-based data to the existing evals.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

_The PR was developed with Cursor + gpt-5.2-high_
