### PR TITLE
[ci] Use a consistent number of retries for agent lost

### DIFF
--- a/.buildkite/pipelines/build_api_docs.yml
+++ b/.buildkite/pipelines/build_api_docs.yml
@@ -12,6 +12,10 @@ steps:
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 70
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
 
   - command: .buildkite/scripts/steps/api_docs/build_api_docs.sh
     label: 'Build API Docs'

--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -37,6 +37,8 @@ steps:
     timeout_in_minutes: 60
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1
 
@@ -97,7 +99,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     label: 'Serverless Explore - Security Solution Cypress Tests'
@@ -111,7 +113,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     label: 'Serverless Investigations - Security Solution Cypress Tests'
@@ -125,7 +127,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
@@ -139,7 +141,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
     label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
@@ -153,7 +155,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
     label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
@@ -167,7 +169,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
     label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
@@ -181,7 +183,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
     label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
@@ -195,7 +197,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     label: 'Rule Management - Security Solution Cypress Tests'
@@ -209,7 +211,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
     label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
@@ -223,7 +225,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
     label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
@@ -237,7 +239,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
     label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
@@ -251,7 +253,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
     label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
@@ -265,7 +267,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
     label: 'Serverless Detection Engine - Security Solution Cypress Tests'
@@ -279,7 +281,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
     label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
@@ -293,7 +295,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
@@ -307,7 +309,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
@@ -321,7 +323,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
     label: 'Serverless AI Assistant - Security Solution Cypress Tests'
@@ -335,7 +337,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
@@ -349,7 +351,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
@@ -363,7 +365,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     label: 'Explore - Security Solution Cypress Tests'
@@ -377,7 +379,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'
@@ -391,7 +393,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
@@ -405,7 +407,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     label: 'Osquery Cypress Tests on Serverless'
@@ -419,13 +421,14 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      preemptible: true
       diskSizeGb: 105
     depends_on:
       - build
@@ -434,13 +437,14 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      preemptible: true
       diskSizeGb: 105
     depends_on:
       - build
@@ -449,7 +453,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipelines/cloud_security_posture/cspm_agentless_scout.yml
+++ b/.buildkite/pipelines/cloud_security_posture/cspm_agentless_scout.yml
@@ -46,5 +46,5 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 

--- a/.buildkite/pipelines/code_coverage/daily.yml
+++ b/.buildkite/pipelines/code_coverage/daily.yml
@@ -37,3 +37,7 @@ steps:
       - jest-integration
     timeout_in_minutes: 50
     key: ingest
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3

--- a/.buildkite/pipelines/console_definitions_sync.yml
+++ b/.buildkite/pipelines/console_definitions_sync.yml
@@ -8,3 +8,7 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -38,6 +38,7 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-8
+          preemptible: true
         key: build
         if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
         depends_on: pre-build
@@ -97,7 +98,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
         label: 'Serverless Explore - Security Solution Cypress Tests'
@@ -114,7 +115,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
         label: 'Serverless Investigations - Security Solution Cypress Tests'
@@ -131,7 +132,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
         label: 'Serverless Rule Management - Security Solution Cypress Tests'
@@ -148,7 +149,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
         label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
@@ -165,7 +166,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
         label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
@@ -182,7 +183,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
         label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
@@ -199,7 +200,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
         label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
@@ -216,7 +217,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
         label: 'Serverless Detection Engine - Security Solution Cypress Tests'
@@ -233,7 +234,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
         label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
@@ -250,7 +251,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
         label: 'Serverless AI Assistant - Security Solution Cypress Tests'
@@ -267,7 +268,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
         label: 'Defend Workflows Cypress Tests on Serverless'
@@ -278,6 +279,7 @@ steps:
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
+          preemptible: true
           diskSizeGb: 105
         depends_on: build
         timeout_in_minutes: 75
@@ -285,7 +287,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
       - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
         label: 'Osquery Cypress Tests on Serverless'
@@ -302,7 +304,7 @@ steps:
         retry:
           automatic:
             - exit_status: '-1'
-              limit: 1
+              limit: 3
 
   - wait: ~
 

--- a/.buildkite/pipelines/esql_grammar_sync.yml
+++ b/.buildkite/pipelines/esql_grammar_sync.yml
@@ -8,6 +8,10 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
   - command: .buildkite/scripts/steps/esql_generate_function_metadata.sh
     label: Generate Function Metadata
     timeout_in_minutes: 15
@@ -17,3 +21,7 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3

--- a/.buildkite/pipelines/fips.yml
+++ b/.buildkite/pipelines/fips.yml
@@ -47,6 +47,10 @@ steps:
     agents:
       machineType: n2-standard-2
       preemptible: true
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
 
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -76,6 +76,7 @@ steps:
       enableNestedVirtualization: true
       machineType: n2-standard-4
       diskSizeGb: 105
+      preemptible: true
     timeout_in_minutes: 75
     parallelism: 22
     key: defend-workflows-stateful
@@ -83,7 +84,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
@@ -94,6 +95,7 @@ steps:
       enableNestedVirtualization: true
       machineType: n2-standard-4
       diskSizeGb: 105
