### PR TITLE
Wait for resources before scheduling dispatcher task

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { createMockResourceManager } from '../services/resource_service/resource_manager.mock';
+import { INTERVAL, scheduleDispatcherTask } from './schedule_task';
+import { DISPATCHER_TASK_ID, DISPATCHER_TASK_TYPE } from './task_definition';
+
+describe('scheduleDispatcherTask', () => {
+  let taskManager: jest.Mocked<Pick<TaskManagerStartContract, 'ensureScheduled'>>;
+  let resourceManager: ReturnType<typeof createMockResourceManager>;
+  let callOrder: string[];
+
+  beforeEach(() => {
+    callOrder = [];
+
+    resourceManager = createMockResourceManager();
+    resourceManager.waitUntilReady.mockImplementation(() => {
+      callOrder.push('waitUntilReady');
+      return Promise.resolve();
+    });
+
+    taskManager = {
+      ensureScheduled: jest.fn().mockImplementation(() => {
+        callOrder.push('ensureScheduled');
+        return Promise.resolve();
+      }),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('waits for resources before scheduling the task', async () => {
+    await scheduleDispatcherTask({
+      taskManager: taskManager as unknown as TaskManagerStartContract,
+      resourceManager,
+    });
+
+    expect(callOrder).toEqual(['waitUntilReady', 'ensureScheduled']);
+  });
+
+  it('does not schedule when resources fail to initialize', async () => {
+    const error = new Error('resource init failed');
+    resourceManager.waitUntilReady.mockRejectedValue(error);
+
+    await expect(
+      scheduleDispatcherTask({
+        taskManager: taskManager as unknown as TaskManagerStartContract,
+        resourceManager,
+      })
+    ).rejects.toThrow(error);
+
+    expect(taskManager.ensureScheduled).not.toHaveBeenCalled();
+  });
+
+  it('passes the correct task configuration to ensureScheduled', async () => {
+    await scheduleDispatcherTask({
+      taskManager: taskManager as unknown as TaskManagerStartContract,
+      resourceManager,
+    });
+
+    expect(taskManager.ensureScheduled).toHaveBeenCalledWith({
+      id: DISPATCHER_TASK_ID,
+      taskType: DISPATCHER_TASK_TYPE,
+      schedule: {
+        interval: INTERVAL,
+      },
+      scope: ['alerting'],
+      state: {},
+      params: {},
+      enabled: true,
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.ts
@@ -6,15 +6,20 @@
  */
 
 import type { AlertingServerStartDependencies } from '../../types';
+import type { ResourceManagerContract } from '../services/resource_service/resource_manager';
 import { DISPATCHER_TASK_ID, DISPATCHER_TASK_TYPE } from './task_definition';
 
 export const INTERVAL = '5s';
 
 export async function scheduleDispatcherTask({
   taskManager,
+  resourceManager,
 }: {
   taskManager: AlertingServerStartDependencies['taskManager'];
+  resourceManager: ResourceManagerContract;
 }): Promise<void> {
+  await resourceManager.waitUntilReady();
+
   await taskManager.ensureScheduled({
     id: DISPATCHER_TASK_ID,
     taskType: DISPATCHER_TASK_TYPE,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_start.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_on_start.ts
@@ -28,7 +28,7 @@ export function bindOnStart({ bind }: ContainerModuleLoadOptions) {
       esClient,
     });
 
-    scheduleDispatcherTask({ taskManager }).catch((error) => {
+    scheduleDispatcherTask({ taskManager, resourceManager }).catch((error) => {
       logger.error(error as Error, {
         error: {
           code: 'DISPATCHER_TASK_SCHEDULE_FAILURE',


### PR DESCRIPTION
## Summary

- `scheduleDispatcherTask` now calls `resourceManager.waitUntilReady()` before scheduling the dispatcher task with Task Manager, preventing the task from being registered while resources (index templates, etc.) are still initializing.
- Adds unit tests verifying call ordering, error propagation, and correct task configuration.

## Test plan

- [x] Unit tests pass: `yarn test:jest x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/schedule_task.test.ts`


Made with [Cursor](https://cursor.com)