### PR TITLE
[9.2] Decouple "Open in Discover" button from ApmServiceContext (#255105)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_overview/error_group_list/error_group_list.stories.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/error_group_overview/error_group_list/error_group_list.stories.tsx
@@ -95,14 +95,6 @@ const stories: Meta<Args> = {
             transactionTypeStatus: FETCH_STATUS.SUCCESS,
             transactionTypes: ['request'],
             serviceAgentStatus: FETCH_STATUS.SUCCESS,
-            indexSettings: [
-              {
-                configurationName: 'span',
-                defaultValue: 'traces-*',
-                savedValue: 'traces-*, apm-*',
-              },
-            ],
-            indexSettingsStatus: FETCH_STATUS.SUCCESS,
           }}
         >
           <StoryComponent />

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/index.test.tsx
@@ -64,14 +64,6 @@ describe('Metrics', () => {
           transactionTypes: [],
           fallbackToTransactions: true,
           serviceAgentStatus: FETCH_STATUS.SUCCESS,
-          indexSettings: [
-            {
-              configurationName: 'span',
-              defaultValue: 'traces-*',
-              savedValue: 'traces-*, apm-*',
-            },
-          ],
-          indexSettingsStatus: FETCH_STATUS.SUCCESS,
         });
       });
 
@@ -94,14 +86,6 @@ describe('Metrics', () => {
           transactionTypes: [],
           fallbackToTransactions: true,
           serviceAgentStatus: FETCH_STATUS.SUCCESS,
-          indexSettings: [
-            {
-              configurationName: 'span',
-              defaultValue: 'traces-*',
-              savedValue: 'traces-*, apm-*',
-            },
-          ],
-          indexSettingsStatus: FETCH_STATUS.SUCCESS,
         });
       });
 
@@ -124,14 +108,6 @@ describe('Metrics', () => {
           transactionTypes: [],
           fallbackToTransactions: true,
           serviceAgentStatus: FETCH_STATUS.SUCCESS,
-          indexSettings: [
-            {
-              configurationName: 'span',
-              defaultValue: 'traces-*',
-              savedValue: 'traces-*, apm-*',
-            },
-          ],
-          indexSettingsStatus: FETCH_STATUS.SUCCESS,
         });
       });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.stories.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.stories.tsx
@@ -57,14 +57,6 @@ export default {
                 serviceName,
                 fallbackToTransactions: false,
                 serviceAgentStatus: FETCH_STATUS.SUCCESS,
-                indexSettings: [
-                  {
-                    configurationName: 'span',
-                    defaultValue: 'traces-*',
-                    savedValue: 'traces-*, apm-*',
-                  },
-                ],
-                indexSettingsStatus: FETCH_STATUS.SUCCESS,
               }}
             >
               <StoryComponent />

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -9,6 +9,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiLoadingLogo, EuiSpacer, EuiTitle } from '
 import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { isMobileAgentName } from '../../../../../common/agent_name';
+import { ApmIndexSettingsContextProvider } from '../../../../context/apm_index_settings/apm_index_settings_context';
 import { ApmServiceContextProvider } from '../../../../context/apm_service/apm_service_context';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useBreadcrumb } from '../../../../context/breadcrumbs/use_breadcrumb';
@@ -34,9 +35,11 @@ interface Props {
 
 export function ApmServiceTemplate(props: Props) {
   return (
-    <ApmServiceContextProvider>
-      <TemplateWithContext {...props} />
-    </ApmServiceContextProvider>
+    <ApmIndexSettingsContextProvider>
+      <ApmServiceContextProvider>
+        <TemplateWithContext {...props} />
+      </ApmServiceContextProvider>
+    </ApmIndexSettingsContextProvider>
   );
 }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/use_tabs.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/use_tabs.test.tsx
@@ -180,14 +180,6 @@ describe('APM service template', () => {
           transactionTypes: [],
           fallbackToTransactions: true,
           serviceAgentStatus: FETCH_STATUS.SUCCESS,
-          indexSettings: [
-            {
-              configurationName: 'span',
-              defaultValue: 'traces-*',
-              savedValue: 'traces-*, apm-*',
-            },
-          ],
-          indexSettingsStatus: FETCH_STATUS.SUCCESS,
         });
       });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/dependency_detail_template.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/dependency_detail_template.tsx
@@ -15,6 +15,7 @@ import { useApmRouter } from '../../../hooks/use_apm_router';
 import { useApmRoutePath } from '../../../hooks/use_apm_route_path';
 import { useFetcher } from '../../../hooks/use_fetcher';
 import { useTimeRange } from '../../../hooks/use_time_range';
