### PR TITLE
[Security Solution][Alert details] make sure that the dataview is ready before fetching data for analyzer preview

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { useAlertPrevalenceFromProcessTree } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
@@ -14,20 +14,12 @@ import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_f
 import { DocumentDetailsContext } from '../../shared/context';
 import { AnalyzerPreview } from './analyzer_preview';
 import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import * as mock from '../mocks/mock_analyzer_data';
-import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
-import type { DataView } from '@kbn/data-views-plugin/common';
-import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 
 jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree', () => ({
   useAlertPrevalenceFromProcessTree: jest.fn(),
 }));
 const mockUseAlertPrevalenceFromProcessTree = useAlertPrevalenceFromProcessTree as jest.Mock;
-
-jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
-jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockTreeValues = {
   loading: false,
@@ -36,36 +28,26 @@ const mockTreeValues = {
   statsNodes: mock.mockStatsNodes,
 };
 
-const renderAnalyzerPreview = (contextValue: DocumentDetailsContext) =>
+const renderAnalyzerPreview = (
+  contextValue: DocumentDetailsContext,
+  dataViewIndices: string[] = ['index']
+) =>
   render(
     <TestProviders>
       <DocumentDetailsContext.Provider value={contextValue}>
-        <AnalyzerPreview />
+        <AnalyzerPreview dataViewIndices={dataViewIndices} />
       </DocumentDetailsContext.Provider>
     </TestProviders>
   );
-
-const dataView: DataView = createStubDataView({
-  spec: { title: '.alerts-security.alerts-default' },
-});
 
 describe('<AnalyzerPreview />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockUseAlertPrevalenceFromProcessTree.mockReturnValue(mockTreeValues);
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-    (useSelectedPatterns as jest.Mock).mockReturnValue(['index']);
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'ready',
-      dataView: {
-        ...dataView,
-        hasMatchedIndices: jest.fn().mockReturnValue(true),
-      },
-    });
   });
 
