### PR TITLE
[ES|QL] Do not display the No suggestions popover

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -487,7 +487,7 @@ const ESQLEditorInternal = function ESQLEditor({
         suppressSuggestionsRef.current = false;
         return;
       }
-      editorRef.current?.trigger(undefined, 'editor.action.triggerSuggest', {});
+      editorRef.current?.trigger(undefined, 'editor.action.triggerSuggest', { auto: true });
     }, 0);
   }, []);
 


### PR DESCRIPTION
## Summary

Sometimes when you focus on the editor and there is no suggestions you see an ugly "No suggestions" popover. 

<img width="2420" height="1668" alt="image" src="https://github.com/user-attachments/assets/96644756-e5b7-44be-8943-73a137832e2b" />

This PR is solving this. With the auto option we tell monaco that this is a programmatic/automatic trigger. When auto is true and there are no completions, Monaco simply does nothing — no "No suggestions." popup.


