### PR TITLE
[One Workflow] Support async step registrations

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -208,6 +208,6 @@ pageLoadAssetSize:
   visualizationListing: 5148
   visualizations: 52210
   watcher: 10485
-  workflowsExtensions: 101161
+  workflowsExtensions: 67119
   workflowsManagement: 21318
   workplaceAIApp: 65547

--- a/src/platform/plugins/shared/workflows_extensions/README.md
+++ b/src/platform/plugins/shared/workflows_extensions/README.md
@@ -42,6 +42,8 @@ This separation ensures that:
 - UI definition is available directly to client-side code without HTTP requests
 - Type safety is maintained between server and client registries via step type IDs
 
+**Async registration (public only):** The public step registry accepts either a definition or a **loader function** `() => Promise<PublicStepDefinition>`. Using a loader (e.g. `() => import('./my_step').then(m => m.myStepDefinition)`) allows step modules—and heavy dependencies like zod—to be loaded asynchronously, keeping them out of your plugin’s main bundle. The registry resolves loaders in the background; the workflows app awaits `workflowsExtensions.isReady()` before rendering so definitions are ready when needed.
+
 ## Architecture
 
 ```
@@ -528,10 +530,11 @@ export class MyPlugin implements Plugin {
 
 **Public-side** (`public/plugin.ts`):
 
+Register the public step definition using either a **direct definition** or an **async loader**. Prefer the loader form so the step module (and its dependencies, e.g. zod) are not pulled into your plugin’s main bundle:
+
 ```typescript
 import type { Plugin, CoreSetup, CoreStart } from '@kbn/core/public';
 import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
-import { myStepDefinition } from './workflows/step_types/my_step';
 
 export interface MyPluginPublicSetupDeps {
   workflowsExtensions: WorkflowsExtensionsPublicPluginSetup;
@@ -539,11 +542,19 @@ export interface MyPluginPublicSetupDeps {
 
 export class MyPlugin implements Plugin {
   public setup(_core: CoreSetup, plugins: MyPluginPublicSetupDeps) {
-    // Register public-side step definitions
-    plugins.workflowsExtensions.registerStepDefinition(myStepDefinition);
+    // Recommended: register via async loader to keep step module + zod out of main bundle
+    plugins.workflowsExtensions.registerStepDefinition(() =>
+      import('./workflows/step_types/my_step').then((m) => m.myStepDefinition)
+    );
+
+    // Alternatively: sync registration (pulls step module into main bundle)
+    // import { myStepDefinition } from './workflows/step_types/my_step';
+    // plugins.workflowsExtensions.registerStepDefinition(myStepDefinition);
   }
 }
 ```
+
+Loaders are resolved in the background after setup. The workflows app waits for `workflowsExtensions.isReady()` before rendering, so step definitions are available when the UI runs.
 
 ### Step 5: Get Approval
 
@@ -581,6 +592,8 @@ function MyComponent() {
   }
 }
 ```
+
+**Waiting for async step definitions:** If your app mounts before step definitions are needed, you can await `workflowsExtensions.isReady()` before rendering. That ensures all step definitions registered via async loaders have resolved. The workflows app does this in its mount so the step registry is ready when the UI runs.
 
 ## Step Type Requirements
 

--- a/src/platform/plugins/shared/workflows_extensions/public/mocks.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/mocks.ts
@@ -27,6 +27,7 @@ const createStartMock: () => jest.Mocked<WorkflowsExtensionsPublicPluginStart> =
     getAllTriggerDefinitions: jest.fn(() => []),
     getTriggerDefinition: jest.fn(),
     hasTriggerDefinition: jest.fn(),
+    isReady: jest.fn(() => Promise.resolve()),
   };
 };
 

--- a/src/platform/plugins/shared/workflows_extensions/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/plugin.ts
@@ -70,6 +70,9 @@ export class WorkflowsExtensionsPublicPlugin
       hasTriggerDefinition: (triggerId: string) => {
         return this.triggerRegistry.has(triggerId);
       },
