### PR TITLE
[Console] Fix JSON highlighting inconsistencies for nested objects

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { monaco } from '../../../monaco_imports';
+import { lexerRules, consoleOutputLexerRules } from '.';
+import { consoleSharedLexerRules, matchTokensWithEOL } from './shared';
+
+const CONSOLE_TEST_LANG_ID = 'console_test';
+const CONSOLE_OUTPUT_TEST_LANG_ID = 'console_output_test';
+
+const getTokenTypeAtOffset = (
+  tokens: Array<{ offset: number; type: string }>,
+  offset: number
+): string => {
+  const token = [...tokens].reverse().find(({ offset: tokenOffset }) => tokenOffset <= offset);
+  if (!token) {
+    throw new Error(`Expected a token at offset ${offset}`);
+  }
+  return token.type;
+};
+
+const getLineTokens = (
+  tokenizedLines: Array<Array<{ offset: number; type: string }>>,
+  text: string
+) => {
+  const lines = text.split('\n');
+  return (lineText: string) => {
+    const index = lines.indexOf(lineText);
+    if (index < 0) throw new Error(`Line not found: ${JSON.stringify(lineText)}`);
+    return tokenizedLines[index];
+  };
+};
+
+describe('Console highlighting', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+
+    monaco.languages.register({ id: CONSOLE_TEST_LANG_ID });
+    monaco.languages.setMonarchTokensProvider(CONSOLE_TEST_LANG_ID, lexerRules);
+    monaco.languages.register({ id: CONSOLE_OUTPUT_TEST_LANG_ID });
+    monaco.languages.setMonarchTokensProvider(CONSOLE_OUTPUT_TEST_LANG_ID, consoleOutputLexerRules);
+
+    // Trigger tokenizer creation.
+    monaco.editor.createModel('', CONSOLE_TEST_LANG_ID).dispose();
+    monaco.editor.createModel('', CONSOLE_OUTPUT_TEST_LANG_ID).dispose();
+  });
+
+  it('keeps nested braces and following JSON keys highlighted in the editor', () => {
+    const text = `GET _all
+{
+  "body": {
+    "properties": {
+      "structured": {
+        "type": "object",
+        "subobjects": false
+      },
+      "text": {
+        "type": "match_only_text"
+      },
+      "event_name": {
+        "type": "keyword"
+      }
+    }
+  }
+}`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+
+    const getLine = getLineTokens(tokenizedLines, text);
+
+    const nestedClosingLine = getLine('      },');
+    const nestedClosingTokenType = getTokenTypeAtOffset(nestedClosingLine, 6);
+    expect(nestedClosingTokenType).toContain('paren.rparen');
+    expect(nestedClosingTokenType).not.toContain('text');
+
+    const eventNameLineText = '      "event_name": {';
+    const eventNameLine = getLine(eventNameLineText);
+    const eventNameTokenType = getTokenTypeAtOffset(eventNameLine, eventNameLineText.indexOf('"'));
+    expect(eventNameTokenType).toContain('variable');
+    expect(eventNameTokenType).not.toContain('text');
+  });
+
+  it('returns to root after the top-level closing brace at end-of-line in the editor', () => {
+    const text = `GET _all
+{
+  "a": {
+    "b": 1
+  }
+}
+GET _search`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+    const getLine = getLineTokens(tokenizedLines, text);
+
+    const requestLineAfterJson = getLine('GET _search');
+    const methodTokenType = getTokenTypeAtOffset(requestLineAfterJson, 0);
+    expect(methodTokenType).toContain('method');
+    expect(methodTokenType).not.toContain('text');
+  });
+
+  it('keeps nested braces and following JSON keys highlighted in output', () => {
+    const text = `{
+  "body": {
+    "properties": {
+      "structured": {
+        "type": "object",
+        "subobjects": false
+      },
+      "text": {
+        "type": "match_only_text"
+      },
+      "event_name": {
+        "type": "keyword"
+      }
+    }
+  }
+}`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_OUTPUT_TEST_LANG_ID);
+
+    const getLine = getLineTokens(tokenizedLines, text);
+
+    const nestedClosingLine = getLine('      },');
+    const nestedClosingTokenType = getTokenTypeAtOffset(nestedClosingLine, 6);
+    expect(nestedClosingTokenType).toContain('paren.rparen');
+    expect(nestedClosingTokenType).not.toContain('text');
+
+    const eventNameLineText = '      "event_name": {';
+    const eventNameLine = getLine(eventNameLineText);
+    const eventNameTokenType = getTokenTypeAtOffset(eventNameLine, eventNameLineText.indexOf('"'));
+    expect(eventNameTokenType).toContain('variable');
+    expect(eventNameTokenType).not.toContain('text');
+  });
+
+  it('does not overflow the tokenizer stack on deeply nested braces', () => {
+    const depth = 2000;
+    const text = `GET _all
+${'{'.repeat(depth)}${'}'.repeat(depth)}`;
+
+    expect(() => monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID)).not.toThrow();
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+    const bracesLine = tokenizedLines[1];
+    expect(bracesLine).toBeDefined();
+
+    const firstTokenType = getTokenTypeAtOffset(bracesLine, 0);
+    const lastTokenType = getTokenTypeAtOffset(bracesLine, depth + (depth - 1));
+    expect(firstTokenType).toContain('paren.lparen');
+    expect(lastTokenType).toContain('paren.rparen');
+  });
+});
+
+describe('Lexer rule composition', () => {
+  it('matchTokensWithEOL() builds @eos/@default cases for string tokens', () => {
+    const rule = matchTokensWithEOL('tok', /x/, 'eol_state', 'default_state');
+    expect(rule.regex).toEqual(/x/);
+    expect(rule.action).toEqual({
+      cases: {
+        '@eos': { token: 'tok', next: 'eol_state' },
+        '@default': { token: 'tok', next: 'default_state' },
+      },
+    });
+  });
+
+  it('matchTokensWithEOL() builds @eos/@default cases for token arrays', () => {
+    const rule = matchTokensWithEOL(['a', 'b'], /x/, 'eol_state', 'default_state');
+    expect(rule.regex).toEqual(/x/);
+    expect(rule.action).toEqual({
+      cases: {
+        '@eos': ['a', { token: 'b', next: 'eol_state' }],
+        '@default': ['a', { token: 'b', next: 'default_state' }],
+      },
+    });
+  });
+
+  it('json_root brace rules do not use @push/@pop', () => {
+    const jsonRoot = (consoleSharedLexerRules.tokenizer as any).json_root as any[];
+
+    const braceRules = jsonRoot.filter((rule) => {
+      const regex = Array.isArray(rule) ? rule[0] : rule?.regex;
+      return regex instanceof RegExp && ['{', '}', '\\{', '\\}'].includes(regex.source);
+    });
+
+    const stringifiedActions = JSON.stringify(
+      braceRules.map((rule) => (Array.isArray(rule) ? rule[1] : rule?.action))
+    );
+
+    expect(stringifiedActions).not.toContain('@push');
+    expect(stringifiedActions).not.toContain('@pop');
+  });
+
+  it('json_root includes the Console-specific closing brace EOL rule', () => {
+    const jsonRoot = (consoleSharedLexerRules.tokenizer as any).json_root as any[];
+
+    const hasRule = jsonRoot.some((rule) => {
+      const regex = Array.isArray(rule) ? rule[0] : rule?.regex;
+      return regex instanceof RegExp && regex.source === '^}\\s*';
+    });
+
+    expect(hasRule).toBe(true);
+  });
+});


