### PR TITLE
[Agent Builder] Fix: canvas mode layout

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation.tsx
@@ -35,6 +35,9 @@ import { useNavigationAbort } from '../../hooks/use_navigation_abort';
 import { ErrorPrompt } from '../common/prompt/error_prompt';
 import { PROMPT_LAYOUT_VARIANTS } from '../common/prompt/layout';
 import { StartNewConversationButton } from './actions/start_new_conversation_button';
+import { CanvasProvider } from './conversation_rounds/round_response/attachments/canvas_context';
+import { CanvasFlyout } from './conversation_rounds/round_response/attachments/canvas_flyout';
+import { useAgentBuilderServices } from '../../hooks/use_agent_builder_service';
 
 export const Conversation: React.FC<{}> = () => {
   const { euiTheme } = useEuiTheme();
@@ -45,6 +48,7 @@ export const Conversation: React.FC<{}> = () => {
   const { errorType } = useConversationError();
   const shouldStickToBottom = useShouldStickToBottom();
   const onAppLeave = useAppLeave();
+  const { attachmentsService } = useAgentBuilderServices();
 
   useSendPredefinedInitialMessage();
 
@@ -121,26 +125,33 @@ export const Conversation: React.FC<{}> = () => {
   }
 
   return (
-    <EuiFlexGroup direction="column" alignItems="center" css={containerStyles} gutterSize="s">
-      <EuiFlexItem grow={true} css={scrollWrapperStyles}>
-        <EuiFlexGroup
-          direction="column"
-          alignItems="center"
-          ref={scrollContainerRef}
-          css={scrollableStyles}
+    <CanvasProvider>
+      <EuiFlexGroup direction="column" alignItems="center" css={containerStyles} gutterSize="s">
+        <EuiFlexItem grow={true} css={scrollWrapperStyles}>
+          <EuiFlexGroup
+            direction="column"
+            alignItems="center"
+            ref={scrollContainerRef}
+            css={scrollableStyles}
+          >
+            <EuiFlexItem css={[conversationElementWidthStyles, conversationElementPaddingStyles]}>
+              <ConversationRounds scrollContainerHeight={scrollContainerHeight} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          {showScrollButton && <ScrollButton onClick={smoothScrollToBottom} />}
+        </EuiFlexItem>
+        <EuiFlexItem
+          css={[
+            conversationElementWidthStyles,
+            conversationElementPaddingStyles,
+            inputPaddingStyles,
+          ]}
+          grow={false}
         >
-          <EuiFlexItem css={[conversationElementWidthStyles, conversationElementPaddingStyles]}>
-            <ConversationRounds scrollContainerHeight={scrollContainerHeight} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        {showScrollButton && <ScrollButton onClick={smoothScrollToBottom} />}
-      </EuiFlexItem>
-      <EuiFlexItem
-        css={[conversationElementWidthStyles, conversationElementPaddingStyles, inputPaddingStyles]}
-        grow={false}
-      >
-        <ConversationInput onSubmit={scrollToMostRecentRoundTop} />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+          <ConversationInput onSubmit={scrollToMostRecentRoundTop} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <CanvasFlyout attachmentsService={attachmentsService} />
+    </CanvasProvider>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/chat_message_text.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/chat_message_text.tsx
@@ -44,8 +44,6 @@ import {
 } from './markdown_plugins';
 import { useStepsFromPrevRounds } from '../../../../hooks/use_conversation';
 import { useConversationContext } from '../../../../context/conversation/conversation_context';
-import { CanvasProvider } from './attachments/canvas_context';
-import { CanvasFlyout } from './attachments/canvas_flyout';
 import { ExternalLinkModal } from './external_link_modal';
 
 interface Props {
@@ -215,7 +213,7 @@ export function ChatMessageText({
   ]);
 
   return (
-    <CanvasProvider>
+    <>
       <EuiText size="m" className={containerClassName}>
         <EuiMarkdownFormat
           textSize="m"
@@ -225,8 +223,7 @@ export function ChatMessageText({
           {content}
         </EuiMarkdownFormat>
       </EuiText>
-      <CanvasFlyout attachmentsService={attachmentsService} />
       <ExternalLinkModal url={pendingExternalUrl} onClose={() => setPendingExternalUrl(null)} />
-    </CanvasProvider>
+    </>
   );
 }


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/13151

When opening a second canvas it's creating another flyout, we should not do this. We should only be replacing the content of the existing flyout.

The solution: Lift the canvas-mode higher so that it wraps the full-conversation and NOT every conversation round like it does now. This way, only one canvas (flyout) can be open at any given time. If a user tries to open another canvas, we just replace the content of the flyout.

- [x] Only one canvas-mode can be open at any given time

Before


https://github.com/user-attachments/assets/0d36a48e-4e2c-47c3-81fc-5754d9493d2c

After

https://github.com/user-attachments/assets/f769e838-0397-4485-a35c-01b11c92074c

