### PR TITLE
[Agent Builder] Exclude conversation_rounds from ES list endpoint for conversations

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -79,9 +79,7 @@ class ConversationClientImpl implements ConversationClient {
     const response = await this.storage.getClient().search({
       track_total_hits: false,
       size: 1000,
-      _source: {
-        excludes: ['rounds', 'conversation_rounds', 'attachments', 'state'],
-      },
+      _source: ['agent_id', 'user_id', 'user_name', 'title', 'created_at', 'updated_at'],
       query: {
         bool: {
           filter: [createSpaceDslFilter(this.space)],

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -80,7 +80,7 @@ class ConversationClientImpl implements ConversationClient {
       track_total_hits: false,
       size: 1000,
       _source: {
-        excludes: ['rounds'],
+        excludes: ['rounds', 'conversation_rounds', 'attachments', 'state'],
       },
       query: {
         bool: {


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/13129

Excludes unnecessary fields from being included in the list endpoint for conversations