### PR TITLE
Adds Entity Store search tool for Agent Builder

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -38,6 +38,12 @@ export type { EntityType } from './domain/definitions/entity_schema';
 export type { IdentitySourceFields } from './domain/euid';
 export { ALL_ENTITY_TYPES } from './domain/definitions/entity_schema';
 
+export const ENTITY_SCHEMA_VERSION_V2 = 'v2';
+export const ENTITY_LATEST = 'latest' as const;
+
+export const getLatestEntityStoreIndexName = (namespace: string) =>
+  `.entities.${ENTITY_SCHEMA_VERSION_V2}.${ENTITY_LATEST}.security_${namespace}` as const;
+
 export type EntityStoreStatus = z.infer<typeof EntityStoreStatus>;
 export const EntityStoreStatus = z.enum([
   'not_installed',

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_store_search_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_store_search_tool.test.ts
@@ -1,0 +1,370 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolResultType, type ErrorResult } from '@kbn/agent-builder-common';
+import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
+import { FF_ENABLE_ENTITY_STORE_V2, getLatestEntityStoreIndexName } from '@kbn/entity-store/common';
+import {
+  createToolAvailabilityContext,
+  createToolHandlerContext,
+  createToolTestMocks,
+  setupMockCoreStartServices,
+} from '../__mocks__/test_helpers';
+import {
+  entityStoreSearchTool,
+  buildEntityStoreSearchQuery,
+  type EntityStoreSearchParams,
+} from './entity_store_search_tool';
+
+describe('entityStoreSearchTool', () => {
+  const { mockCore, mockLogger, mockEsClient, mockRequest } = createToolTestMocks();
+  const tool = entityStoreSearchTool(mockCore, mockLogger);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMockCoreStartServices(mockCore, mockEsClient);
+  });
+
+  describe('schema', () => {
+    it('accepts minimal valid input (no params)', () => {
+      const result = tool.schema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts full valid input', () => {
+      const result = tool.schema.safeParse({
+        entityTypes: ['host', 'user'],
+        entityName: 'server-1',
+        riskLevel: 'High',
+        riskScoreMin: 50,
+        riskScoreMax: 100,
+        criticalityLevel: 'extreme_impact',
+        attributes: { managed: true, watchlists: ['privmon'] },
+        behaviors: { ruleNames: ['brute-force'] },
+        sortBy: 'risk_score',
+        sortOrder: 'desc',
+        limit: 20,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects invalid entity type', () => {
+      const result = tool.schema.safeParse({ entityTypes: ['invalid'] });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid risk level', () => {
+      const result = tool.schema.safeParse({ riskLevel: 'SuperHigh' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid criticality level', () => {
+      const result = tool.schema.safeParse({ criticalityLevel: 'unknown' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects risk score out of range', () => {
+      expect(tool.schema.safeParse({ riskScoreMin: -1 }).success).toBe(false);
+      expect(tool.schema.safeParse({ riskScoreMax: 101 }).success).toBe(false);
+    });
+
+    it('rejects limit out of range', () => {
+      expect(tool.schema.safeParse({ limit: 0 }).success).toBe(false);
+      expect(tool.schema.safeParse({ limit: 101 }).success).toBe(false);
+    });
+  });
+
+  describe('buildEntityStoreSearchQuery', () => {
+    const index = '.entities.v2.latest.security_default';
+
+    it('builds a basic query with no filters', () => {
+      const query = buildEntityStoreSearchQuery({}, index);
+      expect(query).toContain(`FROM ${index}`);
+      expect(query).toContain('WHERE entity.id IS NOT NULL');
+      expect(query).toContain('SORT entity.risk.calculated_score_norm DESC');
+      expect(query).toContain('LIMIT 10');
+    });
+
+    it('filters by a single entity type', () => {
+      const query = buildEntityStoreSearchQuery({ entityTypes: ['host'] }, index);
+      expect(query).toContain('entity.EngineMetadata.Type == "host"');
+    });
+
+    it('filters by multiple entity types using IN', () => {
+      const query = buildEntityStoreSearchQuery(
+        { entityTypes: ['host', 'user'] },
+        index
+      );
+      expect(query).toContain('entity.EngineMetadata.Type IN ("host", "user")');
+    });
+
+    it('filters by exact entity name', () => {
+      const query = buildEntityStoreSearchQuery({ entityName: 'server-1' }, index);
+      expect(query).toContain('entity.name == "server-1"');
+    });
+
+    it('filters by wildcard entity name', () => {
+      const query = buildEntityStoreSearchQuery({ entityName: 'server-*' }, index);
+      expect(query).toContain('entity.name LIKE "server-*"');
+    });
+
+    it('filters by risk level', () => {
+      const query = buildEntityStoreSearchQuery({ riskLevel: 'Critical' }, index);
+      expect(query).toContain('entity.risk.calculated_level == "Critical"');
+    });
+
+    it('filters by risk score range', () => {
+      const query = buildEntityStoreSearchQuery(
+        { riskScoreMin: 50, riskScoreMax: 90 },
+        index
+      );
+      expect(query).toContain('entity.risk.calculated_score_norm >= 50');
+      expect(query).toContain('entity.risk.calculated_score_norm <= 90');
+    });
+
+    it('filters by criticality level', () => {
+      const query = buildEntityStoreSearchQuery(
+        { criticalityLevel: 'high_impact' },
+        index
+      );
+      expect(query).toContain('asset.criticality == "high_impact"');
+    });
+
+    it('filters by attributes', () => {
+      const query = buildEntityStoreSearchQuery(
+        {
+          attributes: {
+            managed: true,
+            mfa_enabled: false,
+            asset: true,
+            watchlists: ['privmon', 'insider_threat'],
+          },
+        },
+        index
+      );
+      expect(query).toContain('entity.attributes.managed == true');
+      expect(query).toContain('entity.attributes.mfa_enabled == false');
+      expect(query).toContain('entity.attributes.asset == true');
+      expect(query).toContain('entity.attributes.watchlists == "privmon"');
+      expect(query).toContain('entity.attributes.watchlists == "insider_threat"');
+    });
+
+    it('filters by behaviors', () => {
+      const query = buildEntityStoreSearchQuery(
+        {
+          behaviors: {
+            ruleNames: ['brute-force'],
+            anomalyJobIds: ['job-123'],
+          },
+        },
+        index
+      );
+      expect(query).toContain('entity.behaviors.rule_names == "brute-force"');
+      expect(query).toContain('entity.behaviors.anomaly_job_ids == "job-123"');
+    });
+
+    it('builds compound query with multiple filters', () => {
+      const params: EntityStoreSearchParams = {
+        entityTypes: ['host'],
+        riskLevel: 'High',
+        criticalityLevel: 'extreme_impact',
+        limit: 5,
+        sortBy: 'name',
+        sortOrder: 'asc',
+      };
+      const query = buildEntityStoreSearchQuery(params, index);
+      expect(query).toContain('entity.EngineMetadata.Type == "host"');
+      expect(query).toContain('entity.risk.calculated_level == "High"');
+      expect(query).toContain('asset.criticality == "extreme_impact"');
+      expect(query).toContain('SORT entity.name ASC');
+      expect(query).toContain('LIMIT 5');
+    });
+
+    it('sorts by last_activity', () => {
+      const query = buildEntityStoreSearchQuery(
+        { sortBy: 'last_activity', sortOrder: 'desc' },
+        index
+      );
+      expect(query).toContain('SORT entity.lifecycle.last_activity DESC');
+    });
+
+    it('sorts by first_seen', () => {
+      const query = buildEntityStoreSearchQuery({ sortBy: 'first_seen' }, index);
+      expect(query).toContain('SORT entity.lifecycle.first_seen DESC');
+    });
+
+    it('escapes special characters in entity name', () => {
+      const query = buildEntityStoreSearchQuery(
+        { entityName: 'server"\\test' },
+        index
+      );
+      expect(query).toContain('entity.name == "server\\"\\\\test"');
+    });
+  });
+
+  describe('availability', () => {
+    it('returns available when entity store v2 is enabled and index exists', async () => {
+      const mockUiSettings = uiSettingsServiceMock.createClient();
+      mockUiSettings.get.mockImplementation(async (key: string) => {
+        if (key === FF_ENABLE_ENTITY_STORE_V2) return true;
+        return false;
+      });
+      mockEsClient.asInternalUser.indices.exists.mockResolvedValueOnce(true);
+
+      const result = await tool.availability!.handler(
+        createToolAvailabilityContext(mockRequest, 'default', mockUiSettings)
+      );
+
+      expect(result.status).toBe('available');
+    });
+
+    it('returns unavailable when entity store v2 is disabled', async () => {
+      const mockUiSettings = uiSettingsServiceMock.createClient();
+      mockUiSettings.get.mockImplementation(async (key: string) => {
+        if (key === FF_ENABLE_ENTITY_STORE_V2) return false;
+        return false;
+      });
+
+      const result = await tool.availability!.handler(
+        createToolAvailabilityContext(mockRequest, 'default', mockUiSettings)
+      );
+
+      expect(result.status).toBe('unavailable');
+      expect(result.reason).toBe('Entity Store v2 is not enabled');
+    });
+
+    it('returns unavailable when index does not exist', async () => {
+      const mockUiSettings = uiSettingsServiceMock.createClient();
+      mockUiSettings.get.mockImplementation(async (key: string) => {
+        if (key === FF_ENABLE_ENTITY_STORE_V2) return true;
+        return false;
+      });
+      mockEsClient.asInternalUser.indices.exists.mockResolvedValueOnce(false);
+
+      const result = await tool.availability!.handler(
+        createToolAvailabilityContext(mockRequest, 'default', mockUiSettings)
+      );
+
+      expect(result.status).toBe('unavailable');
+      expect(result.reason).toBe('Entity Store index does not exist for this space');
+    });
+
+    it('returns unavailable on error', async () => {
+      const mockUiSettings = uiSettingsServiceMock.createClient();
+      mockUiSettings.get.mockRejectedValueOnce(new Error('Settings error'));
+
+      const result = await tool.availability!.handler(
+        createToolAvailabilityContext(mockRequest, 'default', mockUiSettings)
+      );
+
+      expect(result.status).toBe('unavailable');
+      expect(result.reason).toContain('Failed to check Entity Store availability');
+    });
+  });
+
+  describe('handler', () => {
+    it('executes ESQL query and returns results', async () => {
+      const mockColumns = [
+        { name: 'entity.id', type: 'keyword' },
+        { name: 'entity.name', type: 'keyword' },
+      ];
+      const mockValues = [
+        ['host:server-1', 'server-1'],
+        ['host:server-2', 'server-2'],
+      ];
+      mockEsClient.asCurrentUser.esql.query.mockResolvedValueOnce({
+        columns: mockColumns,
+        values: mockValues,
+      });
+
+      const result = (await tool.handler(
+        { entityTypes: ['host'], limit: 10 },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      )) as ToolHandlerStandardReturn;
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+
+      const data = result.results[0].data as {
+        query: string;
+        columns: unknown[];
+        values: unknown[][];
+      };
+      expect(data.query).toContain(getLatestEntityStoreIndexName('default'));
+      expect(data.columns).toEqual(mockColumns);
+      expect(data.values).toEqual(mockValues);
+
+      expect(mockEsClient.asCurrentUser.esql.query).toHaveBeenCalledWith({
+        query: expect.stringContaining('FROM .entities.v2.latest.security_default'),
+        drop_null_columns: true,
+      });
+    });
+
+    it('uses correct space ID for the index', async () => {
+      mockEsClient.asCurrentUser.esql.query.mockResolvedValueOnce({
+        columns: [],
+        values: [],
+      });
+
+      await tool.handler(
+        {},
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger, {
+          spaceId: 'custom-space',
+        })
+      );
+
+      expect(mockEsClient.asCurrentUser.esql.query).toHaveBeenCalledWith({
+        query: expect.stringContaining('.entities.v2.latest.security_custom-space'),
+        drop_null_columns: true,
+      });
+    });
+
+    it('returns error result on ES failure', async () => {
+      mockEsClient.asCurrentUser.esql.query.mockRejectedValueOnce(
+        new Error('ES|QL query failed')
+      );
+
+      const result = (await tool.handler(
+        { entityTypes: ['host'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      )) as ToolHandlerStandardReturn;
+
+      expect(result.results).toHaveLength(1);
+      const errorResult = result.results[0] as ErrorResult;
+      expect(errorResult.type).toBe(ToolResultType.error);
+      expect(errorResult.data.message).toContain('Error searching Entity Store');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('passes compound filters to ESQL query', async () => {
+      mockEsClient.asCurrentUser.esql.query.mockResolvedValueOnce({
+        columns: [],
+        values: [],
+      });
+
+      await tool.handler(
+        {
+          entityTypes: ['host'],
+          riskLevel: 'High',
+          criticalityLevel: 'extreme_impact',
+          sortBy: 'risk_score',
+          sortOrder: 'desc',
+          limit: 5,
+        },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const calledQuery = mockEsClient.asCurrentUser.esql.query.mock.calls[0][0].query as string;
+      expect(calledQuery).toContain('entity.EngineMetadata.Type == "host"');
+      expect(calledQuery).toContain('entity.risk.calculated_level == "High"');
+      expect(calledQuery).toContain('asset.criticality == "extreme_impact"');
+      expect(calledQuery).toContain('SORT entity.risk.calculated_score_norm DESC');
+      expect(calledQuery).toContain('LIMIT 5');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_store_search_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_store_search_tool.ts
@@ -1,0 +1,325 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { z } from '@kbn/zod';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition, ToolAvailabilityContext } from '@kbn/agent-builder-server';
+import { getToolResultId } from '@kbn/agent-builder-server/tools';
+import {
+  FF_ENABLE_ENTITY_STORE_V2,
+  getLatestEntityStoreIndexName,
+} from '@kbn/entity-store/common';
+import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
+import { securityTool } from './constants';
+
+const DEFAULT_LIMIT = 10;
+
+const SORT_FIELD_MAP: Record<string, string> = {
+  risk_score: 'entity.risk.calculated_score_norm',
+  name: 'entity.name',
+  last_activity: 'entity.lifecycle.last_activity',
+  first_seen: 'entity.lifecycle.first_seen',
+};
+
+const KEEP_FIELDS = [
+  '@timestamp',
+  'entity.id',
+  'entity.name',
+  'entity.EngineMetadata.Type',
+  'entity.risk.calculated_score_norm',
+  'entity.risk.calculated_level',
+  'asset.criticality',
+  'entity.source',
+  'entity.lifecycle.first_seen',
+  'entity.lifecycle.last_activity',
+  'entity.attributes.watchlists',
+  'entity.attributes.managed',
+  'entity.attributes.mfa_enabled',
+  'entity.attributes.asset',
+  'entity.behaviors.rule_names',
+  'entity.behaviors.anomaly_job_ids',
+];
+
+const entityStoreSearchSchema = z.object({
+  entityTypes: z
+    .array(z.enum(['user', 'host', 'service', 'generic']))
+    .optional()
+    .describe('Entity types to search. If omitted, searches all types.'),
+  entityName: z
+    .string()
+    .optional()
+    .describe('Entity name or identifier to search for (exact or partial match via wildcard)'),
+  riskLevel: z
+    .enum(['Unknown', 'Low', 'Moderate', 'High', 'Critical'])
+    .optional()
+    .describe('Filter by risk level'),
+  riskScoreMin: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe('Minimum normalized risk score (0-100)'),
+  riskScoreMax: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe('Maximum normalized risk score (0-100)'),
+  criticalityLevel: z
+    .enum(['low_impact', 'medium_impact', 'high_impact', 'extreme_impact'])
+    .optional()
+    .describe('Filter by asset criticality level'),
+  attributes: z
+    .object({
+      watchlists: z.array(z.string()).optional(),
+      managed: z.boolean().optional(),
+      mfa_enabled: z.boolean().optional(),
+      asset: z.boolean().optional(),
+    })
+    .optional()
+    .describe('Filter by entity attributes'),
+  behaviors: z
+    .object({
+      ruleNames: z.array(z.string()).optional(),
+      anomalyJobIds: z.array(z.string()).optional(),
+    })
+    .optional()
+    .describe('Filter by entity behaviors (rule names or anomaly job IDs)'),
+  sortBy: z
+    .enum(['risk_score', 'name', 'last_activity', 'first_seen'])
+    .optional()
+    .describe('Sort field (default: risk_score)'),
+  sortOrder: z.enum(['asc', 'desc']).optional().describe('Sort order (default: desc)'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Maximum number of results to return (default: 10)'),
+});
+
+export type EntityStoreSearchParams = z.infer<typeof entityStoreSearchSchema>;
+
+export const SECURITY_ENTITY_STORE_SEARCH_TOOL_ID = securityTool('entity_store_search');
+
+const escapeEsqlString = (value: string) =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+export const buildEntityStoreSearchQuery = (
+  params: EntityStoreSearchParams,
+  index: string
+): string => {
+  const {
+    entityTypes,
+    entityName,
+    riskLevel,
+    riskScoreMin,
+    riskScoreMax,
+    criticalityLevel,
+    attributes,
+    behaviors,
+    sortBy = 'risk_score',
+    sortOrder = 'desc',
+    limit = DEFAULT_LIMIT,
+  } = params;
+
+  const whereClauses: string[] = ['entity.id IS NOT NULL'];
+
+  if (entityTypes && entityTypes.length > 0) {
+    if (entityTypes.length === 1) {
+      whereClauses.push(
+        `entity.EngineMetadata.Type == "${escapeEsqlString(entityTypes[0])}"`
+      );
+    } else {
+      const inList = entityTypes
+        .map((t) => `"${escapeEsqlString(t)}"`)
+        .join(', ');
+      whereClauses.push(`entity.EngineMetadata.Type IN (${inList})`);
+    }
+  }
+
+  if (entityName) {
+    const escaped = escapeEsqlString(entityName);
+    if (entityName.includes('*')) {
+      whereClauses.push(`entity.name LIKE "${escaped}"`);
+    } else {
+      whereClauses.push(`entity.name == "${escaped}"`);
+    }
+  }
+
+  if (riskLevel) {
+    whereClauses.push(
+      `entity.risk.calculated_level == "${escapeEsqlString(riskLevel)}"`
+    );
+  }
+
+  if (riskScoreMin !== undefined) {
+    whereClauses.push(`entity.risk.calculated_score_norm >= ${riskScoreMin}`);
+  }
+
+  if (riskScoreMax !== undefined) {
+    whereClauses.push(`entity.risk.calculated_score_norm <= ${riskScoreMax}`);
+  }
+
+  if (criticalityLevel) {
+    whereClauses.push(
+      `asset.criticality == "${escapeEsqlString(criticalityLevel)}"`
+    );
+  }
+
+  if (attributes) {
+    if (attributes.watchlists && attributes.watchlists.length > 0) {
+      for (const watchlist of attributes.watchlists) {
+        whereClauses.push(
+          `entity.attributes.watchlists == "${escapeEsqlString(watchlist)}"`
+        );
+      }
+    }
+    if (attributes.managed !== undefined) {
+      whereClauses.push(`entity.attributes.managed == ${attributes.managed}`);
+    }
+    if (attributes.mfa_enabled !== undefined) {
+      whereClauses.push(
+        `entity.attributes.mfa_enabled == ${attributes.mfa_enabled}`
+      );
+    }
+    if (attributes.asset !== undefined) {
+      whereClauses.push(`entity.attributes.asset == ${attributes.asset}`);
+    }
+  }
+
+  if (behaviors) {
+    if (behaviors.ruleNames && behaviors.ruleNames.length > 0) {
+      for (const ruleName of behaviors.ruleNames) {
+        whereClauses.push(
+          `entity.behaviors.rule_names == "${escapeEsqlString(ruleName)}"`
+        );
+      }
+    }
+    if (behaviors.anomalyJobIds && behaviors.anomalyJobIds.length > 0) {
+      for (const jobId of behaviors.anomalyJobIds) {
+        whereClauses.push(
+          `entity.behaviors.anomaly_job_ids == "${escapeEsqlString(jobId)}"`
+        );
+      }
+    }
+  }
+
+  const sortField = SORT_FIELD_MAP[sortBy] ?? SORT_FIELD_MAP.risk_score;
+
+  return [
+    `FROM ${index}`,
+    `| WHERE ${whereClauses.join(' AND ')}`,
+    `| KEEP ${KEEP_FIELDS.join(', ')}`,
+    `| SORT ${sortField} ${sortOrder.toUpperCase()}`,
+    `| LIMIT ${limit}`,
+  ].join('\n');
+};
+
+export const entityStoreSearchTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof entityStoreSearchSchema> => {
+  return {
+    id: SECURITY_ENTITY_STORE_SEARCH_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Search and filter entities in the Entity Store. Supports searching across users, hosts, services, and generic entities with filters for risk level, risk score range, asset criticality, entity attributes (watchlists, managed, MFA, asset), and behaviors (rule names, anomaly jobs). Use this to answer questions like "What are the riskiest hosts?", "Show me high-criticality users", or "Find entities with anomalous behavior". Always use 'entity.risk.calculated_score_norm' (0-100) when reporting risk scores.`,
+    schema: entityStoreSearchSchema,
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request, spaceId, uiSettings }: ToolAvailabilityContext) => {
+        try {
+          const isV2Enabled = await uiSettings.get<boolean>(FF_ENABLE_ENTITY_STORE_V2);
+          if (!isV2Enabled) {
+            return {
+              status: 'unavailable',
+              reason: 'Entity Store v2 is not enabled',
+            };
+          }
+
+          const availability = await getAgentBuilderResourceAvailability({
+            core,
+            request,
+            logger,
+          });
+          if (availability.status !== 'available') {
+            return availability;
+          }
+
+          const [coreStart] = await core.getStartServices();
+          const esClient = coreStart.elasticsearch.client.asInternalUser;
+          const entityStoreIndex = getLatestEntityStoreIndexName(spaceId);
+
+          const indexExists = await esClient.indices.exists({ index: entityStoreIndex });
+          if (!indexExists) {
+            return {
+              status: 'unavailable',
+              reason: 'Entity Store index does not exist for this space',
+            };
+          }
+
+          return { status: 'available' };
+        } catch (error) {
+          return {
+            status: 'unavailable',
+            reason: `Failed to check Entity Store availability: ${
+              error instanceof Error ? error.message : 'Unknown error'
+            }`,
+          };
+        }
+      },
+    },
+    handler: async (params, { spaceId, esClient }) => {
+      logger.debug(
+        `${SECURITY_ENTITY_STORE_SEARCH_TOOL_ID} tool called with params: ${JSON.stringify(params)}`
+      );
+
+      try {
+        const entityStoreIndex = getLatestEntityStoreIndexName(spaceId);
+        const query = buildEntityStoreSearchQuery(params, entityStoreIndex);
+
+        const { columns, values } = await esClient.asCurrentUser.esql.query({
+          query,
+          drop_null_columns: true,
+        });
+
+        return {
+          results: [
+            {
+              tool_result_id: getToolResultId(),
+              type: ToolResultType.esqlResults,
+              data: { query, columns, values },
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(
+          `Error in ${SECURITY_ENTITY_STORE_SEARCH_TOOL_ID} tool: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`
+        );
+        return {
+          results: [
+            {
+              tool_result_id: getToolResultId(),
+              type: ToolResultType.error,
+              data: {
+                message: `Error searching Entity Store: ${
+                  error instanceof Error ? error.message : 'Unknown error'
+                }`,
+              },
+            },
+          ],
+        };
+      }
+    },
+    tags: ['security', 'entity-store', 'entities'],
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -16,3 +16,7 @@ export {
   createDetectionRuleTool,
   SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
 } from './create_detection_rule_tool';
+export {
+  entityStoreSearchTool,
+  SECURITY_ENTITY_STORE_SEARCH_TOOL_ID,
+} from './entity_store_search_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -13,6 +13,7 @@ import { attackDiscoverySearchTool } from './attack_discovery_search_tool';
 import { entityRiskScoreTool } from './entity_risk_score_tool';
 import { alertsTool } from './alerts_tool';
 import { createDetectionRuleTool } from './create_detection_rule_tool';
+import { entityStoreSearchTool } from './entity_store_search_tool';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 
 /**
@@ -29,4 +30,5 @@ export const registerTools = async (
   agentBuilder.tools.register(securityLabsSearchTool(core));
   agentBuilder.tools.register(createDetectionRuleTool(core, logger, experimentalFeatures));
   agentBuilder.tools.register(alertsTool(core, logger));
+  agentBuilder.tools.register(entityStoreSearchTool(core, logger));
 };


### PR DESCRIPTION
Introduces a new tool to enable AI agents to query security entities (users, hosts, services) from the Entity Store.

Provides extensive filtering capabilities by entity type, name, risk level/score, criticality, attributes (watchlists, managed, MFA, asset), and behaviors (rule names, anomaly jobs).

Ensures the tool is only available when Entity Store v2 is enabled and the relevant index exists. Uses ESQL for efficient and flexible querying of entity data, enhancing the Agent Builder's ability to retrieve contextual security information.