### PR TITLE
Fix typo: Recieved to Received

### DIFF
--- a/packages/kbn-capture-oas-snapshot-cli/src/capture_oas_snapshot.ts
+++ b/packages/kbn-capture-oas-snapshot-cli/src/capture_oas_snapshot.ts
@@ -81,7 +81,7 @@ export async function captureOasSnapshot({
       }
     });
 
-    log.info(`Recieved OAS, writing to ${outputFile}...`);
+    log.info(`Received OAS, writing to ${outputFile}...`);
     await fs.writeFile(outputFile, sortAndPrettyPrint(currentOas));
     const { size: sizeBytes } = await fs.stat(outputFile);
     log.success(`OAS written to ${outputFile}. File size ~${twoDeci(sizeBytes / MB)} MB.`);


### PR DESCRIPTION
Fixes typo in packages/kbn-capture-oas-snapshot-cli/src/capture_oas_snapshot.ts where 'Recieved' should be 'Received'.