+import { ApmIndexSettingsContextProvider } from '../../../context/apm_index_settings/apm_index_settings_context';
 import { BetaBadge } from '../../shared/beta_badge';
 import { SearchBar } from '../../shared/search_bar/search_bar';
 import { ApmMainTemplate } from './apm_main_template';
@@ -81,29 +82,31 @@ export function DependencyDetailTemplate({ children }: Props) {
   ];
 
   return (
-    <ApmMainTemplate
-      pageHeader={{
-        tabs,
-        pageTitle: (
-          <EuiFlexGroup alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiTitle size="l">
-                <h1>{dependencyName}</h1>
-              </EuiTitle>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <SpanIcon
-                type={metadata?.spanType}
-                subtype={metadata?.spanSubtype}
-                role="presentation"
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        ),
-      }}
-    >
-      <SearchBar showTimeComparison searchBarPlaceholder={unifiedSearchBarPlaceholder} />
-      {children}
-    </ApmMainTemplate>
+    <ApmIndexSettingsContextProvider>
+      <ApmMainTemplate
+        pageHeader={{
+          tabs,
+          pageTitle: (
+            <EuiFlexGroup alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiTitle size="l">
+                  <h1>{dependencyName}</h1>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <SpanIcon
+                  type={metadata?.spanType}
+                  subtype={metadata?.spanSubtype}
+                  role="presentation"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ),
+        }}
+      >
+        <SearchBar showTimeComparison searchBarPlaceholder={unifiedSearchBarPlaceholder} />
+        {children}
+      </ApmMainTemplate>
+    </ApmIndexSettingsContextProvider>
   );
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { omit } from 'lodash';
 import React from 'react';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
+import { ApmIndexSettingsContextProvider } from '../../../../context/apm_index_settings/apm_index_settings_context';
 import { ApmServiceContextProvider } from '../../../../context/apm_service/apm_service_context';
 import { useBreadcrumb } from '../../../../context/breadcrumbs/use_breadcrumb';
 import { ServiceAnomalyTimeseriesContextProvider } from '../../../../context/service_anomaly_timeseries/service_anomaly_timeseries_context';