-  it('shows analyzer preview correctly when documentId and index are present', () => {
+  it('shows analyzer preview correctly when documentId and index are present', async () => {
     const contextValue = {
       ...mockContextValue,
       dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
@@ -76,24 +58,30 @@ describe('<AnalyzerPreview />', () => {
       documentId: 'eventId',
       indices: ['rule-indices'],
     });
-    expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+    });
   });
 
-  it('should use selected index patterns for non-alerts', () => {
+  it('should use provided data view indices for non-alerts', async () => {
     const contextValue = {
       ...mockContextValue,
       dataFormattedForFieldBrowser: [],
     };
-    const wrapper = renderAnalyzerPreview(contextValue);
+    const wrapper = renderAnalyzerPreview(contextValue, ['index']);
 
     expect(mockUseAlertPrevalenceFromProcessTree).toHaveBeenCalledWith({
       documentId: 'eventId',
       indices: ['index'],
     });
-    expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+    });
   });
 
-  it('should use ancestor id as document id when in preview', () => {
+  it('should use ancestor id as document id when in rule preview', async () => {
     const contextValue = {
       ...mockContextValue,
       getFieldsData: () => 'ancestors-id',
@@ -106,35 +94,10 @@ describe('<AnalyzerPreview />', () => {
       documentId: 'ancestors-id',
       indices: ['rule-indices'],
     });
-    expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
-  });
 
-  it('should show loading skeleton when the data view is loading', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'loading',
+    await waitFor(() => {
+      expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
     });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByTestId } = renderAnalyzerPreview(contextValue);
-
-    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should show loading skeleton when the data view is pristine', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'pristine',
-    });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByTestId } = renderAnalyzerPreview(contextValue);
-
-    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
   });
 
   it('should show loading skeleton when the process tree is being fetched', () => {
@@ -151,44 +114,25 @@ describe('<AnalyzerPreview />', () => {
     expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should show error message if the data view is error', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'error',
-    });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByText } = renderAnalyzerPreview(contextValue);
-
-    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
-  });
-
-  it('should show error message if the data view is ready but no matched indices', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'ready',
-      dataView: {
-        ...dataView,
-        hasMatchedIndices: jest.fn().mockReturnValue(false),
-      },
-    });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByText } = renderAnalyzerPreview(contextValue);
-
-    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
-  });
-
   it('should show error message when there is an error fetching the process tree data', () => {
     mockUseAlertPrevalenceFromProcessTree.mockReturnValue({
       loading: false,
       error: true,
       alertIds: undefined,
       statsNodes: undefined,
+    });
+
+    const { getByText } = renderAnalyzerPreview(mockContextValue);
+
+    expect(getByText('An error is preventing this alert from being analyzed.')).toBeInTheDocument();
+  });
+
+  it('should show error message when the process tree is empty', () => {
+    mockUseAlertPrevalenceFromProcessTree.mockReturnValue({
+      loading: false,
+      error: false,
+      alertIds: [],
+      statsNodes: [],
     });
 
     const { getByText } = renderAnalyzerPreview(mockContextValue);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
@@ -9,8 +9,6 @@ import { find } from 'lodash/fp';
 import { EuiSkeletonText, EuiTreeView } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
-import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { getTreeNodes } from '../utils/analyzer_helpers';
 import { ANCESTOR_ID, RULE_INDICES } from '../../shared/constants/field_names';
@@ -18,23 +16,6 @@ import { useDocumentDetailsContext } from '../../shared/context';
 import type { StatsNode } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
 import { useAlertPrevalenceFromProcessTree } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
 import { getField } from '../../shared/utils';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { PageScope } from '../../../../data_view_manager/constants';
-import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
-
-const DATAVIEW_ERROR = (
-  <FormattedMessage
-    id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.dataViewErrorDescription"
-    defaultMessage="Unable to retrieve the data view for analyzer."
-  />
-);
-
-const ANALYZER_ERROR = (
-  <FormattedMessage
-    id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.errorDescription"
-    defaultMessage="An error is preventing this alert from being analyzed."
-  />
-);
 
 const CHILD_COUNT_LIMIT = 3;
 const ANCESTOR_LEVEL = 3;
@@ -47,10 +28,17 @@ interface Cache {
   statsNodes: StatsNode[];
 }
 
+export interface AnalyzerPreviewProps {
+  /**
+   *
+   */
+  dataViewIndices: string[];
+}
+
 /**
  * Analyzer preview under Overview, Visualizations. It shows a tree representation of analyzer.
  */
-export const AnalyzerPreview: React.FC = () => {
+export const AnalyzerPreview = ({ dataViewIndices }: AnalyzerPreviewProps) => {
   const [cache, setCache] = useState<Partial<Cache>>({});
   const {
     dataFormattedForFieldBrowser: data,
@@ -61,27 +49,10 @@ export const AnalyzerPreview: React.FC = () => {
   const ancestorId = getField(getFieldsData(ANCESTOR_ID)) ?? '';
   const documentId = isRulePreview ? ancestorId : eventId; // use ancestor as fallback for alert preview
 
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { selectedPatterns: oldAnalyzerPatterns } = useSourcererDataView(PageScope.analyzer);
-  const experimentalAnalyzerPatterns = useSelectedPatterns(PageScope.analyzer);
-  const selectedPatterns = newDataViewPickerEnabled
-    ? experimentalAnalyzerPatterns
-    : oldAnalyzerPatterns;
-
-  const { dataView, status } = useDataView(PageScope.analyzer);
-
   const index = find({ category: 'kibana', field: RULE_INDICES }, data);
-  const indices = index?.values ?? selectedPatterns;
+  const indices = index?.values ?? dataViewIndices;
 
-  const needToFallbackToDataViewIndices = Boolean(index?.values);
-  const dataViewLoading =
-    needToFallbackToDataViewIndices && (status === 'loading' || status === 'pristine');
-
-  const {
-    statsNodes,
-    loading: dataLoading,
-    error,
-  } = useAlertPrevalenceFromProcessTree({
+  const { statsNodes, loading, error } = useAlertPrevalenceFromProcessTree({
     documentId,
     indices,
   });
@@ -99,7 +70,7 @@ export const AnalyzerPreview: React.FC = () => {
 
   const showAnalyzerTree = items && items.length > 0 && !error;
 
-  if (dataViewLoading || dataLoading) {
+  if (loading) {
     return (
       <EuiSkeletonText
         data-test-subj={ANALYZER_PREVIEW_LOADING_TEST_ID}
@@ -113,12 +84,13 @@ export const AnalyzerPreview: React.FC = () => {
     );
   }
 
-  if (status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices())) {
-    return DATAVIEW_ERROR;
-  }
-
   if (!showAnalyzerTree) {
-    return ANALYZER_ERROR;
+    return (
+      <FormattedMessage
+        id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.errorDescription"
+        defaultMessage="An error is preventing this alert from being analyzed."
+      />
+    );
   }
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
@@ -30,7 +30,7 @@ interface Cache {
 
 export interface AnalyzerPreviewProps {
   /**
-   *
+   * The list of indices from the data view, used as fallback if the indices cannot be found in the document data.
    */
   dataViewIndices: string[];
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
@@ -12,19 +12,26 @@ import { DocumentDetailsContext } from '../../shared/context';
 import { mockContextValue } from '../../shared/mocks/mock_context';
 import { AnalyzerPreviewContainer } from './analyzer_preview_container';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
-import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
-import { useAlertPrevalenceFromProcessTree } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
-import * as mock from '../mocks/mock_analyzer_data';
+import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID } from '../../../shared/components/test_ids';
-import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
+import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { PageScope } from '../../../../data_view_manager/constants';
 
 jest.mock(
   '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver'
 );
-jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree');
-jest.mock(
-  '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
-);
+jest.mock('../../../../data_view_manager/hooks/use_data_view');
+jest.mock('../../../../common/hooks/use_experimental_features');
+jest.mock('../../../../sourcerer/containers');
+jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+
+const mockAnalyzerPreview = jest.fn(() => <div data-test-subj="analyzerPreviewStub" />);
+jest.mock('./analyzer_preview', () => ({
+  AnalyzerPreview: () => mockAnalyzerPreview(),
+}));
 
 const mockNavigateToAnalyzer = jest.fn();
 jest.mock('../../shared/hooks/use_navigate_to_analyzer', () => {
@@ -56,16 +63,98 @@ const renderAnalyzerPreview = (context = mockContextValue) =>
 describe('AnalyzerPreviewContainer', () => {
   beforeEach(() => {
     (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-    (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-      loading: false,
-      error: false,
-      alertIds: ['alertid'],
-      statsNodes: mock.mockStatsNodes,
+
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+    (useSourcererDataView as jest.Mock).mockReturnValue({
+      selectedPatterns: ['old-analyzer-pattern'],
     });
-    (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-      investigateInTimelineAlertClick: jest.fn(),
+    (useSelectedPatterns as jest.Mock).mockReturnValue(['experimental-analyzer-pattern']);
+
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: {
+        hasMatchedIndices: () => true,
+      },
     });
+
+    mockNavigateToAnalyzer.mockClear();
+    mockAnalyzerPreview.mockClear();
   });
+
+  it('should render AnalyzerPreview with experimental patterns when the new picker is enabled', () => {
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+
+    renderAnalyzerPreview();
+
+    expect(mockAnalyzerPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ dataViewIndices: ['experimental-analyzer-pattern'] })
+    );
+  });
+
+  it('should render AnalyzerPreview with sourcerer patterns when the new picker is disabled', () => {
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+
+    renderAnalyzerPreview();
+    expect(mockAnalyzerPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ dataViewIndices: ['old-analyzer-pattern'] })
+    );
+  });
+
+  it('should show loading skeleton when the data view is loading', () => {
+    (useDataView as jest.Mock).mockReturnValue({ status: 'loading' });
+
+    const { getByTestId } = renderAnalyzerPreview();
+    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
+    expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+  });
+
+  it('should show loading skeleton when the data view is pristine', () => {
+    (useDataView as jest.Mock).mockReturnValue({ status: 'pristine' });
+
+    const { getByTestId } = renderAnalyzerPreview();
+    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
+    expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+  });
+
+  it('should show an error message when the data view is error', () => {
+    (useDataView as jest.Mock).mockReturnValue({ status: 'error' });
+
+    const { getByText } = renderAnalyzerPreview();
+    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
+    expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+  });
+
+  it('should show an error message when the data view has no matched indices', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: { hasMatchedIndices: () => false },
+    });
+
+    const { getByText } = renderAnalyzerPreview();
+    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
+    expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+  });
+
+  it('should show no-data message when analyzer is not enabled', () => {
+    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
+
+    const { getByText, queryByTestId } = renderAnalyzerPreview();
+    expect(queryByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).not.toBeInTheDocument();
+    expect(
+      getByText(/You can only visualize events triggered by hosts configured/i)
+    ).toBeInTheDocument();
+    expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+  });
+
+  it('should not render a title link when analyzer is not enabled', () => {
+    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
+
+    const { queryByTestId } = renderAnalyzerPreview();
+    expect(
+      queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
+    ).not.toBeInTheDocument();
+  });
+
   it('should open left flyout visualization tab when clicking on title', () => {
     const { getByTestId } = renderAnalyzerPreview();
 
@@ -88,5 +177,13 @@ describe('AnalyzerPreviewContainer', () => {
 
     getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
     expect(mockNavigateToAnalyzer).toHaveBeenCalled();
+  });
+
+  it('should use the analyzer page scope hooks', () => {
+    renderAnalyzerPreview();
+
+    expect(useSourcererDataView).toHaveBeenCalledWith(PageScope.analyzer);
+    expect(useSelectedPatterns).toHaveBeenCalledWith(PageScope.analyzer);
+    expect(useDataView).toHaveBeenCalledWith(PageScope.analyzer);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
@@ -28,9 +28,11 @@ jest.mock('../../../../common/hooks/use_experimental_features');
 jest.mock('../../../../sourcerer/containers');
 jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
 
-const mockAnalyzerPreview = jest.fn(() => <div data-test-subj="analyzerPreviewStub" />);
+const mockAnalyzerPreview = jest.fn((indices: string) => (
+  <div data-test-subj="analyzerPreviewStub" />
+));
 jest.mock('./analyzer_preview', () => ({
-  AnalyzerPreview: () => mockAnalyzerPreview(),
+  AnalyzerPreview: (indices: string) => mockAnalyzerPreview(indices),
 }));
 
 const mockNavigateToAnalyzer = jest.fn();
@@ -62,14 +64,14 @@ const renderAnalyzerPreview = (context = mockContextValue) =>
 
 describe('AnalyzerPreviewContainer', () => {
   beforeEach(() => {
-    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
+    jest.clearAllMocks();
 
+    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
     (useSourcererDataView as jest.Mock).mockReturnValue({
       selectedPatterns: ['old-analyzer-pattern'],
     });
     (useSelectedPatterns as jest.Mock).mockReturnValue(['experimental-analyzer-pattern']);
-
     (useDataView as jest.Mock).mockReturnValue({
       status: 'ready',
       dataView: {
@@ -82,8 +84,6 @@ describe('AnalyzerPreviewContainer', () => {
   });
 
   it('should render AnalyzerPreview with experimental patterns when the new picker is enabled', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-
     renderAnalyzerPreview();
 
     expect(mockAnalyzerPreview).toHaveBeenCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.tsx
@@ -6,14 +6,20 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiLink, EuiMark } from '@elastic/eui';
+import { EuiLink, EuiMark, EuiSkeletonText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
 import { AnalyzerPreview } from './analyzer_preview';
-import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
+import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { useNavigateToAnalyzer } from '../../shared/hooks/use_navigate_to_analyzer';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
+import { PageScope } from '../../../../data_view_manager/constants';
+import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
 /**
  * Analyzer preview under Overview, Visualizations. It shows a tree representation of analyzer.
@@ -41,6 +47,16 @@ export const AnalyzerPreviewContainer: React.FC = () => {
     [isEnabled, isRulePreview]
   );
 
+  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+  const { selectedPatterns: oldAnalyzerPatterns } = useSourcererDataView(PageScope.analyzer);
+  const experimentalAnalyzerPatterns = useSelectedPatterns(PageScope.analyzer);
+  const selectedPatterns = newDataViewPickerEnabled
+    ? experimentalAnalyzerPatterns
+    : oldAnalyzerPatterns;
+  const { dataView, status } = useDataView(PageScope.analyzer);
+  const dataViewLoading = status === 'loading' || status === 'pristine';
+  const dataViewError = status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
+
   return (
     <ExpandablePanel
       header={{
@@ -65,7 +81,30 @@ export const AnalyzerPreviewContainer: React.FC = () => {
       }}
       data-test-subj={ANALYZER_PREVIEW_TEST_ID}
     >
-      {isEnabled ? <AnalyzerPreview /> : <AnalyzerPreviewNoDataMessage />}
+      {isEnabled ? (
+        <>
+          {dataViewLoading ? (
+            <EuiSkeletonText
+              data-test-subj={ANALYZER_PREVIEW_LOADING_TEST_ID}
+              contentAriaLabel={i18n.translate(
+                'xpack.securitySolution.flyout.right.visualizations.analyzerPreview.loadingAriaLabel',
+                {
+                  defaultMessage: 'analyzer preview',
+                }
+              )}
+            />
+          ) : dataViewError ? (
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.dataViewErrorDescription"
+              defaultMessage="Unable to retrieve the data view for analyzer."
+            />
+          ) : (
+            <AnalyzerPreview dataViewIndices={selectedPatterns} />
+          )}
+        </>
+      ) : (
+        <AnalyzerPreviewNoDataMessage />
+      )}
     </ExpandablePanel>
   );
 };


### PR DESCRIPTION
## Summary

This PR fixes an issue related to the `AnalyzerPreview` component code. We are retrieving dataView information and making calls to the `entity` api within the same component. This means that while the dataView is still loading, we are making a call to the `entity` api with the wrong set of indices.

The PR makes a small change to move the dataView logic to the parent `AnalyzerPreviewContainer` component. That way, we can ensure that the call to fetch analyzer data is not triggered until we have a dataView ready with the correct indices.

#### Prior behavior: you can see a long loading screen and multiple calls to the `entity` api

https://github.com/user-attachments/assets/f95ca17a-fccf-4e4f-af40-119961e43a34

#### New behavior: only one call to the `entity` api

https://github.com/user-attachments/assets/0b7de8ab-d1cc-4bbf-80cc-84eb81a7fa5d

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->