### PR TITLE
[ES|QL] Removes unused argument from getInitialESQLQuery as it is unused

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
@@ -55,7 +55,7 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, '@timestamp');
-    expect(getInitialESQLQuery(dataView)).toBe('FROM logs* | LIMIT 10');
+    expect(getInitialESQLQuery(dataView)).toBe('FROM logs*');
   });
 
   it('should NOT add the where clause if there is @timestamp in the index although the dataview timefielName is different', () => {
@@ -78,7 +78,7 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, 'timestamp');
-    expect(getInitialESQLQuery(dataView)).toBe('FROM logs* | LIMIT 10');
+    expect(getInitialESQLQuery(dataView)).toBe('FROM logs*');
   });
 
   it('should append a where clause correctly if there is no @timestamp in the index fields', () => {
@@ -102,7 +102,7 @@ describe('getInitialESQLQuery', () => {
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, '@custom_timestamp');
     expect(getInitialESQLQuery(dataView)).toBe(
-      'FROM logs* | WHERE @custom_timestamp >= ?_tstart AND @custom_timestamp <= ?_tend | LIMIT 10'
+      'FROM logs* | WHERE @custom_timestamp >= ?_tstart AND @custom_timestamp <= ?_tend'
     );
   });
 
@@ -126,7 +126,7 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, '@custom_timestamp');
-    expect(getInitialESQLQuery(dataView, true, { language: 'kuery', query: 'error' })).toBe(
+    expect(getInitialESQLQuery(dataView, { language: 'kuery', query: 'error' })).toBe(
       'FROM logs* | WHERE @custom_timestamp >= ?_tstart AND @custom_timestamp <= ?_tend AND KQL("""error""")'
     );
   });
@@ -151,8 +151,8 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, 'timestamp');
-    expect(getInitialESQLQuery(dataView, false, { language: 'lucene', query: 'error' })).toBe(
-      'FROM logs* | WHERE QSTR("""error""") | LIMIT 10'
+    expect(getInitialESQLQuery(dataView, { language: 'lucene', query: 'error' })).toBe(
+      'FROM logs* | WHERE QSTR("""error""")'
     );
   });
 
@@ -176,7 +176,7 @@ describe('getInitialESQLQuery', () => {
       },
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, 'timestamp');
-    expect(getInitialESQLQuery(dataView, true, { language: 'unknown', query: 'error' })).toBe(
+    expect(getInitialESQLQuery(dataView, { language: 'unknown', query: 'error' })).toBe(
       'FROM logs*'
     );
   });
