### PR TITLE
[ES|QL] Skip fetching fields in adhoc dataview

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_esql_data_view.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_esql_data_view.ts
@@ -43,6 +43,7 @@ export async function getEsqlDataView(
         // otherwise a single mutated data view instance would be used across tabs (inside currentDataView$) which would be incorrect
         // https://github.com/elastic/kibana/issues/234719
         createNewInstanceEvenIfCachedOneAvailable: !currentDataView || onlyTimeFieldChanged,
+        skipFetchFields: true,
       },
       http: services.http,
     });


### PR DESCRIPTION
## Summary

After the changes we did in Discover to rely more on the columns from the _query this is not needed anymore

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