+      isReady: () => {
+        return this.stepRegistry.whenReady();
+      },
     };
   }
 

--- a/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.test.ts
@@ -173,6 +173,25 @@ describe('PublicStepRegistry', () => {
       expect(registry.get('custom.async')).toEqual(asyncDef);
       expect(registry.getAll()).toHaveLength(2);
     });
+
+    it('should throw when loader resolves with undefined', async () => {
+      registry.register(() => Promise.resolve(undefined as unknown as PublicStepDefinition));
+
+      await expect(registry.whenReady()).rejects.toThrow('Step definition is not loaded correctly');
+    });
+
+    it('should throw when loader resolves with null', async () => {
+      registry.register(() => Promise.resolve(null as unknown as PublicStepDefinition));
+
+      await expect(registry.whenReady()).rejects.toThrow('Step definition is not loaded correctly');
+    });
+
+    it('should reject whenReady() when loader rejects', async () => {
+      const loadError = new Error('Failed to load step module');
+      registry.register(() => Promise.reject(loadError));
+
+      await expect(registry.whenReady()).rejects.toThrow('Failed to load step module');
+    });
   });
 
   describe('whenReady', () => {

--- a/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.test.ts
@@ -108,4 +108,77 @@ describe('PublicStepRegistry', () => {
       expect(all).toEqual([]);
     });
   });