@@ -203,6 +203,6 @@ describe('getInitialESQLQuery', () => {
     ] as DataView['fields'];
     const dataView = getDataView('metrics-*', fields, '@timestamp');
 
-    expect(getInitialESQLQuery(dataView)).toBe('TS metrics-* | LIMIT 10');
+    expect(getInitialESQLQuery(dataView)).toBe('TS metrics-*');
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.ts
@@ -41,11 +41,7 @@ const getFinalWhereClause = (timeFilter?: string, queryFilter?: string) => {
  * If the index pattern contains TSDB fields, we add the TS command, otherwise we add the FROM command
  * @param dataView
  */
-export function getInitialESQLQuery(
-  dataView: DataView,
-  removeLimit?: boolean,
-  query?: Query
-): string {
+export function getInitialESQLQuery(dataView: DataView, query?: Query): string {
   const hasAtTimestampField = dataView?.fields?.getByName?.('@timestamp')?.type === 'date';
   const timeFieldName = dataView?.timeFieldName;
   const filterByTimeParams =
@@ -58,7 +54,5 @@ export function getInitialESQLQuery(
   const whereClause = getFinalWhereClause(filterByTimeParams, filterBySearchText);
   const sourceCommand = dataView.isTSDBMode() ? 'TS' : 'FROM';
 
-  return `${sourceCommand} ${dataView.getIndexPattern()}${whereClause}${
-    removeLimit ? '' : ' | LIMIT 10'
-  }`;
+  return `${sourceCommand} ${dataView.getIndexPattern()}${whereClause}`;
 }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/no_data/dashboard_app_no_data.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/no_data/dashboard_app_no_data.tsx
@@ -75,7 +75,7 @@ export const DashboardAppNoDataPage = ({
         query: `FROM ${indexName}`,
         http: coreServices.http,
       });
-      const esqlQuery = getInitialESQLQuery(dataView, true);
+      const esqlQuery = getInitialESQLQuery(dataView);
 
       try {
         const columns = await getESQLQueryColumns({

--- a/src/platform/plugins/shared/discover/common/esql_locator_get_location.ts
+++ b/src/platform/plugins/shared/discover/common/esql_locator_get_location.ts
@@ -29,7 +29,7 @@ export const esqlLocatorGetLocation = async ({
     query: `FROM ${indexName}`,
     http,
   });
-  const esql = getInitialESQLQuery(dataView, true);
+  const esql = getInitialESQLQuery(dataView);
 
   const params = {
     query: { esql },

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -147,7 +147,7 @@ export const useTopNavLinks = ({
     if (!services.embeddableEditor.isEmbeddedEditor()) {
       const defaultEsqlState: Pick<DiscoverAppState, 'query'> | undefined =
         isEsqlMode && currentDataView.type === ESQL_TYPE
-          ? { query: { esql: getInitialESQLQuery(currentDataView, true) } }
+          ? { query: { esql: getInitialESQLQuery(currentDataView) } }
           : undefined;
       const locatorParams: DiscoverAppLocatorParams = defaultEsqlState
         ? defaultEsqlState

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_state.ts
@@ -235,7 +235,7 @@ export const transitionFromDataViewToESQL: InternalStateThunkActionCreator<
     const appState = selectTab(currentState, tabId).appState;
     const { query, sort } = appState;
     const filterQuery = query && isOfQueryType(query) ? query : undefined;
-    const queryString = getInitialESQLQuery(dataView, true, filterQuery);
+    const queryString = getInitialESQLQuery(dataView, filterQuery);
     const clearedSort = clearTimeFieldFromSort(sort, dataView?.timeFieldName);
 
     dispatch(

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -206,7 +206,7 @@ export const updateTabs: InternalStateThunkActionCreator<
 
         tab.appState = {
           ...(isOfAggregateQueryType(currentQuery)
-            ? { query: { esql: getInitialESQLQuery(currentDataView, true) } }
+            ? { query: { esql: getInitialESQLQuery(currentDataView) } }
             : {}),
           dataSource: createDataSource({
             dataView: currentDataView,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_initial_app_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_initial_app_state.ts
@@ -119,7 +119,7 @@ function getDefaultQuery({
   const canUseEsql = services.uiSettings.get(ENABLE_ESQL) && dataView instanceof DataView;
   const isEsqlDefault = services.discoverFeatureFlags.getIsEsqlDefault();
   if (canUseEsql && (queryMode === 'esql' || isEsqlDefault))
-    return { esql: defaultProfileEsqlQuery?.query ?? getInitialESQLQuery(dataView, true) };
+    return { esql: defaultProfileEsqlQuery?.query ?? getInitialESQLQuery(dataView) };
 
   // Lastly, fall back to classic if we can't use anything else
   return services.data.query.queryString.getDefaultQuery();

--- a/src/platform/plugins/shared/discover/public/plugin_imports/search_provider_find.ts
+++ b/src/platform/plugins/shared/discover/public/plugin_imports/search_provider_find.ts
@@ -50,7 +50,7 @@ export const searchProviderFind: (
 
   const params = {
     query: {
-      esql: getInitialESQLQuery(defaultDataView, true),
+      esql: getInitialESQLQuery(defaultDataView),
     },
     dataViewSpec: defaultDataView?.toSpec(),
   };

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/esql.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/esql.ts
@@ -50,7 +50,7 @@ export async function loadESQLAttributes({
     import('../async_services'),
   ]);
 
-  const esqlQuery = getInitialESQLQuery(dataView, true);
+  const esqlQuery = getInitialESQLQuery(dataView);
 
   const defaultEsqlQuery = {
     esql: esqlQuery,


### PR DESCRIPTION
## Summary

Cleanup of an unused argument

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



