### PR TITLE
[Fleet] Do not use simplified agentless UX for package that replace StepConfigurePackagePolicy

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -478,8 +478,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   const enableSimplifiedAgentlessUX = ExperimentalFeaturesService.get().enableSimplifiedAgentlessUX;
 
   const useCheckableCardsForSetupTechnologySelector = useMemo(() => {
-    return enableSimplifiedAgentlessUX && isDefaultDeploymentMode;
-  }, [enableSimplifiedAgentlessUX, isDefaultDeploymentMode]);
+    return !replaceDefineStepView && enableSimplifiedAgentlessUX && isDefaultDeploymentMode;
+  }, [replaceDefineStepView, enableSimplifiedAgentlessUX, isDefaultDeploymentMode]);
 
   const replaceStepConfigurePackagePolicy =
     replaceDefineStepView && packageInfo?.name ? (


### PR DESCRIPTION
## Description 

Do not use simplified agentless UX for package that replace StepConfigurePackagePolicy so the technology selector is not displayed two times

#### Before  

<img width="632" height="797" alt="Screenshot 2026-03-02 at 9 33 01 AM" src="https://github.com/user-attachments/assets/31a47540-0c65-4b2d-85c1-ca1ca4407a19" />


#### After

<img width="619" height="711" alt="Screenshot 2026-03-02 at 9 32 11 AM" src="https://github.com/user-attachments/assets/23627977-b6b8-43ab-aaa7-54a47593f56e" />

  