### PR TITLE
[Discover][Traces] Fix Attributes glitchy

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_table.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_table.tsx
@@ -136,7 +136,7 @@ export const AttributesTable = ({
         cellPadding: 'm',
         fontSize: 's',
       }}
-      rowHeightsOptions={{ defaultHeight: 'auto' }}
+      rowHeightsOptions={{ defaultHeight: { lineCount: 1 } }}
       inMemory={{ level: 'enhancements' }}
       toolbarVisibility={false}
     />


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/251626

The problem is not the `defaultHeight: auto` itself, but the fact that the Attributes tab dynamically renders three different DataGrids and this causes the problem shown in the linked issue.

The actual problem is a "Maximum update depth exceeded" caused by the attributes dynamically measuring its page height and the `defaultHeight: auto` keeping track of the flyout size, this combination breaks the UI.

The simplest solution is to set the height to be a single line. We should probably review this page layout if we want to keep the `auto` in the future.


https://github.com/user-attachments/assets/b072bd96-e5d4-4456-b9df-9aca0ed08e18



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->