@@ -46,9 +47,11 @@ interface Props {
 
 export function MobileServiceTemplate(props: Props) {
   return (
-    <ApmServiceContextProvider>
-      <TemplateWithContext {...props} />
-    </ApmServiceContextProvider>
+    <ApmIndexSettingsContextProvider>
+      <ApmServiceContextProvider>
+        <TemplateWithContext {...props} />
+      </ApmServiceContextProvider>
+    </ApmIndexSettingsContextProvider>
   );
 }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/service_group_template.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/service_group_template.tsx
@@ -15,6 +15,7 @@ import { useApmRouter } from '../../../hooks/use_apm_router';
 import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
 import { ApmMainTemplate } from './apm_main_template';
 import { useBreadcrumb } from '../../../context/breadcrumbs/use_breadcrumb';
+import { ApmIndexSettingsContextProvider } from '../../../context/apm_index_settings/apm_index_settings_context';
 
 export function ServiceGroupTemplate({
   pageTitle,
@@ -121,37 +122,39 @@ export function ServiceGroupTemplate({
   );
 
   return (
-    <ApmMainTemplate
-      pageTitle={serviceGroupsPageTitle}
-      pageHeader={{
-        tabs,
-        breadcrumbs: !isAllServices
-          ? [
-              {
-                text: (
-                  <>
-                    <EuiIcon size="s" type="arrowLeft" />{' '}
-                    {i18n.translate('xpack.apm.serviceGroups.breadcrumb.return', {
-                      defaultMessage: 'Return to service groups',
-                    })}
-                  </>
-                ),
-                color: 'primary',
-                'aria-current': false,
-                href: serviceGroupsLink,
-              },
-            ]
-          : undefined,
-        ...pageHeader,
-      }}
-      environmentFilter={environmentFilter}
-      showServiceGroupSaveButton={!isAllServices}
-      showServiceGroupsNav={isAllServices}
-      selectedNavButton={isAllServices ? 'allServices' : 'serviceGroups'}
-      {...pageTemplateProps}
-    >
-      {children}
-    </ApmMainTemplate>
+    <ApmIndexSettingsContextProvider>
+      <ApmMainTemplate
+        pageTitle={serviceGroupsPageTitle}
+        pageHeader={{
+          tabs,
+          breadcrumbs: !isAllServices
+            ? [
+                {
+                  text: (
+                    <>
+                      <EuiIcon size="s" type="arrowLeft" />{' '}
+                      {i18n.translate('xpack.apm.serviceGroups.breadcrumb.return', {
+                        defaultMessage: 'Return to service groups',
+                      })}
+                    </>
+                  ),
+                  color: 'primary',
+                  'aria-current': false,
+                  href: serviceGroupsLink,
+                },
+              ]
+            : undefined,
+          ...pageHeader,
+        }}
+        environmentFilter={environmentFilter}
+        showServiceGroupSaveButton={!isAllServices}
+        showServiceGroupsNav={isAllServices}
+        selectedNavButton={isAllServices ? 'allServices' : 'serviceGroups'}
+        {...pageTemplateProps}
+      >
+        {children}
+      </ApmMainTemplate>
+    </ApmIndexSettingsContextProvider>
   );
 }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/latency_chart.stories.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/latency_chart.stories.tsx
@@ -88,14 +88,6 @@ const stories: Meta<Args> = {
                         transactionTypes: [],
                         fallbackToTransactions: false,
                         serviceAgentStatus: FETCH_STATUS.SUCCESS,
-                        indexSettings: [
-                          {
-                            configurationName: 'span',
-                            defaultValue: 'traces-*',
-                            savedValue: 'traces-*, apm-*',
-                          },
-                        ],
-                        indexSettingsStatus: FETCH_STATUS.SUCCESS,
                       }}
                     >
                       <ChartPointerEventContextProvider>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/base_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/base_discover_button.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
-import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmIndexSettingsContext } from '../../../../context/apm_index_settings/use_apm_index_settings_context';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 
 export function BaseDiscoverButton({
@@ -28,7 +28,7 @@ export function BaseDiscoverButton({
   ariaLabel: string;
 }) {
   const { share } = useApmPluginContext();
-  const { indexSettingsStatus } = useApmServiceContext();
+  const { indexSettingsStatus } = useApmIndexSettingsContext();
 
   const discoverHref = share.url.locators.get(DISCOVER_APP_LOCATOR)?.getRedirectUrl({
     timeRange: {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.test.tsx
@@ -13,14 +13,19 @@ import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { ERROR_GROUP_ID, SERVICE_NAME } from '@kbn/apm-types';
 import { OpenErrorInDiscoverButton } from './open_error_in_discover_button';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmIndexSettingsContext } from '../../../../context/apm_index_settings/use_apm_index_settings_context';
 import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 
 jest.mock('../../../../context/apm_service/use_apm_service_context');
+jest.mock('../../../../context/apm_index_settings/use_apm_index_settings_context');
 jest.mock('../../../../hooks/use_apm_params');
 jest.mock('../../../../context/apm_plugin/use_apm_plugin_context');
 
 const mockUseApmServiceContext = useApmServiceContext as jest.MockedFunction<
   typeof useApmServiceContext
+>;
+const mockUseApmIndexSettingsContext = useApmIndexSettingsContext as jest.MockedFunction<
+  typeof useApmIndexSettingsContext
 >;
 const mockUseAnyOfApmParams = useAnyOfApmParams as jest.MockedFunction<any>;
 const mockUseApmPluginContext = useApmPluginContext as jest.MockedFunction<
@@ -40,6 +45,9 @@ describe('OpenErrorInDiscoverButton', () => {
   beforeEach(() => {
     mockUseApmServiceContext.mockReturnValue({
       serviceName,
+    } as any);
+
+    mockUseApmIndexSettingsContext.mockReturnValue({
       indexSettings: [
         {
           configurationName: 'error',
@@ -82,18 +90,6 @@ describe('OpenErrorInDiscoverButton', () => {
 
     mockUseApmServiceContext.mockReturnValue({
       serviceName: '',
-      indexSettings: [
-        {
-          configurationName: 'error',
-          defaultValue: MOCK_INDEX_PATTERN,
-        },
-        {
-          configurationName: 'test',
-          savedValue: 'fake-index',
-          defaultValue: 'fake-*',
-        },
-      ],
-      indexSettingsStatus: FETCH_STATUS.SUCCESS,
     } as any);
 
     mockUseAnyOfApmParams.mockReturnValue({
@@ -145,18 +141,6 @@ describe('OpenErrorInDiscoverButton', () => {
     };
     mockUseApmServiceContext.mockReturnValue({
       serviceName: '',
-      indexSettings: [
-        {
-          configurationName: 'error',
-          defaultValue: MOCK_INDEX_PATTERN,
-        },
-        {
-          configurationName: 'test',
-          savedValue: 'fake-index',
-          defaultValue: 'fake-*',
-        },
-      ],
-      indexSettingsStatus: FETCH_STATUS.SUCCESS,
     } as any);
     mockUseAnyOfApmParams.mockReturnValue({
       query,
@@ -195,8 +179,7 @@ describe('OpenErrorInDiscoverButton', () => {
       query: {},
       path: { groupId: errorGroupId },
     });
-    mockUseApmServiceContext.mockReturnValue({
-      serviceName,
+    mockUseApmIndexSettingsContext.mockReturnValue({
       indexSettings: [],
       indexSettingsStatus: FETCH_STATUS.SUCCESS,
     } as any);

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_error_in_discover_button.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
 import { from } from '@kbn/esql-composer';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmIndexSettingsContext } from '../../../../context/apm_index_settings/use_apm_index_settings_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
 import { BaseDiscoverButton } from './base_discover_button';
 import { filterByErrorGroupId, filterByKuery, filterByServiceName } from './filters';
@@ -62,7 +63,8 @@ export const getESQLQuery = ({
 };
 
 export function OpenErrorInDiscoverButton({ dataTestSubj }: { dataTestSubj: string }) {
-  const { serviceName, indexSettings } = useApmServiceContext();
+  const { serviceName } = useApmServiceContext();
+  const { indexSettings = [] } = useApmIndexSettingsContext();
 
   const {
     query: { rangeFrom, rangeTo, kuery },

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { OpenInDiscoverButton } from './open_in_discover_button';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmIndexSettingsContext } from '../../../../context/apm_index_settings/use_apm_index_settings_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
@@ -27,11 +28,15 @@ import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 const MOCK_INDEX_PATTERN = 'traces-*';
 
 jest.mock('../../../../context/apm_service/use_apm_service_context');
+jest.mock('../../../../context/apm_index_settings/use_apm_index_settings_context');
 jest.mock('../../../../hooks/use_apm_params');
 jest.mock('../../../../context/apm_plugin/use_apm_plugin_context');
 
 const mockUseApmServiceContext = useApmServiceContext as jest.MockedFunction<
   typeof useApmServiceContext
+>;
+const mockUseApmIndexSettingsContext = useApmIndexSettingsContext as jest.MockedFunction<
+  typeof useApmIndexSettingsContext
 >;
 const mockUseAnyOfApmParams = useAnyOfApmParams as jest.MockedFunction<any>;
 const mockUseApmPluginContext = useApmPluginContext as jest.MockedFunction<
@@ -49,6 +54,9 @@ describe('OpenInDiscoverButton', () => {
   beforeEach(() => {
     mockUseApmServiceContext.mockReturnValue({
       serviceName,
+    } as any);
+
+    mockUseApmIndexSettingsContext.mockReturnValue({
       indexSettings: [
         {
           configurationName: 'transaction',
@@ -333,8 +341,7 @@ describe('OpenInDiscoverButton', () => {
     mockUseAnyOfApmParams.mockReturnValue({
       query: {},
     });
-    mockUseApmServiceContext.mockReturnValue({
-      serviceName,
+    mockUseApmIndexSettingsContext.mockReturnValue({
       indexSettings: [],
       indexSettingsStatus: FETCH_STATUS.SUCCESS,
     } as any);

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_in_discover_button.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
 import { from } from '@kbn/esql-composer';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmIndexSettingsContext } from '../../../../context/apm_index_settings/use_apm_index_settings_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
 import {
   ENVIRONMENT_ALL_VALUE,
@@ -106,7 +107,8 @@ const getESQLQuery = ({
 };
 
 export function OpenInDiscoverButton({ dataTestSubj }: { dataTestSubj: string }) {
-  const { serviceName, indexSettings } = useApmServiceContext();
+  const { serviceName } = useApmServiceContext();
+  const { indexSettings = [] } = useApmIndexSettingsContext();
 
   const { query: queryParams } = useAnyOfApmParams(
     '/services/{serviceName}/transactions/view',

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.test.tsx
@@ -12,17 +12,17 @@ import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plug
 import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { SPAN_ID } from '@kbn/apm-types';
 import { OpenSpanInDiscoverLink } from './open_span_in_discover_link';
-import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmIndexSettingsContext } from '../../../../context/apm_index_settings/use_apm_index_settings_context';
 import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 
 const MOCK_INDEX_PATTERN = 'traces-*';
 
-jest.mock('../../../../context/apm_service/use_apm_service_context');
+jest.mock('../../../../context/apm_index_settings/use_apm_index_settings_context');
 jest.mock('../../../../hooks/use_apm_params');
 jest.mock('../../../../context/apm_plugin/use_apm_plugin_context');
 
-const mockUseApmServiceContext = useApmServiceContext as jest.MockedFunction<
-  typeof useApmServiceContext
+const mockUseApmIndexSettingsContext = useApmIndexSettingsContext as jest.MockedFunction<
+  typeof useApmIndexSettingsContext
 >;
 const mockUseAnyOfApmParams = useAnyOfApmParams as jest.MockedFunction<any>;
 const mockUseApmPluginContext = useApmPluginContext as jest.MockedFunction<
@@ -38,7 +38,7 @@ const spanId = 'test-span-id';
 
 describe('OpenSpanInDiscoverLink', () => {
   beforeEach(() => {
-    mockUseApmServiceContext.mockReturnValue({
+    mockUseApmIndexSettingsContext.mockReturnValue({
       indexSettings: [
         {
           configurationName: 'transaction',
@@ -143,7 +143,7 @@ describe('OpenSpanInDiscoverLink', () => {
     mockUseAnyOfApmParams.mockReturnValue({
       query: {},
     });
-    mockUseApmServiceContext.mockReturnValue({
+    mockUseApmIndexSettingsContext.mockReturnValue({
       indexSettings: [],
       indexSettingsStatus: FETCH_STATUS.SUCCESS,
     } as any);

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/links/discover_links/open_span_in_discover_link.tsx
@@ -15,7 +15,7 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
 import { from } from '@kbn/esql-composer';
-import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmIndexSettingsContext } from '../../../../context/apm_index_settings/use_apm_index_settings_context';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
 import { BaseDiscoverButton } from './base_discover_button';
 import { filterByKuery, filterBySpanId } from './filters';
@@ -63,7 +63,7 @@ export function OpenSpanInDiscoverLink({
   dataTestSubj: string;
   spanId: string;
 }) {
-  const { indexSettings } = useApmServiceContext();
+  const { indexSettings = [] } = useApmIndexSettingsContext();
 
   const {
     query: { rangeFrom, rangeTo, kuery },

--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_index_settings/apm_index_settings_context.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_index_settings/apm_index_settings_context.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import React, { useContext } from 'react';
+import type { ReactNode } from 'react';
+import {
+  ApmIndexSettingsContext,
+  ApmIndexSettingsContextProvider,
+} from './apm_index_settings_context';
+
+jest.mock('../../hooks/use_fetcher', () => ({
+  useFetcher: () => ({
+    data: {
+      apmIndexSettings: [
+        { configurationName: 'transaction', defaultValue: 'traces-apm*', savedValue: undefined },
+      ],
+    },
+    status: 'success',
+  }),
+}));
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({ services: { apmSourcesAccess: { getApmIndexSettings: jest.fn() } } }),
+}));
+
+describe('ApmIndexSettingsContext', () => {
+  it('provides fetched index settings to consumers', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ApmIndexSettingsContextProvider>{children}</ApmIndexSettingsContextProvider>
+    );
+
+    const { result } = renderHook(() => useContext(ApmIndexSettingsContext), { wrapper });
+
+    expect(result.current.indexSettings).toBeDefined();
+    expect(result.current.indexSettingsStatus).toBe('success');
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_index_settings/apm_index_settings_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_index_settings/apm_index_settings_context.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext } from 'react';
+import type { ReactNode } from 'react';
+import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { FETCH_STATUS } from '../../hooks/use_fetcher';
+import { useFetcher } from '../../hooks/use_fetcher';
+import type { ApmPluginStartDeps } from '../../plugin';
+
+export interface ApmIndexSettingsContextValue {
+  indexSettings: ApmIndexSettingsResponse['apmIndexSettings'];
+  indexSettingsStatus: FETCH_STATUS;
+}
+
+export const ApmIndexSettingsContext = createContext<Partial<ApmIndexSettingsContextValue>>({});
+
+export function ApmIndexSettingsContextProvider({ children }: { children: ReactNode }) {
+  const {
+    services: { apmSourcesAccess },
+  } = useKibana<ApmPluginStartDeps>();
+  const { data = { apmIndexSettings: [] }, status: indexSettingsStatus } = useFetcher(
+    (_, signal) => apmSourcesAccess.getApmIndexSettings({ signal }),
+    [apmSourcesAccess]
+  );
+
+  return (
+    <ApmIndexSettingsContext.Provider
+      value={{
+        indexSettings: data.apmIndexSettings,
+        indexSettingsStatus,
+      }}
+    >
+      {children}
+    </ApmIndexSettingsContext.Provider>
+  );
+}

--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_index_settings/use_apm_index_settings_context.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_index_settings/use_apm_index_settings_context.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useContext } from 'react';
+import { ApmIndexSettingsContext } from './apm_index_settings_context';
+
+export function useApmIndexSettingsContext() {
+  return useContext(ApmIndexSettingsContext);
+}

--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_service/apm_service_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_service/apm_service_context.tsx
@@ -9,8 +9,6 @@ import type { ReactNode } from 'react';
 import React, { createContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import type { History } from 'history';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { ApmIndexSettingsResponse } from '@kbn/apm-sources-access-plugin/server/routes/settings';
 import { ApmDocumentType } from '../../../common/document_type';
 import { getDefaultTransactionType } from '../../../common/transaction_types';
 import { useServiceTransactionTypesFetcher } from './use_service_transaction_types_fetcher';
@@ -19,10 +17,10 @@ import { useAnyOfApmParams } from '../../hooks/use_apm_params';
 import { useTimeRange } from '../../hooks/use_time_range';
 import { useFallbackToTransactionsFetcher } from '../../hooks/use_fallback_to_transactions_fetcher';
 import { replace } from '../../components/shared/links/url_helpers';
-import { FETCH_STATUS, useFetcher } from '../../hooks/use_fetcher';
+import { FETCH_STATUS } from '../../hooks/use_fetcher';
 import type { ServerlessType } from '../../../common/serverless';
 import { usePreferredDataSourceAndBucketSize } from '../../hooks/use_preferred_data_source_and_bucket_size';
-import type { ApmPluginStartDeps } from '../../plugin';
+
 export interface APMServiceContextValue {
   serviceName: string;
   agentName?: string;
@@ -35,8 +33,6 @@ export interface APMServiceContextValue {
   runtimeName?: string;
   fallbackToTransactions: boolean;
   serviceAgentStatus: FETCH_STATUS;
-  indexSettings: ApmIndexSettingsResponse['apmIndexSettings'];
-  indexSettingsStatus: FETCH_STATUS;
 }
 
 export const APMServiceContext = createContext<APMServiceContextValue>({
@@ -45,13 +41,10 @@ export const APMServiceContext = createContext<APMServiceContextValue>({
   transactionTypes: [],
   fallbackToTransactions: false,
   serviceAgentStatus: FETCH_STATUS.NOT_INITIATED,
-  indexSettings: [],
-  indexSettingsStatus: FETCH_STATUS.NOT_INITIATED,
 });
 
 export function ApmServiceContextProvider({ children }: { children: ReactNode }) {
   const history = useHistory();
-  const { services } = useKibana<ApmPluginStartDeps>();
   const {
     path: { serviceName },
     query,
@@ -100,11 +93,6 @@ export function ApmServiceContextProvider({ children }: { children: ReactNode })
     kuery,
   });
 
-  const { data = { apmIndexSettings: [] }, status: indexSettingsStatus } = useFetcher(
-    (_, signal) => services.apmSourcesAccess.getApmIndexSettings({ signal }),
-    [services.apmSourcesAccess]
-  );
-
   return (
     <APMServiceContext.Provider
       value={{
@@ -119,8 +107,6 @@ export function ApmServiceContextProvider({ children }: { children: ReactNode })
         runtimeName,
         fallbackToTransactions,
         serviceAgentStatus,
-        indexSettings: data?.apmIndexSettings,
-        indexSettingsStatus,
       }}
       children={children}
     />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Decouple "Open in Discover" button from ApmServiceContext (#255105)](https://github.com/elastic/kibana/pull/255105)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Marcinkowski","email":"38698566+miloszmarcinkowski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-02T11:56:54Z","message":"Decouple \"Open in Discover\" button from ApmServiceContext (#255105)\n\n## Summary\n\nCloses #254239\n\nThe \"Open in Discover\" button relied on `indexSettings` from\n`ApmServiceContext`, which is only available on service-level routes.\nThis meant the button was always disabled on pages without a service\ncontext, such as the dependency operation detail page.\n\n### Changes\n\n- Extracted `indexSettings` into a new dedicated\n`ApmIndexSettingsContext` so it can be provided independently of the\nservice context.\n- Wrapped `DependencyDetailTemplate`, `ApmServiceTemplate`,\n`MobileServiceTemplate`, and `ServiceGroupTemplate` with the new\nprovider.\n- Updated consumers to read from `useApmIndexSettingsContext()` instead\nof `useApmServiceContext()`.\n\nFixed button on dependency operation detail page:\n<img width=\"2560\" height=\"1287\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1af3e3c2-442c-4662-b4e5-1fb138f10b7d\"\n/>\n\n### Tessting\n\nDue to new context provider, the following `OpenInDiscover` button\nusages were tested manually:\n\n- **Latency chart link** (`apmLatencyChartOpenInDiscover`)\n- **Routes:** `/services/{serviceName}/overview`,\n`/services/{serviceName}/transactions`,\n`/services/{serviceName}/transactions/view`, and mobile equivalents\n  - **Source:** `components/shared/charts/latency_chart/index.tsx`\n\n- **Failed transaction rate chart link**\n(`apmFailedTransactionRateChartOpenInDiscover`)\n  - **Context:** Service detail (service + mobile)\n- **Source:**\n`components/shared/charts/failed_transaction_rate_chart/index.tsx`\n\n- **Service overview throughput chart link**\n(`apmServiceOverviewThroughputChartOpenInDiscover`)\n  - **Context:** Service detail overview (service + mobile)\n- **Source:**\n`components/app/service_overview/service_overview_throughput_chart/index.tsx`\n\n- **Waterfall header button** (`Open full trace in Discover`,\n`apmWaterfallOpenInDiscoverButton`)\n  - **Appears where `WaterfallWithSummary` is used:**\n    - Service/mobile transaction detail view\n- ~~Trace explorer waterfall (`/traces/explorer/waterfall`)~~ (scheduled\nto be removed https://github.com/elastic/kibana/issues/254449)\n    - Dependency operation detail (`/dependencies/operation`)\n- **Source:**\n`components/app/transaction_details/waterfall_with_summary/index.tsx`\n\n- **Span flyout button** (`spanFlyoutViewSpanInDiscoverLink`)\n- **Context:** In span flyout inside waterfall pages (same waterfall\ncontexts as above)\n- **Source:**\n`components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx`\n\n- **Error sample details button**\n(`errorGroupDetailsOpenErrorInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/errors/{groupId}`,\n`/mobile-services/{serviceName}/errors-and-crashes/errors/{groupId}`,\n`/mobile-services/{serviceName}/errors-and-crashes/crashes/{groupId}`\n- **Source:**\n`components/app/error_group_details/error_sampler/error_sample_detail.tsx`\n\n- **Latency correlations button**\n(`apmLatencyCorrelationsOpenInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/transactions/view`,\n`/mobile-services/{serviceName}/transactions/view`\n  - **Source:** `components/app/correlations/latency_correlations.tsx`\n\n- **Failed transaction correlations button**\n(`apmFailedCorrelationsViewInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/transactions/view`,\n`/mobile-services/{serviceName}/transactions/view`\n- **Source:**\n`components/app/correlations/failed_transactions_correlations.tsx`","sha":"f618b1dce58c8f4dab22d286a2c1ca67de2d1197","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","apm","backport:version","v9.4.0","Team:obs-presentation","v9.2.7","v9.3.2"],"title":"Decouple \"Open in Discover\" button from ApmServiceContext","number":255105,"url":"https://github.com/elastic/kibana/pull/255105","mergeCommit":{"message":"Decouple \"Open in Discover\" button from ApmServiceContext (#255105)\n\n## Summary\n\nCloses #254239\n\nThe \"Open in Discover\" button relied on `indexSettings` from\n`ApmServiceContext`, which is only available on service-level routes.\nThis meant the button was always disabled on pages without a service\ncontext, such as the dependency operation detail page.\n\n### Changes\n\n- Extracted `indexSettings` into a new dedicated\n`ApmIndexSettingsContext` so it can be provided independently of the\nservice context.\n- Wrapped `DependencyDetailTemplate`, `ApmServiceTemplate`,\n`MobileServiceTemplate`, and `ServiceGroupTemplate` with the new\nprovider.\n- Updated consumers to read from `useApmIndexSettingsContext()` instead\nof `useApmServiceContext()`.\n\nFixed button on dependency operation detail page:\n<img width=\"2560\" height=\"1287\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1af3e3c2-442c-4662-b4e5-1fb138f10b7d\"\n/>\n\n### Tessting\n\nDue to new context provider, the following `OpenInDiscover` button\nusages were tested manually:\n\n- **Latency chart link** (`apmLatencyChartOpenInDiscover`)\n- **Routes:** `/services/{serviceName}/overview`,\n`/services/{serviceName}/transactions`,\n`/services/{serviceName}/transactions/view`, and mobile equivalents\n  - **Source:** `components/shared/charts/latency_chart/index.tsx`\n\n- **Failed transaction rate chart link**\n(`apmFailedTransactionRateChartOpenInDiscover`)\n  - **Context:** Service detail (service + mobile)\n- **Source:**\n`components/shared/charts/failed_transaction_rate_chart/index.tsx`\n\n- **Service overview throughput chart link**\n(`apmServiceOverviewThroughputChartOpenInDiscover`)\n  - **Context:** Service detail overview (service + mobile)\n- **Source:**\n`components/app/service_overview/service_overview_throughput_chart/index.tsx`\n\n- **Waterfall header button** (`Open full trace in Discover`,\n`apmWaterfallOpenInDiscoverButton`)\n  - **Appears where `WaterfallWithSummary` is used:**\n    - Service/mobile transaction detail view\n- ~~Trace explorer waterfall (`/traces/explorer/waterfall`)~~ (scheduled\nto be removed https://github.com/elastic/kibana/issues/254449)\n    - Dependency operation detail (`/dependencies/operation`)\n- **Source:**\n`components/app/transaction_details/waterfall_with_summary/index.tsx`\n\n- **Span flyout button** (`spanFlyoutViewSpanInDiscoverLink`)\n- **Context:** In span flyout inside waterfall pages (same waterfall\ncontexts as above)\n- **Source:**\n`components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx`\n\n- **Error sample details button**\n(`errorGroupDetailsOpenErrorInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/errors/{groupId}`,\n`/mobile-services/{serviceName}/errors-and-crashes/errors/{groupId}`,\n`/mobile-services/{serviceName}/errors-and-crashes/crashes/{groupId}`\n- **Source:**\n`components/app/error_group_details/error_sampler/error_sample_detail.tsx`\n\n- **Latency correlations button**\n(`apmLatencyCorrelationsOpenInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/transactions/view`,\n`/mobile-services/{serviceName}/transactions/view`\n  - **Source:** `components/app/correlations/latency_correlations.tsx`\n\n- **Failed transaction correlations button**\n(`apmFailedCorrelationsViewInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/transactions/view`,\n`/mobile-services/{serviceName}/transactions/view`\n- **Source:**\n`components/app/correlations/failed_transactions_correlations.tsx`","sha":"f618b1dce58c8f4dab22d286a2c1ca67de2d1197"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255105","number":255105,"mergeCommit":{"message":"Decouple \"Open in Discover\" button from ApmServiceContext (#255105)\n\n## Summary\n\nCloses #254239\n\nThe \"Open in Discover\" button relied on `indexSettings` from\n`ApmServiceContext`, which is only available on service-level routes.\nThis meant the button was always disabled on pages without a service\ncontext, such as the dependency operation detail page.\n\n### Changes\n\n- Extracted `indexSettings` into a new dedicated\n`ApmIndexSettingsContext` so it can be provided independently of the\nservice context.\n- Wrapped `DependencyDetailTemplate`, `ApmServiceTemplate`,\n`MobileServiceTemplate`, and `ServiceGroupTemplate` with the new\nprovider.\n- Updated consumers to read from `useApmIndexSettingsContext()` instead\nof `useApmServiceContext()`.\n\nFixed button on dependency operation detail page:\n<img width=\"2560\" height=\"1287\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1af3e3c2-442c-4662-b4e5-1fb138f10b7d\"\n/>\n\n### Tessting\n\nDue to new context provider, the following `OpenInDiscover` button\nusages were tested manually:\n\n- **Latency chart link** (`apmLatencyChartOpenInDiscover`)\n- **Routes:** `/services/{serviceName}/overview`,\n`/services/{serviceName}/transactions`,\n`/services/{serviceName}/transactions/view`, and mobile equivalents\n  - **Source:** `components/shared/charts/latency_chart/index.tsx`\n\n- **Failed transaction rate chart link**\n(`apmFailedTransactionRateChartOpenInDiscover`)\n  - **Context:** Service detail (service + mobile)\n- **Source:**\n`components/shared/charts/failed_transaction_rate_chart/index.tsx`\n\n- **Service overview throughput chart link**\n(`apmServiceOverviewThroughputChartOpenInDiscover`)\n  - **Context:** Service detail overview (service + mobile)\n- **Source:**\n`components/app/service_overview/service_overview_throughput_chart/index.tsx`\n\n- **Waterfall header button** (`Open full trace in Discover`,\n`apmWaterfallOpenInDiscoverButton`)\n  - **Appears where `WaterfallWithSummary` is used:**\n    - Service/mobile transaction detail view\n- ~~Trace explorer waterfall (`/traces/explorer/waterfall`)~~ (scheduled\nto be removed https://github.com/elastic/kibana/issues/254449)\n    - Dependency operation detail (`/dependencies/operation`)\n- **Source:**\n`components/app/transaction_details/waterfall_with_summary/index.tsx`\n\n- **Span flyout button** (`spanFlyoutViewSpanInDiscoverLink`)\n- **Context:** In span flyout inside waterfall pages (same waterfall\ncontexts as above)\n- **Source:**\n`components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx`\n\n- **Error sample details button**\n(`errorGroupDetailsOpenErrorInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/errors/{groupId}`,\n`/mobile-services/{serviceName}/errors-and-crashes/errors/{groupId}`,\n`/mobile-services/{serviceName}/errors-and-crashes/crashes/{groupId}`\n- **Source:**\n`components/app/error_group_details/error_sampler/error_sample_detail.tsx`\n\n- **Latency correlations button**\n(`apmLatencyCorrelationsOpenInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/transactions/view`,\n`/mobile-services/{serviceName}/transactions/view`\n  - **Source:** `components/app/correlations/latency_correlations.tsx`\n\n- **Failed transaction correlations button**\n(`apmFailedCorrelationsViewInDiscoverButton`)\n- **Routes:** `/services/{serviceName}/transactions/view`,\n`/mobile-services/{serviceName}/transactions/view`\n- **Source:**\n`components/app/correlations/failed_transactions_correlations.tsx`","sha":"f618b1dce58c8f4dab22d286a2c1ca67de2d1197"}},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->