### PR DESCRIPTION
Addresses #245820

## Summary
- Fixes an issue in Dev Tools Console where closing nested braces incorrectly returned the lexer to the root state, breaking syntax highlighting for subsequent elements.

## Root Cause
- The lexer rules matched any `}` to return to the root state, which caused it to pop out of the JSON context prematurely when encountering nested objects.

## Fix
- Updated the rule to only return to the root state when an unindented closing brace ends the line (`/^}\s*/`), keeping nested braces highlighted properly without state changes.
- Added tests to cover nested objects highlighting and avoid stack limit issues.

## Screenshots

### Before

<img width="1713" height="1083" alt="console_highlight_before" src="https://github.com/user-attachments/assets/46ac5181-ca61-46e8-be02-fd401e4bb6ad" />
 
### After

<img width="1708" height="1084" alt="console_highlight_after" src="https://github.com/user-attachments/assets/0ade816e-95ce-472e-b27b-31b048db4d12" />

## Test Plan
- Run tests: `yarn test:jest src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts`
- Manual verification:
  1. Open the Dev Tools Console in Kibana.
  2. Paste the following request with nested JSON objects (as shown in the screenshots):
     ```json
     PUT console_highlight_bug_test2
     {
       "mappings": {
         "properties": {
           "body": {
             "properties": {
               "properties": {
                 "properties": {
                   "structured": {
                     "type": "object",
                     "subobjects": false
                   },
                   "text": {
                     "type": "match_only_text"
                   }
                 }
               },
               "event_name": {
                 "type": "keyword"
               },
               "host": {
                 "properties": {
                   "name": {
                     "type": "alias",
                     "path": "resource.attributes.host.name"
                   }
                 }
               }
             }
           }
         }
       }
     }
     ```
  3. Verify that the syntax highlighting remains consistent and doesn't break (turn un-highlighted text/white) after the first nested closing brace `}`. Properties like `"text"`, `"event_name"` and `"host"` should retain their correct coloring.

## Release note
Fixes an issue in Dev Tools Console where closing nested braces broke syntax highlighting for subsequent elements.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->