### PR TITLE
[8.19] [Scout] auto-enable generated modules (#253184)

### DIFF
--- a/.agent/skills/scout-api-testing/SKILL.md
+++ b/.agent/skills/scout-api-testing/SKILL.md
@@ -99,6 +99,11 @@ Tests then import `apiTest` from the local fixtures: `import { apiTest } from '.
 - `start-server` has no Playwright config to inspect, so pass `--config-dir <name>` when your tests require a custom server config.
 - Debug: `SCOUT_LOG_LEVEL=debug`
 
+## CI enablement
+
+- Scout tests run in CI only for modules listed under `plugins.enabled` / `packages.enabled` in `.buildkite/scout_ci_config.yml`.
+- `node scripts/scout.js generate` registers the module under `enabled` so the new configs run in CI.
+
 ## References
 
 Open only what you need:

--- a/.agent/skills/scout-create-scaffold/SKILL.md
+++ b/.agent/skills/scout-create-scaffold/SKILL.md
@@ -63,8 +63,6 @@ Notes:
 
 - Update `.meta` manifests when adding/moving configs or tests:
   - `node scripts/scout.js update-test-config-manifests`
-- CI plumbing:
-  - Add the plugin/package to `.buildkite/scout_ci_config.yml` (the generator warns about this).
 - Custom server config sets:
   - If you create/use `test/scout_<configSet>`, you typically also need a matching server config under `src/platform/packages/shared/kbn-scout/src/servers/configs/custom/<configSet>`.
   - `start-server` requires `--config-dir <configSet>` when using a custom server config set.

--- a/.agent/skills/scout-ui-testing/SKILL.md
+++ b/.agent/skills/scout-ui-testing/SKILL.md
@@ -112,6 +112,11 @@ test('creates and verifies a dashboard', async ({ pageObjects, page }) => {
 - `start-server` has no Playwright config to inspect, so pass `--config-dir <name>` when your tests require a custom server config.
 - Debug: `SCOUT_LOG_LEVEL=debug`, or `npx playwright test --config <...> --project local --ui`
 
+## CI enablement
+
+- Scout tests run in CI only for modules listed under `plugins.enabled` / `packages.enabled` in `.buildkite/scout_ci_config.yml`.
+- `node scripts/scout.js generate` registers the module under `enabled` so the new configs run in CI.
+
 ## References
 
 Open only what you need:

--- a/src/platform/packages/shared/kbn-scout/src/cli/scout_ci_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/scout_ci_config.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  getScoutCiConfigModuleFromPath,
+  upsertEnabledModuleInScoutCiConfigYml,
+} from './scout_ci_config';
+
+describe('scout_ci_config helpers', () => {
+  describe('getScoutCiConfigModuleFromPath', () => {
+    it.each([
+      ['x-pack/platform/plugins/shared/maps', { kind: 'plugins', name: 'maps' }],
+      [
+        'src/platform/plugins/private/vis_types/timelion',
+        { kind: 'plugins', name: 'vis_types/timelion' },
+      ],
+      [
+        'src/platform/packages/private/kbn-streamlang-tests',
+        { kind: 'packages', name: 'kbn-streamlang-tests' },
+      ],
+      ['x-pack\\platform\\plugins\\shared\\maps', { kind: 'plugins', name: 'maps' }],
+    ])('derives module from path: %s', (path, expected) => {
+      expect(getScoutCiConfigModuleFromPath(path)).toEqual(expected);
+    });
+  });
+
+  describe('upsertEnabledModuleInScoutCiConfigYml', () => {
+    const baseYml = `plugins:
+  enabled:
+    - apm
+    - maps
+  disabled:
+    - discover_enhanced
+
+packages:
+  enabled:
+    - kbn-streamlang-tests
+  disabled:
+
+excluded_configs:
+  - x-pack/some/path/ui/playwright.config.ts
+`;
+
+    it('adds a new plugin to enabled and sorts the enabled list', () => {
+      const result = upsertEnabledModuleInScoutCiConfigYml(baseYml, {
+        kind: 'plugins',
+        name: 'lens',
+      });
+
+      expect(result).toMatchObject({ didChange: true, wasAlreadyEnabled: false });
+      expect(result.updatedYml).toContain(`plugins:
+  enabled:
+    - apm
+    - lens
+    - maps
+`);
+    });
+
+    it('does not change the file when the module is already enabled', () => {
+      const result = upsertEnabledModuleInScoutCiConfigYml(baseYml, {
+        kind: 'plugins',
+        name: 'maps',
+      });
+
+      expect(result).toMatchObject({ didChange: false, wasAlreadyEnabled: true });
+      expect(result.updatedYml).toBe(baseYml);
+    });
+
+    it('moves a module from disabled to enabled', () => {
+      const yml = `plugins:
+  enabled:
+    - apm
+  disabled:
+    - lens
+
+packages:
+  enabled:
+  disabled:
+`;
+
+      const result = upsertEnabledModuleInScoutCiConfigYml(yml, { kind: 'plugins', name: 'lens' });
+      expect(result).toMatchObject({ didChange: true, movedFromDisabled: true });
+      expect(result.updatedYml).toContain(`plugins:
+  enabled:
+    - apm
+    - lens
+  disabled:
+`);
+    });
+
+    it('adds a package under packages.enabled (without touching plugins)', () => {
+      const result = upsertEnabledModuleInScoutCiConfigYml(baseYml, {
+        kind: 'packages',
+        name: 'kbn-scout-release-testing',
+      });
+
+      expect(result).toMatchObject({ didChange: true });
+      expect(result.updatedYml).toContain(`packages:
+  enabled:
+    - kbn-scout-release-testing
+    - kbn-streamlang-tests
+`);
+      expect(result.updatedYml).toContain(`plugins:
+  enabled:
+    - apm
+    - maps
+`);
+    });
+
+    it('adds a nested module and sorts it correctly', () => {
+      const yml = `plugins:
+  enabled:
+    - apm
+    - maps
+  disabled:
+
+packages:
+  enabled:
+  disabled:
+`;
+
+      const result = upsertEnabledModuleInScoutCiConfigYml(yml, {
+        kind: 'plugins',
+        name: 'vis_types/timelion',
+      });
+
+      expect(result).toMatchObject({ didChange: true, wasAlreadyEnabled: false });
+      expect(result.updatedYml).toContain(`plugins:
+  enabled:
+    - apm
+    - maps
+    - vis_types/timelion
+  disabled:
+`);
+    });
+
+    it('does not duplicate a nested module that is already enabled', () => {
+      const yml = `plugins:
+  enabled:
+    - apm
+    - vis_types/timelion
+  disabled:
+
+packages:
+  enabled:
+  disabled:
+`;
+
+      const result = upsertEnabledModuleInScoutCiConfigYml(yml, {
+        kind: 'plugins',
+        name: 'vis_types/timelion',
+      });
+
+      expect(result).toMatchObject({ didChange: false, wasAlreadyEnabled: true });
+      expect(result.updatedYml).toBe(yml);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/cli/scout_ci_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/scout_ci_config.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type ScoutCiConfigModuleKind = 'plugins' | 'packages';
+
+export interface ScoutCiConfigModule {
+  kind: ScoutCiConfigModuleKind;
+  name: string;
+}
+
+const TOP_LEVEL_KEY_RE = /^[a-zA-Z_][\w-]*:\s*$/;
+
+const readListItems = (
+  lines: string[],
+  startIndex: number,
+  itemIndent: string
+): { items: string[]; endIndex: number } => {
+  const items: string[] = [];
+  let i = startIndex;
+
+  const prefix = `${itemIndent}- `;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.startsWith(prefix)) break;
+    items.push(line.slice(prefix.length).trim());
+    i += 1;
+  }
+
+  return { items, endIndex: i };
+};
+
+const replaceRange = (
+  lines: string[],
+  startIndex: number,
+  endIndex: number,
+  replacement: string[]
+): string[] => {
+  return [...lines.slice(0, startIndex), ...replacement, ...lines.slice(endIndex)];
+};
+
+const findLineIndex = (
+  lines: string[],
+  startIndex: number,
+  endIndex: number,
+  predicate: (line: string) => boolean
+): number => {
+  for (let i = startIndex; i < endIndex; i++) {
+    if (predicate(lines[i])) return i;
+  }
+  return -1;
+};
+
+const findTopLevelSection = (
+  lines: string[],
+  section: string
+): { startIndex: number; endIndex: number } => {
+  const startIndex = findLineIndex(
+    lines,
+    0,
+    lines.length,
+    (l) => !l.startsWith(' ') && l.trimEnd() === `${section}:`
+  );
+  if (startIndex === -1) {
+    throw new Error(`Unable to find top-level YAML section "${section}:"`);
+  }
+
+  let endIndex = lines.length;
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line && TOP_LEVEL_KEY_RE.test(line)) {
+      endIndex = i;
+      break;
+    }
+  }
+
+  return { startIndex, endIndex };
+};
+
+const findIndentedKey = (
+  lines: string[],
+  sectionStartIndex: number,
+  sectionEndIndex: number,
+  key: string
+): number => {
+  return findLineIndex(
+    lines,
+    sectionStartIndex,
+    sectionEndIndex,
+    (l) => l.trimEnd() === `  ${key}:`
+  );
+};
+
+export const getScoutCiConfigModuleFromPath = (relativePath: string): ScoutCiConfigModule => {
+  const normalized = relativePath.trim().replace(/\\/g, '/').replace(/\/+$/g, '');
+  const parts = normalized.split('/').filter(Boolean);
+
+  const typeIndex = parts.findIndex((p) => p === 'plugins' || p === 'packages');
+  if (typeIndex === -1 || typeIndex === parts.length - 1) {
+    throw new Error(
+      `Unable to determine whether "${relativePath}" is a plugin or package (expected path to include "/plugins/" or "/packages/")`
+    );
+  }
+
+  const kind = parts[typeIndex] as ScoutCiConfigModuleKind;
+
+  let nameParts = parts.slice(typeIndex + 1);
+  if (nameParts[0] === 'shared' || nameParts[0] === 'private') {
+    nameParts = nameParts.slice(1);
+  }
+
+  const name = nameParts.join('/');
+  if (!name) {
+    throw new Error(`Unable to determine module name from path "${relativePath}"`);
+  }
+
+  return { kind, name };
+};
+
+export interface UpsertScoutCiConfigModuleResult {
+  updatedYml: string;
+  didChange: boolean;
+  wasAlreadyEnabled: boolean;
+  movedFromDisabled: boolean;
+}
+
+export const upsertEnabledModuleInScoutCiConfigYml = (
+  yml: string,
+  module: ScoutCiConfigModule
+): UpsertScoutCiConfigModuleResult => {
+  const eol = yml.includes('\r\n') ? '\r\n' : '\n';
+  const lines = yml.split(/\r?\n/);
+
+  const { startIndex: sectionStartIndex, endIndex: sectionEndIndex } = findTopLevelSection(
+    lines,
+    module.kind
+  );
+
+  const enabledKeyIndex = findIndentedKey(lines, sectionStartIndex, sectionEndIndex, 'enabled');
+  const disabledKeyIndex = findIndentedKey(lines, sectionStartIndex, sectionEndIndex, 'disabled');
+
+  if (enabledKeyIndex === -1) {
+    throw new Error(`Unable to find "${module.kind}.enabled" in Scout CI config`);
+  }
+  if (disabledKeyIndex === -1) {
+    throw new Error(`Unable to find "${module.kind}.disabled" in Scout CI config`);
+  }
+
+  const enabledListStart = enabledKeyIndex + 1;
+  const enabledList = readListItems(lines, enabledListStart, '    ');
+
+  const disabledListStart = disabledKeyIndex + 1;
+  const disabledList = readListItems(lines, disabledListStart, '    ');
+
+  const wasAlreadyEnabled = enabledList.items.includes(module.name);
+
+  const filteredDisabled = disabledList.items.filter((item) => item !== module.name);
+  const movedFromDisabled = filteredDisabled.length !== disabledList.items.length;
+
+  const nextEnabled = wasAlreadyEnabled ? enabledList.items : [...enabledList.items, module.name];
+  const didChange = movedFromDisabled || !wasAlreadyEnabled;
+
+  if (!didChange) {
+    return { updatedYml: yml, didChange: false, wasAlreadyEnabled: true, movedFromDisabled: false };
+  }
+
+  const sortedEnabled = [...nextEnabled].sort();
+
+  const enabledReplacement = sortedEnabled.map((item) => `    - ${item}`);
+  const disabledReplacement = filteredDisabled.map((item) => `    - ${item}`);
+
+  // Replace from bottom to top so earlier indices don't shift.
+  let updatedLines = lines;
+  updatedLines = replaceRange(
+    updatedLines,
+    disabledListStart,
+    disabledList.endIndex,
+    disabledReplacement
+  );
+  updatedLines = replaceRange(
+    updatedLines,
+    enabledListStart,
+    enabledList.endIndex,
+    enabledReplacement
+  );
+
+  return {
+    updatedYml: updatedLines.join(eol),
+    didChange: true,
+    wasAlreadyEnabled,
+    movedFromDisabled,
+  };
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Scout] auto-enable generated modules (#253184)](https://github.com/elastic/kibana/pull/253184)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-02-18T17:48:49Z","message":"[Scout] auto-enable generated modules (#253184)\n\nWhen using `scout generate`, it will now automatically enable the new module in CI.","sha":"caf7737e78742de1d5291f116f9d97c74547a36b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"[Scout] auto-enable generated modules","number":253184,"url":"https://github.com/elastic/kibana/pull/253184","mergeCommit":{"message":"[Scout] auto-enable generated modules (#253184)\n\nWhen using `scout generate`, it will now automatically enable the new module in CI.","sha":"caf7737e78742de1d5291f116f9d97c74547a36b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253184","number":253184,"mergeCommit":{"message":"[Scout] auto-enable generated modules (#253184)\n\nWhen using `scout generate`, it will now automatically enable the new module in CI.","sha":"caf7737e78742de1d5291f116f9d97c74547a36b"}}]}] BACKPORT-->