### PR TITLE
[ES|QL] Do not return 500s when the route fails

### DIFF
--- a/src/platform/plugins/shared/esql/server/routes/get_views.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_views.ts
@@ -34,7 +34,9 @@ export const registerGetViewsRoute = (router: IRouter, { logger }: PluginInitial
         });
       } catch (error) {
         logger.get().debug(error);
-        throw error;
+        return response.ok({
+          body: { views: [] },
+        });
       }
     }
   );


### PR DESCRIPTION
## Summary

Small one, ensures that the views route wont throw 500s when the views api fails


