### PR TITLE
[Security Solution] fix issue where analyzer is not showing when the newDataViewPickerEnabled feature flag is off

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -67,7 +67,35 @@ export const AnalyzeGraph: FC = () => {
     ? experimentalAnalyzerPatterns
     : oldAnalyzerPatterns;
 
-  const { dataView, status } = useDataView(PageScope.analyzer);
+  const { dataView: experimentalDataView, status: experimentalDataViewStatus } = useDataView(
+    PageScope.analyzer
+  );
+  const { sourcererDataView: oldSourcererDataViewSpec, loading: oldSourcererDataViewIsLoading } =
+    useSourcererDataView(PageScope.analyzer);
+
+  const isLoading: boolean = useMemo(
+    () =>
+      newDataViewPickerEnabled
+        ? experimentalDataViewStatus === 'loading' || experimentalDataViewStatus === 'pristine'
+        : oldSourcererDataViewIsLoading,
+    [experimentalDataViewStatus, newDataViewPickerEnabled, oldSourcererDataViewIsLoading]
+  );
+
+  const isDataViewInvalid: boolean = useMemo(
+    () =>
+      newDataViewPickerEnabled
+        ? experimentalDataViewStatus === 'error' ||
+          (experimentalDataViewStatus === 'ready' && !experimentalDataView.hasMatchedIndices())
+        : !oldSourcererDataViewSpec ||
+          !oldSourcererDataViewSpec.id ||
+          !oldSourcererDataViewSpec.title,
+    [
+      experimentalDataView,
+      experimentalDataViewStatus,
+      newDataViewPickerEnabled,
+      oldSourcererDataViewSpec,
+    ]
+  );
 
   const { openPreviewPanel } = useExpandableFlyoutApi();
 
@@ -89,7 +117,7 @@ export const AnalyzeGraph: FC = () => {
     );
   }
 
-  if (status === 'loading' || status === 'pristine') {
+  if (isLoading) {
     return (
       <EuiFlexGroup gutterSize="m" justifyContent="center" alignItems="center">
         <EuiFlexItem grow={false}>
@@ -99,7 +127,7 @@ export const AnalyzeGraph: FC = () => {
     );
   }
 
-  if (status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices())) {
+  if (isDataViewInvalid) {
     return (
       <EuiEmptyPrompt
         color="danger"


### PR DESCRIPTION
## Summary

This somewhat recent [PR](https://github.com/elastic/kibana/pull/245712) that was aiming at fixing a bug related to dataViews with analyzer actually introduced another bug. The code added in that previous PR was verifying that the dataView was correctly loaded before showing analyzer, but the check was done only for the `newDataViewPickerEnabled` feature flag turned on...

This PR fixes that issue and handles both the `newDataViewPickerEnabled` feature flag on and off.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->