### PR TITLE
[Fleet] Agentless enable deployment sync by default

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -13,8 +13,6 @@ xpack.fleet.internal.useMeteringApi: true
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 xpack.fleet.internal.registry.spec.min: '3.0'
 xpack.fleet.internal.registry.spec.max: '3.5'
-xpack.fleet.agentless.backgroundSync.enabled: true
-xpack.fleet.agentless.backgroundSync.interval: '10m'
 
 ## Fine-tune the feature privileges.
 xpack.features.overrides:

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -223,9 +223,9 @@ export const config: PluginConfigDescriptor = {
           ),
           backgroundSync: schema.maybe(
             schema.object({
-              enabled: schema.boolean({ defaultValue: false }),
+              enabled: schema.boolean({ defaultValue: true }),
               dryRun: schema.boolean({ defaultValue: false }),
-              interval: schema.maybe(schema.string({ defaultValue: '1h' })),
+              interval: schema.maybe(schema.string({ defaultValue: '10m' })),
             })
           ),
         })

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.test.ts
@@ -10,8 +10,8 @@ import { createAppContextStartContractMock } from '../../mocks';
 import { appContextService } from '../app_context';
 import { agentPolicyService } from '../agent_policy';
 import type { AgentPolicy } from '../../types';
-
 import { isAgentlessEnabled } from '../utils/agentless';
+
 import { syncAgentlessDeployments } from './deployment_sync';
 
 jest.mock('../agent_policy');

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.test.ts
@@ -11,11 +11,15 @@ import { appContextService } from '../app_context';
 import { agentPolicyService } from '../agent_policy';
 import type { AgentPolicy } from '../../types';
 
+import { isAgentlessEnabled } from '../utils/agentless';
 import { syncAgentlessDeployments } from './deployment_sync';
 
 jest.mock('../agent_policy');
+jest.mock('../utils/agentless');
 
 function mockDependencies() {
+  jest.mocked(isAgentlessEnabled).mockReturnValue(true);
+
   const logger = loggingSystemMock.createLogger();
   const agentlessAgentService = {
     listAgentlessDeployments: jest.fn(),
@@ -453,6 +457,27 @@ describe('Agentless Deployment Sync', () => {
       expect(logger.info).toHaveBeenCalledWith(
         `[Agentless Deployment Sync][Dry Run] Creating deployment for policy policy8`
       );
+    });
+  });
+
+  describe('agentless not enabled', () => {
+    it('skips sync when agentless is not enabled', async () => {
+      jest.mocked(isAgentlessEnabled).mockReturnValue(false);
+      const logger = loggingSystemMock.createLogger();
+      const agentlessAgentService = {
+        listAgentlessDeployments: jest.fn(),
+        createAgentlessAgent: jest.fn(),
+        deleteAgentlessAgent: jest.fn(),
+      };
+
+      await syncAgentlessDeployments({ logger, agentlessAgentService });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[Agentless Deployment Sync] Agentless is not enabled. Skipping sync process.'
+      );
+      expect(agentlessAgentService.listAgentlessDeployments).not.toHaveBeenCalled();
+      expect(agentlessAgentService.createAgentlessAgent).not.toHaveBeenCalled();
+      expect(agentlessAgentService.deleteAgentlessAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
@@ -13,6 +13,7 @@ import { agentPolicyService, appContextService } from '..';
 
 import { AGENT_POLICY_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../constants';
 import { AgentlessAgentListNotFoundError } from '../../errors';
+import { isAgentlessEnabled } from '../utils/agentless';
 
 const AGENTLESS_CONCURRENCY = 1;
 const PAGE_SIZE = 20;
@@ -37,6 +38,11 @@ export async function syncAgentlessDeployments(
     abortController?: AbortController;
   }
 ) {
+  if (!isAgentlessEnabled()) {
+    logger.info(`[Agentless Deployment Sync] Agentless is not enabled. Skipping sync process.`);
+    return;
+  }
+
   logger.info(`[Agentless Deployment Sync] Starting sync process`);
   const soClient = appContextService.getInternalUserSOClientWithoutSpaceExtension();
 


### PR DESCRIPTION
## Summary

Enabled agentless deployment sync task so it's run on all environment with agentless (ECH+serverless) 

For context, that task sync agentless polices with agentless deployment.

Resolve https://github.com/elastic/kibana-team/issues/2959 

