### PR TITLE
fix(dev,ci): fix `Scout Test Run Builder` script location for the Cosmos DB emulator verification pipeline

### DIFF
--- a/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
+++ b/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
@@ -33,7 +33,7 @@ steps:
         - exit_status: '-1'
           limit: 3
 
-  - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
+  - command: .buildkite/scripts/steps/test/scout/test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
       machineType: n2-standard-4


### PR DESCRIPTION
## Summary

Fix `Scout Test Run Builder` script location for the Cosmos DB emulator verification pipeline (oversight from #253420).
