### PR TITLE
[9.2] [Security Solution][Alert details] make sure that the dataview is ready before fetching data for analyzer preview (#255400)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { useAlertPrevalenceFromProcessTree } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
@@ -14,12 +14,7 @@ import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_f
 import { DocumentDetailsContext } from '../../shared/context';
 import { AnalyzerPreview } from './analyzer_preview';
 import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import * as mock from '../mocks/mock_analyzer_data';
-import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
-import type { DataView } from '@kbn/data-views-plugin/common';
-import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 
 jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree', () => ({
   useAlertPrevalenceFromProcessTree: jest.fn(),
@@ -37,36 +32,26 @@ const mockTreeValues = {
   statsNodes: mock.mockStatsNodes,
 };
 
-const renderAnalyzerPreview = (contextValue: DocumentDetailsContext) =>
+const renderAnalyzerPreview = (
+  contextValue: DocumentDetailsContext,
+  dataViewIndices: string[] = ['index']
+) =>
   render(
     <TestProviders>
       <DocumentDetailsContext.Provider value={contextValue}>
-        <AnalyzerPreview />
+        <AnalyzerPreview dataViewIndices={dataViewIndices} />
       </DocumentDetailsContext.Provider>
     </TestProviders>
   );
-
-const dataView: DataView = createStubDataView({
-  spec: { title: '.alerts-security.alerts-default' },
-});
 
 describe('<AnalyzerPreview />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockUseAlertPrevalenceFromProcessTree.mockReturnValue(mockTreeValues);
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-    (useSelectedPatterns as jest.Mock).mockReturnValue(['index']);
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'ready',
-      dataView: {
-        ...dataView,
-        hasMatchedIndices: jest.fn().mockReturnValue(true),
-      },
-    });
   });
 
