### PR TITLE
[Security Solution]: Fix for trial_license_complete_tier/resolve_read_rules·ts Rules Management - Rule Read API @ess resolve_read_rules reading rules "before each" hook for "should create a rule and a "conflicting rule" where the SO _id matches the sourceId

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/trial_license_complete_tier/resolve_read_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_read/trial_license_complete_tier/resolve_read_rules.ts
@@ -158,6 +158,13 @@ export default ({ getService }: FtrProviderContext) => {
           .expect(200);
 
         expect(readRulesConflictRes.body.outcome).to.eql('conflict');
+
+        // We should try cleaning up manually
+        // // extra teardown to avoid errors on cleanup
+        // await es.delete({
+        //   index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+        //   id: 'alert:90e3ca0e-71f7-513a-b60a-ac678efd8887',
+        // });
       });
     });
   });


### PR DESCRIPTION
**Resolves: #254709**

## Summary

This is a ticket to try and find ways to resolve the supposedly flaky test "Fix for trial_license_complete_tier/resolve_read_rules·ts Rules Management - Rule Read API @ess resolve_read_rules reading rules "before each" hook for "should create a rule and a "conflicting rule" where the SO _id matches the sourceId".

The ticket was originally entered (duplicate) as follows:

https://github.com/elastic/kibana/issues/254709
https://github.com/elastic/kibana/issues/254710

## Closing - Unable to replicate. 

I was unable to verify this is a flaky test. 

When using the [flaky test runner x100 times](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10900) we get no such errors.

Probably a one-off issue, there was some [underprovisioning reported in QA clusters](https://elastic.slack.com/archives/C02HA9E8221/p1771940634412919) the same week. Its possible this might be related. 

Since we cannot verify a potential fix, there is not much point in trying to find one.
