### PR TITLE
[Lens as API] Propagate ES|QL column metadata (data_type, label, format) through the Lens config builder

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/datatable.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/datatable.ts
@@ -10,7 +10,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { DEFAULT_HEADER_ROW_HEIGHT_LINES, DEFAULT_ROW_HEIGHT_LINES } from '@kbn/lens-common';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnSchema } from '../metric_ops';
 import { applyColorToSchema, colorByValueSchema, colorMappingSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -424,7 +424,7 @@ export const datatableStateSchemaESQL = schema.object(
      */
     metrics: schema.maybe(
       schema.arrayOf(
-        esqlColumnOperationWithLabelAndFormatSchema.extends(datatableStateMetricsOptionsSchema, {
+        esqlColumnSchema.extends(datatableStateMetricsOptionsSchema, {
           meta: { id: 'datatableESQLMetric', title: 'Datatable Metric (ES|QL)' },
         }),
         {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/gauge.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/gauge.ts
@@ -9,11 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import {
-  esqlColumnOperationWithLabelAndFormatSchema,
-  esqlColumnSchema,
-  metricOperationDefinitionSchema,
-} from '../metric_ops';
+import { esqlColumnSchema, metricOperationDefinitionSchema } from '../metric_ops';
 import { colorByValueSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import { dslOnlyPanelInfoSchema, layerSettingsSchema, sharedPanelInfoSchema } from '../shared';
@@ -154,7 +150,7 @@ export const gaugeStateSchemaESQL = schema.object(
     /**
      * Primary value configuration, must define operation.
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema.extends({
+    metric: esqlColumnSchema.extends({
       ...gaugeStateMetricOptionsSchema,
       ...gaugeStateMetricInnerESQLOpsSchema,
     }),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/legacy_metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/legacy_metric.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema } from '../metric_ops';
+import { esqlColumnSchema } from '../metric_ops';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import { layerSettingsSchema, sharedPanelInfoSchema, dslOnlyPanelInfoSchema } from '../shared';
 import { applyColorToSchema, colorByValueAbsolute } from '../color';
@@ -100,9 +100,7 @@ const esqlLegacyMetricState = schema.object(
     /**
      * Metric configuration, must define operation.
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema.extends(
-      legacyMetricStateMetricOptionsSchema
-    ),
+    metric: esqlColumnSchema.extends(legacyMetricStateMetricOptionsSchema),
   },
   { meta: { id: 'legacyMetricESQL', title: 'Legacy Metric Chart (ES|QL)' } }
 );

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/metric.ts
@@ -13,11 +13,7 @@ import {
   LENS_METRIC_BREAKDOWN_DEFAULT_MAX_COLUMNS,
   LENS_METRIC_STATE_DEFAULTS,
 } from '@kbn/lens-common';
-import {
-  metricOperationDefinitionSchema,
-  esqlColumnSchema,
-  esqlColumnOperationWithLabelAndFormatSchema,
-} from '../metric_ops';
+import { metricOperationDefinitionSchema, esqlColumnSchema } from '../metric_ops';
 import {
   colorByValueAbsolute,
   staticColorSchema,
@@ -350,13 +346,11 @@ export const metricStateSchemaNoESQL = schema.object({
   ),
 });
 
-const primaryMetricESQL = esqlColumnOperationWithLabelAndFormatSchema
+const primaryMetricESQL = esqlColumnSchema
   .extends(metricStatePrimaryMetricOptionsSchema)
   .extends(metricStateBackgroundChartSchemaESQL);
 
-const secondaryMetricESQL = esqlColumnOperationWithLabelAndFormatSchema.extends(
-  metricStateSecondaryMetricOptionsSchema
-);
+const secondaryMetricESQL = esqlColumnSchema.extends(metricStateSecondaryMetricOptionsSchema);
 
 export const esqlMetricState = schema.object({
   type: schema.literal('metric'),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/mosaic.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/mosaic.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -161,15 +161,12 @@ const mosaicStateSchemaESQL = schema.object(
      * Primary value configuration, must define operation. In ES|QL mode, uses column-based configuration.
      */
     metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(
-        partitionStatePrimaryMetricOptionsSchema,
-        {
-          meta: {
-            description:
-              'Metric configuration for ES|QL mode, combining generic options, primary metric options, and column selection',
-          },
-        }
-      ),
+      esqlColumnSchema.extends(partitionStatePrimaryMetricOptionsSchema, {
+        meta: {
+          description:
+            'Metric configuration for ES|QL mode, combining generic options, primary metric options, and column selection',
+        },
+      }),
       {
         minSize: 1,
         maxSize: 1,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/pie.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/pie.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema, staticColorSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -169,10 +169,9 @@ const pieStateSchemaESQL = schema.object(
     ...datasetEsqlTableSchema,
     ...pieStateSharedSchema,
     metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(
-        partitionStatePrimaryMetricOptionsSchema,
-        { meta: { description: 'ES|QL column reference for primary metric' } }
-      ),
+      esqlColumnSchema.extends(partitionStatePrimaryMetricOptionsSchema, {
+        meta: { description: 'ES|QL column reference for primary metric' },
+      }),
       {
         minSize: 1,
         maxSize: 100,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.ts
@@ -9,11 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import {
-  fieldMetricOrFormulaOperationDefinitionSchema,
-  esqlColumnSchema,
-  esqlColumnOperationWithLabelAndFormatSchema,
-} from '../metric_ops';
+import { fieldMetricOrFormulaOperationDefinitionSchema, esqlColumnSchema } from '../metric_ops';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import { dslOnlyPanelInfoSchema, layerSettingsSchema, sharedPanelInfoSchema } from '../shared';
 import { mergeAllBucketsWithChartDimensionSchema } from './shared';
@@ -55,7 +51,7 @@ export const regionMapStateSchemaESQL = schema.object(
     /**
      * Metric configuration
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema,
+    metric: esqlColumnSchema,
     /**
      * Configure how to break down to regions
      */

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.ts
@@ -10,7 +10,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { LENS_TAGCLOUD_DEFAULT_STATE } from '@kbn/lens-common';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import { dslOnlyPanelInfoSchema, layerSettingsSchema, sharedPanelInfoSchema } from '../shared';
@@ -97,7 +97,7 @@ export const tagcloudStateSchemaESQL = schema.object(
     /**
      * Primary value configuration, must define operation.
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema.extends(tagcloudStateMetricOptionsSchema),
+    metric: esqlColumnSchema.extends(tagcloudStateMetricOptionsSchema),
     /**
      * Configure how to break down the metric (e.g. show one metric per term).
      */

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/treemap.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/treemap.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema, staticColorSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 
@@ -169,14 +169,11 @@ const treemapStateSchemaESQL = schema.object(
     /**
      * Primary value configuration, must define operation. In ES|QL mode, uses column-based configuration.
      */
-    metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema),
-      {
-        minSize: 1,
-        maxSize: 100,
-        meta: { description: 'Array of metric configurations (minimum 1)' },
-      }
-    ),
+    metrics: schema.arrayOf(esqlColumnSchema.extends(partitionStatePrimaryMetricOptionsSchema), {
+      minSize: 1,
+      maxSize: 100,
+      meta: { description: 'Array of metric configurations (minimum 1)' },
+    }),
     /**
      * Configure how to break down the metric (e.g. show one metric per term). In ES|QL mode, uses column-based configuration.
      */

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/waffle.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/waffle.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema, staticColorSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -135,14 +135,11 @@ const waffleStateSchemaESQL = schema.object(
     ...layerSettingsSchema,
     ...datasetEsqlTableSchema,
     ...waffleStateSharedSchema,
-    metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema),
-      {
-        minSize: 1,
-        maxSize: 100,
-        meta: { description: 'Array of metric configurations (minimum 1)' },
-      }
-    ),
+    metrics: schema.arrayOf(esqlColumnSchema.extends(partitionStatePrimaryMetricOptionsSchema), {
+      minSize: 1,
+      maxSize: 100,
+      meta: { description: 'Array of metric configurations (minimum 1)' },
+    }),
     group_by: schema.maybe(
       schema.arrayOf(esqlColumnSchema.extends(partitionStateBreakdownByOptionsSchema), {
         minSize: 1,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
@@ -42,6 +42,71 @@ describe('Metric Operations Schemas', () => {
       const validated = esqlColumnSchema.validate(input);
       expect(validated).toEqual(input);
     });
+
+    it('validates with an optional label', () => {
+      const input = {
+        operation: 'value' as const,
+        column: 'bytes',
+        label: 'Network Traffic',
+      };
+
+      const validated = esqlColumnSchema.validate(input);
+      expect(validated).toEqual(input);
+    });
+
+    it('validates without label (label remains undefined)', () => {
+      const input = {
+        operation: 'value' as const,
+        column: 'bytes',
+      };
+
+      const validated = esqlColumnSchema.validate(input);
+      expect(validated.label).toBeUndefined();
+    });
+
+    it('validates with format when data_type is number', () => {
+      const input = {
+        operation: 'value' as const,
+        column: 'bytes',
+        data_type: 'number',
+        format: { type: 'percent', decimals: 1, compact: false },
+      };
+
+      const validated = esqlColumnSchema.validate(input);
+      expect(validated.format).toEqual({ type: 'percent', decimals: 1, compact: false });
+    });
+
+    it('rejects format when data_type is not number', () => {
+      const input = {
+        operation: 'value' as const,
+        column: 'host',
+        data_type: 'string',
+        format: { type: 'number', decimals: 2, compact: false },
+      };
+
+      expect(() => esqlColumnSchema.validate(input)).toThrow();
+    });
+
+    it('rejects format when data_type is missing', () => {
+      const input = {
+        operation: 'value' as const,
+        column: 'host',
+        format: { type: 'number', decimals: 2, compact: false },
+      };
+
+      expect(() => esqlColumnSchema.validate(input)).toThrow();
+    });
+
+    it('allows omitting format when data_type is number', () => {
+      const input = {
+        operation: 'value' as const,
+        column: 'bytes',
+        data_type: 'number',
+      };
+
+      const validated = esqlColumnSchema.validate(input);
+      expect(validated.format).toBeUndefined();
+    });
   });
 
   describe('staticOperationDefinition', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.ts
@@ -11,7 +11,7 @@ import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { omit } from 'lodash';
 import { filterSchema } from './filter';
-import { formatSchema } from './format';
+import { formatSchema, formatTypeSchema } from './format';
 import {
   LENS_LAST_VALUE_DEFAULT_SHOW_ARRAY_VALUES,
   LENS_MOVING_AVERAGE_DEFAULT_WINDOW,
@@ -124,12 +124,19 @@ const esqlColumn = {
       description: 'Column to use',
     },
   }),
+  data_type: schema.maybe(
+    schema.string({
+      meta: { description: 'Column data type (e.g. date, number, string)' },
+    })
+  ),
+  ...labelSharedProp,
+  // format is only applicable for the columns with number data types
+  format: schema.maybe(
+    schema.conditional(schema.siblingRef('data_type'), 'number', formatTypeSchema, schema.never())
+  ),
 };
 
 export const esqlColumnSchema = schema.object(esqlColumn);
-
-export const esqlColumnOperationWithLabelAndFormatSchema =
-  genericOperationOptionsSchema.extends(esqlColumn);
 
 export const metricOperationSharedSchema =
   genericOperationOptionsSchema.extends(advancedOperationSettings);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.test.ts
@@ -96,13 +96,39 @@ describe('Datatable ES|QL column ordering', () => {
           columnId: 'datatable_accessor_metric_0',
           fieldName: 'bytes',
           inMetricDimension: true,
-          meta: { type: 'number' },
+          meta: { type: 'string' },
         },
         {
           columnId: 'datatable_accessor_metric_1',
           fieldName: 'requests',
           inMetricDimension: true,
-          meta: { type: 'number' },
+          meta: { type: 'string' },
+        },
+      ]);
+    });
+
+    test('passes label and customLabel through when label is provided', () => {
+      const config = {
+        type: 'datatable',
+        metrics: [{ operation: 'value', column: 'bytes', label: 'Network Traffic' }],
+        rows: [{ operation: 'value', column: 'host' }],
+      } as unknown as DatatableStateESQL;
+
+      const result = getValueColumns(config);
+
+      expect(result).toEqual([
+        {
+          columnId: 'datatable_accessor_row_0',
+          fieldName: 'host',
+          meta: { type: 'string' },
+        },
+        {
+          columnId: 'datatable_accessor_metric_0',
+          fieldName: 'bytes',
+          inMetricDimension: true,
+          label: 'Network Traffic',
+          customLabel: true,
+          meta: { type: 'string' },
         },
       ]);
     });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.ts
@@ -75,13 +75,13 @@ export function buildFormBasedLayer(
 export function getValueColumns(config: DatatableStateESQL) {
   return [
     ...(config.rows ?? []).map((row, index) =>
-      getValueColumn(getAccessorName(ROW_ACCESSOR_PREFIX, index), row.column)
+      getValueColumn(getAccessorName(ROW_ACCESSOR_PREFIX, index), row)
     ),
     ...(config.split_metrics_by ?? []).map((splitBy, index) =>
-      getValueColumn(getAccessorName(SPLIT_METRIC_BY_ACCESSOR_PREFIX, index), splitBy.column)
+      getValueColumn(getAccessorName(SPLIT_METRIC_BY_ACCESSOR_PREFIX, index), splitBy)
     ),
     ...(config.metrics ?? []).map((metric, index) =>
-      getValueColumn(getAccessorName(METRIC_ACCESSOR_PREFIX, index), metric.column, 'number', true)
+      getValueColumn(getAccessorName(METRIC_ACCESSOR_PREFIX, index), metric, true)
     ),
   ];
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/gauge.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/gauge.ts
@@ -211,12 +211,10 @@ function buildFormBasedLayer(layer: GaugeStateNoESQL): FormBasedPersistedState['
 
 function getValueColumns(layer: GaugeStateESQL) {
   return [
-    getValueColumn(getAccessorName('metric'), layer.metric.column, 'number'),
-    ...(layer.metric.max ? [getValueColumn(getAccessorName('max'), layer.metric.max.column)] : []),
-    ...(layer.metric.min ? [getValueColumn(getAccessorName('min'), layer.metric.min.column)] : []),
-    ...(layer.metric.goal
-      ? [getValueColumn(getAccessorName('goal'), layer.metric.goal.column)]
-      : []),
+    getValueColumn(getAccessorName('metric'), layer.metric),
+    ...(layer.metric.max ? [getValueColumn(getAccessorName('max'), layer.metric.max)] : []),
+    ...(layer.metric.min ? [getValueColumn(getAccessorName('min'), layer.metric.min)] : []),
+    ...(layer.metric.goal ? [getValueColumn(getAccessorName('goal'), layer.metric.goal)] : []),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/from_api.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/from_api.ts
@@ -128,9 +128,9 @@ function buildFormBasedLayer(layer: HeatmapStateNoESQL): FormBasedPersistedState
 
 function getValueColumns(layer: HeatmapStateESQL) {
   return [
-    getValueColumn(getAccessorName('value'), layer.metric.column, 'number'),
-    ...(layer.xAxis ? [getValueColumn(getAccessorName('x'), layer.xAxis.column)] : []),
-    ...(layer.yAxis ? [getValueColumn(getAccessorName('y'), layer.yAxis.column)] : []),
+    getValueColumn(getAccessorName('value'), layer.metric),
+    ...(layer.xAxis ? [getValueColumn(getAccessorName('x'), layer.xAxis)] : []),
+    ...(layer.yAxis ? [getValueColumn(getAccessorName('y'), layer.yAxis)] : []),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/legacy_metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/legacy_metric.ts
@@ -133,7 +133,7 @@ function buildFormBasedLayer(layer: LegacyMetricStateNoESQL): FormBasedPersisted
 }
 
 function getValueColumns(layer: LegacyMetricStateESQL) {
-  return [getValueColumn(ACCESSOR, layer.metric.column, 'number')];
+  return [getValueColumn(ACCESSOR, layer.metric)];
 }
 
 type LegacyMetricAttributes = Extract<

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/metric.ts
@@ -564,21 +564,13 @@ function getValueColumns(layer: MetricStateESQL) {
   }
   return [
     ...(layer.breakdown_by
-      ? [getValueColumn(getAccessorName('breakdown'), layer.breakdown_by.column)]
+      ? [getValueColumn(getAccessorName('breakdown'), layer.breakdown_by)]
       : []),
-    getValueColumn(getAccessorName('metric'), primaryMetric.column, 'number'),
+    getValueColumn(getAccessorName('metric'), primaryMetric),
     ...(primaryMetric.background_chart?.type === 'bar'
-      ? [
-          getValueColumn(
-            getAccessorName('max'),
-            primaryMetric.background_chart.max_value.column,
-            'number'
-          ),
-        ]
+      ? [getValueColumn(getAccessorName('max'), primaryMetric.background_chart.max_value)]
       : []),
-    ...(secondaryMetric
-      ? [getValueColumn(getAccessorName('secondary'), secondaryMetric.column)]
-      : []),
+    ...(secondaryMetric ? [getValueColumn(getAccessorName('secondary'), secondaryMetric)] : []),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/partition.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/partition.ts
@@ -148,12 +148,12 @@ export function getValueColumns(layer: unknown) {
 
   const esqlMetricColumns =
     layer.metrics?.map((metric, index) =>
-      getValueColumn(getAccessorName('metric', index), metric.column, 'number')
+      getValueColumn(getAccessorName('metric', index), metric)
     ) ?? [];
 
   const esqlBucketColumns =
     layer.group_by?.map((bucket, index) =>
-      getValueColumn(getAccessorName('group_by', index), bucket.column)
+      getValueColumn(getAccessorName('group_by', index), bucket)
     ) ?? [];
   return esqlMetricColumns.concat(esqlBucketColumns);
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/region_map.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/region_map.ts
@@ -155,8 +155,8 @@ function buildFormBasedLayer(layer: RegionMapStateNoESQL): FormBasedPersistedSta
 
 function getValueColumns(layer: RegionMapStateESQL) {
   return [
-    getValueColumn(getAccessorName('metric'), layer.metric.column, 'number'),
-    getValueColumn(getAccessorName('region'), layer.region.column),
+    getValueColumn(getAccessorName('metric'), layer.metric),
+    getValueColumn(getAccessorName('region'), layer.region),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/tagcloud.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/tagcloud.ts
@@ -180,8 +180,8 @@ function buildFormBasedLayer(layer: TagcloudStateNoESQL): FormBasedPersistedStat
 
 function getValueColumns(layer: TagcloudStateESQL) {
   return [
-    getValueColumn(getAccessorName('metric'), layer.metric.column, 'number'),
-    getValueColumn(getAccessorName('tag'), layer.tag_by.column),
+    getValueColumn(getAccessorName('metric'), layer.metric),
+    getValueColumn(getAccessorName('tag'), layer.tag_by),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
@@ -49,19 +49,15 @@ export function getValueColumns(layer: unknown, i: number) {
     return [];
   }
   if (isAPIReferenceLineLayer(layer)) {
-    return [
-      ...layer.thresholds.map((t, index) =>
-        getValueColumn(`referenceLine${index}`, t.column, 'number')
-      ),
-    ];
+    return [...layer.thresholds.map((t, index) => getValueColumn(`referenceLine${index}`, t))];
   }
   return [
-    ...(layer.x ? [getValueColumn(getAccessorNameForXY(layer, X_ACCESSOR), layer.x.column)] : []),
+    ...(layer.x ? [getValueColumn(getAccessorNameForXY(layer, X_ACCESSOR), layer.x)] : []),
     ...layer.y.map((y, index) =>
-      getValueColumn(getAccessorNameForXY(layer, METRIC_ACCESSOR_PREFIX, index), y.column, 'number')
+      getValueColumn(getAccessorNameForXY(layer, METRIC_ACCESSOR_PREFIX, index), y)
     ),
     ...(layer.breakdown_by
-      ? [getValueColumn(getAccessorNameForXY(layer, BREAKDOWN_ACCESSOR), layer.breakdown_by.column)]
+      ? [getValueColumn(getAccessorNameForXY(layer, BREAKDOWN_ACCESSOR), layer.breakdown_by)]
       : []),
   ];
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring.test.ts
@@ -432,6 +432,62 @@ describe('Color util transforms', () => {
         ],
       });
     });
+
+    it('should inherit top-level palette when from_palette color has no explicit palette', () => {
+      expect(
+        fromColorMappingAPIToLensState({
+          palette: 'kibana_palette',
+          mode: 'categorical',
+          mapping: [
+            {
+              values: ['Mary'],
+              color: { type: 'from_palette', index: 0 },
+            },
+          ],
+        })
+      ).toEqual({
+        colorMode: { type: 'categorical' },
+        paletteId: 'kibana_palette',
+        assignments: [
+          {
+            rules: [{ type: 'raw', value: 'Mary' }],
+            color: { type: 'categorical', paletteId: 'kibana_palette', colorIndex: 0 },
+            touched: false,
+          },
+        ],
+        specialAssignments: [
+          { color: { type: 'loop' }, rules: [{ type: 'other' }], touched: false },
+        ],
+      });
+    });
+
+    it('should use explicit palette on from_palette color when provided', () => {
+      expect(
+        fromColorMappingAPIToLensState({
+          palette: 'kibana_palette',
+          mode: 'categorical',
+          mapping: [
+            {
+              values: ['Mary'],
+              color: { type: 'from_palette', index: 0, palette: 'other_palette' },
+            },
+          ],
+        })
+      ).toEqual({
+        colorMode: { type: 'categorical' },
+        paletteId: 'kibana_palette',
+        assignments: [
+          {
+            rules: [{ type: 'raw', value: 'Mary' }],
+            color: { type: 'categorical', paletteId: 'other_palette', colorIndex: 0 },
+            touched: false,
+          },
+        ],
+        specialAssignments: [
+          { color: { type: 'loop' }, rules: [{ type: 'other' }], touched: false },
+        ],
+      });
+    });
   });
 
   describe('round-trip conversions', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring.ts
@@ -187,8 +187,8 @@ export function fromColorMappingLensStateToAPI(
     colorMapping.specialAssignments[0]?.color
   );
   if (isLensStateCategoricalConfigColorMapping(colorMapping)) {
-    return {
-      mode: 'categorical',
+    const result = {
+      mode: 'categorical' as const,
       palette: colorMapping.paletteId,
       mapping: colorMapping.assignments.map(({ rules, color }) => {
         return {
@@ -198,6 +198,7 @@ export function fromColorMappingLensStateToAPI(
       }),
       ...unassignedColor,
     };
+    return result;
   }
   const colorAssignments = colorMapping.assignments.filter(
     (
@@ -221,7 +222,8 @@ export function fromColorMappingLensStateToAPI(
 }
 
 function fromColorDefAPIToLensState(
-  color: ColorMappingColorDefType
+  color: ColorMappingColorDefType,
+  defaultPalette: string = LENS_DEFAULT_COLOR_MAPPING_PALETTE
 ): ColorMapping.CategoricalColor | ColorMapping.ColorCode {
   if (color.type === 'colorCode') {
     return {
@@ -229,9 +231,10 @@ function fromColorDefAPIToLensState(
       colorCode: color.value,
     };
   }
+  const resolvedPalette = color.palette ?? defaultPalette;
   return {
     type: 'categorical',
-    paletteId: color.palette ?? LENS_DEFAULT_COLOR_MAPPING_PALETTE,
+    paletteId: resolvedPalette,
     colorIndex: color.index,
   };
 }
@@ -266,7 +269,7 @@ function fromAPIMappingToAssignments(
     return colorMapping.mapping.map((assignment) => {
       return {
         rules: fromRulesAPIToLensState(assignment.values),
-        color: fromColorDefAPIToLensState(assignment.color),
+        color: fromColorDefAPIToLensState(assignment.color, colorMapping.palette),
         touched: false,
       };
     });
@@ -275,7 +278,7 @@ function fromAPIMappingToAssignments(
     const step = colorMapping.gradient?.[index];
     return {
       rules: fromRulesAPIToLensState(assignment.values),
-      color: fromColorDefAPIToLensState(step!),
+      color: fromColorDefAPIToLensState(step!, colorMapping.palette),
       touched: false,
     };
   });
@@ -309,7 +312,11 @@ export function fromColorMappingAPIToLensState(
       ? { type: colorMapping.mode }
       : {
           type: colorMapping.mode,
-          steps: (colorMapping.gradient?.map(fromColorDefAPIToLensState) ?? []).map((step) => ({
+          steps: (
+            colorMapping.gradient?.map((c) =>
+              fromColorDefAPIToLensState(c, colorMapping.palette)
+            ) ?? []
+          ).map((step) => ({
             ...step,
             touched: false,
           })),
@@ -317,10 +324,11 @@ export function fromColorMappingAPIToLensState(
           sort: 'asc',
         };
 
-  return {
+  const result = {
     colorMode,
     paletteId: colorMapping.palette,
     assignments,
     specialAssignments,
   };
+  return result;
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TextBasedLayer } from '@kbn/lens-common';
+import { getValueColumn, getValueApiColumn } from './esql_column';
+
+describe('esql_column transforms', () => {
+  describe('getValueColumn', () => {
+    it('returns a column with the correct id and fieldName', () => {
+      const result = getValueColumn('col_0', { column: 'bytes' });
+      expect(result).toEqual({
+        columnId: 'col_0',
+        fieldName: 'bytes',
+        meta: { type: 'string' },
+      });
+    });
+
+    it('uses the id as fieldName when column is empty', () => {
+      const result = getValueColumn('col_0', { column: '' });
+      expect(result.fieldName).toBe('col_0');
+    });
+
+    it('respects data_type when provided', () => {
+      const result = getValueColumn('col_0', { column: 'bytes', data_type: 'number' });
+      expect(result.meta).toEqual({ type: 'number' });
+    });
+
+    it('sets label and customLabel when label is provided', () => {
+      const result = getValueColumn('col_0', { column: 'bytes', label: 'Network Traffic' });
+      expect(result.label).toBe('Network Traffic');
+      expect(result.customLabel).toBe(true);
+    });
+
+    it('does not set label or customLabel when label is absent', () => {
+      const result = getValueColumn('col_0', { column: 'bytes' });
+      expect(result.label).toBeUndefined();
+      expect(result.customLabel).toBeUndefined();
+    });
+
+    it('sets inMetricDimension when provided', () => {
+      const result = getValueColumn('col_0', { column: 'bytes' }, true);
+      expect(result.inMetricDimension).toBe(true);
+    });
+
+    it('does not set inMetricDimension when not provided', () => {
+      const result = getValueColumn('col_0', { column: 'bytes' });
+      expect(result.inMetricDimension).toBeUndefined();
+    });
+
+    it('sets params.format when format is provided', () => {
+      const result = getValueColumn('col_0', {
+        column: 'bytes',
+        data_type: 'number',
+        format: { type: 'number', decimals: 1, compact: false },
+      });
+      expect(result.params).toEqual({
+        format: { id: 'number', params: { decimals: 1, compact: false } },
+      });
+    });
+
+    it('does not set params when format is absent', () => {
+      const result = getValueColumn('col_0', { column: 'bytes', data_type: 'number' });
+      expect(result.params).toBeUndefined();
+    });
+  });
+
+  describe('getValueApiColumn', () => {
+    const buildLayer = (columns: TextBasedLayer['columns']): TextBasedLayer => ({
+      index: 'test-*',
+      query: { esql: 'FROM test | LIMIT 10' },
+      columns,
+    });
+
+    it('returns the basic API column shape', () => {
+      const layer = buildLayer([{ columnId: 'col_0', fieldName: 'bytes' }]);
+      const result = getValueApiColumn('col_0', layer);
+      expect(result).toEqual({
+        operation: 'value',
+        column: 'bytes',
+      });
+    });
+
+    it('includes data_type when meta.type is present', () => {
+      const layer = buildLayer([
+        { columnId: 'col_0', fieldName: 'bytes', meta: { type: 'number' } },
+      ]);
+      const result = getValueApiColumn('col_0', layer);
+      expect(result.data_type).toBe('number');
+    });
+
+    it('includes label when customLabel is true', () => {
+      const layer = buildLayer([
+        { columnId: 'col_0', fieldName: 'bytes', label: 'Network Traffic', customLabel: true },
+      ]);
+      const result = getValueApiColumn('col_0', layer);
+      expect(result.label).toBe('Network Traffic');
+    });
+
+    it('does not include label when customLabel is false', () => {
+      const layer = buildLayer([
+        { columnId: 'col_0', fieldName: 'bytes', label: 'bytes', customLabel: false },
+      ]);
+      const result = getValueApiColumn('col_0', layer);
+      expect(result.label).toBeUndefined();
+    });
+
+    it('does not include label when customLabel is absent', () => {
+      const layer = buildLayer([{ columnId: 'col_0', fieldName: 'bytes', label: 'bytes' }]);
+      const result = getValueApiColumn('col_0', layer);
+      expect(result.label).toBeUndefined();
+    });
+
+    it('round-trips label through getValueColumn and getValueApiColumn', () => {
+      const apiColumn = { column: 'bytes', label: 'Network Traffic' };
+      const stateColumn = getValueColumn('col_0', apiColumn);
+      const layer = buildLayer([stateColumn]);
+      const roundTripped = getValueApiColumn('col_0', layer);
+      expect(roundTripped.label).toBe('Network Traffic');
+    });
+
+    it('round-trips without label when not provided', () => {
+      const apiColumn = { column: 'bytes' };
+      const stateColumn = getValueColumn('col_0', apiColumn);
+      const layer = buildLayer([stateColumn]);
+      const roundTripped = getValueApiColumn('col_0', layer);
+      expect(roundTripped.label).toBeUndefined();
+    });
+
+    it('includes format when params.format is present', () => {
+      const layer = buildLayer([
+        {
+          columnId: 'col_0',
+          fieldName: 'bytes',
+          meta: { type: 'number' },
+          params: { format: { id: 'percent', params: { decimals: 1 } } },
+        },
+      ]);
+      const result = getValueApiColumn('col_0', layer);
+      expect(result.format).toEqual({ type: 'percent', decimals: 1 });
+    });
+
+    it('does not include format when params.format is absent', () => {
+      const layer = buildLayer([
+        { columnId: 'col_0', fieldName: 'bytes', meta: { type: 'number' } },
+      ]);
+      const result = getValueApiColumn('col_0', layer);
+      expect(result.format).toBeUndefined();
+    });
+
+    it('round-trips format through getValueColumn and getValueApiColumn', () => {
+      const apiColumn = {
+        column: 'bytes',
+        data_type: 'number',
+        format: { type: 'number' as const, decimals: 2, compact: true },
+      };
+      const stateColumn = getValueColumn('col_0', apiColumn);
+      const layer = buildLayer([stateColumn]);
+      const roundTripped = getValueApiColumn('col_0', layer);
+      expect(roundTripped.format).toEqual({ type: 'number', decimals: 2, compact: true });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.ts
@@ -9,24 +9,42 @@
 
 import type { TextBasedLayer, TextBasedLayerColumn } from '@kbn/lens-common';
 import type { DatatableColumnType } from '@kbn/expressions-plugin/common';
+import type { LensApiMetricOperation } from '../../schema/metric_ops';
+import { fromFormatAPIToLensState, fromFormatLensStateToAPI } from './format';
+
+interface ApiColumn {
+  column: string;
+  data_type?: string;
+  label?: string;
+  format?: LensApiMetricOperation['format'];
+}
 
 export const getValueColumn = (
   id: string,
-  fieldName?: string,
-  fieldType: DatatableColumnType = 'string',
+  apiColumn: ApiColumn,
   inMetricDimension?: boolean
 ): TextBasedLayerColumn => {
-  return {
+  const fieldType = (apiColumn.data_type ?? 'string') as DatatableColumnType;
+  const format = apiColumn.format ? fromFormatAPIToLensState(apiColumn.format) : undefined;
+  const result = {
     columnId: id,
-    fieldName: fieldName || id,
-    ...(fieldType ? { meta: { type: fieldType } } : {}),
+    fieldName: apiColumn.column || id,
+    meta: { type: fieldType },
+    ...(apiColumn.label != null ? { label: apiColumn.label, customLabel: true } : {}),
+    ...(format ? { params: { format } } : {}),
     ...(inMetricDimension != null ? { inMetricDimension } : {}),
   };
+  return result;
 };
 
 export const getValueApiColumn = (accessor: string, layer: TextBasedLayer) => {
+  const col = layer.columns.find((c) => c.columnId === accessor)!;
+  const format = fromFormatLensStateToAPI(col.params?.format);
   return {
     operation: 'value' as const,
-    column: layer.columns.find((c) => c.columnId === accessor)!.fieldName,
+    column: col.fieldName,
+    ...(col.meta?.type ? { data_type: col.meta.type } : {}),
+    ...(col.customLabel && col.label != null ? { label: col.label } : {}),
+    ...(format ? { format } : {}),
   };
 };

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer.test.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer.test.ts
@@ -43,6 +43,8 @@ describe('extendedDataLayerConfig', () => {
       type: 'extendedDataLayer',
       layerType: LayerTypes.DATA,
       ...fullArgs,
+      xScaleType: false,
+      isHistogram: false,
       table: data,
       showLines: true,
     });

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer_fn.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer_fn.ts
@@ -8,9 +8,10 @@
  */
 
 import type { ExpressionValueVisDimension } from '@kbn/chart-expressions-common';
-import { validateAccessor } from '@kbn/chart-expressions-common';
-import type { ExtendedDataLayerArgs, ExtendedDataLayerFn } from '../types';
-import { EXTENDED_DATA_LAYER, LayerTypes } from '../constants';
+import { getColumnByAccessor, validateAccessor } from '@kbn/chart-expressions-common';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import type { ExtendedDataLayerArgs, ExtendedDataLayerFn, XScaleType } from '../types';
+import { EXTENDED_DATA_LAYER, LayerTypes, XScaleTypes } from '../constants';
 import { getAccessors, normalizeTable, getShowLines } from '../helpers';
 import {
   validateLinesVisibilityForChartType,
@@ -19,6 +20,38 @@ import {
   validatePointsRadiusForChartType,
   validateShowPointsForChartType,
 } from './validate';
+
+/**
+ * Reconciles xScaleType and isHistogram with the actual Datatable column metadata.
+ * This ensures that date columns are always rendered with a time scale and histogram
+ * behavior (enabling brush/zoom), even when the pre-computed values from the expression
+ * builder are stale (e.g. after restoring a saved ES|QL visualization that lost column
+ * type info).
+ */
+function resolveXAxisMeta(
+  args: Pick<ExtendedDataLayerArgs, 'xScaleType' | 'isHistogram'>,
+  xAccessor: string | ExpressionValueVisDimension | undefined,
+  columns: Datatable['columns']
+): Pick<ExtendedDataLayerArgs, 'xScaleType' | 'isHistogram'> {
+  if (!xAccessor) {
+    return args;
+  }
+  const column = getColumnByAccessor(xAccessor, columns);
+  if (!column) {
+    return args;
+  }
+
+  let { xScaleType, isHistogram } = args;
+
+  if (column.meta?.type === 'date') {
+    xScaleType = XScaleTypes.TIME as XScaleType;
+    isHistogram = true;
+  } else if (column.meta?.type === 'number' && xScaleType === XScaleTypes.ORDINAL) {
+    xScaleType = XScaleTypes.LINEAR as XScaleType;
+  }
+
+  return { xScaleType, isHistogram };
+}
 
 export const extendedDataLayerFn: ExtendedDataLayerFn['fn'] = async (data, args, context) => {
   const table = data;
@@ -40,10 +73,13 @@ export const extendedDataLayerFn: ExtendedDataLayerFn['fn'] = async (data, args,
   const normalizedTable = normalizeTable(table, accessors.xAccessor);
 
   const showLines = getShowLines(args);
+  // const { xScaleType, isHistogram } = resolveXAxisMeta(args, accessors.xAccessor, table.columns);
 
   return {
     type: EXTENDED_DATA_LAYER,
     ...args,
+    // xScaleType,
+    // isHistogram,
     layerType: LayerTypes.DATA,
     ...accessors,
     table: normalizedTable,

--- a/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
@@ -35,26 +35,33 @@ export const isDatatable = (datatable: unknown): datatable is Datatable =>
   (datatable as ExpressionValueBoxed | undefined)?.type === 'datatable';
 
 /**
+ * All valid column types for a `DatatableColumn`. Duplicated from KBN_FIELD_TYPES.
+ * Exported as a const array so downstream packages can build schemas from it.
+ */
+export const DATATABLE_COLUMN_TYPES = [
+  '_source',
+  'attachment',
+  'boolean',
+  'date',
+  'geo_point',
+  'geo_shape',
+  'ip',
+  'murmur3',
+  'number',
+  'string',
+  'unknown',
+  'conflict',
+  'object',
+  'nested',
+  'histogram',
+  'null',
+] as const;
+
+/**
  * This type represents the `type` of any `DatatableColumn` in a `Datatable`.
  * its duplicated from KBN_FIELD_TYPES
  */
-export type DatatableColumnType =
-  | '_source'
-  | 'attachment'
-  | 'boolean'
-  | 'date'
-  | 'geo_point'
-  | 'geo_shape'
-  | 'ip'
-  | 'murmur3'
-  | 'number'
-  | 'string'
-  | 'unknown'
-  | 'conflict'
-  | 'object'
-  | 'nested'
-  | 'histogram'
-  | 'null';
+export type DatatableColumnType = (typeof DATATABLE_COLUMN_TYPES)[number];
 
 /**
  * This type represents a row in a `Datatable`.

--- a/src/platform/plugins/shared/expressions/common/index.ts
+++ b/src/platform/plugins/shared/expressions/common/index.ts
@@ -108,6 +108,7 @@ export type {
   ExpressionValue,
   Render,
   ExpressionImage,
+  DATATABLE_COLUMN_TYPES,
   DatatableColumnType,
   DatatableRow,
   Datatable,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/dnd/on_drop.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/dnd/on_drop.ts
@@ -36,12 +36,17 @@ export const onDrop = (props: DatasourceDimensionDropHandlerProps<TextBasedPriva
   const allColumns = retrieveLayerColumnsFromCache(layer.columns, layer.query);
   const sourceField = allColumns.find((f) => f.columnId === source.id || f.variable === source.id);
   const targetField = allColumns.find((f) => f.columnId === target.columnId);
+  const sourceLayerColumn = layer.columns.find((c) => c.columnId === source.id);
   const newColumn = {
     columnId: target.columnId,
     fieldName: sourceField?.variable ? `??${sourceField.variable}` : sourceField?.fieldName ?? '',
     meta: sourceField?.meta,
     variable: sourceField?.variable,
     ...(target.isMetricDimension && { inMetricDimension: true }),
+    ...(sourceLayerColumn?.customLabel && sourceLayerColumn.label != null
+      ? { label: sourceLayerColumn.label, customLabel: true }
+      : {}),
+    ...(sourceLayerColumn?.params ? { params: sourceLayerColumn.params } : {}),
   };
   let columns: TextBasedLayerColumn[] | undefined;
 
@@ -59,6 +64,7 @@ export const onDrop = (props: DatasourceDimensionDropHandlerProps<TextBasedPriva
       columns = [...layer.columns, newColumn];
       break;
     case 'swap_compatible':
+      const targetLayerColumn = layer.columns.find((c) => c.columnId === target.columnId);
       const swapTwoColumns = (c: TextBasedLayerColumn) =>
         c.columnId === target.columnId
           ? newColumn
@@ -67,6 +73,10 @@ export const onDrop = (props: DatasourceDimensionDropHandlerProps<TextBasedPriva
               columnId: source.columnId,
               fieldName: targetField?.fieldName ?? '',
               meta: targetField?.meta,
+              ...(targetLayerColumn?.customLabel && targetLayerColumn.label != null
+                ? { label: targetLayerColumn.label, customLabel: true }
+                : {}),
+              ...(targetLayerColumn?.params ? { params: targetLayerColumn.params } : {}),
             }
           : c;
       columns = layer.columns.map(swapTwoColumns);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/253009
Fixes https://github.com/elastic/kibana/issues/248464
Fixes https://github.com/elastic/kibana/issues/255311
May partially address https://github.com/elastic/kibana/issues/249280
Fixes brushing through ESQL charts.

### Summary

ES|QL columns in Lens were losing metadata (data type, custom labels, and number formatting) across save/restore cycles and drag-and-drop operations. This PR ensures that `data_type`, `label`, and `format` are persisted through the config builder schema, round-tripped through the API-to-state transforms, and preserved during DnD interactions.

### Changes

**Unified ES|QL column schema**

The separate `esqlColumnOperationWithLabelAndFormatSchema` has been removed. Its capabilities (`label` and `format`) are now part of the base `esqlColumnSchema`, along with a new optional `data_type` field. The `format` property uses `schema.conditional` to only validate when `data_type` is `'number'`, preventing invalid format configurations on non-numeric columns. All chart schemas (datatable, gauge, metric, pie, tagcloud, etc.) now use `esqlColumnSchema` directly.

**Full metadata round-tripping in transforms**

`getValueColumn` now accepts the full API column object instead of individual `fieldName`/`fieldType` parameters. It reads `data_type` (defaulting to `'string'`), `label`, and `format` from the column, and maps them into the Lens internal state (including `meta.type`, `customLabel`, and `params.format`). The inverse function `getValueApiColumn` extracts these fields back from the Lens state, ensuring clean round-tripping. All chart transform call sites have been updated.

**DnD preserves custom labels and format params**

When dragging or swapping columns in the ES|QL datasource, `on_drop.ts` now carries over `label`, `customLabel`, and `params` (which includes formatting) from the source column to the new position, preventing metadata loss during reordering.

**Color mapping palette inheritance fix**

`fromColorDefAPIToLensState` now accepts a `defaultPalette` parameter. When individual color definitions of type `from_palette` omit the `palette` field, they inherit the top-level `colorMapping.palette` instead of always falling back to the global default. This fixes incorrect color resolution when a non-default palette is configured.

**Expression-level axis type reconciliation (WIP cc @markov00 )**

A `resolveXAxisMeta` function has been added to `extended_data_layer_fn.ts` that reconciles `xScaleType` and `isHistogram` based on actual column metadata — ensuring date columns use a time scale and histogram behavior even when pre-computed values are stale. This function is currently **implemented but commented out** pending a decision on whether to activate it as a safety net for axis display.

### Open question

Should `resolveXAxisMeta` be activated? It would serve as a safety net at the expression level — correcting axis scale type and histogram behavior based on actual column metadata from the data. This would help with displaying the correct time axis for date columns, but only affects the chart rendering, not the config panel. The config-panel-level fix (persisting `data_type` in the saved object) is already addressed by this PR.

### Test plan

- I added unit tests for the new API support, 
but to test it:
1. Add format and custom label to ESQL columns
2. Add a date column to X axis and see if it displays the proper axis (also check string and number cases)
3. Check out color palettes - now that the data type is passed, it's properly set (numbers receive numerical color mapping UI, string receive coloring by value UI)