### PR TITLE
fix(cps): inject project_routing as query param for msearch/msearch_template

### DIFF
--- a/src/core/packages/elasticsearch/client-server-internal/src/cps_request_handler.test.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/cps_request_handler.test.ts
@@ -132,6 +132,98 @@ describe('getCpsRequestHandler', () => {
     });
   });
 
+  describe('msearch and msearch_template NDJSON APIs', () => {
+    const onRequest = getCpsRequestHandler(true, PROJECT_ROUTING_ORIGIN);
+
+    it.each(['msearch', 'msearch_template'])(
+      'injects project_routing as a query param for %s',
+      (apiName) => {
+        const params: TransportRequestParams = {
+          method: 'POST',
+          path: `/_${apiName}`,
+          meta: { name: apiName, acceptedParams: ['project_routing'] },
+          body: 'header\nbody\n',
+        };
+
+        onRequest({ scoped: true }, params, {});
+
+        expect((params.querystring as Record<string, unknown>)?.project_routing).toBe(
+          PROJECT_ROUTING_ORIGIN
+        );
+        expect(params.body).toBe('header\nbody\n');
+      }
+    );
+
+    it.each(['msearch', 'msearch_template'])(
+      'creates querystring object when not present for %s',
+      (apiName) => {
+        const params: TransportRequestParams = {
+          method: 'POST',
+          path: `/_${apiName}`,
+          meta: { name: apiName, acceptedParams: ['project_routing'] },
+          body: 'header\nbody\n',
+        };
+
+        expect(params.querystring).toBeUndefined();
+        onRequest({ scoped: true }, params, {});
+
+        expect(params.querystring).toEqual({ project_routing: PROJECT_ROUTING_ORIGIN });
+      }
+    );
+
+    it.each(['msearch', 'msearch_template'])(
+      'does not override existing project_routing in querystring for %s',
+      (apiName) => {
+        const params: TransportRequestParams = {
+          method: 'POST',
+          path: `/_${apiName}`,
+          meta: { name: apiName, acceptedParams: ['project_routing'] },
+          body: 'header\nbody\n',
+          querystring: { project_routing: 'custom-value' },
+        };
+
+        onRequest({ scoped: true }, params, {});
+
+        expect((params.querystring as Record<string, unknown>)?.project_routing).toBe(
+          'custom-value'
+        );
+      }
+    );
+
+    it.each(['msearch', 'msearch_template'])('does not inject into body for %s', (apiName) => {
+      const params: TransportRequestParams = {
+        method: 'POST',
+        path: `/_${apiName}`,
+        meta: { name: apiName, acceptedParams: ['project_routing'] },
+        body: 'header\nbody\n',
+      };
+
+      onRequest({ scoped: true }, params, {});
+
+      expect(params.body).toBe('header\nbody\n');
+    });
+
+    it.each(['msearch', 'msearch_template'])(
+      'preserves existing querystring params when injecting for %s',
+      (apiName) => {
+        const params: TransportRequestParams = {
+          method: 'POST',
+          path: `/_${apiName}`,
+          meta: { name: apiName, acceptedParams: ['project_routing'] },
+          body: 'header\nbody\n',
+          querystring: { max_concurrent_searches: 5 },
+        };
+
+        onRequest({ scoped: true }, params, {});
+
+        expect(params.querystring).toEqual({
+          max_concurrent_searches: 5,
+          project_routing: PROJECT_ROUTING_ORIGIN,
+        });
+      }
+    );
+  });
+
   describe('when CPS is disabled', () => {
     const onRequest = getCpsRequestHandler(false, PROJECT_ROUTING_ORIGIN);
 
@@ -172,6 +264,57 @@ describe('getCpsRequestHandler', () => {
       onRequest({ scoped: true }, params, {});
 
       expect((params.body as Record<string, unknown>)?.project_routing).toBeUndefined();
+    });
+
+    describe('msearch and msearch_template NDJSON APIs', () => {
+      it.each(['msearch', 'msearch_template'])(
+        'does not inject project_routing for %s',
+        (apiName) => {
+          const params: TransportRequestParams = {
+            method: 'POST',
+            path: `/_${apiName}`,
+            meta: { name: apiName, acceptedParams: ['project_routing'] },
+            body: 'header\nbody\n',
+          };
+
+          onRequest({ scoped: true }, params, {});
+
+          expect(params.querystring).toBeUndefined();
+        }
+      );
+
+      it.each(['msearch', 'msearch_template'])(
+        'strips project_routing from querystring for %s',
+        (apiName) => {
+          const params: TransportRequestParams = {
+            method: 'POST',
+            path: `/_${apiName}`,
+            meta: { name: apiName, acceptedParams: ['project_routing'] },
+            body: 'header\nbody\n',
+            querystring: { project_routing: 'should-be-removed', max_concurrent_searches: 5 },
+          };
+
+          onRequest({ scoped: true }, params, {});
+
+          expect((params.querystring as Record<string, unknown>)?.project_routing).toBeUndefined();
+          expect((params.querystring as Record<string, unknown>)?.max_concurrent_searches).toBe(5);
+        }
+      );
+
+      it.each(['msearch', 'msearch_template'])(
+        'does not fail when querystring is absent for %s',
+        (apiName) => {
+          const params: TransportRequestParams = {
+            method: 'POST',
+            path: `/_${apiName}`,
+            meta: { name: apiName, acceptedParams: ['project_routing'] },
+            body: 'header\nbody\n',
+          };
+
+          expect(() => onRequest({ scoped: true }, params, {})).not.toThrow();
+          expect(params.querystring).toBeUndefined();
+        }
+      );
     });
   });
 });

