### PR TITLE
[SigEvents] Fix snapshot creation for features

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/significant_events_workflow.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/scripts/significant_events_snapshots/lib/significant_events_workflow.ts
@@ -6,8 +6,12 @@
  */
 
 import type { Client } from '@elastic/elasticsearch';
+import type { Flags } from '@kbn/dev-cli-runner';
 import type { ToolingLog } from '@kbn/tooling-log';
-import type { Feature } from '@kbn/streams-schema';
+import type { Feature, Streams } from '@kbn/streams-schema';
+import { generateAllComputedFeatures } from '@kbn/streams-ai';
+import { toolingLogToLogger } from '@kbn/kibana-api-cli';
+import { v5 as uuidv5 } from 'uuid';
 import type { ConnectionConfig } from './get_connection_config';
 import { kibanaRequest } from './kibana';
 import { FEATURE_EXTRACTION_POLL_INTERVAL_MS, FEATURE_EXTRACTION_TIMEOUT_MS } from './constants';
@@ -125,9 +129,22 @@ export async function persistSigEventsExtractedFeaturesForSnapshot(
   esClient: Client,
   log: ToolingLog,
   snapshotName: string,
-  streamName: string = 'logs'
+  streamName: string = 'logs',
+  additionalFeatures: Feature[] = []
 ): Promise<{ index: string; count: number }> {
-  const features = await fetchSigEventsExtractedFeatures(config, log, streamName);
+  const inferredFeatures = await fetchSigEventsExtractedFeatures(config, log, streamName);
+
+  const mergedById = new Map<string, Feature>();
+  for (const feature of inferredFeatures) {
+    mergedById.set(feature.id, feature);
+  }
+
+  for (const feature of additionalFeatures) {
+    mergedById.set(feature.id, feature);
+  }
+
+  const features = Array.from(mergedById.values());
+
   const index = getSigeventsSnapshotFeaturesIndex(snapshotName);
 
   await esClient.indices.delete({ index, ignore_unavailable: true });
@@ -174,8 +191,63 @@ export async function persistSigEventsExtractedFeaturesForSnapshot(
     }
   }
 
-  log.info(`Persisted ${features.length} features to "${index}" for snapshotting`);
+  log.info(
+    `Persisted ${features.length} features to "${index}" for snapshotting ` +
+      `(${inferredFeatures.length} inferred + ${additionalFeatures.length} computed, ` +
+      `${inferredFeatures.length + additionalFeatures.length - features.length} duplicates removed)`
+  );
   return { index, count: features.length };
+}
+
+/**
+ * Generates computed features (dataset_analysis, log_samples, log_patterns,
+ * error_logs) directly from the indexed data. This mirrors what the production
+ * `features_identification` task does via {@link generateAllComputedFeatures},
+ * ensuring the snapshot always contains field-level context the LLM needs for
+ * proper KQL generation.
+ */
+export async function generateComputedFeaturesForSnapshot({
+  esClient,
+  log,
+  flags,
+  streamName,
+  start,
+  end,
+}: {
+  esClient: Client;
+  log: ToolingLog;
+  flags: Flags;
+  streamName: string;
+  start: number;
+  end: number;
+}): Promise<Feature[]> {
+  log.info('Generating computed features from indexed data...');
+
+  const stream = { name: streamName } as Streams.all.Definition;
+  const logger = toolingLogToLogger({ flags, log });
+
+  const baseFeatures = await generateAllComputedFeatures({
+    stream,
+    start,
+    end,
+    esClient,
+    logger,
+  });
+
+  const now = new Date().toISOString();
+  const features: Feature[] = baseFeatures.map((baseFeature) => ({
+    ...baseFeature,
+    status: 'active' as const,
+    last_seen: now,
+    uuid: uuidv5(`${streamName}:${baseFeature.id}`, uuidv5.DNS),
+  }));
+
+  log.info(`Generated ${features.length} computed features:`);
+  for (const feature of features) {
+    log.info(`  - ${feature.type}: ${feature.description}`);
+  }
+
+  return features;
 }
 
 export async function cleanupSigEventsExtractedFeaturesData(

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.test.ts
@@ -23,7 +23,7 @@ describe('snapshot_run_config', () => {
     jest.resetModules();
 
     const mod = await import('./snapshot_run_config');
-    expect(mod.SIGEVENTS_SNAPSHOT_RUN).toBe('2026-02-25');
+    expect(mod.SIGEVENTS_SNAPSHOT_RUN).toBe('2026-02-27');
   });
 
   it('uses SIGEVENTS_SNAPSHOT_RUN from env when set', async () => {

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/data_generators/snapshot_run_config.ts
@@ -17,7 +17,7 @@ export interface GcsConfig {
  * Override at runtime with:
  *   SIGEVENTS_SNAPSHOT_RUN=2026-02-25 node scripts/scout ...
  */
-export const SIGEVENTS_SNAPSHOT_RUN = process.env.SIGEVENTS_SNAPSHOT_RUN || '2026-02-25';
+export const SIGEVENTS_SNAPSHOT_RUN = process.env.SIGEVENTS_SNAPSHOT_RUN || '2026-02-27';
 
 export const resolveBasePath = (gcs: GcsConfig) =>
   `${gcs.basePathPrefix}/${SIGEVENTS_SNAPSHOT_RUN}`;


### PR DESCRIPTION
## Summary

The snapshot capture script for Significant Events evals was only persisting LLM-extracted features. It was missing computed features - `dataset_analysis`, `log_samples`, `log_patterns`, and `error_logs` - which are generated by the `features_identification` task via `generateAllComputedFeatures`. Without these, snapshots lacked the field-level context the LLM needs for proper KQL generation during query generation evals.

### Why it's needed
Query generation evals rely on features loaded from the snapshot as input context. When computed features (field schemas, log samples, log patterns, error logs) are absent, the LLM lacks the structural information it needs to generate accurate KQL queries, leading to degraded eval results that don't reflect production behaviour.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
