### PR TITLE
[8.19] [skills] Normalize skill names for slash commands (#252996)

### DIFF
--- a/.agent/skills/ftr-testing/SKILL.md
+++ b/.agent/skills/ftr-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: FTR Testing
+name: ftr-testing
 description: Use when creating, updating, debugging, or reviewing Kibana Functional Test Runner (FTR) tests, including test structure, services/page objects, loadTestFile patterns, tags, and how to run FTR locally.
 ---
 

--- a/.agent/skills/scout-api-testing/SKILL.md
+++ b/.agent/skills/scout-api-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Scout API Testing
+name: scout-api-testing
 description: Use when creating, updating, debugging, or reviewing Scout API tests in Kibana (apiTest/apiClient/requestAuth/samlAuth/apiServices), including auth choices, response assertions, and API service patterns.
 ---
 

--- a/.agent/skills/scout-best-practices-reviewer/SKILL.md
+++ b/.agent/skills/scout-best-practices-reviewer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Scout Best Practices Reviewer
+name: scout-best-practices-reviewer
 description: Use when writing and reviewing Scout UI and API test files.
 ---
 

--- a/.agent/skills/scout-create-scaffold/SKILL.md
+++ b/.agent/skills/scout-create-scaffold/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Scout Create Scaffold
+name: scout-create-scaffold
 description: Generate or repair a Scout test scaffold for a Kibana plugin/package (test/scout*/{api,ui} Playwright configs, fixtures, example specs). Use when you need the initial Scout directory structure; prefer `node scripts/scout.js generate` with flags for non-interactive/LLM execution.
 ---
 

--- a/.agent/skills/scout-migrate-from-ftr/SKILL.md
+++ b/.agent/skills/scout-migrate-from-ftr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Scout Migrate From FTR
+name: scout-migrate-from-ftr
 description: Use when migrating Kibana Functional Test Runner (FTR) tests to Scout, including decisions about UI vs API tests, mapping FTR services/page objects/hooks to Scout fixtures, and splitting loadTestFile patterns.
 ---
 

--- a/.agent/skills/scout-ui-testing/SKILL.md
+++ b/.agent/skills/scout-ui-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Scout UI Testing
+name: scout-ui-testing
 description: Use when creating, updating, debugging, or reviewing Scout UI tests in Kibana (Playwright + Scout fixtures), including page objects, browser authentication, parallel UI tests (spaceTest/scoutSpace), a11y checks, and flake control.
 ---
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[skills] Normalize skill names for slash commands (#252996)](https://github.com/elastic/kibana/pull/252996)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-02-13T05:41:35Z","message":"[skills] Normalize skill names for slash commands (#252996)","sha":"7d076d319c8f459f197f159c56b735d8a82e6498","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0"],"title":"[skills] Normalize skill names for slash commands","number":252996,"url":"https://github.com/elastic/kibana/pull/252996","mergeCommit":{"message":"[skills] Normalize skill names for slash commands (#252996)","sha":"7d076d319c8f459f197f159c56b735d8a82e6498"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252996","number":252996,"mergeCommit":{"message":"[skills] Normalize skill names for slash commands (#252996)","sha":"7d076d319c8f459f197f159c56b735d8a82e6498"}}]}] BACKPORT-->