+
+  describe('register with async loader', () => {
+    it('should resolve loader and add definition to registry', async () => {
+      registry.register(() => Promise.resolve(defaultDefinition));
+
+      expect(registry.has(stepId)).toBe(false);
+      await registry.whenReady();
+      expect(registry.has(stepId)).toBe(true);
+      expect(registry.get(stepId)).toEqual(defaultDefinition);
+    });
+
+    it('should throw when resolved definition duplicates an existing step type ID', async () => {
+      registry.register(defaultDefinition);
+      const loader = () => Promise.resolve({ ...defaultDefinition, label: 'Other' });
+
+      registry.register(loader);
+
+      await expect(registry.whenReady()).rejects.toThrow(
+        'Step definition for type "custom.myStep" is already registered'
+      );
+    });
+
+    it('whenReady() should resolve after all loaders have settled', async () => {
+      const def1: PublicStepDefinition = { ...defaultDefinition, id: 'custom.step1' };
+      const def2: PublicStepDefinition = { ...defaultDefinition, id: 'custom.step2' };
+      let resolve1!: (d: PublicStepDefinition) => void;
+      let resolve2!: (d: PublicStepDefinition) => void;
+      const promise1 = new Promise<PublicStepDefinition>((r) => {
+        resolve1 = r;
+      });
+      const promise2 = new Promise<PublicStepDefinition>((r) => {
+        resolve2 = r;
+      });
+
+      registry.register(() => promise1);
+      registry.register(() => promise2);
+
+      const readyPromise = registry.whenReady();
+      expect(registry.getAll()).toHaveLength(0);
+
+      resolve1(def1);
+      await Promise.resolve();
+      expect(registry.getAll()).toHaveLength(1);
+
+      resolve2(def2);
+      await readyPromise;
+      expect(registry.getAll()).toHaveLength(2);
+    });
+
+    it('should support mixed sync and async registration', async () => {
+      const syncDef: PublicStepDefinition = { ...defaultDefinition, id: 'custom.sync' };
+      const asyncDef: PublicStepDefinition = { ...defaultDefinition, id: 'custom.async' };
+
+      registry.register(syncDef);
+      registry.register(() => Promise.resolve(asyncDef));
+
+      expect(registry.has('custom.sync')).toBe(true);
+      expect(registry.has('custom.async')).toBe(false);
+
+      await registry.whenReady();
+
+      expect(registry.get('custom.sync')).toEqual(syncDef);
+      expect(registry.get('custom.async')).toEqual(asyncDef);
+      expect(registry.getAll()).toHaveLength(2);
+    });
+  });
+
+  describe('whenReady', () => {
+    it('should resolve immediately when no pending loaders', async () => {
+      registry.register(defaultDefinition);
+      await expect(registry.whenReady()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.ts
@@ -9,33 +9,56 @@
 
 import type { z } from '@kbn/zod/v4';
 import type { PublicStepDefinition } from './types';
+import type { PublicStepDefinitionOrLoader } from '../types';
 
 /**
  * Registry for public-side workflow step definition.
  * Stores UI-related information (label, description, icon) for step types.
+ * Accepts either a definition directly or a loader function that returns a promise of a definition.
  */
 export class PublicStepRegistry {
   private readonly registry = new Map<string, PublicStepDefinition>();
+  private readonly pending = new Set<Promise<void>>();
 
   /**
    * Register step definition.
-   * @param definition - The step definition to register
-   * @throws Error if definition for the same step type ID is already registered
+   * @param definitionOrLoader - The step definition to register, or a function that returns a promise of the definition (e.g. for dynamic imports)
+   * @throws Error if definition for the same step type ID is already registered (for sync; for async, when the promise resolves)
    */
   public register<
     Input extends z.ZodType = z.ZodType,
     Output extends z.ZodType = z.ZodType,
     Config extends z.ZodObject = z.ZodObject
-  >(definition: PublicStepDefinition<Input, Output, Config>): void {
+  >(definitionOrLoader: PublicStepDefinitionOrLoader<Input, Output, Config>): void {
+    if (typeof definitionOrLoader === 'function') {
+      const promise = definitionOrLoader()
+        .then((resolved) => this.addToRegistry(resolved as PublicStepDefinition))
+        .finally(() => this.pending.delete(promise));
+      this.pending.add(promise);
+    } else {
+      this.addToRegistry(definitionOrLoader as PublicStepDefinition);
+    }
+  }
+
+  private addToRegistry(definition: PublicStepDefinition): void {
     const stepTypeId = String(definition.id);
     if (this.registry.has(stepTypeId)) {
       throw new Error(
         `Step definition for type "${stepTypeId}" is already registered. Each step type must have unique definition.`
       );
     }
-    // Type assertion is safe here because the Map stores the base type
-    // and we don't need to preserve specific generic types after storage
-    this.registry.set(stepTypeId, definition as PublicStepDefinition);
+    this.registry.set(stepTypeId, definition);
+  }
+
+  /**
+   * Returns a promise that resolves when all pending async loaders have settled.
+   * Use before reading the registry if you need to guarantee all async registrations are complete.
+   */
+  public async whenReady(): Promise<void> {
+    if (this.pending.size === 0) {
+      return Promise.resolve();
+    }
+    return Promise.all([...this.pending]).then(() => {});
   }
 
   /**

--- a/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.ts
@@ -18,7 +18,7 @@ import type { PublicStepDefinitionOrLoader } from '../types';
  */
 export class PublicStepRegistry {
   private readonly registry = new Map<string, PublicStepDefinition>();
-  private readonly pending = new Set<Promise<void>>(); // Stores promises that in progress or rejected
+  private readonly pending = new Set<Promise<void>>(); // Stores promises that are either in progress or have been rejected
 
   /**
    * Register step definition.
@@ -67,13 +67,12 @@ export class PublicStepRegistry {
    */
   public async whenReady(): Promise<void> {
     if (this.pending.size > 0) {
-      return Promise.allSettled(this.pending).then((results) => {
-        results.forEach((result) => {
-          if (result.status === 'rejected') {
-            throw result.reason;
-          }
-        });
-      });
+      const results = await Promise.allSettled(this.pending);
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          throw result.reason;
+        }
+      }
     }
   }
 

--- a/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/step_registry/step_registry.ts
@@ -18,12 +18,11 @@ import type { PublicStepDefinitionOrLoader } from '../types';
  */
 export class PublicStepRegistry {
   private readonly registry = new Map<string, PublicStepDefinition>();
-  private readonly pending = new Set<Promise<void>>();
+  private readonly pending = new Set<Promise<void>>(); // Stores promises that in progress or rejected
 
   /**
    * Register step definition.
    * @param definitionOrLoader - The step definition to register, or a function that returns a promise of the definition (e.g. for dynamic imports)
-   * @throws Error if definition for the same step type ID is already registered (for sync; for async, when the promise resolves)
    */
   public register<
     Input extends z.ZodType = z.ZodType,
@@ -31,23 +30,35 @@ export class PublicStepRegistry {
     Config extends z.ZodObject = z.ZodObject
   >(definitionOrLoader: PublicStepDefinitionOrLoader<Input, Output, Config>): void {
     if (typeof definitionOrLoader === 'function') {
-      const promise = definitionOrLoader()
-        .then((resolved) => this.addToRegistry(resolved as PublicStepDefinition))
-        .finally(() => this.pending.delete(promise));
+      const promise = definitionOrLoader().then((definition) => {
+        if (!definition) {
+          throw new Error('Step definition is not loaded correctly');
+        }
+        this.addToRegistry(definition);
+        this.pending.delete(promise);
+      });
       this.pending.add(promise);
     } else {
-      this.addToRegistry(definitionOrLoader as PublicStepDefinition);
+      this.addToRegistry(definitionOrLoader);
     }
   }
 
-  private addToRegistry(definition: PublicStepDefinition): void {
-    const stepTypeId = String(definition.id);
-    if (this.registry.has(stepTypeId)) {
+  /**
+   * Add a step definition to the registry.
+   * @param definition - The step definition to add
+   * @throws Error if the step id is already registered
+   */
+  private addToRegistry<
+    Input extends z.ZodType = z.ZodType,
+    Output extends z.ZodType = z.ZodType,
+    Config extends z.ZodObject = z.ZodObject
+  >(definition: PublicStepDefinition<Input, Output, Config>): void {
+    if (this.registry.has(definition.id)) {
       throw new Error(
-        `Step definition for type "${stepTypeId}" is already registered. Each step type must have unique definition.`
+        `Step definition for type "${definition.id}" is already registered. Each step type must have unique definition.`
       );
     }
-    this.registry.set(stepTypeId, definition);
+    this.registry.set(definition.id, definition as PublicStepDefinition);
   }
 
   /**
@@ -55,10 +66,15 @@ export class PublicStepRegistry {
    * Use before reading the registry if you need to guarantee all async registrations are complete.
    */
   public async whenReady(): Promise<void> {
-    if (this.pending.size === 0) {
-      return Promise.resolve();
+    if (this.pending.size > 0) {
+      return Promise.allSettled(this.pending).then((results) => {
+        results.forEach((result) => {
+          if (result.status === 'rejected') {
+            throw result.reason;
+          }
+        });
+      });
     }
-    return Promise.all([...this.pending]).then(() => {});
   }
 
   /**

--- a/src/platform/plugins/shared/workflows_extensions/public/steps/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/steps/index.ts
@@ -7,29 +7,33 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { AiClassifyStepDefinition } from './ai/ai_classify_step';
-import { AiPromptStepDefinition } from './ai/ai_prompt_step';
-import { AiSummarizeStepDefinition } from './ai/ai_summarize_step';
-import {
-  dataAggregateStepDefinition,
-  dataDedupeStepDefinition,
-  dataFilterStepDefinition,
-  dataFindStepDefinition,
-  dataMapStepDefinition,
-  dataRegexExtractStepDefinition,
-  dataRegexReplaceStepDefinition,
-} from './data';
 import type { PublicStepRegistry } from '../step_registry';
 
 export const registerInternalStepDefinitions = (stepRegistry: PublicStepRegistry) => {
-  stepRegistry.register(dataMapStepDefinition);
-  stepRegistry.register(dataDedupeStepDefinition);
-  stepRegistry.register(dataFilterStepDefinition);
-  stepRegistry.register(dataFindStepDefinition);
-  stepRegistry.register(dataRegexExtractStepDefinition);
-  stepRegistry.register(dataRegexReplaceStepDefinition);
-  stepRegistry.register(dataAggregateStepDefinition);
-  stepRegistry.register(AiPromptStepDefinition);
-  stepRegistry.register(AiSummarizeStepDefinition);
-  stepRegistry.register(AiClassifyStepDefinition);
+  stepRegistry.register(() => import('./data/data_map_step').then((m) => m.dataMapStepDefinition));
+  stepRegistry.register(() =>
+    import('./data/data_dedupe_step').then((m) => m.dataDedupeStepDefinition)
+  );
+  stepRegistry.register(() =>
+    import('./data/data_filter_step').then((m) => m.dataFilterStepDefinition)
+  );
+  stepRegistry.register(() =>
+    import('./data/data_find_step').then((m) => m.dataFindStepDefinition)
+  );
+  stepRegistry.register(() =>
+    import('./data/data_regex_extract_step').then((m) => m.dataRegexExtractStepDefinition)
+  );
+  stepRegistry.register(() =>
+    import('./data/data_regex_replace_step').then((m) => m.dataRegexReplaceStepDefinition)
+  );
+  stepRegistry.register(() =>
+    import('./data/data_aggregate_step').then((m) => m.dataAggregateStepDefinition)
+  );
+  stepRegistry.register(() => import('./ai/ai_prompt_step').then((m) => m.AiPromptStepDefinition));
+  stepRegistry.register(() =>
+    import('./ai/ai_summarize_step').then((m) => m.AiSummarizeStepDefinition)
+  );
+  stepRegistry.register(() =>
+    import('./ai/ai_classify_step').then((m) => m.AiClassifyStepDefinition)
+  );
 };

--- a/src/platform/plugins/shared/workflows_extensions/public/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/types.ts
@@ -12,17 +12,24 @@ import type { PublicStepDefinition } from './step_registry/types';
 import type { PublicTriggerDefinition } from './trigger_registry/types';
 import type { WorkflowsExtensionsStartContract } from '../common/types';
 
+export type PublicStepDefinitionOrLoader<
+  Input extends z.ZodType = z.ZodType,
+  Output extends z.ZodType = z.ZodType,
+  Config extends z.ZodObject = z.ZodObject
+> =
+  | PublicStepDefinition<Input, Output, Config>
+  | (() => Promise<PublicStepDefinition<Input, Output, Config>>);
+
 /**
  * Public-side plugin setup contract.
  * Exposes methods for other plugins to register public-side step and trigger definitions.
  */
-
 export interface WorkflowsExtensionsPublicPluginSetup {
   /**
    * Register user-facing definition for a workflow step.
    * This should be called during the plugin's setup phase.
    *
-   * @param definition - The public-side step definition
+   * @param definition - The public-side step definition, or a function that returns a promise of the definition (e.g. for dynamic imports)
    * @throws Error if definition for the same step type ID is already registered
    */
   registerStepDefinition<
@@ -30,7 +37,7 @@ export interface WorkflowsExtensionsPublicPluginSetup {
     Output extends z.ZodType = z.ZodType,
     Config extends z.ZodObject = z.ZodObject
   >(
-    definition: PublicStepDefinition<Input, Output, Config>
+    definition: PublicStepDefinitionOrLoader<Input, Output, Config>
   ): void;
 
   /**
@@ -60,7 +67,14 @@ export interface TriggerRegistryStartContract {
  * Exposes methods for retrieving registered step and trigger definitions.
  */
 export type WorkflowsExtensionsPublicPluginStart =
-  WorkflowsExtensionsStartContract<PublicStepDefinition> & TriggerRegistryStartContract;
+  WorkflowsExtensionsStartContract<PublicStepDefinition> &
+    TriggerRegistryStartContract & {
+      /**
+       * Resolves when all async loaders have settled.
+       * Use before rendering the workflows UI to guarantee the registries are ready.
+       */
+      isReady(): Promise<void>;
+    };
 
 /**
  * Dependencies for the public plugin setup phase.

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
@@ -10,6 +10,7 @@
 import type { EuiThemeComputed } from '@elastic/eui';
 import { isDynamicConnector } from '@kbn/workflows';
 import type { WorkflowsExtensionsPublicPluginStart } from '@kbn/workflows-extensions/public';
+import { workflowsExtensionsMock } from '@kbn/workflows-extensions/public/mocks';
 import { z } from '@kbn/zod/v4';
 import { flattenOptions, getActionOptions } from './get_action_options';
 import { getAllConnectors } from '../../../../common/schema';
@@ -53,14 +54,7 @@ describe('getActionOptions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockWorkflowsExtensions = {
-      getStepDefinition: jest.fn(),
-      getAllStepDefinitions: jest.fn(),
-      hasStepDefinition: jest.fn(),
-      getAllTriggerDefinitions: jest.fn(() => []),
-      getTriggerDefinition: jest.fn(),
-      hasTriggerDefinition: jest.fn(),
-    };
+    mockWorkflowsExtensions = workflowsExtensionsMock.createStart();
 
     (getAllConnectors as jest.Mock).mockReturnValue([]);
     (isDynamicConnector as jest.MockedFunction<typeof isDynamicConnector>).mockImplementation(

--- a/src/platform/plugins/shared/workflows_management/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/public/plugin.ts
@@ -91,6 +91,7 @@ export class WorkflowsPlugin
         // Load application bundle
         const { renderApp } = await import('./application');
         const services = await this.createWorkflowsStartServices(core);
+
         return renderApp(services, params);
       },
     });
@@ -131,6 +132,9 @@ export class WorkflowsPlugin
       storage: new Storage(localStorage),
       workflowsManagement: { telemetry: this.telemetryService.getClient() },
     };
+
+    // Make sure the workflows extensions registries are ready before using the services
+    await depsStart.workflowsExtensions.isReady();
 
     return {
       ...coreStart,


### PR DESCRIPTION
## Summary

Step registration in `workflows_extensions` now supports async loaders (e.g. `() => import('./step').then(m => m.definition`)). 
Plugins can register steps without pulling zod and other heavy deps into their main bundle. The registry still exposes a sync read API (`get` / `getAll` / `has`); async resolution is handled internally and is awaited at app mount time.

## What changed

- **`PublicStepRegistry`** accepts either a definition or a **loader**: `() => Promise<PublicStepDefinition>`.
- Loaders are started in the background during setup; definitions are added to the registry when their promises resolve.
- **`isReady()`** was added to the workflows_extensions **start** contract so consumers can wait until all async step definitions have resolved.
- **Workflows Management** app now **awaits `workflowsExtensions.isReady()`** in its `mount` before rendering, so the step registry is fully ready when the UI runs.
- **Internal steps** (data.* and ai.*) in `workflows_extensions` were switched to async loaders so the plugin’s own main bundle stays small.

## For contributors: how to keep your plugin’s bundle small

You no longer need to synchronously import step modules (and thus zod, etc.) in your plugin’s setup. Use a **dynamic import** when registering:

**Before (pulls step module + zod into main bundle):**

```ts
import { myStepDefinition } from './workflows/my_step';

export function setup(core, plugins) {
  plugins.workflowsExtensions.registerStepDefinition(myStepDefinition);
}
```

**After (step module + zod loaded only when the loader runs):**

```ts
export function setup(core, plugins) {
  plugins.workflowsExtensions.registerStepDefinition(
    () => import('./workflows/my_step').then((m) => m.myStepDefinition)
  );
}
```

Registration stays **synchronous**; only the *loading* of the definition is async. The workflows app waits for `isReady()` before rendering, so step definitions are available when the UI needs them. No need to grow your plugin’s main bundle for workflow steps anymore.