--- a/src/core/packages/elasticsearch/client-server-internal/src/cps_request_handler.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/cps_request_handler.ts
@@ -11,6 +11,13 @@ import { set } from '@kbn/safer-lodash-set';
 import { isPlainObject } from 'lodash';
 import type { OnRequestHandler } from './create_transport';
 
+/**
+ * APIs that use NDJSON (newline-delimited JSON) bodies. For these, `project_routing` must be
+ * passed as a query parameter rather than in the body, since injecting into the body would
+ * corrupt the NDJSON format and cause ES to return an `illegal_argument_exception`.
+ */
+const NDJSON_APIS = new Set(['msearch', 'msearch_template']);
+
 /** @internal */
 export function getCpsRequestHandler(
   cpsEnabled: boolean,
@@ -18,35 +25,73 @@ export function getCpsRequestHandler(
 ): OnRequestHandler {
   return (_ctx, params, _options) => {
     const body = isPlainObject(params.body) ? (params.body as Record<string, unknown>) : undefined;
+    const ndjsonApi = isNdjsonApi(params);
 
     if (cpsEnabled) {
       if (shouldApplyProjectRouting(params.meta?.acceptedParams)) {
-        if (body?.pit) {
-          // The project_routing is set by the openPit API, and thus part of the PIT context.
-          stripProjectRouting(body);
+        if (ndjsonApi) {
+          injectProjectRoutingQueryString(projectRouting, params);
         } else {
-          injectProjectRouting(projectRouting, params, body);
+          if (body?.pit) {
+            // The project_routing is set by the openPit API, and thus part of the PIT context.
+            stripProjectRoutingBody(body);
+          } else {
+            injectProjectRoutingBody(projectRouting, params, body);
+          }
         }
       }
     } else {
-      stripProjectRouting(body);
+      // Strip from both body and querystring unconditionally: project_routing is only valid
+      // when CPS is enabled on ES, so it must be removed from all requests regardless of location.
+      stripProjectRoutingBody(body);
+      stripProjectRoutingQueryString(params);
     }
   };
 }
 
-function stripProjectRouting(body: Record<string, unknown> | undefined): void {
+function isNdjsonApi(params: Parameters<OnRequestHandler>[1]): boolean {
+  return NDJSON_APIS.has(params.meta?.name ?? '');
+}
+
+function stripProjectRoutingBody(body: Record<string, unknown> | undefined): void {
   if (body?.project_routing != null) {
     delete body.project_routing;
   }
 }
 
-function injectProjectRouting(
+function injectProjectRoutingBody(
   projectRouting: string,
   params: Parameters<OnRequestHandler>[1],
   body: Record<string, unknown> | undefined
 ): void {
   if (!body?.project_routing) {
     set(params, 'body.project_routing', projectRouting);
+  }
+}
+
+function injectProjectRoutingQueryString(
+  projectRouting: string,
+  params: Parameters<OnRequestHandler>[1]
+): void {
+  if (typeof params.querystring === 'string') {
+    // Cannot safely inject into a pre-serialized querystring; skip.
+    return;
+  }
+
+  if (!params.querystring) {
+    params.querystring = {};
+  }
+
+  if (params.querystring.project_routing) {
+    return;
+  }
+  params.querystring.project_routing = projectRouting;
+}
+
+function stripProjectRoutingQueryString(params: Parameters<OnRequestHandler>[1]): void {
+  const qs = params.querystring;
+  if (qs != null && typeof qs === 'object' && qs.project_routing != null) {
+    delete qs.project_routing;
   }
 }
 

--- a/src/core/server/integration_tests/elasticsearch/project_routing_non_serverless.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/project_routing_non_serverless.test.ts
@@ -12,34 +12,67 @@
  */
 
 import { createTestServers } from '@kbn/core-test-helpers-kbn-server';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 
 const LOCAL_PROJECT_ROUTING = '_alias:_origin';
 
 describe('project_routing on non-serverless', () => {
-  it('Kibana removes project_routing information from requests when not serverless', async () => {
-    // When not serverless, ElasticsearchService sets cpsEnabled to false (elasticsearch_service.ts),
-    // so CpsRequestHandler strips project_routing. The cps plugin config only exposes cpsEnabled
-    // for the serverless offering (offeringBasedSchema), so are not allowed to enable it here.
-    const { startES, startKibana } = createTestServers({
+  // When not serverless, ElasticsearchService sets cpsEnabled to false (elasticsearch_service.ts),
+  // so CpsRequestHandler strips project_routing. The cps plugin config only exposes cpsEnabled
+  // for the serverless offering (offeringBasedSchema), so are not allowed to enable it here.
+  let esServer: Awaited<ReturnType<ReturnType<typeof createTestServers>['startES']>>;
+  let kibanaServer: Awaited<ReturnType<ReturnType<typeof createTestServers>['startKibana']>>;
+  let esClient: ElasticsearchClient;
+
+  beforeAll(async () => {
+    const servers = createTestServers({
       adjustTimeout: (timeout: number) => jest.setTimeout(timeout),
     });
-    const esServer = await startES();
-    const kibanaServer = await startKibana();
-    const esClient = kibanaServer.coreStart.elasticsearch.client.asInternalUser;
+    esServer = await servers.startES();
+    kibanaServer = await servers.startKibana();
+    esClient = kibanaServer.coreStart.elasticsearch.client.asInternalUser;
+  });
 
-    try {
-      const response = await esClient.search({
-        index: '.kibana',
-        size: 0,
-        body: {
-          // @ts-expect-error - project_routing is a valid body parameter
-          project_routing: LOCAL_PROJECT_ROUTING,
+  afterAll(async () => {
+    await kibanaServer?.stop();
+    await esServer?.stop();
+  });
+
+  it('strips project_routing from body for search requests', async () => {
+    const response = await esClient.search({
+      index: '.kibana',
+      size: 0,
+      body: {
+        // @ts-expect-error - project_routing is a valid body parameter
+        project_routing: LOCAL_PROJECT_ROUTING,
+      },
+    });
+    expect(response.hits.hits).toBeDefined();
+  });
+
+  it('strips project_routing from querystring for msearch requests', async () => {
+    // project_routing in the querystring must be stripped for msearch when not on serverless CPS.
+    await expect(
+      esClient.transport.request(
+        {
+          method: 'POST',
+          path: '/.kibana/_msearch',
+          body:
+            JSON.stringify({}) +
+            '\n' +
+            JSON.stringify({ query: { match_all: {} }, size: 0 }) +
+            '\n',
+          querystring: { project_routing: LOCAL_PROJECT_ROUTING },
         },
-      });
-      expect(response.hits.hits).toBeDefined();
-    } finally {
-      await kibanaServer.stop();
-      await esServer.stop();
-    }
+        { headers: { 'content-type': 'application/x-ndjson' } }
+      )
+    ).resolves.not.toThrow();
+  });
+
+  it('msearch via high-level client does not inject project_routing and succeeds', async () => {
+    const response = await esClient.msearch({
+      searches: [{ index: '.kibana' }, { query: { match_all: {} }, size: 0 }],
+    });
+    expect(response.responses.length).toBe(1);
   });
 });

--- a/src/core/server/integration_tests/elasticsearch/project_routing_serverless_cps.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/project_routing_serverless_cps.test.ts
@@ -487,6 +487,48 @@ describe('project_routing on serverless CPS', () => {
       expect(response.responses[0].hits.hits.length).toBe(TOTAL_DOCS_COUNT);
       expect((response.responses[1] as any).hits.hits.length).toBe(ALPHA_CATEGORY_DOCS_COUNT);
     });
+
+    it('injects project_routing as query param via high-level client.msearch()', async () => {
+      // The CPS request handler must inject project_routing as a query param, not in the body,
+      // because msearch uses NDJSON format and injecting into the body would corrupt the request.
+      const response = await client.msearch({
+        searches: [
+          { index: TEST_INDEX },
+          { query: { match_all: {} } },
+          { index: TEST_INDEX },
+          { query: { term: { category: 'alpha' } } },
+        ],
+      });
+
+      const expectedMsearchQueries = 2;
+      expect(response.responses.length).toBe(expectedMsearchQueries);
+      expect((response.responses[0] as any).hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      expect((response.responses[1] as any).hits.hits.length).toBe(ALPHA_CATEGORY_DOCS_COUNT);
+    });
+  });
+
+  describe('msearch_template API with project_routing', () => {
+    it('injects project_routing as query param via high-level client.msearchTemplate()', async () => {
+      // First, create a search template to use
+      await client.putScript({
+        id: 'cps-test-template',
+        script: {
+          lang: 'mustache',
+          source: JSON.stringify({ query: { match_all: {} } }),
+        },
+      });
+
+      try {
+        const response = await client.msearchTemplate({
+          search_templates: [{ index: TEST_INDEX }, { id: 'cps-test-template', params: {} }],
+        });
+
+        expect(response.responses.length).toBe(1);
+        expect((response.responses[0] as any).hits.hits.length).toBe(TOTAL_DOCS_COUNT);
+      } finally {
+        await client.deleteScript({ id: 'cps-test-template' }).catch(() => {});
+      }
+    });
   });
 
   describe('count API with project_routing', () => {

--- a/src/core/server/integration_tests/elasticsearch/project_routing_serverless_non_cps.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/project_routing_serverless_non_cps.test.ts
@@ -87,6 +87,32 @@ describe('project_routing on serverless non-CPS', () => {
         })
       ).resolves.not.toThrow();
     });
+
+    it('msearch does NOT inject project_routing and succeeds', async () => {
+      await expect(
+        client.msearch({
+          searches: [{ index: TEST_INDEX }, { query: { match_all: {} } }],
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('msearch strips project_routing from querystring and succeeds', async () => {
+      await expect(
+        client.transport.request(
+          {
+            method: 'POST',
+            path: '/_msearch',
+            body:
+              JSON.stringify({ index: TEST_INDEX }) +
+              '\n' +
+              JSON.stringify({ query: { match_all: {} } }) +
+              '\n',
+            querystring: { project_routing: ALL_PROJECT_ROUTING },
+          },
+          { headers: { 'content-type': 'application/x-ndjson' } }
+        )
+      ).resolves.not.toThrow();
+    });
   });
 
   describe(`'cps' plugin enabled`, () => {
@@ -128,6 +154,16 @@ describe('project_routing on serverless non-CPS', () => {
           query: { match_all: {} },
           // @ts-expect-error - project_routing is a valid body parameter
           body: { project_routing: ALL_PROJECT_ROUTING },
+        })
+      ).rejects.toThrow();
+    });
+
+    it('msearch injects project_routing as query param and requests fail (ES non-CPS)', async () => {
+      // Even though project_routing is injected correctly (as a query param), ES itself
+      // does not support CPS, so requests are expected to fail.
+      await expect(
+        client.msearch({
+          searches: [{ index: TEST_INDEX }, { query: { match_all: {} } }],
         })
       ).rejects.toThrow();
     });


### PR DESCRIPTION
## Problem

`msearch` and `msearch_template` use NDJSON (newline-delimited JSON) bodies. Injecting `project_routing` into the body corrupts the format, causing ES to return:

```
illegal_argument_exception: The msearch request must be terminated by a newline [\n]
```

Both APIs accept `project_routing` as a query parameter instead.

## Changes

- `cps_request_handler.ts`: NDJSON APIs (`msearch`, `msearch_template`) are detected via `meta.name`. When CPS is enabled, `project_routing` is injected into `params.querystring` rather than the body. When CPS is disabled, `project_routing` is stripped from both body and querystring unconditionally (the querystring case is important for requests made via `transport.request()` directly, where `meta.name` may not be set).
- Unit tests extended with `msearch`/`msearch_template` coverage for both CPS-enabled and CPS-disabled paths.
- Integration tests extended across all three variants (serverless CPS, serverless non-CPS, non-serverless) to verify the high-level client `msearch()`/`msearchTemplate()` calls work end-to-end, and that `project_routing` stripping from the querystring works correctly.

Made with [Cursor](https://cursor.com)