### PR TITLE
[Fleet] Log warning if policy revisions don't match

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.test.ts
@@ -85,6 +85,9 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
 
     expect(mockedEnsureDefaultEnrollmentAPIKeyForAgentPolicy).toBeCalledTimes(2);
     expect(mockedAgentPolicyService.deployPolicies).not.toBeCalled();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('has mismatched revisions')
+    );
   });
 
   it('should do deploy policies out of sync', async () => {
@@ -117,6 +120,9 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     expect(scheduleDeployAgentPoliciesTask).toBeCalledWith(undefined, [
       { id: 'policy2', spaceId: undefined },
     ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Policy [policy2] has mismatched revisions: .kibana_ingest revision [2], .fleet-policies revision_idx [1]'
+    );
   });
 
   it('should do deploy policies never deployed', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.ts
@@ -46,6 +46,14 @@ export async function ensureAgentPoliciesFleetServerKeysAndPolicies({
         ensureDefaultEnrollmentAPIKeyForAgentPolicy(soClient, esClient, agentPolicy.id),
       ]);
 
+      if (latestFleetPolicy && latestFleetPolicy.revision_idx !== agentPolicy.revision) {
+        logger.warn(
+          `Policy [${agentPolicy.id}] has mismatched revisions: ` +
+            `.kibana_ingest revision [${agentPolicy.revision}], ` +
+            `.fleet-policies revision_idx [${latestFleetPolicy.revision_idx}]`
+        );
+      }
+
       if ((latestFleetPolicy?.revision_idx ?? -1) < agentPolicy.revision) {
         outdatedAgentPolicyIds.push({ id: agentPolicy.id, spaceId: agentPolicy.space_ids?.[0] });
       }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/248082

This PR adds warn logging if a mismatch is detected in policy revision between `.fleet-policies` and `. kibana_ingest`.

Changes summary:
* Log warning on Fleet setup
   * `ensureAgentPoliciesFleetServerKeysAndPolicies` runs on every Kibana startup and already fetches both the SO revision and the `.fleet-policies` revision for every agent policy, so there is no extra cost in comparing them. This warns about desyncs that accumulated between restarts.
* Changes in policy deploy:
   * Bulk write error handler maps errored items to their `policy_id` and `revision_idx`, so the error message should make it clearer which policy deployment failed and what revision was lost..
   * Log warning after policy deploy
      * Check for mismatch (probably due to write failures or race conditions) after writing to `.fleet-policies`. This costs an extra ES read but probably worth it for this purpose since it seems like a probable moment where a desync could happen.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low probability risk of impacting agent policy deploy.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->