### PR TITLE
[ES|QL] Add strict preferredExpressionType to suggestForExpression

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/context_fixtures.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/context_fixtures.ts
@@ -209,9 +209,12 @@ export type MockedICommandCallbacks = {
 };
 
 export const getMockCallbacks = (): MockedICommandCallbacks => {
-  const expectedFields = getFieldNamesByType('any');
   return {
     getByType: jest.fn().mockImplementation(async (types, ignoredColumns = []) => {
+      const requestedTypes = Array.isArray(types) ? types : [types];
+      const normalizedRequestedTypes = requestedTypes.length > 0 ? requestedTypes : ['any'];
+      const expectedFields = getFieldNamesByType(normalizedRequestedTypes);
+
       return (
         expectedFields
           // Exclude columns already used (e.g., used in STATS BY or parent function scope)

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_complete/should_suggest_operators.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_complete/should_suggest_operators.ts
@@ -71,6 +71,13 @@ const rules: Rule[] = [
         const isBooleanContext =
           preferredTypes.includes('boolean') || preferredTypes.includes('any');
 
+        if (!isBooleanContext && preferredTypes.length > 0) {
+          return {
+            shouldSuggest: false,
+            reason: 'Strict type context - no operators for text/keyword (all produce boolean)',
+          };
+        }
+
         const stringOperators = [
           ...(isBooleanContext ? comparisonFunctions.map(({ name }) => name) : []),
           ...patternMatchOperators.map(({ name }) => name),

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_complete/should_suggest_operators.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_complete/should_suggest_operators.ts
@@ -19,6 +19,7 @@ import {
   inOperators,
   nullCheckOperators,
 } from '../../../../../all_operators';
+import { normalizePreferredExpressionTypes } from '../../utils';
 
 export interface OperatorRuleContext {
   expressionType: SupportedDataType | 'unknown';
@@ -62,10 +63,13 @@ const rules: Rule[] = [
   (ctx) => {
     if (!ctx.functionParameterContext) {
       const { expressionType } = ctx;
-      const preferredType = ctx.ctx.options.preferredExpressionType;
+      const preferredTypes = normalizePreferredExpressionTypes(
+        ctx.ctx.options.preferredExpressionType
+      );
 
       if (expressionType === 'text' || expressionType === 'keyword') {
-        const isBooleanContext = preferredType === 'boolean' || preferredType === 'any';
+        const isBooleanContext =
+          preferredTypes.includes('boolean') || preferredTypes.includes('any');
 
         const stringOperators = [
           ...(isBooleanContext ? comparisonFunctions.map(({ name }) => name) : []),

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_operator.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_operator.ts
@@ -22,6 +22,7 @@ import { dispatchOperators } from '../operators/dispatcher';
 import type { ExpressionContext } from '../types';
 import { SuggestionBuilder } from '../suggestion_builder';
 import { shouldSuggestOperators } from './after_complete/should_suggest_operators';
+import { normalizePreferredExpressionTypes } from '../utils';
 
 /**
  * Suggests completions after an operator (e.g., field = |, field IN |)
@@ -251,15 +252,17 @@ async function handleIncompleteOperator(
   }
 
   if (reason === 'wrongTypes') {
-    if (leftArgType && options.preferredExpressionType) {
+    const preferredTypes = normalizePreferredExpressionTypes(options.preferredExpressionType);
+
+    if (leftArgType && preferredTypes.length) {
       if (
-        leftArgType !== options.preferredExpressionType &&
+        !preferredTypes.includes(leftArgType) &&
         leftArgType !== 'unknown' &&
         leftArgType !== 'unsupported'
       ) {
         builder.addOperators({
           leftParamType: leftArgType,
-          returnTypes: [options.preferredExpressionType],
+          returnTypes: preferredTypes,
         });
       }
     }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
@@ -9,7 +9,7 @@
 
 import { ControlTriggerSource, ESQLVariableType } from '@kbn/esql-types';
 import { isEqual, uniq, uniqWith } from 'lodash';
-import { matchesSpecialFunction } from '../utils';
+import { matchesSpecialFunction, normalizePreferredExpressionTypes } from '../utils';
 import { shouldSuggestComma, type CommaContext } from '../comma_decision_engine';
 import type { ExpressionContext } from '../types';
 import { ensureKeywordAndText } from '../../functions';
@@ -256,9 +256,16 @@ async function handleDefaultContext(ctx: ExpressionContext): Promise<ISuggestion
   const suggestFields = options.suggestFields ?? true;
   const suggestFunctions = options.suggestFunctions ?? true;
   const controlType = options.controlType ?? ESQLVariableType.FIELDS;
+  const preferredTypes = normalizePreferredExpressionTypes(options.preferredExpressionType);
 
   const suggestions: ISuggestionItem[] = [];
-  const acceptedTypes: FunctionParameterType[] = ['any'];
+  // Keep boolean/any contexts permissive at expression start:
+  // boolean expressions are often built from non-boolean operands (e.g. field > 10).
+  const isStrictPreferredType =
+    preferredTypes.length > 0 &&
+    !preferredTypes.includes('boolean') &&
+    !preferredTypes.includes('any');
+  const acceptedTypes: FunctionParameterType[] = isStrictPreferredType ? preferredTypes : ['any'];
 
   // Suggest fields/columns and functions using SuggestionBuilder
   if (suggestFields || suggestFunctions) {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
@@ -8,10 +8,11 @@
  */
 
 import type { ISuggestionItem } from '../../../../registry/types';
-import type { FunctionParameterType, SupportedDataType } from '../../../types';
+import type { FunctionParameterType } from '../../../types';
 import { getFieldsSuggestions, getFunctionsSuggestions, getLiteralsSuggestions } from '../helpers';
 import { getOperatorSuggestions } from '../../operators';
 import type { ExpressionContext } from './types';
+import type { PreferredExpressionType } from './types';
 import { commaCompleteItem } from '../../../../registry/complete_items';
 import { shouldSuggestComma, type CommaContext } from './comma_decision_engine';
 
@@ -121,7 +122,7 @@ export class SuggestionBuilder {
     leftParamType?: FunctionParameterType;
     allowed?: string[];
     ignored?: string[];
-    returnTypes?: SupportedDataType[];
+    returnTypes?: PreferredExpressionType[];
   }): this {
     const operatorSuggestions = getOperatorSuggestions(
       {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/types.ts
@@ -25,6 +25,8 @@ import type {
 } from '../../../types';
 import type { ExpressionPosition } from './position';
 
+export type PreferredExpressionType = SupportedDataType | 'any';
+
 export interface SuggestForExpressionParams {
   query: string;
   expressionRoot?: ESQLSingleAstItem;
@@ -51,7 +53,7 @@ export interface ExpressionContext {
 
 export interface ExpressionContextOptions {
   functionParameterContext?: FunctionParameterContext; // Set when cursor is inside a function arg; drives param-aware types, commas, and enum values
-  preferredExpressionType?: SupportedDataType; // Expected return type for the whole expression; filters/ranks operators and operands (e.g., boolean in WHERE)
+  preferredExpressionType?: PreferredExpressionType | PreferredExpressionType[]; // Expected return type(s) for the whole expression; filters/ranks operators and operands (e.g., boolean in WHERE)
   addSpaceAfterFirstField?: boolean; // Whether to append a space after inserting the first field of a top-level expression
   ignoredColumnsForEmptyExpression?: string[]; // Field names to exclude when suggesting for an empty expression
   isCursorFollowedByComma?: boolean; // Computed from the remaining query to avoid inserting an extra comma after the cursor

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
@@ -14,6 +14,7 @@ import type { ICommandContext, ISuggestionItem } from '../../../../registry/type
 import { getFunctionDefinition } from '../..';
 import { SignatureAnalyzer } from './signature_analyzer';
 import type { Signature } from '../../../types';
+import type { PreferredExpressionType } from './types';
 
 export type SpecialFunctionName = 'case' | 'count' | 'bucket';
 
@@ -144,4 +145,17 @@ export async function getKqlSuggestionsIfApplicable(
   } catch (error) {
     return null;
   }
+}
+
+/** Normalizes preferred expression type option into an array form for downstream checks. */
+export function normalizePreferredExpressionTypes(
+  preferredExpressionType?: PreferredExpressionType | PreferredExpressionType[]
+): PreferredExpressionType[] {
+  if (!preferredExpressionType) {
+    return [];
+  }
+
+  return Array.isArray(preferredExpressionType)
+    ? preferredExpressionType
+    : [preferredExpressionType];
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
@@ -230,21 +230,7 @@ describe('RERANK Autocomplete', () => {
     test('suggests continuations after field with more trailing spaces', async () => {
       const query = buildRerankQuery({ query: '"search query"', onClause: 'keywordField' }) + ' ';
 
-      await expectRerankSuggestions(query, [
-        ...NEXT_ACTIONS,
-        ...getFunctionSignaturesByReturnType(
-          Location.RERANK,
-          'any',
-          {
-            operators: true,
-            excludeOperatorGroups: [],
-            skipAssign: true,
-            agg: false,
-            scalar: false,
-          },
-          ['keyword']
-        ),
-      ]);
+      await expectRerankSuggestions(query, NEXT_ACTIONS);
     });
   });
 
@@ -457,19 +443,14 @@ describe('RERANK Autocomplete', () => {
   describe('Partial completions and prefixes', () => {
     test.each([
       {
-        name: 'IS NULL operators',
-        partial: 'IS N',
-        expected: OPERATOR_SUGGESTIONS.EXISTENCE,
-      },
-      {
         name: 'LIKE operator',
         partial: 'LI',
-        expected: addPlaceholder([OPERATOR_SUGGESTIONS.PATTERN[0]]),
+        notExpected: addPlaceholder([OPERATOR_SUGGESTIONS.PATTERN[0]]),
       },
       {
         name: 'IN and IS operators',
         partial: 'I',
-        expected: [
+        notExpected: [
           addPlaceholder([OPERATOR_SUGGESTIONS.SET[0]])[0],
           ...OPERATOR_SUGGESTIONS.EXISTENCE,
         ],
@@ -477,21 +458,24 @@ describe('RERANK Autocomplete', () => {
       {
         name: 'NOT operators',
         partial: 'NO',
-        expected: [
+        notExpected: [
           addPlaceholder([OPERATOR_SUGGESTIONS.SET[1]])[0],
           addPlaceholder([OPERATOR_SUGGESTIONS.PATTERN[1]])[0],
           addPlaceholder([OPERATOR_SUGGESTIONS.PATTERN[3]])[0],
         ],
       },
-    ])('completes partial $name', async ({ partial, expected }) => {
-      const query = buildRerankQuery({
-        query: '"search query"',
-        onClause: `textField = keywordField ${partial}`,
-      });
+    ])(
+      'does not complete partial $name (strict text/keyword context)',
+      async ({ partial, notExpected }) => {
+        const query = buildRerankQuery({
+          query: '"search query"',
+          onClause: `textField = keywordField ${partial}`,
+        });
 
-      await expectRerankSuggestions(query, {
-        contains: expected,
-      });
-    });
+        await expectRerankSuggestions(query, {
+          notContains: notExpected,
+        });
+      }
+    );
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.test.ts
@@ -180,9 +180,14 @@ describe('RERANK Autocomplete', () => {
     test('suggests field columns after ON keyword', async () => {
       const query = buildRerankQuery({ query: '"search query"' }) + ' ON ';
 
-      await expectRerankSuggestions(query, {
-        contains: ['textField', 'keywordField', 'integerField'],
-      });
+      await expectRerankSuggestions(
+        query,
+        {
+          contains: ['textField', 'keywordField'],
+          notContains: ['integerField'],
+        },
+        mockCallbacks
+      );
     });
 
     test('suggests field columns after a list of keyword fields and comma', async () => {
@@ -192,23 +197,34 @@ describe('RERANK Autocomplete', () => {
           onClause: 'textField, col0 = TRUE, keywordField, integerField,',
         }) + ' ';
 
-      await expectRerankSuggestions(query, {
-        contains: ['textField', 'keywordField', 'integerField'],
-      });
+      await expectRerankSuggestions(
+        query,
+        {
+          contains: ['textField', 'keywordField'],
+          notContains: ['integerField'],
+        },
+        mockCallbacks
+      );
     });
 
     test('suggests field continuations after selecting a field', async () => {
       const query = buildRerankQuery({ query: '"search query"', onClause: 'keywordField' });
 
-      await expectRerankSuggestions(query, {
-        contains: [
-          ', ',
-          'WITH { $0 }',
-          '| ',
-          ...getFieldNamesByType('any'),
-          ...getFunctionSignaturesByReturnType(Location.RERANK, 'any', { scalar: true }),
-        ],
-      });
+      await expectRerankSuggestions(
+        query,
+        {
+          contains: [
+            ', ',
+            'WITH { $0 }',
+            '| ',
+            ...getFieldNamesByType(['text', 'keyword']),
+            ...getFunctionSignaturesByReturnType(Location.RERANK, ['text', 'keyword'], {
+              scalar: true,
+            }),
+          ],
+        },
+        mockCallbacks
+      );
     });
 
     test('suggests continuations after field with more trailing spaces', async () => {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/rerank/autocomplete.ts
@@ -117,7 +117,7 @@ export async function autocomplete(
         {
           afterCompleteSuggestions,
           allowSingleColumnFields: true,
-          preferredExpressionType: 'text',
+          preferredExpressionType: ['text', 'keyword'],
         }
       );
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/251246

Make expression autocomplete respect `preferredExpressionType `even when we are not inside function arguments (for example in command arguments like RERANK ON).

For `RERANK`, suggest only` text/keyword` fields and expressions, not every type.

Also let `preferredExpressionType `accept multiple types (array), and handle that format in all related autocomplete logic.


<img width="1067" height="377" alt="1" src="https://github.com/user-attachments/assets/7a9bcfaf-547c-4fe7-8a16-991286cacdb8" />
<img width="1067" height="377" alt="2" src="https://github.com/user-attachments/assets/2acb8188-312c-4a7f-bcd4-9d212397e126" />
