### PR TITLE
[Security Solution][Analyzer] remove unnecessary showPanelOnClick prop

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
@@ -12,12 +12,7 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { DocumentDetailsContext } from '../../shared/context';
 import { TestProviders } from '../../../../common/mock';
-import {
-  AnalyzeGraph,
-  ANALYZER_PREVIEW_BANNER,
-  DATA_VIEW_ERROR_TEST_ID,
-  DATA_VIEW_LOADING_TEST_ID,
-} from './analyze_graph';
+import { AnalyzeGraph, DATA_VIEW_ERROR_TEST_ID, DATA_VIEW_LOADING_TEST_ID } from './analyze_graph';
 import { ANALYZER_GRAPH_TEST_ID } from './test_ids';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
 import { mockFlyoutApi } from '../../shared/mocks/mock_flyout_context';
@@ -29,6 +24,7 @@ import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
+import { ANALYZER_PREVIEW_BANNER } from '../../../../resolver/view/resolver_without_providers';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -6,8 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useCallback, useMemo } from 'react';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiEmptyPrompt,
@@ -24,7 +23,6 @@ import { ANALYZER_GRAPH_TEST_ID } from './test_ids';
 import { Resolver } from '../../../../resolver/view';
 import { useTimelineDataFilters } from '../../../../timelines/containers/use_timeline_data_filters';
 import { isActiveTimeline } from '../../../../helpers';
-import { DocumentDetailsAnalyzerPanelKey } from '../../shared/constants/panel_keys';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
 import { AnalyzerPreviewNoDataMessage } from '../../right/components/analyzer_preview_container';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
@@ -38,17 +36,6 @@ export const DATA_VIEW_ERROR_TEST_ID = 'analyzer-data-view-error';
 const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.analyzer.dataViewError', {
   defaultMessage: 'Unable to retrieve the data view for analyzer',
 });
-export const ANALYZER_PREVIEW_BANNER = {
-  title: i18n.translate(
-    'xpack.securitySolution.flyout.left.visualizations.analyzer.panelPreviewTitle',
-    {
-      defaultMessage: 'Preview analyzer panel',
-    }
-  ),
-  backgroundColor: 'warning',
-  textColor: 'warning',
-};
-
 /**
  * Analyzer graph view displayed in the document details expandable flyout left section under the Visualize tab
  */
@@ -97,18 +84,6 @@ export const AnalyzeGraph: FC = () => {
     ]
   );
 