+      preemptible: true
     timeout_in_minutes: 75
     parallelism: 14
     key: defend-workflows-serverless
@@ -101,7 +103,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
@@ -117,7 +119,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     label: 'Osquery Cypress Tests on Serverless'
@@ -133,7 +135,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: |
       echo "--- Promoting base image to temp..."

--- a/.buildkite/pipelines/node_glibc_217.yml
+++ b/.buildkite/pipelines/node_glibc_217.yml
@@ -27,6 +27,8 @@ steps:
     timeout_in_minutes: 60
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1
 
@@ -82,7 +84,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     label: 'Serverless Explore - Security Solution Cypress Tests'
@@ -99,7 +101,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     label: 'Serverless Investigations - Security Solution Cypress Tests'
@@ -116,7 +118,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
@@ -133,7 +135,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
     label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
@@ -150,7 +152,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
     label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
@@ -167,7 +169,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
     label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
@@ -184,7 +186,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
     label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
@@ -201,7 +203,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     label: 'Rule Management - Security Solution Cypress Tests'
@@ -218,7 +220,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
     label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
@@ -235,7 +237,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
     label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
@@ -252,7 +254,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
     label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
@@ -269,7 +271,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
     label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
@@ -286,7 +288,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
     label: 'Serverless Detection Engine - Security Solution Cypress Tests'
@@ -303,7 +305,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
     label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
@@ -320,7 +322,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
@@ -337,7 +339,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
@@ -354,7 +356,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
     label: 'Serverless AI Assistant - Security Solution Cypress Tests'
@@ -371,7 +373,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
@@ -388,7 +390,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
@@ -405,7 +407,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     label: 'Explore - Security Solution Cypress Tests'
@@ -422,7 +424,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'
@@ -439,7 +441,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
@@ -456,7 +458,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     label: 'Osquery Cypress Tests on Serverless'
@@ -473,7 +475,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
@@ -484,6 +486,7 @@ steps:
       enableNestedVirtualization: true
       machineType: n2-standard-4
       diskSizeGb: 105
+      preemptible: true
     depends_on:
       - build
     timeout_in_minutes: 75
@@ -491,7 +494,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
@@ -502,6 +505,7 @@ steps:
       enableNestedVirtualization: true
       machineType: n2-standard-4
       diskSizeGb: 105
+      preemptible: true
     depends_on:
       - build
     timeout_in_minutes: 75
@@ -509,7 +513,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipelines/node_pointer_compression.yml
+++ b/.buildkite/pipelines/node_pointer_compression.yml
@@ -29,6 +29,8 @@ steps:
       CI_FORCE_NODE_POINTER_COMPRESSION: false
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1
 
@@ -84,7 +86,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     label: 'Serverless Explore - Security Solution Cypress Tests'
@@ -101,7 +103,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     label: 'Serverless Investigations - Security Solution Cypress Tests'
@@ -118,7 +120,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
@@ -135,7 +137,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
     label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
@@ -152,7 +154,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
     label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
@@ -169,7 +171,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
     label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
@@ -186,7 +188,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
     label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
@@ -203,7 +205,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     label: 'Rule Management - Security Solution Cypress Tests'
@@ -220,7 +222,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
     label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
@@ -237,7 +239,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
     label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
@@ -254,7 +256,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
     label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
@@ -271,7 +273,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
     label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
@@ -288,7 +290,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
     label: 'Serverless Detection Engine - Security Solution Cypress Tests'
@@ -305,7 +307,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
     label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
@@ -322,7 +324,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
@@ -339,7 +341,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
@@ -356,7 +358,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
     label: 'Serverless AI Assistant - Security Solution Cypress Tests'
@@ -373,7 +375,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
@@ -390,7 +392,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
@@ -407,7 +409,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     label: 'Explore - Security Solution Cypress Tests'
@@ -424,7 +426,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'
@@ -441,7 +443,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
@@ -458,7 +460,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     label: 'Osquery Cypress Tests on Serverless'
@@ -475,7 +477,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
@@ -486,6 +488,7 @@ steps:
       enableNestedVirtualization: true
       machineType: n2-standard-4
       diskSizeGb: 105
+      preemptible: true
     depends_on:
       - build
     timeout_in_minutes: 75
@@ -493,7 +496,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
@@ -504,6 +507,7 @@ steps:
       enableNestedVirtualization: true
       machineType: n2-standard-4
       diskSizeGb: 105
+      preemptible: true
     depends_on:
       - build
     timeout_in_minutes: 75
@@ -511,7 +515,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -45,6 +45,8 @@ steps:
     timeout_in_minutes: 60
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1
 

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -18,7 +18,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     cancel_on_build_failing: true
@@ -36,7 +36,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     cancel_on_build_failing: true
@@ -54,7 +54,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
     cancel_on_build_failing: true
@@ -72,7 +72,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
     cancel_on_build_failing: true
@@ -90,7 +90,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
     cancel_on_build_failing: true
@@ -108,7 +108,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
     cancel_on_build_failing: true
@@ -126,7 +126,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
     cancel_on_build_failing: true
