### PR TITLE
[dashboards as code] remove 'version' key from panel schema

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -63,15 +63,6 @@ export function getPanelSchema(isDashboardAppRequest: boolean) {
         meta: { description: 'The unique ID of the panel.' },
       })
     ),
-    version: schema.maybe(
-      schema.string({
-        meta: {
-          description:
-            "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (config in this type).",
-          deprecated: true,
-        },
-      })
-    ),
   };
 
   // looser route validation for dashboard application requests

--- a/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.test.ts
@@ -50,7 +50,6 @@ describe('transformDashboardIn', () => {
           uid: '1',
           title: 'title1',
           type: 'type1',
-          version: '2',
         },
       ],
       tags: [],
@@ -71,7 +70,7 @@ describe('transformDashboardIn', () => {
             "searchSourceJSON": "{\\"query\\":{\\"query\\":\\"test\\",\\"language\\":\\"KQL\\"}}",
           },
           "optionsJSON": "{\\"hidePanelTitles\\":true,\\"useMargins\\":false,\\"syncColors\\":false,\\"syncTooltips\\":false,\\"syncCursor\\":false,\\"autoApplyFilters\\":true}",
-          "panelsJSON": "[{\\"title\\":\\"title1\\",\\"type\\":\\"type1\\",\\"version\\":\\"2\\",\\"embeddableConfig\\":{\\"enhancements\\":{},\\"savedObjectId\\":\\"1\\"},\\"panelIndex\\":\\"1\\",\\"gridData\\":{\\"x\\":0,\\"y\\":0,\\"w\\":10,\\"h\\":10,\\"i\\":\\"1\\"}}]",
+          "panelsJSON": "[{\\"title\\":\\"title1\\",\\"type\\":\\"type1\\",\\"embeddableConfig\\":{\\"enhancements\\":{},\\"savedObjectId\\":\\"1\\"},\\"panelIndex\\":\\"1\\",\\"gridData\\":{\\"x\\":0,\\"y\\":0,\\"w\\":10,\\"h\\":10,\\"i\\":\\"1\\"}}]",
           "pinned_panels": Object {
             "panels": Object {
               "foo": Object {

--- a/src/platform/plugins/shared/dashboard/server/api/transforms/out/transform_dashboard_out.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/out/transform_dashboard_out.test.ts
@@ -91,7 +91,6 @@ describe('transformDashboardOut', () => {
           grid: { x: 0, y: 0, w: 10, h: 10 },
           uid: '1',
           type: 'type1',
-          version: '2',
         },
       ],
       title: 'my title',
@@ -181,7 +180,6 @@ describe('transformDashboardOut', () => {
           },
           uid: '1',
           type: 'type1',
-          version: '2',
         },
       ],
       refresh_interval: {
@@ -268,7 +266,6 @@ describe('transformDashboardOut', () => {
           },
           uid: '1',
           type: 'type1',
-          version: '2',
         },
       ],
       title: 'title',

--- a/src/platform/plugins/shared/dashboard/server/api/transforms/out/transform_panels_out.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/out/transform_panels_out.ts
@@ -62,7 +62,7 @@ function transformPanelProperties(
   containerReferences?: SavedObjectReference[]
 ) {
   const { panel, panelReferences } = panelBwc(storedPanel, storedPanelReferences ?? []);
-  const { embeddableConfig, gridData, panelIndex, type, version } = panel;
+  const { embeddableConfig, gridData, panelIndex, type } = panel;
 
   const { sectionId, i, ...restOfGrid } = gridData;
 
@@ -85,6 +85,5 @@ function transformPanelProperties(
     config: transformedPanelConfig ? transformedPanelConfig : embeddableConfig,
     uid: panelIndex,
     type,
-    ...(version && { version }),
   };
 }


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/255826

PR removes deprecated `version` key from panel schema. Version key not used in Kibana.