### PR TITLE
[8.19] [Task Manager] add x_opaque_id to more task manager taskStore (#252442)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/moon.yml
+++ b/x-pack/platform/plugins/shared/task_manager/moon.yml
@@ -47,6 +47,9 @@ dependsOn:
   - '@kbn/logging-mocks'
   - '@kbn/spaces-utils'
   - '@kbn/es-errors'
+  - '@kbn/core-execution-context-server-mocks'
+  - '@kbn/core-execution-context-common'
+  - '@kbn/core-http-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/task_manager/moon.yml
+++ b/x-pack/platform/plugins/shared/task_manager/moon.yml
@@ -49,7 +49,6 @@ dependsOn:
   - '@kbn/es-errors'
   - '@kbn/core-execution-context-server-mocks'
   - '@kbn/core-execution-context-common'
-  - '@kbn/core-http-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/execution_context.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/execution_context.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { executionContextServiceMock } from '@kbn/core-execution-context-server-mocks';
+
+// import type { ExecutionContextRunner } from './execution_context';
+import { getExecutionContextRunner } from './execution_context';
+
+function getContextSetup() {
+  return executionContextServiceMock.createInternalSetupContract();
+}
+
+describe('execution_context', () => {
+  describe('getExecutionContextRunner', () => {
+    test('works as expected for async usage', async () => {
+      const contextSetup = getContextSetup();
+      const runner = getExecutionContextRunner(contextSetup, {
+        id: 'foo',
+        name: 'bar',
+      });
+
+      const result = await runner.run(async () => Promise.resolve(42));
+      expect(result).toBe(42);
+
+      expect(contextSetup.withContext).toBeCalledWith(
+        {
+          id: 'foo',
+          name: 'bar',
+          type: 'task manager',
+        },
+        expect.any(Function)
+      );
+    });
+
+    test('works as expected for sync usage', async () => {
+      const contextSetup = getContextSetup();
+      const runner = getExecutionContextRunner(contextSetup, {
+        id: 'foo',
+        name: 'bar',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await runner.run(() => 42 as any);
+      expect(result).toBe(42);
+
+      expect(contextSetup.withContext).toBeCalledWith(
+        {
+          id: 'foo',
+          name: 'bar',
+          type: 'task manager',
+        },
+        expect.any(Function)
+      );
+    });
+
+    test('type can not be overridden', async () => {
+      const contextSetup = getContextSetup();
+      const runner = getExecutionContextRunner(contextSetup, {
+        type: 'kinda global',
+      });
+
+      const result = await runner.run(async () => Promise.resolve(42), {
+        type: 'more local',
+      });
+      expect(result).toBe(42);
+
+      expect(contextSetup.withContext).toBeCalledWith(
+        {
+          type: 'task manager',
+        },
+        expect.any(Function)
+      );
+    });
+
+    test('top-level properties cannot be overridden', async () => {
+      const contextSetup = getContextSetup();
+      const runner = getExecutionContextRunner(contextSetup, {
+        id: 'kinda global',
+      });
+
+      const result = await runner.run(async () => Promise.resolve(42), {
+        id: 'more local',
+      });
+      expect(result).toBe(42);
+
+      expect(contextSetup.withContext).toBeCalledWith(
+        {
+          type: 'task manager',
+          id: 'kinda global',
+        },
+        expect.any(Function)
+      );
+    });
+
+    test('works with no extra properties', async () => {
+      const contextSetup = getContextSetup();
+      const runner = getExecutionContextRunner(contextSetup);
+
+      const result = await runner.run(async () => Promise.resolve(42));
+      expect(result).toBe(42);
+
+      expect(contextSetup.withContext).toBeCalledWith(
+        {
+          type: 'task manager',
+        },
+        expect.any(Function)
+      );
+    });
+
+    test('works with no top-level properties', async () => {
+      const contextSetup = getContextSetup();
+      const runner = getExecutionContextRunner(contextSetup);
+
+      const result = await runner.run(async () => Promise.resolve(42), { id: 'foo' });
+      expect(result).toBe(42);
+
+      expect(contextSetup.withContext).toBeCalledWith(
+        {
+          type: 'task manager',
+          id: 'foo',
+        },
+        expect.any(Function)
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/execution_context.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/execution_context.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaExecutionContext } from '@kbn/core-execution-context-common';
+import type { ExecutionContextSetup } from '@kbn/core/server';
+
+export interface CreateExecutionContextArgs {
+  contextSetup: ExecutionContextSetup;
+  baseContext: KibanaExecutionContext;
+}
+
+export interface ExecutionContextRunner {
+  run<T>(fn: () => Promise<T>, context?: KibanaExecutionContext): Promise<T>;
+}
+export class ExecutionContextRunnerImpl implements ExecutionContextRunner {
+  private contextSetup: ExecutionContextSetup;
+  private baseContext: KibanaExecutionContext;
+
+  constructor(args: CreateExecutionContextArgs) {
+    this.contextSetup = args.contextSetup;
+    this.baseContext = args.baseContext;
+  }
+
+  async run<T>(fn: () => Promise<T>, context: KibanaExecutionContext = {}): Promise<T> {
+    // apply the contexts in order, always add type: "task manager"
+    const finalContext = { ...context, ...this.baseContext, type: 'task manager' };
+    return this.contextSetup.withContext(finalContext, fn);
+  }
+}
+
+export function getExecutionContextRunner(
+  contextSetup: ExecutionContextSetup,
+  baseContext: KibanaExecutionContext = {}
+): ExecutionContextRunner {
+  return new ExecutionContextRunnerImpl({ contextSetup, baseContext });
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -333,6 +333,7 @@ export class TaskManagerPlugin
       canEncryptSavedObjects: this.canEncryptSavedObjects,
       getIsSecurityEnabled: this.licenseSubscriber?.getIsSecurityEnabled,
       basePath: http.basePath,
+      executionContext,
     });
 
     const isServerless = this.initContext.env.packageInfo.buildFlavor === 'serverless';

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -122,8 +122,9 @@ export interface FailedTaskResult {
   status: TaskStatus.Failed | TaskStatus.DeadLetter;
 }
 
-export type RunFunction = () => Promise<RunResult | undefined | void>;
-export type CancelFunction = () => Promise<RunResult | undefined | void>;
+export type AnyRunResult = RunResult | undefined | void;
+export type RunFunction = () => Promise<AnyRunResult>;
+export type CancelFunction = () => Promise<AnyRunResult>;
 export interface CancellableTask<T = never> {
   run: RunFunction;
   cancel?: CancelFunction;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -39,6 +39,7 @@ import {
   promiseResult,
   unwrap,
 } from '../lib/result_type';
+import { getExecutionContextRunner } from '../lib/execution_context';
 import type { TaskMarkRunning, TaskRun, TaskTiming, TaskManagerStat } from '../task_events';
 import {
   asTaskMarkRunningEvent,
@@ -397,14 +398,13 @@ export class TaskManagerRunner implements TaskRunner {
       );
       this.task = definition.createTaskRunner({ taskInstance: sanitizedTaskInstance, fakeRequest });
 
-      const ctx = {
-        type: 'task manager',
+      const runner = getExecutionContextRunner(this.executionContext, {
         name: `run ${this.instance.task.taskType}`,
         id: this.instance.task.id,
         description: 'run task',
-      };
+      });
 
-      const result = await this.executionContext.withContext(ctx, () =>
+      const result = await runner.run(() =>
         withSpan({ name: 'run', type: 'task manager' }, () => this.task!.run())
       );
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -26,6 +26,8 @@ import { TaskStore, taskInstanceToAttributes } from './task_store';
 import { savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
 import type { SavedObjectAttributes, IBasePath } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { executionContextServiceMock } from '@kbn/core-execution-context-server-mocks';
+
 import { TaskTypeDictionary } from './task_type_dictionary';
 import { mockLogger } from './test_utils';
 import { AdHocTaskCounter } from './lib/adhoc_task_counter';
@@ -65,6 +67,7 @@ const adHocTaskCounter = new AdHocTaskCounter();
 const randomId = () => `id-${_.random(1, 20)}`;
 
 const coreStart = coreMock.createStart();
+const mockExecutionContextStart = executionContextServiceMock.createSetupContract();
 
 const basePathMock = { get: () => '/', serverBasePath: '/' } as unknown as IBasePath;
 
@@ -78,6 +81,10 @@ beforeEach(() => {
   mockGetValidatedTaskInstanceForUpdating = jest
     .spyOn(TaskValidator.prototype, 'getValidatedTaskInstanceForUpdating')
     .mockImplementation((task) => task);
+
+  mockExecutionContextStart.withContext.mockImplementation((ctx: unknown, fn: () => unknown) =>
+    fn()
+  );
 });
 
 const mockedDate = new Date('2019-02-12T21:01:22.479Z');
@@ -140,6 +147,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       store.registerEncryptedSavedObjectsClient(esoClient);
@@ -269,6 +277,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => false,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       store.registerEncryptedSavedObjectsClient(esoClient);
@@ -423,6 +432,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: false,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       const task = {
@@ -551,6 +561,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -689,6 +700,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       esoClient.createPointInTimeFinderDecryptedAsInternalUser = jest.fn().mockResolvedValue({
@@ -876,6 +888,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -1010,6 +1023,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -1210,6 +1224,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -1439,6 +1454,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -1991,6 +2007,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       esoClient.createPointInTimeFinderDecryptedAsInternalUser = jest.fn().mockResolvedValue({
@@ -2113,6 +2130,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       esoClient.createPointInTimeFinderDecryptedAsInternalUser = jest.fn().mockResolvedValue({
@@ -2185,6 +2203,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -2252,6 +2271,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -2354,6 +2374,7 @@ describe('TaskStore', () => {
             security: coreStart.security,
             getIsSecurityEnabled: () => true,
             basePath: basePathMock,
+            executionContext: mockExecutionContextStart,
           });
 
           expect(await store.getLifecycle(task.id)).toEqual(status);
@@ -2383,6 +2404,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       expect(await store.getLifecycle(randomId())).toEqual(TaskLifecycleResult.NotFound);
@@ -2410,6 +2432,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       return expect(store.getLifecycle(randomId())).rejects.toThrow('Bad Request');
@@ -2439,6 +2462,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       store.registerEncryptedSavedObjectsClient(esoClient);
@@ -2712,6 +2736,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: false,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       const task1 = {
@@ -2747,6 +2772,7 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => false,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       store.registerEncryptedSavedObjectsClient(esoClient);
@@ -3005,6 +3031,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       savedObjectsClient.create.mockImplementation(async (type: string, attributes: unknown) => ({
@@ -3057,6 +3084,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
 
       savedObjectsClient.create.mockImplementation(async (type: string, attributes: unknown) => ({
@@ -3110,6 +3138,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
     test('should pass requestTimeout', async () => {
@@ -3151,6 +3180,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 
@@ -3273,6 +3303,7 @@ describe('TaskStore', () => {
         security: coreStart.security,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
       });
     });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -38,10 +38,13 @@ import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-s
 
 import { decodeRequestVersion, encodeVersion } from '@kbn/core-saved-objects-base-server-internal';
 import { nodeBuilder } from '@kbn/es-query';
-import type { IBasePath } from '@kbn/core/server';
+import type { IBasePath, ExecutionContextStart } from '@kbn/core/server';
+
 import type { RequestTimeoutsConfig } from './config';
 import type { Result } from './lib/result_type';
 import { asOk, asErr, unwrap } from './lib/result_type';
+import type { ExecutionContextRunner } from './lib/execution_context';
+import { getExecutionContextRunner } from './lib/execution_context';
 
 import type {
   ConcreteTaskInstance,
@@ -85,6 +88,7 @@ export interface StoreOpts {
   esoClient?: EncryptedSavedObjectsClient;
   getIsSecurityEnabled: () => boolean;
   basePath: IBasePath;
+  executionContext: ExecutionContextStart;
 }
 
 export interface SearchOpts {
@@ -157,6 +161,7 @@ export class TaskStore {
   private getIsSecurityEnabled: () => boolean;
   private logger: Logger;
   private basePath: IBasePath;
+  private executionContextRunner: ExecutionContextRunner;
 
   /**
    * Constructs a new TaskStore.
@@ -193,6 +198,10 @@ export class TaskStore {
     this.getIsSecurityEnabled = opts.getIsSecurityEnabled;
     this.logger = opts.logger;
     this.basePath = opts.basePath;
+    this.executionContextRunner = getExecutionContextRunner(opts.executionContext, {
+      name: 'taskStore',
+      // individual executions can be specialized with an `id` property ...
+    });
   }
 
   public registerEncryptedSavedObjectsClient(client: EncryptedSavedObjectsClient) {
@@ -324,6 +333,14 @@ export class TaskStore {
     taskInstance: TaskInstance,
     options?: ApiKeyOptions
   ): Promise<ConcreteTaskInstance> {
+    return this.executionContextRunner.run(() => this._schedule(taskInstance, options), {
+      id: 'schedule',
+    });
+  }
+  private async _schedule(
+    taskInstance: TaskInstance,
+    options?: ApiKeyOptions
+  ): Promise<ConcreteTaskInstance> {
     try {
       this.validateCanEncryptSavedObjects(options?.request);
     } catch (e) {
@@ -382,6 +399,15 @@ export class TaskStore {
    * @param tasks - The tasks being scheduled.
    */
   public async bulkSchedule(
+    taskInstances: TaskInstance[],
+    options?: ApiKeyOptions
+  ): Promise<ConcreteTaskInstance[]> {
+    return this.executionContextRunner.run(() => this._bulkSchedule(taskInstances, options), {
+      id: 'bulk-schedule',
+    });
+  }
+
+  private async _bulkSchedule(
     taskInstances: TaskInstance[],
     options?: ApiKeyOptions
   ): Promise<ConcreteTaskInstance[]> {
@@ -483,6 +509,15 @@ export class TaskStore {
     doc: ConcreteTaskInstance,
     options: { validate: boolean }
   ): Promise<ConcreteTaskInstance> {
+    return this.executionContextRunner.run(() => this._update(doc, options), {
+      id: 'update',
+    });
+  }
+
+  private async _update(
+    doc: ConcreteTaskInstance,
+    options: { validate: boolean }
+  ): Promise<ConcreteTaskInstance> {
     let updatedSavedObject;
     let attributes;
     try {
@@ -524,6 +559,15 @@ export class TaskStore {
    * @returns {Promise<Array<TaskDoc>>}
    */
   public async bulkUpdate(
+    docs: ConcreteTaskInstance[],
+    options: BulkUpdateOpts
+  ): Promise<BulkUpdateResult[]> {
+    return this.executionContextRunner.run(() => this._bulkUpdate(docs, options), {
+      id: 'bulk-update',
+    });
+  }
+
+  private async _bulkUpdate(
     docs: ConcreteTaskInstance[],
     { validate }: BulkUpdateOpts
   ): Promise<BulkUpdateResult[]> {
@@ -587,6 +631,14 @@ export class TaskStore {
   }
 
   public async bulkPartialUpdate(
+    docs: PartialConcreteTaskInstance[]
+  ): Promise<PartialBulkUpdateResult[]> {
+    return this.executionContextRunner.run(() => this._bulkPartialUpdate(docs), {
+      id: 'bulk-partial-update',
+    });
+  }
+
+  private async _bulkPartialUpdate(
     docs: PartialConcreteTaskInstance[]
   ): Promise<PartialBulkUpdateResult[]> {
     if (docs.length === 0) {
@@ -675,7 +727,13 @@ export class TaskStore {
    * @returns {Promise<void>}
    */
   public async remove(id: string): Promise<void> {
-    const taskInstance = await this.get(id);
+    return this.executionContextRunner.run(() => this._remove(id), {
+      id: 'remove',
+    });
+  }
+
+  private async _remove(id: string): Promise<void> {
+    const taskInstance = await this._get(id);
     const { apiKey, userScope } = taskInstance;
 
     if (apiKey && userScope) {
@@ -699,7 +757,13 @@ export class TaskStore {
    * @returns {Promise<SavedObjectsBulkDeleteResponse>}
    */
   public async bulkRemove(taskIds: string[]): Promise<SavedObjectsBulkDeleteResponse> {
-    const taskInstances = await this.bulkGet(taskIds);
+    return this.executionContextRunner.run(() => this._bulkRemove(taskIds), {
+      id: 'bulk-remove',
+    });
+  }
+
+  private async _bulkRemove(taskIds: string[]): Promise<SavedObjectsBulkDeleteResponse> {
+    const taskInstances = await this._bulkGet(taskIds);
     const apiKeyIdsToRemove: string[] = [];
 
     taskInstances.forEach((taskInstance) => {
@@ -731,9 +795,15 @@ export class TaskStore {
    * Gets a task by id
    *
    * @param {string} id
-   * @returns {Promise<void>}
+   * @returns {Promise<ConcreteTaskInstance>}
    */
   public async get(id: string): Promise<ConcreteTaskInstance> {
+    return this.executionContextRunner.run(() => this._get(id), {
+      id: 'get',
+    });
+  }
+
+  private async _get(id: string): Promise<ConcreteTaskInstance> {
     let result;
     try {
       result = await this.savedObjectsRepository.get<SerializedConcreteTaskInstance>('task', id);
@@ -752,9 +822,15 @@ export class TaskStore {
    * Gets tasks by ids
    *
    * @param {Array<string>} ids
-   * @returns {Promise<ConcreteTaskInstance[]>}
+   * @returns {Promise<BulkGetResult>}
    */
   public async bulkGet(ids: string[]): Promise<BulkGetResult> {
+    return this.executionContextRunner.run(() => this._bulkGet(ids), {
+      id: 'bulk-get',
+    });
+  }
+
+  private async _bulkGet(ids: string[]): Promise<BulkGetResult> {
     let result;
     try {
       result = await this.savedObjectsRepository.bulkGet<SerializedConcreteTaskInstance>(
@@ -788,9 +864,15 @@ export class TaskStore {
    * Gets task version info by ids
    *
    * @param {Array<string>} esIds
-   * @returns {Promise<ConcreteTaskInstance[]>}
+   * @returns {Promise<ConcreteTaskInstanceVersion[]>}
    */
   public async bulkGetVersions(ids: string[]): Promise<ConcreteTaskInstanceVersion[]> {
+    return this.executionContextRunner.run(() => this._bulkGetVersions(ids), {
+      id: 'bulk-get-versions',
+    });
+  }
+
+  private async _bulkGetVersions(ids: string[]): Promise<ConcreteTaskInstanceVersion[]> {
     let taskVersions: estypes.MgetResponse<never>;
     try {
       taskVersions = await this.esClientWithoutRetries.mget<never>({
@@ -853,6 +935,12 @@ export class TaskStore {
 
   // like search(), only runs multiple searches in parallel returning the combined results
   async msearch(opts: SearchOpts[] = []): Promise<FetchResult> {
+    return this.executionContextRunner.run(() => this._msearch(opts), {
+      id: 'msearch',
+    });
+  }
+
+  private async _msearch(opts: SearchOpts[] = []): Promise<FetchResult> {
     const queries = opts.map(({ sort = [{ 'task.runAt': 'asc' }], ...opt }) =>
       ensureQueryOnlyReturnsTaskObjects({ sort, ...opt })
     );
@@ -888,7 +976,13 @@ export class TaskStore {
     return { docs: tasksWithDecryptedApiKeys, versionMap };
   }
 
-  private async search(
+  public async search(opts: SearchOpts = {}, limitResponse: boolean = false): Promise<FetchResult> {
+    return this.executionContextRunner.run(() => this._search(opts, limitResponse), {
+      id: 'search',
+    });
+  }
+
+  private async _search(
     opts: SearchOpts = {},
     limitResponse: boolean = false
   ): Promise<FetchResult> {
@@ -967,6 +1061,18 @@ export class TaskStore {
     runtime_mappings,
     size = 0,
   }: TSearchRequest): Promise<estypes.SearchResponse<ConcreteTaskInstance>> {
+    return this.executionContextRunner.run(
+      () => this._aggregate({ aggs, query, runtime_mappings, size }),
+      { id: 'aggregate' }
+    );
+  }
+
+  private async _aggregate<TSearchRequest extends AggregationOpts>({
+    aggs,
+    query,
+    runtime_mappings,
+    size = 0,
+  }: TSearchRequest): Promise<estypes.SearchResponse<ConcreteTaskInstance>> {
     const body = await this.esClient.search<
       ConcreteTaskInstance,
       Record<string, estypes.AggregationsAggregate>
@@ -985,6 +1091,15 @@ export class TaskStore {
   }
 
   public async updateByQuery(
+    opts: UpdateByQuerySearchOpts = {},
+    updateByQueryOpts: UpdateByQueryOpts = {}
+  ): Promise<UpdateByQueryResult> {
+    return this.executionContextRunner.run(() => this._updateByQuery(opts, updateByQueryOpts), {
+      id: 'update-by-query',
+    });
+  }
+
+  private async _updateByQuery(
     opts: UpdateByQuerySearchOpts = {},
     { max_docs: max_docs }: UpdateByQueryOpts = {}
   ): Promise<UpdateByQueryResult> {
@@ -1023,7 +1138,15 @@ export class TaskStore {
   }
 
   public async getDocVersions(esIds: string[]): Promise<Map<string, ConcreteTaskInstanceVersion>> {
-    const versions = await this.bulkGetVersions(esIds);
+    return this.executionContextRunner.run(() => this._getDocVersions(esIds), {
+      id: 'get-doc-versions',
+    });
+  }
+
+  private async _getDocVersions(
+    esIds: string[]
+  ): Promise<Map<string, ConcreteTaskInstanceVersion>> {
+    const versions = await this._bulkGetVersions(esIds);
     const result = new Map<string, ConcreteTaskInstanceVersion>();
     for (const version of versions) {
       result.set(version.esId, version);

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -41,7 +41,6 @@
     "@kbn/es-errors",
     "@kbn/core-execution-context-server-mocks",
     "@kbn/core-execution-context-common",
-    "@kbn/core-http-server",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -39,6 +39,9 @@
     "@kbn/logging-mocks",
     "@kbn/spaces-utils",
     "@kbn/es-errors",
+    "@kbn/core-execution-context-server-mocks",
+    "@kbn/core-execution-context-common",
+    "@kbn/core-http-server",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Task Manager] add x_opaque_id to more task manager taskStore (#252442)](https://github.com/elastic/kibana/pull/252442)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2026-02-27T19:09:05Z","message":"[Task Manager] add x_opaque_id to more task manager taskStore (#252442)\n\nresolves https://github.com/elastic/kibana/issues/249293\n\nAdds execution context wrapping around task manager's taskStore calls to\nES. This will allow us to \"see\" TM requests in proxy logs (and other\nplaces `x_opaque_id` is available) to improve problem analysis.","sha":"ef5023197731adf7f5ef18ee8228841f83566ace","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","Team:ResponseOps","backport:all-open","ci:cloud-deploy","ci:cloud-persist-deployment","v9.4.0"],"title":"[Task Manager] add x_opaque_id to more task manager taskStore","number":252442,"url":"https://github.com/elastic/kibana/pull/252442","mergeCommit":{"message":"[Task Manager] add x_opaque_id to more task manager taskStore (#252442)\n\nresolves https://github.com/elastic/kibana/issues/249293\n\nAdds execution context wrapping around task manager's taskStore calls to\nES. This will allow us to \"see\" TM requests in proxy logs (and other\nplaces `x_opaque_id` is available) to improve problem analysis.","sha":"ef5023197731adf7f5ef18ee8228841f83566ace"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252442","number":252442,"mergeCommit":{"message":"[Task Manager] add x_opaque_id to more task manager taskStore (#252442)\n\nresolves https://github.com/elastic/kibana/issues/249293\n\nAdds execution context wrapping around task manager's taskStore calls to\nES. This will allow us to \"see\" TM requests in proxy logs (and other\nplaces `x_opaque_id` is available) to improve problem analysis.","sha":"ef5023197731adf7f5ef18ee8228841f83566ace"}}]}] BACKPORT-->