### PR TITLE
Fix task runner error serialization for non-Error objects

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -994,6 +994,34 @@ describe('TaskManagerRunner', () => {
       );
       expect(loggerMeta?.tags).toEqual(['bar', 'foo', 'task-run-failed', 'user-error']);
     });
+    test('logs plain object errors with JSON.stringify instead of [object Object]', async () => {
+      const { runner, logger } = await readyToRunStageSetup({
+        instance: {
+          params: { a: 'b' },
+          state: { hey: 'there' },
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            createTaskRunner: () => ({
+              async run() {
+                // eslint-disable-next-line no-throw-literal
+                throw { message: 'some error', statusCode: 500 };
+              },
+            }),
+          },
+        },
+      });
+      await runner.run();
+
+      const loggerCall = logger.error.mock.calls[0][0];
+      const loggerMeta = logger.error.mock.calls[0][1];
+      expect(loggerCall as string).toMatchInlineSnapshot(
+        `"Task bar \\"foo\\" failed: {\\"message\\":\\"some error\\",\\"statusCode\\":500}"`
+      );
+      expect(loggerMeta?.tags).toEqual(['bar', 'foo', 'task-run-failed', 'framework-error']);
+      expect(loggerMeta?.error?.stack_trace).toBeUndefined();
+    });
     test('provides execution context on run', async () => {
       const { runner } = await readyToRunStageSetup({
         definitions: {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -438,9 +438,15 @@ export class TaskManagerRunner implements TaskRunner {
       return processedResult;
     } catch (err) {
       const errorSource = isUserError(err) ? TaskErrorSource.USER : TaskErrorSource.FRAMEWORK;
-      this.logger.error(`Task ${this} failed: ${err}`, {
+      const errorMessage =
+        err instanceof Error
+          ? String(err)
+          : typeof err === 'object' && err !== null
+          ? JSON.stringify(err)
+          : String(err);
+      this.logger.error(`Task ${this} failed: ${errorMessage}`, {
         tags: [this.taskType, this.instance.task.id, 'task-run-failed', `${errorSource}-error`],
-        error: { stack_trace: err.stack },
+        error: { stack_trace: err instanceof Error ? err.stack : undefined },
       });
       // in error scenario, we can not get the RunResult
       // re-use modifiedContext's state, which is correct as of beforeRun


### PR DESCRIPTION
## Summary

- When a task throws a plain object (not an `Error` instance), the task runner logs `failed: [object Object]` because template literal coercion calls `Object.prototype.toString()`. The `error.stack_trace` field is also empty since plain objects lack a `.stack` property.
- This change safely serializes the error: `JSON.stringify` for plain objects, `String(err)` for proper `Error` instances (preserving existing format), and `String(err)` for primitives.
- Adds a test covering the plain object error scenario.

### Context

We discovered this while investigating workflow task failures across multiple serverless projects in different regions. All `workflow:scheduled` failures logged `[object Object]` with empty error metadata, making it impossible to determine root cause from logs alone.

### Changes

**`task_runner.ts`** (line 441):
```diff
- this.logger.error(`Task ${this} failed: ${err}`, {
-   error: { stack_trace: err.stack },
+ const errorMessage =
+   err instanceof Error
+     ? String(err)
+     : typeof err === 'object' && err !== null
+     ? JSON.stringify(err)
+     : String(err);
+ this.logger.error(`Task ${this} failed: ${errorMessage}`, {
+   error: { stack_trace: err instanceof Error ? err.stack : undefined },
```

**`task_runner.test.ts`**: New test verifying plain object errors are logged with `JSON.stringify` output.


Made with [Cursor](https://cursor.com)