-  const { openPreviewPanel } = useExpandableFlyoutApi();
-
-  const onClick = useCallback(() => {
-    openPreviewPanel({
-      id: DocumentDetailsAnalyzerPanelKey,
-      params: {
-        resolverComponentInstanceID: `${key}-${scopeId}`,
-        banner: ANALYZER_PREVIEW_BANNER,
-      },
-    });
-  }, [openPreviewPanel, key, scopeId]);
-
   if (!isEnabled) {
     return (
       <EuiPanel hasShadow={false}>
@@ -146,7 +121,6 @@ export const AnalyzeGraph: FC = () => {
         indices={selectedPatterns}
         shouldUpdate={shouldUpdate}
         filters={filters}
-        showPanelOnClick={onClick}
       />
     </div>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
@@ -80,7 +80,6 @@ export class Simulator {
     history,
     filters,
     shouldUpdate,
-    showPanelOnClick,
   }: {
     /**
      * A (mock) data access layer that will be used to create the Resolver store.
@@ -101,7 +100,6 @@ export class Simulator {
     history: HistoryPackageHistoryInterface;
     filters: TimeFilters;
     shouldUpdate: boolean;
-    showPanelOnClick?: () => void;
   }) {
     // create the spy middleware (for debugging tests)
     this.spyMiddleware = spyMiddlewareFactory();
@@ -151,7 +149,6 @@ export class Simulator {
         indices={indices}
         filters={filters}
         shouldUpdate={shouldUpdate}
-        showPanelOnClick={showPanelOnClick}
       />
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
 import { Router } from '@kbn/shared-ux-router';
 import { I18nProvider } from '@kbn/i18n-react';
 import { Provider } from 'react-redux';
-import type { Store, AnyAction } from 'redux';
+import type { AnyAction, Store } from 'redux';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { CoreStart } from '@kbn/core/public';
 import { enableMapSet } from 'immer';
-import type { SideEffectSimulator, ResolverProps } from '../../types';
+import type { ResolverProps, SideEffectSimulator } from '../../types';
 import { ResolverWithoutProviders } from '../../view/resolver_without_providers';
 import { DetailsPanel } from '../../view/details_panel';
 import { SideEffectContext } from '../../view/side_effect_context';
@@ -99,22 +100,23 @@ export const MockResolver = React.memo((props: MockResolverProps) => {
       <I18nProvider>
         <Router history={props.history}>
           <KibanaContextProvider services={props.coreStart}>
-            <SideEffectContext.Provider value={props.sideEffectSimulator.mock}>
-              <Provider store={props.store}>
-                <>
-                  <ResolverWithoutProviders
-                    ref={resolverRef}
-                    databaseDocumentID={props.databaseDocumentID}
-                    resolverComponentInstanceID={props.resolverComponentInstanceID}
-                    indices={props.indices}
-                    shouldUpdate={props.shouldUpdate}
-                    filters={props.filters}
-                    showPanelOnClick={props.showPanelOnClick}
-                  />
-                  <DetailsPanel resolverComponentInstanceID={props.resolverComponentInstanceID} />
-                </>
-              </Provider>
-            </SideEffectContext.Provider>
+            <ExpandableFlyoutProvider>
+              <SideEffectContext.Provider value={props.sideEffectSimulator.mock}>
+                <Provider store={props.store}>
+                  <>
+                    <ResolverWithoutProviders
+                      ref={resolverRef}
+                      databaseDocumentID={props.databaseDocumentID}
+                      resolverComponentInstanceID={props.resolverComponentInstanceID}
+                      indices={props.indices}
+                      shouldUpdate={props.shouldUpdate}
+                      filters={props.filters}
+                    />
+                    <DetailsPanel resolverComponentInstanceID={props.resolverComponentInstanceID} />
+                  </>
+                </Provider>
+              </SideEffectContext.Provider>
+            </ExpandableFlyoutProvider>
           </KibanaContextProvider>
         </Router>
       </I18nProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
@@ -6,17 +6,17 @@
  */
 
 import type React from 'react';
-import type { Store, Middleware, Dispatch, AnyAction } from 'redux';
+import type { AnyAction, Dispatch, Middleware, Store } from 'redux';
 import type { BBox } from 'rbush';
 import type { Provider } from 'react-redux';
 import type {
-  ResolverNode,
-  ResolverRelatedEvents,
-  ResolverEntityIndex,
-  SafeResolverEvent,
-  ResolverPaginatedEvents,
   NewResolverTree,
+  ResolverEntityIndex,
+  ResolverNode,
+  ResolverPaginatedEvents,
+  ResolverRelatedEvents,
   ResolverSchema,
+  SafeResolverEvent,
 } from '../../common/endpoint/types';
 import type { Tree } from '../../common/endpoint/generate_data';
 import type { State } from '../common/store/types';
@@ -846,11 +846,6 @@ export interface ResolverProps {
    * A flag to update data from an external source
    */
   shouldUpdate: boolean;
-
-  /**
-   * Optional callback for showing details panels separately from the graph.
-   */
-  showPanelOnClick?: () => void;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
@@ -7,9 +7,18 @@
 
 import { Simulator } from '../../test_utilities/simulator';
 import { createMemoryHistory } from 'history';
+import React from 'react';
+import type { ReactNode } from 'react';
 import { noAncestorsTwoChildren } from '../../data_access_layer/mocks/no_ancestors_two_children';
 import { nudgeAnimationDuration } from '../../store/camera/scaling_constants';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { mockFlyoutApi } from '../../../flyout/document_details/shared/mocks/mock_flyout_context';
 import '../../test_utilities/extend_jest';
+
+jest.mock('@kbn/expandable-flyout', () => ({
+  ExpandableFlyoutProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useExpandableFlyoutApi: jest.fn(),
+}));
 
 describe('graph controls: when relsover is loaded with an origin node', () => {
   let simulator: Simulator;
@@ -27,6 +36,8 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
     const {
       metadata: { databaseDocumentID, entityIDs },
       dataAccessLayer,
@@ -52,94 +63,47 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
         }
         return null;
       });
+
+    // Resolver graph controls now mount asynchronously after initial tree setup.
+    // Wait for a stable control element before running assertions in each test.
+    await simulator.resolve('resolver:graph-controls:zoom-in');
   });
 
   it('should display all cardinal panning buttons and the center button', async () => {
-    await expect(
-      simulator.map(() => ({
-        westPanButton: simulator.testSubject('resolver:graph-controls:west-button').length,
-        southPanButton: simulator.testSubject('resolver:graph-controls:south-button').length,
-        eastPanButton: simulator.testSubject('resolver:graph-controls:east-button').length,
-        northPanButton: simulator.testSubject('resolver:graph-controls:north-button').length,
-        centerButton: simulator.testSubject('resolver:graph-controls:center-button').length,
-      }))
-    ).toYieldEqualTo({
-      westPanButton: 1,
-      southPanButton: 1,
-      eastPanButton: 1,
-      northPanButton: 1,
-      centerButton: 1,
-    });
+    expect(await simulator.resolve('resolver:graph-controls:west-button')).toBeDefined();
+    expect(await simulator.resolve('resolver:graph-controls:south-button')).toBeDefined();
+    expect(await simulator.resolve('resolver:graph-controls:east-button')).toBeDefined();
+    expect(await simulator.resolve('resolver:graph-controls:north-button')).toBeDefined();
+    expect(await simulator.resolve('resolver:graph-controls:center-button')).toBeDefined();
   });
 
   it('should display the zoom buttons and slider', async () => {
-    await expect(
-      simulator.map(() => ({
-        zoomInButton: simulator.testSubject('resolver:graph-controls:zoom-in').length,
-        zoomOutButton: simulator.testSubject('resolver:graph-controls:zoom-out').length,
-        zoomSlider: simulator.testSubject('resolver:graph-controls:zoom-slider').length,
-      }))
-    ).toYieldEqualTo({
-      zoomInButton: 1,
-      zoomOutButton: 1,
-      zoomSlider: 1,
-    });
+    expect(await simulator.resolve('resolver:graph-controls:zoom-in')).toBeDefined();
+    expect(await simulator.resolve('resolver:graph-controls:zoom-out')).toBeDefined();
+    expect(await simulator.resolve('resolver:graph-controls:zoom-slider')).toBeDefined();
   });
 
   it('should display the legend and schema popover buttons', async () => {
-    await expect(
-      simulator.map(() => ({
-        schemaInfoButton: simulator.testSubject('resolver:graph-controls:schema-info-button')
-          .length,
-        nodeLegendButton: simulator.testSubject('resolver:graph-controls:node-legend-button')
-          .length,
-      }))
-    ).toYieldEqualTo({
-      schemaInfoButton: 1,
-      nodeLegendButton: 1,
-    });
+    expect(await simulator.resolve('resolver:graph-controls:schema-info-button')).toBeDefined();
+    expect(await simulator.resolve('resolver:graph-controls:node-legend-button')).toBeDefined();
   });
 
   it("should show the origin node in it's original position", async () => {
     await expect(originNodeStyle()).toYieldObjectEqualTo(originalPositionStyle);
   });
 
-  it('should not display the view button by default', async () => {
+  it('should display the view button by default', async () => {
     await expect(
       simulator.map(() => ({
         showPanelButton: simulator.testSubject('resolver:graph-controls:show-panel-button').length,
       }))
-    ).toYieldEqualTo({ showPanelButton: 0 });
+    ).toYieldEqualTo({ showPanelButton: 1 });
   });
 
-  describe('when show panel callback is available', () => {
-    it('should display the view button', async () => {
-      const {
-        metadata: { databaseDocumentID },
-        dataAccessLayer,
-      } = noAncestorsTwoChildren();
+  it('should open the analyzer details panel when clicking the view button', async () => {
+    (await simulator.resolve('resolver:graph-controls:show-panel-button'))?.simulate('click');
 
-      const showPanelOnClick = jest.fn();
-      simulator = new Simulator({
-        dataAccessLayer,
-        databaseDocumentID,
-        resolverComponentInstanceID,
-        history: createMemoryHistory(),
-        indices: [],
-        shouldUpdate: false,
-        filters: {},
-        showPanelOnClick,
-      });
-
-      await expect(
-        simulator.map(() => ({
-          showPanelButton: simulator.testSubject('resolver:graph-controls:show-panel-button')
-            .length,
-        }))
-      ).toYieldEqualTo({ showPanelButton: 1 });
-      (await simulator.resolve('resolver:graph-controls:show-panel-button'))?.simulate('click');
-      expect(showPanelOnClick).toHaveBeenCalled();
-    });
+    expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledTimes(1);
   });
 
   describe('when the user clicks the west panning button', () => {
@@ -285,13 +249,15 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
     });
 
     it('should show the schema information table with the expected values', async () => {
-      await expect(
-        simulator.map(() =>
-          simulator
-            .testSubject('resolver:graph-controls:schema-info:description')
-            .map((description) => description.text())
-        )
-      ).toYieldEqualTo(['endpoint', 'process.entity_id', 'process.parent.entity_id']);
+      const schemaInfoDescriptions = await simulator.resolve(
+        'resolver:graph-controls:schema-info:description'
+      );
+
+      expect(schemaInfoDescriptions?.map((description) => description.text())).toEqual([
+        'endpoint',
+        'process.entity_id',
+        'process.parent.entity_id',
+      ]);
     });
   });
 
@@ -303,13 +269,11 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
     });
 
     it('should show the node legend table with the expected values', async () => {
-      await expect(
-        simulator.map(() =>
-          simulator
-            .testSubject('resolver:graph-controls:node-legend:description')
-            .map((description) => description.text())
-        )
-      ).toYieldEqualTo([
+      const nodeLegendDescriptions = await simulator.resolve(
+        'resolver:graph-controls:node-legend:description'
+      );
+
+      expect(nodeLegendDescriptions?.map((description) => description.text())).toEqual([
         'Running Process',
         'Terminated Process',
         'Loading Process',
@@ -326,21 +290,19 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
     });
 
     it('should close the schema information table and open the node legend table', async () => {
-      expect(simulator.testSubject('resolver:graph-controls:schema-info').length).toBe(1);
+      expect(await simulator.resolve('resolver:graph-controls:schema-info')).toBeDefined();
 
-      await simulator
-        .testSubject('resolver:graph-controls:node-legend-button')
-        ?.simulate('click', { button: 0 });
-
-      await expect(
-        simulator.map(() => ({
-          nodeLegend: simulator.testSubject('resolver:graph-controls:node-legend').length,
-          schemaInfo: simulator.testSubject('resolver:graph-controls:schema-info').length,
-        }))
-      ).toYieldObjectEqualTo({
-        nodeLegend: 1,
-        schemaInfo: 0,
+      (await simulator.resolve('resolver:graph-controls:node-legend-button'))?.simulate('click', {
+        button: 0,
       });
+
+      expect(await simulator.resolve('resolver:graph-controls:node-legend')).toBeDefined();
+      await expect(
+        simulator.resolveWrapper(
+          () => simulator.testSubject('resolver:graph-controls:schema-info'),
+          (wrapper) => wrapper.length === 0
+        )
+      ).resolves.toBeDefined();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.tsx
@@ -35,7 +35,7 @@ export const GraphControls = React.memo(
   ({
     id,
     className,
-    showPanelOnClick,
+    onShowPanel,
   }: {
     /**
      * Id that identify the scope of analyzer
@@ -46,9 +46,9 @@ export const GraphControls = React.memo(
      */
     className?: string;
     /**
-     * Callback for showing the panel when it is displayed separately
+     * Callback for showing the analyzer details panel
      */
-    showPanelOnClick?: () => void;
+    onShowPanel: () => void;
   }) => {
     const dispatch = useDispatch();
     const scalingFactor = useSelector((state: State) =>
@@ -146,7 +146,7 @@ export const GraphControls = React.memo(
             isOpen={activePopover === 'datePicker'}
             setActivePopover={setActivePopover}
           />
-          {showPanelOnClick && <ShowPanelButton showPanelOnClick={showPanelOnClick} />}
+          <ShowPanelButton onClick={onShowPanel} />
         </StyledGraphControlsColumn>
         <StyledGraphControlsColumn>
           <EuiPanel className="panning-controls" paddingSize="none" hasBorder>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/show_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/show_panel.tsx
@@ -17,7 +17,7 @@ const showPanelButtonTitle = i18n.translate(
   }
 );
 
-export const ShowPanelButton = memo(({ showPanelOnClick }: { showPanelOnClick: () => void }) => {
+export const ShowPanelButton = memo(({ onClick }: { onClick: () => void }) => {
   const colorMap = useColors();
 
   return (
@@ -26,7 +26,7 @@ export const ShowPanelButton = memo(({ showPanelOnClick }: { showPanelOnClick: (
       size="m"
       title={showPanelButtonTitle}
       aria-label={showPanelButtonTitle}
-      onClick={showPanelOnClick}
+      onClick={onClick}
       iconType={'list'}
       $backgroundColor={colorMap.graphControlsBackground}
       $iconColor={colorMap.graphControls}

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -8,7 +8,9 @@
 import React, { useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import { EuiLoadingSpinner } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { useResolverQueryParamCleaner } from './use_resolver_query_params_cleaner';
 import * as selectors from '../store/selectors';
 import { EdgeLine } from './edge_line';
@@ -26,6 +28,18 @@ import { useSyncSelectedNode } from './use_sync_selected_node';
 import { ResolverNoProcessEvents } from './resolver_no_process_events';
 import { useAutotuneTimerange } from './use_autotune_timerange';
 import type { State } from '../../common/store/types';
+import { DocumentDetailsAnalyzerPanelKey } from '../../flyout/document_details/shared/constants/panel_keys';
+
+export const ANALYZER_PREVIEW_BANNER = {
+  title: i18n.translate(
+    'xpack.securitySolution.flyout.left.visualizations.analyzer.panelPreviewTitle',
+    {
+      defaultMessage: 'Preview analyzer panel',
+    }
+  ),
+  backgroundColor: 'warning',
+  textColor: 'warning',
+} as const;
 
 /**
  * The highest level connected Resolver component. Needs a `Provider` in its ancestry to work.
@@ -42,10 +56,10 @@ export const ResolverWithoutProviders = React.memo(
       indices,
       shouldUpdate,
       filters,
-      showPanelOnClick,
     }: ResolverProps,
     refToForward
   ) {
+    const { openPreviewPanel } = useExpandableFlyoutApi();
     useResolverQueryParamCleaner(resolverComponentInstanceID);
     /**
      * This is responsible for dispatching actions that include any external data.
@@ -107,6 +121,16 @@ export const ResolverWithoutProviders = React.memo(
     );
     const colorMap = useColors();
 
+    const openAnalyzerDetailsPanel = useCallback(() => {
+      openPreviewPanel({
+        id: DocumentDetailsAnalyzerPanelKey,
+        params: {
+          resolverComponentInstanceID,
+          banner: ANALYZER_PREVIEW_BANNER,
+        },
+      });
+    }, [openPreviewPanel, resolverComponentInstanceID]);
+
     return (
       <StyledMapContainer
         className={className}
@@ -163,7 +187,7 @@ export const ResolverWithoutProviders = React.memo(
                     projectionMatrix={projectionMatrix}
                     node={treeNode}
                     timeAtRender={timeAtRender}
-                    onClick={showPanelOnClick}
+                    onClick={openAnalyzerDetailsPanel}
                   />
                 );
               })}
@@ -172,7 +196,7 @@ export const ResolverWithoutProviders = React.memo(
         ) : (
           <ResolverNoProcessEvents />
         )}
-        <GraphControls id={resolverComponentInstanceID} showPanelOnClick={showPanelOnClick} />
+        <GraphControls id={resolverComponentInstanceID} onShowPanel={openAnalyzerDetailsPanel} />
         <SymbolDefinitions id={resolverComponentInstanceID} />
       </StyledMapContainer>
     );

--- a/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/kibana.jsonc
+++ b/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/kibana.jsonc
@@ -16,7 +16,8 @@
       "securitySolution"
     ],
     "requiredBundles": [
-      "kibanaReact"
+      "kibanaReact",
+      "kibanaUtils"
     ]
   }
 }

--- a/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/moon.yml
+++ b/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/moon.yml
@@ -24,6 +24,7 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/i18n-react'
   - '@kbn/shared-ux-router'
+  - '@kbn/expandable-flyout'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/public/applications/resolver_test/index.tsx
+++ b/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/public/applications/resolver_test/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Router } from '@kbn/shared-ux-router';
+import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
@@ -77,17 +78,19 @@ const AppRoot = React.memo(
       <I18nProvider>
         <Router history={parameters.history}>
           <KibanaContextProvider services={coreStart}>
-            <Provider store={store}>
-              <Wrapper>
-                <ResolverWithoutProviders
-                  databaseDocumentID=""
-                  resolverComponentInstanceID="test"
-                  indices={[]}
-                  shouldUpdate={false}
-                  filters={{}}
-                />
-              </Wrapper>
-            </Provider>
+            <ExpandableFlyoutProvider>
+              <Provider store={store}>
+                <Wrapper>
+                  <ResolverWithoutProviders
+                    databaseDocumentID=""
+                    resolverComponentInstanceID="test"
+                    indices={[]}
+                    shouldUpdate={false}
+                    filters={{}}
+                  />
+                </Wrapper>
+              </Provider>
+            </ExpandableFlyoutProvider>
           </KibanaContextProvider>
         </Router>
       </I18nProvider>

--- a/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/tsconfig.json
+++ b/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/tsconfig.json
@@ -17,5 +17,6 @@
     "@kbn/i18n",
     "@kbn/i18n-react",
     "@kbn/shared-ux-router",
+    "@kbn/expandable-flyout",
   ]
 }


### PR DESCRIPTION
## Summary

This PR is a follow up of this previous [one](https://github.com/elastic/kibana/pull/255609), which removed the unused `isSplitPanel` property.

This current PR removes the unnecessary `showPanelOnClick` property. The `showPanelOnClick` was introduced when we wanted to support Analyzer being rendered in the alerts table and in the flyout at he same time. For the last few months/years, Analyzer has only been used within the expandable flyout. With the upcoming flyout work, we will continue to render Analyzer in a flyout environment only.

> [!WARNING]
> No UI or behavior changes should be introduced by this PR!

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