-  it('shows analyzer preview correctly when documentId and index are present', () => {
+  it('shows analyzer preview correctly when documentId and index are present', async () => {
     const contextValue = {
       ...mockContextValue,
       dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
@@ -77,24 +62,30 @@ describe('<AnalyzerPreview />', () => {
       documentId: 'eventId',
       indices: ['rule-indices'],
     });
-    expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+    });
   });
 
-  it('should use selected index patterns for non-alerts', () => {
+  it('should use provided data view indices for non-alerts', async () => {
     const contextValue = {
       ...mockContextValue,
       dataFormattedForFieldBrowser: [],
     };
-    const wrapper = renderAnalyzerPreview(contextValue);
+    const wrapper = renderAnalyzerPreview(contextValue, ['index']);
 
     expect(mockUseAlertPrevalenceFromProcessTree).toHaveBeenCalledWith({
       documentId: 'eventId',
       indices: ['index'],
     });
-    expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+    });
   });
 
-  it('should use ancestor id as document id when in preview', () => {
+  it('should use ancestor id as document id when in rule preview', async () => {
     const contextValue = {
       ...mockContextValue,
       getFieldsData: () => 'ancestors-id',
@@ -107,35 +98,10 @@ describe('<AnalyzerPreview />', () => {
       documentId: 'ancestors-id',
       indices: ['rule-indices'],
     });
-    expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
-  });
 
-  it('should show loading skeleton when the data view is loading', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'loading',
+    await waitFor(() => {
+      expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
     });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByTestId } = renderAnalyzerPreview(contextValue);
-
-    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should show loading skeleton when the data view is pristine', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'pristine',
-    });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByTestId } = renderAnalyzerPreview(contextValue);
-
-    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
   });
 
   it('should show loading skeleton when the process tree is being fetched', () => {
@@ -152,44 +118,25 @@ describe('<AnalyzerPreview />', () => {
     expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should show error message if the data view is error', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'error',
-    });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByText } = renderAnalyzerPreview(contextValue);
-
-    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
-  });
-
-  it('should show error message if the data view is ready but no matched indices', () => {
-    (useDataView as jest.Mock).mockReturnValue({
-      status: 'ready',
-      dataView: {
-        ...dataView,
-        hasMatchedIndices: jest.fn().mockReturnValue(false),
-      },
-    });
-
-    const contextValue = {
-      ...mockContextValue,
-      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
-    };
-    const { getByText } = renderAnalyzerPreview(contextValue);
-
-    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
-  });
-
   it('should show error message when there is an error fetching the process tree data', () => {
     mockUseAlertPrevalenceFromProcessTree.mockReturnValue({
       loading: false,
       error: true,
       alertIds: undefined,
       statsNodes: undefined,
+    });
+
+    const { getByText } = renderAnalyzerPreview(mockContextValue);
+
+    expect(getByText('An error is preventing this alert from being analyzed.')).toBeInTheDocument();
+  });
+
+  it('should show error message when the process tree is empty', () => {
+    mockUseAlertPrevalenceFromProcessTree.mockReturnValue({
+      loading: false,
+      error: false,
+      alertIds: [],
+      statsNodes: [],
     });
 
     const { getByText } = renderAnalyzerPreview(mockContextValue);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
@@ -9,8 +9,6 @@ import { find } from 'lodash/fp';
 import { EuiSkeletonText, EuiTreeView } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
-import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { getTreeNodes } from '../utils/analyzer_helpers';
 import { ANCESTOR_ID, RULE_INDICES } from '../../shared/constants/field_names';
@@ -18,23 +16,6 @@ import { useDocumentDetailsContext } from '../../shared/context';
 import type { StatsNode } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
 import { useAlertPrevalenceFromProcessTree } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
 import { getField } from '../../shared/utils';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
-import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
-
-const DATAVIEW_ERROR = (
-  <FormattedMessage
-    id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.dataViewErrorDescription"
-    defaultMessage="Unable to retrieve the data view for analyzer."
-  />
-);
-
-const ANALYZER_ERROR = (
-  <FormattedMessage
-    id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.errorDescription"
-    defaultMessage="An error is preventing this alert from being analyzed."
-  />
-);
 
 const CHILD_COUNT_LIMIT = 3;
 const ANCESTOR_LEVEL = 3;
@@ -47,10 +28,17 @@ interface Cache {
   statsNodes: StatsNode[];
 }
 
+export interface AnalyzerPreviewProps {
+  /**
+   * The list of indices from the data view, used as fallback if the indices cannot be found in the document data.
+   */
+  dataViewIndices: string[];
+}
+
 /**
  * Analyzer preview under Overview, Visualizations. It shows a tree representation of analyzer.
  */
-export const AnalyzerPreview: React.FC = () => {
+export const AnalyzerPreview = ({ dataViewIndices }: AnalyzerPreviewProps) => {
   const [cache, setCache] = useState<Partial<Cache>>({});
   const {
     dataFormattedForFieldBrowser: data,
@@ -61,29 +49,10 @@ export const AnalyzerPreview: React.FC = () => {
   const ancestorId = getField(getFieldsData(ANCESTOR_ID)) ?? '';
   const documentId = isRulePreview ? ancestorId : eventId; // use ancestor as fallback for alert preview
 
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { selectedPatterns: oldAnalyzerPatterns } = useSourcererDataView(
-    DataViewManagerScopeName.analyzer
-  );
-  const experimentalAnalyzerPatterns = useSelectedPatterns(DataViewManagerScopeName.analyzer);
-  const selectedPatterns = newDataViewPickerEnabled
-    ? experimentalAnalyzerPatterns
-    : oldAnalyzerPatterns;
-
-  const { dataView, status } = useDataView(DataViewManagerScopeName.analyzer);
-
   const index = find({ category: 'kibana', field: RULE_INDICES }, data);
-  const indices = index?.values ?? selectedPatterns;
+  const indices = index?.values ?? dataViewIndices;
 
-  const needToFallbackToDataViewIndices = Boolean(index?.values);
-  const dataViewLoading =
-    needToFallbackToDataViewIndices && (status === 'loading' || status === 'pristine');
-
-  const {
-    statsNodes,
-    loading: dataLoading,
-    error,
-  } = useAlertPrevalenceFromProcessTree({
+  const { statsNodes, loading, error } = useAlertPrevalenceFromProcessTree({
     documentId,
     indices,
   });
@@ -101,7 +70,7 @@ export const AnalyzerPreview: React.FC = () => {
 
   const showAnalyzerTree = items && items.length > 0 && !error;
 
-  if (dataViewLoading || dataLoading) {
+  if (loading) {
     return (
       <EuiSkeletonText
         data-test-subj={ANALYZER_PREVIEW_LOADING_TEST_ID}
@@ -115,12 +84,13 @@ export const AnalyzerPreview: React.FC = () => {
     );
   }
 
-  if (status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices())) {
-    return DATAVIEW_ERROR;
-  }
-
   if (!showAnalyzerTree) {
-    return ANALYZER_ERROR;
+    return (
+      <FormattedMessage
+        id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.errorDescription"
+        defaultMessage="An error is preventing this alert from being analyzed."
+      />
+    );
   }
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
@@ -12,9 +12,7 @@ import { DocumentDetailsContext } from '../../shared/context';
 import { mockContextValue } from '../../shared/mocks/mock_context';
 import { AnalyzerPreviewContainer } from './analyzer_preview_container';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
-import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
-import { useAlertPrevalenceFromProcessTree } from '../../shared/hooks/use_alert_prevalence_from_process_tree';
-import * as mock from '../mocks/mock_analyzer_data';
+import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import {
   EXPANDABLE_PANEL_CONTENT_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID,
@@ -23,20 +21,34 @@ import {
   EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID,
 } from '../../../shared/components/test_ids';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
-import type { DataView } from '@kbn/data-views-plugin/common';
-import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
+import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
 
 jest.mock(
   '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver'
 );
-jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree');
-jest.mock(
-  '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
-);
 jest.mock('../../../../common/hooks/use_experimental_features');
 jest.mock('../../../../data_view_manager/hooks/use_data_view');
+jest.mock('../../../../sourcerer/containers');
+jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+jest.mock('../../../../data_view_manager/constants', () => {
+  const actual = jest.requireActual('../../../../data_view_manager/constants');
+  return {
+    ...actual,
+    PageScope: {
+      analyzer: 'analyzer',
+    },
+  };
+});
+
+const mockAnalyzerPreview = jest.fn((props: unknown) => (
+  <div data-test-subj="analyzerPreviewStub" />
+));
+jest.mock('./analyzer_preview', () => ({
+  AnalyzerPreview: (props: unknown) => mockAnalyzerPreview(props),
+}));
 
 const mockNavigateToAnalyzer = jest.fn();
 jest.mock('../../shared/hooks/use_navigate_to_analyzer', () => {
@@ -56,10 +68,6 @@ jest.mock('react-redux', () => {
   };
 });
 
-const dataView: DataView = createStubDataView({
-  spec: { title: '.alerts-security.alerts-default' },
-});
-
 const NO_ANALYZER_MESSAGE =
   'You can only visualize events triggered by hosts configured with the Elastic Defend integration or any sysmon data from winlogbeat. Refer to Visual event analyzer(external, opens in a new tab or window) for more information.';
 
@@ -72,35 +80,54 @@ const renderAnalyzerPreview = (context = mockContextValue) =>
     </TestProviders>
   );
 
+const setExperimentalFeatureFlags = ({
+  newExpandableFlyoutNavigationDisabled,
+  newDataViewPickerEnabled,
+}: {
+  newExpandableFlyoutNavigationDisabled: boolean;
+  newDataViewPickerEnabled: boolean;
+}) => {
+  (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation((featureName: string) => {
+    if (featureName === 'newExpandableFlyoutNavigationDisabled') {
+      return newExpandableFlyoutNavigationDisabled;
+    }
+
+    if (featureName === 'newDataViewPickerEnabled') {
+      return newDataViewPickerEnabled;
+    }
+
+    return false;
+  });
+};
+
 describe('AnalyzerPreviewContainer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
+    (useSourcererDataView as jest.Mock).mockReturnValue({
+      selectedPatterns: ['old-analyzer-pattern'],
+    });
+    (useSelectedPatterns as jest.Mock).mockReturnValue(['experimental-analyzer-pattern']);
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: {
+        hasMatchedIndices: () => true,
+      },
+    });
+  });
+
   describe('when newExpandableFlyoutNavigationDisabled is true', () => {
     beforeEach(() => {
-      jest.clearAllMocks();
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+      setExperimentalFeatureFlags({
+        newExpandableFlyoutNavigationDisabled: true,
+        newDataViewPickerEnabled: true,
+      });
     });
 
     it('should render component and link in header', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-      (useDataView as jest.Mock).mockReturnValue({
-        status: 'ready',
-        dataView: {
-          ...dataView,
-          hasMatchedIndices: jest.fn().mockReturnValue(true),
-        },
-      });
-
       const { getByTestId } = renderAnalyzerPreview();
 
-      expect(getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
       expect(
         getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
       ).toBeInTheDocument();
@@ -119,13 +146,13 @@ describe('AnalyzerPreviewContainer', () => {
       expect(
         screen.getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
       ).not.toHaveTextContent(NO_ANALYZER_MESSAGE);
+      expect(mockAnalyzerPreview).toHaveBeenCalledWith(
+        expect.objectContaining({ dataViewIndices: ['experimental-analyzer-pattern'] })
+      );
     });
 
     it('should render error message and text in header', () => {
       (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
 
       const { getByTestId } = renderAnalyzerPreview();
       expect(
@@ -137,17 +164,6 @@ describe('AnalyzerPreviewContainer', () => {
     });
 
     it('should open left flyout visualization tab when clicking on title', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
       const { getByTestId } = renderAnalyzerPreview();
 
       getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
@@ -155,17 +171,6 @@ describe('AnalyzerPreviewContainer', () => {
     });
 
     it('should disable link when in rule preview', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
       const { queryByTestId } = renderAnalyzerPreview({
         ...mockContextValue,
         isRulePreview: true,
@@ -176,17 +181,6 @@ describe('AnalyzerPreviewContainer', () => {
     });
 
     it('should disable link when in preview mode', () => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
-      });
-
       const { queryByTestId } = renderAnalyzerPreview({
         ...mockContextValue,
         isPreviewMode: true,
@@ -195,24 +189,51 @@ describe('AnalyzerPreviewContainer', () => {
         queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
       ).not.toBeInTheDocument();
     });
+
+    it('should show loading skeleton when the data view is loading', () => {
+      (useDataView as jest.Mock).mockReturnValue({ status: 'loading' });
+
+      const { getByTestId } = renderAnalyzerPreview();
+      expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
+      expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+    });
+
+    it('should show loading skeleton when the data view is pristine', () => {
+      (useDataView as jest.Mock).mockReturnValue({ status: 'pristine' });
+
+      const { getByTestId } = renderAnalyzerPreview();
+      expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
+      expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+    });
+
+    it('should show an error message when the data view is error', () => {
+      (useDataView as jest.Mock).mockReturnValue({ status: 'error' });
+
+      const { getByText } = renderAnalyzerPreview();
+      expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
+      expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+    });
+
+    it('should show an error message when the data view has no matched indices', () => {
+      (useDataView as jest.Mock).mockReturnValue({
+        status: 'ready',
+        dataView: { hasMatchedIndices: () => false },
+      });
+
+      const { getByText } = renderAnalyzerPreview();
+      expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
+      expect(mockAnalyzerPreview).not.toHaveBeenCalled();
+    });
   });
 
   describe('when newExpandableFlyoutNavigationDisabled is false', () => {
     beforeEach(() => {
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-    });
-    beforeEach(() => {
-      (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-      (useAlertPrevalenceFromProcessTree as jest.Mock).mockReturnValue({
-        loading: false,
-        error: false,
-        alertIds: ['alertid'],
-        statsNodes: mock.mockStatsNodes,
-      });
-      (useInvestigateInTimeline as jest.Mock).mockReturnValue({
-        investigateInTimelineAlertClick: jest.fn(),
+      setExperimentalFeatureFlags({
+        newExpandableFlyoutNavigationDisabled: false,
+        newDataViewPickerEnabled: false,
       });
     });
+
     it('should open left flyout visualization tab when clicking on title', () => {
       const { getByTestId } = renderAnalyzerPreview();
 
@@ -236,5 +257,26 @@ describe('AnalyzerPreviewContainer', () => {
       getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(ANALYZER_PREVIEW_TEST_ID)).click();
       expect(mockNavigateToAnalyzer).toHaveBeenCalled();
     });
+
+    it('should render AnalyzerPreview with sourcerer patterns when new picker is disabled', () => {
+      renderAnalyzerPreview();
+
+      expect(mockAnalyzerPreview).toHaveBeenCalledWith(
+        expect.objectContaining({ dataViewIndices: ['old-analyzer-pattern'] })
+      );
+    });
+  });
+
+  it('should use the analyzer page scope hooks', () => {
+    setExperimentalFeatureFlags({
+      newExpandableFlyoutNavigationDisabled: false,
+      newDataViewPickerEnabled: true,
+    });
+
+    renderAnalyzerPreview();
+
+    expect(useSourcererDataView).toHaveBeenCalledWith(DataViewManagerScopeName.analyzer);
+    expect(useSelectedPatterns).toHaveBeenCalledWith(DataViewManagerScopeName.analyzer);
+    expect(useDataView).toHaveBeenCalledWith(DataViewManagerScopeName.analyzer);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.tsx
@@ -6,15 +6,20 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiLink, EuiMark } from '@elastic/eui';
+import { EuiLink, EuiMark, EuiSkeletonText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
 import { AnalyzerPreview } from './analyzer_preview';
-import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
+import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { useNavigateToAnalyzer } from '../../shared/hooks/use_navigate_to_analyzer';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
+import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
+import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
 /**
  * Analyzer preview under Overview, Visualizations. It shows a tree representation of analyzer.
@@ -52,6 +57,18 @@ export const AnalyzerPreviewContainer: React.FC = () => {
     return !isPreviewMode;
   }, [isNewNavigationEnabled, isPreviewMode, isEnabled, isRulePreview]);
 
+  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+  const { selectedPatterns: oldAnalyzerPatterns } = useSourcererDataView(
+    DataViewManagerScopeName.analyzer
+  );
+  const experimentalAnalyzerPatterns = useSelectedPatterns(DataViewManagerScopeName.analyzer);
+  const selectedPatterns = newDataViewPickerEnabled
+    ? experimentalAnalyzerPatterns
+    : oldAnalyzerPatterns;
+  const { dataView, status } = useDataView(DataViewManagerScopeName.analyzer);
+  const dataViewLoading = status === 'loading' || status === 'pristine';
+  const dataViewError = status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
+
   return (
     <ExpandablePanel
       header={{
@@ -76,7 +93,30 @@ export const AnalyzerPreviewContainer: React.FC = () => {
       }}
       data-test-subj={ANALYZER_PREVIEW_TEST_ID}
     >
-      {isEnabled ? <AnalyzerPreview /> : <AnalyzerPreviewNoDataMessage />}
+      {isEnabled ? (
+        <>
+          {dataViewLoading ? (
+            <EuiSkeletonText
+              data-test-subj={ANALYZER_PREVIEW_LOADING_TEST_ID}
+              contentAriaLabel={i18n.translate(
+                'xpack.securitySolution.flyout.right.visualizations.analyzerPreview.loadingAriaLabel',
+                {
+                  defaultMessage: 'analyzer preview',
+                }
+              )}
+            />
+          ) : dataViewError ? (
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.dataViewErrorDescription"
+              defaultMessage="Unable to retrieve the data view for analyzer."
+            />
+          ) : (
+            <AnalyzerPreview dataViewIndices={selectedPatterns} />
+          )}
+        </>
+      ) : (
+        <AnalyzerPreviewNoDataMessage />
+      )}
     </ExpandablePanel>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security Solution][Alert details] make sure that the dataview is ready before fetching data for analyzer preview (#255400)](https://github.com/elastic/kibana/pull/255400)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-03-02T21:46:55Z","message":"[Security Solution][Alert details] make sure that the dataview is ready before fetching data for analyzer preview (#255400)\n\n## Summary\n\nThis PR fixes an issue related to the `AnalyzerPreview` component code.\nWe are retrieving dataView information and making calls to the `entity`\napi within the same component. This means that while the dataView is\nstill loading, we are making a call to the `entity` api with the wrong\nset of indices.\n\nThe PR makes a small change to move the dataView logic to the parent\n`AnalyzerPreviewContainer` component. That way, we can ensure that the\ncall to fetch analyzer data is not triggered until we have a dataView\nready with the correct indices.\n\n#### Prior behavior: you can see a long loading screen and multiple\ncalls to the `entity` api\n\n\nhttps://github.com/user-attachments/assets/f95ca17a-fccf-4e4f-af40-119961e43a34\n\n#### New behavior: only one call to the `entity` api\n\n\nhttps://github.com/user-attachments/assets/0b7de8ab-d1cc-4bbf-80cc-84eb81a7fa5d\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"66eca71b064d8ac6184ca6168fc7c835cf1bb2ca","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:version","v9.4.0","v9.2.7","v9.3.2"],"title":"[Security Solution][Alert details] make sure that the dataview is ready before fetching data for analyzer preview","number":255400,"url":"https://github.com/elastic/kibana/pull/255400","mergeCommit":{"message":"[Security Solution][Alert details] make sure that the dataview is ready before fetching data for analyzer preview (#255400)\n\n## Summary\n\nThis PR fixes an issue related to the `AnalyzerPreview` component code.\nWe are retrieving dataView information and making calls to the `entity`\napi within the same component. This means that while the dataView is\nstill loading, we are making a call to the `entity` api with the wrong\nset of indices.\n\nThe PR makes a small change to move the dataView logic to the parent\n`AnalyzerPreviewContainer` component. That way, we can ensure that the\ncall to fetch analyzer data is not triggered until we have a dataView\nready with the correct indices.\n\n#### Prior behavior: you can see a long loading screen and multiple\ncalls to the `entity` api\n\n\nhttps://github.com/user-attachments/assets/f95ca17a-fccf-4e4f-af40-119961e43a34\n\n#### New behavior: only one call to the `entity` api\n\n\nhttps://github.com/user-attachments/assets/0b7de8ab-d1cc-4bbf-80cc-84eb81a7fa5d\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"66eca71b064d8ac6184ca6168fc7c835cf1bb2ca"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255400","number":255400,"mergeCommit":{"message":"[Security Solution][Alert details] make sure that the dataview is ready before fetching data for analyzer preview (#255400)\n\n## Summary\n\nThis PR fixes an issue related to the `AnalyzerPreview` component code.\nWe are retrieving dataView information and making calls to the `entity`\napi within the same component. This means that while the dataView is\nstill loading, we are making a call to the `entity` api with the wrong\nset of indices.\n\nThe PR makes a small change to move the dataView logic to the parent\n`AnalyzerPreviewContainer` component. That way, we can ensure that the\ncall to fetch analyzer data is not triggered until we have a dataView\nready with the correct indices.\n\n#### Prior behavior: you can see a long loading screen and multiple\ncalls to the `entity` api\n\n\nhttps://github.com/user-attachments/assets/f95ca17a-fccf-4e4f-af40-119961e43a34\n\n#### New behavior: only one call to the `entity` api\n\n\nhttps://github.com/user-attachments/assets/0b7de8ab-d1cc-4bbf-80cc-84eb81a7fa5d\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"66eca71b064d8ac6184ca6168fc7c835cf1bb2ca"}},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->