@@ -144,7 +144,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     cancel_on_build_failing: true
@@ -162,7 +162,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
     cancel_on_build_failing: true
@@ -180,7 +180,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
     cancel_on_build_failing: true
@@ -198,7 +198,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
     cancel_on_build_failing: true
@@ -216,7 +216,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
     cancel_on_build_failing: true
@@ -234,7 +234,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
     cancel_on_build_failing: true
@@ -252,7 +252,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
     cancel_on_build_failing: true
@@ -270,7 +270,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     cancel_on_build_failing: true
@@ -288,7 +288,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     cancel_on_build_failing: true
@@ -306,7 +306,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
     cancel_on_build_failing: true
@@ -324,7 +324,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     cancel_on_build_failing: true
@@ -342,7 +342,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     cancel_on_build_failing: true
@@ -360,7 +360,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     cancel_on_build_failing: true
@@ -378,7 +378,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     cancel_on_build_failing: true
@@ -396,7 +396,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     cancel_on_build_failing: true
@@ -414,7 +414,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     cancel_on_build_failing: true
@@ -432,7 +432,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     cancel_on_build_failing: true
@@ -452,7 +452,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     cancel_on_build_failing: true
@@ -472,7 +472,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/apm_cypress.sh
     cancel_on_build_failing: true
@@ -490,4 +490,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/otel_semconv_sync.yml
+++ b/.buildkite/pipelines/otel_semconv_sync.yml
@@ -8,6 +8,10 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
     env:
       # Docker is available on these agents
       DOCKER_REQUIRED: 'true'

--- a/.buildkite/pipelines/performance/data_set_extraction_daily.yml
+++ b/.buildkite/pipelines/performance/data_set_extraction_daily.yml
@@ -34,7 +34,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
         - exit_status: '*'
           limit: 1
 

--- a/.buildkite/pipelines/pull_request/kbn_handlebars.yml
+++ b/.buildkite/pipelines/pull_request/kbn_handlebars.yml
@@ -11,5 +11,7 @@ steps:
     timeout_in_minutes: 5
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -12,5 +12,7 @@ steps:
     parallelism: 11
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -11,5 +11,7 @@ steps:
     timeout_in_minutes: 60
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
@@ -13,4 +13,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     cancel_on_build_failing: true
@@ -29,4 +29,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/asset_inventory.sh
     cancel_on_build_failing: true
@@ -29,4 +29,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
@@ -13,4 +13,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/cloud_security_posture_serverless.sh
     cancel_on_build_failing: true
@@ -29,4 +29,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/cspm_agentless_scout.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cspm_agentless_scout.yml
@@ -12,5 +12,5 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -15,7 +15,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     cancel_on_build_failing: true
@@ -33,4 +33,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
     cancel_on_build_failing: true
@@ -29,7 +29,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     cancel_on_build_failing: true
@@ -45,7 +45,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     cancel_on_build_failing: true
@@ -61,4 +61,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     cancel_on_build_failing: true
@@ -29,4 +29,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/explore.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/explore.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     cancel_on_build_failing: true
@@ -29,4 +29,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     cancel_on_build_failing: true
@@ -29,4 +29,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
     cancel_on_build_failing: true
@@ -29,4 +29,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
     cancel_on_build_failing: true
@@ -29,7 +29,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
     cancel_on_build_failing: true
@@ -45,7 +45,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
     cancel_on_build_failing: true
@@ -61,7 +61,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
     cancel_on_build_failing: true
@@ -77,7 +77,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     cancel_on_build_failing: true
@@ -93,7 +93,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
     cancel_on_build_failing: true
@@ -109,7 +109,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
     cancel_on_build_failing: true
@@ -125,7 +125,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
     cancel_on_build_failing: true
@@ -141,7 +141,7 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
     cancel_on_build_failing: true
@@ -157,4 +157,4 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3

--- a/.buildkite/pipelines/scout_update_metadata.yml
+++ b/.buildkite/pipelines/scout_update_metadata.yml
@@ -9,3 +9,7 @@ steps:
       machineType: n2-standard-4
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_ai4dsoc.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
@@ -11,6 +11,8 @@ steps:
     timeout_in_minutes: 300
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: "*"
           limit: 1
 

--- a/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
+++ b/.buildkite/pipelines/serverless_deployment/build_pr_and_deploy_project.yml
@@ -79,6 +79,10 @@ steps:
           machineType: n2-standard-4
           preemptible: true
         timeout_in_minutes: 10
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 3
 
       - wait: ~
 

--- a/.buildkite/pipelines/storybooks_from_pr.yml
+++ b/.buildkite/pipelines/storybooks_from_pr.yml
@@ -14,8 +14,9 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       machineType: n2-standard-8
+      preemptible: true
     timeout_in_minutes: 50
     retry:
       automatic:
         - exit_status: '-1'
-          limit: 1
+          limit: 3


### PR DESCRIPTION
We're seeing relatively frequent build failures due to double spot instance preemptions, in particular for cypress tests with nested virtualization enabled.

This updates all build steps to allow up to three retries on spot instance preemption.  Prior to this, generally, ftr and jest tests were at three retries while the cypress tests were at a single retry. 