### PR TITLE
[Security Solution][Analyzer] remove unused isSplitPanel prop

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -146,7 +146,6 @@ export const AnalyzeGraph: FC = () => {
         indices={selectedPatterns}
         shouldUpdate={shouldUpdate}
         filters={filters}
-        isSplitPanel
         showPanelOnClick={onClick}
       />
     </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
@@ -10,7 +10,6 @@ import type { Store, AnyAction } from 'redux';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 import type { History as HistoryPackageHistoryInterface } from 'history';
-import { createMemoryHistory } from 'history';
 import { coreMock } from '@kbn/core/public/mocks';
 import { spyMiddlewareFactory } from '../spy_middleware_factory';
 import { resolverMiddlewareFactory } from '../../store/middleware';
@@ -81,7 +80,6 @@ export class Simulator {
     history,
     filters,
     shouldUpdate,
-    isSplitPanel,
     showPanelOnClick,
   }: {
     /**
@@ -100,10 +98,9 @@ export class Simulator {
      * a databaseDocumentID to pass to Resolver. Resolver will use this in requests to the mock data layer.
      */
     databaseDocumentID: string;
-    history?: HistoryPackageHistoryInterface<never>;
+    history: HistoryPackageHistoryInterface;
     filters: TimeFilters;
     shouldUpdate: boolean;
-    isSplitPanel?: boolean;
     showPanelOnClick?: () => void;
   }) {
     // create the spy middleware (for debugging tests)
@@ -133,9 +130,7 @@ export class Simulator {
       [resolverMiddlewareFactory(dataAccessLayer), this.spyMiddleware.middleware]
     );
 
-    // If needed, create a fake 'history' instance.
-    // Resolver will use to read and write query string values.
-    this.history = history ?? createMemoryHistory();
+    this.history = history;
 
     // Used for `KibanaContextProvider`
     const coreStart = coreMock.createStart();
@@ -156,7 +151,6 @@ export class Simulator {
         indices={indices}
         filters={filters}
         shouldUpdate={shouldUpdate}
-        isSplitPanel={isSplitPanel}
         showPanelOnClick={showPanelOnClick}
       />
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
@@ -15,6 +15,7 @@ import type { CoreStart } from '@kbn/core/public';
 import { enableMapSet } from 'immer';
 import type { SideEffectSimulator, ResolverProps } from '../../types';
 import { ResolverWithoutProviders } from '../../view/resolver_without_providers';
+import { DetailsPanel } from '../../view/details_panel';
 import { SideEffectContext } from '../../view/side_effect_context';
 import type { State } from '../../../common/store/types';
 import { TestProviders } from '../../../common/mock';
@@ -100,16 +101,18 @@ export const MockResolver = React.memo((props: MockResolverProps) => {
           <KibanaContextProvider services={props.coreStart}>
             <SideEffectContext.Provider value={props.sideEffectSimulator.mock}>
               <Provider store={props.store}>
-                <ResolverWithoutProviders
-                  ref={resolverRef}
-                  databaseDocumentID={props.databaseDocumentID}
-                  resolverComponentInstanceID={props.resolverComponentInstanceID}
-                  indices={props.indices}
-                  shouldUpdate={props.shouldUpdate}
-                  filters={props.filters}
-                  isSplitPanel={props.isSplitPanel}
-                  showPanelOnClick={props.showPanelOnClick}
-                />
+                <>
+                  <ResolverWithoutProviders
+                    ref={resolverRef}
+                    databaseDocumentID={props.databaseDocumentID}
+                    resolverComponentInstanceID={props.resolverComponentInstanceID}
+                    indices={props.indices}
+                    shouldUpdate={props.shouldUpdate}
+                    filters={props.filters}
+                    showPanelOnClick={props.showPanelOnClick}
+                  />
+                  <DetailsPanel resolverComponentInstanceID={props.resolverComponentInstanceID} />
+                </>
               </Provider>
             </SideEffectContext.Provider>
           </KibanaContextProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
@@ -848,11 +848,6 @@ export interface ResolverProps {
   shouldUpdate: boolean;
 
   /**
-   * If true, the details panel is not shown in the graph and a view button is shown to manage the panel visibility.
-   */
-  isSplitPanel?: boolean;
-
-  /**
    * Optional callback for showing details panels separately from the graph.
    */
   showPanelOnClick?: () => void;

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/clickthrough.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/clickthrough.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { ReactWrapper } from 'enzyme';
+import { createMemoryHistory } from 'history';
 import { noAncestorsTwoChildenInIndexCalledAwesomeIndex } from '../data_access_layer/mocks/no_ancestors_two_children_in_index_called_awesome_index';
 import { noAncestorsTwoChildren } from '../data_access_layer/mocks/no_ancestors_two_children';
 import { Simulator } from '../test_utilities/simulator';
@@ -41,6 +42,7 @@ describe("Resolver, when rendered with the `indices` prop set to `[]` and the `d
       databaseDocumentID,
       dataAccessLayer,
       resolverComponentInstanceID,
+      history: createMemoryHistory(),
       indices: [],
       shouldUpdate: false,
       filters: {},
@@ -96,6 +98,7 @@ describe('Resolver, when analyzing a tree that has no ancestors and 2 children',
       databaseDocumentID,
       dataAccessLayer,
       resolverComponentInstanceID,
+      history: createMemoryHistory(),
       indices: [],
       shouldUpdate: false,
       filters: {},
@@ -302,6 +305,7 @@ describe.skip('Resolver, when using a generated tree with 20 generations, 4 chil
         databaseDocumentID,
         dataAccessLayer: { ...generatorDAL, nodeData: nodeDataError },
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},
@@ -360,6 +364,7 @@ describe.skip('Resolver, when using a generated tree with 20 generations, 4 chil
         databaseDocumentID,
         dataAccessLayer: generatorDAL,
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},
@@ -436,6 +441,7 @@ describe('Resolver, when analyzing a tree that has 2 related registry and 1 rela
       databaseDocumentID,
       dataAccessLayer,
       resolverComponentInstanceID,
+      history: createMemoryHistory(),
       indices: [],
       shouldUpdate: false,
       filters: {},

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Simulator } from '../../test_utilities/simulator';
+import { createMemoryHistory } from 'history';
 import { noAncestorsTwoChildren } from '../../data_access_layer/mocks/no_ancestors_two_children';
 import { nudgeAnimationDuration } from '../../store/camera/scaling_constants';
 import '../../test_utilities/extend_jest';
@@ -35,6 +36,7 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
       dataAccessLayer,
       databaseDocumentID,
       resolverComponentInstanceID,
+      history: createMemoryHistory(),
       indices: [],
       shouldUpdate: false,
       filters: {},
@@ -110,8 +112,8 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
     ).toYieldEqualTo({ showPanelButton: 0 });
   });
 
-  describe('when split mode is enabled', () => {
-    it('should display the view button when callback is available', async () => {
+  describe('when show panel callback is available', () => {
+    it('should display the view button', async () => {
       const {
         metadata: { databaseDocumentID },
         dataAccessLayer,
@@ -122,10 +124,10 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
         dataAccessLayer,
         databaseDocumentID,
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},
-        isSplitPanel: true,
         showPanelOnClick,
       });
 
@@ -137,30 +139,6 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
       ).toYieldEqualTo({ showPanelButton: 1 });
       (await simulator.resolve('resolver:graph-controls:show-panel-button'))?.simulate('click');
       expect(showPanelOnClick).toHaveBeenCalled();
-    });
-
-    it('should not display the view button when callback is not available', async () => {
-      const {
-        metadata: { databaseDocumentID },
-        dataAccessLayer,
-      } = noAncestorsTwoChildren();
-
-      simulator = new Simulator({
-        dataAccessLayer,
-        databaseDocumentID,
-        resolverComponentInstanceID,
-        indices: [],
-        shouldUpdate: false,
-        filters: {},
-        isSplitPanel: true,
-      });
-
-      await expect(
-        simulator.map(() => ({
-          showPanelButton: simulator.testSubject('resolver:graph-controls:show-panel-button')
-            .length,
-        }))
-      ).toYieldEqualTo({ showPanelButton: 0 });
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.tsx
@@ -35,7 +35,6 @@ export const GraphControls = React.memo(
   ({
     id,
     className,
-    isSplitPanel,
     showPanelOnClick,
   }: {
     /**
@@ -47,11 +46,7 @@ export const GraphControls = React.memo(
      */
     className?: string;
     /**
-     * Indicate if the panel is displayed separately
-     */
-    isSplitPanel?: boolean;
-    /**
-     * Callback for showing the panel when isSplitPanel is true
+     * Callback for showing the panel when it is displayed separately
      */
     showPanelOnClick?: () => void;
   }) => {
@@ -151,9 +146,7 @@ export const GraphControls = React.memo(
             isOpen={activePopover === 'datePicker'}
             setActivePopover={setActivePopover}
           />
-          {isSplitPanel && showPanelOnClick && (
-            <ShowPanelButton showPanelOnClick={showPanelOnClick} />
-          )}
+          {showPanelOnClick && <ShowPanelButton showPanelOnClick={showPanelOnClick} />}
         </StyledGraphControlsColumn>
         <StyledGraphControlsColumn>
           <EuiPanel className="panning-controls" paddingSize="none" hasBorder>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/node.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/node.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { noAncestorsTwoChildren } from '../data_access_layer/mocks/no_ancestors_two_children';
+import { createMemoryHistory } from 'history';
 import { Simulator } from '../test_utilities/simulator';
 // Extend jest with a custom matcher
 import '../test_utilities/extend_jest';
@@ -29,6 +30,7 @@ describe('Resolver, when analyzing a tree that has no ancestors and 2 children',
       databaseDocumentID,
       dataAccessLayer,
       resolverComponentInstanceID,
+      history: createMemoryHistory(),
       indices: [],
       shouldUpdate: false,
       filters: {},

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/query_params.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/query_params.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { noAncestorsTwoChildren } from '../data_access_layer/mocks/no_ancestors_two_children';
+import { createMemoryHistory } from 'history';
 import { Simulator } from '../test_utilities/simulator';
 // Extend jest with a custom matcher
 import '../test_utilities/extend_jest';
@@ -34,6 +35,7 @@ describe('Resolver, when analyzing a tree that has no ancestors and 2 children',
       databaseDocumentID,
       dataAccessLayer,
       resolverComponentInstanceID,
+      history: createMemoryHistory(),
       indices: [],
       shouldUpdate: false,
       filters: {},

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_loading_state.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_loading_state.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Simulator } from '../test_utilities/simulator';
+import { createMemoryHistory } from 'history';
 import { pausifyMock } from '../data_access_layer/mocks/pausify_mock';
 import { emptifyMock } from '../data_access_layer/mocks/emptify_mock';
 import { noAncestorsTwoChildren } from '../data_access_layer/mocks/no_ancestors_two_children';
@@ -27,6 +28,7 @@ describe('Resolver: data loading and resolution states', () => {
         dataAccessLayer,
         databaseDocumentID,
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},
@@ -60,6 +62,7 @@ describe('Resolver: data loading and resolution states', () => {
         dataAccessLayer,
         databaseDocumentID,
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},
@@ -92,6 +95,7 @@ describe('Resolver: data loading and resolution states', () => {
         dataAccessLayer,
         databaseDocumentID,
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},
@@ -124,6 +128,7 @@ describe('Resolver: data loading and resolution states', () => {
         dataAccessLayer,
         databaseDocumentID,
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},
@@ -141,7 +146,7 @@ describe('Resolver: data loading and resolution states', () => {
       ).toYieldEqualTo({
         resolverGraphLoading: 0,
         resolverGraphError: 0,
-        resolverEmptyMessage: 1,
+        resolverEmptyMessage: 2,
         resolverGraphNodes: 0,
       });
     });
@@ -158,6 +163,7 @@ describe('Resolver: data loading and resolution states', () => {
         dataAccessLayer,
         databaseDocumentID,
         resolverComponentInstanceID,
+        history: createMemoryHistory(),
         indices: [],
         shouldUpdate: false,
         filters: {},

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -17,11 +17,10 @@ import { ProcessEventDot } from './process_event_dot';
 import { useCamera } from './use_camera';
 import { SymbolDefinitions } from './symbol_definitions';
 import { useStateSyncingActions } from './use_state_syncing_actions';
-import { GraphContainer, StyledMapContainer, StyledPanel } from './styles';
+import { GraphContainer, StyledMapContainer } from './styles';
 import * as nodeModel from '../../../common/endpoint/models/node';
 import { SideEffectContext } from './side_effect_context';
 import type { ResolverProps } from '../types';
-import { PanelRouter } from './panels';
 import { useColors } from './use_colors';
 import { useSyncSelectedNode } from './use_sync_selected_node';
 import { ResolverNoProcessEvents } from './resolver_no_process_events';
@@ -43,7 +42,6 @@ export const ResolverWithoutProviders = React.memo(
       indices,
       shouldUpdate,
       filters,
-      isSplitPanel = false,
       showPanelOnClick,
     }: ResolverProps,
     refToForward
@@ -165,25 +163,16 @@ export const ResolverWithoutProviders = React.memo(
                     projectionMatrix={projectionMatrix}
                     node={treeNode}
                     timeAtRender={timeAtRender}
-                    onClick={isSplitPanel ? showPanelOnClick : undefined}
+                    onClick={showPanelOnClick}
                   />
                 );
               })}
             </GraphContainer>
-            {!isSplitPanel && (
-              <StyledPanel hasBorder>
-                <PanelRouter id={resolverComponentInstanceID} />
-              </StyledPanel>
-            )}
           </>
         ) : (
           <ResolverNoProcessEvents />
         )}
-        <GraphControls
-          id={resolverComponentInstanceID}
-          isSplitPanel={isSplitPanel}
-          showPanelOnClick={showPanelOnClick}
-        />
+        <GraphControls id={resolverComponentInstanceID} showPanelOnClick={showPanelOnClick} />
         <SymbolDefinitions id={resolverComponentInstanceID} />
       </StyledMapContainer>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/styles.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/styles.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiCallOut, EuiPanel } from '@elastic/eui';
+import { EuiCallOut } from '@elastic/eui';
 import styled from 'styled-components';
 import { NodeSubMenuComponents } from './submenu';
 
@@ -120,21 +120,6 @@ export const StyledMapContainer = styled.div<{ backgroundColor: string; windowHe
   overflow: hidden;
   contain: strict;
   background-color: ${(props) => props.backgroundColor};
-`;
-
-/**
- * The Panel, styled for use in `ResolverMap`.
- */
-export const StyledPanel = styled(EuiPanel)`
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  overflow: auto;
-  width: 25em;
-  max-width: 50%;
-  border-radius: 0;
-  border-top: none;
 `;
 
 /**


### PR DESCRIPTION
## Summary

This PR makes a very small code cleanup related to `Analyzer`/`Resolver`. We're removing the `isSplitPanel` property, which was added a little while back to support Analyzer being rendered in the alerts table as well as in the expandable flyout.

We long ago removed the usage of Analyzer in the alert table and we're now fully committed to a flyout experience, where the detail panels are rendered outside of the analyzer main component.

> [!WARNING]
> No UI or behavior changes should be introduced by this PR!

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.