### PR TITLE
[Observability:Streams] Fix processor description truncation and add tooltip

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -214,6 +214,7 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                   size="xs"
                   color="subdued"
                   tabIndex={0}
+                  data-test-subj="streamsAppProcessorDescription"
                   css={css`
                     font-family: ${euiTheme.font.familyCode};
                     ${euiTextTruncate()}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -12,7 +12,6 @@ import {
   EuiFlexItem,
   EuiPanel,
   EuiText,
-  EuiTextTruncate,
   euiTextTruncate,
   EuiToolTip,
   useEuiTheme,
@@ -210,21 +209,19 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                 )}
               />
             ) : (
-              <EuiTextTruncate
-                text={stepDescription}
-                truncation="end"
-                children={() => (
-                  <EuiText
-                    size="xs"
-                    color="subdued"
-                    css={css`
-                      font-family: ${euiTheme.font.familyCode};
-                    `}
-                  >
-                    {stepDescription}
-                  </EuiText>
-                )}
-              />
+              <EuiToolTip content={stepDescription} display="block">
+                <EuiText
+                  size="xs"
+                  color="subdued"
+                  tabIndex={0}
+                  css={css`
+                    font-family: ${euiTheme.font.familyCode};
+                    ${euiTextTruncate()}
+                  `}
+                >
+                  {stepDescription}
+                </EuiText>
+              </EuiToolTip>
             )}
           </EuiPanel>
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -514,7 +514,7 @@ export class StreamsApp {
     ).toBeVisible({ timeout: 30000 });
   }
   async getProcessorPatternText() {
-    return await this.page.getByTestId('fullText').locator('.euiText').textContent();
+    return await this.page.getByTestId('streamsAppProcessorDescription').textContent();
   }
 
   async clickSaveProcessor() {


### PR DESCRIPTION
Closes https://github.com/elastic/streams-program/issues/742

## Summary
This PR adds an elipsis to processor descriptions that are truncated to indicate there is more text, it also wraps the text in an EUI tooltip to view the full content rather than relying on the browsers default hover behavior. `tabIndex={0}` was added to the EuiText component to ensure the tooltrip trigger is accessible with a keyboard, this behavior was verified on Voiceover for Mac.

## Demo
https://github.com/user-attachments/assets/73280fdf-d2e3-44db-af0f-462253457b2a