### PR TITLE
[ci] Do not cancel on-merge builds

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -315,6 +315,8 @@ export async function pickTestGroupRunOrder() {
   console.log('test run order is determined by builds:');
   console.dir(sources, { depth: Infinity, maxArrayLength: Infinity });
 
+  const cancelOnBuildFailing = pipelineSlug !== 'kibana-on-merge';
+
   const unit = getRunGroup(bk, types, UNIT_TYPE);
   const integration = getRunGroup(bk, types, INTEGRATION_TYPE);
 
@@ -384,7 +386,7 @@ export async function pickTestGroupRunOrder() {
         ? {
             label: 'Jest Tests',
             command: getRequiredEnv('JEST_UNIT_SCRIPT'),
-            cancel_on_build_failing: true,
+            cancel_on_build_failing: cancelOnBuildFailing,
             parallelism: unit.count,
             timeout_in_minutes: 50,
             key: 'jest',
@@ -404,7 +406,7 @@ export async function pickTestGroupRunOrder() {
         ? {
             label: 'Jest Integration Tests',
             command: getRequiredEnv('JEST_INTEGRATION_SCRIPT'),
-            cancel_on_build_failing: true,
+            cancel_on_build_failing: cancelOnBuildFailing,
             parallelism: integration.count,
             // TODO: Reduce once we have identified the cause of random long-running tests
             timeout_in_minutes: 50,
@@ -443,7 +445,7 @@ export async function pickTestGroupRunOrder() {
                 ({ title, key, queue = defaultQueue }): BuildkiteStep => ({
                   label: title,
                   command: getRequiredEnv('FTR_CONFIGS_SCRIPT'),
-                  cancel_on_build_failing: true,
+                  cancel_on_build_failing: cancelOnBuildFailing,
                   timeout_in_minutes: 50,
                   agents: expandAgentQueue(queue, 105),
                   env: {

--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -43,6 +43,8 @@ if (process.env.UIAM_COSMOSDB_DOCKER_IMAGE) {
 export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
   const bk = new BuildkiteClient();
   const envFromlabels: Record<string, string> = collectEnvFromLabels();
+  const pipelineSlug = process.env.BUILDKITE_PIPELINE_SLUG as string;
+  const cancelOnBuildFailing = pipelineSlug !== 'kibana-on-merge';
 
   if (!Fs.existsSync(scoutConfigsPath)) {
     throw new Error(`Scout configs file not found at ${scoutConfigsPath}`);
@@ -87,7 +89,7 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
           ({ label, key, group, agents }): BuildkiteStep => ({
             label,
             command: getRequiredEnv('SCOUT_CONFIGS_SCRIPT'),
-            cancel_on_build_failing: true,
+            cancel_on_build_failing: cancelOnBuildFailing,
             timeout_in_minutes: 60,
             agents,
             env: {

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -31,7 +31,6 @@ steps:
       diskSizeGb: 95
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
-    cancel_on_build_failing: true
     label: Build Kibana Distribution
     agents:
       image: family/kibana-ubuntu-2404
@@ -49,7 +48,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/quick_checks.sh
-    cancel_on_build_failing: true
     label: 'Quick Checks'
     agents:
       image: family/kibana-ubuntu-2404
@@ -68,7 +66,6 @@ steps:
           limit: 3
 
   - command: .buildkite/scripts/steps/checks.sh
-    cancel_on_build_failing: true
     label: 'Checks'
     agents:
       image: family/kibana-ubuntu-2404
@@ -87,7 +84,6 @@ steps:
           limit: 3
 
   - command: .buildkite/scripts/steps/lint.sh
-    cancel_on_build_failing: true
     label: 'Linting'
     agents:
       image: family/kibana-ubuntu-2404
@@ -106,7 +102,6 @@ steps:
           limit: 3
 
   - command: .buildkite/scripts/steps/lint_with_types.sh
-    cancel_on_build_failing: true
     label: 'Linting (with types)'
     agents:
       image: family/kibana-ubuntu-2404
@@ -125,7 +120,6 @@ steps:
           limit: 3
 
   - command: .buildkite/scripts/steps/typecheck/check_types.sh
-    cancel_on_build_failing: true
     label: 'Check Types'
     agents:
       image: family/kibana-ubuntu-2404
@@ -144,7 +138,6 @@ steps:
           limit: 3
 
   - command: .buildkite/scripts/steps/checks/capture_oas_snapshot.sh
-    cancel_on_build_failing: true
     label: 'Check OAS Snapshot'
     agents:
       image: family/kibana-ubuntu-2404
@@ -180,7 +173,6 @@ steps:
 #          limit: 3
 
   - command: .buildkite/scripts/steps/on_merge_api_docs.sh
-    cancel_on_build_failing: true
     label: Check Public API Docs
     key: public-api-docs
     agents:
@@ -200,7 +192,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/ci_stats_ready.sh
-    cancel_on_build_failing: true
     label: Mark CI Stats as ready
     agents:
       image: family/kibana-ubuntu-2404
@@ -218,7 +209,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
-    cancel_on_build_failing: true
     label: 'Pick Test Group Run Order'
     agents:
       image: family/kibana-ubuntu-2404
@@ -238,7 +228,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/test/scout/test_run_builder.sh
-    cancel_on_build_failing: true
     label: 'Scout Test Run Builder'
     agents:
       image: family/kibana-ubuntu-2404
@@ -259,7 +248,6 @@ steps:
           limit: 1
 
   - label: 'Upload on-merge fanout'
-    cancel_on_build_failing: true
     command: buildkite-agent pipeline upload .buildkite/pipelines/on_merge_fanout.yml
     agents:
       image: family/kibana-ubuntu-2404
@@ -289,7 +277,6 @@ steps:
       - check_types
 
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
-    cancel_on_build_failing: true
     label: 'Build Storybooks'
     agents:
       image: family/kibana-ubuntu-2404
@@ -308,7 +295,6 @@ steps:
           limit: 3
 
   - command: .buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
-    cancel_on_build_failing: true
     label: 'Publish OAS docs to bump.sh'
     agents:
       image: family/kibana-ubuntu-2404
@@ -327,7 +313,6 @@ steps:
           limit: 3
 
   - command: .buildkite/scripts/steps/archive_so_migration_snapshot.sh target/plugin_so_types_snapshot.json
-    cancel_on_build_failing: true
     label: 'Extract Saved Object migration plugin types'
     agents:
       image: family/kibana-ubuntu-2404

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -3,7 +3,6 @@ x-on-merge-gates: &on_merge_gates
 
 steps:
   - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
-    cancel_on_build_failing: true
     label: 'Serverless Entity Analytics - Security Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -21,7 +20,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
-    cancel_on_build_failing: true
     label: 'Serverless Explore - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -39,7 +37,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
-    cancel_on_build_failing: true
     label: 'Serverless Investigations - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -57,7 +54,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
-    cancel_on_build_failing: true
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -75,7 +71,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
-    cancel_on_build_failing: true
     label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -93,7 +88,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
-    cancel_on_build_failing: true
     label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -111,7 +105,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
-    cancel_on_build_failing: true
     label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -129,7 +122,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
-    cancel_on_build_failing: true
     label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -147,7 +139,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
-    cancel_on_build_failing: true
     label: 'Rule Management - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -165,7 +156,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
-    cancel_on_build_failing: true
     label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -183,7 +173,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
-    cancel_on_build_failing: true
     label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -201,7 +190,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
-    cancel_on_build_failing: true
     label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -219,7 +207,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
-    cancel_on_build_failing: true
     label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -237,7 +224,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
-    cancel_on_build_failing: true
     label: 'Serverless Detection Engine - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -255,7 +241,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
-    cancel_on_build_failing: true
     label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -273,7 +258,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
-    cancel_on_build_failing: true
     label: 'Detection Engine - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -291,7 +275,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
-    cancel_on_build_failing: true
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -309,7 +292,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
-    cancel_on_build_failing: true
     label: 'Serverless AI Assistant - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -327,7 +309,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
-    cancel_on_build_failing: true
     label: 'AI Assistant - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -345,7 +326,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
-    cancel_on_build_failing: true
     label: 'Entity Analytics - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -363,7 +343,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
-    cancel_on_build_failing: true
     label: 'Explore - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -381,7 +360,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
-    cancel_on_build_failing: true
     label: 'Investigations - Security Solution Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -399,7 +377,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
-    cancel_on_build_failing: true
     label: 'Osquery Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -417,7 +394,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    cancel_on_build_failing: true
     label: 'Osquery Cypress Tests on Serverless'
     agents:
       image: family/kibana-ubuntu-2404
@@ -435,7 +411,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
-    cancel_on_build_failing: true
     label: 'Defend Workflows Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404
@@ -455,7 +430,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
-    cancel_on_build_failing: true
     label: 'Defend Workflows Cypress Tests on Serverless'
     agents:
       image: family/kibana-ubuntu-2404
@@ -475,7 +449,6 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/apm_cypress.sh
-    cancel_on_build_failing: true
     label: 'APM Cypress Tests'
     agents:
       image: family/kibana-ubuntu-2404


### PR DESCRIPTION
We need on-merge to run for all commits to pick up bundle size baselines to compare pull requests to.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->