### PR TITLE
[8.19] [Console] Only show ESQL suggestions in ESQL query request (#240264)

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/console/index.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/index.ts
@@ -67,7 +67,14 @@ export const ConsoleLang: LangModuleType = {
             context,
             esqlCallbacks
           );
-          return wrapAsMonacoSuggestions(esqlSuggestions, queryText, false, !insideTripleQuotes);
+          return {
+            suggestions: wrapAsMonacoSuggestions(
+              esqlSuggestions,
+              queryText,
+              false,
+              !insideTripleQuotes
+            ),
+          };
         } else if (actionsProvider.current) {
           return actionsProvider.current?.provideCompletionItems(model, position, context);
         }

--- a/src/platform/packages/shared/kbn-monaco/src/console/index.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/index.ts
@@ -26,7 +26,7 @@ import {
 import { foldingRangeProvider } from './folding_range_provider';
 import { ESQL_AUTOCOMPLETE_TRIGGER_CHARS } from '../esql';
 import { wrapAsMonacoSuggestions } from '../esql/lib/converters/suggestions';
-import { checkForTripleQuotesAndQueries, unescapeInvalidChars } from './utils';
+import { checkForTripleQuotesAndEsqlQuery, unescapeInvalidChars } from './utils';
 
 export { CONSOLE_LANG_ID, CONSOLE_OUTPUT_LANG_ID } from './constants';
 /**
@@ -56,10 +56,10 @@ export const ConsoleLang: LangModuleType = {
         const fullText = model.getValue();
         const cursorOffset = model.getOffsetAt(position);
         const textBeforeCursor = fullText.slice(0, cursorOffset);
-        const { insideSingleQuotesQuery, insideTripleQuotesQuery, queryIndex } =
-          checkForTripleQuotesAndQueries(textBeforeCursor);
-        if (esqlCallbacks && (insideSingleQuotesQuery || insideTripleQuotesQuery)) {
-          const queryText = textBeforeCursor.slice(queryIndex, cursorOffset);
+        const { insideTripleQuotes, insideEsqlQuery, esqlQueryIndex } =
+          checkForTripleQuotesAndEsqlQuery(textBeforeCursor);
+        if (esqlCallbacks && insideEsqlQuery) {
+          const queryText = textBeforeCursor.slice(esqlQueryIndex, cursorOffset);
           const unescapedQuery = unescapeInvalidChars(queryText);
           const esqlSuggestions = await suggest(
             unescapedQuery,
@@ -67,14 +67,7 @@ export const ConsoleLang: LangModuleType = {
             context,
             esqlCallbacks
           );
-          return {
-            suggestions: wrapAsMonacoSuggestions(
-              esqlSuggestions,
-              queryText,
-              false,
-              insideSingleQuotesQuery
-            ),
-          };
+          return wrapAsMonacoSuggestions(esqlSuggestions, queryText, false, !insideTripleQuotes);
         } else if (actionsProvider.current) {
           return actionsProvider.current?.provideCompletionItems(model, position, context);
         }

--- a/src/platform/packages/shared/kbn-monaco/src/console/utils/index.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/utils/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { checkForTripleQuotesAndQueries, unescapeInvalidChars } from './autocomplete_utils';
+export { checkForTripleQuotesAndEsqlQuery, unescapeInvalidChars } from './autocomplete_utils';

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
@@ -14,7 +14,7 @@ import { i18n } from '@kbn/i18n';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { XJson } from '@kbn/es-ui-shared-plugin/public';
 import { ErrorAnnotation } from '@kbn/monaco/src/console/types';
-import { checkForTripleQuotesAndQueries } from '@kbn/monaco/src/console/utils';
+import { checkForTripleQuotesAndEsqlQuery } from '@kbn/monaco/src/console/utils';
 import { isQuotaExceededError } from '../../../services/history';
 import { DEFAULT_VARIABLES, KIBANA_API_PREFIX } from '../../../../common/constants';
 import { getStorage, StorageKeys } from '../../../services';
@@ -785,7 +785,7 @@ export class MonacoEditorActionsProvider {
   private async isPositionInsideTripleQuotesAndQuery(
     model: monaco.editor.ITextModel,
     position: monaco.Position
-  ): Promise<{ insideTripleQuotes: boolean; insideQuery: boolean }> {
+  ): Promise<{ insideTripleQuotes: boolean; insideEsqlQuery: boolean }> {
     const selectedRequests = await this.getSelectedParsedRequests();
 
     for (const request of selectedRequests) {
@@ -800,21 +800,21 @@ export class MonacoEditorActionsProvider {
           endColumn: position.column,
         });
 
-        const { insideTripleQuotes, insideSingleQuotesQuery, insideTripleQuotesQuery } =
-          checkForTripleQuotesAndQueries(requestContentBefore);
+        const { insideTripleQuotes, insideEsqlQuery } =
+          checkForTripleQuotesAndEsqlQuery(requestContentBefore);
         return {
           insideTripleQuotes,
-          insideQuery: insideSingleQuotesQuery || insideTripleQuotesQuery,
+          insideEsqlQuery,
         };
       }
       if (request.startLineNumber > position.lineNumber) {
         // Stop iteration once we pass the cursor position
-        return { insideTripleQuotes: false, insideQuery: false };
+        return { insideTripleQuotes: false, insideEsqlQuery: false };
       }
     }
 
     // Return false if the position is not inside a request
-    return { insideTripleQuotes: false, insideQuery: false };
+    return { insideTripleQuotes: false, insideEsqlQuery: false };
   }
 
   private triggerSuggestions() {
@@ -824,8 +824,8 @@ export class MonacoEditorActionsProvider {
       return;
     }
     this.isPositionInsideTripleQuotesAndQuery(model, position).then(
-      ({ insideTripleQuotes, insideQuery }) => {
-        if (insideTripleQuotes && !insideQuery) {
+      ({ insideTripleQuotes, insideEsqlQuery }) => {
+        if (insideTripleQuotes && !insideEsqlQuery) {
           // Don't trigger autocomplete suggestions inside scripts and strings
           return;
         }
@@ -839,11 +839,11 @@ export class MonacoEditorActionsProvider {
         // Trigger suggestions if the line:
         // - is empty
         // - matches specified regex
-        // - is inside a query
+        // - is inside an ESQL query
         if (
           !lineContentBefore.trim() ||
           shouldTriggerSuggestions(lineContentBefore) ||
-          insideQuery
+          insideEsqlQuery
         ) {
           this.editor.trigger(TRIGGER_SUGGESTIONS_ACTION_LABEL, TRIGGER_SUGGESTIONS_HANDLER_ID, {});
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Only show ESQL suggestions in ESQL query request (#240264)](https://github.com/elastic/kibana/pull/240264)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-27T14:48:54Z","message":"[Console] Only show ESQL suggestions in ESQL query request (#240264)\n\nCloses https://github.com/elastic/kibana/issues/225685\n\n## Summary\n\nPreviously, ESQL suggestions were shown inside all `query` body params\n(`\"query\": \"...` or `\"query\": \"\"\"...`). However, there are some requests\nwith a `query` body param that don't work with ESLQ (e.g. SQL query).\nThis PR makes sure that ESQL suggestions are only displayed inside `POST\n_query` request (which is the request for sending ESQL queries).\n\n**How to test:**\n\nVerify that ESQL suggestions are displayed in `POST _query` requests:\n\n```\nPOST /_query\n{\n  \"query\": \"...\"\n}\n```\n\nVerify that ESQL suggestions are **not** displayed in any other\nrequests; for example:\n\n```\nPOST /_sql\n{\n  \"query\": \"....\"\n}\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7f03a89707f337416f3b898be884f9f81280e837","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:version","v9.3.0","v9.2.6","v8.19.13","v9.2.7"],"title":"[Console] Only show ESQL suggestions in ESQL query request","number":240264,"url":"https://github.com/elastic/kibana/pull/240264","mergeCommit":{"message":"[Console] Only show ESQL suggestions in ESQL query request (#240264)\n\nCloses https://github.com/elastic/kibana/issues/225685\n\n## Summary\n\nPreviously, ESQL suggestions were shown inside all `query` body params\n(`\"query\": \"...` or `\"query\": \"\"\"...`). However, there are some requests\nwith a `query` body param that don't work with ESLQ (e.g. SQL query).\nThis PR makes sure that ESQL suggestions are only displayed inside `POST\n_query` request (which is the request for sending ESQL queries).\n\n**How to test:**\n\nVerify that ESQL suggestions are displayed in `POST _query` requests:\n\n```\nPOST /_query\n{\n  \"query\": \"...\"\n}\n```\n\nVerify that ESQL suggestions are **not** displayed in any other\nrequests; for example:\n\n```\nPOST /_sql\n{\n  \"query\": \"....\"\n}\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7f03a89707f337416f3b898be884f9f81280e837"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240264","number":240264,"mergeCommit":{"message":"[Console] Only show ESQL suggestions in ESQL query request (#240264)\n\nCloses https://github.com/elastic/kibana/issues/225685\n\n## Summary\n\nPreviously, ESQL suggestions were shown inside all `query` body params\n(`\"query\": \"...` or `\"query\": \"\"\"...`). However, there are some requests\nwith a `query` body param that don't work with ESLQ (e.g. SQL query).\nThis PR makes sure that ESQL suggestions are only displayed inside `POST\n_query` request (which is the request for sending ESQL queries).\n\n**How to test:**\n\nVerify that ESQL suggestions are displayed in `POST _query` requests:\n\n```\nPOST /_query\n{\n  \"query\": \"...\"\n}\n```\n\nVerify that ESQL suggestions are **not** displayed in any other\nrequests; for example:\n\n```\nPOST /_sql\n{\n  \"query\": \"....\"\n}\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7f03a89707f337416f3b898be884f9f81280e837"}},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/255098","number":255098,"state":"MERGED","mergeCommit":{"sha":"8d2b19194006d7282b33d8f7225a02bff2a2b649","message":"[9.2] [Console] Only show ESQL suggestions in ESQL query request (#240264) (#255098)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Console] Only show ESQL suggestions in ESQL query request\n(#240264)](https://github.com/elastic/kibana/pull/240264)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Elena Stoeva <59341489+ElenaStoeva@users.noreply.github.com>"}},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->