### PR TITLE
[Entity Store] Add Historical Snapshots

### DIFF
--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -183,6 +183,7 @@ export default function ({ getService }: FtrProviderContext) {
         'entity_store:v2:extract_entity_task:host',
         'entity_store:v2:extract_entity_task:service',
         'entity_store:v2:extract_entity_task:user',
+        'entity_store:v2:history_snapshot_task',
         'fleet:agent-status-change-task',
         'fleet:agentless-deployment-sync-task',
         'fleet:auto-install-content-packages-task',

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/common_fields.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/definitions/common_fields.ts
@@ -57,6 +57,7 @@ export const getEntityFieldsDescriptions = (rootField?: EntityType) => {
     newestValue({ source: `${prefix}.sub_type`, destination: 'entity.sub_type' }),
     newestValue({ source: `${prefix}.url`, destination: 'entity.url' }),
 
+    // ATTRIBUTES ------------------------------------------------------------
     collectValues({
       source: `${prefix}.attributes.watchlists`,
       destination: 'entity.attributes.watchlists',
@@ -81,6 +82,8 @@ export const getEntityFieldsDescriptions = (rootField?: EntityType) => {
       mapping: { type: 'boolean' },
       allowAPIUpdate: true,
     }),
+
+    // LIFECYCLE ------------------------------------------------------------
     newestValue({
       source: `${prefix}.lifecycle.first_seen`,
       destination: 'entity.lifecycle.first_seen',
@@ -91,6 +94,11 @@ export const getEntityFieldsDescriptions = (rootField?: EntityType) => {
       destination: 'entity.lifecycle.last_activity',
       mapping: { type: 'date' },
     }),
+
+    // BEHAVIORS ------------------------------------------------------------
+    // Behaviors are reset periodically by the history snapshot feature
+    // The current reset implementation only resets lists and strings
+    // if we ever add a boolean, reset via snapshot needs to be updated
     collectValues({
       source: `${prefix}.behaviors.rule_names`,
       destination: 'entity.behaviors.rule_names',
@@ -105,6 +113,8 @@ export const getEntityFieldsDescriptions = (rootField?: EntityType) => {
       fieldHistoryLength: 100,
       allowAPIUpdate: true,
     }),
+
+    // RELATIONSHIPS ------------------------------------------------------------
     collectValues({
       source: `${prefix}.relationships.communicates_with`,
       destination: 'entity.relationships.communicates_with',

--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -57,6 +57,7 @@ export const ENTITY_STORE_ROUTES = {
   START: `${ENTITY_STORE_BASE_ROUTE}/start`,
   STOP: `${ENTITY_STORE_BASE_ROUTE}/stop`,
   FORCE_LOG_EXTRACTION: `${ENTITY_STORE_BASE_ROUTE}/{entityType}/force_log_extraction`,
+  FORCE_HISTORY_SNAPSHOT: `${ENTITY_STORE_BASE_ROUTE}/force_history_snapshot`,
   CRUD_UPSERT: `${ENTITY_STORE_BASE_ROUTE}/entities/{entityType}`,
   CRUD_UPSERT_BULK: `${ENTITY_STORE_BASE_ROUTE}/entities/bulk`,
   CRUD_DELETE: `${ENTITY_STORE_BASE_ROUTE}/entities/`,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
@@ -118,7 +118,7 @@ export class AssetManager {
           request,
           frequency: historySnapshot.frequency,
         }),
-        
+
         installEuidStoredScripts({
           esClient: this.esClient,
           logger: this.logger,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager.ts
@@ -13,6 +13,7 @@ import type { CheckPrivilegesResponse } from '@kbn/security-plugin-types-server'
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { EntityType } from '../../common';
 import { scheduleExtractEntityTask, stopExtractEntityTask } from '../tasks/extract_entity_task';
+import { scheduleHistorySnapshotTasks } from '../tasks/history_snapshot_task';
 import { installElasticsearchAssets, uninstallElasticsearchAssets } from './assets/install_assets';
 import {
   EngineDescriptorTypeName,
@@ -110,6 +111,14 @@ export class AssetManager {
 
         ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
 
+        scheduleHistorySnapshotTasks({
+          logger: this.logger,
+          taskManager: this.taskManager,
+          namespace: this.namespace,
+          request,
+          frequency: historySnapshot.frequency,
+        }),
+        
         installEuidStoredScripts({
           esClient: this.esClient,
           logger: this.logger,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/assets/history_snapshot_index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/assets/history_snapshot_index.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getEntityIndexPattern, ENTITY_HISTORY, ENTITY_SCHEMA_VERSION_V2 } from '../constants';
+
+/**
+ * Base index pattern for history snapshot indices in a namespace.
+ * Actual indices have a date-hour suffix, e.g. ".entities.v2.history.security_default.2025-02-27-14"
+ */
+const getHistorySnapshotBasePattern = (namespace: string): string =>
+  getEntityIndexPattern({
+    schemaVersion: ENTITY_SCHEMA_VERSION_V2,
+    dataset: ENTITY_HISTORY,
+    namespace,
+  });
+
+/**
+ * Returns the history snapshot index name for a given namespace and date (with hour).
+ * Format: .entities.v2.history.security_<namespace>.<YYYY-MM-DD>-<HH>
+ * Hour is included so sub-daily frequencies (e.g. 12h, 1h) use distinct indices.
+ */
+export const getHistorySnapshotIndexName = (
+  namespace: string,
+  historySnapshotDate: Date
+): string => {
+  const y = historySnapshotDate.getUTCFullYear();
+  const m = String(historySnapshotDate.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(historySnapshotDate.getUTCDate()).padStart(2, '0');
+  const h = String(historySnapshotDate.getUTCHours()).padStart(2, '0');
+  const dateHourStr = `${y}-${m}-${d}-${h}`;
+  return `${getHistorySnapshotBasePattern(namespace)}.${dateHourStr}`;
+};
+
+/**
+ * Returns the index pattern matching all history snapshot indices for a namespace.
+ * Used for delete and status.
+ */
+export const getHistorySnapshotIndexPattern = (namespace: string): string =>
+  `${getHistorySnapshotBasePattern(namespace)}*`;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/assets/history_snapshot_index_template.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/assets/history_snapshot_index_template.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IndicesPutIndexTemplateRequest } from '@elastic/elasticsearch/lib/api/types';
+import {
+  ENTITY_HISTORY,
+  ENTITY_BASE_PREFIX,
+  ENTITY_SCHEMA_VERSION_V2,
+  ECS_MAPPINGS_COMPONENT_TEMPLATE,
+} from '../constants';
+import { getComponentTemplateName } from './component_templates';
+import { getHistorySnapshotIndexPattern } from './history_snapshot_index';
+import { ALL_ENTITY_TYPES } from '../../../common/domain/definitions/entity_schema';
+
+export const getHistorySnapshotIndexTemplateId = (namespace: string) =>
+  `${ENTITY_BASE_PREFIX}_${ENTITY_SCHEMA_VERSION_V2}_${ENTITY_HISTORY}_security_${namespace}_index_template` as const;
+
+export const getHistorySnapshotIndexTemplateConfig = (
+  namespace: string
+): IndicesPutIndexTemplateRequest => ({
+  name: getHistorySnapshotIndexTemplateId(namespace),
+  _meta: {
+    description: 'Index template for history snapshot indices managed by the Elastic Entity Store',
+    ecs_version: '8.0.0',
+    managed: true,
+    managed_by: 'security_context_core_analysis',
+  },
+  composed_of: [
+    ECS_MAPPINGS_COMPONENT_TEMPLATE,
+    ...ALL_ENTITY_TYPES.map((t) => getComponentTemplateName(t, namespace)),
+  ],
+  ignore_missing_component_templates: [
+    ...ALL_ENTITY_TYPES.map((t) => getComponentTemplateName(t, namespace)),
+  ],
+  index_patterns: [getHistorySnapshotIndexPattern(namespace)],
+  priority: 200,
+  template: {
+    mappings: {
+      _meta: { n: '1.6.0' },
+      date_detection: false,
+      dynamic_templates: [
+        {
+          strings_as_keyword: {
+            mapping: {
+              ignore_above: 1024,
+              type: 'keyword',
+              fields: { text: { type: 'text' } },
+            },
+            match_mapping_type: 'string',
+          },
+        },
+      ],
+    },
+    settings: {
+      index: {
+        codec: 'best_compression',
+        mapping: { total_fields: { limit: 2000 } },
+        mode: 'lookup',
+      },
+    },
+  },
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/assets/history_snapshot_index_template.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/assets/history_snapshot_index_template.ts
@@ -25,9 +25,9 @@ export const getHistorySnapshotIndexTemplateConfig = (
   name: getHistorySnapshotIndexTemplateId(namespace),
   _meta: {
     description: 'Index template for history snapshot indices managed by the Elastic Entity Store',
-    ecs_version: '8.0.0',
+    ecs_version: '9.3.0',
     managed: true,
-    managed_by: 'security_context_core_analysis',
+    managed_by: 'contextual_security_core_analysis',
   },
   composed_of: [
     ECS_MAPPINGS_COMPONENT_TEMPLATE,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/assets/install_assets.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/assets/install_assets.ts
@@ -32,6 +32,10 @@ import {
   getUpdatesEntityDefinitionComponentTemplate,
 } from './component_templates';
 import {
+  getHistorySnapshotIndexTemplateConfig,
+  getHistorySnapshotIndexTemplateId,
+} from './history_snapshot_index_template';
+import {
   getUpdatesEntityIndexTemplateConfig,
   getUpdatesIndexTemplateId,
 } from './updates_index_template';
@@ -101,6 +105,11 @@ async function installIndexTemplates(
     (async () => {
       await putIndexTemplate(esClient, getUpdatesEntityIndexTemplateConfig(namespace));
       logger.debug(`installed updates index template in ${namespace}`);
+    })(),
+
+    (async () => {
+      await putIndexTemplate(esClient, getHistorySnapshotIndexTemplateConfig(namespace));
+      logger.debug(`installed history snapshot index template in ${namespace}`);
     })(),
   ]);
 }
@@ -183,6 +192,10 @@ async function uninstallIndexTemplates(
     (async () => {
       await deleteIndexTemplate(esClient, getUpdatesIndexTemplateId(namespace));
       logger.debug(`deleted entity updates index template`);
+    })(),
+    (async () => {
+      await deleteIndexTemplate(esClient, getHistorySnapshotIndexTemplateId(namespace));
+      logger.debug(`deleted history snapshot index template`);
     })(),
   ]);
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
@@ -10,6 +10,7 @@ import type { EntityStoreStatus } from './types';
 
 export const ENTITY_LATEST = 'latest' as const;
 export const ENTITY_UPDATES = 'updates' as const;
+export const ENTITY_HISTORY = 'history' as const;
 
 export const ENTITY_BASE_PREFIX = 'entities';
 
@@ -22,7 +23,7 @@ export const ENTITY_STORE_TARGET_INDICES_PRIVILEGES = ['read', 'manage'];
 export const ENTITY_STORE_CLUSTER_PRIVILEGES = ['manage_index_templates'];
 
 type SchemaVersion = `v${number}`;
-type Dataset = typeof ENTITY_LATEST | typeof ENTITY_UPDATES;
+type Dataset = typeof ENTITY_LATEST | typeof ENTITY_UPDATES | typeof ENTITY_HISTORY;
 
 interface IndexPatternOptions<TDataset extends Dataset> {
   dataset: TDataset;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/definitions/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/definitions/saved_objects/global_state/constants.ts
@@ -44,7 +44,7 @@ export const HistorySnapshotStatus = z.enum(['started', 'stopped']);
 
 export type HistorySnapshotState = z.infer<typeof HistorySnapshotState>;
 export const HistorySnapshotState = z.object({
-  status: HistorySnapshotStatus.default('stopped'),
+  status: HistorySnapshotStatus.default('started'),
   frequency: z
     .string()
     .regex(/[smdh]$/)

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/constants.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Painless script that resets entity state on the latest index using nested field access.
+ * - Sets @timestamp to params.timestampNow.
+ * - If entity exists: updates entity.lifecycle.last_activity (creating lifecycle if needed), clears entity.behaviors.
+ */
+export const HISTORY_SNAPSHOT_RESET_SCRIPT = `
+ctx._source['@timestamp'] = params.timestampNow;
+if (ctx._source.entity != null) {
+  if (ctx._source.entity.lifecycle == null) {
+    ctx._source.entity.lifecycle = new HashMap();
+  }
+  ctx._source.entity.lifecycle.last_activity = params.timestampNow;
+  if (ctx._source.entity.behaviors != null) {
+    def behaviors = ctx._source.entity.behaviors;
+    def reset = new HashMap();
+    for (entry in behaviors.entrySet()) {
+      def key = entry.getKey();
+      def value = entry.getValue();
+      if (value instanceof List || value instanceof String) {
+        reset.put(key, new ArrayList());
+      } else if (value instanceof Boolean) {
+        reset.put(key, false);
+      } else {
+        // don't reset other types of values
+        reset.put(key, value);
+      }
+    }
+    ctx._source.entity.behaviors = reset;
+  }
+}
+`;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/constants.ts
@@ -25,8 +25,6 @@ if (ctx._source.entity != null) {
       def value = entry.getValue();
       if (value instanceof List || value instanceof String) {
         reset.put(key, new ArrayList());
-      } else if (value instanceof Boolean) {
-        reset.put(key, false);
       } else {
         // don't reset other types of values
         reset.put(key, value);

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/index.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/index.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { HistorySnapshotClient, HISTORY_SNAPSHOT_RESET_SCRIPT } from '.';
+import { createIndex, reindex, updateByQueryWithScript } from '../../infra/elasticsearch';
+
+jest.mock('../../infra/elasticsearch');
+
+const mockCreateIndex = createIndex as jest.MockedFunction<typeof createIndex>;
+const mockReindex = reindex as jest.MockedFunction<typeof reindex>;
+const mockUpdateByQueryWithScript = updateByQueryWithScript as jest.MockedFunction<
+  typeof updateByQueryWithScript
+>;
+
+const mockGlobalStateStarted = {
+  historySnapshot: { status: 'started' as const, frequency: '24h' },
+  logsExtraction: {},
+};
+
+function createMockGlobalStateClient(overrides?: { status?: 'started' | 'stopped' }) {
+  const historySnapshot = {
+    ...mockGlobalStateStarted.historySnapshot,
+    ...(overrides?.status && { status: overrides.status }),
+  };
+  return {
+    findOrThrow: jest.fn().mockResolvedValue({
+      ...mockGlobalStateStarted,
+      historySnapshot,
+    }),
+    update: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('HistorySnapshotClient', () => {
+  const namespace = 'default';
+  let mockEsClient: jest.Mocked<ElasticsearchClient>;
+  let mockGlobalStateClient: ReturnType<typeof createMockGlobalStateClient>;
+  let client: HistorySnapshotClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEsClient = {} as jest.Mocked<ElasticsearchClient>;
+    mockGlobalStateClient = createMockGlobalStateClient();
+    client = new HistorySnapshotClient({
+      logger: loggerMock.create(),
+      esClient: mockEsClient,
+      namespace,
+      globalStateClient:
+        mockGlobalStateClient as unknown as import('../definitions/saved_objects').EntityStoreGlobalStateClient,
+    });
+  });
+
+  describe('runHistorySnapshot', () => {
+    it('returns success with docCount and resetCount when reindex and updateByQuery succeed', async () => {
+      mockCreateIndex.mockResolvedValue(undefined);
+      mockReindex.mockResolvedValue({ created: 5, total: 5 });
+      mockUpdateByQueryWithScript.mockResolvedValue({ updated: 5, total: 5 });
+
+      const result = await client.runHistorySnapshot();
+
+      expect(result.ok).toBe(true);
+      if (result.ok && !('skipped' in result)) {
+        expect(result.docCount).toBe(5);
+        expect(result.resetCount).toBe(5);
+        expect(result.historySnapshotIndex).toMatch(
+          /\.entities\.v2\.history\.security_default\.\d{4}-\d{2}-\d{2}-\d{2}$/
+        );
+      }
+      expect(mockCreateIndex).toHaveBeenCalledTimes(1);
+      expect(mockReindex).toHaveBeenCalledWith(
+        mockEsClient,
+        expect.objectContaining({
+          source: { index: '.entities.v2.latest.security_default' },
+          dest: { index: expect.stringMatching(/\.entities\.v2\.history\.security_default\./) },
+        })
+      );
+      expect(mockUpdateByQueryWithScript).toHaveBeenCalledWith(
+        mockEsClient,
+        expect.objectContaining({
+          index: '.entities.v2.latest.security_default',
+          query: { match_all: {} },
+          script: HISTORY_SNAPSHOT_RESET_SCRIPT,
+          params: expect.objectContaining({ timestampNow: expect.any(String) }),
+        })
+      );
+      expect(mockGlobalStateClient.update).toHaveBeenCalledWith({
+        historySnapshot: expect.objectContaining({
+          lastExecutionTimestamp: expect.any(String),
+          lastError: undefined,
+        }),
+      });
+    });
+
+    it('uses nested entity field access in the reset script (no flat dotted keys)', () => {
+      expect(HISTORY_SNAPSHOT_RESET_SCRIPT).toContain('ctx._source.entity.lifecycle');
+      expect(HISTORY_SNAPSHOT_RESET_SCRIPT).toContain('ctx._source.entity.behaviors');
+      expect(HISTORY_SNAPSHOT_RESET_SCRIPT).not.toMatch(/ctx\._source\s*\[\s*['"]entity\./);
+    });
+
+    it('returns success with docCount 0 and resetCount 0 when latest index has no docs', async () => {
+      mockCreateIndex.mockResolvedValue(undefined);
+      mockReindex.mockResolvedValue({ created: 0, total: 0 });
+
+      const result = await client.runHistorySnapshot();
+
+      expect(result.ok).toBe(true);
+      if (result.ok && !('skipped' in result)) {
+        expect(result.docCount).toBe(0);
+        expect(result.resetCount).toBe(0);
+      }
+      expect(mockUpdateByQueryWithScript).not.toHaveBeenCalled();
+      expect(mockGlobalStateClient.update).toHaveBeenCalledWith({
+        historySnapshot: expect.objectContaining({
+          lastExecutionTimestamp: expect.any(String),
+          lastError: undefined,
+        }),
+      });
+    });
+
+    it('returns skipped when history snapshot status is not started', async () => {
+      mockGlobalStateClient.findOrThrow.mockResolvedValue({
+        ...mockGlobalStateStarted,
+        historySnapshot: { ...mockGlobalStateStarted.historySnapshot, status: 'stopped' },
+      });
+      client = new HistorySnapshotClient({
+        logger: loggerMock.create(),
+        esClient: mockEsClient,
+        namespace,
+        globalStateClient:
+          mockGlobalStateClient as unknown as import('../definitions/saved_objects').EntityStoreGlobalStateClient,
+      });
+
+      const result = await client.runHistorySnapshot();
+
+      expect(result.ok).toBe(true);
+      expect(result).toHaveProperty('skipped', true);
+      expect(mockCreateIndex).not.toHaveBeenCalled();
+      expect(mockReindex).not.toHaveBeenCalled();
+      expect(mockGlobalStateClient.update).not.toHaveBeenCalled();
+    });
+
+    it('returns error when createIndex throws', async () => {
+      mockCreateIndex.mockRejectedValue(new Error('index creation failed'));
+
+      const result = await client.runHistorySnapshot();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe('History snapshot failed');
+      }
+      expect(mockReindex).not.toHaveBeenCalled();
+      expect(mockUpdateByQueryWithScript).not.toHaveBeenCalled();
+      expect(mockGlobalStateClient.update).toHaveBeenCalledWith({
+        historySnapshot: expect.objectContaining({
+          lastError: { message: 'index creation failed', timestamp: expect.any(String) },
+        }),
+      });
+    });
+
+    it('returns error when reindex throws', async () => {
+      mockCreateIndex.mockResolvedValue(undefined);
+      mockReindex.mockRejectedValue(new Error('reindex failed'));
+
+      const result = await client.runHistorySnapshot();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe('History snapshot failed');
+      }
+      expect(mockUpdateByQueryWithScript).not.toHaveBeenCalled();
+      expect(mockGlobalStateClient.update).toHaveBeenCalledWith({
+        historySnapshot: expect.objectContaining({
+          lastError: { message: 'reindex failed', timestamp: expect.any(String) },
+        }),
+      });
+    });
+
+    it('returns error when updateByQueryWithScript throws', async () => {
+      mockCreateIndex.mockResolvedValue(undefined);
+      mockReindex.mockResolvedValue({ created: 3, total: 3 });
+      mockUpdateByQueryWithScript.mockRejectedValue(new Error('update_by_query failed'));
+
+      const result = await client.runHistorySnapshot();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe('History snapshot failed');
+      }
+      expect(mockGlobalStateClient.update).toHaveBeenCalledWith({
+        historySnapshot: expect.objectContaining({
+          lastError: {
+            message: 'update_by_query failed',
+            timestamp: expect.any(String),
+          },
+        }),
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/history_snapshot_client/index.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import moment from 'moment';
+import type { EntityStoreGlobalState } from '../definitions/saved_objects';
+import type { EntityStoreGlobalStateClient } from '../definitions/saved_objects';
+import { createIndex, reindex, updateByQueryWithScript } from '../../infra/elasticsearch';
+import { getLatestEntitiesIndexName } from '../assets/latest_index';
+import { getErrorMessage } from '../../../common';
+import { getHistorySnapshotIndexName } from '../assets/history_snapshot_index';
+import { HISTORY_SNAPSHOT_RESET_SCRIPT } from './constants';
+
+export type RunHistorySnapshotResult =
+  | { ok: true; historySnapshotIndex: string; docCount: number; resetCount: number }
+  | { ok: true; skipped: true }
+  | { ok: false; error: Error };
+
+export interface RunHistorySnapshotOptions {
+  abortSignal?: AbortSignal;
+}
+
+export { HISTORY_SNAPSHOT_RESET_SCRIPT } from './constants';
+
+export interface HistorySnapshotClientDependencies {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  namespace: string;
+  globalStateClient: EntityStoreGlobalStateClient;
+}
+
+export class HistorySnapshotClient {
+  private readonly logger: Logger;
+  private readonly esClient: ElasticsearchClient;
+  private readonly namespace: string;
+  private readonly globalStateClient: EntityStoreGlobalStateClient;
+
+  constructor({
+    logger,
+    esClient,
+    namespace,
+    globalStateClient,
+  }: HistorySnapshotClientDependencies) {
+    this.logger = logger;
+    this.esClient = esClient;
+    this.namespace = namespace;
+    this.globalStateClient = globalStateClient;
+  }
+
+  public async runHistorySnapshot(
+    options: RunHistorySnapshotOptions = {}
+  ): Promise<RunHistorySnapshotResult> {
+    const { abortSignal } = options;
+
+    const globalState = await this.globalStateClient.findOrThrow();
+
+    if (globalState.historySnapshot?.status !== 'started') {
+      this.logger.debug('History snapshot status is not started, skipping run');
+      return { ok: true, skipped: true };
+    }
+
+    const timestampNow = moment.utc().toISOString();
+    const snapshotDate = moment.utc().toDate();
+    const latestIndex = getLatestEntitiesIndexName(this.namespace);
+    const historySnapshotIndex = getHistorySnapshotIndexName(this.namespace, snapshotDate);
+
+    try {
+      await createIndex(this.esClient, historySnapshotIndex, { throwIfExists: false });
+
+      const reindexResult = await reindex(this.esClient, {
+        source: { index: latestIndex },
+        dest: { index: historySnapshotIndex },
+        signal: abortSignal,
+      });
+      const docCount = reindexResult.total;
+      if (docCount === 0) {
+        await this.updateGlobalStateOnSuccess(globalState);
+        return { ok: true, historySnapshotIndex, docCount: 0, resetCount: 0 };
+      }
+
+      const updateResult = await updateByQueryWithScript(this.esClient, {
+        index: latestIndex,
+        query: { match_all: {} },
+        script: HISTORY_SNAPSHOT_RESET_SCRIPT,
+        params: { timestampNow },
+        signal: abortSignal,
+      });
+      await this.updateGlobalStateOnSuccess(globalState);
+      return {
+        ok: true,
+        historySnapshotIndex,
+        docCount,
+        resetCount: updateResult.updated,
+      };
+    } catch (err) {
+      const caughtError = err instanceof Error ? err : new Error(String(err));
+      this.logger.error(`history snapshot failed: ${caughtError.message}`);
+      await this.updateGlobalStateOnError(globalState, caughtError);
+      return { ok: false, error: new Error('History snapshot failed') };
+    }
+  }
+
+  private async updateGlobalStateOnSuccess(globalState: EntityStoreGlobalState): Promise<void> {
+    try {
+      await this.globalStateClient.update({
+        historySnapshot: {
+          ...globalState.historySnapshot,
+          lastExecutionTimestamp: moment.utc().toISOString(),
+          lastError: undefined,
+        },
+      });
+    } catch (updateErr) {
+      this.logger.error(
+        `history snapshot: failed to update global state: ${getErrorMessage(updateErr)}`
+      );
+    }
+  }
+
+  private async updateGlobalStateOnError(
+    globalState: EntityStoreGlobalState,
+    error: Error
+  ): Promise<void> {
+    try {
+      await this.globalStateClient.update({
+        historySnapshot: {
+          ...globalState.historySnapshot,
+          lastError: {
+            message: error.message,
+            timestamp: moment.utc().toISOString(),
+          },
+        },
+      });
+    } catch (updateErr) {
+      this.logger.error(
+        `history snapshot: failed to update global state: ${getErrorMessage(updateErr)}`
+      );
+    }
+  }
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/index.ts
@@ -13,6 +13,11 @@ import type {
   ClusterPutComponentTemplateRequest,
 } from '@elastic/elasticsearch/lib/api/types';
 
+export { reindex } from './reindex';
+export type { ReindexOptions } from './reindex';
+export { updateByQueryWithScript } from './ingest';
+export type { UpdateByQueryWithScriptOptions } from './ingest';
+
 export interface CreateOptions {
   throwIfExists?: boolean;
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/ingest.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/ingest.ts
@@ -5,11 +5,47 @@
  * 2.0.
  */
 import type { TransportRequestOptions } from '@elastic/elasticsearch';
+import type { IndexName, QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { ESQLSearchResponse } from '@kbn/es-types';
 
 const BATCH_SIZE = 5 * 1024 * 1024; // 5MB
 const RETRY_ON_CONFLICT = 3;
+
+export interface UpdateByQueryWithScriptOptions {
+  index: IndexName;
+  query: QueryDslQueryContainer;
+  script: string;
+  params: Record<string, unknown>;
+  signal?: AbortSignal;
+}
+
+export const updateByQueryWithScript = async (
+  esClient: ElasticsearchClient,
+  options: UpdateByQueryWithScriptOptions
+): Promise<{ updated: number; total: number }> => {
+  const { index, query, script, params, signal } = options;
+  const response = await esClient.updateByQuery(
+    {
+      index,
+      query,
+      refresh: true,
+      // Uses conflicts: 'proceed' so Elasticsearch continues on version conflicts.
+      // Conflicted documents are not updated.
+      conflicts: 'proceed',
+      wait_for_completion: true,
+      script: {
+        source: script,
+        lang: 'painless',
+        params,
+      },
+    },
+    { signal }
+  );
+  const updated = response.updated ?? 0;
+  const total = response.total ?? 0;
+  return { updated, total };
+};
 
 interface IngestEntitiesParams {
   esClient: ElasticsearchClient;

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/reindex.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/reindex.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient as EsClient } from '@kbn/core/server';
+import type {
+  IndexName,
+  Names,
+  ReindexRequest,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+
+export interface ReindexOptions {
+  source: { index: Names; query?: QueryDslQueryContainer };
+  dest: { index: IndexName };
+  signal?: AbortSignal;
+}
+
+export const reindex = async (
+  esClient: EsClient,
+  options: ReindexOptions
+): Promise<{ created: number; total: number }> => {
+  const { source, dest, signal } = options;
+  const body: ReindexRequest = {
+    source: { index: source.index, query: source.query },
+    dest: { index: dest.index },
+    wait_for_completion: true,
+    refresh: true,
+    conflicts: 'proceed',
+  };
+  const response = await esClient.reindex(body, { signal });
+  const created = response.created ?? 0;
+  const total = response.total ?? 0;
+  return { created, total };
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
@@ -20,6 +20,7 @@ import {
   EntityStoreGlobalStateClient,
 } from './domain/definitions/saved_objects';
 import { CcsLogsExtractionClient, LogsExtractionClient } from './domain/logs_extraction';
+import { HistorySnapshotClient } from './domain/history_snapshot_client';
 import { CRUDClient } from './domain/crud_client';
 import type { TelemetryReporter } from './telemetry/events';
 
@@ -80,6 +81,13 @@ export async function createRequestHandlerContext({
     ccsLogsExtractionClient,
   });
 
+  const historySnapshotClient = new HistorySnapshotClient({
+    logger,
+    esClient,
+    namespace,
+    globalStateClient,
+  });
+
   return {
     core,
     logger,
@@ -104,6 +112,7 @@ export async function createRequestHandlerContext({
     ccsLogsExtractionClient,
     featureFlags: new FeatureFlags(core.uiSettings.client),
     logsExtractionClient,
+    historySnapshotClient,
     security: startPlugins.security,
     namespace,
   };

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/force_history_snapshot.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/force_history_snapshot.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IKibanaResponse } from '@kbn/core-http-server';
+import { ENTITY_STORE_ROUTES } from '../../../common';
+import { API_VERSIONS, DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
+import type { EntityStorePluginRouter } from '../../types';
+import { wrapMiddlewares } from '../middleware';
+
+export function registerForceHistorySnapshot(router: EntityStorePluginRouter) {
+  router.versioned
+    .post({
+      path: ENTITY_STORE_ROUTES.FORCE_HISTORY_SNAPSHOT,
+      access: 'internal',
+      security: {
+        authz: DEFAULT_ENTITY_STORE_PERMISSIONS,
+      },
+      enableQueryVersion: true,
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v2,
+        validate: {},
+      },
+      wrapMiddlewares(async (ctx, _req, res): Promise<IKibanaResponse> => {
+        const entityStoreCtx = await ctx.entityStore;
+        const { historySnapshotClient } = entityStoreCtx;
+
+        const result = await historySnapshotClient.runHistorySnapshot();
+
+        if (result.ok) {
+          return res.ok({ body: result });
+        }
+
+        return res.customError({
+          statusCode: 500,
+          body: { message: result.error.message },
+        });
+      })
+    );
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
@@ -10,6 +10,7 @@ export { registerStop } from './stop';
 export { registerStatus } from './status';
 export { registerForceLogExtraction } from './force_log_extraction';
 export { registerForceCcsExtractToUpdates } from './force_ccs_extract_to_updates';
+export { registerForceHistorySnapshot } from './force_history_snapshot';
 export { registerUninstall } from './uninstall';
 export { registerCRUDUpsert } from './crud/upsert';
 export { registerCRUDUpsertBulk } from './crud/upsert_bulk';

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
@@ -16,6 +16,7 @@ import {
   registerStopMaintainer,
   registerGetMaintainers,
   registerForceCcsExtractToUpdates,
+  registerForceHistorySnapshot,
   registerCRUDUpsert,
   registerCRUDUpsertBulk,
   registerCRUDDelete,
@@ -29,6 +30,7 @@ export function registerRoutes(router: EntityStorePluginRouter) {
   registerUninstall(router);
   registerForceLogExtraction(router);
   registerForceCcsExtractToUpdates(router);
+  registerForceHistorySnapshot(router);
   registerCRUDUpsert(router);
   registerCRUDUpsertBulk(router);
   registerCRUDDelete(router);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
@@ -28,7 +28,7 @@ export const TasksConfig: Record<EntityStoreTaskType, EntityStoreTaskConfig> = {
   },
   [EntityStoreTaskType.enum.historySnapshot]: {
     title: 'Entity Store - History Snapshot Task',
-    type: 'entity_store:v2:snapshot_task',
+    type: 'entity_store:v2:history_snapshot_task',
     timeout: '30m',
   },
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
@@ -26,4 +26,9 @@ export const TasksConfig: Record<EntityStoreTaskType, EntityStoreTaskConfig> = {
     title: 'Entity Store - Entity Maintainer Task',
     type: 'entity_store:v2:entity_maintainer_task',
   },
+  [EntityStoreTaskType.enum.historySnapshot]: {
+    title: 'Entity Store - History Snapshot Task',
+    type: 'entity_store:v2:snapshot_task',
+    timeout: '30m',
+  },
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/constants.ts
@@ -8,4 +8,4 @@
 import { z } from '@kbn/zod/v4';
 
 export type EntityStoreTaskType = z.infer<typeof EntityStoreTaskType>;
-export const EntityStoreTaskType = z.enum(['extractEntity', 'entityMaintainer']);
+export const EntityStoreTaskType = z.enum(['extractEntity', 'entityMaintainer', 'historySnapshot']);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  TaskCost,
+  type TaskManagerSetupContract,
+  type TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { Logger } from '@kbn/logging';
+import type { KibanaRequest } from '@kbn/core/server';
+import { TasksConfig } from './config';
+import { EntityStoreTaskType } from './constants';
+import type { EntityStoreCoreSetup } from '../types';
+import { EntityStoreGlobalStateClient } from '../domain/definitions/saved_objects';
+import { HistorySnapshotClient } from '../domain/history_snapshot_client';
+
+const config = TasksConfig[EntityStoreTaskType.enum.historySnapshot];
+
+export const getHistorySnapshotTaskId = (namespace: string): string =>
+  `${config.type}:${namespace}`;
+
+interface RunHistorySnapshotTaskParams {
+  taskInstance: { state: Record<string, unknown>; id: string };
+  abortController: AbortController;
+  fakeRequest: KibanaRequest | null | undefined;
+  core: EntityStoreCoreSetup;
+  logger: Logger;
+}
+
+async function runHistorySnapshotTask({
+  taskInstance,
+  abortController,
+  fakeRequest,
+  core,
+  logger,
+}: RunHistorySnapshotTaskParams): Promise<{ state: Record<string, unknown> }> {
+  const namespace = taskInstance.state?.namespace as string | undefined;
+  if (!namespace) {
+    logger.error('History snapshot task missing namespace in state');
+    return { state: taskInstance.state };
+  }
+  if (!fakeRequest) {
+    logger.error('No fake request found, skipping history snapshot task');
+    return { state: taskInstance.state };
+  }
+
+  const [start] = await core.getStartServices();
+  const soClient = start.savedObjects.getScopedClient(fakeRequest);
+  const esClient = start.elasticsearch.client.asScoped(fakeRequest).asCurrentUser;
+  const taskLogger = logger.get(taskInstance.id);
+
+  const globalStateClient = new EntityStoreGlobalStateClient(soClient, namespace, taskLogger);
+  const historySnapshotClient = new HistorySnapshotClient({
+    logger: taskLogger,
+    esClient,
+    namespace,
+    globalStateClient,
+  });
+
+  await historySnapshotClient.runHistorySnapshot({
+    abortSignal: abortController.signal,
+  });
+
+  return { state: taskInstance.state };
+}
+
+export function registerHistorySnapshotTask({
+  taskManager,
+  logger,
+  core,
+}: {
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+  core: EntityStoreCoreSetup;
+}): void {
+  const taskType = config.type;
+  taskManager.registerTaskDefinitions({
+    [taskType]: {
+      title: config.title,
+      timeout: config.timeout,
+      cost: TaskCost.ExtraLarge,
+      createTaskRunner: ({ taskInstance, abortController, fakeRequest }) => ({
+        run: () =>
+          runHistorySnapshotTask({
+            taskInstance,
+            abortController,
+            fakeRequest,
+            core,
+            logger,
+          }),
+      }),
+    },
+  });
+}
+
+export async function scheduleHistorySnapshotTasks({
+  logger,
+  taskManager,
+  namespace,
+  request,
+  frequency,
+}: {
+  logger: Logger;
+  taskManager: TaskManagerStartContract;
+  namespace: string;
+  request: KibanaRequest;
+  frequency: string;
+}): Promise<void> {
+  try {
+    const taskId = getHistorySnapshotTaskId(namespace);
+    await taskManager.ensureScheduled(
+      {
+        id: taskId,
+        taskType: config.type,
+        schedule: { interval: frequency },
+        state: { namespace },
+        params: {},
+      },
+      { request }
+    );
+    logger.debug(`Scheduled history snapshot task ${taskId} with interval ${frequency}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`Failed to schedule history snapshot tasks: ${message}`);
+    throw err;
+  }
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { schema } from '@kbn/config-schema';
 import {
   TaskCost,
   type TaskManagerSetupContract,
@@ -82,7 +83,17 @@ export function registerHistorySnapshotTask({
     [taskType]: {
       title: config.title,
       timeout: config.timeout,
-      cost: TaskCost.ExtraLarge,
+      cost: TaskCost.Normal,
+      stateSchemaByVersion: {
+        1: {
+          up: (state: Record<string, unknown>) => ({
+            namespace: typeof state.namespace === 'string' ? state.namespace : 'default',
+          }),
+          schema: schema.object({
+            namespace: schema.string(),
+          }),
+        },
+      },
       createTaskRunner: ({ taskInstance, abortController, fakeRequest }) => ({
         run: () =>
           runHistorySnapshotTask({

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
@@ -9,6 +9,7 @@ import type { Logger } from '@kbn/logging';
 import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
 
 import { registerExtractEntityTasks } from './extract_entity_task';
+import { registerHistorySnapshotTask } from './history_snapshot_task';
 import type { EntityStoreCoreSetup } from '../types';
 import { ALL_ENTITY_TYPES } from '../../common/domain/definitions/entity_schema';
 
@@ -18,4 +19,5 @@ export function registerTasks(
   core: EntityStoreCoreSetup
 ) {
   registerExtractEntityTasks({ taskManager, logger, entityTypes: ALL_ENTITY_TYPES, core });
+  registerHistorySnapshotTask({ taskManager, logger, core });
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -27,8 +27,8 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 import type { AssetManager } from './domain/asset_manager';
 import type { EntityMaintainersClient } from './domain/entity_maintainers';
 import type { FeatureFlags } from './infra/feature_flags';
-import type { CcsLogsExtractionClient } from './domain/logs_extraction';
-import type { LogsExtractionClient } from './domain/logs_extraction';
+import type { CcsLogsExtractionClient, LogsExtractionClient } from './domain/logs_extraction';
+import type { HistorySnapshotClient } from './domain/history_snapshot_client';
 import type { CRUDClient } from './domain/crud_client';
 import type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/types';
 
@@ -55,6 +55,7 @@ export interface EntityStoreApiRequestHandlerContext {
   ccsLogsExtractionClient: CcsLogsExtractionClient;
   featureFlags: FeatureFlags;
   logsExtractionClient: LogsExtractionClient;
+  historySnapshotClient: HistorySnapshotClient;
   security: SecurityPluginStart;
   namespace: string;
 }

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/es_archives/updates/data.json
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/es_archives/updates/data.json
@@ -22,7 +22,13 @@
     "source": {
       "@timestamp": "2026-01-20T12:05:00Z",
       "host": {
-        "id": "host-123"
+        "id": "host-123",
+        "entity": {
+          "behaviors": {
+            "rule_names": ["rule-a", "rule-b"],
+            "anomaly_job_ids": ["job-1"]
+          }
+        }
       }
     }
   }
@@ -38,7 +44,13 @@
       "@timestamp": "2026-01-20T12:05:01Z",
       "host": {
         "domain": "example.com",
-        "name": "server-01"
+        "name": "server-01",
+        "entity": {
+          "behaviors": {
+            "rule_names": ["rule-c"],
+            "anomaly_job_ids": ["job-2", "job-3"]
+          }
+        }
       }
     }
   }

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
@@ -26,6 +26,7 @@ export const ENTITY_STORE_ROUTES = {
     `internal/security/entity_store/${entityType}/force_log_extraction`,
   FORCE_CCS_EXTRACT_TO_UPDATES: (entityType: string) =>
     `internal/security/entity_store/${entityType}/force_ccs_extract_to_updates`,
+  FORCE_HISTORY_SNAPSHOT: 'internal/security/entity_store/force_history_snapshot',
   CRUD_UPSERT: (entityType: string) => `internal/security/entity_store/entities/${entityType}`,
   CRUD_UPSERT_BULK: 'internal/security/entity_store/entities/bulk',
   CRUD_DELETE: 'internal/security/entity_store/entities/',

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/history_snapshot.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/history_snapshot.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import {
+  COMMON_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+  LATEST_INDEX,
+} from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import { forceLogExtraction } from '../fixtures/helpers';
+
+apiTest.describe('Entity Store History Snapshot', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth, apiClient, esArchiver, kbnClient }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = {
+      ...credentials.cookieHeader,
+      ...COMMON_HEADERS,
+    };
+
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+
+    const installResponse = await apiClient.post(ENTITY_STORE_ROUTES.INSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: { historySnapshot: { frequency: '24h' } },
+    });
+    expect(installResponse.statusCode).toBe(201);
+
+    await esArchiver.loadIfNeeded(
+      'x-pack/solutions/security/plugins/entity_store/test/scout/api/es_archives/updates'
+    );
+  });
+
+  apiTest.afterAll(async ({ apiClient }) => {
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(response.statusCode).toBe(200);
+  });
+
+  apiTest(
+    'history snapshot: copies latest to history index and resets behaviors on latest',
+    async ({ apiClient, esClient }) => {
+      await forceLogExtraction(
+        apiClient,
+        defaultHeaders,
+        'host',
+        '2026-01-20T11:00:00Z',
+        '2026-01-20T13:00:00Z'
+      );
+
+      const snapshotResponse = await apiClient.post(ENTITY_STORE_ROUTES.FORCE_HISTORY_SNAPSHOT, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+      expect(snapshotResponse.statusCode).toBe(200);
+      const body = snapshotResponse.body as {
+        ok: boolean;
+        historySnapshotIndex: string;
+        docCount: number;
+        resetCount: number;
+      };
+      expect(body.ok).toBe(true);
+
+      expect(body.historySnapshotIndex).toMatch(
+        /\.entities\.v2\.history\.security_default\.\d{4}-\d{2}-\d{2}-\d{2}$/
+      );
+      expect(typeof body.docCount).toBe('number');
+      expect(typeof body.resetCount).toBe('number');
+      expect(body.resetCount).toBe(body.docCount);
+
+      const historyIndex = body.historySnapshotIndex;
+      await esClient.indices.refresh({ index: historyIndex });
+      const historyCount = await esClient.count({ index: historyIndex });
+      expect(historyCount.count).toBe(body.docCount);
+
+      const entityIdsWithBehaviors = ['host:host-123', 'host:server-01.example.com'] as const;
+      const expectedBehaviorsInHistory = [
+        { rule_names: ['rule-a', 'rule-b'], anomaly_job_ids: 'job-1' },
+        { rule_names: 'rule-c', anomaly_job_ids: ['job-2', 'job-3'] },
+      ];
+
+      const historySearchResult = await esClient.search({
+        index: historyIndex,
+        query: { terms: { 'entity.id': [...entityIdsWithBehaviors] } },
+        size: entityIdsWithBehaviors.length,
+      });
+
+      const latestSearchResult = await esClient.search({
+        index: LATEST_INDEX,
+        query: { terms: { 'entity.id': [...entityIdsWithBehaviors] } },
+        size: entityIdsWithBehaviors.length,
+      });
+
+      const historyHits = (
+        historySearchResult.hits.hits as Array<{ _source?: Record<string, unknown> }>
+      ).filter((h) => h._source != null);
+      const latestHits = (
+        latestSearchResult.hits.hits as Array<{ _source?: Record<string, unknown> }>
+      ).filter((h) => h._source != null);
+
+      expect(historyHits).toHaveLength(entityIdsWithBehaviors.length);
+      expect(latestHits).toHaveLength(entityIdsWithBehaviors.length);
+
+      for (let i = 0; i < entityIdsWithBehaviors.length; i++) {
+        const entityId = entityIdsWithBehaviors[i];
+        const expectedBehavior = expectedBehaviorsInHistory[i];
+
+        const historyHit = historyHits.find(
+          (h) => (h._source!.entity as Record<string, unknown>)?.id === entityId
+        );
+        expect(historyHit).toBeDefined();
+        const historyEntity = historyHit!._source!.entity as Record<string, unknown>;
+        expect(historyEntity.behaviors).toStrictEqual(expectedBehavior);
+
+        const latestHit = latestHits.find(
+          (h) => (h._source!.entity as Record<string, unknown>)?.id === entityId
+        );
+        expect(latestHit).toBeDefined();
+        expect(latestHit!._source!['@timestamp']).toBeDefined();
+        const latestEntity = latestHit!._source!.entity as Record<string, unknown>;
+        expect(latestEntity.behaviors).toStrictEqual({
+          rule_names: [],
+          anomaly_job_ids: [],
+        });
+        expect((latestEntity.lifecycle as Record<string, unknown>)?.last_activity).toBeDefined();
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Adds **History Snapshots** to Entity Store (v2): a scheduled job that copies the latest entity index into a point-in-time history index, then resets behavior fields in latest so the next period only accumulates new behaviors. Keeps a rolling history for compliance/analytics while latest stays focused on current activity.

## Features

### Configuration

- Install API accepts optional `historySnapshot: { frequency?: string }` (e.g. `24h`, `1h`).
- Frequency validated to at least 1 hour; stored on engine descriptor as `historySnapshotState`.
- One Task Manager task per namespace; schedule taken from first engine’s frequency or default `24h`.

### Snapshot execution

- Creates a new history index (no-op if it already exists).
- Reindexes the **entire** latest index into that history index (no entity-type filter).
- Runs `update_by_query` with `match_all` on latest to set `@timestamp` and `entity.lifecycle.last_activity` to now and to reset `entity.behaviors`.

### Behavior reset

- Painless script: booleans → `false`, lists/strings → `null`; identity and other fields unchanged.
- Uses `conflicts: 'proceed'` on `update_by_query` so version conflicts don’t abort the run.

### History index naming

- Format: `.entities.v2.history.security_<namespace>.<YYYY-MM-DD>-<HH>` so sub-daily frequencies (e.g. 1h, 12h) use distinct indices.
- Index template and helpers for name and pattern (e.g. for cleanup).

### Force snapshot API

- **POST** internal route to trigger a snapshot on demand (no entity type in path).
- Response: `{ ok: true, historySnapshotIndex, docCount, resetCount }` or 500 with error message.

### Error handling

- Client returns a result type: `{ ok: true, ... }` or `{ ok: false, error }`; does not throw.
- Task stores `lastError` / `lastErrorTimestamp` on failure; force-snapshot route returns 500 with message.