### PR TITLE
[Streams] Add EIS cost callout in all places

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/additional_charges_callout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/additional_charges_callout.tsx
@@ -8,8 +8,8 @@
 import React from 'react';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import type { AIFeatures } from '../../../../../../../hooks/use_ai_features';
-import { useKibana } from '../../../../../../../hooks/use_kibana';
+import type { AIFeatures } from '../../../hooks/use_ai_features';
+import { useKibana } from '../../../hooks/use_kibana';
 
 export interface AdditionalChargesCalloutProps {
   aiFeatures: AIFeatures;
@@ -31,6 +31,7 @@ export const AdditionalChargesCallout = ({ aiFeatures }: AdditionalChargesCallou
               href={docLinks?.links?.observability?.elasticManagedLlmUsageCost}
               target="_blank"
               rel="noopener noreferrer"
+              external
             >
               {chunks}
             </EuiLink>
@@ -40,6 +41,7 @@ export const AdditionalChargesCallout = ({ aiFeatures }: AdditionalChargesCallou
               href={docLinks?.links?.observability?.elasticManagedLlm}
               target="_blank"
               rel="noopener noreferrer"
+              external
             >
               {chunks}
             </EuiLink>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/dissect/dissect_pattern_suggestion.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/dissect/dissect_pattern_suggestion.tsx
@@ -27,7 +27,7 @@ import { useStreamDetail } from '../../../../../../../hooks/use_stream_detail';
 import { selectPreviewRecords } from '../../../../state_management/simulation_state_machine/selectors';
 import { useSimulatorSelector } from '../../../../state_management/stream_enrichment_state_machine';
 import type { ProcessorFormState } from '../../../../types';
-import { AdditionalChargesCallout } from '../grok/additional_charges_callout';
+import { AdditionalChargesCallout } from '../../../../../shared/additional_charges_callout';
 import { GenerateSuggestionButton } from '../../../../../stream_detail_routing/review_suggestions_form/generate_suggestions_button';
 import { useDissectPatternSuggestion } from './use_dissect_pattern_suggestion';
 import type { AIFeatures } from '../../../../../../../hooks/use_ai_features';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/grok/grok_pattern_suggestion.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/grok/grok_pattern_suggestion.tsx
@@ -29,7 +29,7 @@ import { useStreamDetail } from '../../../../../../../hooks/use_stream_detail';
 import { selectPreviewRecords } from '../../../../state_management/simulation_state_machine/selectors';
 import { useSimulatorSelector } from '../../../../state_management/stream_enrichment_state_machine';
 import type { GrokFormState, ProcessorFormState } from '../../../../types';
-import { AdditionalChargesCallout } from './additional_charges_callout';
+import { AdditionalChargesCallout } from '../../../../../shared/additional_charges_callout';
 import { GenerateSuggestionButton } from '../../../../../stream_detail_routing/review_suggestions_form/generate_suggestions_button';
 import { useGrokPatternSuggestion } from './use_grok_pattern_suggestion';
 import type { AIFeatures } from '../../../../../../../hooks/use_ai_features';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/steps_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/steps_editor.tsx
@@ -26,6 +26,7 @@ import { validationErrorTypeLabels } from '@kbn/streamlang';
 import { useAIFeatures } from '../../../../hooks/use_ai_features';
 import { useStreamDetail } from '../../../../hooks/use_stream_detail';
 import { GenerateSuggestionButton } from '../../stream_detail_routing/review_suggestions_form/generate_suggestions_button';
+import { AdditionalChargesCallout } from '../../shared/additional_charges_callout';
 import { NoStepsEmptyPrompt } from '../empty_prompts';
 import { PipelineSuggestion } from '../pipeline_suggestions/pipeline_suggestion';
 import {
@@ -371,15 +372,23 @@ export const StepsEditor = React.memo(() => {
       !canUsePipelineSuggestions && canUsePipelineSuggestionsPending ? null : (
         <NoStepsEmptyPrompt canUsePipelineSuggestions={!!canUsePipelineSuggestions}>
           {canUsePipelineSuggestions && (
-            <GenerateSuggestionButton
-              aiFeatures={aiFeatures}
-              isLoading={isLoadingSuggestion}
-              onClick={(connectorId) => suggestPipeline({ connectorId, streamName: stream.name })}
-            >
-              {i18n.translate('xpack.streams.stepsEditor.suggestPipelineButtonLabel', {
-                defaultMessage: 'Suggest a pipeline',
-              })}
-            </GenerateSuggestionButton>
+            <>
+              <GenerateSuggestionButton
+                aiFeatures={aiFeatures}
+                isLoading={isLoadingSuggestion}
+                onClick={(connectorId) => suggestPipeline({ connectorId, streamName: stream.name })}
+              >
+                {i18n.translate('xpack.streams.stepsEditor.suggestPipelineButtonLabel', {
+                  defaultMessage: 'Suggest a pipeline',
+                })}
+              </GenerateSuggestionButton>
+              {aiFeatures.isManagedAIConnector && !aiFeatures.hasAcknowledgedAdditionalCharges && (
+                <>
+                  <EuiSpacer size="s" />
+                  <AdditionalChargesCallout aiFeatures={aiFeatures} />
+                </>
+              )}
+            </>
           )}
         </NoStepsEmptyPrompt>
       )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
@@ -40,6 +40,7 @@ import {
 import { IdleQueryStreamEntry, CreatingQueryStreamEntry } from './query_stream_entry';
 import { ReviewSuggestionsForm } from './review_suggestions_form/review_suggestions_form';
 import { GenerateSuggestionButton } from './review_suggestions_form/generate_suggestions_button';
+import { AdditionalChargesCallout } from '../shared/additional_charges_callout';
 import { NoSuggestionsCallout } from './review_suggestions_form/no_suggestions_callout';
 import { useReviewSuggestionsForm } from './review_suggestions_form/use_review_suggestions_form';
 import { useTimefilter } from '../../../hooks/use_timefilter';
@@ -198,6 +199,9 @@ function IngestModeChildrenList({ availableStreams }: { availableStreams: string
   // This isRefreshing tracks async gap between operation completion and server data arrival
   const isRefreshing = useStreamsRoutingSelector((snapshot) => snapshot.context.isRefreshing);
 
+  const showAdditionalChargesCallout =
+    !!aiFeatures?.isManagedAIConnector && !aiFeatures?.hasAcknowledgedAdditionalCharges;
+
   const hasData = routing.length > 0 || (aiFeatures?.enabled && suggestions);
 
   const handlerItemDrag: DragDropContextProps['onDragEnd'] = ({ source, destination }) => {
@@ -231,17 +235,24 @@ function IngestModeChildrenList({ availableStreams }: { availableStreams: string
           wrap
         >
           {aiFeatures?.enabled && !isLoadingSuggestions && !suggestions && (
-            <EuiFlexItem grow={false}>
-              <GenerateSuggestionButton
-                size="s"
-                onClick={getSuggestionsForStream}
-                isLoading={isLoadingSuggestions}
-                isDisabled={isEditingOrReorderingStreams}
-                aiFeatures={aiFeatures}
-              >
-                {suggestPartitionsWithAIText}
-              </GenerateSuggestionButton>
-            </EuiFlexItem>
+            <>
+              <EuiFlexItem grow={false}>
+                <GenerateSuggestionButton
+                  size="s"
+                  onClick={getSuggestionsForStream}
+                  isLoading={isLoadingSuggestions}
+                  isDisabled={isEditingOrReorderingStreams}
+                  aiFeatures={aiFeatures}
+                >
+                  {suggestPartitionsWithAIText}
+                </GenerateSuggestionButton>
+              </EuiFlexItem>
+              {showAdditionalChargesCallout && (
+                <EuiFlexItem grow={false}>
+                  <AdditionalChargesCallout aiFeatures={aiFeatures} />
+                </EuiFlexItem>
+              )}
+            </>
           )}
           <EuiFlexItem grow={false}>
             <EuiToolTip
@@ -270,15 +281,23 @@ function IngestModeChildrenList({ availableStreams }: { availableStreams: string
       isAiEnabled={!!aiFeatures?.enabled}
     >
       {aiFeatures?.enabled && (
-        <GenerateSuggestionButton
-          size="s"
-          onClick={getSuggestionsForStream}
-          isLoading={isLoadingSuggestions}
-          isDisabled={isEditingOrReorderingStreams}
-          aiFeatures={aiFeatures}
-        >
-          {suggestPartitionsWithAIText}
-        </GenerateSuggestionButton>
+        <>
+          <GenerateSuggestionButton
+            size="s"
+            onClick={getSuggestionsForStream}
+            isLoading={isLoadingSuggestions}
+            isDisabled={isEditingOrReorderingStreams}
+            aiFeatures={aiFeatures}
+          >
+            {suggestPartitionsWithAIText}
+          </GenerateSuggestionButton>
+          {showAdditionalChargesCallout && (
+            <>
+              <EuiSpacer size="s" />
+              <AdditionalChargesCallout aiFeatures={aiFeatures} />
+            </>
+          )}
+        </>
       )}
     </NoDataEmptyPrompt>
   ) : (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/review_suggestions_form/generate_suggestions_button.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/review_suggestions_form/generate_suggestions_button.test.tsx
@@ -10,9 +10,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import {
   GenerateSuggestionButton,
-  AdditionalChargesCallout,
   type GenerateSuggestionButtonProps,
 } from './generate_suggestions_button';
+import { AdditionalChargesCallout } from '../../shared/additional_charges_callout';
 import type { AIFeatures } from '../../../../hooks/use_ai_features';
 import type { UseGenAIConnectorsResult, Connector } from '../../../../hooks/use_genai_connectors';
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/review_suggestions_form/generate_suggestions_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/review_suggestions_form/generate_suggestions_button.tsx
@@ -6,11 +6,9 @@
  */
 
 import React from 'react';
-import { type EuiButtonProps, EuiCallOut, EuiLink } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import type { EuiButtonProps } from '@elastic/eui';
 import type { AIFeatures } from '../../../../hooks/use_ai_features';
 import { ConnectorListButtonBase } from '../../../connector_list_button/connector_list_button';
-import { useKibana } from '../../../../hooks/use_kibana';
 
 export interface GenerateSuggestionButtonProps extends EuiButtonProps {
   onClick(connectorId: string): void;
@@ -40,46 +38,5 @@ export const GenerateSuggestionButton = ({
         ...rest,
       }}
     />
-  );
-};
-
-export interface AdditionalChargesCalloutProps {
-  aiFeatures: AIFeatures;
-}
-
-export const AdditionalChargesCallout = ({ aiFeatures }: AdditionalChargesCalloutProps) => {
-  const {
-    core: { docLinks },
-  } = useKibana();
-
-  return (
-    <EuiCallOut onDismiss={() => aiFeatures.acknowledgeAdditionalCharges(true)}>
-      <FormattedMessage
-        id="xpack.streams.streamDetailView.managementTab.enrichment.processorFlyout.managedConnectorTooltip"
-        defaultMessage="Elastic Managed LLM is the new default for generating patterns and incurs <costLink>additional charges</costLink>. Other LLM connectors remain available. <learnMoreLink>Learn more</learnMoreLink>"
-        values={{
-          costLink: (...chunks: React.ReactNode[]) => (
-            <EuiLink
-              href={docLinks?.links?.observability?.elasticManagedLlmUsageCost}
-              target="_blank"
-              rel="noopener noreferrer"
-              external
-            >
-              {chunks}
-            </EuiLink>
-          ),
-          learnMoreLink: (...chunks: React.ReactNode[]) => (
-            <EuiLink
-              href={docLinks?.links?.observability?.elasticManagedLlm}
-              target="_blank"
-              rel="noopener noreferrer"
-              external
-            >
-              {chunks}
-            </EuiLink>
-          ),
-        }}
-      />
-    </EuiCallOut>
   );
 };


### PR DESCRIPTION
Closes https://github.com/elastic/streams-program/issues/915

## Summary

- Moved AdditionalChargesCallout from `grok/additional_charges_callout.tsx` to `data_management/shared/additional_charges_callout.tsx`, consolidating the two duplicate copies (one in `grok/`, one in `generate_suggestions_button.tsx`) into a single shared component with the external prop on doc links
- Added the EIS cost callout to the suggest pipeline empty state (steps_editor.tsx) and the creating partitions suggestions (`child_stream_list.tsx`)
- Updated all existing consumers (grok, dissect) and the test file to import from the shared location

Test plan

With Elastic Managed LLM connector selected, verify the callout appears on:

- [x] Enrichment tab > empty state ("Suggest a pipeline" button)
- [x] Partitioning tab > empty state ("Suggest partitions with AI" button)
- [x] Partitioning tab > non-empty state (existing partitions with "Suggest partitions with AI" button)
- [x] Enrichment tab > Grok processor flyout ("Generate pattern" button)
- [x] Enrichment tab > Dissect processor flyout ("Generate pattern" button)
- [x] Verify dismissing the callout in any location hides it everywhere
- [x] Verify callout does not appear when a non-Elastic Managed connector is selected