### PR TITLE
[Maps] fix timeFilter mode 'quick' in map stored state prevents map from loading

### DIFF
--- a/x-pack/platform/plugins/shared/maps/common/content_management/transform_map_attributes_out.test.ts
+++ b/x-pack/platform/plugins/shared/maps/common/content_management/transform_map_attributes_out.test.ts
@@ -85,6 +85,32 @@ describe('transformMapOut', () => {
     `);
   });
 
+  test('should remove mode from timeFilters', () => {
+    expect(
+      transformMapAttributesOut(
+        {
+          title: 'my map',
+          mapStateJSON: JSON.stringify({
+            timeFilters: {
+              from: 'now-17m',
+              to: 'now',
+              mode: 'quick',
+            },
+          }),
+        },
+        findReference
+      )
+    ).toMatchInlineSnapshot(`
+      Object {
+        "timeFilters": Object {
+          "from": "now-17m",
+          "to": "now",
+        },
+        "title": "my map",
+      }
+    `);
+  });
+
   test('uiStateJSON', () => {
     expect(
       transformMapAttributesOut(

--- a/x-pack/platform/plugins/shared/maps/common/content_management/transform_map_attributes_out.ts
+++ b/x-pack/platform/plugins/shared/maps/common/content_management/transform_map_attributes_out.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Reference } from '@kbn/content-management-utils';
+import type { TimeRange } from '@kbn/es-query';
 import type { MapAttributes, StoredMapAttributes } from '../../server';
 import { injectReferences } from '../migrations/references';
 import type { LayerDescriptor } from '../descriptor_types';
@@ -39,7 +40,7 @@ function parseLayerListJSON(layerListJSON?: string) {
 
 function parseMapStateJSON(mapStateJSON?: string) {
   const parsedMapState = parseJSON<{ [key: string]: unknown }>({}, mapStateJSON);
-  const { refreshConfig, ...rest } = dropUnknownKeys(
+  const { refreshConfig, timeFilters, ...rest } = dropUnknownKeys(
     parsedMapState,
     mapStateKeys
   ) as Partial<MapAttributes> & { refreshConfig: StoredRefreshInterval };
@@ -47,6 +48,11 @@ function parseMapStateJSON(mapStateJSON?: string) {
     ...rest,
     ...(refreshConfig
       ? { refreshInterval: { pause: refreshConfig.isPaused, value: refreshConfig.interval } }
+      : {}),
+    // BWC drop mode - no longer needed.
+    // mode stored in timeRange with values not supported in timeRangeSchema
+    ...(timeFilters
+      ? { timeFilters: dropUnknownKeys(timeFilters, ['from', 'to']) as TimeRange }
       : {}),
   };
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/255156

Remove mode from stored timeRange to prevent schema validation errors.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->