### PR TITLE
[9.2] [Security Solution] fix issue where analyzer is not showing when the newDataViewPickerEnabled feature flag is off (#255182)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
@@ -26,8 +26,9 @@ import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/
 import { useEnableExperimental } from '../../../../common/hooks/use_experimental_features';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
-import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -41,6 +42,7 @@ jest.mock(
 );
 jest.mock('../../../../common/hooks/use_experimental_features');
 jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+jest.mock('../../../../sourcerer/containers');
 
 const mockUseWhichFlyout = useWhichFlyout as jest.Mock;
 const FLYOUT_KEY = 'securitySolution';
@@ -61,6 +63,7 @@ const NO_ANALYZER_MESSAGE =
 const dataView: DataView = createStubDataView({
   spec: { title: '.alerts-security.alerts-default' },
 });
+const dataViewSpec: DataViewSpec = createStubDataView({ spec: {} }).toSpec();
 
 const renderAnalyzer = (
   contextValue = {
@@ -96,85 +99,162 @@ describe('<AnalyzeGraph />', () => {
     });
   });
 
-  it('renders analyzer graph correctly', () => {
-    const wrapper = renderAnalyzer();
-
-    expect(wrapper.getByTestId(ANALYZER_GRAPH_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should render no data message when analyzer is not enabled', () => {
-    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
-
-    const contextValue = {
-      eventId: 'eventId',
-      scopeId: TableId.test,
-      dataAsNestedObject: {},
-    } as unknown as DocumentDetailsContext;
-
-    const { container } = renderAnalyzer(contextValue);
-
-    expect(container).toHaveTextContent(NO_ANALYZER_MESSAGE);
-  });
-
-  it('should show loading spinner while data view is loading', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'loading',
+  describe('newDataViewPickerEnabled true', () => {
+    beforeEach(() => {
+      (useSourcererDataView as jest.Mock).mockReturnValue({});
     });
 
-    const { getByTestId } = renderAnalyzer();
+    it('renders analyzer graph correctly', () => {
+      const wrapper = renderAnalyzer();
 
-    expect(getByTestId(DATA_VIEW_LOADING_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should show loading spinner while data view is pristine', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'pristine',
+      expect(wrapper.getByTestId(ANALYZER_GRAPH_TEST_ID)).toBeInTheDocument();
     });
 
-    const { getByTestId } = renderAnalyzer();
+    it('should render no data message when analyzer is not enabled', () => {
+      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
 
-    expect(getByTestId(DATA_VIEW_LOADING_TEST_ID)).toBeInTheDocument();
-  });
+      const contextValue = {
+        eventId: 'eventId',
+        scopeId: TableId.test,
+        dataAsNestedObject: {},
+      } as unknown as DocumentDetailsContext;
 
-  it('should show error message if data view is error', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'error',
+      const { container } = renderAnalyzer(contextValue);
+
+      expect(container).toHaveTextContent(NO_ANALYZER_MESSAGE);
     });
 
-    const { getByTestId } = renderAnalyzer();
+    it('should show loading spinner while data view is loading', () => {
+      (useDataView as jest.Mock).mockReturnValue({
+        status: 'loading',
+      });
 
-    expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
-      'Unable to retrieve the data view for analyzer'
-    );
-  });
+      const { getByTestId } = renderAnalyzer();
 
-  it('should show error message if data view is ready but no matched indices', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'ready',
-      dataView: {
-        ...dataView,
-        hasMatchedIndices: jest.fn().mockReturnValue(false),
-      },
+      expect(getByTestId(DATA_VIEW_LOADING_TEST_ID)).toBeInTheDocument();
     });
 
-    const { getByTestId } = renderAnalyzer();
+    it('should show loading spinner while data view is pristine', () => {
+      (useDataView as jest.Mock).mockReturnValue({
+        status: 'pristine',
+      });
 
-    expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
-      'Unable to retrieve the data view for analyzer'
-    );
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(DATA_VIEW_LOADING_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('should show error message if data view is error', () => {
+      (useDataView as jest.Mock).mockReturnValue({
+        status: 'error',
+      });
+
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+        'Unable to retrieve the data view for analyzer'
+      );
+    });
+
+    it('should show error message if data view is ready but no matched indices', () => {
+      (useDataView as jest.Mock).mockReturnValue({
+        status: 'ready',
+        dataView: {
+          ...dataView,
+          hasMatchedIndices: jest.fn().mockReturnValue(false),
+        },
+      });
+
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+        'Unable to retrieve the data view for analyzer'
+      );
+    });
+
+    it('should open details panel in preview when clicking on view button', () => {
+      const wrapper = renderAnalyzer();
+
+      expect(wrapper.getByTestId('resolver:graph-controls:show-panel-button')).toBeInTheDocument();
+      wrapper.getByTestId('resolver:graph-controls:show-panel-button').click();
+      expect(mockFlyoutApi.openPreviewPanel).toBeCalledWith({
+        id: DocumentDetailsAnalyzerPanelKey,
+        params: {
+          resolverComponentInstanceID: `${FLYOUT_KEY}-${TableId.test}`,
+          banner: ANALYZER_PREVIEW_BANNER,
+        },
+      });
+    });
   });
 
-  it('should open details panel in preview when clicking on view button', () => {
-    const wrapper = renderAnalyzer();
+  describe('newDataViewPickerEnabled false', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
 
-    expect(wrapper.getByTestId('resolver:graph-controls:show-panel-button')).toBeInTheDocument();
-    wrapper.getByTestId('resolver:graph-controls:show-panel-button').click();
-    expect(mockFlyoutApi.openPreviewPanel).toBeCalledWith({
-      id: DocumentDetailsAnalyzerPanelKey,
-      params: {
-        resolverComponentInstanceID: `${FLYOUT_KEY}-${TableId.test}`,
-        banner: ANALYZER_PREVIEW_BANNER,
-      },
+      (useEnableExperimental as jest.Mock).mockReturnValue({
+        newDataViewPickerEnabled: false,
+      });
+    });
+
+    it('should show loading spinner while sourcerer data view is loading', () => {
+      (useSourcererDataView as jest.Mock).mockReturnValue({
+        loading: true,
+        sourcererDataView: dataViewSpec,
+      });
+
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(DATA_VIEW_LOADING_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('should render an error if the dataViewSpec is undefined', () => {
+      (useSourcererDataView as jest.Mock).mockReturnValue({
+        loading: false,
+        sourcererDataView: undefined,
+      });
+
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+        'Unable to retrieve the data view for analyzer'
+      );
+    });
+
+    it('should render an error if the dataViewSpec is invalid because id is undefined', () => {
+      (useSourcererDataView as jest.Mock).mockReturnValue({
+        loading: false,
+        sourcererDataView: { ...dataViewSpec, id: undefined, title: 'title' },
+      });
+
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+        'Unable to retrieve the data view for analyzer'
+      );
+    });
+
+    it('should render an error if the dataViewSpec is invalid because title is empty', () => {
+      (useSourcererDataView as jest.Mock).mockReturnValue({
+        loading: false,
+        sourcererDataView: { ...dataViewSpec, id: 'id', title: '' },
+      });
+
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+        'Unable to retrieve the data view for analyzer'
+      );
+    });
+
+    it('should render the content', () => {
+      (useSourcererDataView as jest.Mock).mockReturnValue({
+        loading: false,
+        sourcererDataView: { ...dataViewSpec, id: 'id', title: 'title' },
+      });
+
+      const { getByTestId } = renderAnalyzer();
+
+      expect(getByTestId(ANALYZER_GRAPH_TEST_ID)).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -69,7 +69,35 @@ export const AnalyzeGraph: FC = () => {
     ? experimentalAnalyzerPatterns
     : oldAnalyzerPatterns;
 
-  const { dataView, status } = useDataView(SourcererScopeName.analyzer);
+  const { dataView: experimentalDataView, status: experimentalDataViewStatus } = useDataView(
+    SourcererScopeName.analyzer
+  );
+  const { sourcererDataView: oldSourcererDataViewSpec, loading: oldSourcererDataViewIsLoading } =
+    useSourcererDataView(SourcererScopeName.analyzer);
+
+  const isLoading: boolean = useMemo(
+    () =>
+      newDataViewPickerEnabled
+        ? experimentalDataViewStatus === 'loading' || experimentalDataViewStatus === 'pristine'
+        : oldSourcererDataViewIsLoading,
+    [experimentalDataViewStatus, newDataViewPickerEnabled, oldSourcererDataViewIsLoading]
+  );
+
+  const isDataViewInvalid: boolean = useMemo(
+    () =>
+      newDataViewPickerEnabled
+        ? experimentalDataViewStatus === 'error' ||
+          (experimentalDataViewStatus === 'ready' && !experimentalDataView.hasMatchedIndices())
+        : !oldSourcererDataViewSpec ||
+          !oldSourcererDataViewSpec.id ||
+          !oldSourcererDataViewSpec.title,
+    [
+      experimentalDataView,
+      experimentalDataViewStatus,
+      newDataViewPickerEnabled,
+      oldSourcererDataViewSpec,
+    ]
+  );
 
   const { openPreviewPanel } = useExpandableFlyoutApi();
 
@@ -91,7 +119,7 @@ export const AnalyzeGraph: FC = () => {
     );
   }
 
-  if (status === 'loading' || status === 'pristine') {
+  if (isLoading) {
     return (
       <EuiFlexGroup gutterSize="m" justifyContent="center" alignItems="center">
         <EuiFlexItem grow={false}>
@@ -101,7 +129,7 @@ export const AnalyzeGraph: FC = () => {
     );
   }
 
-  if (status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices())) {
+  if (isDataViewInvalid) {
     return (
       <EuiEmptyPrompt
         color="danger"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security Solution] fix issue where analyzer is not showing when the newDataViewPickerEnabled feature flag is off (#255182)](https://github.com/elastic/kibana/pull/255182)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-02-27T23:46:55Z","message":"[Security Solution] fix issue where analyzer is not showing when the newDataViewPickerEnabled feature flag is off (#255182)\n\n## Summary\n\nThis somewhat recent [PR](https://github.com/elastic/kibana/pull/245712)\nthat was aiming at fixing a bug related to dataViews with analyzer\nactually introduced another bug. The code added in that previous PR was\nverifying that the dataView was correctly loaded before showing\nanalyzer, but the check was done only for the `newDataViewPickerEnabled`\nfeature flag turned on...\n\nThis PR fixes that issue and handles both the `newDataViewPickerEnabled`\nfeature flag on and off.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e314aaf64e0e35366a1e3133ab22960db756be17","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:version","v9.4.0","v9.2.7","v9.3.2"],"title":"[Security Solution] fix issue where analyzer is not showing when the newDataViewPickerEnabled feature flag is off","number":255182,"url":"https://github.com/elastic/kibana/pull/255182","mergeCommit":{"message":"[Security Solution] fix issue where analyzer is not showing when the newDataViewPickerEnabled feature flag is off (#255182)\n\n## Summary\n\nThis somewhat recent [PR](https://github.com/elastic/kibana/pull/245712)\nthat was aiming at fixing a bug related to dataViews with analyzer\nactually introduced another bug. The code added in that previous PR was\nverifying that the dataView was correctly loaded before showing\nanalyzer, but the check was done only for the `newDataViewPickerEnabled`\nfeature flag turned on...\n\nThis PR fixes that issue and handles both the `newDataViewPickerEnabled`\nfeature flag on and off.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e314aaf64e0e35366a1e3133ab22960db756be17"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255182","number":255182,"mergeCommit":{"message":"[Security Solution] fix issue where analyzer is not showing when the newDataViewPickerEnabled feature flag is off (#255182)\n\n## Summary\n\nThis somewhat recent [PR](https://github.com/elastic/kibana/pull/245712)\nthat was aiming at fixing a bug related to dataViews with analyzer\nactually introduced another bug. The code added in that previous PR was\nverifying that the dataView was correctly loaded before showing\nanalyzer, but the check was done only for the `newDataViewPickerEnabled`\nfeature flag turned on...\n\nThis PR fixes that issue and handles both the `newDataViewPickerEnabled`\nfeature flag on and off.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e314aaf64e0e35366a1e3133ab22960db756be17"}},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/255402","number":255402,"state":"OPEN"}]}] BACKPORT-->