### PR TITLE
[Security Solution] remove Discover appWrapper unused code

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_root_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_root_profile/profile.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { FunctionComponent, PropsWithChildren } from 'react';
+import type { FunctionComponent } from 'react';
 import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
 import type { RootProfileProvider } from '../../../profiles';
 import { SolutionType } from '../../../profiles';
@@ -19,7 +19,6 @@ import { getAlertEventRowIndicator } from '../accessors/get_row_indicator';
 import { ALERTS_INDEX_PATTERN, SECURITY_PROFILE_ID } from '../constants';
 
 interface SecurityRootProfileContext {
-  appWrapper?: FunctionComponent<PropsWithChildren<{}>>;
   getSecuritySolutionCellRenderer?: (
     fieldName: string
   ) => FunctionComponent<DataGridCellValueElementProps> | undefined;

--- a/src/platform/plugins/shared/discover_shared/public/index.ts
+++ b/src/platform/plugins/shared/discover_shared/public/index.ts
@@ -22,7 +22,6 @@ export type {
   ObservabilityStreamsFeatureRenderDeps,
   ObservabilityStreamsFeature,
   SecuritySolutionCellRendererFeature,
-  SecuritySolutionAppWrapperFeature,
   SecuritySolutionAlertFlyoutOverviewTabFeature,
   DiscoverFeature,
   DiscoverFeaturesServiceSetup,

--- a/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
+++ b/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
-import type { FunctionComponent, PropsWithChildren } from 'react';
+import type { FunctionComponent } from 'react';
 import type React from 'react';
 import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
 import type { Query, TimeRange } from '@kbn/es-query';
@@ -114,11 +114,6 @@ export interface SecuritySolutionCellRendererFeature {
   >;
 }
 
-export interface SecuritySolutionAppWrapperFeature {
-  id: 'security-solution-app-wrapper';
-  getWrapper: () => Promise<() => FunctionComponent<PropsWithChildren<{}>>>;
-}
-
 export interface SecuritySolutionAlertFlyoutOverviewTabFeature {
   id: 'security-solution-alert-flyout-overview-tab';
   render: (hit: DataTableRecord) => JSX.Element;
@@ -126,7 +121,6 @@ export interface SecuritySolutionAlertFlyoutOverviewTabFeature {
 
 export type SecuritySolutionFeature =
   | SecuritySolutionCellRendererFeature
-  | SecuritySolutionAppWrapperFeature
   | SecuritySolutionAlertFlyoutOverviewTabFeature;
 
 /** ****************************************************************************************/


### PR DESCRIPTION
## Summary

Added in this previous [PR](https://github.com/elastic/kibana/pull/199279), Security Solution has actually not being using the app wrapper functionality provided by Discover.

This PR removes the left over unused code from the Security Solution side.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.