### PR TITLE
[Alerting v2] [Rule form] provide services via context

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_create_rule.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_create_rule.tsx
@@ -7,17 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { Suspense, useEffect, useRef, useState, useMemo } from 'react';
+import { from } from 'rxjs';
 import type { AggregateQuery } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
+import { EuiLoadingSpinner } from '@elastic/eui';
 import type { DiscoverAppMenuItemType, DiscoverAppMenuPopoverItem } from '@kbn/discover-utils';
 import { AppMenuActionId } from '@kbn/discover-utils';
-import { DynamicRuleFormFlyout } from '@kbn/alerting-v2-rule-form';
 import { ES_QUERY_ID } from '@kbn/rule-data-utils';
 import type { DiscoverStateContainer } from '../../../state_management/discover_state';
+import { createTabAppStateObservable } from '../../../state_management/utils/create_tab_app_state_observable';
 import type { AppMenuDiscoverParams } from './types';
 import type { DiscoverServices } from '../../../../../build_services';
 import { CreateAlertFlyout, getManageRulesUrl, getTimeField } from './get_alerts';
+
+// Lazy load to avoid Jest module resolution issues with Monaco dependencies
+const DynamicRuleFormFlyout = React.lazy(() =>
+  import('@kbn/alerting-v2-rule-form').then((m) => ({ default: m.DynamicRuleFormFlyout }))
+);
 
 export function CreateESQLRuleFlyout({
   services,
@@ -33,7 +40,7 @@ export function CreateESQLRuleFlyout({
     (stateContainer.getCurrentTab().appState.query as AggregateQuery)?.esql || ''
   );
 
-  const { http, data, dataViews, notifications, history } = services;
+  const { http, data, dataViews, notifications, history, core } = services;
 
   // Use a ref to avoid stale closure issues with onClose
   const onCloseRef = useRef(onClose);
@@ -43,7 +50,17 @@ export function CreateESQLRuleFlyout({
   const initialPathnameRef = useRef(history.location.pathname);
 
   // Create the app state observable once and memoize it
-  const appState$ = useMemo(() => stateContainer.createAppStateObservable(), [stateContainer]);
+  // Note: We create this manually instead of using ExtendedDiscoverStateContainer
+  // because we receive a DiscoverStateContainer from the top nav
+  const appState$ = useMemo(
+    () =>
+      createTabAppStateObservable({
+        tabId: stateContainer.getCurrentTab().id,
+        internalState$: from(stateContainer.internalState),
+        getState: stateContainer.internalState.getState,
+      }),
+    [stateContainer]
+  );
 
   useEffect(() => {
     const querySubscription = appState$.subscribe((appState) => {
@@ -53,7 +70,7 @@ export function CreateESQLRuleFlyout({
       }
     });
 
-    // Listen for route changes to close the flyout
+    // Listen for route changes within Discover to close the flyout
     // Only close on actual navigation (pathname change), not query param changes
     const unlisten = history.listen((location) => {
       if (location.pathname !== initialPathnameRef.current) {
@@ -61,23 +78,34 @@ export function CreateESQLRuleFlyout({
       }
     });
 
+    // Listen for app changes (navigating away from Discover entirely)
+    const appChangeSubscription = core.application.currentAppId$.subscribe((appId) => {
+      // If the app changes to something other than Discover, close the flyout
+      if (appId && appId !== 'discover') {
+        onCloseRef.current();
+      }
+    });
+
     return () => {
       querySubscription.unsubscribe();
       unlisten();
+      appChangeSubscription.unsubscribe();
     };
-  }, [appState$, history]);
+  }, [appState$, history, core.application.currentAppId$]);
 
   return (
-    <DynamicRuleFormFlyout
-      services={{
-        http,
-        data,
-        dataViews,
-        notifications,
-      }}
-      query={query}
-      onClose={onClose}
-    />
+    <Suspense fallback={<EuiLoadingSpinner size="l" />}>
+      <DynamicRuleFormFlyout
+        services={{
+          http,
+          data,
+          dataViews,
+          notifications,
+        }}
+        query={query}
+        onClose={onClose}
+      />
+    </Suspense>
   );
 }
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/__stories__/rule_form_flyout.stories.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/__stories__/rule_form_flyout.stories.tsx
@@ -58,6 +58,7 @@ const mockFormServices: RuleFormServices = {
   http: mockServices.http,
   data: mockServices.data,
   dataViews: mockServices.dataViews,
+  notifications: mockServices.notifications,
 };
 
 // =============================================================================

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
@@ -6,14 +6,12 @@
  */
 
 import React, { useMemo } from 'react';
-import type { HttpStart, NotificationsStart } from '@kbn/core/public';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { RuleFormFlyout, RULE_FORM_ID } from './rule_form_flyout';
 import { DynamicRuleForm } from '../form/dynamic_rule_form';
 import { useCreateRule } from '../form/hooks/use_create_rule';
 import type { FormValues } from '../form/types';
+import type { RuleFormServices } from '../form/contexts';
 
 export interface DynamicRuleFormFlyoutProps {
   /** Whether to use push flyout or overlay */
@@ -23,12 +21,7 @@ export interface DynamicRuleFormFlyoutProps {
   /** The query that drives form values - changes will sync to form state */
   query: string;
   /** Required services */
-  services: {
-    http: HttpStart;
-    data: DataPublicPluginStart;
-    dataViews: DataViewsPublicPluginStart;
-    notifications: NotificationsStart;
-  };
+  services: RuleFormServices;
 }
 
 /**
@@ -45,7 +38,7 @@ const DynamicRuleFormFlyoutInner: React.FC<DynamicRuleFormFlyoutProps> = ({
   query,
   services,
 }) => {
-  const { http, notifications, data, dataViews } = services;
+  const { http, notifications } = services;
 
   const { createRule, isLoading } = useCreateRule({
     http,
@@ -63,7 +56,7 @@ const DynamicRuleFormFlyoutInner: React.FC<DynamicRuleFormFlyoutProps> = ({
         formId={RULE_FORM_ID}
         onSubmit={handleSubmit}
         query={query}
-        services={{ http, data, dataViews }}
+        services={services}
       />
     </RuleFormFlyout>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/standalone_rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/standalone_rule_form_flyout.tsx
@@ -6,14 +6,12 @@
  */
 
 import React, { useMemo } from 'react';
-import type { HttpStart, NotificationsStart } from '@kbn/core/public';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { RuleFormFlyout, RULE_FORM_ID } from './rule_form_flyout';
 import { StandaloneRuleForm } from '../form/standalone_rule_form';
 import { useCreateRule } from '../form/hooks/use_create_rule';
 import type { FormValues } from '../form/types';
+import type { RuleFormServices } from '../form/contexts';
 
 export interface StandaloneRuleFormFlyoutProps {
   /** Whether to use push flyout or overlay */
@@ -23,12 +21,7 @@ export interface StandaloneRuleFormFlyoutProps {
   /** Initial query for the rule (only used on mount) */
   query: string;
   /** Required services */
-  services: {
-    http: HttpStart;
-    data: DataPublicPluginStart;
-    dataViews: DataViewsPublicPluginStart;
-    notifications: NotificationsStart;
-  };
+  services: RuleFormServices;
 }
 
 /**
@@ -45,7 +38,7 @@ const StandaloneRuleFormFlyoutInner: React.FC<StandaloneRuleFormFlyoutProps> = (
   query,
   services,
 }) => {
-  const { http, notifications, data, dataViews } = services;
+  const { http, notifications } = services;
 
   const { createRule, isLoading } = useCreateRule({
     http,
@@ -63,7 +56,7 @@ const StandaloneRuleFormFlyoutInner: React.FC<StandaloneRuleFormFlyoutProps> = (
         formId={RULE_FORM_ID}
         onSubmit={handleSubmit}
         query={query}
-        services={{ http, data, dataViews }}
+        services={services}
       />
     </RuleFormFlyout>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  RuleFormServicesProvider,
+  useRuleFormServices,
+  type RuleFormServices,
+} from './rule_form_services_context';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_services_context.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_services_context.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PropsWithChildren } from 'react';
+import React, { createContext, useContext } from 'react';
+import type { HttpStart, NotificationsStart } from '@kbn/core/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+
+export interface RuleFormServices {
+  http: HttpStart;
+  data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
+  notifications: NotificationsStart;
+}
+
+const RuleFormServicesContext = createContext<RuleFormServices | undefined>(undefined);
+
+export const RuleFormServicesProvider: React.FC<
+  PropsWithChildren<{ services: RuleFormServices }>
+> = ({ children, services }) => (
+  <RuleFormServicesContext.Provider value={services}>{children}</RuleFormServicesContext.Provider>
+);
+
+export const useRuleFormServices = (): RuleFormServices => {
+  const context = useContext(RuleFormServicesContext);
+  if (!context) {
+    throw new Error('useRuleFormServices must be used within RuleFormServicesProvider');
+  }
+  return context;
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_execution_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_execution_field_group.tsx
@@ -7,24 +7,13 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import type { HttpStart } from '@kbn/core/public';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { FieldGroup } from './field_group';
 import { ScheduleField } from '../fields/schedule_field';
 import { TimeFieldSelect } from '../fields/time_field_select';
 import { LookbackWindowField } from '../fields/lookback_window_field';
 import { GroupFieldSelect } from '../fields/group_field_select';
 
-interface RuleExecutionFieldGroupProps {
-  services: {
-    http: HttpStart;
-    data: DataPublicPluginStart;
-    dataViews: DataViewsPublicPluginStart;
-  };
-}
-
-export const RuleExecutionFieldGroup: React.FC<RuleExecutionFieldGroupProps> = ({ services }) => {
+export const RuleExecutionFieldGroup: React.FC = () => {
   return (
     <FieldGroup
       title={i18n.translate('xpack.alertingV2.ruleForm.ruleExecution', {
@@ -32,9 +21,9 @@ export const RuleExecutionFieldGroup: React.FC<RuleExecutionFieldGroupProps> = (
       })}
     >
       <ScheduleField />
-      <TimeFieldSelect services={services} />
+      <TimeFieldSelect />
       <LookbackWindowField />
-      <GroupFieldSelect services={services} />
+      <GroupFieldSelect />
     </FieldGroup>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.test.tsx
@@ -8,7 +8,10 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { createFormWrapper } from '../../test_utils';
 import { GroupFieldSelect } from './group_field_select';
 import { useQueryColumns } from '../hooks/use_query_columns';
@@ -17,9 +20,12 @@ jest.mock('../hooks/use_query_columns');
 
 const mockUseQueryColumns = jest.mocked(useQueryColumns);
 
-const createMockServices = () => ({
+const mockServices = {
+  http: httpServiceMock.createStartContract(),
   data: dataPluginMock.createStartContract(),
-});
+  dataViews: dataViewPluginMocks.createStartContract(),
+  notifications: notificationServiceMock.createStartContract(),
+};
 
 describe('GroupFieldSelect', () => {
   beforeEach(() => {
@@ -39,14 +45,9 @@ describe('GroupFieldSelect', () => {
   const defaultQuery = 'FROM logs-* | STATS count() BY host.name';
 
   it('renders with label', () => {
-    const Wrapper = createFormWrapper({ evaluation: { query: { base: defaultQuery } } });
-    const services = createMockServices();
-
-    render(
-      <Wrapper>
-        <GroupFieldSelect services={services} />
-      </Wrapper>
-    );
+    render(<GroupFieldSelect />, {
+      wrapper: createFormWrapper({ evaluation: { query: { base: defaultQuery } } }, mockServices),
+    });
 
     expect(screen.getByText('Group Fields')).toBeInTheDocument();
   });
@@ -66,14 +67,9 @@ describe('GroupFieldSelect', () => {
       fetchStatus: 'idle',
     } as any);
 
-    const Wrapper = createFormWrapper({ evaluation: { query: { base: defaultQuery } } });
-    const services = createMockServices();
-
-    render(
-      <Wrapper>
-        <GroupFieldSelect services={services} />
-      </Wrapper>
-    );
+    render(<GroupFieldSelect />, {
+      wrapper: createFormWrapper({ evaluation: { query: { base: defaultQuery } } }, mockServices),
+    });
 
     // Click to open the combo box
     const comboBox = screen.getByRole('combobox');
@@ -101,37 +97,33 @@ describe('GroupFieldSelect', () => {
       fetchStatus: 'idle',
     } as any);
 
-    const Wrapper = createFormWrapper({
-      evaluation: { query: { base: defaultQuery } },
-      grouping: { fields: ['host.name'] },
+    render(<GroupFieldSelect />, {
+      wrapper: createFormWrapper(
+        {
+          evaluation: { query: { base: defaultQuery } },
+          grouping: { fields: ['host.name'] },
+        },
+        mockServices
+      ),
     });
-    const services = createMockServices();
-
-    render(
-      <Wrapper>
-        <GroupFieldSelect services={services} />
-      </Wrapper>
-    );
 
     // Check that the selected value is shown as a pill/badge
     expect(screen.getByText('host.name')).toBeInTheDocument();
   });
 
   it('calls useQueryColumns with query and onSuccess from form', () => {
-    const Wrapper = createFormWrapper({
-      evaluation: {
-        query: {
-          base: 'FROM metrics-* | STATS avg(value) BY region',
+    render(<GroupFieldSelect />, {
+      wrapper: createFormWrapper(
+        {
+          evaluation: {
+            query: {
+              base: 'FROM metrics-* | STATS avg(value) BY region',
+            },
+          },
         },
-      },
+        mockServices
+      ),
     });
-    const services = createMockServices();
-
-    render(
-      <Wrapper>
-        <GroupFieldSelect services={services} />
-      </Wrapper>
-    );
 
     expect(mockUseQueryColumns).toHaveBeenCalledWith({
       query: 'FROM metrics-* | STATS avg(value) BY region',
@@ -155,14 +147,9 @@ describe('GroupFieldSelect', () => {
       fetchStatus: 'idle',
     } as any);
 
-    const Wrapper = createFormWrapper({ evaluation: { query: { base: defaultQuery } } });
-    const services = createMockServices();
-
-    render(
-      <Wrapper>
-        <GroupFieldSelect services={services} />
-      </Wrapper>
-    );
+    render(<GroupFieldSelect />, {
+      wrapper: createFormWrapper({ evaluation: { query: { base: defaultQuery } } }, mockServices),
+    });
 
     // Click to open the combo box
     const comboBox = screen.getByRole('combobox');
@@ -195,14 +182,9 @@ describe('GroupFieldSelect', () => {
       fetchStatus: 'idle',
     } as any);
 
-    const Wrapper = createFormWrapper({ evaluation: { query: { base: defaultQuery } } });
-    const services = createMockServices();
-
-    render(
-      <Wrapper>
-        <GroupFieldSelect services={services} />
-      </Wrapper>
-    );
+    render(<GroupFieldSelect />, {
+      wrapper: createFormWrapper({ evaluation: { query: { base: defaultQuery } } }, mockServices),
+    });
 
     // Component should still render, just with no options
     expect(screen.getByRole('combobox')).toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.tsx
@@ -9,17 +9,12 @@ import React, { useCallback, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiComboBox, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { FormValues } from '../types';
 import { useQueryColumns, type QueryColumn } from '../hooks/use_query_columns';
+import { useRuleFormServices } from '../contexts';
 
-interface GroupBySelectProps {
-  services: {
-    data: DataPublicPluginStart;
-  };
-}
-
-export const GroupFieldSelect: React.FC<GroupBySelectProps> = ({ services }) => {
+export const GroupFieldSelect: React.FC = () => {
+  const { data } = useRuleFormServices();
   const { control, setValue, getValues, watch } = useFormContext<FormValues>();
   const query = watch('evaluation.query.base');
   const groupByRowId = 'ruleV2FormGroupByField';
@@ -41,7 +36,7 @@ export const GroupFieldSelect: React.FC<GroupBySelectProps> = ({ services }) => 
 
   const { data: columns, isLoading } = useQueryColumns({
     query,
-    search: services.data.search.search,
+    search: data.search.search,
     onSuccess: handleColumnsSuccess,
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.test.tsx
@@ -9,7 +9,9 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { TimeFieldSelect } from './time_field_select';
 import { createFormWrapper } from '../../test_utils';
 import * as useDataFieldsModule from '../hooks/use_data_fields';
@@ -18,13 +20,17 @@ jest.mock('../hooks/use_data_fields');
 
 const mockHttp = httpServiceMock.createStartContract();
 const mockDataViews = dataViewPluginMocks.createStartContract();
+const mockData = dataPluginMock.createStartContract();
+const mockNotifications = notificationServiceMock.createStartContract();
+
+const mockServices = {
+  http: mockHttp,
+  data: mockData,
+  dataViews: mockDataViews,
+  notifications: mockNotifications,
+};
 
 describe('TimeFieldSelect', () => {
-  const defaultServices = {
-    http: mockHttp,
-    dataViews: mockDataViews,
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(useDataFieldsModule.useDataFields).mockReturnValue({
@@ -34,19 +40,19 @@ describe('TimeFieldSelect', () => {
   });
 
   it('renders the time field label', () => {
-    render(<TimeFieldSelect services={defaultServices} />, { wrapper: createFormWrapper() });
+    render(<TimeFieldSelect />, { wrapper: createFormWrapper({}, mockServices) });
 
     expect(screen.getByText('Time Field')).toBeInTheDocument();
   });
 
   it('renders a select input', () => {
-    render(<TimeFieldSelect services={defaultServices} />, { wrapper: createFormWrapper() });
+    render(<TimeFieldSelect />, { wrapper: createFormWrapper({}, mockServices) });
 
     expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
   it('renders aria-label for accessibility', () => {
-    render(<TimeFieldSelect services={defaultServices} />, { wrapper: createFormWrapper() });
+    render(<TimeFieldSelect />, { wrapper: createFormWrapper({}, mockServices) });
 
     expect(screen.getByLabelText('Select time field for rule execution')).toBeInTheDocument();
   });
@@ -57,7 +63,7 @@ describe('TimeFieldSelect', () => {
       isLoading: true,
     } as unknown as ReturnType<typeof useDataFieldsModule.useDataFields>);
 
-    render(<TimeFieldSelect services={defaultServices} />, { wrapper: createFormWrapper() });
+    render(<TimeFieldSelect />, { wrapper: createFormWrapper({}, mockServices) });
 
     // EuiSelect shows loading spinner, check the select is in the document
     expect(screen.getByRole('combobox')).toBeInTheDocument();
@@ -72,10 +78,13 @@ describe('TimeFieldSelect', () => {
       isLoading: false,
     } as unknown as ReturnType<typeof useDataFieldsModule.useDataFields>);
 
-    render(<TimeFieldSelect services={defaultServices} />, {
-      wrapper: createFormWrapper({
-        timeField: '@timestamp',
-      }),
+    render(<TimeFieldSelect />, {
+      wrapper: createFormWrapper(
+        {
+          timeField: '@timestamp',
+        },
+        mockServices
+      ),
     });
 
     expect(screen.getByRole('combobox')).toHaveValue('@timestamp');
@@ -93,10 +102,13 @@ describe('TimeFieldSelect', () => {
       isLoading: false,
     } as unknown as ReturnType<typeof useDataFieldsModule.useDataFields>);
 
-    render(<TimeFieldSelect services={defaultServices} />, {
-      wrapper: createFormWrapper({
-        timeField: '@timestamp',
-      }),
+    render(<TimeFieldSelect />, {
+      wrapper: createFormWrapper(
+        {
+          timeField: '@timestamp',
+        },
+        mockServices
+      ),
     });
 
     await waitFor(() => {
@@ -110,14 +122,17 @@ describe('TimeFieldSelect', () => {
   });
 
   it('passes query to useDataFields hook', () => {
-    render(<TimeFieldSelect services={defaultServices} />, {
-      wrapper: createFormWrapper({
-        evaluation: {
-          query: {
-            base: 'FROM logs-*',
+    render(<TimeFieldSelect />, {
+      wrapper: createFormWrapper(
+        {
+          evaluation: {
+            query: {
+              base: 'FROM logs-*',
+            },
           },
         },
-      }),
+        mockServices
+      ),
     });
 
     expect(useDataFieldsModule.useDataFields).toHaveBeenCalledWith(

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
@@ -6,26 +6,19 @@
  */
 
 import React, { useMemo, useCallback } from 'react';
-import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { DataViewFieldMap } from '@kbn/data-views-plugin/common';
-import type { HttpStart } from '@kbn/core/public';
 import { Controller, useWatch, useFormContext } from 'react-hook-form';
 import { EuiSelect, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { FormValues } from '../types';
 import { firstFieldOption, getTimeFieldOptions } from '../../flyout/utils';
 import { useDataFields } from '../hooks/use_data_fields';
+import { useRuleFormServices } from '../contexts';
 
 const PREFERRED_TIME_FIELD = '@timestamp';
 
-interface TimeFieldSelectProps {
-  services: {
-    http: HttpStart;
-    dataViews: DataViewsPublicPluginStart;
-  };
-}
-
-export const TimeFieldSelect: React.FC<TimeFieldSelectProps> = ({ services }) => {
+export const TimeFieldSelect: React.FC = () => {
+  const { http, dataViews } = useRuleFormServices();
   const { control, setValue, getValues } = useFormContext<FormValues>();
   const query = useWatch({ name: 'evaluation.query.base', control });
 
@@ -52,8 +45,8 @@ export const TimeFieldSelect: React.FC<TimeFieldSelectProps> = ({ services }) =>
 
   const { data, isLoading } = useDataFields({
     query,
-    http: services.http,
-    dataViews: services.dataViews,
+    http,
+    dataViews,
     onSuccess: handleAutoSelect,
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
@@ -35,8 +35,8 @@ export const StandaloneRuleForm: React.FC<StandaloneRuleFormProps> = (props) => 
   </Suspense>
 );
 
-// Export types
 export type { FormValues } from './types';
 export type { DynamicRuleFormProps } from './dynamic_rule_form';
 export type { StandaloneRuleFormProps } from './standalone_rule_form';
-export type { RuleFormServices } from './rule_form';
+export type { RuleFormServices } from './contexts';
+export { RuleFormServicesProvider, useRuleFormServices } from './contexts';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -8,19 +8,13 @@
 import React from 'react';
 import { EuiForm, EuiSpacer } from '@elastic/eui';
 import { useFormContext } from 'react-hook-form';
-import type { HttpStart } from '@kbn/core/public';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { FormValues } from './types';
 import { RuleExecutionFieldGroup } from './field_groups/rule_execution_field_group';
 import { RuleDetailsFieldGroup } from './field_groups/rule_details_field_group';
 import { ErrorCallOut } from '../flyout/error_callout';
+import { RuleFormServicesProvider, type RuleFormServices } from './contexts';
 
-export interface RuleFormServices {
-  http: HttpStart;
-  data: DataPublicPluginStart;
-  dataViews: DataViewsPublicPluginStart;
-}
+export type { RuleFormServices } from './contexts';
 
 export interface RuleFormProps {
   /** Form ID for submission */
@@ -37,16 +31,20 @@ export interface RuleFormProps {
  * This component renders form fields and expects a FormProvider context to exist.
  * It does not manage form state - that responsibility belongs to the parent component
  * (DynamicRuleForm or StandaloneRuleForm).
+ *
+ * Services are provided via RuleFormServicesProvider context, eliminating prop drilling.
  */
 export const RuleForm: React.FC<RuleFormProps> = ({ formId, services, onSubmit }) => {
   const { handleSubmit } = useFormContext<FormValues>();
 
   return (
-    <EuiForm id={formId} component="form" onSubmit={handleSubmit(onSubmit)}>
-      <ErrorCallOut />
-      <RuleDetailsFieldGroup />
-      <EuiSpacer size="m" />
-      <RuleExecutionFieldGroup services={services} />
-    </EuiForm>
+    <RuleFormServicesProvider services={services}>
+      <EuiForm id={formId} component="form" onSubmit={handleSubmit(onSubmit)}>
+        <ErrorCallOut />
+        <RuleDetailsFieldGroup />
+        <EuiSpacer size="m" />
+        <RuleExecutionFieldGroup />
+      </EuiForm>
+    </RuleFormServicesProvider>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -11,6 +11,9 @@ export { DynamicRuleFormFlyout, StandaloneRuleFormFlyout, RULE_FORM_ID } from '.
 // Form components (lazy loaded) - for embedding in custom forms
 export { DynamicRuleForm, StandaloneRuleForm } from './form';
 
+// Context - for consumers who need custom integrations
+export { RuleFormServicesProvider, useRuleFormServices } from './form';
+
 // Types
 export type {
   FormValues,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/test_utils.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/test_utils.tsx
@@ -8,7 +8,12 @@
 import React from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import type { FormValues } from './form/types';
+import { RuleFormServicesProvider, type RuleFormServices } from './form/contexts';
 
 /**
  * Creates a QueryClient configured for testing (no retries, silent logger).
@@ -25,6 +30,16 @@ export const createTestQueryClient = () =>
       error: () => {},
     },
   });
+
+/**
+ * Creates mock services for testing.
+ */
+export const createMockServices = (): RuleFormServices => ({
+  http: httpServiceMock.createStartContract(),
+  data: dataPluginMock.createStartContract(),
+  dataViews: dataViewPluginMocks.createStartContract(),
+  notifications: notificationServiceMock.createStartContract(),
+});
 
 /**
  * Creates a wrapper component with QueryClientProvider for testing hooks.
@@ -56,10 +71,14 @@ export const defaultTestFormValues: FormValues = {
 };
 
 /**
- * Creates a wrapper component with QueryClientProvider and FormProvider for testing components.
- * Use this for component tests that need both React Query and react-hook-form context.
+ * Creates a wrapper component with QueryClientProvider, FormProvider, and RuleFormServicesProvider
+ * for testing components. Use this for component tests that need React Query, react-hook-form,
+ * and services context.
  */
-export const createFormWrapper = (defaultValues: Partial<FormValues> = {}) => {
+export const createFormWrapper = (
+  defaultValues: Partial<FormValues> = {},
+  services: RuleFormServices = createMockServices()
+) => {
   const queryClient = createTestQueryClient();
 
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -72,7 +91,9 @@ export const createFormWrapper = (defaultValues: Partial<FormValues> = {}) => {
 
     return (
       <QueryClientProvider client={queryClient}>
-        <FormProvider {...form}>{children}</FormProvider>
+        <FormProvider {...form}>
+          <RuleFormServicesProvider services={services}>{children}</RuleFormServicesProvider>
+        </FormProvider>
       </QueryClientProvider>
     );
   };


### PR DESCRIPTION
## Summary

This PR refactors the `@kbn/alerting-v2-rule-form` package to provide services via React Context instead of prop drilling. This improves code maintainability by eliminating the need to pass services through multiple component layers.

### Changes

#### New Context System

Created a dedicated services context for the rule form:

- **`RuleFormServicesProvider`** - Context provider component that wraps the form
- **`useRuleFormServices()`** - Hook for consuming services in child components
- **`RuleFormServices`** - Unified type interface for required services (`http`, `data`, `dataViews`, `notifications`)

#### Component Simplification

Components no longer need services passed as props:

```tsx
// Before
<TimeFieldSelect services={services} />
<GroupFieldSelect services={services} />

// After  
<TimeFieldSelect />
<GroupFieldSelect />
```

The `RuleExecutionFieldGroup` component is now simplified as it no longer needs to forward services to its children.

#### Discover Integration Fix

Fixed a runtime error in the Discover → Create Rule integration where `stateContainer.createAppStateObservable()` was being called on `DiscoverStateContainer`, but this method only exists on `ExtendedDiscoverStateContainer`. The fix creates the observable directly using `createTabAppStateObservable()`, matching the pattern used elsewhere in Discover.

Also added:
- Lazy loading for `DynamicRuleFormFlyout` to avoid Jest module resolution issues with Monaco dependencies
- App change subscription to properly close the flyout when navigating away from Discover

#### Type Unification

Consolidated the `RuleFormServices` type definition into a single location (`form/contexts/rule_form_services_context.tsx`) and updated all consumers to use this unified type.

#### Test Utilities

Updated test utilities to support the new context pattern:
- Added `createMockServices()` helper function
- Updated `createFormWrapper()` to include `RuleFormServicesProvider`
- All existing tests updated to use the new pattern

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Low Risk**: This is an internal refactor that doesn't change external APIs. The `RuleFormServices` type and exports remain backward compatible.
- **Low Risk**: The Discover integration fix addresses a runtime error that would have been caught during testing.
