### PR TITLE
[Discover] Revert changes to attributes overview

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_overview.tsx
@@ -74,9 +74,10 @@ export function AttributesOverview({
         flattened,
         searchTerm,
         shouldShowFieldHandler,
+        isEsqlMode,
         areNullValuesHidden,
       }),
-    [allFields, flattened, searchTerm, shouldShowFieldHandler, areNullValuesHidden]
+    [allFields, flattened, searchTerm, shouldShowFieldHandler, isEsqlMode, areNullValuesHidden]
   );
 
   const { attributesFields, resourceAttributesFields, scopeAttributesFields } = groupedFields;
@@ -194,18 +195,20 @@ export function AttributesOverview({
           alignItems="center"
           gutterSize="m"
         >
-          <EuiFlexItem grow={false}>
-            <EuiSwitch
-              label={i18n.translate('unifiedDocViewer.hideNullValues.switchLabel', {
-                defaultMessage: 'Hide null fields',
-                description: 'Switch label to hide fields with null values in the table',
-              })}
-              checked={areNullValuesHidden ?? false}
-              onChange={onHideNullValuesChange}
-              compressed
-              data-test-subj="unifiedDocViewerHideNullValuesSwitch"
-            />
-          </EuiFlexItem>
+          {isEsqlMode && (
+            <EuiFlexItem grow={false}>
+              <EuiSwitch
+                label={i18n.translate('unifiedDocViewer.hideNullValues.switchLabel', {
+                  defaultMessage: 'Hide null fields',
+                  description: 'Switch label to hide fields with null values in the table',
+                })}
+                checked={areNullValuesHidden ?? false}
+                onChange={onHideNullValuesChange}
+                compressed
+                data-test-subj="unifiedDocViewerHideNullValuesSwitch"
+              />
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/group_attributes_fields.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/group_attributes_fields.test.ts
@@ -27,6 +27,7 @@ describe('groupAttributesFields', () => {
       flattened,
       searchTerm: '',
       shouldShowFieldHandler: alwaysShow,
+      isEsqlMode: false,
       areNullValuesHidden: false,
     });
 
@@ -45,6 +46,7 @@ describe('groupAttributesFields', () => {
       flattened,
       searchTerm: 'env',
       shouldShowFieldHandler: alwaysShow,
+      isEsqlMode: false,
       areNullValuesHidden: false,
     });
 
@@ -55,7 +57,7 @@ describe('groupAttributesFields', () => {
     expect(result.scopeAttributesFields).toEqual([]);
   });
 
-  it('filters out null values when areNullValuesHidden is true', () => {
+  it('filters out null values in ES|QL mode', () => {
     const flattenedWithNull = { ...flattened, 'attributes.null': null };
     const allFieldsWithNull = Object.keys(flattenedWithNull);
 
@@ -64,6 +66,7 @@ describe('groupAttributesFields', () => {
       flattened: flattenedWithNull,
       searchTerm: '',
       shouldShowFieldHandler: alwaysShow,
+      isEsqlMode: true,
       areNullValuesHidden: true,
     });
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/group_attributes_fields.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/group_attributes_fields.ts
@@ -15,6 +15,7 @@ interface GroupAttributesFieldsParams {
   flattened: Record<string, unknown>;
   searchTerm: string;
   shouldShowFieldHandler: (fieldName: string) => boolean;
+  isEsqlMode: boolean;
   areNullValuesHidden?: boolean;
 }
 
@@ -23,6 +24,7 @@ export function groupAttributesFields({
   flattened,
   searchTerm,
   shouldShowFieldHandler,
+  isEsqlMode,
   areNullValuesHidden,
 }: GroupAttributesFieldsParams): {
   attributesFields: AttributeField[];
@@ -39,7 +41,7 @@ export function groupAttributesFields({
 
     if (!shouldShowFieldHandler(fieldName)) return;
     if (!lowerFieldName.includes(lowerSearchTerm)) return;
-    if (areNullValuesHidden && flattened[fieldName] == null) return;
+    if (isEsqlMode && areNullValuesHidden && flattened[fieldName] == null) return;
 
     const field: AttributeField = {
       name: fieldName,


### PR DESCRIPTION
## Summary

Addressing https://github.com/elastic/kibana/pull/254929#issuecomment-3983906886 by reverting the changes from Attributes view. The switch will appear only in ES|QL mode as before the mentioned PR.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



