### PR TITLE
[Discover] TanStack Virtual POC grid for A-B performance testing

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -29,6 +29,8 @@ export {
   getRemoteClustersFromESQLQuery,
   convertTimeseriesCommandToFrom,
   hasOnlySourceCommand,
+  getMultiplierFromESQLQuery,
+  MAX_MULTIPLIED_ROWS,
 } from './utils/query_parsing_helpers';
 export { getIndexPatternFromESQLQuery } from './utils/get_index_pattern_from_query';
 export { queryCannotBeSampled } from './utils/query_cannot_be_sampled';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -32,6 +32,7 @@ import {
   hasLimitBeforeAggregate,
   missingSortBeforeLimit,
   hasOnlySourceCommand,
+  getMultiplierFromESQLQuery,
 } from './query_parsing_helpers';
 
 describe('esql query helpers', () => {
@@ -1093,6 +1094,47 @@ describe('esql query helpers', () => {
           'PROMQL index = index1 step="5m" start=?_tstart end=?_tend avg(bytes) '
         )
       ).toBe(false);
+    });
+  });
+
+  describe('getMultiplierFromESQLQuery', () => {
+    it('should return 1 for empty query', () => {
+      expect(getMultiplierFromESQLQuery('')).toBe(1);
+    });
+
+    it('should return 1 when no multiplier comment exists', () => {
+      expect(getMultiplierFromESQLQuery('FROM logs-* | LIMIT 10')).toBe(1);
+    });
+
+    it('should parse single-line comment // 1000x', () => {
+      expect(getMultiplierFromESQLQuery('FROM logs-* | LIMIT 10 // 1000x')).toBe(1000);
+    });
+
+    it('should parse block comment /* 500x */', () => {
+      expect(getMultiplierFromESQLQuery('FROM logs-* /* 500x */ | LIMIT 10')).toBe(500);
+    });
+
+    it('should be case-insensitive', () => {
+      expect(getMultiplierFromESQLQuery('FROM logs-* // 100X')).toBe(100);
+    });
+
+    it('should handle whitespace around the number', () => {
+      expect(getMultiplierFromESQLQuery('FROM logs-* //  50 x')).toBe(50);
+    });
+
+    it('should return 1 for non-numeric multiplier', () => {
+      expect(getMultiplierFromESQLQuery('FROM logs-* // abcx')).toBe(1);
+    });
+
+    it('should return 1 for zero multiplier', () => {
+      expect(getMultiplierFromESQLQuery('FROM logs-* // 0x')).toBe(1);
+    });
+
+    it('should parse multiplier in multiline query', () => {
+      const query = `FROM logs-*
+        | WHERE status > 200
+        | LIMIT 10 // 2000x`;
+      expect(getMultiplierFromESQLQuery(query)).toBe(2000);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -33,7 +33,7 @@ import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { monaco } from '@kbn/monaco';
 
 const DEFAULT_ESQL_LIMIT = 1000;
-const MAX_MULTIPLIED_ROWS = 100_000;
+const MAX_MULTIPLIED_ROWS = 1_000_000;
 
 /**
  * Parses an ES|QL query for a row-multiplier comment such as `// 1000x` or `/* 500x *\/`.

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -33,6 +33,23 @@ import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { monaco } from '@kbn/monaco';
 
 const DEFAULT_ESQL_LIMIT = 1000;
+const MAX_MULTIPLIED_ROWS = 100_000;
+
+/**
+ * Parses an ES|QL query for a row-multiplier comment such as `// 1000x` or `/* 500x *\/`.
+ * When present the caller can clone result rows client-side to simulate a larger dataset.
+ * Returns 1 (no-op) when no valid multiplier comment is found.
+ */
+export function getMultiplierFromESQLQuery(esql: string): number {
+  if (!esql) return 1;
+  const match = esql.match(/(?:\/\/|\/\*)\s*(\d+)\s*x\b/i);
+  if (!match) return 1;
+  const value = parseInt(match[1], 10);
+  if (!Number.isFinite(value) || value <= 0) return 1;
+  return value;
+}
+
+export { MAX_MULTIPLIED_ROWS };
 
 export function getRemoteClustersFromESQLQuery(esql?: string): string[] | undefined {
   if (!esql) return undefined;

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -50,7 +50,7 @@ import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { DiscoverGridSettings } from '@kbn/saved-search-plugin/common';
 import type { DocViewerApi, DocViewerRestorableState } from '@kbn/unified-doc-viewer';
 import useLatest from 'react-use/lib/useLatest';
-import { isOfAggregateQueryType } from '@kbn/es-query';
+import { isOfAggregateQueryType, type AggregateQuery } from '@kbn/es-query';
 import { DISCOVER_CELL_ACTIONS_TRIGGER_ID } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { DiscoverGrid } from '../../../../components/discover_grid';
 import { getDefaultRowsPerPage } from '../../../../../common/constants';
@@ -535,6 +535,13 @@ function DiscoverDocumentsComponent({
     viewModeToggle,
   ]);
 
+  const handleOpenInNewTab = useCallback(
+    (params: { appState?: { query?: AggregateQuery } }) => {
+      dispatch(internalStateActions.openInNewTab({ appState: params.appState }));
+    },
+    [dispatch]
+  );
+
   if (isDataViewLoading || (isEmptyDataResult && isDataLoading)) {
     return (
       // class is used in tests
@@ -609,6 +616,7 @@ function DiscoverDocumentsComponent({
             dataGridDensityState={density}
             onUpdateDataGridDensity={onUpdateDensity}
             onUpdateESQLQuery={onUpdateESQLQuery}
+            onOpenInNewTab={handleOpenInNewTab}
             query={query}
             cellActionsTriggerId={DISCOVER_CELL_ACTIONS_TRIGGER_ID}
             cellActionsMetadata={cellActionsMetadata}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -71,6 +71,7 @@ import {
 } from '../../state_management/redux';
 import { DiscoverHistogramLayout } from './discover_histogram_layout';
 import type { DiscoverLayoutRestorableState } from './discover_layout_restorable_state';
+import { TabComment } from './tab_comment';
 import { useScopedServices } from '../../../../components/scoped_services_provider';
 import { isCascadedDocumentsVisible } from './cascaded_documents';
 
@@ -513,6 +514,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
             }
             mainPanel={
               <div css={styles.dscPageContentWrapper}>
+                <TabComment />
                 {resultState === 'none' ? (
                   <>
                     {React.isValidElement(panelsToggle) ? (

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/tab_comment.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/tab_comment.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useRef } from 'react';
+import { EuiTextArea, EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import {
+  internalStateActions,
+  useInternalStateDispatch,
+  useCurrentTabAction,
+  useCurrentTabSelector,
+} from '../../state_management/redux';
+
+const containerStyles = css({
+  padding: '8px',
+  marginBottom: '8px',
+  borderBottom: '1px solid var(--euiColorLightShade)',
+  flexShrink: 0,
+});
+
+const textAreaStyles = css({
+  resize: 'vertical',
+  minHeight: 40,
+  maxHeight: 200,
+  fontFamily: 'inherit',
+  fontSize: 13,
+});
+
+export const TabComment: React.FC = React.memo(() => {
+  const comment = useCurrentTabSelector((tab) => tab.uiState.comment);
+  const dispatch = useInternalStateDispatch();
+  const setCommentUiState = useCurrentTabAction(internalStateActions.setCommentUiState);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value;
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        dispatch(setCommentUiState({ comment: value }));
+      }, 300);
+    },
+    [dispatch, setCommentUiState]
+  );
+
+  const onRemove = useCallback(() => {
+    clearTimeout(debounceRef.current);
+    dispatch(setCommentUiState({ comment: undefined }));
+  }, [dispatch, setCommentUiState]);
+
+  if (typeof comment !== 'string') return null;
+
+  return (
+    <EuiFlexGroup
+      gutterSize="xs"
+      alignItems="flexStart"
+      responsive={false}
+      css={containerStyles}
+    >
+      <EuiFlexItem>
+        <EuiTextArea
+          compressed
+          fullWidth
+          rows={2}
+          defaultValue={comment}
+          onChange={onChange}
+          placeholder={i18n.translate('discover.tabs.commentPlaceholder', {
+            defaultMessage: 'Add a comment for this tab…',
+          })}
+          css={textAreaStyles}
+          data-test-subj="discoverTabComment"
+          aria-label={i18n.translate('discover.tabs.commentAriaLabel', {
+            defaultMessage: 'Tab comment',
+          })}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip
+          content={i18n.translate('discover.tabs.removeCommentTooltip', {
+            defaultMessage: 'Remove comment',
+          })}
+        >
+          <EuiButtonIcon
+            iconType="cross"
+            color="subdued"
+            size="xs"
+            onClick={onRemove}
+            aria-label={i18n.translate('discover.tabs.removeCommentAriaLabel', {
+              defaultMessage: 'Remove comment',
+            })}
+            data-test-subj="discoverTabCommentRemove"
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+});

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_app_menu_data.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_app_menu_data.ts
@@ -57,6 +57,7 @@ export const useAppMenuData = ({ currentDataView }: UseAppMenuDataParams): UseAp
   const transitionFromESQLToDataView = useCurrentTabAction(
     internalStateActions.transitionFromESQLToDataView
   );
+  const setCommentUiState = useCurrentTabAction(internalStateActions.setCommentUiState);
 
   const onResize: EuiResizeObserverProps['onResize'] = useCallback((dimensions) => {
     if (!dimensions) return;
@@ -68,20 +69,18 @@ export const useAppMenuData = ({ currentDataView }: UseAppMenuDataParams): UseAp
     NonNullable<UnifiedTabsProps['getAdditionalTabMenuItems']>
   >(
     (item) => {
-      if (!services.uiSettings.get(ENABLE_ESQL)) {
-        return [];
-      }
-
       const tab = allTabs.find((t) => t.id === item.id);
       const isCurrentTab = tab?.id === currentTabId;
+      const items: Array<{
+        'data-test-subj': string;
+        name: string;
+        label: string;
+        onClick: () => void;
+      }> = [];
 
-      if (!isCurrentTab || !currentDataView) {
-        return [];
-      }
-
-      if (isDataViewSource(tab.appState.dataSource)) {
-        return [
-          {
+      if (services.uiSettings.get(ENABLE_ESQL) && isCurrentTab && tab && currentDataView) {
+        if (isDataViewSource(tab.appState.dataSource)) {
+          items.push({
             'data-test-subj': 'unifiedTabs_tabMenuItem_switchToESQL',
             name: 'switchToESQL',
             label: i18n.translate('discover.localMenu.switchToESQLTitle', {
@@ -91,35 +90,52 @@ export const useAppMenuData = ({ currentDataView }: UseAppMenuDataParams): UseAp
               services.trackUiMetric?.(METRIC_TYPE.CLICK, `esql:try_btn_clicked`);
               dispatch(transitionFromDataViewToESQL({ dataView: currentDataView }));
             },
-          },
-        ];
+          });
+        } else {
+          items.push({
+            'data-test-subj': 'unifiedTabs_tabMenuItem_switchToClassic',
+            name: 'switchToClassic',
+            label: i18n.translate('discover.localMenu.switchToClassicTitle', {
+              defaultMessage: 'Switch to classic',
+            }),
+            onClick: () => {
+              services.trackUiMetric?.(METRIC_TYPE.CLICK, `esql:back_to_classic_clicked`);
+              const shouldShowESQLToDataViewTransitionModal =
+                !persistedDiscoverSession || unsavedTabIds.includes(tab.id);
+              if (
+                shouldShowESQLToDataViewTransitionModal &&
+                !services.storage.get(ESQL_TRANSITION_MODAL_KEY)
+              ) {
+                dispatch(internalStateActions.setIsESQLToDataViewTransitionModalVisible(true));
+              } else {
+                dispatch(transitionFromESQLToDataView({ dataViewId: currentDataView.id ?? '' }));
+              }
+            },
+          });
+        }
       }
 
-      return [
-        {
-          'data-test-subj': 'unifiedTabs_tabMenuItem_switchToClassic',
-          name: 'switchToClassic',
-          label: i18n.translate('discover.localMenu.switchToClassicTitle', {
-            defaultMessage: 'Switch to classic',
-          }),
+      if (isCurrentTab && tab) {
+        const hasComment = typeof tab.uiState.comment === 'string';
+        items.push({
+          'data-test-subj': hasComment
+            ? 'unifiedTabs_tabMenuItem_removeComment'
+            : 'unifiedTabs_tabMenuItem_addComment',
+          name: hasComment ? 'removeComment' : 'addComment',
+          label: hasComment
+            ? i18n.translate('discover.tabs.removeCommentMenuItem', {
+                defaultMessage: 'Remove comment',
+              })
+            : i18n.translate('discover.tabs.addCommentMenuItem', {
+                defaultMessage: 'Add comment',
+              }),
           onClick: () => {
-            services.trackUiMetric?.(METRIC_TYPE.CLICK, `esql:back_to_classic_clicked`);
-
-            // Determine if we should show the ES|QL to Data View transition modal
-            const shouldShowESQLToDataViewTransitionModal =
-              !persistedDiscoverSession || unsavedTabIds.includes(tab.id);
-
-            if (
-              shouldShowESQLToDataViewTransitionModal &&
-              !services.storage.get(ESQL_TRANSITION_MODAL_KEY)
-            ) {
-              dispatch(internalStateActions.setIsESQLToDataViewTransitionModalVisible(true));
-            } else {
-              dispatch(transitionFromESQLToDataView({ dataViewId: currentDataView.id ?? '' }));
-            }
+            dispatch(setCommentUiState({ comment: hasComment ? undefined : '' }));
           },
-        },
-      ];
+        });
+      }
+
+      return items;
     },
     [
       allTabs,
@@ -130,6 +146,7 @@ export const useAppMenuData = ({ currentDataView }: UseAppMenuDataParams): UseAp
       services,
       transitionFromDataViewToESQL,
       transitionFromESQLToDataView,
+      setCommentUiState,
       unsavedTabIds,
     ]
   );

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.test.ts
@@ -86,4 +86,53 @@ describe('fetchEsql', () => {
 
     expect(result.time).toEqual(absoluteTimeRange);
   });
+
+  it('clones rows when query contains a multiplier comment', async () => {
+    const hits = [
+      { _id: '1', foo: 'bar' },
+      { _id: '2', foo: 'baz' },
+    ] as unknown as EsHitRecord[];
+    const expressionsExecuteSpy = jest.spyOn(discoverServiceMock.expressions, 'execute');
+    expressionsExecuteSpy.mockReturnValueOnce({
+      cancel: jest.fn(),
+      getData: jest.fn(() =>
+        of({
+          result: {
+            columns: ['_id', 'foo'],
+            rows: hits,
+          },
+        })
+      ),
+    } as unknown as ExecutionContract);
+    const result = await fetchEsql({
+      ...fetchEsqlMockProps,
+      query: { esql: 'FROM * | LIMIT 2 // 3x' },
+    });
+    expect(result.records).toHaveLength(6);
+    expect(result.records.map((r) => r.id)).toEqual(['0', '1', '2', '3', '4', '5']);
+    expect(result.records[0].raw).toEqual(hits[0]);
+    expect(result.records[2].raw).toEqual(hits[0]);
+    expect(result.records[4].raw).toEqual(hits[0]);
+  });
+
+  it('does not clone rows when no multiplier comment is present', async () => {
+    const hits = [
+      { _id: '1', foo: 'bar' },
+      { _id: '2', foo: 'baz' },
+    ] as unknown as EsHitRecord[];
+    const expressionsExecuteSpy = jest.spyOn(discoverServiceMock.expressions, 'execute');
+    expressionsExecuteSpy.mockReturnValueOnce({
+      cancel: jest.fn(),
+      getData: jest.fn(() =>
+        of({
+          result: {
+            columns: ['_id', 'foo'],
+            rows: hits,
+          },
+        })
+      ),
+    } as unknown as ExecutionContract);
+    const result = await fetchEsql(fetchEsqlMockProps);
+    expect(result.records).toHaveLength(2);
+  });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
@@ -124,8 +124,19 @@ export function fetchEsql({
                 : 1;
             const expandedRows =
               effectiveMultiplier > 1
-                ? Array.from({ length: effectiveMultiplier }, () => rows).flat()
+                ? Array.from({ length: effectiveMultiplier }, () =>
+                    rows.map((row) => structuredClone(row))
+                  ).flat()
                 : rows;
+
+            if (effectiveMultiplier > 1) {
+              expandedRows.forEach((row, idx) => {
+                row['@nr'] = idx + 1;
+              });
+              if (esqlQueryColumns && !esqlQueryColumns.some((c) => c.id === '@nr')) {
+                esqlQueryColumns = [{ id: '@nr', name: '@nr', meta: { type: 'number' } }, ...esqlQueryColumns];
+              }
+            }
 
             finalData = expandedRows.map((row, idx) => {
               const record: DataTableRecord = {

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
@@ -50,7 +50,7 @@ export interface FetchEsqlParams {
   };
 }
 
-const MAX_MULTIPLIED_ROWS = 100_000;
+const MAX_MULTIPLIED_ROWS = 1_000_000;
 
 function getMultiplierFromESQLQuery(esql: string): number {
   if (!esql) return 1;

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/fetch_esql.ts
@@ -50,6 +50,17 @@ export interface FetchEsqlParams {
   };
 }
 
+const MAX_MULTIPLIED_ROWS = 100_000;
+
+function getMultiplierFromESQLQuery(esql: string): number {
+  if (!esql) return 1;
+  const match = esql.match(/(?:\/\/|\/\*)\s*(\d+)\s*x\b/i);
+  if (!match) return 1;
+  const value = parseInt(match[1], 10);
+  if (!Number.isFinite(value) || value <= 0) return 1;
+  return value;
+}
+
 export function fetchEsql({
   query,
   inputQuery,
@@ -104,7 +115,19 @@ export function fetchEsql({
             const rows = table?.rows ?? [];
             esqlQueryColumns = table?.columns ?? undefined;
             esqlHeaderWarning = table.warning ?? undefined;
-            finalData = rows.map((row, idx) => {
+
+            const esqlString = 'esql' in query ? query.esql : '';
+            const multiplier = getMultiplierFromESQLQuery(esqlString);
+            const effectiveMultiplier =
+              multiplier > 1
+                ? Math.min(multiplier, Math.ceil(MAX_MULTIPLIED_ROWS / Math.max(rows.length, 1)))
+                : 1;
+            const expandedRows =
+              effectiveMultiplier > 1
+                ? Array.from({ length: effectiveMultiplier }, () => rows).flat()
+                : rows;
+
+            finalData = expandedRows.map((row, idx) => {
               const record: DataTableRecord = {
                 id: String(idx),
                 raw: row,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -393,6 +393,14 @@ export const internalStateSlice = createSlice({
         tab.uiState.searchDraft = action.payload.searchDraftUiState;
       }),
 
+    setCommentUiState: (
+      state,
+      action: TabAction<{ comment: string | undefined }>
+    ) =>
+      withTab(state, action.payload, (tab) => {
+        tab.uiState.comment = action.payload.comment;
+      }),
+
     setMetricsGridState: (
       state,
       action: TabAction<{ metricsGridState: Partial<TabState['uiState']['metricsGrid']> }>
@@ -518,6 +526,7 @@ const createMiddleware = (options: InternalStateDependencies) => {
             attributes: tab.attributes,
             appState: tab.appState,
             globalState: tab.globalState,
+            comment: tab.uiState.comment,
           });
         });
       },

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -177,6 +177,7 @@ export interface TabState extends TabItem {
     searchDraft?: Partial<UnifiedSearchDraft>;
     metricsGrid?: Partial<UnifiedMetricsGridRestorableState>;
     docViewer?: Partial<DocViewerRestorableState>;
+    comment?: string;
   };
   expandedDoc: DataTableRecord | undefined;
   initialDocViewerTabId?: string;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.ts
@@ -31,6 +31,7 @@ export type TabStateInLocalStorage = Pick<TabState, 'id' | 'label'> & {
   attributes: TabState['attributes'] | undefined;
   appState: DiscoverAppState | undefined;
   globalState: TabState['globalState'] | undefined;
+  comment?: string;
 };
 
 type RecentlyClosedTabStateInLocalStorage = TabStateInLocalStorage &
@@ -73,7 +74,7 @@ export interface TabsStorageManager {
     tabId: string,
     tabState: Pick<
       TabStateInLocalStorage,
-      'internalState' | 'attributes' | 'appState' | 'globalState'
+      'internalState' | 'attributes' | 'appState' | 'globalState' | 'comment'
     >
   ) => void;
   loadLocally: (props: {
@@ -186,6 +187,7 @@ export const createTabsStorageManager = ({
       attributes: tabState.attributes,
       appState: tabState.appState,
       globalState: tabState.globalState,
+      comment: tabState.uiState.comment,
     };
   };
 
@@ -245,6 +247,10 @@ export const createTabsStorageManager = ({
       appState: appState || {},
       globalState: globalState || {},
       esqlVariables,
+      uiState: {
+        ...defaultTabState.uiState,
+        comment: tabStateInStorage.comment,
+      },
     };
 
     // migration from the older format where visContext was stored in internalState
@@ -368,6 +374,7 @@ export const createTabsStorageManager = ({
             attributes: tabStatePartial.attributes,
             appState: tabStatePartial.appState,
             globalState: tabStatePartial.globalState,
+            comment: tabStatePartial.comment,
           };
         }
         return tab;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_tab_persistable_state_observable.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_tab_persistable_state_observable.ts
@@ -20,14 +20,15 @@ export const createTabPersistableStateObservable = ({
   tabId: string;
   internalState$: Observable<DiscoverInternalState>;
   getState: () => DiscoverInternalState;
-}): Observable<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> => {
-  const getTabState = (): Pick<TabState, 'appState' | 'globalState' | 'attributes'> => {
+}): Observable<Pick<TabState, 'appState' | 'globalState' | 'attributes'> & { comment?: string }> => {
+  const getTabState = (): Pick<TabState, 'appState' | 'globalState' | 'attributes'> & { comment?: string } => {
     const tabState = selectTab(getState(), tabId);
 
     return {
       appState: tabState.appState,
       globalState: tabState.globalState,
       attributes: tabState.attributes,
+      comment: tabState.uiState.comment,
     };
   };
 
@@ -37,7 +38,8 @@ export const createTabPersistableStateObservable = ({
       (a, b) =>
         isEqualState(a.appState, b.appState) &&
         isEqualState(a.globalState, b.globalState) &&
-        isEqual(a.attributes, b.attributes)
+        isEqual(a.attributes, b.attributes) &&
+        a.comment === b.comment
     ),
     skip(1)
   );

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -150,6 +150,8 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
           dataView={props.dataView}
           query={isOfAggregateQueryType(query) ? query : undefined}
           showTimeCol={props.showTimeCol}
+          isPlainRecord={props.isPlainRecord}
+          showColumnTokens
           sort={props.sort}
           onSort={props.onSort}
           isSortEnabled={props.isSortEnabled}
@@ -163,6 +165,13 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
           onFilter={props.onFilter}
           getRowIndicator={getRowIndicator}
           rowAdditionalLeadingControls={rowAdditionalLeadingControls}
+          dataGridDensityState={props.dataGridDensityState}
+          onUpdateDataGridDensity={props.onUpdateDataGridDensity}
+          rowHeightState={props.rowHeightState}
+          onUpdateRowHeight={props.onUpdateRowHeight}
+          headerRowHeightState={props.headerRowHeightState}
+          onUpdateHeaderRowHeight={props.onUpdateHeaderRowHeight}
+          externalAdditionalControls={externalAdditionalControls}
         />
       );
     }

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -25,13 +25,20 @@ import {
   LazyCascadedDocumentsLayout,
   CascadedDocumentsProvider,
 } from '../../application/main/components/layout/cascaded_documents';
+import { lastValueFrom, map } from 'rxjs';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import { textBasedQueryStateToAstWithValidation } from '@kbn/data-plugin/common';
 import { TanstackVirtualGrid } from './tanstack_virtual_grid';
 import { TanStackDataGrid } from './tanstack_data_grid';
+import { TanStackCascadeGrid, type FetchGroupDocsParams, type OpenInNewTabFn } from './tanstack_cascade_grid';
+import { useDiscoverServices } from '../../hooks/use_discover_services';
 
 export interface DiscoverGridProps extends UnifiedDataTableProps {
   query?: DiscoverAppState['query'];
   cascadedDocumentsContext?: CascadedDocumentsContext;
   onUpdateESQLQuery?: UpdateESQLQueryFn;
+  onOpenInNewTab?: OpenInNewTabFn;
 }
 
 /**
@@ -45,6 +52,7 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
     externalAdditionalControls: customExternalAdditionalControls,
     rowAdditionalLeadingControls: customRowAdditionalLeadingControls,
     onUpdateESQLQuery,
+    onOpenInNewTab,
     onFullScreenChange,
     ...props
   }) => {
@@ -127,6 +135,55 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
       isCascadedDocumentsAvailable,
     ]);
 
+    const isTanStackCascade = useMemo(() => {
+      if (!isOfAggregateQueryType(query)) return false;
+      return /\/\*[\s\S]*?\bTanStackCascade\b[\s\S]*?\*\/|\/\/.*\bTanStackCascade\b/.test(query.esql);
+    }, [query]);
+
+    const services = useDiscoverServices();
+
+    const fetchGroupDocuments = useCallback(
+      async ({ subQuery, dataView: dv, signal }: FetchGroupDocsParams): Promise<DataTableRecord[]> => {
+        try {
+          const ast = await textBasedQueryStateToAstWithValidation({
+            query: subQuery,
+            time: services.data.query.timefilter.timefilter.getTime(),
+            dataView: dv,
+          });
+
+          if (!ast) return [];
+
+          const table = await lastValueFrom(
+            services.expressions.run<null, Datatable>(ast, null, {
+              inspectorAdapters: {},
+              abortSignal: signal,
+            }).pipe(map((v) => v.result))
+          );
+
+          if (!table?.rows?.length) return [];
+
+          const colIds = table.columns.map((c) => c.id);
+          return table.rows.map((row, i) => {
+            const flattened: Record<string, unknown> = {};
+            for (const col of colIds) {
+              flattened[col] = row[col];
+            }
+            return {
+              id: String(i),
+              raw: { _id: String(i), _index: '', _source: flattened } as any,
+              flattened,
+            };
+          });
+        } catch (err: any) {
+          if (err?.name === 'AbortError') throw err;
+          // eslint-disable-next-line no-console
+          console.error('[TanStackCascade] fetchGroupDocuments error:', err);
+          return [];
+        }
+      },
+      [services.data.query.timefilter.timefilter, services.expressions]
+    );
+
     const isTanstackVirtualPoc = useMemo(() => {
       if (!isOfAggregateQueryType(query)) {
         return false;
@@ -140,6 +197,33 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
       }
       return /\/\*[\s\S]*?\bTanStackGrid\b[\s\S]*?\*\/|\/\/.*\bTanStackGrid\b/.test(query.esql);
     }, [query]);
+
+    if (isTanStackCascade) {
+      return (
+        <TanStackCascadeGrid
+          rows={props.rows ?? []}
+          columns={props.columns}
+          columnsMeta={props.columnsMeta}
+          dataView={props.dataView}
+          query={isOfAggregateQueryType(query) ? query : { esql: '' }}
+          showTimeCol={props.showTimeCol}
+          sort={props.sort}
+          onSort={props.onSort}
+          onFilter={props.onFilter}
+          expandedDoc={props.expandedDoc}
+          setExpandedDoc={props.setExpandedDoc}
+          renderDocumentView={props.renderDocumentView}
+          loadingState={props.loadingState}
+          settings={props.settings}
+          fetchGroupDocuments={fetchGroupDocuments}
+          onOpenInNewTab={onOpenInNewTab}
+          availableCascadeGroups={cascadedDocumentsContext?.availableCascadeGroups}
+          selectedCascadeGroups={cascadedDocumentsContext?.selectedCascadeGroups}
+          onCascadeGroupingChange={cascadedDocumentsContext?.cascadeGroupingChangeHandler}
+          externalCustomRenderers={props.externalCustomRenderers}
+        />
+      );
+    }
 
     if (isTanStackDataGrid) {
       return (

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -26,6 +26,7 @@ import {
   CascadedDocumentsProvider,
 } from '../../application/main/components/layout/cascaded_documents';
 import { TanstackVirtualGrid } from './tanstack_virtual_grid';
+import { TanStackDataGrid } from './tanstack_data_grid';
 
 export interface DiscoverGridProps extends UnifiedDataTableProps {
   query?: DiscoverAppState['query'];
@@ -132,6 +133,39 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
       }
       return /\/\*[\s\S]*?\btanstack\b[\s\S]*?\*\/|\/\/.*\btanstack\b/i.test(query.esql);
     }, [query]);
+
+    const isTanStackDataGrid = useMemo(() => {
+      if (!isOfAggregateQueryType(query)) {
+        return false;
+      }
+      return /\/\*[\s\S]*?\bTanStackGrid\b[\s\S]*?\*\/|\/\/.*\bTanStackGrid\b/.test(query.esql);
+    }, [query]);
+
+    if (isTanStackDataGrid) {
+      return (
+        <TanStackDataGrid
+          rows={props.rows ?? []}
+          columns={props.columns}
+          columnsMeta={props.columnsMeta}
+          dataView={props.dataView}
+          query={isOfAggregateQueryType(query) ? query : undefined}
+          showTimeCol={props.showTimeCol}
+          sort={props.sort}
+          onSort={props.onSort}
+          isSortEnabled={props.isSortEnabled}
+          settings={props.settings}
+          onResize={props.onResize}
+          onSetColumns={props.onSetColumns}
+          expandedDoc={props.expandedDoc}
+          setExpandedDoc={props.setExpandedDoc}
+          renderDocumentView={props.renderDocumentView}
+          loadingState={props.loadingState}
+          onFilter={props.onFilter}
+          getRowIndicator={getRowIndicator}
+          rowAdditionalLeadingControls={rowAdditionalLeadingControls}
+        />
+      );
+    }
 
     if (isTanstackVirtualPoc) {
       return (

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -15,6 +15,7 @@ import {
   UnifiedDataTable,
   type UnifiedDataTableProps,
 } from '@kbn/unified-data-table';
+import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { UpdateESQLQueryFn } from '../../context_awareness';
 import { useProfileAccessor } from '../../context_awareness';
 import type { DiscoverAppState } from '../../application/main/state_management/redux';
@@ -24,6 +25,7 @@ import {
   LazyCascadedDocumentsLayout,
   CascadedDocumentsProvider,
 } from '../../application/main/components/layout/cascaded_documents';
+import { TanstackVirtualGrid } from './tanstack_virtual_grid';
 
 export interface DiscoverGridProps extends UnifiedDataTableProps {
   query?: DiscoverAppState['query'];
@@ -123,6 +125,28 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
       groupBySelectorRenderer,
       isCascadedDocumentsAvailable,
     ]);
+
+    const isTanstackVirtualPoc = useMemo(() => {
+      if (!isOfAggregateQueryType(query)) {
+        return false;
+      }
+      return /\/\*[\s\S]*?\btanstack\b[\s\S]*?\*\/|\/\/.*\btanstack\b/i.test(query.esql);
+    }, [query]);
+
+    if (isTanstackVirtualPoc) {
+      return (
+        <TanstackVirtualGrid
+          rows={props.rows ?? []}
+          columns={props.columns}
+          dataView={props.dataView}
+          showTimeCol={props.showTimeCol}
+          expandedDoc={props.expandedDoc}
+          setExpandedDoc={props.setExpandedDoc}
+          renderDocumentView={props.renderDocumentView}
+          columnsMeta={props.columnsMeta}
+        />
+      );
+    }
 
     return isCascadedDocumentsAvailable && cascadedDocumentsContext.selectedCascadeGroups.length ? (
       <CascadedDocumentsProvider value={cascadedDocumentsContext}>

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -144,6 +144,7 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
           setExpandedDoc={props.setExpandedDoc}
           renderDocumentView={props.renderDocumentView}
           columnsMeta={props.columnsMeta}
+          query={isOfAggregateQueryType(query) ? query : undefined}
         />
       );
     }

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/perf_tanstack_virtual_grid.playwright.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/perf_tanstack_virtual_grid.playwright.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Playwright performance analysis script for the TanStack Virtual POC grid.
+ *
+ * Usage:
+ *   npx playwright test src/platform/plugins/shared/discover/public/components/discover_grid/perf_tanstack_virtual_grid.playwright.ts
+ *
+ * Environment variables:
+ *   KIBANA_URL  - base URL  (default: https://kertal-branch-virtualized-list-experiment.kbndev.co)
+ *   KIBANA_USER - login user (default: elastic)
+ *   KIBANA_PASS - login password (default: changeme)
+ */
+
+/* eslint-disable no-console, import/no-extraneous-dependencies */
+
+import { test, expect, type CDPSession, type Page } from '@playwright/test';
+
+const KIBANA_URL =
+  process.env.KIBANA_URL ?? 'https://kertal-branch-virtualized-list-experiment.kbndev.co';
+const SAVED_SEARCH_PATH = '/app/discover#/view/0613fa47-b5b7-4181-ba12-91500fa2c0bd';
+const KIBANA_USER = process.env.KIBANA_USER ?? 'elastic';
+const KIBANA_PASS = process.env.KIBANA_PASS ?? 'changeme';
+
+interface PerfSnapshot {
+  timestamp: number;
+  nodesCount?: number;
+  jsHeapUsedSize?: number;
+  jsHeapTotalSize?: number;
+  layoutCount?: number;
+  styleRecalcCount?: number;
+  scriptDuration?: number;
+  layoutDuration?: number;
+  taskDuration?: number;
+}
+
+const captureCDPMetrics = async (cdp: CDPSession): Promise<PerfSnapshot> => {
+  const { metrics } = await cdp.send('Performance.getMetrics');
+  const get = (name: string) => metrics.find((m) => m.name === name)?.value;
+  return {
+    timestamp: Date.now(),
+    nodesCount: get('Nodes'),
+    jsHeapUsedSize: get('JSHeapUsedSize'),
+    jsHeapTotalSize: get('JSHeapTotalSize'),
+    layoutCount: get('LayoutCount'),
+    styleRecalcCount: get('RecalcStyleCount'),
+    scriptDuration: get('ScriptDuration'),
+    layoutDuration: get('LayoutDuration'),
+    taskDuration: get('TaskDuration'),
+  };
+};
+
+const diffSnapshots = (before: PerfSnapshot, after: PerfSnapshot) => {
+  const diff: Record<string, { before: number; after: number; delta: number }> = {};
+  for (const key of Object.keys(after) as Array<keyof PerfSnapshot>) {
+    if (key === 'timestamp') continue;
+    const b = before[key] ?? 0;
+    const a = after[key] ?? 0;
+    diff[key] = { before: b, after: a, delta: a - b };
+  }
+  return diff;
+};
+
+const login = async (page: Page) => {
+  await page.goto(`${KIBANA_URL}/login`);
+  const userField = page.locator('[data-test-subj="loginUsername"]');
+  if (await userField.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await userField.fill(KIBANA_USER);
+    await page.locator('[data-test-subj="loginPassword"]').fill(KIBANA_PASS);
+    await page.locator('[data-test-subj="loginSubmit"]').click();
+    await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+  }
+};
+
+test.describe('TanStack Virtual POC - performance analysis', () => {
+  test('measure initial render & scroll performance', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await login(page);
+
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('Performance.enable');
+
+    const beforeNav = await captureCDPMetrics(cdp);
+
+    await page.goto(`${KIBANA_URL}${SAVED_SEARCH_PATH}`, { waitUntil: 'domcontentloaded' });
+
+    const pocBadge = page.getByText('TanStack Virtual POC');
+    await expect(pocBadge).toBeVisible({ timeout: 60_000 });
+
+    const afterRender = await captureCDPMetrics(cdp);
+    const renderDiff = diffSnapshots(beforeNav, afterRender);
+
+    console.log('\n=== INITIAL RENDER METRICS ===');
+    console.table(renderDiff);
+
+    const gridDomStats = await page.evaluate(() => {
+      const grid = document.querySelector('[role="grid"]');
+      if (!grid) return { totalNodes: 0, rowCount: 0, cellCount: 0 };
+      return {
+        totalNodes: grid.querySelectorAll('*').length,
+        rowCount: grid.querySelectorAll('[role="row"]').length,
+        cellCount: grid.querySelectorAll('[role="gridcell"]').length,
+      };
+    });
+
+    console.log('\n=== DOM NODE COUNTS (initial) ===');
+    console.table(gridDomStats);
+
+    await cdp.send('Tracing.start', {
+      categories: ['devtools.timeline', 'v8.execute'].join(','),
+      options: 'sampling-frequency=1000',
+    });
+
+    const beforeScroll = await captureCDPMetrics(cdp);
+
+    const scrollContainer = page.locator('[role="grid"]');
+    await scrollContainer.evaluate((el) => {
+      el.scrollTo({ top: el.scrollHeight / 2, behavior: 'smooth' });
+    });
+    await page.waitForTimeout(1500);
+
+    await scrollContainer.evaluate((el) => {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    });
+    await page.waitForTimeout(1500);
+
+    await scrollContainer.evaluate((el) => {
+      el.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+    await page.waitForTimeout(1500);
+
+    const afterScroll = await captureCDPMetrics(cdp);
+    const scrollDiff = diffSnapshots(beforeScroll, afterScroll);
+
+    const traceBuffer = await cdp.send('Tracing.end');
+    void traceBuffer;
+
+    console.log('\n=== SCROLL PERFORMANCE METRICS (3 scrolls: mid -> end -> top) ===');
+    console.table(scrollDiff);
+
+    const gridDomStatsAfterScroll = await page.evaluate(() => {
+      const grid = document.querySelector('[role="grid"]');
+      if (!grid) return { totalNodes: 0, rowCount: 0, cellCount: 0 };
+      return {
+        totalNodes: grid.querySelectorAll('*').length,
+        rowCount: grid.querySelectorAll('[role="row"]').length,
+        cellCount: grid.querySelectorAll('[role="gridcell"]').length,
+      };
+    });
+
+    console.log('\n=== DOM NODE COUNTS (after scroll) ===');
+    console.table(gridDomStatsAfterScroll);
+
+    const longTaskCount = await page.evaluate(() => {
+      return new Promise<number>((resolve) => {
+        let count = 0;
+        const observer = new PerformanceObserver((list) => {
+          count += list.getEntries().length;
+        });
+        observer.observe({ type: 'longtask', buffered: true });
+
+        const grid = document.querySelector('[role="grid"]');
+        if (grid) {
+          let pos = 0;
+          const step = () => {
+            pos += 200;
+            grid.scrollTop = pos;
+            if (pos < grid.scrollHeight) {
+              requestAnimationFrame(step);
+            } else {
+              setTimeout(() => {
+                observer.disconnect();
+                resolve(count);
+              }, 500);
+            }
+          };
+          requestAnimationFrame(step);
+        } else {
+          resolve(0);
+        }
+      });
+    });
+
+    console.log(`\n=== LONG TASKS during rapid scroll: ${longTaskCount} ===`);
+
+    const scrollDiffMetrics = scrollDiff;
+    console.log('\n=== SUMMARY ===');
+    console.log(`Initial DOM nodes in grid: ${gridDomStats.totalNodes}`);
+    console.log(`DOM nodes after scroll:    ${gridDomStatsAfterScroll.totalNodes}`);
+    console.log(
+      `DOM node churn on scroll:  ${scrollDiffMetrics.nodesCount?.delta ?? 0} (page-wide)`
+    );
+    console.log(`Layout recalcs on scroll:  ${scrollDiffMetrics.layoutCount?.delta ?? 0}`);
+    console.log(`Style recalcs on scroll:   ${scrollDiffMetrics.styleRecalcCount?.delta ?? 0}`);
+    console.log(`Long tasks (rapid scroll): ${longTaskCount}`);
+
+    await cdp.send('Performance.disable');
+    await cdp.detach();
+  });
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/index.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { TanStackCascadeGrid, type TanStackCascadeGridProps, type FetchGroupDocsParams, type OpenInNewTabFn } from './tanstack_cascade_grid';

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/playwright.config.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/playwright.config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '*.playwright.ts',
+  timeout: 180_000,
+  retries: 0,
+  use: {
+    ...devices['Desktop Chrome'],
+    headless: true,
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1440, height: 900 },
+  },
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.playwright.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.playwright.ts
@@ -220,7 +220,7 @@ test.describe('TanStack Cascade Grid', () => {
     await setupCascade(page);
 
     // Click the 3-dot actions button on first group row
-    const actionsBtn = page.locator('[data-test-subj="cascadeRowActionsBtn"]').first();
+    const actionsBtn = page.locator('[data-test-subj$="-dscCascadeRowContextActionButton"]').first();
     await expect(actionsBtn).toBeVisible();
     await actionsBtn.click();
     await page.waitForTimeout(500);

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.playwright.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.playwright.ts
@@ -1,0 +1,282 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Playwright functional tests for TanStack Cascade Grid.
+ *
+ * Usage:
+ *   npx playwright test --config=src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/playwright.config.ts
+ */
+
+/* eslint-disable no-console, import/no-extraneous-dependencies */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const KIBANA_URL = process.env.KIBANA_URL ?? 'http://localhost:5601';
+const KIBANA_USER = process.env.KIBANA_USER ?? 'elastic';
+const KIBANA_PASS = process.env.KIBANA_PASS ?? 'changeme';
+
+const ESQL_QUERY =
+  'ROW a=1, b="US" | STATS c=COUNT(*) BY b // TanStackCascade';
+
+const login = async (page: Page) => {
+  await page.goto(`${KIBANA_URL}/app/discover`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  if (page.url().includes('/login')) {
+    await page.getByRole('textbox', { name: 'Username' }).fill(KIBANA_USER);
+    await page.getByRole('textbox', { name: 'Password' }).fill(KIBANA_PASS);
+    await page.getByRole('button', { name: 'Log in' }).click();
+    await page.waitForURL((url) => !url.pathname.includes('/login'), {
+      timeout: 60_000,
+    });
+  }
+};
+
+const navigateToDiscover = async (page: Page) => {
+  if (!page.url().includes('/app/discover')) {
+    await page.goto(`${KIBANA_URL}/app/discover`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+  }
+  await page
+    .getByText('Discover', { exact: false })
+    .first()
+    .waitFor({ timeout: 60_000 });
+  const closeBtn = page.getByRole('button', { name: 'Close' });
+  if (await closeBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await closeBtn.click();
+    await page.waitForTimeout(500);
+  }
+};
+
+const switchToEsqlMode = async (page: Page) => {
+  const esqlBtn = page.getByRole('button', { name: 'ES|QL' });
+  if (await esqlBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await esqlBtn.click();
+    await page.waitForTimeout(2000);
+    return;
+  }
+  const langToggle = page
+    .locator('[data-test-subj="discover-dataView-switch-link"]')
+    .or(page.getByText('Try ES|QL'));
+  if (
+    await langToggle
+      .first()
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false)
+  ) {
+    await langToggle.first().click();
+    await page.waitForTimeout(2000);
+  }
+};
+
+const setupDiscover = async (page: Page) => {
+  await login(page);
+  await navigateToDiscover(page);
+  await switchToEsqlMode(page);
+};
+
+const submitEsqlQuery = async (page: Page, query: string) => {
+  const monacoEditor = page.locator('.monaco-editor').first();
+  await monacoEditor.click({ force: true });
+  await page.waitForTimeout(300);
+  await page.keyboard.press('Control+a');
+  await page.waitForTimeout(100);
+  await page.keyboard.type(query, { delay: 5 });
+  await page.waitForTimeout(500);
+  const submitBtn = page
+    .locator('[data-test-subj="querySubmitButton"]')
+    .or(page.getByRole('button', { name: 'Run query' }));
+  await submitBtn.first().click();
+  await page.waitForTimeout(5000);
+};
+
+const setupCascade = async (page: Page, query = ESQL_QUERY) => {
+  await setupDiscover(page);
+  await submitEsqlQuery(page, query);
+  // Wait for the cascade wrapper to appear (no badge — uses group count text)
+  const wrapper = page.locator('[data-test-subj="tanstackCascadeWrapper"]');
+  await expect(wrapper).toBeVisible({ timeout: 60_000 });
+};
+
+test.describe('TanStack Cascade Grid', () => {
+  test('renders cascade grid with group rows and toolbar', async ({ page }) => {
+    test.setTimeout(90_000);
+    await setupCascade(page);
+
+    const groupRows = page.locator('[data-test-subj="cascadeGroupRow"]');
+    const count = await groupRows.count();
+    console.log(`Group rows: ${count}`);
+    expect(count).toBeGreaterThan(0);
+
+    // Toolbar shows group count
+    const wrapper = page.locator('[data-test-subj="tanstackCascadeWrapper"]');
+    const toolbarText = await wrapper.innerText();
+    console.log(`Toolbar: ${toolbarText.slice(0, 80)}`);
+    expect(toolbarText).toContain('group');
+  });
+
+  test('expand and collapse group row', async ({ page }) => {
+    test.setTimeout(120_000);
+    await setupCascade(page);
+
+    const firstGroup = page
+      .locator('[data-test-subj="cascadeGroupRow"]')
+      .first();
+    await firstGroup.click();
+    await page.waitForTimeout(5000);
+
+    const docsPanel = page.locator('[data-test-subj="cascadeDocsPanel"]');
+    const loadingText = page.locator('text=Loading documents');
+    const noDocsText = page.locator('text=No documents found');
+    const errorText = page.locator('text=Fetch failed');
+
+    const hasDocs = await docsPanel.isVisible({ timeout: 15_000 }).catch(() => false);
+    const hasLoading = await loadingText.isVisible().catch(() => false);
+    const hasNoDocs = await noDocsText.isVisible().catch(() => false);
+    const hasError = await errorText.isVisible().catch(() => false);
+    console.log(`Docs: ${hasDocs}, Loading: ${hasLoading}, NoDocs: ${hasNoDocs}, Error: ${hasError}`);
+    expect(hasDocs || hasLoading || hasNoDocs || hasError).toBe(true);
+
+    await firstGroup.click();
+    await page.waitForTimeout(1000);
+    expect(await docsPanel.isVisible().catch(() => false)).toBe(false);
+  });
+
+  test('full screen toggle', async ({ page }) => {
+    test.setTimeout(90_000);
+    await setupCascade(page);
+
+    const fullScreenBtn = page.locator('[data-test-subj="cascadeFullScreenButton"]');
+    await expect(fullScreenBtn).toBeVisible();
+    await fullScreenBtn.click();
+    await page.waitForTimeout(500);
+
+    const wrapper = page.locator('[data-test-subj="tanstackCascadeWrapper"]');
+    const position = await wrapper.evaluate((el) => getComputedStyle(el).position);
+    console.log(`Full screen position: ${position}`);
+    expect(position).toBe('fixed');
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(1000);
+    let positionAfter = await wrapper.evaluate((el) => getComputedStyle(el).position);
+    if (positionAfter === 'fixed') {
+      await fullScreenBtn.dispatchEvent('click');
+      await page.waitForTimeout(500);
+      positionAfter = await wrapper.evaluate((el) => getComputedStyle(el).position);
+    }
+    console.log(`After exit: ${positionAfter}`);
+    expect(positionAfter).not.toBe('fixed');
+  });
+
+  test('group row shows by-field, value, and aggregates', async ({ page }) => {
+    test.setTimeout(90_000);
+    await setupCascade(page);
+
+    const firstGroup = page.locator('[data-test-subj="cascadeGroupRow"]').first();
+    const text = await firstGroup.innerText();
+    console.log(`Group text: ${text}`);
+    // Title shows group value, meta shows aggregate columns
+    expect(text).toContain('US');
+    expect(text).toContain('c:');
+  });
+
+  test('expand all and collapse all buttons', async ({ page }) => {
+    test.setTimeout(90_000);
+    await setupCascade(page);
+
+    const expandAllBtn = page.locator('[data-test-subj="cascadeExpandAll"]');
+    await expect(expandAllBtn).toBeVisible();
+    await expandAllBtn.click();
+    await page.waitForTimeout(5000);
+
+    // Toolbar should show expanded badge
+    const expandedBadge = page.locator('[data-test-subj="tanstackCascadeWrapper"]').getByText('expanded');
+    const hasExpanded = await expandedBadge.isVisible({ timeout: 5_000 }).catch(() => false);
+    console.log(`Expanded badge visible: ${hasExpanded}`);
+    expect(hasExpanded).toBe(true);
+
+    const collapseAllBtn = page.locator('[data-test-subj="cascadeCollapseAll"]');
+    await collapseAllBtn.click();
+    await page.waitForTimeout(1000);
+
+    const docsPanel = page.locator('[data-test-subj="cascadeDocsPanel"]');
+    const docsPanelVisible = await docsPanel.isVisible().catch(() => false);
+    console.log(`Docs panel after collapse all: ${docsPanelVisible}`);
+    expect(docsPanelVisible).toBe(false);
+  });
+
+  test('3-dot actions menu on group row', async ({ page }) => {
+    test.setTimeout(90_000);
+    await setupCascade(page);
+
+    // Click the 3-dot actions button on first group row
+    const actionsBtn = page.locator('[data-test-subj="cascadeRowActionsBtn"]').first();
+    await expect(actionsBtn).toBeVisible();
+    await actionsBtn.click();
+    await page.waitForTimeout(500);
+
+    const menu = page.locator('[data-test-subj="cascadeContextMenu"]');
+    const menuVisible = await menu.isVisible({ timeout: 5_000 }).catch(() => false);
+    console.log(`Context menu visible: ${menuVisible}`);
+    expect(menuVisible).toBe(true);
+
+    const copyItem = page.locator('text=Copy to clipboard');
+    await expect(copyItem).toBeVisible();
+
+    // Close via Escape
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    const menuAfter = await menu.isVisible().catch(() => false);
+    console.log(`Context menu after Escape: ${menuAfter}`);
+    expect(menuAfter).toBe(false);
+  });
+
+  test('keyboard navigation: ArrowDown, ArrowUp, ArrowRight to expand', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await setupCascade(page);
+
+    // Focus the scroll container (treegrid)
+    const treegrid = page.locator('[role="treegrid"]');
+    await treegrid.focus();
+    await page.waitForTimeout(300);
+
+    // Press ArrowDown to focus first row
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(300);
+
+    // Press ArrowRight to expand the focused row
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(3000);
+
+    // Check if expanded (look for docs panel or loading)
+    const docsPanel = page.locator('[data-test-subj="cascadeDocsPanel"]');
+    const loading = page.locator('text=Loading documents');
+    const noDocs = page.locator('text=No documents found');
+
+    const hasAny =
+      (await docsPanel.isVisible().catch(() => false)) ||
+      (await loading.isVisible().catch(() => false)) ||
+      (await noDocs.isVisible().catch(() => false));
+    console.log(`Expanded via keyboard: ${hasAny}`);
+    expect(hasAny).toBe(true);
+
+    // ArrowLeft to collapse
+    await page.keyboard.press('ArrowLeft');
+    await page.waitForTimeout(1000);
+
+    const collapsed = !(await docsPanel.isVisible().catch(() => false));
+    console.log(`Collapsed via keyboard: ${collapsed}`);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.styles.ts
@@ -28,19 +28,16 @@ export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
   }),
 
   toolbar: css({
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
     padding: `${euiTheme.size.s} 0`,
     flexShrink: 0,
-    gap: euiTheme.size.s,
-    flexWrap: 'wrap',
   }),
 
-  toolbarRight: css({
+  contentArea: css({
+    flex: 1,
+    overflow: 'hidden',
+    position: 'relative',
     display: 'flex',
-    alignItems: 'center',
-    gap: euiTheme.size.xs,
+    flexDirection: 'column',
   }),
 
   scrollContainer: css({
@@ -58,6 +55,7 @@ export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
   virtualOuter: css({
     position: 'relative',
     width: '100%',
+    contain: 'layout style',
   }),
 
   virtualInner: css({
@@ -65,19 +63,15 @@ export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
     top: 0,
     left: 0,
     width: '100%',
+    willChange: 'transform',
   }),
 
-  // -- Group row (matches CascadeRowPrimitive size="s" = 32px) --
+  // -- Group row (matches CascadeRowPrimitive) --
   groupRow: css({
-    display: 'flex',
-    alignItems: 'center',
     cursor: 'pointer',
-    padding: `0 ${euiTheme.size.s}`,
-    height: 32,
     borderBottom: euiTheme.border.thin,
     transition: 'background-color 100ms ease',
     userSelect: 'none',
-    gap: euiTheme.size.xs,
     outline: 'none',
     backgroundColor: euiTheme.colors.backgroundBasePlain,
     '&:hover': {
@@ -90,25 +84,25 @@ export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
 
   groupRowExpanded: css({
     backgroundColor: euiTheme.colors.backgroundBaseSubdued,
-    fontWeight: euiTheme.font.weight.semiBold,
   }),
 
-  // Title slot: 4/10 flex growth
+  rowHeader: css({
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    minHeight: 32,
+  }),
+
   groupTitle: css({
-    flex: '4 1 0',
     minWidth: 0,
+    overflow: 'hidden',
+  }),
+
+  titleText: css({
+    margin: 0,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    fontSize: euiTheme.font.scale.s * euiTheme.base,
-    fontWeight: euiTheme.font.weight.semiBold,
-    '& h4': {
-      margin: 0,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      fontSize: 'inherit',
-      fontWeight: 'inherit',
-    },
+    fontSize: 'inherit',
+    fontWeight: 'inherit',
   }),
 
   groupTitleBlank: css({
@@ -116,39 +110,17 @@ export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
     color: euiTheme.colors.textSubdued,
   }),
 
-  // Meta slots: 6/10 flex growth
-  groupMeta: css({
-    flex: '6 1 0',
-    display: 'flex',
-    alignItems: 'center',
-    gap: euiTheme.size.m,
-    overflow: 'hidden',
-    justifyContent: 'space-between',
-  }),
-
-  metaSlot: css({
-    display: 'flex',
-    alignItems: 'center',
-    gap: euiTheme.size.xs,
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-    fontSize: euiTheme.font.scale.s * euiTheme.base,
-  }),
-
   metaLabel: css({
-    fontWeight: euiTheme.font.weight.bold,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    flexShrink: 0,
   }),
 
   numberBadge: css({
-    width: '7ch',
     textAlign: 'right',
     fontVariantNumeric: 'tabular-nums',
-    fontWeight: euiTheme.font.weight.semiBold,
-    flexShrink: 0,
+    '& h5': {
+      margin: 0,
+      fontSize: 'inherit',
+    },
   }),
 
   textBadge: css({
@@ -156,11 +128,6 @@ export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-  }),
-
-  actionsBtn: css({
-    flexShrink: 0,
-    marginLeft: 'auto',
   }),
 
   // -- Documents panel (expanded leaf — wraps UnifiedDataTable) --

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.styles.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { css } from '@emotion/react';
+import type { EuiThemeComputed } from '@elastic/eui';
+
+export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
+    padding: `0 ${euiTheme.size.s} ${euiTheme.size.s}`,
+  }),
+
+  fullScreen: css({
+    position: 'fixed',
+    inset: 0,
+    zIndex: 9999,
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+    padding: euiTheme.size.s,
+  }),
+
+  toolbar: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: `${euiTheme.size.s} 0`,
+    flexShrink: 0,
+    gap: euiTheme.size.s,
+    flexWrap: 'wrap',
+  }),
+
+  toolbarRight: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: euiTheme.size.xs,
+  }),
+
+  scrollContainer: css({
+    flex: 1,
+    overflow: 'auto',
+    position: 'relative',
+    border: euiTheme.border.thin,
+    borderRadius: euiTheme.border.radius.small,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    '&:focus': {
+      outline: 'none',
+    },
+  }),
+
+  virtualOuter: css({
+    position: 'relative',
+    width: '100%',
+  }),
+
+  virtualInner: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+  }),
+
+  // -- Group row (matches CascadeRowPrimitive size="s" = 32px) --
+  groupRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+    padding: `0 ${euiTheme.size.s}`,
+    height: 32,
+    borderBottom: euiTheme.border.thin,
+    transition: 'background-color 100ms ease',
+    userSelect: 'none',
+    gap: euiTheme.size.xs,
+    outline: 'none',
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    },
+    '&:focus-visible': {
+      boxShadow: `inset 0 0 0 2px ${euiTheme.colors.primary}`,
+    },
+  }),
+
+  groupRowExpanded: css({
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    fontWeight: euiTheme.font.weight.semiBold,
+  }),
+
+  // Title slot: 4/10 flex growth
+  groupTitle: css({
+    flex: '4 1 0',
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    fontSize: euiTheme.font.scale.s * euiTheme.base,
+    fontWeight: euiTheme.font.weight.semiBold,
+    '& h4': {
+      margin: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      fontSize: 'inherit',
+      fontWeight: 'inherit',
+    },
+  }),
+
+  groupTitleBlank: css({
+    fontStyle: 'italic',
+    color: euiTheme.colors.textSubdued,
+  }),
+
+  // Meta slots: 6/10 flex growth
+  groupMeta: css({
+    flex: '6 1 0',
+    display: 'flex',
+    alignItems: 'center',
+    gap: euiTheme.size.m,
+    overflow: 'hidden',
+    justifyContent: 'space-between',
+  }),
+
+  metaSlot: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: euiTheme.size.xs,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    fontSize: euiTheme.font.scale.s * euiTheme.base,
+  }),
+
+  metaLabel: css({
+    fontWeight: euiTheme.font.weight.bold,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
+  }),
+
+  numberBadge: css({
+    width: '7ch',
+    textAlign: 'right',
+    fontVariantNumeric: 'tabular-nums',
+    fontWeight: euiTheme.font.weight.semiBold,
+    flexShrink: 0,
+  }),
+
+  textBadge: css({
+    maxWidth: '20ch',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
+
+  actionsBtn: css({
+    flexShrink: 0,
+    marginLeft: 'auto',
+  }),
+
+  // -- Documents panel (expanded leaf — wraps UnifiedDataTable) --
+  docsPanel: css({
+    borderBottom: euiTheme.border.thin,
+    position: 'relative',
+    overflow: 'hidden',
+  }),
+
+  docsPanelInner: css({
+    height: '100%',
+    borderRadius: euiTheme.border.radius.small,
+    overflow: 'hidden',
+    margin: `0 ${euiTheme.size.s} ${euiTheme.size.xs}`,
+  }),
+
+  docsPanelLoading: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: euiTheme.size.l,
+    gap: euiTheme.size.s,
+  }),
+
+  docsPanelError: css({
+    display: 'flex',
+    alignItems: 'center',
+    padding: euiTheme.size.m,
+    gap: euiTheme.size.s,
+    color: euiTheme.colors.textDanger,
+  }),
+
+  loadingOverlay: css({
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.6)',
+    zIndex: 10,
+  }),
+
+  emptyState: css({
+    padding: euiTheme.size.xxl,
+  }),
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.styles.ts
@@ -28,7 +28,7 @@ export const getCascadeGridStyles = (euiTheme: EuiThemeComputed) => ({
   }),
 
   toolbar: css({
-    padding: `${euiTheme.size.s} 0`,
+    padding: 0,
     flexShrink: 0,
   }),
 

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.tsx
@@ -1,0 +1,699 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import {
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiContextMenu,
+  EuiEmptyPrompt,
+  EuiFilterGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiPopover,
+  EuiSelectable,
+  EuiText,
+  EuiToolTip,
+  EuiWrappingPopover,
+  copyToClipboard,
+  useEuiTheme,
+} from '@elastic/eui';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils';
+import {
+  DataLoadingState,
+  UnifiedDataTable,
+  DataGridDensity,
+  getRenderCustomToolbarWithElements,
+  type UnifiedDataTableProps,
+  type SortOrder,
+} from '@kbn/unified-data-table';
+import type { AggregateQuery } from '@kbn/es-query';
+import { getCascadeGridStyles } from './tanstack_cascade_grid.styles';
+import { useDiscoverServices } from '../../../hooks/use_discover_services';
+
+const GROUP_ROW_HEIGHT = 32;
+const EXPANDED_PANEL_HEIGHT = 400;
+const MAX_DOCS_PER_GROUP = 100;
+const OVERSCAN = 25;
+
+// ── SI prefix number formatting (matching NumberBadge) ──
+
+const SI_PREFIXES_CENTER = 8;
+const siPrefixes = ['y', 'z', 'a', 'f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+
+const getSiPrefixedNumber = (n: number): string => {
+  if (n === 0) return '0';
+  const base = Math.floor(Math.log10(Math.abs(n)));
+  const siBase = (base < 0 ? Math.ceil : Math.floor)(base / 3);
+  const prefix = siPrefixes[siBase + SI_PREFIXES_CENTER];
+  if (siBase === 0) return n.toString();
+  const baseNumber = parseFloat((n / Math.pow(10, siBase * 3)).toFixed(2));
+  return `${baseNumber}${prefix}`;
+};
+
+const formatNumberBadge = (value: number): string => {
+  if (Math.floor(value / 1000) >= 1) return getSiPrefixedNumber(value);
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+};
+
+const formatCellValue = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (Array.isArray(value)) return value.join(', ');
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+const isBlankValue = (v: unknown): boolean => v === null || v === undefined || v === '';
+
+interface StatsByInfo {
+  byFields: string[];
+  aggregateColumns: string[];
+}
+
+const parseStatsByColumns = (query: AggregateQuery | undefined, columns: string[]): StatsByInfo | undefined => {
+  if (!query || !('esql' in query)) return undefined;
+  // Use [\s\S]+? to span newlines between STATS and BY, and (.+) greedy to capture the rest
+  const byMatch = query.esql.match(/\bSTATS\b[\s\S]+?\bBY\b\s+(.+)/i);
+  if (!byMatch) return undefined;
+  // Strip everything after a pipe or end-of-line comment
+  let byClause = byMatch[1];
+  const pipeIdx = byClause.indexOf('|');
+  if (pipeIdx >= 0) byClause = byClause.slice(0, pipeIdx);
+  byClause = byClause.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '').trim();
+  const byFields = byClause.split(',').map((f) => f.trim()).filter(Boolean);
+  if (byFields.length === 0) return undefined;
+  return { byFields, aggregateColumns: columns.filter((c) => !byFields.includes(c)) };
+};
+
+const buildWhereClause = (byFields: string[], record: DataTableRecord): string => {
+  return byFields.map((field) => {
+    const val = record.flattened[field];
+    if (val === null || val === undefined) return `\`${field}\` IS NULL`;
+    if (typeof val === 'number') return `\`${field}\` == ${val}`;
+    if (typeof val === 'boolean') return `\`${field}\` == ${val}`;
+    const escaped = String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return `\`${field}\` == "${escaped}"`;
+  }).join(' AND ');
+};
+
+const buildSubQuery = (originalQuery: string, byFields: string[], record: DataTableRecord): string => {
+  const parts = originalQuery.split('|').map((s) => s.trim());
+  const statsIdx = parts.findIndex((p) => /^\s*STATS\b/i.test(p));
+  const base = statsIdx > 0 ? parts.slice(0, statsIdx) : [parts[0]];
+  return `${base.join(' | ')} | WHERE ${buildWhereClause(byFields, record)} | LIMIT ${MAX_DOCS_PER_GROUP}`;
+};
+
+// ── Types ──
+
+export interface FetchGroupDocsParams {
+  subQuery: AggregateQuery;
+  dataView: DataView;
+  signal: AbortSignal;
+}
+
+export type FetchGroupDocsFn = (params: FetchGroupDocsParams) => Promise<DataTableRecord[]>;
+
+export type OpenInNewTabFn = (params: { appState?: { query?: AggregateQuery } }) => void;
+
+export interface TanStackCascadeGridProps {
+  rows: DataTableRecord[];
+  columns: string[];
+  columnsMeta?: DataTableColumnsMeta;
+  dataView: DataView;
+  query: AggregateQuery;
+  showTimeCol: boolean;
+  sort?: SortOrder[];
+  onSort?: (sort: SortOrder[]) => void;
+  onFilter?: UnifiedDataTableProps['onFilter'];
+  expandedDoc?: DataTableRecord;
+  setExpandedDoc?: UnifiedDataTableProps['setExpandedDoc'];
+  renderDocumentView?: UnifiedDataTableProps['renderDocumentView'];
+  loadingState?: DataLoadingState;
+  settings?: UnifiedDataTableProps['settings'];
+  fetchGroupDocuments: FetchGroupDocsFn;
+  onOpenInNewTab?: OpenInNewTabFn;
+  availableCascadeGroups?: string[];
+  selectedCascadeGroups?: string[];
+  onCascadeGroupingChange?: (groups: string[]) => void;
+  externalCustomRenderers?: UnifiedDataTableProps['externalCustomRenderers'];
+}
+
+interface GroupDocsState {
+  docs: DataTableRecord[] | null;
+  loading: boolean;
+  error: string | null;
+}
+
+// Module-level caches that survive tab switches (component unmount/remount)
+const scrollPositionCache = new Map<string, number>();
+const expandedGroupsCache = new Map<string, Set<string>>();
+const groupDocsCacheMap = new Map<string, Map<string, GroupDocsState>>();
+
+// ── Expanded group grid (UnifiedDataTable) ──
+
+const EMPTY_SORT: SortOrder[] = [];
+
+const ExpandedGroupGrid = React.memo(({
+  state, dataView, showTimeCol, renderDocumentView, externalCustomRenderers, onRetry, styles, rowId,
+}: {
+  state: GroupDocsState; dataView: DataView; showTimeCol: boolean;
+  renderDocumentView?: UnifiedDataTableProps['renderDocumentView'];
+  externalCustomRenderers?: UnifiedDataTableProps['externalCustomRenderers'];
+  onRetry: () => void; styles: ReturnType<typeof getCascadeGridStyles>; rowId: string;
+}) => {
+  const services = useDiscoverServices();
+  const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>();
+  const [selectedColumns, setSelectedColumns] = useState<string[]>([]);
+  const [density, setDensity] = useState<DataGridDensity>(DataGridDensity.COMPACT);
+
+  const setExpandedDocFn = useCallback(
+    (...args: Parameters<NonNullable<UnifiedDataTableProps['setExpandedDoc']>>) => setExpandedDoc(args[0]),
+    []
+  );
+
+  if (state.loading && !state.docs) {
+    return <div css={styles.docsPanelLoading}><EuiLoadingSpinner size="m" /><EuiText size="xs" color="subdued">Loading documents…</EuiText></div>;
+  }
+  if (state.error) {
+    return (
+      <div css={styles.docsPanelError}>
+        <EuiIcon type="warning" color="danger" /><EuiText size="xs" color="danger">{state.error}</EuiText>
+        <EuiButtonEmpty size="xs" onClick={onRetry}>Retry</EuiButtonEmpty>
+      </div>
+    );
+  }
+  const docs = state.docs ?? [];
+  if (docs.length === 0) {
+    return <div css={styles.docsPanelLoading}><EuiText size="xs" color="subdued">No documents found for this group.</EuiText></div>;
+  }
+
+  const renderCustomToolbar = getRenderCustomToolbarWithElements({
+    leftSide: (
+      <EuiText size="s">
+        <strong>{docs.length} {docs.length === 1 ? 'result' : 'results'}</strong>
+      </EuiText>
+    ),
+  });
+
+  return (
+    <div css={styles.docsPanel} data-test-subj="cascadeDocsPanel" style={{ height: EXPANDED_PANEL_HEIGHT }}>
+      <EuiPanel paddingSize="none" css={styles.docsPanelInner}>
+        <UnifiedDataTable
+          isPlainRecord
+          dataView={dataView}
+          showTimeCol={showTimeCol}
+          services={services}
+          sort={EMPTY_SORT}
+          isSortEnabled={false}
+          ariaLabelledBy={`cascade-leaf-${rowId}`}
+          consumer={`discover_cascade_leaf_${rowId}`}
+          rows={docs}
+          loadingState={state.loading ? DataLoadingState.loading : DataLoadingState.loaded}
+          columns={selectedColumns}
+          onSetColumns={setSelectedColumns}
+          renderCustomToolbar={renderCustomToolbar}
+          expandedDoc={expandedDoc}
+          setExpandedDoc={setExpandedDocFn}
+          dataGridDensityState={density}
+          onUpdateDataGridDensity={setDensity}
+          renderDocumentView={renderDocumentView}
+          externalCustomRenderers={externalCustomRenderers}
+          paginationMode="infinite"
+          sampleSizeState={docs.length}
+        />
+      </EuiPanel>
+    </div>
+  );
+});
+
+// ── Group row (matching old cascade layout: expand btn | title 4/10 | meta 6/10 | actions btn) ──
+
+const CascadeGroupRow = React.memo(({
+  record, isExpanded, onToggle, onActionsClick, byFields, aggregateColumns, styles, ariaProps,
+}: {
+  record: DataTableRecord; isExpanded: boolean; onToggle: () => void;
+  onActionsClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  byFields: string[]; aggregateColumns: string[];
+  styles: ReturnType<typeof getCascadeGridStyles>;
+  ariaProps: Record<string, string | number | boolean>;
+}) => {
+  const groupValue = byFields.map((f) => record.flattened[f]).map(formatCellValue).join(', ');
+  const blank = byFields.every((f) => isBlankValue(record.flattened[f]));
+
+  return (
+    <div
+      css={[styles.groupRow, isExpanded && styles.groupRowExpanded]}
+      role="row"
+      tabIndex={-1}
+      data-test-subj="cascadeGroupRow"
+      data-row-id={record.id}
+      {...ariaProps}
+      onClick={onToggle}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); } }}
+    >
+      {/* Expand/collapse button */}
+      <EuiIcon type={isExpanded ? 'arrowDown' : 'arrowRight'} size="s" />
+
+      {/* Title slot (4/10 flex growth) */}
+      <div css={[styles.groupTitle, blank && styles.groupTitleBlank]}>
+        <h4>{blank ? '(blank)' : groupValue}</h4>
+      </div>
+
+      {/* Meta slots (6/10 flex growth) — aggregates */}
+      <div css={styles.groupMeta}>
+        {aggregateColumns.map((col) => {
+          const val = record.flattened[col];
+          return (
+            <div key={col} css={styles.metaSlot}>
+              <span css={styles.metaLabel}>{col}:</span>
+              {typeof val === 'number' ? (
+                <span css={styles.numberBadge} title={String(val)}>
+                  {formatNumberBadge(val)}
+                </span>
+              ) : (
+                <EuiBadge color="hollow" css={styles.textBadge}>
+                  {isBlankValue(val) ? '(blank)' : formatCellValue(val)}
+                </EuiBadge>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Actions button (3-dot menu) */}
+      <EuiButtonIcon
+        css={styles.actionsBtn}
+        iconType="boxesVertical"
+        aria-label="Row actions"
+        size="xs"
+        color="text"
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onActionsClick(e); }}
+        data-test-subj="cascadeRowActionsBtn"
+      />
+    </div>
+  );
+});
+
+// ── Group By selector (matching old cascade header) ──
+
+const NONE_GROUP_OPTION = 'none';
+
+const GroupBySelector = React.memo(({
+  availableColumns, currentSelectedColumns, onChange,
+}: {
+  availableColumns: string[]; currentSelectedColumns: string[];
+  onChange: (groups: string[]) => void;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const options = useMemo(
+    () => [NONE_GROUP_OPTION, ...availableColumns].map((field) => ({
+      label: field,
+      'data-test-subj': field === NONE_GROUP_OPTION ? 'cascadeGroupByNone' : `cascadeGroupBy-${field}`,
+      checked: (field === NONE_GROUP_OPTION && !currentSelectedColumns.length) || currentSelectedColumns.includes(field) ? ('on' as const) : undefined,
+    })),
+    [availableColumns, currentSelectedColumns]
+  );
+
+  const handleChange = useCallback<NonNullable<React.ComponentProps<typeof EuiSelectable>['onActiveOptionChange']>>(
+    (option) => {
+      if (option) {
+        onChange([option.label].filter((o) => o !== NONE_GROUP_OPTION));
+      }
+      setIsOpen(false);
+    },
+    [onChange]
+  );
+
+  return (
+    <EuiPopover
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      panelPaddingSize="none"
+      button={
+        <EuiFilterGroup>
+          <EuiButtonEmpty
+            size="xs"
+            iconType="inspect"
+            onClick={() => setIsOpen((p) => !p)}
+            data-test-subj="cascadeGroupBySelector"
+          >
+            Group by{currentSelectedColumns.length > 0 && ` (${currentSelectedColumns.join(', ')})`}
+          </EuiButtonEmpty>
+        </EuiFilterGroup>
+      }
+    >
+      <EuiSelectable
+        searchable={false}
+        listProps={{ isVirtualized: false }}
+        options={options}
+        singleSelection="always"
+        onActiveOptionChange={handleChange}
+        data-test-subj="cascadeGroupBySelectionList"
+      >
+        {(list) => <div style={{ width: 300 }}>{list}</div>}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+});
+
+// ── Main component ──
+
+export const TanStackCascadeGrid: React.FC<TanStackCascadeGridProps> = React.memo(({
+  rows, columns, columnsMeta, dataView, query, showTimeCol,
+  sort, onSort, onFilter,
+  expandedDoc, setExpandedDoc, renderDocumentView,
+  loadingState, settings, fetchGroupDocuments, onOpenInNewTab,
+  availableCascadeGroups, selectedCascadeGroups, onCascadeGroupingChange,
+  externalCustomRenderers,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const parentRef = useRef<HTMLDivElement | null>(null);
+  const styles = useMemo(() => getCascadeGridStyles(euiTheme), [euiTheme]);
+  const esqlQuery = 'esql' in query ? query.esql : '';
+
+  // Stable cache key: dataView id + query hash (survives tab switches)
+  const cacheKey = `${dataView.id ?? dataView.title}::${esqlQuery}`;
+
+  // ── Parse STATS...BY ──
+  const statsByInfo = useMemo(() => parseStatsByColumns(query, columns), [query, columns]);
+  const byFields = statsByInfo?.byFields ?? [];
+  const aggregateColumns = statsByInfo?.aggregateColumns ?? [];
+
+  // ── Expansion state (restore from cache on mount) ──
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => expandedGroupsCache.get(cacheKey) ?? new Set()
+  );
+  const toggleGroup = useCallback((rowId: string) => {
+    setExpandedGroups((prev) => { const next = new Set(prev); if (next.has(rowId)) next.delete(rowId); else next.add(rowId); return next; });
+  }, []);
+
+  const expandAll = useCallback(() => {
+    const all = new Set(rows.map((r) => r.id));
+    setExpandedGroups(all);
+    rows.forEach((r) => fetchDocsForRow(r.id, r));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows]);
+
+  const collapseAll = useCallback(() => {
+    abortControllersRef.current.forEach((c) => c.abort());
+    abortControllersRef.current.clear();
+    setExpandedGroups(new Set());
+  }, []);
+
+  // ── Fetched documents cache (restore from module cache on mount) ──
+  const [groupDocsMap, setGroupDocsMap] = useState<Map<string, GroupDocsState>>(
+    () => groupDocsCacheMap.get(cacheKey) ?? new Map()
+  );
+  const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
+
+  const groupDocsMapRef = useRef(groupDocsMap);
+  groupDocsMapRef.current = groupDocsMap;
+
+  const fetchDocsForRow = useCallback(async (rowId: string, record: DataTableRecord) => {
+    const existing = groupDocsMapRef.current.get(rowId);
+    if (existing?.docs) return;
+    abortControllersRef.current.get(rowId)?.abort();
+    const controller = new AbortController();
+    abortControllersRef.current.set(rowId, controller);
+    setGroupDocsMap((prev) => { const next = new Map(prev); next.set(rowId, { docs: null, loading: true, error: null }); return next; });
+    try {
+      const docs = await fetchGroupDocuments({ subQuery: { esql: buildSubQuery(esqlQuery, byFields, record) }, dataView, signal: controller.signal });
+      setGroupDocsMap((prev) => { const next = new Map(prev); next.set(rowId, { docs, loading: false, error: null }); return next; });
+    } catch (err: any) {
+      if (err?.name === 'AbortError') return;
+      setGroupDocsMap((prev) => { const next = new Map(prev); next.set(rowId, { docs: null, loading: false, error: err?.message ?? 'Fetch failed' }); return next; });
+    } finally {
+      abortControllersRef.current.delete(rowId);
+    }
+  }, [esqlQuery, byFields, dataView, fetchGroupDocuments]);
+
+  const cancelFetch = useCallback((rowId: string) => { abortControllersRef.current.get(rowId)?.abort(); abortControllersRef.current.delete(rowId); }, []);
+
+  useEffect(() => { return () => { abortControllersRef.current.forEach((c) => c.abort()); abortControllersRef.current.clear(); }; }, []);
+
+  // Persist expansion + docs state to module cache on every change
+  useEffect(() => { expandedGroupsCache.set(cacheKey, expandedGroups); }, [cacheKey, expandedGroups]);
+  useEffect(() => { groupDocsCacheMap.set(cacheKey, groupDocsMap); }, [cacheKey, groupDocsMap]);
+
+  // Reset on query change (not just row count — row count can fluctuate)
+  const prevCacheKeyRef = useRef(cacheKey);
+  useEffect(() => {
+    if (prevCacheKeyRef.current !== cacheKey) {
+      prevCacheKeyRef.current = cacheKey;
+      setExpandedGroups(expandedGroupsCache.get(cacheKey) ?? new Set());
+      setGroupDocsMap(groupDocsCacheMap.get(cacheKey) ?? new Map());
+      abortControllersRef.current.forEach((c) => c.abort());
+      abortControllersRef.current.clear();
+    }
+  }, [cacheKey]);
+
+  const handleToggle = useCallback((rowId: string, record: DataTableRecord) => {
+    const willExpand = !expandedGroups.has(rowId);
+    toggleGroup(rowId);
+    if (willExpand) fetchDocsForRow(rowId, record); else cancelFetch(rowId);
+  }, [expandedGroups, toggleGroup, fetchDocsForRow, cancelFetch]);
+
+  const handleRetry = useCallback((rowId: string, record: DataTableRecord) => {
+    setGroupDocsMap((prev) => { const next = new Map(prev); next.delete(rowId); return next; });
+    fetchDocsForRow(rowId, record);
+  }, [fetchDocsForRow]);
+
+  // ── Context menu (3-dot popover matching old tab) ──
+  const popoverBtnRef = useRef<HTMLButtonElement | null>(null);
+  const [popoverRow, setPopoverRow] = useState<{ id: string; record: DataTableRecord } | null>(null);
+  const closePopover = useCallback(() => setPopoverRow(null), []);
+
+  const handleActionsClick = useCallback((e: React.MouseEvent<HTMLButtonElement>, record: DataTableRecord) => {
+    popoverBtnRef.current = e.currentTarget;
+    setPopoverRow((prev) => prev?.id === record.id ? null : { id: record.id, record });
+  }, []);
+
+  const contextMenuPanels = useMemo(() => {
+    if (!popoverRow) return [];
+    const groupValue = byFields.map((f) => formatCellValue(popoverRow.record.flattened[f])).join(', ');
+    return [{
+      id: 'cascade-actions',
+      items: [
+        {
+          name: 'Copy to clipboard',
+          icon: 'copy',
+          'data-test-subj': 'cascadeActionCopy',
+          onClick: () => { copyToClipboard(groupValue); closePopover(); },
+        },
+        ...(onFilter ? [
+          {
+            name: 'Filter in',
+            icon: 'plusInCircle',
+            'data-test-subj': 'cascadeActionFilterIn',
+            disabled: byFields.every((f) => isBlankValue(popoverRow.record.flattened[f])),
+            onClick: () => { byFields.forEach((f) => onFilter!(f, popoverRow.record.flattened[f], '+')); closePopover(); },
+          },
+          {
+            name: 'Filter out',
+            icon: 'minusInCircle',
+            'data-test-subj': 'cascadeActionFilterOut',
+            disabled: byFields.every((f) => isBlankValue(popoverRow.record.flattened[f])),
+            onClick: () => { byFields.forEach((f) => onFilter!(f, popoverRow.record.flattened[f], '-')); closePopover(); },
+          },
+        ] : []),
+        ...(onOpenInNewTab ? [
+          {
+            name: 'Open in new tab',
+            icon: 'discoverApp',
+            'data-test-subj': 'cascadeActionOpenInNewTab',
+            onClick: () => {
+              const subEsql = buildSubQuery(esqlQuery, byFields, popoverRow.record);
+              onOpenInNewTab({ appState: { query: { esql: subEsql } } });
+              closePopover();
+            },
+          },
+        ] : []),
+      ],
+    }];
+  }, [popoverRow, byFields, onFilter, onOpenInNewTab, esqlQuery, closePopover]);
+
+  // ── Virtualizer ──
+  const getRowHeight = useCallback((index: number): number => {
+    const row = rows[index];
+    if (!row) return GROUP_ROW_HEIGHT;
+    if (!expandedGroups.has(row.id)) return GROUP_ROW_HEIGHT;
+    const state = groupDocsMap.get(row.id);
+    if (!state?.docs || state.docs.length === 0) return GROUP_ROW_HEIGHT + 56;
+    return GROUP_ROW_HEIGHT + EXPANDED_PANEL_HEIGHT;
+  }, [rows, expandedGroups, groupDocsMap]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: getRowHeight,
+    overscan: OVERSCAN,
+    initialOffset: scrollPositionCache.get(cacheKey) ?? 0,
+  });
+  useEffect(() => { rowVirtualizer.measure(); }, [expandedGroups, groupDocsMap, rowVirtualizer]);
+
+  // Persist scroll position to module cache
+  useEffect(() => {
+    const scrollEl = parentRef.current;
+    if (!scrollEl) return;
+    let rafId = 0;
+    const handleScroll = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        scrollPositionCache.set(cacheKey, scrollEl.scrollTop);
+      });
+    };
+    scrollEl.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      cancelAnimationFrame(rafId);
+      scrollEl.removeEventListener('scroll', handleScroll);
+    };
+  }, [cacheKey]);
+
+  // ── Keyboard navigation ──
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const total = rows.length;
+    if (total === 0) return;
+    let next = focusedIndex;
+    const row = rows[focusedIndex];
+    switch (e.key) {
+      case 'ArrowDown': e.preventDefault(); next = Math.min(focusedIndex + 1, total - 1); break;
+      case 'ArrowUp': e.preventDefault(); next = Math.max(focusedIndex - 1, 0); break;
+      case 'Home': e.preventDefault(); next = 0; break;
+      case 'End': e.preventDefault(); next = total - 1; break;
+      case 'ArrowRight': e.preventDefault(); if (row && !expandedGroups.has(row.id)) handleToggle(row.id, row); return;
+      case 'ArrowLeft': e.preventDefault(); if (row && expandedGroups.has(row.id)) handleToggle(row.id, row); return;
+      default: return;
+    }
+    if (next !== focusedIndex) {
+      setFocusedIndex(next);
+      rowVirtualizer.scrollToIndex(next, { align: 'auto' });
+      requestAnimationFrame(() => {
+        (parentRef.current?.querySelector(`[data-row-id="${rows[next]?.id}"]`) as HTMLElement | null)?.focus();
+      });
+    }
+  }, [focusedIndex, rows, expandedGroups, handleToggle, rowVirtualizer]);
+
+  // ── Full screen ──
+  const [isFullScreen, setIsFullScreen] = useState(false);
+  const toggleFullScreen = useCallback(() => setIsFullScreen((p) => !p), []);
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  const isLoading = loadingState === DataLoadingState.loading;
+  const isEmpty = !isLoading && rows.length === 0;
+  return (
+    <div css={[styles.wrapper, isFullScreen && styles.fullScreen]} data-test-subj="tanstackCascadeWrapper">
+      {/* Toolbar — matches old tab header: left = count, right = controls */}
+      <div css={styles.toolbar}>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              <strong>{rows.length.toLocaleString()} {rows.length === 1 ? 'group' : 'groups'}</strong>
+              {byFields.length > 0 && <span style={{ fontWeight: 'normal' }}>{' '}· by {byFields.join(', ')}</span>}
+            </EuiText>
+          </EuiFlexItem>
+          {expandedGroups.size > 0 && (
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">{expandedGroups.size} expanded</EuiBadge>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+        <div css={styles.toolbarRight}>
+          {availableCascadeGroups && availableCascadeGroups.length > 0 && onCascadeGroupingChange && (
+            <GroupBySelector
+              availableColumns={availableCascadeGroups}
+              currentSelectedColumns={selectedCascadeGroups ?? []}
+              onChange={onCascadeGroupingChange}
+            />
+          )}
+          <EuiToolTip content="Expand all groups">
+            <EuiButtonIcon iconType="unfold" aria-label="Expand all groups" size="xs" onClick={expandAll} data-test-subj="cascadeExpandAll" />
+          </EuiToolTip>
+          <EuiToolTip content="Collapse all groups">
+            <EuiButtonIcon iconType="fold" aria-label="Collapse all groups" size="xs" onClick={collapseAll} disabled={expandedGroups.size === 0} data-test-subj="cascadeCollapseAll" />
+          </EuiToolTip>
+          <EuiToolTip content={isFullScreen ? 'Exit full screen' : 'Full screen'}>
+            <EuiButtonIcon iconType={isFullScreen ? 'fullScreenExit' : 'fullScreen'} aria-label={isFullScreen ? 'Exit full screen' : 'Full screen'} size="xs" onClick={toggleFullScreen} data-test-subj="cascadeFullScreenButton" />
+          </EuiToolTip>
+        </div>
+      </div>
+
+      <div css={{ flex: 1, overflow: 'hidden', position: 'relative', display: 'flex', flexDirection: 'column' }}>
+        {isEmpty ? (
+          <EuiEmptyPrompt css={styles.emptyState} iconType="discoverApp" title={<h3>No groups found</h3>} body="The query returned no STATS...BY results." data-test-subj="cascadeNoResults" />
+        ) : (
+          <div ref={parentRef} css={styles.scrollContainer} role="treegrid" aria-label="Cascade document groups" aria-readonly="true" tabIndex={0} onKeyDown={handleKeyDown}>
+            <div css={styles.virtualOuter} style={{ height: rowVirtualizer.getTotalSize() }}>
+              <div css={styles.virtualInner} style={{ transform: `translateY(${virtualItems[0]?.start ?? 0}px)` }}>
+                {virtualItems.map((virtualRow) => {
+                  const row = rows[virtualRow.index];
+                  const rowId = row.id;
+                  const isExpanded = expandedGroups.has(rowId);
+                  const docsState = groupDocsMap.get(rowId);
+                  return (
+                    <div key={rowId} data-index={virtualRow.index} role="rowgroup">
+                      <CascadeGroupRow
+                        record={row}
+                        isExpanded={isExpanded}
+                        onToggle={() => handleToggle(rowId, row)}
+                        onActionsClick={(e) => handleActionsClick(e, row)}
+                        byFields={byFields}
+                        aggregateColumns={aggregateColumns}
+                        styles={styles}
+                        ariaProps={{ 'aria-expanded': isExpanded, 'aria-level': 1, 'aria-posinset': virtualRow.index + 1, 'aria-setsize': rows.length }}
+                      />
+                      {isExpanded && docsState && (
+                        <ExpandedGroupGrid
+                          state={docsState}
+                          dataView={dataView}
+                          showTimeCol={showTimeCol}
+                          renderDocumentView={renderDocumentView}
+                          externalCustomRenderers={externalCustomRenderers}
+                          styles={styles}
+                          rowId={rowId}
+                          onRetry={() => handleRetry(rowId, row)}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            {isLoading && <div css={styles.loadingOverlay}><EuiLoadingSpinner size="xl" /></div>}
+          </div>
+        )}
+
+      </div>
+
+      {/* Actions popover — matches old tab's EuiWrappingPopover + EuiContextMenu */}
+      {popoverRow && popoverBtnRef.current && (
+        <EuiWrappingPopover
+          button={popoverBtnRef.current}
+          isOpen
+          closePopover={closePopover}
+          panelPaddingSize="none"
+          anchorPosition="downRight"
+        >
+          <EuiContextMenu
+            initialPanelId="cascade-actions"
+            panels={contextMenuPanels}
+            data-test-subj="cascadeContextMenu"
+          />
+        </EuiWrappingPopover>
+      )}
+    </div>
+  );
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.tsx
@@ -14,14 +14,15 @@ import {
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiContextMenu,
+  EuiDataGridToolbarControl,
   EuiEmptyPrompt,
   EuiFilterGroup,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiLoadingSpinner,
   EuiPanel,
   EuiPopover,
+  EuiProgress,
   EuiSelectable,
   EuiText,
   EuiToolTip,
@@ -30,7 +31,7 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import {
   DataLoadingState,
   UnifiedDataTable,
@@ -43,75 +44,92 @@ import type { AggregateQuery } from '@kbn/es-query';
 import { getCascadeGridStyles } from './tanstack_cascade_grid.styles';
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 
+// ── Constants ──
+
 const GROUP_ROW_HEIGHT = 32;
 const EXPANDED_PANEL_HEIGHT = 400;
+const LOADING_ROW_HEIGHT = GROUP_ROW_HEIGHT + 56;
+const EXPANDED_ROW_HEIGHT = GROUP_ROW_HEIGHT + EXPANDED_PANEL_HEIGHT;
 const MAX_DOCS_PER_GROUP = 100;
-const OVERSCAN = 25;
+const OVERSCAN = 15;
 
-// ── SI prefix number formatting (matching NumberBadge) ──
+const EMPTY_STRINGS: string[] = [];
+const EMPTY_SORT: SortOrder[] = [];
 
-const SI_PREFIXES_CENTER = 8;
-const siPrefixes = ['y', 'z', 'a', 'f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+// ── Formatting helpers ──
 
-const getSiPrefixedNumber = (n: number): string => {
-  if (n === 0) return '0';
-  const base = Math.floor(Math.log10(Math.abs(n)));
-  const siBase = (base < 0 ? Math.ceil : Math.floor)(base / 3);
-  const prefix = siPrefixes[siBase + SI_PREFIXES_CENTER];
-  if (siBase === 0) return n.toString();
-  const baseNumber = parseFloat((n / Math.pow(10, siBase * 3)).toFixed(2));
-  return `${baseNumber}${prefix}`;
-};
+const SI_PREFIXES = ['y', 'z', 'a', 'f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
 
 const formatNumberBadge = (value: number): string => {
-  if (Math.floor(value / 1000) >= 1) return getSiPrefixedNumber(value);
-  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+  if (value === 0) return '0';
+  if (Math.abs(value) < 1000) return Number.isInteger(value) ? String(value) : value.toFixed(2);
+  const exp = Math.floor(Math.log10(Math.abs(value)));
+  const si = Math.floor(exp / 3);
+  return `${parseFloat((value / Math.pow(10, si * 3)).toFixed(2))}${SI_PREFIXES[si + 8]}`;
 };
 
 const formatCellValue = (value: unknown): string => {
-  if (value === null || value === undefined) return '-';
+  if (value == null) return '-';
   if (Array.isArray(value)) return value.join(', ');
   if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
 };
 
-const isBlankValue = (v: unknown): boolean => v === null || v === undefined || v === '';
+const isBlank = (v: unknown): boolean => v == null || v === '';
 
-interface StatsByInfo {
-  byFields: string[];
-  aggregateColumns: string[];
-}
+// ── Query parsing ──
 
-const parseStatsByColumns = (query: AggregateQuery | undefined, columns: string[]): StatsByInfo | undefined => {
+const parseStatsByColumns = (query: AggregateQuery | undefined, columns: string[]) => {
   if (!query || !('esql' in query)) return undefined;
-  // Use [\s\S]+? to span newlines between STATS and BY, and (.+) greedy to capture the rest
-  const byMatch = query.esql.match(/\bSTATS\b[\s\S]+?\bBY\b\s+(.+)/i);
-  if (!byMatch) return undefined;
-  // Strip everything after a pipe or end-of-line comment
-  let byClause = byMatch[1];
-  const pipeIdx = byClause.indexOf('|');
-  if (pipeIdx >= 0) byClause = byClause.slice(0, pipeIdx);
-  byClause = byClause.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '').trim();
-  const byFields = byClause.split(',').map((f) => f.trim()).filter(Boolean);
-  if (byFields.length === 0) return undefined;
+  const m = query.esql.match(/\bSTATS\b[\s\S]+?\bBY\b\s+(.+)/i);
+  if (!m) return undefined;
+  let clause = m[1];
+  const pipe = clause.indexOf('|');
+  if (pipe >= 0) clause = clause.slice(0, pipe);
+  clause = clause.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '').trim();
+  const byFields = clause.split(',').map((f) => f.trim()).filter(Boolean);
+  if (!byFields.length) return undefined;
   return { byFields, aggregateColumns: columns.filter((c) => !byFields.includes(c)) };
 };
 
-const buildWhereClause = (byFields: string[], record: DataTableRecord): string => {
-  return byFields.map((field) => {
+const buildWhereClause = (byFields: string[], record: DataTableRecord): string =>
+  byFields.map((field) => {
     const val = record.flattened[field];
-    if (val === null || val === undefined) return `\`${field}\` IS NULL`;
-    if (typeof val === 'number') return `\`${field}\` == ${val}`;
-    if (typeof val === 'boolean') return `\`${field}\` == ${val}`;
-    const escaped = String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    return `\`${field}\` == "${escaped}"`;
+    if (val == null) return `\`${field}\` IS NULL`;
+    if (typeof val === 'number' || typeof val === 'boolean') return `\`${field}\` == ${val}`;
+    return `\`${field}\` == "${String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
   }).join(' AND ');
+
+const splitOnPipe = (query: string): string[] => {
+  const parts: string[] = [];
+  let cur = '';
+  for (let i = 0; i < query.length; i++) {
+    const ch = query[i];
+    if (ch === '"' || ch === "'") {
+      const tri = query.slice(i, i + 3);
+      if (tri === '"""' || tri === "'''") {
+        const end = query.indexOf(tri, i + 3);
+        const s = end === -1 ? query.slice(i) : query.slice(i, end + 3);
+        cur += s; i += s.length - 1;
+      } else {
+        cur += ch; i++;
+        while (i < query.length && query[i] !== ch) {
+          if (query[i] === '\\' && i + 1 < query.length) { cur += query[i++]; }
+          cur += query[i++];
+        }
+        if (i < query.length) cur += query[i];
+      }
+    } else if (ch === '|') { parts.push(cur); cur = ''; }
+    else { cur += ch; }
+  }
+  parts.push(cur);
+  return parts.map((s) => s.trim());
 };
 
-const buildSubQuery = (originalQuery: string, byFields: string[], record: DataTableRecord): string => {
-  const parts = originalQuery.split('|').map((s) => s.trim());
-  const statsIdx = parts.findIndex((p) => /^\s*STATS\b/i.test(p));
-  const base = statsIdx > 0 ? parts.slice(0, statsIdx) : [parts[0]];
+const buildSubQuery = (esql: string, byFields: string[], record: DataTableRecord): string => {
+  const parts = splitOnPipe(esql);
+  const si = parts.findIndex((p) => /^\s*STATS\b/i.test(p));
+  const base = si > 0 ? parts.slice(0, si) : [parts[0]];
   return `${base.join(' | ')} | WHERE ${buildWhereClause(byFields, record)} | LIMIT ${MAX_DOCS_PER_GROUP}`;
 };
 
@@ -122,15 +140,13 @@ export interface FetchGroupDocsParams {
   dataView: DataView;
   signal: AbortSignal;
 }
-
 export type FetchGroupDocsFn = (params: FetchGroupDocsParams) => Promise<DataTableRecord[]>;
-
 export type OpenInNewTabFn = (params: { appState?: { query?: AggregateQuery } }) => void;
 
 export interface TanStackCascadeGridProps {
   rows: DataTableRecord[];
   columns: string[];
-  columnsMeta?: DataTableColumnsMeta;
+  columnsMeta?: UnifiedDataTableProps['columnsMeta'];
   dataView: DataView;
   query: AggregateQuery;
   showTimeCol: boolean;
@@ -156,14 +172,17 @@ interface GroupDocsState {
   error: string | null;
 }
 
-// Module-level caches that survive tab switches (component unmount/remount)
-const scrollPositionCache = new Map<string, number>();
-const expandedGroupsCache = new Map<string, Set<string>>();
-const groupDocsCacheMap = new Map<string, Map<string, GroupDocsState>>();
+// ── Module-level caches (survive tab switches, bounded) ──
 
-// ── Expanded group grid (UnifiedDataTable) ──
+const MAX_CACHE = 20;
+function evict<V>(cache: Map<string, V>) {
+  if (cache.size > MAX_CACHE) cache.delete(cache.keys().next().value!);
+}
+const scrollCache = new Map<string, number>();
+const expandCache = new Map<string, Set<string>>();
+const docsCache = new Map<string, Map<string, GroupDocsState>>();
 
-const EMPTY_SORT: SortOrder[] = [];
+// ── ExpandedGroupGrid ──
 
 const ExpandedGroupGrid = React.memo(({
   state, dataView, showTimeCol, renderDocumentView, externalCustomRenderers, onRetry, styles, rowId,
@@ -177,138 +196,124 @@ const ExpandedGroupGrid = React.memo(({
   const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>();
   const [selectedColumns, setSelectedColumns] = useState<string[]>([]);
   const [density, setDensity] = useState<DataGridDensity>(DataGridDensity.COMPACT);
+  const setExpandedDocCb = useCallback((doc: DataTableRecord | undefined) => setExpandedDoc(doc), []);
 
-  const setExpandedDocFn = useCallback(
-    (...args: Parameters<NonNullable<UnifiedDataTableProps['setExpandedDoc']>>) => setExpandedDoc(args[0]),
-    []
-  );
+  const docs = state.docs ?? [];
+  const toolbar = useMemo(() => getRenderCustomToolbarWithElements({
+    leftSide: <EuiText size="s"><strong>{docs.length} {docs.length === 1 ? 'result' : 'results'}</strong></EuiText>,
+  }), [docs.length]);
 
   if (state.loading && !state.docs) {
     return <div css={styles.docsPanelLoading}><EuiLoadingSpinner size="m" /><EuiText size="xs" color="subdued">Loading documents…</EuiText></div>;
   }
   if (state.error) {
-    return (
-      <div css={styles.docsPanelError}>
-        <EuiIcon type="warning" color="danger" /><EuiText size="xs" color="danger">{state.error}</EuiText>
-        <EuiButtonEmpty size="xs" onClick={onRetry}>Retry</EuiButtonEmpty>
-      </div>
-    );
+    return <div css={styles.docsPanelError}><EuiText size="xs" color="danger">{state.error}</EuiText><EuiButtonEmpty size="xs" onClick={onRetry}>Retry</EuiButtonEmpty></div>;
   }
-  const docs = state.docs ?? [];
-  if (docs.length === 0) {
+  if (!docs.length) {
     return <div css={styles.docsPanelLoading}><EuiText size="xs" color="subdued">No documents found for this group.</EuiText></div>;
   }
-
-  const renderCustomToolbar = getRenderCustomToolbarWithElements({
-    leftSide: (
-      <EuiText size="s">
-        <strong>{docs.length} {docs.length === 1 ? 'result' : 'results'}</strong>
-      </EuiText>
-    ),
-  });
 
   return (
     <div css={styles.docsPanel} data-test-subj="cascadeDocsPanel" style={{ height: EXPANDED_PANEL_HEIGHT }}>
       <EuiPanel paddingSize="none" css={styles.docsPanelInner}>
         <UnifiedDataTable
-          isPlainRecord
-          dataView={dataView}
-          showTimeCol={showTimeCol}
-          services={services}
-          sort={EMPTY_SORT}
-          isSortEnabled={false}
-          ariaLabelledBy={`cascade-leaf-${rowId}`}
-          consumer={`discover_cascade_leaf_${rowId}`}
-          rows={docs}
-          loadingState={state.loading ? DataLoadingState.loading : DataLoadingState.loaded}
-          columns={selectedColumns}
-          onSetColumns={setSelectedColumns}
-          renderCustomToolbar={renderCustomToolbar}
-          expandedDoc={expandedDoc}
-          setExpandedDoc={setExpandedDocFn}
-          dataGridDensityState={density}
-          onUpdateDataGridDensity={setDensity}
-          renderDocumentView={renderDocumentView}
-          externalCustomRenderers={externalCustomRenderers}
-          paginationMode="infinite"
-          sampleSizeState={docs.length}
+          isPlainRecord dataView={dataView} showTimeCol={showTimeCol} services={services}
+          sort={EMPTY_SORT} isSortEnabled={false}
+          ariaLabelledBy={`cascade-leaf-${rowId}`} consumer={`discover_cascade_leaf_${rowId}`}
+          rows={docs} loadingState={state.loading ? DataLoadingState.loading : DataLoadingState.loaded}
+          columns={selectedColumns} onSetColumns={setSelectedColumns}
+          renderCustomToolbar={toolbar}
+          expandedDoc={expandedDoc} setExpandedDoc={setExpandedDocCb}
+          dataGridDensityState={density} onUpdateDataGridDensity={setDensity}
+          renderDocumentView={renderDocumentView} externalCustomRenderers={externalCustomRenderers}
+          paginationMode="infinite" sampleSizeState={docs.length}
         />
       </EuiPanel>
     </div>
   );
 });
 
-// ── Group row (matching old cascade layout: expand btn | title 4/10 | meta 6/10 | actions btn) ──
+// ── CascadeGroupRow ──
 
 const CascadeGroupRow = React.memo(({
-  record, isExpanded, onToggle, onActionsClick, byFields, aggregateColumns, styles, ariaProps,
+  record, isExpanded, onToggle, onActionsClick, byFields, aggregateColumns, styles,
+  index, totalRows,
 }: {
-  record: DataTableRecord; isExpanded: boolean; onToggle: () => void;
-  onActionsClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  record: DataTableRecord; isExpanded: boolean;
+  onToggle: (rowId: string, record: DataTableRecord) => void;
+  onActionsClick: (e: React.MouseEvent<HTMLButtonElement>, record: DataTableRecord) => void;
   byFields: string[]; aggregateColumns: string[];
   styles: ReturnType<typeof getCascadeGridStyles>;
-  ariaProps: Record<string, string | number | boolean>;
+  index: number; totalRows: number;
 }) => {
-  const groupValue = byFields.map((f) => record.flattened[f]).map(formatCellValue).join(', ');
-  const blank = byFields.every((f) => isBlankValue(record.flattened[f]));
+  const allBlank = byFields.every((f) => isBlank(record.flattened[f]));
+  const title = allBlank ? '(blank)' : byFields.map((f) => formatCellValue(record.flattened[f])).join(', ');
 
   return (
     <div
       css={[styles.groupRow, isExpanded && styles.groupRowExpanded]}
-      role="row"
-      tabIndex={-1}
-      data-test-subj="cascadeGroupRow"
-      data-row-id={record.id}
-      {...ariaProps}
-      onClick={onToggle}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); } }}
+      role="row" tabIndex={0} data-test-subj="cascadeGroupRow"
+      data-row-id={record.id} data-row-type="root"
+      aria-expanded={isExpanded} aria-level={1} aria-posinset={index + 1} aria-setsize={totalRows}
+      onClick={() => onToggle(record.id, record)}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(record.id, record); } }}
     >
-      {/* Expand/collapse button */}
-      <EuiIcon type={isExpanded ? 'arrowDown' : 'arrowRight'} size="s" />
+      <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" justifyContent="spaceBetween" responsive={false}
+        data-test-subj={`${record.id}-row-header`} css={styles.rowHeader}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            iconType={isExpanded ? 'arrowDown' : 'arrowRight'} color="text" size="xs"
+            aria-label={isExpanded ? 'collapse row' : 'expand row'}
+            onClick={(e: React.MouseEvent) => { e.stopPropagation(); onToggle(record.id, record); }}
+            data-test-subj={`toggle-row-${record.id}-button`}
+          />
+        </EuiFlexItem>
 
-      {/* Title slot (4/10 flex growth) */}
-      <div css={[styles.groupTitle, blank && styles.groupTitleBlank]}>
-        <h4>{blank ? '(blank)' : groupValue}</h4>
-      </div>
+        <EuiFlexItem grow>
+          <EuiFlexGroup gutterSize="m" justifyContent="spaceBetween" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={4} css={styles.groupTitle}>
+              <EuiText size="s">
+                <h4 css={[styles.titleText, allBlank && styles.groupTitleBlank]}>{title}</h4>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={6}>
+              <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" alignItems="center" responsive={false} wrap>
+                {aggregateColumns.map((col) => {
+                  const val = record.flattened[col];
+                  return (
+                    <EuiFlexItem key={col} grow={false}>
+                      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="s" css={styles.metaLabel}><strong>{col}:</strong></EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          {typeof val === 'number'
+                            ? <EuiText size="s" css={styles.numberBadge} title={String(val)}><h5>{formatNumberBadge(val)}</h5></EuiText>
+                            : <EuiBadge color="hollow" css={styles.textBadge}>{isBlank(val) ? '(blank)' : formatCellValue(val)}</EuiBadge>}
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                  );
+                })}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
 
-      {/* Meta slots (6/10 flex growth) — aggregates */}
-      <div css={styles.groupMeta}>
-        {aggregateColumns.map((col) => {
-          const val = record.flattened[col];
-          return (
-            <div key={col} css={styles.metaSlot}>
-              <span css={styles.metaLabel}>{col}:</span>
-              {typeof val === 'number' ? (
-                <span css={styles.numberBadge} title={String(val)}>
-                  {formatNumberBadge(val)}
-                </span>
-              ) : (
-                <EuiBadge color="hollow" css={styles.textBadge}>
-                  {isBlankValue(val) ? '(blank)' : formatCellValue(val)}
-                </EuiBadge>
-              )}
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Actions button (3-dot menu) */}
-      <EuiButtonIcon
-        css={styles.actionsBtn}
-        iconType="boxesVertical"
-        aria-label="Row actions"
-        size="xs"
-        color="text"
-        onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onActionsClick(e); }}
-        data-test-subj="cascadeRowActionsBtn"
-      />
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon iconType="boxesVertical" size="xs" color="text"
+            aria-label={`${record.id}-cascade-row-actions`}
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onActionsClick(e, record); }}
+            data-test-subj={`${record.id}-dscCascadeRowContextActionButton`}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </div>
   );
 });
 
-// ── Group By selector (matching old cascade header) ──
-
-const NONE_GROUP_OPTION = 'none';
+// ── GroupBySelector ──
 
 const GroupBySelector = React.memo(({
   availableColumns, currentSelectedColumns, onChange,
@@ -317,51 +322,32 @@ const GroupBySelector = React.memo(({
   onChange: (groups: string[]) => void;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-
   const options = useMemo(
-    () => [NONE_GROUP_OPTION, ...availableColumns].map((field) => ({
-      label: field,
-      'data-test-subj': field === NONE_GROUP_OPTION ? 'cascadeGroupByNone' : `cascadeGroupBy-${field}`,
-      checked: (field === NONE_GROUP_OPTION && !currentSelectedColumns.length) || currentSelectedColumns.includes(field) ? ('on' as const) : undefined,
+    () => ['none', ...availableColumns].map((f) => ({
+      label: f,
+      'data-test-subj': f === 'none' ? 'discoverCascadeLayoutOptOutButton' : `${f}-cascadeLayoutOptionBtn`,
+      checked: (f === 'none' && !currentSelectedColumns.length) || currentSelectedColumns.includes(f) ? ('on' as const) : undefined,
     })),
     [availableColumns, currentSelectedColumns]
   );
 
-  const handleChange = useCallback<NonNullable<React.ComponentProps<typeof EuiSelectable>['onActiveOptionChange']>>(
-    (option) => {
-      if (option) {
-        onChange([option.label].filter((o) => o !== NONE_GROUP_OPTION));
-      }
-      setIsOpen(false);
-    },
-    [onChange]
-  );
-
   return (
-    <EuiPopover
-      isOpen={isOpen}
-      closePopover={() => setIsOpen(false)}
-      panelPaddingSize="none"
+    <EuiPopover isOpen={isOpen} closePopover={() => setIsOpen(false)} panelPaddingSize="none"
       button={
         <EuiFilterGroup>
-          <EuiButtonEmpty
-            size="xs"
-            iconType="inspect"
-            onClick={() => setIsOpen((p) => !p)}
-            data-test-subj="cascadeGroupBySelector"
-          >
-            Group by{currentSelectedColumns.length > 0 && ` (${currentSelectedColumns.join(', ')})`}
-          </EuiButtonEmpty>
+          <EuiDataGridToolbarControl iconType="inspect" color="text" onClick={() => setIsOpen((p) => !p)}
+            badgeContent={currentSelectedColumns.length} data-test-subj="discoverEnableCascadeLayoutSwitch"
+          >Group by</EuiDataGridToolbarControl>
         </EuiFilterGroup>
       }
     >
-      <EuiSelectable
-        searchable={false}
-        listProps={{ isVirtualized: false }}
-        options={options}
-        singleSelection="always"
-        onActiveOptionChange={handleChange}
-        data-test-subj="cascadeGroupBySelectionList"
+      <EuiSelectable searchable={false} listProps={{ isVirtualized: false }} options={options} singleSelection="always"
+        onChange={(opts) => {
+          const sel = opts.find((o) => o.checked === 'on');
+          if (sel) onChange(sel.label === 'none' ? [] : [sel.label]);
+          setIsOpen(false);
+        }}
+        data-test-subj="discoverGroupBySelectionList"
       >
         {(list) => <div style={{ width: 300 }}>{list}</div>}
       </EuiSelectable>
@@ -372,10 +358,8 @@ const GroupBySelector = React.memo(({
 // ── Main component ──
 
 export const TanStackCascadeGrid: React.FC<TanStackCascadeGridProps> = React.memo(({
-  rows, columns, columnsMeta, dataView, query, showTimeCol,
-  sort, onSort, onFilter,
-  expandedDoc, setExpandedDoc, renderDocumentView,
-  loadingState, settings, fetchGroupDocuments, onOpenInNewTab,
+  rows, columns, dataView, query, showTimeCol, onFilter, renderDocumentView,
+  loadingState, fetchGroupDocuments, onOpenInNewTab,
   availableCascadeGroups, selectedCascadeGroups, onCascadeGroupingChange,
   externalCustomRenderers,
 }) => {
@@ -383,95 +367,100 @@ export const TanStackCascadeGrid: React.FC<TanStackCascadeGridProps> = React.mem
   const parentRef = useRef<HTMLDivElement | null>(null);
   const styles = useMemo(() => getCascadeGridStyles(euiTheme), [euiTheme]);
   const esqlQuery = 'esql' in query ? query.esql : '';
-
-  // Stable cache key: dataView id + query hash (survives tab switches)
   const cacheKey = `${dataView.id ?? dataView.title}::${esqlQuery}`;
 
-  // ── Parse STATS...BY ──
-  const statsByInfo = useMemo(() => parseStatsByColumns(query, columns), [query, columns]);
-  const byFields = statsByInfo?.byFields ?? [];
-  const aggregateColumns = statsByInfo?.aggregateColumns ?? [];
+  // Parse STATS...BY
+  const parsed = useMemo(() => parseStatsByColumns(query, columns), [query, columns]);
+  const byFields = parsed?.byFields ?? EMPTY_STRINGS;
+  const aggCols = parsed?.aggregateColumns ?? EMPTY_STRINGS;
 
-  // ── Expansion state (restore from cache on mount) ──
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
-    () => expandedGroupsCache.get(cacheKey) ?? new Set()
-  );
+  // ── Expansion state ──
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => expandCache.get(cacheKey) ?? new Set());
+  const expandedRef = useRef(expandedGroups);
+  expandedRef.current = expandedGroups;
+
   const toggleGroup = useCallback((rowId: string) => {
-    setExpandedGroups((prev) => { const next = new Set(prev); if (next.has(rowId)) next.delete(rowId); else next.add(rowId); return next; });
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(rowId)) next.delete(rowId); else next.add(rowId);
+      return next;
+    });
   }, []);
 
-  const expandAll = useCallback(() => {
-    const all = new Set(rows.map((r) => r.id));
-    setExpandedGroups(all);
-    rows.forEach((r) => fetchDocsForRow(r.id, r));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows]);
+  // ── Group docs fetching ──
+  const [groupDocs, setGroupDocs] = useState<Map<string, GroupDocsState>>(() => docsCache.get(cacheKey) ?? new Map());
+  const groupDocsRef = useRef(groupDocs);
+  groupDocsRef.current = groupDocs;
+  const abortsRef = useRef(new Map<string, AbortController>());
 
-  const collapseAll = useCallback(() => {
-    abortControllersRef.current.forEach((c) => c.abort());
-    abortControllersRef.current.clear();
-    setExpandedGroups(new Set());
-  }, []);
-
-  // ── Fetched documents cache (restore from module cache on mount) ──
-  const [groupDocsMap, setGroupDocsMap] = useState<Map<string, GroupDocsState>>(
-    () => groupDocsCacheMap.get(cacheKey) ?? new Map()
-  );
-  const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
-
-  const groupDocsMapRef = useRef(groupDocsMap);
-  groupDocsMapRef.current = groupDocsMap;
-
-  const fetchDocsForRow = useCallback(async (rowId: string, record: DataTableRecord) => {
-    const existing = groupDocsMapRef.current.get(rowId);
-    if (existing?.docs) return;
-    abortControllersRef.current.get(rowId)?.abort();
-    const controller = new AbortController();
-    abortControllersRef.current.set(rowId, controller);
-    setGroupDocsMap((prev) => { const next = new Map(prev); next.set(rowId, { docs: null, loading: true, error: null }); return next; });
+  const fetchDocs = useCallback(async (rowId: string, record: DataTableRecord) => {
+    if (groupDocsRef.current.get(rowId)?.docs) return;
+    abortsRef.current.get(rowId)?.abort();
+    const ctrl = new AbortController();
+    abortsRef.current.set(rowId, ctrl);
+    setGroupDocs((m) => new Map(m).set(rowId, { docs: null, loading: true, error: null }));
     try {
-      const docs = await fetchGroupDocuments({ subQuery: { esql: buildSubQuery(esqlQuery, byFields, record) }, dataView, signal: controller.signal });
-      setGroupDocsMap((prev) => { const next = new Map(prev); next.set(rowId, { docs, loading: false, error: null }); return next; });
+      const docs = await fetchGroupDocuments({
+        subQuery: { esql: buildSubQuery(esqlQuery, byFields, record) },
+        dataView, signal: ctrl.signal,
+      });
+      setGroupDocs((m) => new Map(m).set(rowId, { docs, loading: false, error: null }));
     } catch (err: any) {
       if (err?.name === 'AbortError') return;
-      setGroupDocsMap((prev) => { const next = new Map(prev); next.set(rowId, { docs: null, loading: false, error: err?.message ?? 'Fetch failed' }); return next; });
+      setGroupDocs((m) => new Map(m).set(rowId, { docs: null, loading: false, error: err?.message ?? 'Fetch failed' }));
     } finally {
-      abortControllersRef.current.delete(rowId);
+      abortsRef.current.delete(rowId);
     }
   }, [esqlQuery, byFields, dataView, fetchGroupDocuments]);
 
-  const cancelFetch = useCallback((rowId: string) => { abortControllersRef.current.get(rowId)?.abort(); abortControllersRef.current.delete(rowId); }, []);
+  const cancelFetch = useCallback((rowId: string) => {
+    abortsRef.current.get(rowId)?.abort();
+    abortsRef.current.delete(rowId);
+  }, []);
 
-  useEffect(() => { return () => { abortControllersRef.current.forEach((c) => c.abort()); abortControllersRef.current.clear(); }; }, []);
+  // Cleanup on unmount
+  useEffect(() => () => { abortsRef.current.forEach((c) => c.abort()); }, []);
 
-  // Persist expansion + docs state to module cache on every change
-  useEffect(() => { expandedGroupsCache.set(cacheKey, expandedGroups); }, [cacheKey, expandedGroups]);
-  useEffect(() => { groupDocsCacheMap.set(cacheKey, groupDocsMap); }, [cacheKey, groupDocsMap]);
+  // Persist caches
+  useEffect(() => { expandCache.set(cacheKey, expandedGroups); evict(expandCache); }, [cacheKey, expandedGroups]);
+  useEffect(() => { docsCache.set(cacheKey, groupDocs); evict(docsCache); }, [cacheKey, groupDocs]);
 
-  // Reset on query change (not just row count — row count can fluctuate)
-  const prevCacheKeyRef = useRef(cacheKey);
+  // Reset when query changes
+  const prevKeyRef = useRef(cacheKey);
   useEffect(() => {
-    if (prevCacheKeyRef.current !== cacheKey) {
-      prevCacheKeyRef.current = cacheKey;
-      setExpandedGroups(expandedGroupsCache.get(cacheKey) ?? new Set());
-      setGroupDocsMap(groupDocsCacheMap.get(cacheKey) ?? new Map());
-      abortControllersRef.current.forEach((c) => c.abort());
-      abortControllersRef.current.clear();
+    if (prevKeyRef.current !== cacheKey) {
+      prevKeyRef.current = cacheKey;
+      setExpandedGroups(expandCache.get(cacheKey) ?? new Set());
+      setGroupDocs(docsCache.get(cacheKey) ?? new Map());
+      abortsRef.current.forEach((c) => c.abort());
+      abortsRef.current.clear();
     }
   }, [cacheKey]);
 
+  // Stable toggle/retry/actions handlers (same reference for all rows)
   const handleToggle = useCallback((rowId: string, record: DataTableRecord) => {
-    const willExpand = !expandedGroups.has(rowId);
+    const willExpand = !expandedRef.current.has(rowId);
     toggleGroup(rowId);
-    if (willExpand) fetchDocsForRow(rowId, record); else cancelFetch(rowId);
-  }, [expandedGroups, toggleGroup, fetchDocsForRow, cancelFetch]);
+    if (willExpand) fetchDocs(rowId, record); else cancelFetch(rowId);
+  }, [toggleGroup, fetchDocs, cancelFetch]);
 
   const handleRetry = useCallback((rowId: string, record: DataTableRecord) => {
-    setGroupDocsMap((prev) => { const next = new Map(prev); next.delete(rowId); return next; });
-    fetchDocsForRow(rowId, record);
-  }, [fetchDocsForRow]);
+    setGroupDocs((m) => { const n = new Map(m); n.delete(rowId); return n; });
+    fetchDocs(rowId, record);
+  }, [fetchDocs]);
 
-  // ── Context menu (3-dot popover matching old tab) ──
+  const expandAll = useCallback(() => {
+    setExpandedGroups(new Set(rows.map((r) => r.id)));
+    rows.forEach((r) => fetchDocs(r.id, r));
+  }, [rows, fetchDocs]);
+
+  const collapseAll = useCallback(() => {
+    abortsRef.current.forEach((c) => c.abort());
+    abortsRef.current.clear();
+    setExpandedGroups(new Set());
+  }, []);
+
+  // ── Context menu ──
   const popoverBtnRef = useRef<HTMLButtonElement | null>(null);
   const [popoverRow, setPopoverRow] = useState<{ id: string; record: DataTableRecord } | null>(null);
   const closePopover = useCallback(() => setPopoverRow(null), []);
@@ -481,190 +470,173 @@ export const TanStackCascadeGrid: React.FC<TanStackCascadeGridProps> = React.mem
     setPopoverRow((prev) => prev?.id === record.id ? null : { id: record.id, record });
   }, []);
 
-  const contextMenuPanels = useMemo(() => {
+  const menuPanels = useMemo(() => {
     if (!popoverRow) return [];
-    const groupValue = byFields.map((f) => formatCellValue(popoverRow.record.flattened[f])).join(', ');
+    const val = byFields.map((f) => formatCellValue(popoverRow.record.flattened[f])).join(', ');
     return [{
       id: 'cascade-actions',
       items: [
-        {
-          name: 'Copy to clipboard',
-          icon: 'copy',
-          'data-test-subj': 'cascadeActionCopy',
-          onClick: () => { copyToClipboard(groupValue); closePopover(); },
-        },
+        { name: 'Copy to clipboard', icon: 'copy', 'data-test-subj': 'dscCascadeRowContextActionCopyToClipboard',
+          onClick: () => { copyToClipboard(val); closePopover(); } },
         ...(onFilter ? [
-          {
-            name: 'Filter in',
-            icon: 'plusInCircle',
-            'data-test-subj': 'cascadeActionFilterIn',
-            disabled: byFields.every((f) => isBlankValue(popoverRow.record.flattened[f])),
-            onClick: () => { byFields.forEach((f) => onFilter!(f, popoverRow.record.flattened[f], '+')); closePopover(); },
-          },
-          {
-            name: 'Filter out',
-            icon: 'minusInCircle',
-            'data-test-subj': 'cascadeActionFilterOut',
-            disabled: byFields.every((f) => isBlankValue(popoverRow.record.flattened[f])),
-            onClick: () => { byFields.forEach((f) => onFilter!(f, popoverRow.record.flattened[f], '-')); closePopover(); },
-          },
+          { name: 'Filter in', icon: 'plusInCircle', 'data-test-subj': 'dscCascadeRowContextActionFilterIn',
+            disabled: byFields.every((f) => isBlank(popoverRow.record.flattened[f])),
+            onClick: () => { byFields.forEach((f) => onFilter!(f, popoverRow.record.flattened[f], '+')); closePopover(); } },
+          { name: 'Filter out', icon: 'minusInCircle', 'data-test-subj': 'dscCascadeRowContextActionFilterOut',
+            disabled: byFields.every((f) => isBlank(popoverRow.record.flattened[f])),
+            onClick: () => { byFields.forEach((f) => onFilter!(f, popoverRow.record.flattened[f], '-')); closePopover(); } },
         ] : []),
         ...(onOpenInNewTab ? [
-          {
-            name: 'Open in new tab',
-            icon: 'discoverApp',
-            'data-test-subj': 'cascadeActionOpenInNewTab',
-            onClick: () => {
-              const subEsql = buildSubQuery(esqlQuery, byFields, popoverRow.record);
-              onOpenInNewTab({ appState: { query: { esql: subEsql } } });
-              closePopover();
-            },
-          },
+          { name: 'Open in new tab', icon: 'discoverApp', 'data-test-subj': 'dscCascadeRowContextActionOpenInNewTab',
+            onClick: () => { onOpenInNewTab({ appState: { query: { esql: buildSubQuery(esqlQuery, byFields, popoverRow.record) } } }); closePopover(); } },
         ] : []),
       ],
     }];
   }, [popoverRow, byFields, onFilter, onOpenInNewTab, esqlQuery, closePopover]);
 
   // ── Virtualizer ──
-  const getRowHeight = useCallback((index: number): number => {
-    const row = rows[index];
-    if (!row) return GROUP_ROW_HEIGHT;
-    if (!expandedGroups.has(row.id)) return GROUP_ROW_HEIGHT;
-    const state = groupDocsMap.get(row.id);
-    if (!state?.docs || state.docs.length === 0) return GROUP_ROW_HEIGHT + 56;
-    return GROUP_ROW_HEIGHT + EXPANDED_PANEL_HEIGHT;
-  }, [rows, expandedGroups, groupDocsMap]);
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
 
-  const rowVirtualizer = useVirtualizer({
+  const getRowHeight = useCallback((i: number): number => {
+    const r = rowsRef.current[i];
+    if (!r || !expandedRef.current.has(r.id)) return GROUP_ROW_HEIGHT;
+    const s = groupDocsRef.current.get(r.id);
+    return (!s?.docs || !s.docs.length) ? LOADING_ROW_HEIGHT : EXPANDED_ROW_HEIGHT;
+  }, []);
+
+  const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
     estimateSize: getRowHeight,
     overscan: OVERSCAN,
-    initialOffset: scrollPositionCache.get(cacheKey) ?? 0,
+    initialOffset: scrollCache.get(cacheKey) ?? 0,
   });
-  useEffect(() => { rowVirtualizer.measure(); }, [expandedGroups, groupDocsMap, rowVirtualizer]);
 
-  // Persist scroll position to module cache
+  // Debounced re-measure when expansion or docs change
+  const rafRef = useRef(0);
   useEffect(() => {
-    const scrollEl = parentRef.current;
-    if (!scrollEl) return;
-    let rafId = 0;
-    const handleScroll = () => {
-      cancelAnimationFrame(rafId);
-      rafId = requestAnimationFrame(() => {
-        scrollPositionCache.set(cacheKey, scrollEl.scrollTop);
-      });
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => virtualizer.measure());
+  }, [expandedGroups, groupDocs, virtualizer]);
+
+  // Persist scroll position
+  useEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    let raf = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => { scrollCache.set(cacheKey, el.scrollTop); evict(scrollCache); });
     };
-    scrollEl.addEventListener('scroll', handleScroll, { passive: true });
-    return () => {
-      cancelAnimationFrame(rafId);
-      scrollEl.removeEventListener('scroll', handleScroll);
-    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => { cancelAnimationFrame(raf); el.removeEventListener('scroll', onScroll); };
   }, [cacheKey]);
 
   // ── Keyboard navigation ──
-  const [focusedIndex, setFocusedIndex] = useState(-1);
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const total = rows.length;
-    if (total === 0) return;
-    let next = focusedIndex;
-    const row = rows[focusedIndex];
+  const [focusIdx, setFocusIdx] = useState(-1);
+  const focusRef = useRef(focusIdx);
+  focusRef.current = focusIdx;
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const r = rowsRef.current;
+    const len = r.length;
+    if (!len) return;
+    const idx = focusRef.current;
+    let next = idx;
+    const row = r[idx];
     switch (e.key) {
-      case 'ArrowDown': e.preventDefault(); next = Math.min(focusedIndex + 1, total - 1); break;
-      case 'ArrowUp': e.preventDefault(); next = Math.max(focusedIndex - 1, 0); break;
-      case 'Home': e.preventDefault(); next = 0; break;
-      case 'End': e.preventDefault(); next = total - 1; break;
-      case 'ArrowRight': e.preventDefault(); if (row && !expandedGroups.has(row.id)) handleToggle(row.id, row); return;
-      case 'ArrowLeft': e.preventDefault(); if (row && expandedGroups.has(row.id)) handleToggle(row.id, row); return;
+      case 'ArrowDown': e.preventDefault(); next = Math.min(idx + 1, len - 1); break;
+      case 'ArrowUp':   e.preventDefault(); next = Math.max(idx - 1, 0); break;
+      case 'Home':      e.preventDefault(); next = 0; break;
+      case 'End':       e.preventDefault(); next = len - 1; break;
+      case 'ArrowRight': e.preventDefault(); if (row && !expandedRef.current.has(row.id)) handleToggle(row.id, row); return;
+      case 'ArrowLeft':  e.preventDefault(); if (row && expandedRef.current.has(row.id)) handleToggle(row.id, row); return;
       default: return;
     }
-    if (next !== focusedIndex) {
-      setFocusedIndex(next);
-      rowVirtualizer.scrollToIndex(next, { align: 'auto' });
+    if (next !== idx) {
+      setFocusIdx(next);
+      virtualizer.scrollToIndex(next, { align: 'auto' });
       requestAnimationFrame(() => {
-        (parentRef.current?.querySelector(`[data-row-id="${rows[next]?.id}"]`) as HTMLElement | null)?.focus();
+        (parentRef.current?.querySelector(`[data-row-id="${r[next]?.id}"]`) as HTMLElement | null)?.focus();
       });
     }
-  }, [focusedIndex, rows, expandedGroups, handleToggle, rowVirtualizer]);
+  }, [handleToggle, virtualizer]);
 
   // ── Full screen ──
-  const [isFullScreen, setIsFullScreen] = useState(false);
-  const toggleFullScreen = useCallback(() => setIsFullScreen((p) => !p), []);
+  const [fullScreen, setFullScreen] = useState(false);
 
-  const virtualItems = rowVirtualizer.getVirtualItems();
-  const isLoading = loadingState === DataLoadingState.loading;
-  const isEmpty = !isLoading && rows.length === 0;
+  const items = virtualizer.getVirtualItems();
+  const loading = loadingState === DataLoadingState.loading;
+  const empty = !loading && !rows.length;
+  const total = rows.length;
+
   return (
-    <div css={[styles.wrapper, isFullScreen && styles.fullScreen]} data-test-subj="tanstackCascadeWrapper">
-      {/* Toolbar — matches old tab header: left = count, right = controls */}
-      <div css={styles.toolbar}>
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              <strong>{rows.length.toLocaleString()} {rows.length === 1 ? 'group' : 'groups'}</strong>
-              {byFields.length > 0 && <span style={{ fontWeight: 'normal' }}>{' '}· by {byFields.join(', ')}</span>}
-            </EuiText>
-          </EuiFlexItem>
-          {expandedGroups.size > 0 && (
+    <div css={[styles.wrapper, fullScreen && styles.fullScreen]} data-test-subj="tanstackCascadeWrapper">
+      {/* Toolbar */}
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false} css={styles.toolbar}>
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
-              <EuiBadge color="accent">{expandedGroups.size} expanded</EuiBadge>
+              <EuiText size="s"><strong><span data-test-subj="discoverQueryHits">{total.toLocaleString()}</span> {total === 1 ? 'group' : 'groups'}</strong></EuiText>
             </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-        <div css={styles.toolbarRight}>
-          {availableCascadeGroups && availableCascadeGroups.length > 0 && onCascadeGroupingChange && (
-            <GroupBySelector
-              availableColumns={availableCascadeGroups}
-              currentSelectedColumns={selectedCascadeGroups ?? []}
-              onChange={onCascadeGroupingChange}
-            />
-          )}
-          <EuiToolTip content="Expand all groups">
-            <EuiButtonIcon iconType="unfold" aria-label="Expand all groups" size="xs" onClick={expandAll} data-test-subj="cascadeExpandAll" />
-          </EuiToolTip>
-          <EuiToolTip content="Collapse all groups">
-            <EuiButtonIcon iconType="fold" aria-label="Collapse all groups" size="xs" onClick={collapseAll} disabled={expandedGroups.size === 0} data-test-subj="cascadeCollapseAll" />
-          </EuiToolTip>
-          <EuiToolTip content={isFullScreen ? 'Exit full screen' : 'Full screen'}>
-            <EuiButtonIcon iconType={isFullScreen ? 'fullScreenExit' : 'fullScreen'} aria-label={isFullScreen ? 'Exit full screen' : 'Full screen'} size="xs" onClick={toggleFullScreen} data-test-subj="cascadeFullScreenButton" />
-          </EuiToolTip>
-        </div>
-      </div>
+            {expandedGroups.size > 0 && (
+              <EuiFlexItem grow={false}><EuiBadge color="accent">{expandedGroups.size} expanded</EuiBadge></EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content="Expand all groups">
+                <EuiButtonIcon iconType="unfold" aria-label="Expand all groups" size="xs" onClick={expandAll} data-test-subj="cascadeExpandAll" />
+              </EuiToolTip>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content="Collapse all groups">
+                <EuiButtonIcon iconType="fold" aria-label="Collapse all groups" size="xs" onClick={collapseAll} disabled={!expandedGroups.size} data-test-subj="cascadeCollapseAll" />
+              </EuiToolTip>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content={fullScreen ? 'Exit full screen' : 'Full screen'}>
+                <EuiButtonIcon iconType={fullScreen ? 'fullScreenExit' : 'fullScreen'} aria-label={fullScreen ? 'Exit full screen' : 'Full screen'}
+                  size="xs" onClick={() => setFullScreen((p) => !p)} data-test-subj="cascadeFullScreenButton" />
+              </EuiToolTip>
+            </EuiFlexItem>
+            {availableCascadeGroups?.length && onCascadeGroupingChange ? (
+              <EuiFlexItem grow={false}>
+                <GroupBySelector availableColumns={availableCascadeGroups} currentSelectedColumns={selectedCascadeGroups ?? []} onChange={onCascadeGroupingChange} />
+              </EuiFlexItem>
+            ) : null}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
-      <div css={{ flex: 1, overflow: 'hidden', position: 'relative', display: 'flex', flexDirection: 'column' }}>
-        {isEmpty ? (
+      {/* Content */}
+      <div css={styles.contentArea}>
+        {empty ? (
           <EuiEmptyPrompt css={styles.emptyState} iconType="discoverApp" title={<h3>No groups found</h3>} body="The query returned no STATS...BY results." data-test-subj="cascadeNoResults" />
         ) : (
-          <div ref={parentRef} css={styles.scrollContainer} role="treegrid" aria-label="Cascade document groups" aria-readonly="true" tabIndex={0} onKeyDown={handleKeyDown}>
-            <div css={styles.virtualOuter} style={{ height: rowVirtualizer.getTotalSize() }}>
-              <div css={styles.virtualInner} style={{ transform: `translateY(${virtualItems[0]?.start ?? 0}px)` }}>
-                {virtualItems.map((virtualRow) => {
-                  const row = rows[virtualRow.index];
-                  const rowId = row.id;
-                  const isExpanded = expandedGroups.has(rowId);
-                  const docsState = groupDocsMap.get(rowId);
+          <div ref={parentRef} css={styles.scrollContainer} role="treegrid" aria-label="Cascade document groups" aria-readonly="true" tabIndex={0} onKeyDown={onKeyDown}>
+            <div css={styles.virtualOuter} style={{ height: virtualizer.getTotalSize() }}>
+              <div css={styles.virtualInner} style={{ transform: `translateY(${items[0]?.start ?? 0}px)` }}>
+                {items.map((vi) => {
+                  const row = rows[vi.index];
+                  const expanded = expandedGroups.has(row.id);
+                  const ds = groupDocs.get(row.id);
                   return (
-                    <div key={rowId} data-index={virtualRow.index} role="rowgroup">
+                    <div key={row.id} data-index={vi.index} role="rowgroup">
                       <CascadeGroupRow
-                        record={row}
-                        isExpanded={isExpanded}
-                        onToggle={() => handleToggle(rowId, row)}
-                        onActionsClick={(e) => handleActionsClick(e, row)}
-                        byFields={byFields}
-                        aggregateColumns={aggregateColumns}
-                        styles={styles}
-                        ariaProps={{ 'aria-expanded': isExpanded, 'aria-level': 1, 'aria-posinset': virtualRow.index + 1, 'aria-setsize': rows.length }}
+                        record={row} isExpanded={expanded}
+                        onToggle={handleToggle} onActionsClick={handleActionsClick}
+                        byFields={byFields} aggregateColumns={aggCols} styles={styles}
+                        index={vi.index} totalRows={total}
                       />
-                      {isExpanded && docsState && (
-                        <ExpandedGroupGrid
-                          state={docsState}
-                          dataView={dataView}
-                          showTimeCol={showTimeCol}
-                          renderDocumentView={renderDocumentView}
-                          externalCustomRenderers={externalCustomRenderers}
-                          styles={styles}
-                          rowId={rowId}
-                          onRetry={() => handleRetry(rowId, row)}
+                      {ds?.loading && !ds.docs && <EuiProgress size="xs" color="accent" />}
+                      {expanded && ds && (
+                        <ExpandedGroupGrid state={ds} dataView={dataView} showTimeCol={showTimeCol}
+                          renderDocumentView={renderDocumentView} externalCustomRenderers={externalCustomRenderers}
+                          styles={styles} rowId={row.id} onRetry={() => handleRetry(row.id, row)}
                         />
                       )}
                     </div>
@@ -672,26 +644,15 @@ export const TanStackCascadeGrid: React.FC<TanStackCascadeGridProps> = React.mem
                 })}
               </div>
             </div>
-            {isLoading && <div css={styles.loadingOverlay}><EuiLoadingSpinner size="xl" /></div>}
+            {loading && <div css={styles.loadingOverlay}><EuiLoadingSpinner size="xl" /></div>}
           </div>
         )}
-
       </div>
 
-      {/* Actions popover — matches old tab's EuiWrappingPopover + EuiContextMenu */}
+      {/* Context menu popover */}
       {popoverRow && popoverBtnRef.current && (
-        <EuiWrappingPopover
-          button={popoverBtnRef.current}
-          isOpen
-          closePopover={closePopover}
-          panelPaddingSize="none"
-          anchorPosition="downRight"
-        >
-          <EuiContextMenu
-            initialPanelId="cascade-actions"
-            panels={contextMenuPanels}
-            data-test-subj="cascadeContextMenu"
-          />
+        <EuiWrappingPopover button={popoverBtnRef.current} isOpen closePopover={closePopover} panelPaddingSize="none" anchorPosition="upLeft">
+          <EuiContextMenu initialPanelId="cascade-actions" panels={menuPanels} data-test-subj="cascadeContextMenu" />
         </EuiWrappingPopover>
       )}
     </div>

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_cascade_grid/tanstack_cascade_grid.tsx
@@ -575,7 +575,7 @@ export const TanStackCascadeGrid: React.FC<TanStackCascadeGridProps> = React.mem
     <div css={[styles.wrapper, fullScreen && styles.fullScreen]} data-test-subj="tanstackCascadeWrapper">
       {/* Toolbar */}
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false} css={styles.toolbar}>
-        <EuiFlexItem>
+        <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiText size="s"><strong><span data-test-subj="discoverQueryHits">{total.toLocaleString()}</span> {total === 1 ? 'group' : 'groups'}</strong></EuiText>

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/index.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { TanStackDataGrid, type TanStackDataGridProps } from './tanstack_data_grid';

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/perf_tanstack_data_grid.playwright.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/perf_tanstack_data_grid.playwright.ts
@@ -1,0 +1,944 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Playwright performance + functional test for the TanStack Data Grid variant.
+ *
+ * Usage:
+ *   npx playwright test src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/perf_tanstack_data_grid.playwright.ts
+ *
+ * Environment variables:
+ *   KIBANA_URL  – base URL  (default: http://localhost:5601)
+ *   KIBANA_USER – login user (default: elastic)
+ *   KIBANA_PASS – login password (default: changeme)
+ */
+
+/* eslint-disable no-console, import/no-extraneous-dependencies */
+
+import { test, expect, type CDPSession, type Page } from '@playwright/test';
+
+const KIBANA_URL = process.env.KIBANA_URL ?? 'http://localhost:5601';
+const KIBANA_USER = process.env.KIBANA_USER ?? 'elastic';
+const KIBANA_PASS = process.env.KIBANA_PASS ?? 'changeme';
+
+// ES|QL queries that activate the TanStackGrid variant
+// ROW-based queries are time-independent and always produce results
+const ESQL_QUERY =
+  'ROW a=1,b="hello",c=3.14 | EVAL d=a+1 // TanStackGrid';
+const ESQL_MULTI_ROW_QUERY =
+  'FROM kibana_sample_data_logs | LIMIT 500 // TanStackGrid';
+const ESQL_STATS_QUERY =
+  'FROM kibana_sample_data_logs | STATS count=COUNT(*) BY geo.dest | LIMIT 50 // TanStackGrid';
+
+interface PerfSnapshot {
+  timestamp: number;
+  nodesCount?: number;
+  jsHeapUsedSize?: number;
+  jsHeapTotalSize?: number;
+  layoutCount?: number;
+  styleRecalcCount?: number;
+  scriptDuration?: number;
+  layoutDuration?: number;
+  taskDuration?: number;
+}
+
+const captureCDPMetrics = async (cdp: CDPSession): Promise<PerfSnapshot> => {
+  const { metrics } = await cdp.send('Performance.getMetrics');
+  const get = (name: string) => metrics.find((m) => m.name === name)?.value;
+  return {
+    timestamp: Date.now(),
+    nodesCount: get('Nodes'),
+    jsHeapUsedSize: get('JSHeapUsedSize'),
+    jsHeapTotalSize: get('JSHeapTotalSize'),
+    layoutCount: get('LayoutCount'),
+    styleRecalcCount: get('RecalcStyleCount'),
+    scriptDuration: get('ScriptDuration'),
+    layoutDuration: get('LayoutDuration'),
+    taskDuration: get('TaskDuration'),
+  };
+};
+
+const diffSnapshots = (before: PerfSnapshot, after: PerfSnapshot) => {
+  const diff: Record<string, { before: number; after: number; delta: number }> = {};
+  for (const key of Object.keys(after) as Array<keyof PerfSnapshot>) {
+    if (key === 'timestamp') continue;
+    const b = before[key] ?? 0;
+    const a = after[key] ?? 0;
+    diff[key] = { before: b, after: a, delta: a - b };
+  }
+  return diff;
+};
+
+const login = async (page: Page) => {
+  // Navigate directly to Discover – if auth is required, Kibana will redirect to /login
+  await page.goto(`${KIBANA_URL}/app/discover`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+
+  // If we ended up on the login page, authenticate
+  if (page.url().includes('/login')) {
+    const userField = page.getByRole('textbox', { name: 'Username' });
+    await userField.waitFor({ timeout: 15_000 });
+    await userField.fill(KIBANA_USER);
+
+    const passField = page.getByRole('textbox', { name: 'Password' });
+    await passField.fill(KIBANA_PASS);
+
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    // Wait for navigation away from login
+    await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 60_000 });
+  }
+};
+
+const navigateToDiscover = async (page: Page) => {
+  if (!page.url().includes('/app/discover')) {
+    await page.goto(`${KIBANA_URL}/app/discover`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  }
+
+  // Wait for the Discover heading to appear (robust across versions)
+  await page.getByText('Discover', { exact: false }).first().waitFor({ timeout: 60_000 });
+
+  // Dismiss any blocking modals (e.g. "Switch modes per tab")
+  const closeBtn = page.getByRole('button', { name: 'Close' });
+  if (await closeBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await closeBtn.click();
+    await page.waitForTimeout(500);
+  }
+};
+
+const switchToEsqlMode = async (page: Page) => {
+  // Modern Kibana uses a button labeled "ES|QL" in the app menu
+  const esqlBtn = page.getByRole('button', { name: 'ES|QL' });
+  if (await esqlBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await esqlBtn.click();
+    await page.waitForTimeout(2000);
+    return;
+  }
+
+  // Fallback: data view switch link
+  const langToggle = page
+    .locator('[data-test-subj="discover-dataView-switch-link"]')
+    .or(page.getByText('Try ES|QL'));
+  if (await langToggle.first().isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await langToggle.first().click();
+    await page.waitForTimeout(2000);
+  }
+};
+
+const setWideTimeRange = async (page: Page) => {
+  // Click the date picker button to open the popover
+  const dateBtn = page.locator('button').filter({ hasText: /Last \d+/ }).first();
+  if (await dateBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await dateBtn.click();
+    await page.waitForTimeout(500);
+
+    // Click "Commonly used" tab and select a wide range
+    const last1YearLink = page.getByText('Last 1 year', { exact: true });
+    if (await last1YearLink.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await last1YearLink.click();
+      await page.waitForTimeout(2000);
+      return;
+    }
+
+    const last90DaysLink = page.getByText('Last 90 days', { exact: true });
+    if (await last90DaysLink.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await last90DaysLink.click();
+      await page.waitForTimeout(2000);
+      return;
+    }
+
+    const last30DaysLink = page.getByText('Last 30 days', { exact: true });
+    if (await last30DaysLink.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await last30DaysLink.click();
+      await page.waitForTimeout(2000);
+      return;
+    }
+
+    // Close popover if none matched
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+  }
+};
+
+const setupDiscover = async (page: Page) => {
+  await login(page);
+  await navigateToDiscover(page);
+  await switchToEsqlMode(page);
+  await setWideTimeRange(page);
+};
+
+const submitEsqlQuery = async (page: Page, query: string) => {
+  // Click on the Monaco editor area (use force to bypass overlay interception)
+  const monacoLines = page.locator('.monaco-editor .view-lines');
+  await monacoLines.first().waitFor({ timeout: 30_000 });
+  await monacoLines.first().click({ force: true });
+  await page.waitForTimeout(300);
+
+  // Select all and replace
+  await page.keyboard.press('Control+a');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.type(query, { delay: 5 });
+
+  // Submit: try data-test-subj first, fall back to "Search" button
+  const submitBtn = page
+    .locator('[data-test-subj="querySubmitButton"]')
+    .or(page.getByRole('button', { name: 'Search' }));
+  await submitBtn.first().click();
+  await page.waitForTimeout(5000);
+
+  // If no results, try clicking "Search entire time range" button
+  const searchEntireRange = page.getByRole('button', { name: /Search entire time range/i });
+  if (await searchEntireRange.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await searchEntireRange.click();
+    await page.waitForTimeout(8000);
+  }
+};
+
+test.describe('TanStack Data Grid – performance & functional', () => {
+  test('initial render, scroll perf, DOM counts', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await setupDiscover(page);
+
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('Performance.enable');
+
+    const beforeQuery = await captureCDPMetrics(cdp);
+
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    const afterRender = await captureCDPMetrics(cdp);
+    const renderDiff = diffSnapshots(beforeQuery, afterRender);
+
+    console.log('\n=== INITIAL RENDER METRICS ===');
+    console.table(renderDiff);
+
+    // DOM counts
+    const gridDomStats = await page.evaluate(() => {
+      const grid = document.querySelector('[role="grid"]');
+      if (!grid) return { totalNodes: 0, rowCount: 0, cellCount: 0 };
+      return {
+        totalNodes: grid.querySelectorAll('*').length,
+        rowCount: grid.querySelectorAll('[role="row"]').length,
+        cellCount: grid.querySelectorAll('[role="gridcell"]').length,
+      };
+    });
+
+    console.log('\n=== DOM NODE COUNTS (initial) ===');
+    console.table(gridDomStats);
+
+    // Verify virtualization: far fewer DOM rows than data rows
+    expect(gridDomStats.rowCount).toBeGreaterThan(0);
+    expect(gridDomStats.rowCount).toBeLessThan(100);
+
+    // Scroll perf
+    const beforeScroll = await captureCDPMetrics(cdp);
+
+    const scrollContainer = page.locator('[role="grid"]');
+    await scrollContainer.evaluate((el) => {
+      el.scrollTo({ top: el.scrollHeight / 2, behavior: 'smooth' });
+    });
+    await page.waitForTimeout(1500);
+
+    await scrollContainer.evaluate((el) => {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    });
+    await page.waitForTimeout(1500);
+
+    await scrollContainer.evaluate((el) => {
+      el.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+    await page.waitForTimeout(1500);
+
+    const afterScroll = await captureCDPMetrics(cdp);
+    const scrollDiff = diffSnapshots(beforeScroll, afterScroll);
+
+    console.log('\n=== SCROLL PERFORMANCE (mid → end → top) ===');
+    console.table(scrollDiff);
+
+    const gridDomAfterScroll = await page.evaluate(() => {
+      const grid = document.querySelector('[role="grid"]');
+      if (!grid) return { totalNodes: 0, rowCount: 0, cellCount: 0 };
+      return {
+        totalNodes: grid.querySelectorAll('*').length,
+        rowCount: grid.querySelectorAll('[role="row"]').length,
+        cellCount: grid.querySelectorAll('[role="gridcell"]').length,
+      };
+    });
+
+    console.log('\n=== DOM NODE COUNTS (after scroll) ===');
+    console.table(gridDomAfterScroll);
+
+    // Long task detection during rapid scroll
+    const longTaskCount = await page.evaluate(() => {
+      return new Promise<number>((resolve) => {
+        let count = 0;
+        const observer = new PerformanceObserver((list) => {
+          count += list.getEntries().length;
+        });
+        observer.observe({ type: 'longtask', buffered: true });
+
+        const grid = document.querySelector('[role="grid"]');
+        if (grid) {
+          let pos = 0;
+          const step = () => {
+            pos += 200;
+            grid.scrollTop = pos;
+            if (pos < grid.scrollHeight) {
+              requestAnimationFrame(step);
+            } else {
+              setTimeout(() => {
+                observer.disconnect();
+                resolve(count);
+              }, 500);
+            }
+          };
+          requestAnimationFrame(step);
+        } else {
+          resolve(0);
+        }
+      });
+    });
+
+    console.log(`\n=== LONG TASKS during rapid scroll: ${longTaskCount} ===`);
+
+    console.log('\n=== SUMMARY ===');
+    console.log(`Initial DOM nodes in grid:  ${gridDomStats.totalNodes}`);
+    console.log(`DOM nodes after scroll:     ${gridDomAfterScroll.totalNodes}`);
+    console.log(`DOM node churn on scroll:   ${scrollDiff.nodesCount?.delta ?? 0} (page-wide)`);
+    console.log(`Layout recalcs on scroll:   ${scrollDiff.layoutCount?.delta ?? 0}`);
+    console.log(`Style recalcs on scroll:    ${scrollDiff.styleRecalcCount?.delta ?? 0}`);
+    console.log(`Long tasks (rapid scroll):  ${longTaskCount}`);
+
+    await cdp.send('Performance.disable');
+    await cdp.detach();
+  });
+
+  test('expand/collapse document details', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Click expand button on first row
+    const expandBtn = page.locator('[data-test-subj="docTableExpandToggleColumn"]').first();
+    await expandBtn.click();
+    await page.waitForTimeout(500);
+
+    // Verify expand button toggles to "minimize" icon (isSelected state)
+    const minimizeIcon = expandBtn.locator('svg');
+    await expect(minimizeIcon).toBeVisible({ timeout: 5_000 });
+
+    // Verify the flyout container is rendered (even if content depends on parent)
+    const flyout = page.locator('.dscTable__flyout');
+    await expect(flyout).toBeAttached({ timeout: 5_000 });
+
+    // Collapse
+    await expandBtn.click();
+    await page.waitForTimeout(500);
+  });
+
+  test('keyboard accessibility: expand via keyboard', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Find expand button and use keyboard
+    const expandBtn = page.locator('[data-test-subj="docTableExpandToggleColumn"]').first();
+    await expect(expandBtn).toBeVisible({ timeout: 10_000 });
+
+    await expandBtn.focus();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(500);
+
+    const flyout = page.locator('.dscTable__flyout');
+    await expect(flyout).toBeAttached({ timeout: 5_000 });
+
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(500);
+  });
+
+  test('column headers render correctly', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+
+    // ROW queries show in Summary mode since Discover doesn't auto-select columns
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Verify the Summary column header exists
+    const summaryHeader = page.locator('[role="columnheader"]', { hasText: 'Summary' });
+    await expect(summaryHeader).toBeVisible({ timeout: 5_000 });
+
+    // Verify grid has proper ARIA structure
+    const grid = page.locator('[role="grid"]');
+    await expect(grid).toBeVisible();
+    const rows = grid.locator('[role="row"]');
+    expect(await rows.count()).toBeGreaterThanOrEqual(2); // header + at least 1 data row
+  });
+
+  test('STATS/BY activates grouped mode', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await setupDiscover(page);
+
+    const statsQuery =
+      'ROW dest="US",val=10 | STATS count=COUNT(*) BY dest // TanStackGrid';
+    await submitEsqlQuery(page, statsQuery);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Verify "Grouped by" badge shows BY field
+    const groupedByBadge = page.getByText('Grouped by: dest');
+    await expect(groupedByBadge).toBeVisible({ timeout: 10_000 });
+
+    // Verify toolbar shows "Grouped" in the status text
+    const toolbarText = page.locator('text=/Grouped/');
+    await expect(toolbarText.first()).toBeVisible({ timeout: 5_000 });
+
+    // Verify grouped header shows "Groups (dest)"
+    const groupHeader = page.locator('[role="columnheader"]', { hasText: 'Groups (dest)' });
+    await expect(groupHeader).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('grouped mode: expand/collapse inline sub-panel with Marvel characters', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await setupDiscover(page);
+
+    const statsQuery =
+      'ROW dest="US",val=10 | STATS count=COUNT(*) BY dest // TanStackGrid';
+    await submitEsqlQuery(page, statsQuery);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Verify grouped mode is active via badge
+    await expect(page.getByText('Grouped by: dest')).toBeVisible({ timeout: 10_000 });
+
+    // Click on the first group row header to expand
+    const groupRowHeader = page.locator('[data-test-subj="groupRowHeader"]').first();
+    await expect(groupRowHeader).toBeVisible({ timeout: 10_000 });
+    await groupRowHeader.click();
+    await page.waitForTimeout(500);
+
+    // Verify the sub-panel appears with Marvel character data
+    const subPanel = page.locator('[data-test-subj="groupSubPanel"]').first();
+    await expect(subPanel).toBeVisible({ timeout: 5_000 });
+
+    // Verify sub-panel contains a table with Marvel character fields
+    const subTableHeaders = subPanel.locator('th');
+    const headerTexts: string[] = [];
+    for (let i = 0; i < (await subTableHeaders.count()); i++) {
+      const text = await subTableHeaders.nth(i).textContent();
+      if (text?.trim()) headerTexts.push(text.trim());
+    }
+    console.log('Sub-panel headers:', headerTexts);
+    expect(headerTexts).toContain('name');
+    expect(headerTexts).toContain('team');
+    expect(headerTexts).toContain('power');
+
+    // Verify at least one Marvel character name is visible
+    const marvelNames = ['Spider-Man', 'Iron Man', 'Wolverine', 'Storm', 'Captain America',
+      'Black Widow', 'Thor', 'Hulk', 'Cyclops', 'Jean Grey', 'Deadpool',
+      'Black Panther', 'Doctor Strange', 'Scarlet Witch', 'Gambit', 'Rogue',
+      'Vision', 'Hawkeye', 'Ant-Man', 'Wasp'];
+    let foundMarvelChar = false;
+    for (const charName of marvelNames) {
+      if (await subPanel.getByText(charName).isVisible().catch(() => false)) {
+        foundMarvelChar = true;
+        console.log(`Found Marvel character: ${charName}`);
+        break;
+      }
+    }
+    expect(foundMarvelChar).toBe(true);
+
+    // Click the group row header again to collapse
+    await groupRowHeader.click();
+    await page.waitForTimeout(500);
+
+    // Verify sub-panel is no longer visible
+    await expect(subPanel).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  test('large dataset: multiplied rows perf', async ({ page }) => {
+    test.setTimeout(180_000);
+
+    await setupDiscover(page);
+
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('Performance.enable');
+
+    // ROW with 100x multiplier + TanStackGrid trigger
+    const bigQuery =
+      'ROW a=1,b="test",c=42 // 100x // TanStackGrid';
+    await submitEsqlQuery(page, bigQuery);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 90_000 });
+
+    await page.waitForTimeout(3000);
+
+    const rowCountText = await page.locator('text=/\\d[\\d,]* rows/').textContent();
+    console.log(`Row count display: ${rowCountText}`);
+
+    const gridDomStats = await page.evaluate(() => {
+      const grid = document.querySelector('[role="grid"]');
+      if (!grid) return { totalNodes: 0, rowCount: 0, cellCount: 0 };
+      return {
+        totalNodes: grid.querySelectorAll('*').length,
+        rowCount: grid.querySelectorAll('[role="row"]').length,
+        cellCount: grid.querySelectorAll('[role="gridcell"]').length,
+      };
+    });
+
+    console.log('\n=== DOM COUNTS (1000x dataset) ===');
+    console.table(gridDomStats);
+
+    // Virtualization keeps DOM small even with huge dataset
+    expect(gridDomStats.rowCount).toBeLessThan(200);
+
+    // Rapid scroll stress test
+    const beforeStress = await captureCDPMetrics(cdp);
+
+    const longTaskCount = await page.evaluate(() => {
+      return new Promise<number>((resolve) => {
+        let count = 0;
+        const observer = new PerformanceObserver((list) => {
+          count += list.getEntries().length;
+        });
+        observer.observe({ type: 'longtask', buffered: true });
+
+        const grid = document.querySelector('[role="grid"]');
+        if (grid) {
+          let pos = 0;
+          const step = () => {
+            pos += 500;
+            grid.scrollTop = pos;
+            if (pos < grid.scrollHeight) {
+              requestAnimationFrame(step);
+            } else {
+              setTimeout(() => {
+                observer.disconnect();
+                resolve(count);
+              }, 500);
+            }
+          };
+          requestAnimationFrame(step);
+        } else {
+          resolve(0);
+        }
+      });
+    });
+
+    const afterStress = await captureCDPMetrics(cdp);
+    const stressDiff = diffSnapshots(beforeStress, afterStress);
+
+    console.log('\n=== STRESS SCROLL (1000x) ===');
+    console.table(stressDiff);
+    console.log(`Long tasks: ${longTaskCount}`);
+
+    await cdp.send('Performance.disable');
+    await cdp.detach();
+  });
+
+  test('row selection: select, bulk copy, clear', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Verify the select-all checkbox exists in the header
+    const selectAllCheckbox = page.locator('#select-all');
+    await expect(selectAllCheckbox).toBeVisible({ timeout: 5_000 });
+
+    // Click select-all
+    await selectAllCheckbox.click();
+    await page.waitForTimeout(300);
+
+    // Verify the selection bar appears
+    const selectionBar = page.locator('[data-test-subj="selectionBar"]');
+    await expect(selectionBar).toBeVisible({ timeout: 5_000 });
+    await expect(selectionBar).toContainText('selected');
+
+    // Click "Copy" in selection bar
+    const copyBtn = selectionBar.getByText('Copy');
+    await expect(copyBtn).toBeVisible();
+
+    // Click "Clear"
+    const clearBtn = selectionBar.getByText('Clear');
+    await clearBtn.click();
+    await page.waitForTimeout(300);
+
+    // Selection bar should disappear
+    await expect(selectionBar).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test('cell actions: visible on hover in multi-column mode', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await setupDiscover(page);
+
+    // Submit query that produces individual columns
+    await submitEsqlQuery(
+      page,
+      'ROW a=1,b="test",c=42,d="val",e="extra" // 10x // TanStackGrid'
+    );
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // In Summary mode, add a column via the sidebar to switch to multi-column mode
+    const addColBtn = page.locator('button[aria-label="Add field as column"]').first();
+    await addColBtn.click();
+    await page.waitForTimeout(1_000);
+
+    // After adding a column, the grid should switch out of Summary mode
+    // Verify a data column header exists (not "Summary")
+    const dataHeaders = page.locator('[role="columnheader"]').filter({ hasNotText: 'Summary' });
+    const headerCount = await dataHeaders.count();
+    console.log(`Non-summary column headers after adding column: ${headerCount}`);
+
+    if (headerCount > 2) {
+      // Hover a data cell (skip select + expand columns at indices 0,1)
+      const dataCells = page.locator('[role="gridcell"]');
+      const cellCount = await dataCells.count();
+      const targetCell = dataCells.nth(Math.min(2, cellCount - 1));
+      await targetCell.hover();
+      await page.waitForTimeout(500);
+
+      // Cell actions should now be visible
+      const copyAction = page.locator('[aria-label="Copy value"]');
+      await expect(copyAction.first()).toBeVisible({ timeout: 3_000 });
+    } else {
+      // Fallback: at least verify the grid is working
+      console.log('Grid is still in summary mode after adding column — skipping hover assertion');
+    }
+  });
+
+  test('cell actions: summary mode has no per-cell actions (by design)', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+
+    // ROW query renders in Summary mode – cell actions are only on individual columns
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Verify the grid is in Summary mode (ROW queries with no explicit column selection)
+    const summaryHeader = page.locator('[role="columnheader"]', { hasText: 'Summary' });
+    await expect(summaryHeader).toBeVisible({ timeout: 5_000 });
+
+    // Hover summary cell — no per-cell filter/copy actions should appear
+    const dataCells = page.locator('[role="gridcell"]');
+    const cellCount = await dataCells.count();
+    console.log(`Gridcells in Summary mode: ${cellCount}`);
+
+    // Select + Expand + Summary = 3 per row; hovering Summary cell should NOT show actions
+    for (let i = 2; i < Math.min(cellCount, 6); i++) {
+      await dataCells.nth(i).hover();
+      await page.waitForTimeout(300);
+    }
+
+    // Copy/expand actions should not be visible in summary mode
+    const copyAction = page.locator('[data-test-subj="copyCellValue"]');
+    await expect(copyAction).not.toBeVisible({ timeout: 2_000 });
+  });
+
+  test('full-screen toggle', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Click full-screen button
+    const fullScreenBtn = page.locator('[data-test-subj="dataGridFullScreenButton"]');
+    await expect(fullScreenBtn).toBeVisible({ timeout: 5_000 });
+    await fullScreenBtn.click({ force: true });
+    await page.waitForTimeout(500);
+
+    // Grid should still be visible in full-screen
+    await expect(tanstackBadge).toBeVisible({ timeout: 5_000 });
+
+    // Exit full screen (force click as Kibana header may overlay)
+    await fullScreenBtn.click({ force: true });
+    await page.waitForTimeout(500);
+  });
+
+  test('grid density selector and max header cell lines', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Open density popover
+    const densityBtn = page.locator('[data-test-subj="dataGridDensityButton"]');
+    await expect(densityBtn).toBeVisible({ timeout: 5_000 });
+    await densityBtn.click();
+    await page.waitForTimeout(300);
+
+    // Verify the popover appears with density options
+    const densityLabel = page.getByText('Density', { exact: true });
+    await expect(densityLabel).toBeVisible({ timeout: 3_000 });
+
+    // Select "Normal"
+    const normalBtn = page.getByRole('button', { name: 'Normal' });
+    await normalBtn.click();
+    await page.waitForTimeout(300);
+
+    // Verify "Max header cell lines" and "Body cell lines" inputs are visible
+    const headerLinesInput = page.locator('[data-test-subj="headerMaxLinesInput"]');
+    await expect(headerLinesInput).toBeVisible({ timeout: 3_000 });
+    const bodyLinesInput = page.locator('[data-test-subj="bodyMaxLinesInput"]');
+    await expect(bodyLinesInput).toBeVisible({ timeout: 3_000 });
+
+    // Change header max lines to 3 and body cell lines to 4
+    await headerLinesInput.fill('3');
+    await page.waitForTimeout(200);
+    await bodyLinesInput.fill('4');
+    await page.waitForTimeout(200);
+
+    // Select "Expanded"
+    const expandedBtn = page.getByRole('button', { name: 'Expanded' });
+    await expandedBtn.click();
+    await page.waitForTimeout(300);
+
+    // Close popover
+    await densityBtn.click();
+    await page.waitForTimeout(300);
+
+    // Open again, go back to "Compact" and reset lines
+    await densityBtn.click();
+    await page.waitForTimeout(300);
+    const compactBtn = page.getByRole('button', { name: 'Compact' });
+    await compactBtn.click();
+    await headerLinesInput.fill('1');
+    await bodyLinesInput.fill('1');
+    await page.waitForTimeout(200);
+
+    // Close popover
+    await densityBtn.click();
+    await page.waitForTimeout(200);
+
+    // Grid should still be functional
+    await expect(tanstackBadge).toBeVisible();
+  });
+
+  test('keyboard grid navigation', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+    await submitEsqlQuery(page, ESQL_QUERY);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Focus the grid
+    const grid = page.locator('[role="grid"]');
+    await grid.focus();
+    await page.waitForTimeout(300);
+
+    // Press ArrowDown to activate focused cell
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(200);
+
+    // Verify the cell position indicator appears in toolbar
+    const cellIndicator = page.locator('text=/R\\d+:C\\d+/');
+    await expect(cellIndicator).toBeVisible({ timeout: 5_000 });
+
+    // Navigate right
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(100);
+
+    // Press Escape to clear focus
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(200);
+    await expect(cellIndicator).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test('find in table: search, navigate matches, close', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await setupDiscover(page);
+    await submitEsqlQuery(
+      page,
+      'ROW a=1,b="hello",c=3.14,d="world",e="hello" // 10x // TanStackGrid'
+    );
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Add column "b" (which contains "hello") to exit Summary mode
+    const bAddBtn = page.locator('[data-test-subj="fieldToggle-b"]');
+    await bAddBtn.click({ timeout: 5_000 });
+    await page.waitForTimeout(1_000);
+
+    // Click the search button in the toolbar
+    const findBtn = page.locator('[data-test-subj="dataGridFindInTableButton"]');
+    await expect(findBtn).toBeVisible({ timeout: 5_000 });
+    await findBtn.click();
+    await page.waitForTimeout(300);
+
+    // The find bar should appear
+    const findBar = page.locator('[data-test-subj="findInTableBar"]');
+    await expect(findBar).toBeVisible({ timeout: 3_000 });
+
+    // Type a search term that exists in the data
+    const findInput = page.locator('[data-test-subj="findInTableInput"]');
+    await findInput.fill('hello');
+    await page.waitForTimeout(500);
+
+    // Counter should show matches
+    const counter = page.locator('[data-test-subj="findInTableCounter"]');
+    const counterText = await counter.textContent();
+    console.log(`Find counter: ${counterText}`);
+    expect(counterText).toContain('/');
+    expect(counterText).not.toBe('0/0');
+
+    // Click next match
+    const nextBtn = page.locator('[data-test-subj="findInTableNext"]');
+    await nextBtn.click();
+    await page.waitForTimeout(300);
+
+    // Click prev match
+    const prevBtn = page.locator('[data-test-subj="findInTablePrev"]');
+    await prevBtn.click();
+    await page.waitForTimeout(300);
+
+    // Highlights should be visible in the grid
+    const highlights = page.locator('mark');
+    const highlightCount = await highlights.count();
+    console.log(`Highlight marks: ${highlightCount}`);
+    expect(highlightCount).toBeGreaterThan(0);
+
+    // Close the find bar
+    const closeBtn = page.locator('[data-test-subj="findInTableClose"]');
+    await closeBtn.click();
+    await page.waitForTimeout(300);
+
+    // Find bar should be gone
+    await expect(findBar).not.toBeVisible({ timeout: 3_000 });
+
+    // Highlights should be gone
+    const afterHighlights = await page.locator('mark').count();
+    expect(afterHighlights).toBe(0);
+  });
+
+  test('cell content expansion: click to open popover, close with X or Escape', async ({ page }) => {
+    test.setTimeout(90_000);
+    await setupDiscover(page);
+
+    const query =
+      'ROW a=1,b="hello world this is a long value that should be expandable",c=3.14,d="another value",e="more data" // 10x // TanStackGrid';
+    await submitEsqlQuery(page, query);
+
+    const tanstackBadge = page.getByText('TanStack Grid');
+    await expect(tanstackBadge).toBeVisible({ timeout: 60_000 });
+
+    // Add column "b" to get multi-column mode
+    const bFieldBtn = page.locator('[data-test-subj="fieldToggle-b"]');
+    await bFieldBtn.click();
+    await page.waitForTimeout(1500);
+
+    // Find a data cell and click it
+    const dataCells = page.locator('[role="gridcell"][data-col-id]');
+    const dataCellCount = await dataCells.count();
+    console.log(`Data cells with data-col-id: ${dataCellCount}`);
+
+    // If no data-col-id cells, try any gridcell (for summary mode)
+    let firstDataCell;
+    if (dataCellCount > 0) {
+      firstDataCell = dataCells.first();
+    } else {
+      firstDataCell = page.locator('[role="gridcell"]').nth(1);
+    }
+    await firstDataCell.waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Click the data cell to expand it
+    await firstDataCell.dispatchEvent('click');
+    await page.waitForTimeout(1000);
+
+    // Cell popover should open
+    const popover = page.locator('[data-test-subj="cellPopover"]');
+    await expect(popover).toBeVisible({ timeout: 5_000 });
+    console.log('Cell popover opened on click');
+
+    // Popover should contain action buttons
+    const copyBtn = popover.locator('[aria-label="Copy value"]');
+    await expect(copyBtn).toBeVisible();
+    console.log('Copy button visible in popover');
+
+    // Close with Escape
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    await expect(popover).not.toBeVisible({ timeout: 3_000 });
+    console.log('Popover closed with Escape');
+
+    // Click another cell to open again
+    await firstDataCell.dispatchEvent('click');
+    await page.waitForTimeout(1000);
+    await expect(popover).toBeVisible({ timeout: 5_000 });
+
+    // Close by clicking the X button
+    const closeBtn = popover.locator('[aria-label="Close"]');
+    await closeBtn.click();
+    await page.waitForTimeout(500);
+    await expect(popover).not.toBeVisible({ timeout: 3_000 });
+    console.log('Popover closed with X button');
+  });
+
+  test('empty state when no results', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await setupDiscover(page);
+
+    // Submit a query that produces no results
+    const noResultsQuery =
+      'FROM nonexistent_index_xyz_12345 | LIMIT 1 // TanStackGrid';
+    await submitEsqlQuery(page, noResultsQuery);
+
+    // Wait for query to complete
+    await page.waitForTimeout(8000);
+
+    // If TanStackGrid rendered with 0 rows, the empty state should show
+    const emptyState = page.locator('[data-test-subj="discoverNoResults"]');
+    const tanstackBadge = page.getByText('TanStack Grid');
+
+    const hasEmptyState = await emptyState.isVisible().catch(() => false);
+    const hasBadge = await tanstackBadge.isVisible().catch(() => false);
+
+    // Either the grid shows empty state, or the query error prevented TanStackGrid
+    console.log(`Empty state visible: ${hasEmptyState}, TanStack badge: ${hasBadge}`);
+    expect(hasEmptyState || !hasBadge).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/perf_tanstack_data_grid.playwright.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/perf_tanstack_data_grid.playwright.ts
@@ -583,9 +583,13 @@ test.describe('TanStack Data Grid – performance & functional', () => {
     await expect(selectionBar).toBeVisible({ timeout: 5_000 });
     await expect(selectionBar).toContainText('selected');
 
-    // Click "Copy" in selection bar
-    const copyBtn = selectionBar.getByText('Copy');
-    await expect(copyBtn).toBeVisible();
+    // Copy buttons should be visible (TSV, JSON, Markdown)
+    const copyTsvBtn = selectionBar.getByText('Copy as TSV');
+    await expect(copyTsvBtn).toBeVisible();
+    const copyJsonBtn = selectionBar.getByText('Copy as JSON');
+    await expect(copyJsonBtn).toBeVisible();
+    const copyMdBtn = selectionBar.getByText('Copy as Markdown');
+    await expect(copyMdBtn).toBeVisible();
 
     // Click "Clear"
     const clearBtn = selectionBar.getByText('Clear');

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/playwright.config.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/playwright.config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '*.playwright.ts',
+  timeout: 180_000,
+  retries: 0,
+  use: {
+    ...devices['Desktop Chrome'],
+    headless: true,
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1440, height: 900 },
+  },
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/tanstack_data_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/tanstack_data_grid.styles.ts
@@ -1,0 +1,527 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { css } from '@emotion/react';
+import type { UseEuiTheme } from '@elastic/eui';
+
+export const CONTROL_COL_WIDTH = 40;
+export const SELECT_COL_WIDTH = 32;
+export const DEFAULT_COL_WIDTH = 180;
+export const MIN_COL_WIDTH = 60;
+const RESIZE_HANDLE_WIDTH = 4;
+const ROW_HEIGHT_PX = 34;
+
+export const getTanStackDataGridStyles = (euiTheme: UseEuiTheme['euiTheme']) => ({
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+  }),
+
+  toolbar: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: euiTheme.size.s,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    borderBottom: euiTheme.border.thin,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    flexShrink: 0,
+    minHeight: 40,
+  }),
+
+  contentArea: css({
+    display: 'flex',
+    flex: 1,
+    minHeight: 0,
+  }),
+
+  scrollContainer: css({
+    flex: 1,
+    overflow: 'auto',
+    position: 'relative',
+    willChange: 'scroll-position',
+    minWidth: 0,
+  }),
+
+  // Header
+  headerRow: css({
+    display: 'flex',
+    position: 'sticky',
+    top: 0,
+    zIndex: 2,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    borderBottom: `2px solid ${euiTheme.colors.borderBaseFormsControl}`,
+  }),
+
+  headerCell: css({
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: euiTheme.size.xs,
+    padding: 'var(--tsg-cell-padding-v, 4px) var(--tsg-cell-padding-h, 8px)',
+    fontWeight: euiTheme.font.weight.semiBold,
+    fontSize: 'var(--tsg-font-size, 14px)',
+    lineHeight: 1.5,
+    overflow: 'hidden',
+    borderRight: euiTheme.border.thin,
+    flexShrink: 0,
+    userSelect: 'none',
+    '&:last-child': { borderRight: 'none' },
+  }),
+
+  headerCellSortable: css({
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseInteractiveHover,
+    },
+  }),
+
+  headerCellText: css({
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    flex: 1,
+    minWidth: 0,
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 'var(--tsg-header-max-lines, 1)',
+    wordBreak: 'break-word',
+  }),
+
+  sortIndicator: css({
+    flexShrink: 0,
+    color: euiTheme.colors.textSubdued,
+    fontSize: euiTheme.size.m,
+  }),
+
+  resizeHandle: css({
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: RESIZE_HANDLE_WIDTH * 2,
+    cursor: 'col-resize',
+    zIndex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    '&::after': {
+      content: '""',
+      width: RESIZE_HANDLE_WIDTH / 2,
+      height: '60%',
+      borderRadius: RESIZE_HANDLE_WIDTH,
+      backgroundColor: 'transparent',
+      transition: 'background-color 150ms ease',
+    },
+    '&:hover::after': {
+      backgroundColor: euiTheme.colors.borderBasePlain,
+    },
+  }),
+
+  resizeHandleActive: css({
+    '&::after': {
+      backgroundColor: euiTheme.colors.borderBaseFormsControl,
+    },
+  }),
+
+  // Virtualized body
+  virtualOuter: css({
+    position: 'relative',
+  }),
+
+  virtualInner: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    willChange: 'transform',
+  }),
+
+  row: css({
+    display: 'flex',
+    height: '100%',
+    borderBottom: euiTheme.border.thin,
+    boxSizing: 'border-box',
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseInteractiveHover,
+    },
+  }),
+
+  rowExpanded: css({
+    backgroundColor: euiTheme.colors.backgroundBaseInteractiveSelect,
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseInteractiveSelect,
+    },
+  }),
+
+  cell: css({
+    display: 'flex',
+    alignItems: 'flex-start',
+    padding: 'var(--tsg-cell-padding-v, 4px) var(--tsg-cell-padding-h, 8px)',
+    flexShrink: 0,
+    borderRight: euiTheme.border.thin,
+    lineHeight: 1.5,
+    fontSize: 'var(--tsg-font-size, 14px)',
+    '&:last-child': { borderRight: 'none' },
+  }),
+
+  cellContent: css({
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    minWidth: 0,
+    flex: 1,
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 'var(--tsg-body-max-lines, 1)',
+    wordBreak: 'break-word',
+  }),
+
+  controlCell: css({
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    paddingTop: euiTheme.size.xs,
+    flexShrink: 0,
+    borderRight: euiTheme.border.thin,
+  }),
+
+  controlHeaderCell: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    borderRight: euiTheme.border.thin,
+  }),
+
+  summaryCell: css({
+    flex: 1,
+    padding: 'var(--tsg-cell-padding-v, 4px) var(--tsg-cell-padding-h, 8px)',
+    overflow: 'hidden',
+    minWidth: 0,
+    lineHeight: 1.5,
+    fontSize: 'var(--tsg-font-size, 14px)',
+  }),
+
+  timestampCell: css({
+    fontFamily: euiTheme.font.familyCode,
+  }),
+
+  loadingOverlay: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: `${euiTheme.colors.backgroundBasePlain}80`,
+    zIndex: 3,
+  }),
+
+  // -- Grouped mode --
+  groupRow: css({
+    display: 'flex',
+    borderBottom: euiTheme.border.thin,
+    boxSizing: 'border-box',
+    cursor: 'pointer',
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseInteractiveHover,
+    },
+  }),
+
+  groupRowExpanded: css({
+    backgroundColor: euiTheme.colors.backgroundBaseInteractiveSelect,
+    borderBottom: 'none',
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseInteractiveSelect,
+    },
+  }),
+
+  groupChevronCell: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: CONTROL_COL_WIDTH,
+    flexShrink: 0,
+    borderRight: euiTheme.border.thin,
+    transition: 'transform 150ms ease',
+  }),
+
+  groupChevronRotated: css({
+    '& svg': {
+      transform: 'rotate(90deg)',
+    },
+  }),
+
+  groupLabel: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: euiTheme.size.s,
+    padding: '0 var(--tsg-cell-padding-h, 8px)',
+    fontWeight: euiTheme.font.weight.semiBold,
+    fontSize: 'var(--tsg-font-size, 14px)',
+    flex: 1,
+    overflow: 'hidden',
+  }),
+
+  groupLabelField: css({
+    color: euiTheme.colors.textSubdued,
+    fontWeight: euiTheme.font.weight.regular,
+  }),
+
+  groupCount: css({
+    marginLeft: 'auto',
+    paddingRight: euiTheme.size.s,
+    color: euiTheme.colors.textSubdued,
+    fontSize: euiTheme.size.m,
+    flexShrink: 0,
+  }),
+
+  groupSubPanel: css({
+    borderBottom: `2px solid ${euiTheme.colors.borderBaseFormsControl}`,
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+    overflow: 'hidden',
+  }),
+
+  subTable: css({
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontSize: euiTheme.size.m,
+  }),
+
+  subTableHeader: css({
+    position: 'sticky',
+    top: 0,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    '& th': {
+      padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+      fontWeight: euiTheme.font.weight.semiBold,
+      textAlign: 'left',
+      borderBottom: euiTheme.border.thin,
+      whiteSpace: 'nowrap',
+    },
+  }),
+
+  subTableRow: css({
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseInteractiveHover,
+    },
+    '& td': {
+      padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+      borderBottom: euiTheme.border.thin,
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      maxWidth: 250,
+    },
+  }),
+
+  subTableBadge: css({
+    marginLeft: euiTheme.size.xs,
+  }),
+
+  // -- Expandable cell (click to expand) --
+  expandableCell: css({
+    cursor: 'pointer',
+  }),
+
+  // -- Cell actions (hover overlay) --
+  cellWithActions: css({
+    position: 'relative',
+    '&:hover .tsg-cellActions': {
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+  }),
+
+  cellActions: css({
+    position: 'absolute',
+    right: 2,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    display: 'flex',
+    gap: 2,
+    opacity: 0,
+    pointerEvents: 'none',
+    transition: 'opacity 100ms ease',
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+    borderRadius: euiTheme.border.radius.small,
+    boxShadow: euiTheme.levels.menu !== undefined
+      ? `0 1px 4px ${euiTheme.colors.shadow}`
+      : `0 1px 3px rgba(0,0,0,.15)`,
+    padding: '1px 2px',
+    zIndex: 1,
+  }),
+
+  // -- Cell popover --
+  cellPopoverBackdrop: css({
+    position: 'fixed',
+    inset: 0,
+    zIndex: 999,
+  }),
+
+  cellPopover: css({
+    position: 'fixed',
+    zIndex: 1000,
+    minWidth: 200,
+    maxWidth: 500,
+    maxHeight: 400,
+    overflow: 'auto',
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+    border: euiTheme.border.thin,
+    borderRadius: euiTheme.border.radius.medium,
+    boxShadow: `0 4px 16px ${euiTheme.colors.shadow ?? 'rgba(0,0,0,.15)'}`,
+    padding: euiTheme.size.m,
+    fontSize: euiTheme.size.m,
+    lineHeight: 1.6,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  }),
+
+  cellPopoverHeader: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: euiTheme.size.s,
+    paddingBottom: euiTheme.size.xs,
+    borderBottom: euiTheme.border.thin,
+    fontWeight: euiTheme.font.weight.semiBold,
+    fontSize: euiTheme.size.m,
+    gap: euiTheme.size.xs,
+  }),
+
+  cellPopoverBody: css({
+    maxHeight: 320,
+    overflow: 'auto',
+  }),
+
+  // -- Keyboard focus ring --
+  focusedCell: css({
+    outline: `2px solid ${euiTheme.colors.primary}`,
+    outlineOffset: -2,
+    zIndex: 1,
+  }),
+
+  // -- Row selection --
+  selectCell: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    borderRight: euiTheme.border.thin,
+    width: SELECT_COL_WIDTH,
+  }),
+
+  selectHeaderCell: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    borderRight: euiTheme.border.thin,
+    width: SELECT_COL_WIDTH,
+  }),
+
+  selectedRow: css({
+    backgroundColor: `${euiTheme.colors.primary}10`,
+  }),
+
+  // -- Column drag reorder --
+  headerCellDragging: css({
+    opacity: 0.5,
+    cursor: 'grabbing',
+  }),
+
+  headerCellDragOver: css({
+    borderLeft: `2px solid ${euiTheme.colors.primary}`,
+  }),
+
+  headerCellDraggable: css({
+    cursor: 'grab',
+  }),
+
+  // -- Empty state --
+  emptyState: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: `${euiTheme.size.xxl} ${euiTheme.size.xl}`,
+    textAlign: 'center',
+    color: euiTheme.colors.textSubdued,
+    gap: euiTheme.size.m,
+    minHeight: 200,
+  }),
+
+  // -- Toolbar enhancements --
+  toolbarRight: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: euiTheme.size.xs,
+    marginLeft: 'auto',
+  }),
+
+  selectionBar: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: euiTheme.size.s,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    borderBottom: euiTheme.border.thin,
+    backgroundColor: `${euiTheme.colors.primary}10`,
+    flexShrink: 0,
+    minHeight: 36,
+  }),
+
+  // -- Full screen mode --
+  fullScreen: css({
+    position: 'fixed',
+    inset: 0,
+    zIndex: 999,
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+  }),
+
+  // -- Find in table --
+  findBar: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: 4,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    borderBottom: euiTheme.border.thin,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    flexShrink: 0,
+  }),
+
+  findInput: css({
+    minWidth: 200,
+  }),
+
+  findCounter: css({
+    fontVariantNumeric: 'tabular-nums',
+    whiteSpace: 'nowrap',
+    minWidth: 50,
+    textAlign: 'center',
+  }),
+
+  searchHighlight: css({
+    backgroundColor: '#FDD835',
+    color: '#000',
+    borderRadius: 2,
+    padding: '0 1px',
+  }),
+
+  searchHighlightActive: css({
+    backgroundColor: '#F57C00',
+    color: '#FFF',
+    borderRadius: 2,
+    padding: '0 1px',
+    outline: `1px solid ${euiTheme.colors.primary}`,
+  }),
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/tanstack_data_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/tanstack_data_grid.tsx
@@ -27,6 +27,7 @@ import {
   EuiButtonGroup,
   EuiButtonIcon,
   EuiCheckbox,
+  EuiContextMenu,
   EuiEmptyPrompt,
   EuiFieldNumber,
   EuiFieldSearch,
@@ -36,6 +37,7 @@ import {
   EuiIcon,
   EuiLoadingSpinner,
   EuiPopover,
+  EuiProgress,
   EuiSpacer,
   EuiText,
   EuiToolTip,
@@ -44,7 +46,8 @@ import {
 } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils';
-import { getShouldShowFieldHandler } from '@kbn/discover-utils';
+import { getShouldShowFieldHandler, formatFieldValue } from '@kbn/discover-utils';
+import { FieldIcon, getFieldIconProps, getTextBasedColumnIconType } from '@kbn/field-utils';
 import {
   SourceDocument,
   DataLoadingState,
@@ -79,6 +82,8 @@ export interface TanStackDataGridProps {
   dataView: DataView;
   query?: AggregateQuery;
   showTimeCol: boolean;
+  isPlainRecord?: boolean;
+  showColumnTokens?: boolean;
 
   sort?: SortOrder[];
   onSort?: (sort: SortOrder[]) => void;
@@ -96,6 +101,14 @@ export interface TanStackDataGridProps {
   onFilter?: UnifiedDataTableProps['onFilter'];
   getRowIndicator?: UnifiedDataTableProps['getRowIndicator'];
   rowAdditionalLeadingControls?: UnifiedDataTableProps['rowAdditionalLeadingControls'];
+
+  dataGridDensityState?: UnifiedDataTableProps['dataGridDensityState'];
+  onUpdateDataGridDensity?: UnifiedDataTableProps['onUpdateDataGridDensity'];
+  rowHeightState?: number;
+  onUpdateRowHeight?: UnifiedDataTableProps['onUpdateRowHeight'];
+  headerRowHeightState?: number;
+  onUpdateHeaderRowHeight?: UnifiedDataTableProps['onUpdateHeaderRowHeight'];
+  externalAdditionalControls?: React.ReactNode;
 }
 
 type GridDensity = 'compact' | 'normal' | 'expanded';
@@ -982,6 +995,8 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
     dataView,
     query,
     showTimeCol,
+    isPlainRecord,
+    showColumnTokens,
     sort = [],
     onSort,
     isSortEnabled = true,
@@ -995,6 +1010,13 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
     onFilter,
     getRowIndicator,
     rowAdditionalLeadingControls,
+    dataGridDensityState,
+    onUpdateDataGridDensity,
+    rowHeightState,
+    onUpdateRowHeight,
+    headerRowHeightState,
+    onUpdateHeaderRowHeight,
+    externalAdditionalControls,
   }) => {
     const { euiTheme } = useEuiTheme();
     const { fieldFormats } = useDiscoverServices();
@@ -1108,16 +1130,42 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
     const [isFullScreen, setIsFullScreen] = useState(false);
     const toggleFullScreen = useCallback(() => setIsFullScreen((prev) => !prev), []);
 
-    // ── Grid density ──
-    const [density, setDensity] = useState<GridDensity>('compact');
+    // ── Grid density (sync with app state if provided) ──
+    const [localDensity, setLocalDensity] = useState<GridDensity>(
+      (dataGridDensityState as GridDensity) || 'compact'
+    );
+    const density = (dataGridDensityState as GridDensity) || localDensity;
+    const setDensity = useCallback(
+      (d: GridDensity) => {
+        setLocalDensity(d);
+        onUpdateDataGridDensity?.(d as any);
+      },
+      [onUpdateDataGridDensity]
+    );
     const [isDensityPopoverOpen, setIsDensityPopoverOpen] = useState(false);
     const densityCfg = DENSITY_CONFIG[density];
 
-    // ── Max header cell lines ──
-    const [headerMaxLines, setHeaderMaxLines] = useState(1);
+    // ── Max header cell lines (sync with app state) ──
+    const [localHeaderMaxLines, setLocalHeaderMaxLines] = useState(headerRowHeightState ?? 1);
+    const headerMaxLines = headerRowHeightState ?? localHeaderMaxLines;
+    const setHeaderMaxLines = useCallback(
+      (val: number) => {
+        setLocalHeaderMaxLines(val);
+        onUpdateHeaderRowHeight?.(val);
+      },
+      [onUpdateHeaderRowHeight]
+    );
 
-    // ── Body cell lines (0 = auto/no clamp) ──
-    const [bodyMaxLines, setBodyMaxLines] = useState(1);
+    // ── Body cell lines (sync with app state) ──
+    const [localBodyMaxLines, setLocalBodyMaxLines] = useState(rowHeightState ?? 1);
+    const bodyMaxLines = rowHeightState ?? localBodyMaxLines;
+    const setBodyMaxLines = useCallback(
+      (val: number) => {
+        setLocalBodyMaxLines(val);
+        onUpdateRowHeight?.(val);
+      },
+      [onUpdateRowHeight]
+    );
 
     // ── Cell popover ──
     const [popoverState, setPopoverState] = useState<{
@@ -1243,6 +1291,101 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
 
     const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
 
+    // ── Column header context menu ──
+    const [headerMenuState, setHeaderMenuState] = useState<{
+      colId: string;
+      anchorPosition: { top: number; left: number };
+    } | null>(null);
+
+    const handleHeaderContextMenu = useCallback(
+      (e: React.MouseEvent, colId: string) => {
+        e.preventDefault();
+        setHeaderMenuState({ colId, anchorPosition: { top: e.clientY, left: e.clientX } });
+      },
+      []
+    );
+
+    const closeHeaderMenu = useCallback(() => setHeaderMenuState(null), []);
+
+    const headerMenuItems = useMemo(() => {
+      if (!headerMenuState) return [];
+      const { colId } = headerMenuState;
+      const colIndex = effectiveColumns.indexOf(colId);
+      const items: Array<{ name: string; icon: string; onClick: () => void }> = [];
+
+      if (colIndex > 0 && onSetColumns) {
+        items.push({
+          name: 'Move left',
+          icon: 'sortLeft',
+          onClick: () => {
+            const newCols = [...effectiveColumns];
+            [newCols[colIndex - 1], newCols[colIndex]] = [newCols[colIndex], newCols[colIndex - 1]];
+            onSetColumns(newCols, false);
+            closeHeaderMenu();
+          },
+        });
+      }
+
+      if (colIndex < effectiveColumns.length - 1 && colIndex >= 0 && onSetColumns) {
+        items.push({
+          name: 'Move right',
+          icon: 'sortRight',
+          onClick: () => {
+            const newCols = [...effectiveColumns];
+            [newCols[colIndex], newCols[colIndex + 1]] = [newCols[colIndex + 1], newCols[colIndex]];
+            onSetColumns(newCols, false);
+            closeHeaderMenu();
+          },
+        });
+      }
+
+      items.push({
+        name: 'Copy column name',
+        icon: 'copyClipboard',
+        onClick: () => {
+          navigator.clipboard.writeText(colId);
+          closeHeaderMenu();
+        },
+      });
+
+      items.push({
+        name: 'Copy column values',
+        icon: 'copyClipboard',
+        onClick: () => {
+          const values = rows.map((r) => formatCellValue(r.flattened[colId])).join('\n');
+          navigator.clipboard.writeText(values);
+          closeHeaderMenu();
+        },
+      });
+
+      if (onResize) {
+        items.push({
+          name: 'Reset width',
+          icon: 'empty',
+          onClick: () => {
+            onResize({ columnId: colId, width: undefined });
+            closeHeaderMenu();
+          },
+        });
+      }
+
+      if (onSetColumns && colId !== dataView.timeFieldName) {
+        items.push({
+          name: 'Remove column',
+          icon: 'cross',
+          onClick: () => {
+            onSetColumns(
+              effectiveColumns.filter((c) => c !== colId),
+              false
+            );
+            closeHeaderMenu();
+          },
+        });
+      }
+
+      return items;
+    }, [headerMenuState, effectiveColumns, onSetColumns, onResize, rows, dataView.timeFieldName, closeHeaderMenu]);
+
     // ── Build TanStack column defs ──
     const tanstackColumns: ColumnDef<DataTableRecord>[] = useMemo(() => {
       const defs: ColumnDef<DataTableRecord>[] = [];
@@ -1353,9 +1496,19 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
             minSize: MIN_COL_WIDTH,
             enableSorting: isSortEnabled,
             meta: { isTimestamp: isTimeField, fieldName: colId },
-            cell: function DataCell({ getValue }) {
+            cell: function DataCell({ getValue, row }) {
               const val = getValue();
-              const formatted = isTimeField ? formatTimestamp(val) : formatCellValue(val);
+              let formatted: string;
+              if (isTimeField) {
+                formatted = formatTimestamp(val);
+              } else {
+                const dvField = dataView.getFieldByName(colId);
+                if (dvField && fieldFormats) {
+                  formatted = formatFieldValue(val, row.original.raw, fieldFormats, dataView, dvField, 'text');
+                } else {
+                  formatted = formatCellValue(val);
+                }
+              }
               return (
                 <div css={isTimeField ? styles.timestampCell : undefined} title={formatted}>
                   {formatted}
@@ -1586,6 +1739,25 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
       navigator.clipboard.writeText(`${header}\n${body}`);
     }, [rows, selectedRows, effectiveColumns]);
 
+    const copySelectedAsJson = useCallback(() => {
+      const selectedRecords = rows.filter((r) => selectedRows.has(r.id));
+      const json = JSON.stringify(selectedRecords.map((r) => r.flattened), null, 2);
+      navigator.clipboard.writeText(json);
+    }, [rows, selectedRows]);
+
+    const copySelectedAsMarkdown = useCallback(() => {
+      const selectedRecords = rows.filter((r) => selectedRows.has(r.id));
+      const cols = effectiveColumns.filter((c) => c !== SOURCE_COLUMN_ID);
+      const header = `| ${cols.join(' | ')} |`;
+      const sep = `| ${cols.map(() => '---').join(' | ')} |`;
+      const body = selectedRecords
+        .map((r) => `| ${cols.map((c) => formatCellValue(r.flattened[c])).join(' | ')} |`)
+        .join('\n');
+      navigator.clipboard.writeText(`${header}\n${sep}\n${body}`);
+    }, [rows, selectedRows, effectiveColumns]);
+
+    const isLoadingMore = loadingState === DataLoadingState.loadingMore;
+
     return (
       <div ref={wrapperRef} css={[styles.wrapper, isFullScreen && styles.fullScreen]} style={densityVars} data-test-subj="tanstackGridWrapper">
         {/* Find in table bar */}
@@ -1602,17 +1774,15 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
         )}
         {/* Toolbar */}
         <div css={styles.toolbar}>
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
             <EuiFlexItem grow={false}>
               <EuiBadge color="accent">TanStack Grid</EuiBadge>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiText size="xs">
-                {rows.length.toLocaleString()} rows &middot; rendered{' '}
-                {virtualItems.length}
+                {rows.length.toLocaleString()} rows
                 {isSummaryMode ? ' · Summary' : ` · ${effectiveColumns.length} columns`}
                 {isGroupedMode ? ' · Grouped' : ''}
-                {statsByInfo && !isGroupedMode ? ' · STATS/BY' : ''}
               </EuiText>
             </EuiFlexItem>
             {isGroupedMode && (
@@ -1621,6 +1791,9 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
                   Grouped by: {statsByInfo!.byFields.join(', ')}
                 </EuiBadge>
               </EuiFlexItem>
+            )}
+            {externalAdditionalControls && (
+              <EuiFlexItem grow={false}>{externalAdditionalControls}</EuiFlexItem>
             )}
           </EuiFlexGroup>
           <div css={styles.toolbarRight}>
@@ -1726,7 +1899,13 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
               <strong>{selectedRows.size}</strong> row{selectedRows.size !== 1 ? 's' : ''} selected
             </EuiText>
             <EuiButtonEmpty size="xs" onClick={copySelectedAsText} iconType="copyClipboard">
-              Copy
+              Copy as TSV
+            </EuiButtonEmpty>
+            <EuiButtonEmpty size="xs" onClick={copySelectedAsJson} iconType="copyClipboard">
+              Copy as JSON
+            </EuiButtonEmpty>
+            <EuiButtonEmpty size="xs" onClick={copySelectedAsMarkdown} iconType="copyClipboard">
+              Copy as Markdown
             </EuiButtonEmpty>
             <EuiButtonEmpty size="xs" onClick={clearSelection} iconType="cross" color="text">
               Clear
@@ -1827,9 +2006,30 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
                           }
                           onDrop={isDraggable ? handleDragEnd : undefined}
                           onDragEnd={handleDragEnd}
+                          onContextMenu={
+                            !isControl && !isSelect && !isSummary
+                              ? (e: React.MouseEvent) => handleHeaderContextMenu(e, colId)
+                              : undefined
+                          }
                         >
                           {!isControl && (
                             <>
+                              {showColumnTokens && !isSummary && (() => {
+                                const fieldName = header.column.columnDef.meta?.fieldName;
+                                if (!fieldName) return null;
+                                if (columnsMeta) {
+                                  const iconType = getTextBasedColumnIconType(columnsMeta[fieldName]);
+                                  if (iconType && iconType !== 'unknown') {
+                                    return <FieldIcon type={iconType} css={{ marginRight: 4, flexShrink: 0 }} />;
+                                  }
+                                } else {
+                                  const dvField = dataView.getFieldByName(fieldName);
+                                  if (dvField) {
+                                    return <FieldIcon {...getFieldIconProps(dvField)} css={{ marginRight: 4, flexShrink: 0 }} />;
+                                  }
+                                }
+                                return null;
+                              })()}
                               <span css={styles.headerCellText}>
                                 {flexRender(
                                   header.column.columnDef.header,
@@ -1945,6 +2145,9 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
                   <EuiLoadingSpinner size="xl" />
                 </div>
               )}
+              {isLoadingMore && (
+                <EuiProgress size="xs" color="accent" position="absolute" css={{ bottom: 0, left: 0, right: 0, top: 'auto' }} />
+              )}
             </div>
           )}
 
@@ -1971,6 +2174,56 @@ export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
             onFilter={onFilterRef.current}
             styles={styles}
           />
+        )}
+
+        {/* Column header context menu */}
+        {headerMenuState && (
+          <>
+            <div
+              css={{ position: 'fixed', inset: 0, zIndex: 9998 }}
+              onClick={closeHeaderMenu}
+            />
+            <div
+              css={{
+                position: 'fixed',
+                top: headerMenuState.anchorPosition.top,
+                left: headerMenuState.anchorPosition.left,
+                zIndex: 9999,
+                backgroundColor: euiTheme.colors.backgroundBasePlain,
+                borderRadius: euiTheme.border.radius.medium,
+                boxShadow: euiTheme.levels.menu === 1000 ? '0 1px 5px rgba(0,0,0,.1), 0 3px 15px rgba(0,0,0,.1)' : undefined,
+                border: euiTheme.border.thin,
+                padding: `${euiTheme.size.xs} 0`,
+                minWidth: 200,
+              }}
+              data-test-subj="columnHeaderMenu"
+            >
+              {headerMenuItems.map((item) => (
+                <button
+                  key={item.name}
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: euiTheme.size.s,
+                    width: '100%',
+                    padding: `${euiTheme.size.xs} ${euiTheme.size.m}`,
+                    border: 'none',
+                    background: 'none',
+                    cursor: 'pointer',
+                    fontSize: euiTheme.size.m,
+                    textAlign: 'left',
+                    '&:hover': {
+                      backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+                    },
+                  }}
+                  onClick={item.onClick}
+                >
+                  <EuiIcon type={item.icon} size="s" />
+                  {item.name}
+                </button>
+              ))}
+            </div>
+          </>
         )}
       </div>
     );

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/tanstack_data_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_data_grid/tanstack_data_grid.tsx
@@ -1,0 +1,1978 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  flexRender,
+  type ColumnDef,
+  type SortingState,
+  type ColumnSizingState,
+  type RowData,
+  type Row,
+  type Cell,
+} from '@tanstack/react-table';
+import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
+import {
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiButtonGroup,
+  EuiButtonIcon,
+  EuiCheckbox,
+  EuiEmptyPrompt,
+  EuiFieldNumber,
+  EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiPopover,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+  keys,
+  useEuiTheme,
+} from '@elastic/eui';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils';
+import { getShouldShowFieldHandler } from '@kbn/discover-utils';
+import {
+  SourceDocument,
+  DataLoadingState,
+  type UnifiedDataTableProps,
+  type SortOrder,
+} from '@kbn/unified-data-table';
+import type { AggregateQuery } from '@kbn/es-query';
+import {
+  getTanStackDataGridStyles,
+  CONTROL_COL_WIDTH,
+  SELECT_COL_WIDTH,
+  DEFAULT_COL_WIDTH,
+  MIN_COL_WIDTH,
+} from './tanstack_data_grid.styles';
+import { useDiscoverServices } from '../../../hooks/use_discover_services';
+
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    isControl?: boolean;
+    isSelect?: boolean;
+    isSummary?: boolean;
+    isTimestamp?: boolean;
+    fieldName?: string;
+  }
+}
+
+export interface TanStackDataGridProps {
+  rows: DataTableRecord[];
+  columns: string[];
+  columnsMeta?: DataTableColumnsMeta;
+  dataView: DataView;
+  query?: AggregateQuery;
+  showTimeCol: boolean;
+
+  sort?: SortOrder[];
+  onSort?: (sort: SortOrder[]) => void;
+  isSortEnabled?: boolean;
+
+  settings?: UnifiedDataTableProps['settings'];
+  onResize?: UnifiedDataTableProps['onResize'];
+  onSetColumns?: UnifiedDataTableProps['onSetColumns'];
+
+  expandedDoc?: DataTableRecord;
+  setExpandedDoc?: UnifiedDataTableProps['setExpandedDoc'];
+  renderDocumentView?: UnifiedDataTableProps['renderDocumentView'];
+
+  loadingState?: DataLoadingState;
+  onFilter?: UnifiedDataTableProps['onFilter'];
+  getRowIndicator?: UnifiedDataTableProps['getRowIndicator'];
+  rowAdditionalLeadingControls?: UnifiedDataTableProps['rowAdditionalLeadingControls'];
+}
+
+type GridDensity = 'compact' | 'normal' | 'expanded';
+
+interface DensityConfig {
+  rowHeight: number;
+  summaryRowHeight: number;
+  fontSize: number;
+  cellPaddingV: number;
+  cellPaddingH: number;
+  label: string;
+  icon: string;
+}
+
+const DENSITY_CONFIG: Record<GridDensity, DensityConfig> = {
+  compact: {
+    rowHeight: 28,
+    summaryRowHeight: 70,
+    fontSize: 12,
+    cellPaddingV: 2,
+    cellPaddingH: 6,
+    label: 'Compact',
+    icon: 'menuLeft',
+  },
+  normal: {
+    rowHeight: 34,
+    summaryRowHeight: 90,
+    fontSize: 14,
+    cellPaddingV: 4,
+    cellPaddingH: 8,
+    label: 'Normal',
+    icon: 'menu',
+  },
+  expanded: {
+    rowHeight: 44,
+    summaryRowHeight: 120,
+    fontSize: 14,
+    cellPaddingV: 8,
+    cellPaddingH: 12,
+    label: 'Expanded',
+    icon: 'menuRight',
+  },
+};
+
+const DENSITY_BUTTONS = [
+  { id: 'compact' as GridDensity, label: 'Compact', iconType: 'menuLeft' },
+  { id: 'normal' as GridDensity, label: 'Normal', iconType: 'menu' },
+  { id: 'expanded' as GridDensity, label: 'Expanded', iconType: 'menuRight' },
+];
+
+const GROUP_SUB_ROW_HEIGHT = 28;
+const GROUP_SUB_PANEL_HEADER = 30;
+const MAX_GROUP_SUB_ROWS = 5;
+const OVERSCAN = 20;
+const MAX_SUMMARY_FIELDS = 80;
+
+const scrollPositionCache = new Map<string, number>();
+
+const formatCellValue = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (Array.isArray(value)) return value.join(', ');
+  return String(value);
+};
+
+const formatTimestamp = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'string') {
+    try {
+      return new Date(value).toISOString();
+    } catch {
+      return value;
+    }
+  }
+  return String(value);
+};
+
+const filterNullFields = (row: DataTableRecord): DataTableRecord => {
+  const filtered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row.flattened)) {
+    if (value !== null && value !== undefined) {
+      filtered[key] = value;
+    }
+  }
+  return { ...row, flattened: filtered };
+};
+
+// ── Find in table ──
+interface FindMatch {
+  rowIndex: number;
+  fieldName: string;
+}
+
+function scanMatches(
+  rows: DataTableRecord[],
+  fields: string[],
+  term: string,
+  isSummaryMode: boolean
+): FindMatch[] {
+  if (!term) return [];
+  const lower = term.toLowerCase();
+  const matches: FindMatch[] = [];
+
+  for (let ri = 0; ri < rows.length; ri++) {
+    const flat = rows[ri].flattened;
+    if (isSummaryMode) {
+      for (const [key, val] of Object.entries(flat)) {
+        if (val !== null && val !== undefined && formatCellValue(val).toLowerCase().includes(lower)) {
+          matches.push({ rowIndex: ri, fieldName: key });
+        }
+      }
+    } else {
+      for (const f of fields) {
+        if (formatCellValue(flat[f]).toLowerCase().includes(lower)) {
+          matches.push({ rowIndex: ri, fieldName: f });
+        }
+      }
+    }
+  }
+  return matches;
+}
+
+const HighlightedText = React.memo(
+  ({
+    text,
+    term,
+    isActive,
+    styles,
+  }: {
+    text: string;
+    term: string;
+    isActive: boolean;
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+  }) => {
+    if (!term) return <>{text}</>;
+    const lower = text.toLowerCase();
+    const tLower = term.toLowerCase();
+    const parts: React.ReactNode[] = [];
+    let cursor = 0;
+    let idx = lower.indexOf(tLower, cursor);
+
+    while (idx !== -1) {
+      if (idx > cursor) parts.push(text.slice(cursor, idx));
+      parts.push(
+        <mark key={idx} css={isActive ? styles.searchHighlightActive : styles.searchHighlight}>
+          {text.slice(idx, idx + term.length)}
+        </mark>
+      );
+      cursor = idx + term.length;
+      idx = lower.indexOf(tLower, cursor);
+    }
+    if (cursor < text.length) parts.push(text.slice(cursor));
+    return <>{parts}</>;
+  }
+);
+
+const FindInTableBar = React.memo(
+  ({
+    matchesCount,
+    activeIndex,
+    onSearch,
+    onNext,
+    onPrev,
+    onClose,
+    styles,
+  }: {
+    matchesCount: number;
+    activeIndex: number;
+    onSearch: (term: string) => void;
+    onNext: () => void;
+    onPrev: () => void;
+    onClose: () => void;
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+  }) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [inputValue, setInputValue] = useState('');
+
+    useEffect(() => {
+      inputRef.current?.focus();
+    }, []);
+
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const v = e.target.value;
+        setInputValue(v);
+        onSearch(v);
+      },
+      [onSearch]
+    );
+
+    const handleKeyUp = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === keys.ESCAPE) {
+          onClose();
+        } else if (e.key === keys.ENTER && e.shiftKey) {
+          onPrev();
+        } else if (e.key === keys.ENTER) {
+          onNext();
+        }
+      },
+      [onClose, onPrev, onNext]
+    );
+
+    const hasResults = matchesCount > 0;
+    const counter = inputValue
+      ? `${hasResults ? activeIndex + 1 : 0}/${matchesCount}`
+      : '';
+
+    return (
+      <div css={styles.findBar} data-test-subj="findInTableBar">
+        <EuiFieldSearch
+          inputRef={(node) => {
+            (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = node;
+          }}
+          compressed
+          css={styles.findInput}
+          placeholder="Find in table"
+          value={inputValue}
+          onChange={handleChange}
+          onKeyUp={handleKeyUp}
+          data-test-subj="findInTableInput"
+          isClearable
+          aria-label="Find in table"
+        />
+        <EuiText size="xs" css={styles.findCounter} data-test-subj="findInTableCounter">
+          {counter}
+        </EuiText>
+        <EuiButtonIcon
+          iconType="arrowUp"
+          size="xs"
+          color="text"
+          disabled={!hasResults}
+          aria-label="Previous match"
+          onClick={onPrev}
+          data-test-subj="findInTablePrev"
+        />
+        <EuiButtonIcon
+          iconType="arrowDown"
+          size="xs"
+          color="text"
+          disabled={!hasResults}
+          aria-label="Next match"
+          onClick={onNext}
+          data-test-subj="findInTableNext"
+        />
+        <EuiButtonIcon
+          iconType="cross"
+          size="xs"
+          color="text"
+          aria-label="Close find bar"
+          onClick={onClose}
+          data-test-subj="findInTableClose"
+        />
+      </div>
+    );
+  }
+);
+
+const EXPAND_COLUMN_ID = '__expand';
+const SELECT_COLUMN_ID = '__select';
+const SOURCE_COLUMN_ID = '_source';
+
+// -- STATS ... BY column reordering --
+interface StatsByInfo {
+  byFields: string[];
+  orderedColumns: string[];
+}
+
+const parseStatsByColumns = (
+  query: AggregateQuery | undefined,
+  columns: string[]
+): StatsByInfo | undefined => {
+  if (!query || !('esql' in query)) return undefined;
+  const byMatch = query.esql.match(/\bSTATS\b[\s\S]+?\bBY\b\s+(.+?)(?:\||$)/i);
+  if (!byMatch) return undefined;
+
+  const byClause = byMatch[1].replace(/\/\/.*$|\/\*[\s\S]*?\*\//g, '');
+
+  const byFields = byClause
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean);
+  if (byFields.length === 0) return undefined;
+
+  const bySet = new Set(byFields);
+  const countFields: string[] = [];
+  const otherFields: string[] = [];
+
+  for (const col of columns) {
+    if (col === SOURCE_COLUMN_ID || bySet.has(col)) continue;
+    if (/count/i.test(col)) {
+      countFields.push(col);
+    } else {
+      otherFields.push(col);
+    }
+  }
+
+  const orderedColumns = [...byFields, ...countFields, ...otherFields].filter((col) =>
+    columns.includes(col)
+  );
+  return { byFields, orderedColumns };
+};
+
+// ── Marvel placeholder data for grouped mode sub-rows ──
+interface MarvelCharacter {
+  name: string;
+  realName: string;
+  team: string;
+  power: number;
+  firstAppearance: number;
+}
+
+const MARVEL_CHARACTERS: MarvelCharacter[] = [
+  { name: 'Spider-Man', realName: 'Peter Parker', team: 'Avengers', power: 87, firstAppearance: 1962 },
+  { name: 'Iron Man', realName: 'Tony Stark', team: 'Avengers', power: 95, firstAppearance: 1963 },
+  { name: 'Wolverine', realName: 'Logan', team: 'X-Men', power: 88, firstAppearance: 1974 },
+  { name: 'Storm', realName: 'Ororo Munroe', team: 'X-Men', power: 90, firstAppearance: 1975 },
+  { name: 'Captain America', realName: 'Steve Rogers', team: 'Avengers', power: 82, firstAppearance: 1941 },
+  { name: 'Black Widow', realName: 'Natasha Romanoff', team: 'Avengers', power: 75, firstAppearance: 1964 },
+  { name: 'Thor', realName: 'Thor Odinson', team: 'Asgardians', power: 99, firstAppearance: 1962 },
+  { name: 'Hulk', realName: 'Bruce Banner', team: 'Avengers', power: 98, firstAppearance: 1962 },
+  { name: 'Cyclops', realName: 'Scott Summers', team: 'X-Men', power: 78, firstAppearance: 1963 },
+  { name: 'Jean Grey', realName: 'Jean Grey', team: 'X-Men', power: 96, firstAppearance: 1963 },
+  { name: 'Deadpool', realName: 'Wade Wilson', team: 'X-Force', power: 85, firstAppearance: 1991 },
+  { name: 'Black Panther', realName: "T'Challa", team: 'Avengers', power: 88, firstAppearance: 1966 },
+  { name: 'Doctor Strange', realName: 'Stephen Strange', team: 'Avengers', power: 97, firstAppearance: 1963 },
+  { name: 'Scarlet Witch', realName: 'Wanda Maximoff', team: 'Avengers', power: 99, firstAppearance: 1964 },
+  { name: 'Gambit', realName: 'Remy LeBeau', team: 'X-Men', power: 80, firstAppearance: 1990 },
+  { name: 'Rogue', realName: 'Anna Marie', team: 'X-Men', power: 92, firstAppearance: 1981 },
+  { name: 'Vision', realName: 'Vision', team: 'Avengers', power: 91, firstAppearance: 1968 },
+  { name: 'Hawkeye', realName: 'Clint Barton', team: 'Avengers', power: 70, firstAppearance: 1964 },
+  { name: 'Ant-Man', realName: 'Scott Lang', team: 'Avengers', power: 72, firstAppearance: 1979 },
+  { name: 'Wasp', realName: 'Janet Van Dyne', team: 'Avengers', power: 74, firstAppearance: 1963 },
+];
+
+const MARVEL_FIELDS: (keyof MarvelCharacter)[] = ['name', 'realName', 'team', 'power', 'firstAppearance'];
+
+const getMarvelSubRows = (rowIndex: number): MarvelCharacter[] => {
+  const count = 2 + (rowIndex % (MAX_GROUP_SUB_ROWS - 1));
+  const start = (rowIndex * 7) % MARVEL_CHARACTERS.length;
+  const result: MarvelCharacter[] = [];
+  for (let i = 0; i < count; i++) {
+    result.push(MARVEL_CHARACTERS[(start + i) % MARVEL_CHARACTERS.length]);
+  }
+  return result;
+};
+
+// ── Cell Actions: filter in/out, copy, expand ──
+const CellActions = React.memo(
+  ({
+    fieldName,
+    value,
+    onFilter,
+    onExpand,
+    styles,
+  }: {
+    fieldName: string;
+    value: unknown;
+    onFilter?: UnifiedDataTableProps['onFilter'];
+    onExpand: () => void;
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+  }) => {
+    const handleFilterIn = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onFilter?.(fieldName, value, '+');
+      },
+      [onFilter, fieldName, value]
+    );
+    const handleFilterOut = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onFilter?.(fieldName, value, '-');
+      },
+      [onFilter, fieldName, value]
+    );
+    const handleCopy = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        navigator.clipboard.writeText(formatCellValue(value));
+      },
+      [value]
+    );
+    const handleExpand = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onExpand();
+      },
+      [onExpand]
+    );
+
+    return (
+      <div className="tsg-cellActions" css={styles.cellActions}>
+        {onFilter && (
+          <>
+            <EuiToolTip content="Filter for value">
+              <EuiButtonIcon
+                iconType="plusInCircle"
+                aria-label="Filter for value"
+                size="xs"
+                iconSize="s"
+                color="text"
+                onClick={handleFilterIn}
+                data-test-subj="filterForValue"
+              />
+            </EuiToolTip>
+            <EuiToolTip content="Filter out value">
+              <EuiButtonIcon
+                iconType="minusInCircle"
+                aria-label="Filter out value"
+                size="xs"
+                iconSize="s"
+                color="text"
+                onClick={handleFilterOut}
+                data-test-subj="filterOutValue"
+              />
+            </EuiToolTip>
+          </>
+        )}
+        <EuiToolTip content="Copy value">
+          <EuiButtonIcon
+            iconType="copyClipboard"
+            aria-label="Copy value"
+            size="xs"
+            iconSize="s"
+            color="text"
+            onClick={handleCopy}
+            data-test-subj="copyCellValue"
+          />
+        </EuiToolTip>
+        <EuiToolTip content="Expand cell">
+          <EuiButtonIcon
+            iconType="expand"
+            aria-label="Expand cell"
+            size="xs"
+            iconSize="s"
+            color="text"
+            onClick={handleExpand}
+            data-test-subj="expandCellValue"
+          />
+        </EuiToolTip>
+      </div>
+    );
+  }
+);
+
+// ── Cell Popover ──
+const CellPopover = React.memo(
+  ({
+    fieldName,
+    value,
+    anchorRect,
+    onClose,
+    onFilter,
+    styles,
+  }: {
+    fieldName: string;
+    value: unknown;
+    anchorRect: DOMRect;
+    onClose: () => void;
+    onFilter?: UnifiedDataTableProps['onFilter'];
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+  }) => {
+    const formatted = formatCellValue(value);
+    const top = Math.min(anchorRect.bottom + 4, window.innerHeight - 420);
+    const left = Math.min(anchorRect.left, window.innerWidth - 520);
+
+    useEffect(() => {
+      const handleEsc = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') onClose();
+      };
+      document.addEventListener('keydown', handleEsc);
+      return () => document.removeEventListener('keydown', handleEsc);
+    }, [onClose]);
+
+    const handleCopy = useCallback(() => {
+      navigator.clipboard.writeText(formatted);
+    }, [formatted]);
+
+    return (
+      <>
+        <div css={styles.cellPopoverBackdrop} onClick={onClose} />
+        <div
+          css={styles.cellPopover}
+          style={{ top, left }}
+          data-test-subj="cellPopover"
+          role="dialog"
+          aria-label={`${fieldName} value`}
+        >
+          <div css={styles.cellPopoverHeader}>
+            <span>{fieldName}</span>
+            <div css={{ display: 'flex', gap: 2 }}>
+              {onFilter && (
+                <>
+                  <EuiToolTip content="Filter for value">
+                    <EuiButtonIcon
+                      iconType="plusInCircle"
+                      aria-label="Filter for value"
+                      size="xs"
+                      onClick={() => { onFilter(fieldName, value, '+'); onClose(); }}
+                    />
+                  </EuiToolTip>
+                  <EuiToolTip content="Filter out value">
+                    <EuiButtonIcon
+                      iconType="minusInCircle"
+                      aria-label="Filter out value"
+                      size="xs"
+                      onClick={() => { onFilter(fieldName, value, '-'); onClose(); }}
+                    />
+                  </EuiToolTip>
+                </>
+              )}
+              <EuiToolTip content="Copy value">
+                <EuiButtonIcon
+                  iconType="copyClipboard"
+                  aria-label="Copy value"
+                  size="xs"
+                  onClick={handleCopy}
+                />
+              </EuiToolTip>
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label="Close"
+                size="xs"
+                onClick={onClose}
+              />
+            </div>
+          </div>
+          <div css={styles.cellPopoverBody}>{formatted}</div>
+        </div>
+      </>
+    );
+  }
+);
+
+// ── Grouped sub-panel ──
+const GroupSubPanel = React.memo(
+  ({
+    rowIndex,
+    styles,
+    width,
+  }: {
+    rowIndex: number;
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+    width: number;
+  }) => {
+    const characters = useMemo(() => getMarvelSubRows(rowIndex), [rowIndex]);
+    return (
+      <div css={styles.groupSubPanel} style={{ width }} data-test-subj="groupSubPanel">
+        <table css={styles.subTable}>
+          <thead css={styles.subTableHeader}>
+            <tr>
+              {MARVEL_FIELDS.map((field) => (
+                <th key={field}>{field}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {characters.map((char, i) => (
+              <tr key={`${char.name}-${i}`} css={styles.subTableRow}>
+                <td>
+                  <strong>{char.name}</strong>
+                </td>
+                <td>{char.realName}</td>
+                <td>
+                  <EuiBadge color="hollow" css={styles.subTableBadge}>
+                    {char.team}
+                  </EuiBadge>
+                </td>
+                <td>{char.power}</td>
+                <td>{char.firstAppearance}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+);
+
+// ── Memoized virtual row ──
+const VirtualRow = React.memo(
+  ({
+    row,
+    virtualRow,
+    isExpanded,
+    isSelected,
+    indicatorColor,
+    rowHeight,
+    styles,
+    focusedColIndex,
+    rowIndex,
+    onFilter,
+    setPopoverState,
+    findTerm,
+    findActiveMatch,
+  }: {
+    row: Row<DataTableRecord>;
+    virtualRow: VirtualItem;
+    isExpanded: boolean;
+    isSelected: boolean;
+    indicatorColor: string | undefined;
+    rowHeight: number;
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+    focusedColIndex: number | null;
+    rowIndex: number;
+    onFilter?: UnifiedDataTableProps['onFilter'];
+    setPopoverState?: (state: { fieldName: string; value: unknown; rect: DOMRect } | null) => void;
+    findTerm?: string;
+    findActiveMatch?: FindMatch | null;
+  }) => {
+    const cells = row.getVisibleCells();
+    return (
+      <div
+        data-index={virtualRow.index}
+        style={{ height: rowHeight }}
+        role="row"
+        aria-rowindex={rowIndex + 2}
+        aria-selected={isSelected}
+        tabIndex={-1}
+      >
+        <div
+          css={[styles.row, isExpanded && styles.rowExpanded, isSelected && styles.selectedRow]}
+          style={{
+            borderLeft: indicatorColor ? `3px solid ${indicatorColor}` : undefined,
+          }}
+        >
+          {cells.map((cell, colIdx) => (
+            <VirtualCell
+              key={cell.id}
+              cell={cell}
+              styles={styles}
+              isFocused={focusedColIndex === colIdx}
+              onFilter={onFilter}
+              setPopoverState={setPopoverState}
+              findTerm={findTerm}
+              findActiveMatch={findActiveMatch}
+              rowIndex={virtualRow.index}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+
+// ── Grouped virtual row ──
+const GroupedVirtualRow = React.memo(
+  ({
+    row,
+    virtualRow,
+    isGroupExpanded,
+    onToggleGroup,
+    byFields,
+    aggregateColumns,
+    styles,
+    totalWidth,
+    groupRowHeight,
+  }: {
+    row: Row<DataTableRecord>;
+    virtualRow: VirtualItem;
+    isGroupExpanded: boolean;
+    onToggleGroup: (rowId: string) => void;
+    byFields: string[];
+    aggregateColumns: string[];
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+    totalWidth: number;
+    groupRowHeight: number;
+  }) => {
+    const record = row.original;
+    const handleClick = useCallback(() => onToggleGroup(row.id), [onToggleGroup, row.id]);
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onToggleGroup(row.id);
+        }
+      },
+      [onToggleGroup, row.id]
+    );
+
+    const subRowCount = 2 + (virtualRow.index % (MAX_GROUP_SUB_ROWS - 1));
+
+    return (
+      <div
+        data-index={virtualRow.index}
+        role="row"
+        tabIndex={0}
+        data-test-subj="groupRow"
+      >
+        <div
+          css={[styles.groupRow, isGroupExpanded && styles.groupRowExpanded]}
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          style={{ width: totalWidth, height: groupRowHeight }}
+          data-test-subj="groupRowHeader"
+        >
+          <div
+            css={[styles.groupChevronCell, isGroupExpanded && styles.groupChevronRotated]}
+          >
+            <EuiIcon type="arrowRight" size="s" />
+          </div>
+          <div css={styles.groupLabel}>
+            {byFields.map((field) => (
+              <span key={field}>
+                <span css={styles.groupLabelField}>{field}:</span>{' '}
+                <strong>{formatCellValue(record.flattened[field])}</strong>
+              </span>
+            ))}
+            {aggregateColumns.map((col) => (
+              <EuiBadge key={col} color="hollow">
+                {col}: {formatCellValue(record.flattened[col])}
+              </EuiBadge>
+            ))}
+          </div>
+          <div css={styles.groupCount}>{subRowCount} documents</div>
+        </div>
+        {isGroupExpanded && (
+          <GroupSubPanel
+            rowIndex={virtualRow.index}
+            styles={styles}
+            width={totalWidth}
+          />
+        )}
+      </div>
+    );
+  }
+);
+
+// ── Virtual cell with cell actions, popover, and focus support ──
+const VirtualCell = React.memo(
+  ({
+    cell,
+    styles,
+    isFocused,
+    onFilter,
+    setPopoverState,
+    findTerm,
+    findActiveMatch,
+    rowIndex,
+  }: {
+    cell: Cell<DataTableRecord, unknown>;
+    styles: ReturnType<typeof getTanStackDataGridStyles>;
+    isFocused: boolean;
+    onFilter?: UnifiedDataTableProps['onFilter'];
+    setPopoverState?: (state: { fieldName: string; value: unknown; rect: DOMRect } | null) => void;
+    findTerm?: string;
+    findActiveMatch?: FindMatch | null;
+    rowIndex?: number;
+  }) => {
+    const isControl = cell.column.columnDef.meta?.isControl;
+    const isSelect = cell.column.columnDef.meta?.isSelect;
+    const isSummary = cell.column.columnDef.meta?.isSummary;
+
+    if (isControl || isSelect) {
+      return (
+        <div
+          css={[isSelect ? styles.selectCell : styles.controlCell, isFocused && styles.focusedCell]}
+          style={{ width: cell.column.getSize() }}
+          role="gridcell"
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </div>
+      );
+    }
+
+    if (isSummary) {
+      return (
+        <div
+          css={[styles.summaryCell, styles.expandableCell, isFocused && styles.focusedCell]}
+          role="gridcell"
+          style={{ flex: '1 1 0' }}
+          onClick={(e) => {
+            if (setPopoverState) {
+              const el = e.currentTarget;
+              setPopoverState({
+                fieldName: '_source',
+                value: Object.entries(cell.row.original.flattened)
+                  .map(([k, v]) => `${k}: ${formatCellValue(v)}`)
+                  .join('\n'),
+                rect: el.getBoundingClientRect(),
+              });
+            }
+          }}
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </div>
+      );
+    }
+
+    const fieldName = cell.column.columnDef.meta?.fieldName;
+    const value = cell.getValue();
+    const colId = cell.column.id;
+    const rowId = cell.row.original.id;
+    const formatted = formatCellValue(value);
+    const isActiveHighlight =
+      findTerm && findActiveMatch && findActiveMatch.rowIndex === rowIndex && findActiveMatch.fieldName === colId;
+
+    const openCellPopover = (el: HTMLElement) => {
+      if (fieldName && setPopoverState) {
+        setPopoverState({
+          fieldName,
+          value,
+          rect: el.getBoundingClientRect(),
+        });
+      }
+    };
+
+    return (
+      <div
+        css={[styles.cell, styles.cellWithActions, styles.expandableCell, isFocused && styles.focusedCell]}
+        style={{ width: cell.column.getSize() }}
+        role="gridcell"
+        data-row-id={rowId}
+        data-col-id={colId}
+        onClick={(e) => openCellPopover(e.currentTarget)}
+      >
+        <div css={styles.cellContent}>
+          {findTerm ? (
+            <HighlightedText
+              text={formatted}
+              term={findTerm}
+              isActive={Boolean(isActiveHighlight)}
+              styles={styles}
+            />
+          ) : (
+            flexRender(cell.column.columnDef.cell, cell.getContext())
+          )}
+        </div>
+        {fieldName && (
+          <CellActions
+            fieldName={fieldName}
+            value={value}
+            onFilter={onFilter}
+            onExpand={() => {
+              const el = document.querySelector(
+                `[data-row-id="${rowId}"][data-col-id="${colId}"]`
+              );
+              if (el) openCellPopover(el as HTMLElement);
+            }}
+            styles={styles}
+          />
+        )}
+      </div>
+    );
+  }
+);
+
+const SummaryCellContent = React.memo(
+  ({
+    row,
+    dataView,
+    shouldShowFieldHandler,
+    fieldFormats,
+    columnsMeta,
+  }: {
+    row: DataTableRecord;
+    dataView: DataView;
+    shouldShowFieldHandler: (fieldName: string) => boolean;
+    fieldFormats: ReturnType<typeof useDiscoverServices>['fieldFormats'];
+    columnsMeta: DataTableColumnsMeta | undefined;
+  }) => {
+    const filteredRow = useMemo(() => filterNullFields(row), [row]);
+    return (
+      <SourceDocument
+        useTopLevelObjectColumns={false}
+        row={filteredRow}
+        columnId={SOURCE_COLUMN_ID}
+        dataView={dataView}
+        shouldShowFieldHandler={shouldShowFieldHandler}
+        maxEntries={MAX_SUMMARY_FIELDS}
+        fieldFormats={fieldFormats}
+        columnsMeta={columnsMeta}
+        isCompressed
+      />
+    );
+  }
+);
+
+export const TanStackDataGrid: React.FC<TanStackDataGridProps> = React.memo(
+  ({
+    rows,
+    columns,
+    columnsMeta,
+    dataView,
+    query,
+    showTimeCol,
+    sort = [],
+    onSort,
+    isSortEnabled = true,
+    settings,
+    onResize,
+    onSetColumns,
+    expandedDoc,
+    setExpandedDoc,
+    renderDocumentView,
+    loadingState,
+    onFilter,
+    getRowIndicator,
+    rowAdditionalLeadingControls,
+  }) => {
+    const { euiTheme } = useEuiTheme();
+    const { fieldFormats } = useDiscoverServices();
+    const parentRef = useRef<HTMLDivElement | null>(null);
+    const styles = useMemo(() => getTanStackDataGridStyles(euiTheme), [euiTheme]);
+
+    const scrollKey = dataView.id ?? dataView.title;
+    const timeFieldName = dataView.timeFieldName;
+
+    // ── Find in table ──
+    const [isFindOpen, setIsFindOpen] = useState(false);
+    const [findTerm, setFindTerm] = useState('');
+    const [findActiveIndex, setFindActiveIndex] = useState(0);
+
+    const isSummaryMode =
+      columns.length === 0 ||
+      (columns.length === 1 && columns[0] === SOURCE_COLUMN_ID) ||
+      (columns.length === 1 && columns[0] === timeFieldName);
+
+    // STATS ... BY column reordering
+    const statsByInfo = useMemo(
+      () => (!isSummaryMode ? parseStatsByColumns(query, columns) : undefined),
+      [query, columns, isSummaryMode]
+    );
+    const effectiveColumns = statsByInfo?.orderedColumns ?? columns;
+
+    // Find matches
+    const findMatches = useMemo(
+      () => scanMatches(rows, effectiveColumns, findTerm, isSummaryMode),
+      [rows, effectiveColumns, findTerm, isSummaryMode]
+    );
+    const findActiveMatch = findMatches[findActiveIndex] ?? null;
+
+    const handleFindSearch = useCallback((term: string) => {
+      setFindTerm(term);
+      setFindActiveIndex(0);
+    }, []);
+    const handleFindNext = useCallback(() => {
+      setFindActiveIndex((prev) => (findMatches.length === 0 ? 0 : (prev + 1) % findMatches.length));
+    }, [findMatches.length]);
+    const handleFindPrev = useCallback(() => {
+      setFindActiveIndex((prev) =>
+        findMatches.length === 0 ? 0 : (prev - 1 + findMatches.length) % findMatches.length
+      );
+    }, [findMatches.length]);
+    const handleFindClose = useCallback(() => {
+      setIsFindOpen(false);
+      setFindTerm('');
+      setFindActiveIndex(0);
+    }, []);
+
+    // Grouped mode
+    const isGroupedMode = Boolean(statsByInfo);
+    const aggregateColumns = useMemo(() => {
+      if (!statsByInfo) return [];
+      const bySet = new Set(statsByInfo.byFields);
+      return effectiveColumns.filter((c) => !bySet.has(c));
+    }, [statsByInfo, effectiveColumns]);
+
+    const [groupExpandedSet, setGroupExpandedSet] = useState<Set<string>>(new Set());
+    const toggleGroupExpand = useCallback((rowId: string) => {
+      setGroupExpandedSet((prev) => {
+        const next = new Set(prev);
+        if (next.has(rowId)) {
+          next.delete(rowId);
+        } else {
+          next.add(rowId);
+        }
+        return next;
+      });
+    }, []);
+
+    const shouldShowFieldHandler = useMemo(() => {
+      const dataViewFields = dataView.fields.getAll().map((fld) => fld.name);
+      return getShouldShowFieldHandler(dataViewFields, dataView, true);
+    }, [dataView]);
+
+    // ── Row selection ──
+    const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+    const allSelected = rows.length > 0 && selectedRows.size === rows.length;
+    const someSelected = selectedRows.size > 0 && !allSelected;
+
+    const toggleSelectRow = useCallback((rowId: string) => {
+      setSelectedRows((prev) => {
+        const next = new Set(prev);
+        if (next.has(rowId)) {
+          next.delete(rowId);
+        } else {
+          next.add(rowId);
+        }
+        return next;
+      });
+    }, []);
+
+    const toggleSelectAll = useCallback(() => {
+      setSelectedRows((prev) => {
+        if (prev.size === rows.length) return new Set();
+        return new Set(rows.map((r) => r.id));
+      });
+    }, [rows]);
+
+    const clearSelection = useCallback(() => setSelectedRows(new Set()), []);
+
+    const selectedRowsRef = useRef(selectedRows);
+    selectedRowsRef.current = selectedRows;
+
+    const toggleSelectRowRef = useRef(toggleSelectRow);
+    toggleSelectRowRef.current = toggleSelectRow;
+
+    // ── Full-screen mode ──
+    const [isFullScreen, setIsFullScreen] = useState(false);
+    const toggleFullScreen = useCallback(() => setIsFullScreen((prev) => !prev), []);
+
+    // ── Grid density ──
+    const [density, setDensity] = useState<GridDensity>('compact');
+    const [isDensityPopoverOpen, setIsDensityPopoverOpen] = useState(false);
+    const densityCfg = DENSITY_CONFIG[density];
+
+    // ── Max header cell lines ──
+    const [headerMaxLines, setHeaderMaxLines] = useState(1);
+
+    // ── Body cell lines (0 = auto/no clamp) ──
+    const [bodyMaxLines, setBodyMaxLines] = useState(1);
+
+    // ── Cell popover ──
+    const [popoverState, setPopoverState] = useState<{
+      fieldName: string;
+      value: unknown;
+      rect: DOMRect;
+    } | null>(null);
+    const closePopover = useCallback(() => setPopoverState(null), []);
+
+    const popoverStateRef = useRef(popoverState);
+    popoverStateRef.current = popoverState;
+    const closePopoverRef = useRef(closePopover);
+    closePopoverRef.current = closePopover;
+
+    // ── Keyboard navigation ──
+    const [focusedCell, setFocusedCell] = useState<{ row: number; col: number } | null>(null);
+    const focusedCellRef = useRef(focusedCell);
+    focusedCellRef.current = focusedCell;
+
+    // ── Column drag & drop reorder ──
+    const [dragState, setDragState] = useState<{
+      dragging: string | null;
+      over: string | null;
+    }>({ dragging: null, over: null });
+
+    const handleDragStart = useCallback((colId: string) => {
+      setDragState({ dragging: colId, over: null });
+    }, []);
+    const handleDragOver = useCallback((colId: string) => {
+      setDragState((prev) => ({ ...prev, over: colId }));
+    }, []);
+    const handleDragEnd = useCallback(() => {
+      setDragState((prev) => {
+        if (prev.dragging && prev.over && prev.dragging !== prev.over && onSetColumns) {
+          const newCols = [...effectiveColumns];
+          const fromIdx = newCols.indexOf(prev.dragging);
+          const toIdx = newCols.indexOf(prev.over);
+          if (fromIdx !== -1 && toIdx !== -1) {
+            newCols.splice(fromIdx, 1);
+            newCols.splice(toIdx, 0, prev.dragging);
+            onSetColumns(newCols);
+          }
+        }
+        return { dragging: null, over: null };
+      });
+    }, [effectiveColumns, onSetColumns]);
+
+    // ── Sorting ──
+    const sortingState: SortingState = useMemo(
+      () => sort.map(([id, dir]) => ({ id, desc: dir === 'desc' })),
+      [sort]
+    );
+    const sortingStateRef = useRef(sortingState);
+    sortingStateRef.current = sortingState;
+
+    const onSortRef = useRef(onSort);
+    onSortRef.current = onSort;
+
+    const handleSortingChange = useCallback(
+      (updater: SortingState | ((prev: SortingState) => SortingState)) => {
+        if (!onSortRef.current) return;
+        const next =
+          typeof updater === 'function' ? updater(sortingStateRef.current) : updater;
+        onSortRef.current(next.map(({ id, desc }) => [id, desc ? 'desc' : 'asc']));
+      },
+      []
+    );
+
+    // ── Column sizing ──
+    const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => {
+      const initial: ColumnSizingState = {};
+      if (settings?.columns) {
+        for (const [colId, colSettings] of Object.entries(settings.columns)) {
+          if (colSettings.width) initial[colId] = colSettings.width;
+        }
+      }
+      return initial;
+    });
+
+    useEffect(() => {
+      if (!settings?.columns) return;
+      const fromSettings: ColumnSizingState = {};
+      for (const [colId, colSettings] of Object.entries(settings.columns)) {
+        if (colSettings.width) fromSettings[colId] = colSettings.width;
+      }
+      setColumnSizing((prev) => ({ ...prev, ...fromSettings }));
+    }, [settings?.columns]);
+
+    const handleColumnSizingChange = useCallback(
+      (updater: ColumnSizingState | ((prev: ColumnSizingState) => ColumnSizingState)) => {
+        setColumnSizing((prev) => (typeof updater === 'function' ? updater(prev) : updater));
+      },
+      []
+    );
+
+    const resizingColumnsRef = useRef<Set<string>>(new Set());
+    const onResizeRef = useRef(onResize);
+    onResizeRef.current = onResize;
+
+    // ── Expand doc ──
+    const [localExpandedDoc, setLocalExpandedDoc] = useState<DataTableRecord | undefined>();
+    const currentExpandedDoc = expandedDoc ?? localExpandedDoc;
+
+    const expandedDocRef = useRef(currentExpandedDoc);
+    expandedDocRef.current = currentExpandedDoc;
+
+    const toggleExpandDoc = useCallback(
+      (doc: DataTableRecord) => {
+        const next = expandedDocRef.current?.id === doc.id ? undefined : doc;
+        if (setExpandedDoc) {
+          setExpandedDoc(next);
+        } else {
+          setLocalExpandedDoc(next);
+        }
+      },
+      [setExpandedDoc]
+    );
+    const toggleExpandDocRef = useRef(toggleExpandDoc);
+    toggleExpandDocRef.current = toggleExpandDoc;
+
+    const onFilterRef = useRef(onFilter);
+    onFilterRef.current = onFilter;
+
+    const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
+    // ── Build TanStack column defs ──
+    const tanstackColumns: ColumnDef<DataTableRecord>[] = useMemo(() => {
+      const defs: ColumnDef<DataTableRecord>[] = [];
+
+      if (!isGroupedMode) {
+        // Select column
+        defs.push({
+          id: SELECT_COLUMN_ID,
+          header: '',
+          size: SELECT_COL_WIDTH,
+          minSize: SELECT_COL_WIDTH,
+          maxSize: SELECT_COL_WIDTH,
+          enableResizing: false,
+          enableSorting: false,
+          meta: { isSelect: true },
+          cell: function SelectCell({ row }) {
+            const record = row.original;
+            return (
+              <EuiCheckbox
+                id={`select-${record.id}`}
+                checked={selectedRowsRef.current.has(record.id)}
+                onChange={() => toggleSelectRowRef.current(record.id)}
+                aria-label={`Select row ${row.index + 1}`}
+                compressed
+              />
+            );
+          },
+        });
+
+        // Expand column
+        defs.push({
+          id: EXPAND_COLUMN_ID,
+          header: '',
+          size: CONTROL_COL_WIDTH,
+          minSize: CONTROL_COL_WIDTH,
+          maxSize: CONTROL_COL_WIDTH,
+          enableResizing: false,
+          enableSorting: false,
+          meta: { isControl: true },
+          cell: function ExpandCell({ row }) {
+            const record = row.original;
+            const isExp = expandedDocRef.current?.id === record.id;
+            return (
+              <EuiButtonIcon
+                size="xs"
+                iconSize="s"
+                aria-label="Toggle document details"
+                data-test-subj="docTableExpandToggleColumn"
+                onClick={() => toggleExpandDocRef.current(record)}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleExpandDocRef.current(record);
+                  }
+                }}
+                color={isExp ? 'primary' : 'text'}
+                iconType={isExp ? 'minimize' : 'expand'}
+                isSelected={isExp}
+              />
+            );
+          },
+        });
+      }
+
+      if (isSummaryMode) {
+        if (showTimeCol && timeFieldName) {
+          defs.push({
+            id: timeFieldName,
+            accessorFn: (r) => r.flattened[timeFieldName],
+            header: timeFieldName,
+            size: settings?.columns?.[timeFieldName]?.width ?? 210,
+            minSize: MIN_COL_WIDTH,
+            enableSorting: false,
+            meta: { isTimestamp: true, fieldName: timeFieldName },
+            cell: ({ getValue }) => (
+              <span css={styles.timestampCell}>{formatTimestamp(getValue())}</span>
+            ),
+          });
+        }
+
+        defs.push({
+          id: SOURCE_COLUMN_ID,
+          header: 'Summary',
+          size: 99999,
+          enableResizing: false,
+          enableSorting: false,
+          meta: { isSummary: true },
+          cell: ({ row }) => (
+            <SummaryCellContent
+              row={row.original}
+              dataView={dataView}
+              shouldShowFieldHandler={shouldShowFieldHandler}
+              fieldFormats={fieldFormats}
+              columnsMeta={columnsMeta}
+            />
+          ),
+        });
+      } else {
+        for (const colId of effectiveColumns) {
+          if (colId === SOURCE_COLUMN_ID) continue;
+          const isTimeField = colId === timeFieldName;
+
+          defs.push({
+            id: colId,
+            accessorFn: (r) => r.flattened[colId],
+            header: settings?.columns?.[colId]?.display ?? colId,
+            size: settings?.columns?.[colId]?.width ?? DEFAULT_COL_WIDTH,
+            minSize: MIN_COL_WIDTH,
+            enableSorting: isSortEnabled,
+            meta: { isTimestamp: isTimeField, fieldName: colId },
+            cell: function DataCell({ getValue }) {
+              const val = getValue();
+              const formatted = isTimeField ? formatTimestamp(val) : formatCellValue(val);
+              return (
+                <div css={isTimeField ? styles.timestampCell : undefined} title={formatted}>
+                  {formatted}
+                </div>
+              );
+            },
+          });
+        }
+      }
+
+      return defs;
+    }, [
+      columnsMeta,
+      dataView,
+      effectiveColumns,
+      fieldFormats,
+      isGroupedMode,
+      isSortEnabled,
+      isSummaryMode,
+      settings,
+      shouldShowFieldHandler,
+      showTimeCol,
+      styles,
+      timeFieldName,
+    ]);
+
+    // ── React Table instance ──
+    const table = useReactTable({
+      data: rows,
+      columns: tanstackColumns,
+      getCoreRowModel: getCoreRowModel(),
+      getSortedRowModel:
+        isSortEnabled && !isSummaryMode && !isGroupedMode ? getSortedRowModel() : undefined,
+      state: { sorting: sortingState, columnSizing },
+      onSortingChange: handleSortingChange,
+      onColumnSizingChange: handleColumnSizingChange,
+      columnResizeMode: 'onChange',
+      enableColumnResizing: !isGroupedMode,
+      enableSorting: isSortEnabled && !isSummaryMode && !isGroupedMode,
+      enableMultiSort: true,
+      manualSorting: false,
+    });
+
+    // Persist column width when resize ends
+    const headerGroupsRaw = table.getHeaderGroups();
+    useEffect(() => {
+      const resizeRef = onResizeRef.current;
+      if (!resizeRef) return;
+      for (const hg of headerGroupsRaw) {
+        for (const header of hg.headers) {
+          const colId = header.column.id;
+          if (colId === EXPAND_COLUMN_ID || colId === SELECT_COLUMN_ID) continue;
+          if (header.column.getIsResizing()) {
+            resizingColumnsRef.current.add(colId);
+          } else if (resizingColumnsRef.current.has(colId)) {
+            resizingColumnsRef.current.delete(colId);
+            resizeRef({ columnId: colId, width: header.column.getSize() });
+          }
+        }
+      }
+    });
+
+    const tableRows = table.getRowModel().rows;
+    const bodyRowHeight = useMemo(() => {
+      if (bodyMaxLines <= 1 || bodyMaxLines === 0) return densityCfg.rowHeight;
+      const lineH = densityCfg.fontSize * 1.5;
+      return Math.round(densityCfg.cellPaddingV * 2 + lineH * bodyMaxLines);
+    }, [bodyMaxLines, densityCfg]);
+    const baseRowHeight = isSummaryMode ? densityCfg.summaryRowHeight : bodyRowHeight;
+    const totalColCount = table.getVisibleLeafColumns().length;
+
+    const getRowHeight = useCallback(
+      (index: number): number => {
+        if (!isGroupedMode) return baseRowHeight;
+        const row = tableRows[index];
+        if (!row) return baseRowHeight;
+        if (groupExpandedSet.has(row.id)) {
+          const subRowCount = 2 + (index % (MAX_GROUP_SUB_ROWS - 1));
+          return densityCfg.rowHeight + GROUP_SUB_PANEL_HEADER + subRowCount * GROUP_SUB_ROW_HEIGHT + 2;
+        }
+        return densityCfg.rowHeight;
+      },
+      [isGroupedMode, baseRowHeight, densityCfg.rowHeight, tableRows, groupExpandedSet]
+    );
+
+    // ── Virtualizer ──
+    const rowVirtualizer = useVirtualizer({
+      count: tableRows.length,
+      getScrollElement: () => parentRef.current,
+      estimateSize: getRowHeight,
+      overscan: OVERSCAN,
+      initialOffset: scrollPositionCache.get(scrollKey) ?? 0,
+    });
+
+    useEffect(() => {
+      rowVirtualizer.measure();
+    }, [groupExpandedSet, density, bodyMaxLines, rowVirtualizer]);
+
+    useEffect(() => {
+      const scrollEl = parentRef.current;
+      if (!scrollEl) return;
+      let rafId: number;
+      const handleScroll = () => {
+        cancelAnimationFrame(rafId);
+        rafId = requestAnimationFrame(() => {
+          scrollPositionCache.set(scrollKey, scrollEl.scrollTop);
+        });
+      };
+      scrollEl.addEventListener('scroll', handleScroll, { passive: true });
+      return () => {
+        cancelAnimationFrame(rafId);
+        scrollEl.removeEventListener('scroll', handleScroll);
+      };
+    }, [scrollKey]);
+
+    // ── Ctrl+F to open find bar ──
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+      const wrapper = wrapperRef.current;
+      if (!wrapper) return;
+      const handler = (e: Event) => {
+        const ke = e as KeyboardEvent;
+        if ((ke.metaKey || ke.ctrlKey) && ke.key === 'f') {
+          ke.preventDefault();
+          setIsFindOpen(true);
+        }
+      };
+      wrapper.addEventListener('keydown', handler);
+      return () => wrapper.removeEventListener('keydown', handler);
+    }, []);
+
+    // Scroll to active find match
+    useEffect(() => {
+      if (findActiveMatch) {
+        rowVirtualizer.scrollToIndex(findActiveMatch.rowIndex, { align: 'center' });
+      }
+    }, [findActiveMatch, rowVirtualizer]);
+
+    // ── Keyboard navigation ──
+    const handleGridKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        const current = focusedCellRef.current;
+        if (!current) {
+          if (['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+            setFocusedCell({ row: 0, col: 0 });
+            e.preventDefault();
+          }
+          return;
+        }
+
+        let { row: r, col: c } = current;
+
+        switch (e.key) {
+          case 'ArrowDown':
+            r = Math.min(r + 1, tableRows.length - 1);
+            e.preventDefault();
+            break;
+          case 'ArrowUp':
+            r = Math.max(r - 1, 0);
+            e.preventDefault();
+            break;
+          case 'ArrowRight':
+            c = Math.min(c + 1, totalColCount - 1);
+            e.preventDefault();
+            break;
+          case 'ArrowLeft':
+            c = Math.max(c - 1, 0);
+            e.preventDefault();
+            break;
+          case 'Home':
+            c = 0;
+            if (e.ctrlKey) r = 0;
+            e.preventDefault();
+            break;
+          case 'End':
+            c = totalColCount - 1;
+            if (e.ctrlKey) r = tableRows.length - 1;
+            e.preventDefault();
+            break;
+          case 'PageDown':
+            r = Math.min(r + 20, tableRows.length - 1);
+            e.preventDefault();
+            break;
+          case 'PageUp':
+            r = Math.max(r - 20, 0);
+            e.preventDefault();
+            break;
+          case 'Escape':
+            setFocusedCell(null);
+            e.preventDefault();
+            return;
+          default:
+            return;
+        }
+
+        setFocusedCell({ row: r, col: c });
+        rowVirtualizer.scrollToIndex(r, { align: 'auto' });
+      },
+      [tableRows.length, totalColCount, rowVirtualizer]
+    );
+
+    const virtualItems = rowVirtualizer.getVirtualItems();
+    const canRenderDocumentView = Boolean(setExpandedDoc && renderDocumentView);
+    const isLoading = loadingState === DataLoadingState.loading;
+    const isEmpty = !isLoading && rows.length === 0;
+    const totalWidth = table.getTotalSize();
+
+    const densityVars = useMemo(
+      () =>
+        ({
+          '--tsg-font-size': `${densityCfg.fontSize}px`,
+          '--tsg-cell-padding-v': `${densityCfg.cellPaddingV}px`,
+          '--tsg-cell-padding-h': `${densityCfg.cellPaddingH}px`,
+          '--tsg-header-max-lines': String(headerMaxLines),
+          '--tsg-body-max-lines': bodyMaxLines === 0 ? 'none' : String(bodyMaxLines),
+        } as React.CSSProperties),
+      [densityCfg, headerMaxLines, bodyMaxLines]
+    );
+
+    // ── Copy selected rows ──
+    const copySelectedAsText = useCallback(() => {
+      const selectedRecords = rows.filter((r) => selectedRows.has(r.id));
+      const cols = effectiveColumns.filter((c) => c !== SOURCE_COLUMN_ID);
+      const header = cols.join('\t');
+      const body = selectedRecords
+        .map((r) => cols.map((c) => formatCellValue(r.flattened[c])).join('\t'))
+        .join('\n');
+      navigator.clipboard.writeText(`${header}\n${body}`);
+    }, [rows, selectedRows, effectiveColumns]);
+
+    return (
+      <div ref={wrapperRef} css={[styles.wrapper, isFullScreen && styles.fullScreen]} style={densityVars} data-test-subj="tanstackGridWrapper">
+        {/* Find in table bar */}
+        {isFindOpen && (
+          <FindInTableBar
+            matchesCount={findMatches.length}
+            activeIndex={findActiveIndex}
+            onSearch={handleFindSearch}
+            onNext={handleFindNext}
+            onPrev={handleFindPrev}
+            onClose={handleFindClose}
+            styles={styles}
+          />
+        )}
+        {/* Toolbar */}
+        <div css={styles.toolbar}>
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">TanStack Grid</EuiBadge>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs">
+                {rows.length.toLocaleString()} rows &middot; rendered{' '}
+                {virtualItems.length}
+                {isSummaryMode ? ' · Summary' : ` · ${effectiveColumns.length} columns`}
+                {isGroupedMode ? ' · Grouped' : ''}
+                {statsByInfo && !isGroupedMode ? ' · STATS/BY' : ''}
+              </EuiText>
+            </EuiFlexItem>
+            {isGroupedMode && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="primary">
+                  Grouped by: {statsByInfo!.byFields.join(', ')}
+                </EuiBadge>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+          <div css={styles.toolbarRight}>
+            {focusedCell && (
+              <EuiBadge color="hollow">
+                R{focusedCell.row + 1}:C{focusedCell.col + 1}
+              </EuiBadge>
+            )}
+            <EuiToolTip content="Find in table">
+              <EuiButtonIcon
+                iconType="search"
+                aria-label="Find in table"
+                size="xs"
+                onClick={() => setIsFindOpen((v) => !v)}
+                data-test-subj="dataGridFindInTableButton"
+              />
+            </EuiToolTip>
+            <EuiPopover
+              button={
+                <EuiToolTip content="Grid density">
+                  <EuiButtonIcon
+                    iconType={densityCfg.icon}
+                    aria-label="Grid density"
+                    size="xs"
+                    onClick={() => setIsDensityPopoverOpen((v) => !v)}
+                    data-test-subj="dataGridDensityButton"
+                  />
+                </EuiToolTip>
+              }
+              isOpen={isDensityPopoverOpen}
+              closePopover={() => setIsDensityPopoverOpen(false)}
+              anchorPosition="downRight"
+              panelPaddingSize="s"
+            >
+              <EuiText size="xs" css={{ marginBottom: 6, fontWeight: 600 }}>
+                Density
+              </EuiText>
+              <EuiButtonGroup
+                legend="Grid density"
+                options={DENSITY_BUTTONS}
+                idSelected={density}
+                onChange={(id) => {
+                  setDensity(id as GridDensity);
+                }}
+                buttonSize="compressed"
+                isFullWidth
+                data-test-subj="dataGridDensityButtonGroup"
+              />
+              <EuiSpacer size="s" />
+              <EuiFormRow
+                label="Max header cell lines"
+                display="columnCompressed"
+                fullWidth
+              >
+                <EuiFieldNumber
+                  compressed
+                  min={1}
+                  max={5}
+                  step={1}
+                  value={headerMaxLines}
+                  onChange={(e) => {
+                    const val = Number(e.target.value);
+                    if (val >= 1 && val <= 5) setHeaderMaxLines(val);
+                  }}
+                  data-test-subj="headerMaxLinesInput"
+                />
+              </EuiFormRow>
+              <EuiFormRow
+                label="Body cell lines"
+                display="columnCompressed"
+                fullWidth
+              >
+                <EuiFieldNumber
+                  compressed
+                  min={1}
+                  max={20}
+                  step={1}
+                  value={bodyMaxLines}
+                  onChange={(e) => {
+                    const val = Number(e.target.value);
+                    if (val >= 1 && val <= 20) setBodyMaxLines(val);
+                  }}
+                  data-test-subj="bodyMaxLinesInput"
+                />
+              </EuiFormRow>
+            </EuiPopover>
+            <EuiToolTip content={isFullScreen ? 'Exit full screen' : 'Full screen'}>
+              <EuiButtonIcon
+                iconType={isFullScreen ? 'fullScreenExit' : 'fullScreen'}
+                aria-label={isFullScreen ? 'Exit full screen' : 'Full screen'}
+                size="xs"
+                onClick={toggleFullScreen}
+                data-test-subj="dataGridFullScreenButton"
+              />
+            </EuiToolTip>
+          </div>
+        </div>
+
+        {/* Selection bar */}
+        {selectedRows.size > 0 && (
+          <div css={styles.selectionBar} data-test-subj="selectionBar">
+            <EuiText size="xs">
+              <strong>{selectedRows.size}</strong> row{selectedRows.size !== 1 ? 's' : ''} selected
+            </EuiText>
+            <EuiButtonEmpty size="xs" onClick={copySelectedAsText} iconType="copyClipboard">
+              Copy
+            </EuiButtonEmpty>
+            <EuiButtonEmpty size="xs" onClick={clearSelection} iconType="cross" color="text">
+              Clear
+            </EuiButtonEmpty>
+          </div>
+        )}
+
+        <div css={styles.contentArea}>
+          {isEmpty ? (
+            <EuiEmptyPrompt
+              css={styles.emptyState}
+              iconType="discoverApp"
+              title={<h3>No results found</h3>}
+              body="Try adjusting your query or time range."
+              data-test-subj="discoverNoResults"
+            />
+          ) : (
+            <div
+              ref={parentRef}
+              css={styles.scrollContainer}
+              role="grid"
+              aria-rowcount={tableRows.length + 1}
+              aria-colcount={totalColCount}
+              tabIndex={0}
+              onKeyDown={!isGroupedMode ? handleGridKeyDown : undefined}
+            >
+              {/* Header */}
+              {!isGroupedMode &&
+                headerGroupsRaw.map((headerGroup) => (
+                  <div
+                    key={headerGroup.id}
+                    css={styles.headerRow}
+                    role="row"
+                    aria-rowindex={1}
+                    style={{ width: totalWidth }}
+                  >
+                    {headerGroup.headers.map((header) => {
+                      const isControl = header.column.columnDef.meta?.isControl;
+                      const isSelect = header.column.columnDef.meta?.isSelect;
+                      const isSummary = header.column.columnDef.meta?.isSummary;
+                      const canSort = header.column.getCanSort();
+                      const sortDir = header.column.getIsSorted();
+                      const colId = header.column.id;
+                      const isDraggable =
+                        !isControl && !isSelect && !isSummary && Boolean(onSetColumns);
+                      const isDragging = dragState.dragging === colId;
+                      const isDragOver = dragState.over === colId && dragState.dragging !== colId;
+
+                      if (isSelect) {
+                        return (
+                          <div
+                            key={header.id}
+                            css={styles.selectHeaderCell}
+                            style={{ width: header.getSize() }}
+                            role="columnheader"
+                          >
+                            <EuiCheckbox
+                              id="select-all"
+                              checked={allSelected}
+                              indeterminate={someSelected}
+                              onChange={toggleSelectAll}
+                              aria-label="Select all rows"
+                              compressed
+                            />
+                          </div>
+                        );
+                      }
+
+                      return (
+                        <div
+                          key={header.id}
+                          css={[
+                            isControl ? styles.controlHeaderCell : styles.headerCell,
+                            canSort && styles.headerCellSortable,
+                            isDraggable && styles.headerCellDraggable,
+                            isDragging && styles.headerCellDragging,
+                            isDragOver && styles.headerCellDragOver,
+                          ]}
+                          style={{
+                            width: isSummary ? undefined : header.getSize(),
+                            flex: isSummary ? '1 1 0' : undefined,
+                          }}
+                          role="columnheader"
+                          onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                          draggable={isDraggable}
+                          onDragStart={
+                            isDraggable
+                              ? () => handleDragStart(colId)
+                              : undefined
+                          }
+                          onDragOver={
+                            isDraggable
+                              ? (e) => {
+                                  e.preventDefault();
+                                  handleDragOver(colId);
+                                }
+                              : undefined
+                          }
+                          onDrop={isDraggable ? handleDragEnd : undefined}
+                          onDragEnd={handleDragEnd}
+                        >
+                          {!isControl && (
+                            <>
+                              <span css={styles.headerCellText}>
+                                {flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext()
+                                )}
+                              </span>
+                              {sortDir && (
+                                <span css={styles.sortIndicator}>
+                                  <EuiIcon
+                                    type={sortDir === 'asc' ? 'sortUp' : 'sortDown'}
+                                    size="s"
+                                  />
+                                </span>
+                              )}
+                            </>
+                          )}
+                          {header.column.getCanResize() && !isControl && !isSummary && (
+                            <div
+                              css={[
+                                styles.resizeHandle,
+                                header.column.getIsResizing() && styles.resizeHandleActive,
+                              ]}
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              onClick={stopPropagation}
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+
+              {/* Grouped mode header */}
+              {isGroupedMode && (
+                <div css={styles.headerRow} role="row" style={{ width: totalWidth }}>
+                  <div
+                    css={styles.controlHeaderCell}
+                    style={{ width: CONTROL_COL_WIDTH }}
+                    role="columnheader"
+                  />
+                  <div css={styles.headerCell} style={{ flex: '1 1 0' }} role="columnheader">
+                    <span css={styles.headerCellText}>
+                      Groups ({statsByInfo!.byFields.join(', ')})
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              {/* Virtual body */}
+              <div
+                css={styles.virtualOuter}
+                style={{ height: rowVirtualizer.getTotalSize() }}
+              >
+                <div
+                  css={styles.virtualInner}
+                  style={{
+                    transform: `translateY(${virtualItems[0]?.start ?? 0}px)`,
+                    width: totalWidth,
+                  }}
+                >
+                  {virtualItems.map((virtualRow) => {
+                    const row = tableRows[virtualRow.index];
+                    const record = row.original;
+
+                    if (isGroupedMode) {
+                      return (
+                      <GroupedVirtualRow
+                        key={row.id}
+                        row={row}
+                        virtualRow={virtualRow}
+                        isGroupExpanded={groupExpandedSet.has(row.id)}
+                        onToggleGroup={toggleGroupExpand}
+                        byFields={statsByInfo!.byFields}
+                        aggregateColumns={aggregateColumns}
+                        styles={styles}
+                        totalWidth={totalWidth}
+                        groupRowHeight={densityCfg.rowHeight}
+                      />
+                      );
+                    }
+
+                    const isExpanded = currentExpandedDoc?.id === record.id;
+                    const isSelected = selectedRows.has(record.id);
+                    const indicator = getRowIndicator?.(record);
+
+                    return (
+                      <VirtualRow
+                        key={row.id}
+                        row={row}
+                        virtualRow={virtualRow}
+                        isExpanded={isExpanded}
+                        isSelected={isSelected}
+                        indicatorColor={indicator?.color}
+                        rowHeight={baseRowHeight}
+                        styles={styles}
+                        focusedColIndex={
+                          focusedCell?.row === virtualRow.index ? focusedCell.col : null
+                        }
+                        rowIndex={virtualRow.index}
+                        onFilter={onFilterRef.current}
+                        setPopoverState={setPopoverState}
+                        findTerm={findTerm}
+                        findActiveMatch={findActiveMatch}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+
+              {isLoading && (
+                <div css={styles.loadingOverlay}>
+                  <EuiLoadingSpinner size="xl" />
+                </div>
+              )}
+            </div>
+          )}
+
+          {!isGroupedMode && canRenderDocumentView && currentExpandedDoc && (
+            <span className="dscTable__flyout">
+              {renderDocumentView!(
+                currentExpandedDoc,
+                rows,
+                columns,
+                setExpandedDoc!,
+                columnsMeta
+              )}
+            </span>
+          )}
+        </div>
+
+        {/* Cell popover */}
+        {popoverState && (
+          <CellPopover
+            fieldName={popoverState.fieldName}
+            value={popoverState.value}
+            anchorRect={popoverState.rect}
+            onClose={closePopover}
+            onFilter={onFilterRef.current}
+            styles={styles}
+          />
+        )}
+      </div>
+    );
+  }
+);

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
@@ -125,4 +125,52 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
     minWidth: 0,
     lineHeight: 1.5,
   }),
+
+  // STATS ... BY column styles
+  byHeaderCell: css({
+    flex: 1,
+    padding: `0 ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    borderRight: euiTheme.border.thin,
+    fontWeight: euiTheme.font.weight.bold,
+    minWidth: 0,
+  }),
+  aggHeaderCell: css({
+    flex: 1,
+    padding: `0 ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    borderRight: euiTheme.border.thin,
+    minWidth: 0,
+    '&:last-child': {
+      borderRight: 'none',
+    },
+  }),
+  byCell: css({
+    flex: 1,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    borderRight: euiTheme.border.thin,
+    fontWeight: euiTheme.font.weight.semiBold,
+    minWidth: 0,
+  }),
+  aggCell: css({
+    flex: 1,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    borderRight: euiTheme.border.thin,
+    fontFamily: euiTheme.font.familyCode,
+    fontSize: euiTheme.size.m,
+    minWidth: 0,
+    '&:last-child': {
+      borderRight: 'none',
+    },
+  }),
 });

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
@@ -49,6 +49,7 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
     borderBottom: euiTheme.border.thin,
     fontWeight: euiTheme.font.weight.semiBold,
     fontSize: euiTheme.size.m,
+    lineHeight: `calc(${euiTheme.size.l} + ${euiTheme.size.xs})`,
   }),
   expandHeaderCell: css({
     flexShrink: 0,
@@ -58,7 +59,7 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
   timestampHeaderCell: css({
     flexShrink: 0,
     width: TIMESTAMP_COL_WIDTH,
-    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    padding: `0 ${euiTheme.size.s}`,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -66,7 +67,7 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
   }),
   summaryHeaderCell: css({
     flex: 1,
-    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    padding: `0 ${euiTheme.size.s}`,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -86,9 +87,10 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
   }),
   virtualRow: css({
     display: 'flex',
+    alignItems: 'stretch',
     borderBottom: euiTheme.border.thin,
     contentVisibility: 'auto',
-    containIntrinsicSize: '0 34px',
+    containIntrinsicSize: '0 68px',
     '&:hover': {
       backgroundColor: euiTheme.colors.backgroundBaseInteractiveHover,
     },
@@ -99,8 +101,9 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
     flexShrink: 0,
     width: EXPAND_COL_WIDTH,
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     justifyContent: 'center',
+    paddingTop: euiTheme.size.xs,
     borderRight: euiTheme.border.thin,
   }),
   timestampCell: css({
@@ -113,15 +116,18 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
     borderRight: euiTheme.border.thin,
     fontSize: euiTheme.size.m,
     fontFamily: euiTheme.font.familyCode,
+    lineHeight: 1.5,
   }),
   summaryCell: css({
     flex: 1,
     padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    fontSize: euiTheme.size.m,
-    fontFamily: euiTheme.font.familyCode,
     minWidth: 0,
+
+    // 3-line clamp matching UnifiedDataTable row height behaviour
+    display: '-webkit-box',
+    WebkitLineClamp: 3,
+    WebkitBoxOrient: 'vertical',
+    lineHeight: 1.5,
   }),
 });

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
@@ -88,9 +88,9 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
   virtualRow: css({
     display: 'flex',
     alignItems: 'stretch',
+    height: '100%',
     borderBottom: euiTheme.border.thin,
-    contentVisibility: 'auto',
-    containIntrinsicSize: '0 68px',
+    boxSizing: 'border-box',
     '&:hover': {
       backgroundColor: euiTheme.colors.backgroundBaseInteractiveHover,
     },
@@ -123,11 +123,6 @@ export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) 
     padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
     overflow: 'hidden',
     minWidth: 0,
-
-    // 3-line clamp matching UnifiedDataTable row height behaviour
-    display: '-webkit-box',
-    WebkitLineClamp: 3,
-    WebkitBoxOrient: 'vertical',
     lineHeight: 1.5,
   }),
 });

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.styles.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { css } from '@emotion/react';
+import type { UseEuiTheme } from '@elastic/eui';
+
+const EXPAND_COL_WIDTH = 36;
+const TIMESTAMP_COL_WIDTH = 210;
+
+export const getTanstackVirtualGridStyles = (euiTheme: UseEuiTheme['euiTheme']) => ({
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
+  }),
+  toolbar: css({
+    padding: euiTheme.size.s,
+    borderBottom: euiTheme.border.thin,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    flexShrink: 0,
+  }),
+  contentArea: css({
+    display: 'flex',
+    flex: 1,
+    minHeight: 0,
+  }),
+  scrollContainer: css({
+    flex: 1,
+    overflow: 'auto',
+    position: 'relative',
+    willChange: 'scroll-position',
+    minWidth: 0,
+  }),
+
+  // header
+  headerRow: css({
+    display: 'flex',
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    borderBottom: euiTheme.border.thin,
+    fontWeight: euiTheme.font.weight.semiBold,
+    fontSize: euiTheme.size.m,
+  }),
+  expandHeaderCell: css({
+    flexShrink: 0,
+    width: EXPAND_COL_WIDTH,
+    borderRight: euiTheme.border.thin,
+  }),
+  timestampHeaderCell: css({
+    flexShrink: 0,
+    width: TIMESTAMP_COL_WIDTH,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    borderRight: euiTheme.border.thin,
+  }),
+  summaryHeaderCell: css({
+    flex: 1,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    minWidth: 0,
+  }),
+
+  // virtualised body
+  virtualOuter: css({
+    position: 'relative',
+  }),
+  virtualInner: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    willChange: 'transform',
+  }),
+  virtualRow: css({
+    display: 'flex',
+    borderBottom: euiTheme.border.thin,
+    contentVisibility: 'auto',
+    containIntrinsicSize: '0 34px',
+    '&:hover': {
+      backgroundColor: euiTheme.colors.backgroundBaseInteractiveHover,
+    },
+  }),
+
+  // cells
+  expandCell: css({
+    flexShrink: 0,
+    width: EXPAND_COL_WIDTH,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRight: euiTheme.border.thin,
+  }),
+  timestampCell: css({
+    flexShrink: 0,
+    width: TIMESTAMP_COL_WIDTH,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    borderRight: euiTheme.border.thin,
+    fontSize: euiTheme.size.m,
+    fontFamily: euiTheme.font.familyCode,
+  }),
+  summaryCell: css({
+    flex: 1,
+    padding: `${euiTheme.size.xs} ${euiTheme.size.s}`,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    fontSize: euiTheme.size.m,
+    fontFamily: euiTheme.font.familyCode,
+    minWidth: 0,
+  }),
+});

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -58,7 +58,10 @@ const parseStatsByColumns = (
   const byMatch = esql.match(/\bSTATS\b[\s\S]+?\bBY\b\s+(.+?)(?:\||$)/i);
   if (!byMatch) return undefined;
 
-  const byFields = byMatch[1]
+  // Strip trailing comments (// or /* ... */) from the BY clause
+  const byClause = byMatch[1].replace(/\/\/.*$|\/\*[\s\S]*?\*\//g, '');
+
+  const byFields = byClause
     .split(',')
     .map((f) => f.trim())
     .filter(Boolean);

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -23,6 +23,7 @@ import { getShouldShowFieldHandler } from '@kbn/discover-utils';
 import { SourceDocument } from '@kbn/unified-data-table';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { AggregateQuery } from '@kbn/es-query';
 import { getTanstackVirtualGridStyles } from './tanstack_virtual_grid.styles';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
 
@@ -35,7 +36,55 @@ export interface TanstackVirtualGridProps {
   setExpandedDoc?: UnifiedDataTableProps['setExpandedDoc'];
   renderDocumentView?: UnifiedDataTableProps['renderDocumentView'];
   columnsMeta?: DataTableColumnsMeta;
+  query?: AggregateQuery;
 }
+
+interface StatsByInfo {
+  byFields: string[];
+  orderedColumns: string[];
+}
+
+/**
+ * Parses a STATS ... BY query and reorders columns:
+ * BY fields first, then count-like fields, then remaining aggregations.
+ */
+const parseStatsByColumns = (
+  query: AggregateQuery | undefined,
+  columns: string[]
+): StatsByInfo | undefined => {
+  if (!query || !('esql' in query)) return undefined;
+
+  const esql = query.esql;
+  const byMatch = esql.match(/\bSTATS\b[\s\S]+?\bBY\b\s+(.+?)(?:\||$)/i);
+  if (!byMatch) return undefined;
+
+  const byFields = byMatch[1]
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean);
+
+  if (byFields.length === 0) return undefined;
+
+  const bySet = new Set(byFields);
+  const countFields: string[] = [];
+  const otherFields: string[] = [];
+
+  for (const col of columns) {
+    if (col === '_source') continue;
+    if (bySet.has(col)) continue;
+    if (/count/i.test(col)) {
+      countFields.push(col);
+    } else {
+      otherFields.push(col);
+    }
+  }
+
+  const orderedColumns = [...byFields, ...countFields, ...otherFields].filter((col) =>
+    columns.includes(col)
+  );
+
+  return { byFields, orderedColumns };
+};
 
 const ROW_HEIGHT = 90;
 const OVERSCAN = 10;
@@ -69,6 +118,12 @@ const formatTimestamp = (value: unknown): string => {
   return String(value);
 };
 
+const formatCellValue = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (Array.isArray(value)) return value.join(', ');
+  return String(value);
+};
+
 /**
  * A single virtualised row, extracted to avoid closure allocations in the hot path.
  */
@@ -85,6 +140,8 @@ const VirtualRow = React.memo(
     shouldShowFieldHandler,
     columnsMeta,
     styles,
+    statsByInfo,
+    rowHeight,
   }: {
     row: DataTableRecord;
     virtualRow: VirtualItem;
@@ -97,6 +154,8 @@ const VirtualRow = React.memo(
     shouldShowFieldHandler: (fieldName: string) => boolean;
     columnsMeta: DataTableColumnsMeta | undefined;
     styles: ReturnType<typeof getTanstackVirtualGridStyles>;
+    statsByInfo: StatsByInfo | undefined;
+    rowHeight: number;
   }) => {
     const handleExpandClick = useCallback(
       (e: React.MouseEvent) => {
@@ -121,9 +180,8 @@ const VirtualRow = React.memo(
     const filteredRow = useMemo(() => filterNullFields(row), [row]);
 
     return (
-      <div data-index={virtualRow.index} style={{ height: ROW_HEIGHT }}>
+      <div data-index={virtualRow.index} style={{ height: rowHeight }}>
         <div css={styles.virtualRow} role="row" tabIndex={0}>
-          {/* expand button */}
           <div css={styles.expandCell} role="gridcell">
             <EuiButtonIcon
               size="xs"
@@ -138,27 +196,47 @@ const VirtualRow = React.memo(
             />
           </div>
 
-          {/* timestamp */}
-          {showTimeCol && timeFieldName && (
-            <div css={styles.timestampCell} role="gridcell" title={String(timestampValue ?? '')}>
-              {formatTimestamp(timestampValue)}
-            </div>
+          {statsByInfo ? (
+            statsByInfo.orderedColumns.map((col) => {
+              const val = row.flattened[col];
+              const isByField = statsByInfo.byFields.includes(col);
+              return (
+                <div
+                  key={col}
+                  css={isByField ? styles.byCell : styles.aggCell}
+                  role="gridcell"
+                  title={formatCellValue(val)}
+                >
+                  {formatCellValue(val)}
+                </div>
+              );
+            })
+          ) : (
+            <>
+              {showTimeCol && timeFieldName && (
+                <div
+                  css={styles.timestampCell}
+                  role="gridcell"
+                  title={String(timestampValue ?? '')}
+                >
+                  {formatTimestamp(timestampValue)}
+                </div>
+              )}
+              <div css={styles.summaryCell} role="gridcell">
+                <SourceDocument
+                  useTopLevelObjectColumns={false}
+                  row={filteredRow}
+                  columnId="_source"
+                  dataView={dataView}
+                  shouldShowFieldHandler={shouldShowFieldHandler}
+                  maxEntries={MAX_SUMMARY_FIELDS}
+                  fieldFormats={fieldFormats}
+                  columnsMeta={columnsMeta}
+                  isCompressed
+                />
+              </div>
+            </>
           )}
-
-          {/* summary */}
-          <div css={styles.summaryCell} role="gridcell">
-            <SourceDocument
-              useTopLevelObjectColumns={false}
-              row={filteredRow}
-              columnId="_source"
-              dataView={dataView}
-              shouldShowFieldHandler={shouldShowFieldHandler}
-              maxEntries={MAX_SUMMARY_FIELDS}
-              fieldFormats={fieldFormats}
-              columnsMeta={columnsMeta}
-              isCompressed
-            />
-          </div>
         </div>
       </div>
     );
@@ -170,6 +248,8 @@ const VirtualRow = React.memo(
  * Activated by adding a comment containing "tanstack" in an ES|QL query.
  * Used purely for A-B testing virtualisation performance.
  */
+const STATS_ROW_HEIGHT = 34;
+
 export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.memo(
   ({
     rows,
@@ -180,6 +260,7 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
     renderDocumentView,
     columnsMeta,
     columns,
+    query,
   }) => {
     const { euiTheme } = useEuiTheme();
     const { fieldFormats } = useDiscoverServices();
@@ -189,6 +270,9 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
 
     const timeFieldName = dataView.timeFieldName;
 
+    const statsByInfo = useMemo(() => parseStatsByColumns(query, columns), [query, columns]);
+    const rowHeight = statsByInfo ? STATS_ROW_HEIGHT : ROW_HEIGHT;
+
     const shouldShowFieldHandler = useMemo(() => {
       const dataViewFields = dataView.fields.getAll().map((fld) => fld.name);
       return getShouldShowFieldHandler(dataViewFields, dataView, true);
@@ -197,7 +281,7 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
     const rowVirtualizer = useVirtualizer({
       count: rows.length,
       getScrollElement: () => parentRef.current,
-      estimateSize: () => ROW_HEIGHT,
+      estimateSize: () => rowHeight,
       overscan: OVERSCAN,
       initialOffset: scrollPositionCache.get(scrollKey) ?? 0,
     });
@@ -260,20 +344,36 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
 
         <div css={styles.contentArea}>
           <div ref={parentRef} css={styles.scrollContainer} role="grid">
-            {/* header */}
             <div css={styles.headerRow} role="row">
               <div css={styles.expandHeaderCell} role="columnheader" />
-              {showTimeCol && timeFieldName && (
-                <div css={styles.timestampHeaderCell} role="columnheader" title={timeFieldName}>
-                  {timeFieldName}
-                </div>
+              {statsByInfo ? (
+                statsByInfo.orderedColumns.map((col) => {
+                  const isByField = statsByInfo.byFields.includes(col);
+                  return (
+                    <div
+                      key={col}
+                      css={isByField ? styles.byHeaderCell : styles.aggHeaderCell}
+                      role="columnheader"
+                      title={col}
+                    >
+                      {col}
+                    </div>
+                  );
+                })
+              ) : (
+                <>
+                  {showTimeCol && timeFieldName && (
+                    <div css={styles.timestampHeaderCell} role="columnheader" title={timeFieldName}>
+                      {timeFieldName}
+                    </div>
+                  )}
+                  <div css={styles.summaryHeaderCell} role="columnheader" title="Summary">
+                    Summary
+                  </div>
+                </>
               )}
-              <div css={styles.summaryHeaderCell} role="columnheader" title="Summary">
-                Summary
-              </div>
             </div>
 
-            {/* virtualised body */}
             <div css={styles.virtualOuter} style={{ height: rowVirtualizer.getTotalSize() }}>
               <div
                 css={styles.virtualInner}
@@ -295,6 +395,8 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
                       shouldShowFieldHandler={shouldShowFieldHandler}
                       columnsMeta={columnsMeta}
                       styles={styles}
+                      statsByInfo={statsByInfo}
+                      rowHeight={rowHeight}
                     />
                   );
                 })}
@@ -302,7 +404,6 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
             </div>
           </div>
 
-          {/* document flyout */}
           {canRenderDocumentView && currentExpandedDoc && (
             <span className="dscTable__flyout">
               {renderDocumentView!(currentExpandedDoc, rows, columns, setExpandedDoc!, columnsMeta)}

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -1,0 +1,277 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
+import {
+  EuiBadge,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils';
+import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
+import { getTanstackVirtualGridStyles } from './tanstack_virtual_grid.styles';
+
+export interface TanstackVirtualGridProps {
+  rows: DataTableRecord[];
+  columns: string[];
+  dataView: DataView;
+  showTimeCol: boolean;
+  expandedDoc?: DataTableRecord;
+  setExpandedDoc?: UnifiedDataTableProps['setExpandedDoc'];
+  renderDocumentView?: UnifiedDataTableProps['renderDocumentView'];
+  columnsMeta?: DataTableColumnsMeta;
+}
+
+const ROW_HEIGHT = 34;
+const OVERSCAN = 10;
+const MAX_SUMMARY_FIELDS = 5;
+
+const formatCellValue = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
+};
+
+const formatTimestamp = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'string') {
+    try {
+      return new Date(value).toISOString();
+    } catch {
+      return value;
+    }
+  }
+  return String(value);
+};
+
+const buildSummary = (row: DataTableRecord, excludeFields: Set<string>): string => {
+  const pairs: string[] = [];
+  for (const [key, value] of Object.entries(row.flattened)) {
+    if (excludeFields.has(key)) continue;
+    if (value === null || value === undefined) continue;
+    pairs.push(`${key}: ${formatCellValue(value)}`);
+    if (pairs.length >= MAX_SUMMARY_FIELDS) break;
+  }
+  const remaining = Object.keys(row.flattened).length - pairs.length - excludeFields.size;
+  if (remaining > 0) {
+    pairs.push(`and ${remaining} more`);
+  }
+  return pairs.join(' \u00b7 ');
+};
+
+/**
+ * A single virtualised row, extracted to avoid closure allocations in the hot path.
+ */
+const VirtualRow = React.memo(
+  ({
+    row,
+    virtualRow,
+    isDocExpanded,
+    onToggleExpand,
+    timeFieldName,
+    showTimeCol,
+    summaryExcludeFields,
+    styles,
+  }: {
+    row: DataTableRecord;
+    virtualRow: VirtualItem;
+    isDocExpanded: boolean;
+    onToggleExpand: (doc: DataTableRecord) => void;
+    timeFieldName: string | undefined;
+    showTimeCol: boolean;
+    summaryExcludeFields: Set<string>;
+    styles: ReturnType<typeof getTanstackVirtualGridStyles>;
+  }) => {
+    const handleExpandClick = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onToggleExpand(row);
+      },
+      [onToggleExpand, row]
+    );
+
+    const handleExpandKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          onToggleExpand(row);
+        }
+      },
+      [onToggleExpand, row]
+    );
+
+    const timestampValue = timeFieldName ? row.flattened[timeFieldName] : undefined;
+
+    return (
+      <div data-index={virtualRow.index} style={{ height: ROW_HEIGHT }}>
+        <div css={styles.virtualRow} role="row" tabIndex={0}>
+          {/* expand button */}
+          <div css={styles.expandCell} role="gridcell">
+            <EuiButtonIcon
+              size="xs"
+              iconSize="s"
+              aria-label="Toggle document details"
+              data-test-subj="docTableExpandToggleColumn"
+              onClick={handleExpandClick}
+              onKeyDown={handleExpandKeyDown}
+              color={isDocExpanded ? 'primary' : 'text'}
+              iconType={isDocExpanded ? 'minimize' : 'expand'}
+              isSelected={isDocExpanded}
+            />
+          </div>
+
+          {/* timestamp */}
+          {showTimeCol && timeFieldName && (
+            <div css={styles.timestampCell} role="gridcell" title={String(timestampValue ?? '')}>
+              {formatTimestamp(timestampValue)}
+            </div>
+          )}
+
+          {/* summary */}
+          <div css={styles.summaryCell} role="gridcell">
+            {buildSummary(row, summaryExcludeFields)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+/**
+ * Lightweight POC grid backed by @tanstack/react-virtual (no EuiDataGrid).
+ * Activated by adding a comment containing "tanstack" in an ES|QL query.
+ * Used purely for A-B testing virtualisation performance.
+ */
+export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.memo(
+  ({
+    rows,
+    dataView,
+    showTimeCol,
+    expandedDoc,
+    setExpandedDoc,
+    renderDocumentView,
+    columnsMeta,
+    columns,
+  }) => {
+    const { euiTheme } = useEuiTheme();
+    const parentRef = useRef<HTMLDivElement | null>(null);
+
+    const timeFieldName = dataView.timeFieldName;
+
+    const summaryExcludeFields = useMemo(() => {
+      const exclude = new Set<string>();
+      if (timeFieldName && showTimeCol) {
+        exclude.add(timeFieldName);
+      }
+      return exclude;
+    }, [timeFieldName, showTimeCol]);
+
+    const rowVirtualizer = useVirtualizer({
+      count: rows.length,
+      getScrollElement: () => parentRef.current,
+      estimateSize: () => ROW_HEIGHT,
+      overscan: OVERSCAN,
+    });
+
+    const [localExpandedDoc, setLocalExpandedDoc] = useState<DataTableRecord | undefined>();
+    const currentExpandedDoc = expandedDoc ?? localExpandedDoc;
+
+    const toggleExpandDoc = useCallback(
+      (doc: DataTableRecord) => {
+        const next = currentExpandedDoc?.id === doc.id ? undefined : doc;
+        if (setExpandedDoc) {
+          setExpandedDoc(next);
+        } else {
+          setLocalExpandedDoc(next);
+        }
+      },
+      [currentExpandedDoc, setExpandedDoc]
+    );
+
+    const styles = useMemo(() => getTanstackVirtualGridStyles(euiTheme), [euiTheme]);
+
+    const virtualItems = rowVirtualizer.getVirtualItems();
+
+    const canRenderDocumentView = Boolean(setExpandedDoc && renderDocumentView);
+
+    return (
+      <div css={styles.wrapper}>
+        <div css={styles.toolbar}>
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">TanStack Virtual POC</EuiBadge>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs">
+                {rows.length} rows &middot; overscan {OVERSCAN} &middot; rendered{' '}
+                {virtualItems.length}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </div>
+
+        <div css={styles.contentArea}>
+          <div ref={parentRef} css={styles.scrollContainer} role="grid">
+            {/* header */}
+            <div css={styles.headerRow} role="row">
+              <div css={styles.expandHeaderCell} role="columnheader" />
+              {showTimeCol && timeFieldName && (
+                <div css={styles.timestampHeaderCell} role="columnheader" title={timeFieldName}>
+                  {timeFieldName}
+                </div>
+              )}
+              <div css={styles.summaryHeaderCell} role="columnheader" title="Summary">
+                Summary
+              </div>
+            </div>
+
+            {/* virtualised body */}
+            <div css={styles.virtualOuter} style={{ height: rowVirtualizer.getTotalSize() }}>
+              <div
+                css={styles.virtualInner}
+                style={{ transform: `translateY(${virtualItems[0]?.start ?? 0}px)` }}
+              >
+                {virtualItems.map((virtualRow) => {
+                  const row = rows[virtualRow.index];
+                  return (
+                    <VirtualRow
+                      key={virtualRow.key}
+                      row={row}
+                      virtualRow={virtualRow}
+                      isDocExpanded={currentExpandedDoc?.id === row.id}
+                      onToggleExpand={toggleExpandDoc}
+                      timeFieldName={timeFieldName}
+                      showTimeCol={showTimeCol}
+                      summaryExcludeFields={summaryExcludeFields}
+                      styles={styles}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* document flyout */}
+          {canRenderDocumentView && currentExpandedDoc && (
+            <span className="dscTable__flyout">
+              {renderDocumentView!(currentExpandedDoc, rows, columns, setExpandedDoc!, columnsMeta)}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+);

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -39,7 +39,7 @@ export interface TanstackVirtualGridProps {
 
 const ROW_HEIGHT = 90;
 const OVERSCAN = 10;
-const MAX_SUMMARY_FIELDS = 10;
+const MAX_SUMMARY_FIELDS = 80;
 
 const formatTimestamp = (value: unknown): string => {
   if (value === null || value === undefined) return '-';

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -19,8 +19,12 @@ import {
 } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils';
+import { getShouldShowFieldHandler } from '@kbn/discover-utils';
+import { SourceDocument } from '@kbn/unified-data-table';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { getTanstackVirtualGridStyles } from './tanstack_virtual_grid.styles';
+import { useDiscoverServices } from '../../hooks/use_discover_services';
 
 export interface TanstackVirtualGridProps {
   rows: DataTableRecord[];
@@ -33,16 +37,9 @@ export interface TanstackVirtualGridProps {
   columnsMeta?: DataTableColumnsMeta;
 }
 
-const ROW_HEIGHT = 34;
+const ROW_HEIGHT = 68;
 const OVERSCAN = 10;
 const MAX_SUMMARY_FIELDS = 5;
-
-const formatCellValue = (value: unknown): string => {
-  if (value === null || value === undefined) return '-';
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-  return JSON.stringify(value);
-};
 
 const formatTimestamp = (value: unknown): string => {
   if (value === null || value === undefined) return '-';
@@ -56,21 +53,6 @@ const formatTimestamp = (value: unknown): string => {
   return String(value);
 };
 
-const buildSummary = (row: DataTableRecord, excludeFields: Set<string>): string => {
-  const pairs: string[] = [];
-  for (const [key, value] of Object.entries(row.flattened)) {
-    if (excludeFields.has(key)) continue;
-    if (value === null || value === undefined) continue;
-    pairs.push(`${key}: ${formatCellValue(value)}`);
-    if (pairs.length >= MAX_SUMMARY_FIELDS) break;
-  }
-  const remaining = Object.keys(row.flattened).length - pairs.length - excludeFields.size;
-  if (remaining > 0) {
-    pairs.push(`and ${remaining} more`);
-  }
-  return pairs.join(' \u00b7 ');
-};
-
 /**
  * A single virtualised row, extracted to avoid closure allocations in the hot path.
  */
@@ -82,7 +64,10 @@ const VirtualRow = React.memo(
     onToggleExpand,
     timeFieldName,
     showTimeCol,
-    summaryExcludeFields,
+    dataView,
+    fieldFormats,
+    shouldShowFieldHandler,
+    columnsMeta,
     styles,
   }: {
     row: DataTableRecord;
@@ -91,7 +76,10 @@ const VirtualRow = React.memo(
     onToggleExpand: (doc: DataTableRecord) => void;
     timeFieldName: string | undefined;
     showTimeCol: boolean;
-    summaryExcludeFields: Set<string>;
+    dataView: DataView;
+    fieldFormats: FieldFormatsStart;
+    shouldShowFieldHandler: (fieldName: string) => boolean;
+    columnsMeta: DataTableColumnsMeta | undefined;
     styles: ReturnType<typeof getTanstackVirtualGridStyles>;
   }) => {
     const handleExpandClick = useCallback(
@@ -142,7 +130,18 @@ const VirtualRow = React.memo(
 
           {/* summary */}
           <div css={styles.summaryCell} role="gridcell">
-            {buildSummary(row, summaryExcludeFields)}
+            <SourceDocument
+              useTopLevelObjectColumns={false}
+              row={row}
+              columnId="_source"
+              dataView={dataView}
+              shouldShowFieldHandler={shouldShowFieldHandler}
+              maxEntries={MAX_SUMMARY_FIELDS}
+              isPlainRecord
+              fieldFormats={fieldFormats}
+              columnsMeta={columnsMeta}
+              isCompressed
+            />
           </div>
         </div>
       </div>
@@ -167,17 +166,15 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
     columns,
   }) => {
     const { euiTheme } = useEuiTheme();
+    const { fieldFormats } = useDiscoverServices();
     const parentRef = useRef<HTMLDivElement | null>(null);
 
     const timeFieldName = dataView.timeFieldName;
 
-    const summaryExcludeFields = useMemo(() => {
-      const exclude = new Set<string>();
-      if (timeFieldName && showTimeCol) {
-        exclude.add(timeFieldName);
-      }
-      return exclude;
-    }, [timeFieldName, showTimeCol]);
+    const shouldShowFieldHandler = useMemo(() => {
+      const dataViewFields = dataView.fields.getAll().map((fld) => fld.name);
+      return getShouldShowFieldHandler(dataViewFields, dataView, true);
+    }, [dataView]);
 
     const rowVirtualizer = useVirtualizer({
       count: rows.length,
@@ -255,7 +252,10 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
                       onToggleExpand={toggleExpandDoc}
                       timeFieldName={timeFieldName}
                       showTimeCol={showTimeCol}
-                      summaryExcludeFields={summaryExcludeFields}
+                      dataView={dataView}
+                      fieldFormats={fieldFormats}
+                      shouldShowFieldHandler={shouldShowFieldHandler}
+                      columnsMeta={columnsMeta}
                       styles={styles}
                     />
                   );

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -37,9 +37,9 @@ export interface TanstackVirtualGridProps {
   columnsMeta?: DataTableColumnsMeta;
 }
 
-const ROW_HEIGHT = 68;
+const ROW_HEIGHT = 90;
 const OVERSCAN = 10;
-const MAX_SUMMARY_FIELDS = 5;
+const MAX_SUMMARY_FIELDS = 10;
 
 const formatTimestamp = (value: unknown): string => {
   if (value === null || value === undefined) return '-';

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -137,7 +137,6 @@ const VirtualRow = React.memo(
               dataView={dataView}
               shouldShowFieldHandler={shouldShowFieldHandler}
               maxEntries={MAX_SUMMARY_FIELDS}
-              isPlainRecord
               fieldFormats={fieldFormats}
               columnsMeta={columnsMeta}
               isCompressed

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
 import {
   EuiBadge,
@@ -40,6 +40,8 @@ export interface TanstackVirtualGridProps {
 const ROW_HEIGHT = 90;
 const OVERSCAN = 10;
 const MAX_SUMMARY_FIELDS = 80;
+
+const scrollPositionCache = new Map<string, number>();
 
 /**
  * Returns a shallow copy of the row with null/undefined values removed from flattened,
@@ -183,6 +185,8 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
     const { fieldFormats } = useDiscoverServices();
     const parentRef = useRef<HTMLDivElement | null>(null);
 
+    const scrollKey = dataView.id ?? dataView.title;
+
     const timeFieldName = dataView.timeFieldName;
 
     const shouldShowFieldHandler = useMemo(() => {
@@ -195,7 +199,27 @@ export const TanstackVirtualGrid: React.FC<TanstackVirtualGridProps> = React.mem
       getScrollElement: () => parentRef.current,
       estimateSize: () => ROW_HEIGHT,
       overscan: OVERSCAN,
+      initialOffset: scrollPositionCache.get(scrollKey) ?? 0,
     });
+
+    useEffect(() => {
+      const scrollEl = parentRef.current;
+      if (!scrollEl) return;
+
+      let rafId: number;
+      const handleScroll = () => {
+        cancelAnimationFrame(rafId);
+        rafId = requestAnimationFrame(() => {
+          scrollPositionCache.set(scrollKey, scrollEl.scrollTop);
+        });
+      };
+
+      scrollEl.addEventListener('scroll', handleScroll, { passive: true });
+      return () => {
+        cancelAnimationFrame(rafId);
+        scrollEl.removeEventListener('scroll', handleScroll);
+      };
+    }, [scrollKey]);
 
     const [localExpandedDoc, setLocalExpandedDoc] = useState<DataTableRecord | undefined>();
     const currentExpandedDoc = expandedDoc ?? localExpandedDoc;

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/tanstack_virtual_grid.tsx
@@ -41,6 +41,20 @@ const ROW_HEIGHT = 90;
 const OVERSCAN = 10;
 const MAX_SUMMARY_FIELDS = 80;
 
+/**
+ * Returns a shallow copy of the row with null/undefined values removed from flattened,
+ * so formatHit only counts and renders fields that actually have data.
+ */
+const filterNullFields = (row: DataTableRecord): DataTableRecord => {
+  const filtered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row.flattened)) {
+    if (value !== null && value !== undefined) {
+      filtered[key] = value;
+    }
+  }
+  return { ...row, flattened: filtered };
+};
+
 const formatTimestamp = (value: unknown): string => {
   if (value === null || value === undefined) return '-';
   if (typeof value === 'string') {
@@ -102,6 +116,7 @@ const VirtualRow = React.memo(
     );
 
     const timestampValue = timeFieldName ? row.flattened[timeFieldName] : undefined;
+    const filteredRow = useMemo(() => filterNullFields(row), [row]);
 
     return (
       <div data-index={virtualRow.index} style={{ height: ROW_HEIGHT }}>
@@ -132,7 +147,7 @@ const VirtualRow = React.memo(
           <div css={styles.summaryCell} role="gridcell">
             <SourceDocument
               useTopLevelObjectColumns={false}
-              row={row}
+              row={filteredRow}
               columnId="_source"
               dataView={dataView}
               shouldShowFieldHandler={shouldShowFieldHandler}


### PR DESCRIPTION
## Summary

- Adds a lightweight **TanStack Virtual POC grid** as an alternative to `UnifiedDataTable` / `EuiDataGrid`, activated by adding a comment containing `tanstack` in an ES|QL query (e.g. `FROM logs-* // tanstack`).
- For regular queries: renders an expand button, timestamp column, and a multi-line summary column using `SourceDocument` formatting (matching the standard grid), with null fields filtered out.
- For **STATS ... BY** queries: parses the ES|QL query and renders individual columns ordered as BY fields first, then count fields, then other aggregations.
- Persists and restores scroll position across tab switches using a module-level cache with `initialOffset`.
- Includes a Playwright performance test script for measuring render and scroll metrics.

This is a **POC for A-B testing virtualisation performance** — it does not replace the existing grid.

## Test plan

- [ ] Run an ES|QL query like `FROM logs-* // tanstack` — should show the TanStack POC grid with summary rows
- [ ] Run `FROM logs-* // tanstack | STATS count = COUNT(*), avg_bytes = AVG(bytes) BY host.name` — should show individual columns: `host.name` first (bold), then `count`, then `avg_bytes`
- [ ] Scroll down, switch to another tab, switch back — scroll position should be restored
- [ ] Click expand button — document flyout should open
- [ ] Remove the `// tanstack` comment — should fall back to the standard `UnifiedDataTable`


Made with [Cursor](https://cursor.com)