### PR TITLE
Add test plan generator skill and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,5 @@ src/platform/plugins/shared/console/packaging/react/translations
 
 # Batched commits marker, e.g.: from quick checks
 .collect_commits_marker
+
+.cursor/tmp/

--- a/x-pack/solutions/security/.agent/skills/test-plan-generator/SKILL.md
+++ b/x-pack/solutions/security/.agent/skills/test-plan-generator/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: test-plan-generator
+description: Generate, update, and publish comprehensive test plans for GitHub issues. Use this skill when the user asks to generate, create, write, update, or publish a test plan for a GitHub issue.
+disable-model-invocation: true
+---
+
+# Test Plan Generator
+
+This skill generates comprehensive test plans from GitHub issues and posts them as comments. It navigates the full issue context: parent epics, sub-issues, linked PRs, Figma designs, and images.
+
+## Core rule — never assume, always ask
+
+**This rule applies at every step and overrides the desire to produce output quickly.**
+
+If at any point something is ambiguous, missing, or unclear — stop and ask the user before continuing. Do not fill gaps with invented context or guesses. Do not proceed past the point of uncertainty.
+
+When asking, be specific: quote the ambiguous text or describe exactly what is missing, and offer the most likely interpretation as a suggestion so the user can confirm or correct it.
+
+If the user is not available and the information cannot be found in any source, leave a visible `⚠️` flag in the relevant section noting what needs to be confirmed — never publish an assumption as a fact.
+
+**Producing a test plan with invented or unverified content is a worse outcome than asking a clarifying question.**
+
+---
+
+## Modes of operation
+
+Detect the mode from the user's phrasing before doing anything else.
+
+**Draft mode** — triggered by phrases like:
+- `generate test plan for issue #1234`
+- `create test plan for issue #1234`
+- `write test plan for issue #1234`
+
+**Before starting Step 1**, check whether a published test plan already exists for this issue: look for a comment on the issue whose body starts with `<!-- test-plan-generated -->`.
+
+If one exists, stop and tell the user:
+
+> "A test plan already exists for issue #<number>. Would you like me to check if it is still up to date?
+>
+> **A) Check and update if needed** — I will re-read the issue, sub-issues, and any new PRs, compare them against the published test plan, and add only the scenarios or sections that are missing or outdated. I will not rewrite what is already correct.
+>
+> **B) Generate from scratch** — I will ignore the existing test plan and generate a new one. The existing comment will be overwritten when you publish.
+>
+> **C) Cancel** — do nothing."
+
+If the user selects **A**, proceed as follows:
+1. Read the published test plan in full — this is the baseline.
+2. Run Steps 1 and 2 normally to gather and analyze all current context, including any PRs linked since the test plan was published.
+3. Compare the gathered context against the baseline: identify acceptance criteria, scenarios, or sections that are missing or outdated.
+4. If gaps are found: add only the missing scenarios and update only the outdated sections. Do not rewrite sections that are still accurate. Save the result to `.cursor/tmp/test-plan-#<issue_number>.md` and tell the user exactly what was added or changed.
+5. After saving the draft, read `references/output-formats.md` and output the Sources Summary as specified there.
+6. If no gaps are found: tell the user "The existing test plan appears to be up to date. No changes are needed." Do not save a draft file.
+
+If the user selects **B**, proceed normally through Steps 1, 2, and 3.
+
+If no published test plan exists, proceed normally through Steps 1, 2, and 3.
+
+Generate the test plan and save it to `.cursor/tmp/test-plan-#<issue_number>.md`. Create the `.cursor/tmp/` directory if it does not exist. Do not post anything to GitHub. Do not save the file anywhere else in the repository.
+
+Tell the user: "Draft saved to `.cursor/tmp/test-plan-#<issue_number>.md`. Open it in the editor to review and edit. When you're happy with it, run: `publish test plan for issue #<issue_number>`"
+
+Also add `.cursor/tmp/` to `.gitignore` if it is not already there.
+
+---
+
+**Update mode** — triggered by phrases like:
+- `update test plan for issue #1234`
+- `regenerate test plan for issue #1234`
+
+Update mode is incremental. Its goal is to produce only the changes needed, not to rewrite the plan from scratch.
+
+1. Fetch the published comment on the issue that starts with `<!-- test-plan-generated -->`. This is the current state of the test plan — use it as the base.
+2. Re-fetch the issue body, all sub-issues, and any comments to detect what has changed since the comment was published. Do not re-read PRs unless the user explicitly includes "including PRs" in the command.
+3. Compare the sources against the published comment and identify:
+   - New acceptance criteria or scope items not covered by any existing scenario
+   - Existing scenarios that are now incorrect due to changes in the issue or PRs
+   - Sections that reference outdated information (wrong URLs, wrong feature flag names, wrong milestone)
+   - Known Limitations that have been resolved or new ones that have emerged
+4. Apply only the identified changes to the published comment content. Do not rewrite sections that are still accurate.
+5. Save the result to `.cursor/tmp/test-plan-#<issue_number>.md`.
+6. Tell the user exactly what changed and what was left unchanged, so they can review the diff before publishing.
+7. After saving the draft, read `references/output-formats.md` and output the Sources Summary as specified there.
+
+**If no published comment exists** (no comment starting with `<!-- test-plan-generated -->`), run a full draft generation: proceed through Steps 1, 2, and 3 exactly as in draft mode, reading all sources from scratch. The mode-scoping note at the top of Step 1 does not apply in this fallback case.
+
+**If the user runs `update test plan for issue #1234 including PRs`**, re-read all linked PRs in addition to the issue, applying the same limits as draft mode (max 20 files per PR, skip files over 500 lines, skip generated/binary/translation files).
+
+---
+
+**Publish mode** — triggered by phrases like:
+- `publish test plan for issue #1234`
+- `post test plan for issue #1234`
+
+Read the local file at `.cursor/tmp/test-plan-#<issue_number>.md` and post its contents to GitHub as a comment. Do not regenerate or modify the content. After confirming the comment was posted successfully, delete the local file.
+
+If the file does not exist, tell the user: "No draft found for issue #1234. Run `generate test plan for issue #1234` first."
+
+---
+
+## Step 1 — Gather all context
+
+**This step runs in draft mode** and in update mode when falling back to a full draft (see the Modes section above). In normal update mode, follow the workflow in the Modes section instead of these steps. In publish mode, skip directly to Step 4.
+
+1. Use the GitHub MCP to fetch the full issue: title, body, labels, assignees, linked issues, and all comments.
+2. Parse the issue body and extract all URLs. Categorize them as:
+   - Figma links (contain `figma.com`)
+   - Google Docs / Drive links (contain `docs.google.com` or `drive.google.com`)
+   - GitHub issue or PR links (contain `github.com/elastic`)
+   - Any other external links
+3. For each **image URL** found in the issue body or comments (typically `user-images.githubusercontent.com` or similar): fetch and analyze the image. Do not skip images — they frequently contain UI mockups, annotated screenshots, or acceptance criteria that are not described in text. Extract: UI layout and components visible, user flows implied by the design, labels, button names, states, error messages, and any annotations. Use all of this visual context when writing test scenarios.
+4. For each **Figma link**: use the Figma MCP to fetch the design context. Fetch the specific node referenced in the URL if a `node-id` parameter is present — do not just fetch the file root. From the Figma design extract: component names and states, navigation flows, empty states, error states, loading states, and any interactions or annotations visible in the design. If the Figma MCP returns an error or the file is inaccessible: if the design appears to be the primary source of UX specification for this feature, **ask the user** how to proceed before continuing; if the Figma link appears supplementary, note it in Known Limitations with a `⚠️` flag and continue.
+5. For each **Google Docs link**: use the Google Drive MCP to read the document content, if it is configured. If the Google Drive MCP is not available, note it in Known Limitations with a `⚠️` flag and continue — do not block on this.
+6. For each **GitHub issue or PR link**: use the GitHub MCP to fetch that issue/PR body and comments.
+
+**MANDATORY — Parent issue (never skip this step if a parent exists):**
+
+Check if the issue has a parent issue (visible in the "Relationships" or "Parent issue" section on the right sidebar). If it does:
+
+1. Fetch the parent issue body, labels, and comments using the GitHub MCP.
+2. For each **image URL** found in the parent: fetch and analyze it using the same approach as for the main issue — extract UI layout, component names, states, annotations, and any design context visible.
+3. For each **Figma link** found in the parent: use the Figma MCP to fetch the design context. Parent epics frequently contain the most complete Figma designs for the whole project — treat these as high-value context.
+4. Do not navigate further up — if the parent also has a parent, stop there. One level up is sufficient.
+5. Do not read the parent's sub-issues (the siblings of the current issue) — they are out of scope.
+6. Use the parent content as **background context only**: it informs the "why" and the overall design direction, but do not generate test scenarios based on the parent alone. Only use parent content to enrich scenarios that are already justified by the current issue.
+7. Check the parent issue comments for an existing test plan: look for a comment whose body starts with `<!-- test-plan-generated -->`. If one exists, read it in full and store it as **parent test plan**. Do not treat it as a duplicate — use it in Step 2 to understand what is already covered at the epic level.
+
+If the issue has no parent, skip this step.
+
+**MANDATORY — Sub-issues (never skip this step):**
+
+Look for a "Sub-issues" section in the issue body or metadata. Use the GitHub MCP to fetch **every** sub-issue without exception. For each sub-issue: read the full title, body, all comments, all images, and all URLs. Apply the same context-gathering process recursively to each sub-issue. Treat sub-issue content as first-class context — it is as important as the parent issue.
+
+For each sub-issue, also check its comments for an existing test plan: look for a comment whose body starts with `<!-- test-plan-generated -->`. If one exists, read it in full and store it as **sub-issue test plan for #<number>**. Collect all of them — they will be used in Step 2 to avoid duplication.
+
+**Do not proceed to the PR step until all sub-issues have been fully read.**
+
+**MANDATORY — Pull Requests and test coverage (never skip this step):**
+
+Issue descriptions often reflect the original intent, not the final implementation. PRs contain the ground truth of what was actually built — and their test files reveal what is already covered by automated tests.
+
+Find all PRs linked to the issue. Look in:
+- The "Development" section on the right sidebar of the issue (listed as linked PRs)
+- The issue body (PR URLs mentioned inline)
+- The issue comments (PRs referenced with `#number` or full URLs)
+- Any sub-issue you have already read — apply this same step to each of them
+
+For each PR found, use the GitHub MCP to fetch:
+- **Description** — the PR body, which often contains context, decisions, and implementation notes not present in the issue
+- **Review comments** — reviewer feedback and author responses frequently reveal edge cases, changed behaviour, or scope adjustments made during development
+- **Changed files (diff)** — the actual code changes. Apply the following limits to avoid context overflow:
+  - Read a **maximum of 20 files** per PR
+  - Prioritize in this order: test files, UI component files, files related to feature flags or permissions, files whose name relates to the feature being tested
+  - Skip files over **500 lines of diff** — note the filename was skipped but too large to process
+  - Skip binary files, generated files (`*.snap`, `*.lock`, `*.min.js`), and translation files (`i18n`, `*.json` translation bundles)
+
+**While reading each PR, identify and catalog all test files touched or added.** For each test file found, read its contents and extract:
+- The test type: unit (`*.test.ts`), integration, API integration, or e2e (Cypress `*.cy.ts` or Scout)
+- The file path
+- The describe blocks and test names — these are the specific behaviours already covered
+
+Store this as the **test coverage catalog** — it will be used in Step 3 to populate the automation coverage line of each scenario.
+
+**If a PR has no test files**, search the filesystem for existing tests related to the feature. Use the source files modified in the PR as a starting point:
+- Look for `*.test.ts` / `*.spec.ts` files adjacent to the modified source files
+- Look in `__tests__/` folders near the modified files
+- Search for e2e tests by looking for folders named `cypress`, `e2e`, or `scout` anywhere under `x-pack/solutions/security/`
+- Search for integration and API integration tests by looking for folders named `integration`, `api_integration` anywhere under `x-pack/` that relate to the feature name or modified file names
+
+Read any test files found and add them to the test coverage catalog with the same detail level as above.
+
+If a PR has already been read in a previous session and a draft file exists, do not re-read that PR unless the user explicitly asks.
+
+**Do not proceed to Step 2 until all linked PRs and their sub-issue PRs have been read, within the limits above.**
+
+**Checkpoint before Step 2:** Review everything gathered. If any source is missing, inaccessible, or contradictory — stop and ask the user before moving on. Do not proceed to analysis with known gaps.
+
+---
+
+## Step 2 — Analyze the context
+
+**This step runs in draft mode only** (or in update mode when falling back to a full draft — see above). For publish mode, skip directly to Step 4.
+
+Before writing anything, build a mental model of:
+- What feature or functionality is being built
+- What the acceptance criteria are (explicit or implied)
+- What the UI looks like (from Figma, if available)
+- What technical constraints or edge cases are mentioned
+- What is explicitly out of scope
+
+**PR content takes priority over issue content when there is a conflict.**
+
+Issue descriptions reflect original intent and may be outdated. If a PR description, review comment, or code change contradicts or extends what the issue says, always base the test scenarios on what the PR shows — that is what is actually implemented. When you detect a meaningful discrepancy, note it explicitly in Known Limitations with a `⚠️` flag.
+
+**Cross-check existing test plans from parent and sub-issues.**
+
+If any parent test plan or sub-issue test plans were found in Step 1:
+
+1. Read each one and identify which scenarios and acceptance criteria they already cover.
+2. Do not duplicate those scenarios in the test plan for the current issue. If a scenario is already covered in a sub-issue test plan, omit it here — or reference it with a note like: "Covered in test plan for #<sub-issue-number>."
+3. Focus the current test plan on what is **unique to this issue** and not covered by any existing test plan in the hierarchy.
+4. If the current issue has no unique scenarios of its own — because everything is already covered by sub-issue test plans — stop and tell the user:
+
+   > "All acceptance criteria for this issue appear to be covered by existing test plans in its sub-issues (#X, #Y). How would you like to proceed?
+   >
+   > **A) Generate a summary test plan** — a short document that describes the feature at a high level and links to the existing sub-issue test plans for the detailed scenarios. Useful as an overview for reviewers or as a top-level entry point.
+   >
+   > **B) Generate a full test plan** — write all scenarios from scratch for this issue, incorporating everything from the sub-issues into a single self-contained document.
+   >
+   > **C) Cancel** — do not generate anything."
+
+   Wait for the user's choice before proceeding. If the user selects **A**, write only the Overview, Feature Background, Scope, and a "Test Coverage" section that lists each sub-issue with a direct link to its test plan comment. If the user selects **B**, proceed to Step 3 normally.
+
+**Detect the target release version.**
+
+Look for the target version in the following places, in order of priority:
+
+1. **Milestone** — the milestone assigned to the issue (e.g., `9.3`, `9.4`)
+2. **Project fields** — if the issue belongs to a GitHub Project, check for a custom field named `Target`, `Target version`, `Fix version`, `Release`, or similar
+3. **Labels** — look for labels that match a version pattern (e.g., `v9.3`, `9.4`, `release:9.3`)
+4. **Issue body or comments** — look for explicit mentions like "target: 9.3", "this will ship in 9.4", or similar
+
+Use the first value found and store it as `TARGET_VERSION`. If no version is found in any of these places, **ask the user** before proceeding — do not silently leave an unknown value, since `TARGET_VERSION` affects whether upgrade scenarios are included and what versions they cover.
+
+**Checkpoint before Step 3:** If the mental model built in this step has gaps — unclear acceptance criteria, contradictory sources with no obvious resolution, ambiguous scope — stop and ask the user before writing any scenarios. Writing scenarios based on incomplete or uncertain analysis produces a test plan that requires significant rework.
+
+---
+
+## Step 3 — Generate the test plan
+
+**This step runs in draft mode** (and in update mode when falling back to a full draft — see above). In publish mode, skip directly to Step 4.
+
+**Before writing anything — ask if in doubt.** If there is any remaining ambiguity about scope, acceptance criteria, or expected behaviour that was not resolved in Step 2, stop and ask the user now. It is much cheaper to ask one question before writing than to rewrite sections afterwards.
+
+Write the test plan, save it to `.cursor/tmp/test-plan-#<issue_number>.md`, and add `.cursor/tmp/` to `.gitignore` if not already there.
+
+Tell the user:
+> Draft saved to `.cursor/tmp/test-plan-#<issue_number>.md`. Open it in the editor to review and edit — you can ask me to adjust any section before publishing. When you're happy with it, run: `publish test plan for issue #<issue_number>`
+> ⚠️ This file is temporary. Do not commit it to the repository — it is listed in `.gitignore`.
+
+After saving the draft, read `references/output-formats.md` and output the Sources Summary as specified there.
+
+### Document structure (in this exact order)
+
+1. `# Test Plan: [Feature Name]`
+2. **Overview** — one paragraph explaining what the test plan covers and the scope of validation
+3. **Feature Background** — why this feature exists, what problem it solves
+4. **Scope** — what is included and what is explicitly excluded
+5. **Terminology** _(optional)_ — only include if the issue or sub-issues use domain-specific terms that need definition to understand the scenarios. Omit entirely if no special terminology is needed.
+6. **Assumptions** — always include. Document the baseline conditions that apply to all scenarios unless stated otherwise: license level, RBAC baseline (what role the test user has), data setup (what pre-existing data is assumed), and deployment type (self-managed, serverless, etc.).
+7. **Acceptance Criteria** — numbered list
+8. **Known Limitations** — constraints or deferred functionality
+9. **Test Scenarios** — the core section, organized by feature areas
+10. **Test Coverage Summary** — total scenario count, areas covered, and a summary of automated vs manual coverage
+11. **Test Execution Notes** — priority levels and execution order
+
+Only include a Permission Testing Matrix and RBAC Scenarios if the issue explicitly mentions roles, permissions, or access control.
+
+### Optional sections
+
+Read [`references/optional-scenarios.md`](references/optional-scenarios.md) before writing any scenarios. It contains the Gherkin templates for all optional sections, the Gherkin syntax rules, tags, priority levels, and GitHub comment formatting rules.
+
+Include each optional section only when the evidence clearly supports it. If it is not clear whether a section applies, ask the user before including it — do not include scenarios speculatively.
+
+| Section | Include if | Template |
+|---|---|---|
+| **RBAC** | Issue explicitly mentions roles, permissions, or access control | None — write scenarios manually based on the roles described in the issue |
+| **Multi-space** | Feature involves UI, data, or configuration that could differ between Kibana spaces | See references file |
+| **Multi-tenant** | Feature involves data ingestion, index patterns, or configuration in a Serverless or ECH deployment | See references file |
+| **Upgrade** | Feature modifies stored data, index mappings, saved objects, configuration, or navigation structure | See references file |
+| **CCS** | Feature queries Elasticsearch indices — especially Alerts index or detection rules | See references file |
+
+### Writing scenarios
+
+Only write scenarios for things confirmed by the issue, linked docs, or Figma designs. If something is unclear, ask the user first — see the Core rule at the top of this skill. Use `⚠️ Assumption: [describe assumption] — please confirm.` only as a fallback when the user is not available and the plan must move forward.
+
+**For each scenario**, before writing it, cross-reference the test coverage catalog built in Step 1. Find all tests whose describe blocks or test names match the behaviour described in the scenario. Then write the scenario using this structure:
+````markdown
+#### Scenario: <title>
+
+**Automation coverage**: <result of cross-reference — see rules below>
+```gherkin
+Given ...
+When ...
+Then ...
+```
+````
+
+**Automation coverage rules:**
+- List every matching test individually with its type and file path. Example: `2 unit tests (alerts.test.ts — "should render alert row"`, `"should filter by status"``), 1 e2e test (alerts.cy.ts — "displays alert in table")`.
+- If tests of multiple types cover the scenario, list each type separately.
+- If no tests cover the scenario, write: `No existing tests found covering this scenario.`
+- Never aggregate counts without naming the specific tests — the goal is full traceability, not a summary number.
+
+---
+
+## Step 4 — Post the test plan as a GitHub comment
+
+**This step runs in publish mode only.** In draft mode, stop after Step 3.
+
+1. Read the contents of `.cursor/tmp/test-plan-#<issue_number>.md`. Publish it exactly as it is — do not regenerate or modify.
+2. Ensure the first line of the file is exactly `<!-- test-plan-generated -->`. If it is not, prepend it before posting.
+
+**Try the GitHub MCP first.** If the GitHub MCP tools are available in this session:
+
+3. Use the GitHub MCP to **fetch all comments** on the issue.
+4. Search every comment for one whose body starts with `<!-- test-plan-generated -->`. Do not assume there is no existing comment without having explicitly read the full comment list first.
+5. **If a matching comment is found:** edit that comment with the file contents. Do not create a new comment.
+6. **If no matching comment is found:** create a new comment.
+7. After confirming the comment was posted successfully, **delete the local file**.
+8. Confirm to the user with a direct link to the updated or newly created comment on the issue.
+
+**If the GitHub MCP tools are not available in this session**, fall back to the `gh` CLI:
+
+3. Check that `gh` is installed and authenticated by running `gh auth status`. If it fails, stop and tell the user: "Neither the GitHub MCP nor the `gh` CLI are available. Install `gh` with `brew install gh` and authenticate with `gh auth login`, then try again."
+4. Fetch existing comments to check for a previous test plan: `gh issue view <issue_number> --repo elastic/kibana --comments --json comments`
+5. Search the output for a comment whose body starts with `<!-- test-plan-generated -->`.
+6. **If a matching comment is found:** edit it with `gh api --method PATCH /repos/elastic/kibana/issues/comments/<comment_id> --field body=@.cursor/tmp/test-plan-#<issue_number>.md`
+7. **If no matching comment is found:** post a new comment with `gh issue comment <issue_number> --repo elastic/kibana --body-file .cursor/tmp/test-plan-#<issue_number>.md`
+8. After confirming the comment was posted successfully, **delete the local file**.
+9. Confirm to the user with a direct link to the updated or newly created comment on the issue.
+
+**Creating a duplicate test plan comment is an error.** Always fetch and check existing comments before creating a new one.

--- a/x-pack/solutions/security/.agent/skills/test-plan-generator/references/optional-scenarios.md
+++ b/x-pack/solutions/security/.agent/skills/test-plan-generator/references/optional-scenarios.md
@@ -1,0 +1,146 @@
+# Optional Scenario Templates and Gherkin Reference
+
+This file contains the Gherkin templates for optional test plan sections, and the Gherkin formatting rules that apply to all scenarios. Read this file when generating or reviewing any test scenarios.
+
+---
+
+## Optional section templates
+
+### Multi-space scenarios
+
+```gherkin
+@multi_space
+Scenario: Feature behaves correctly in a non-default space
+  Given user is in a Kibana space other than the default space
+  And the feature flag is enabled
+  When user performs the main action of the feature
+  Then the behaviour is consistent with the default space
+
+@multi_space
+Scenario: Feature data is isolated between spaces
+  Given the feature has been configured in Space A
+  When user switches to Space B
+  Then the configuration from Space A is not visible or applied in Space B
+```
+
+---
+
+### Multi-tenant scenarios
+
+```gherkin
+@multi_tenant
+Scenario: Feature works correctly in a serverless environment
+  Given user is on a serverless Kibana project
+  And the feature flag is enabled
+  When user performs the main action of the feature
+  Then the behaviour is equivalent to a self-managed deployment
+
+@multi_tenant
+Scenario: Feature data is isolated between tenants
+  Given two separate tenants with independent deployments
+  When Tenant A configures the feature
+  Then Tenant B cannot access or see Tenant A's configuration
+```
+
+---
+
+### Upgrade scenarios
+
+Use `TARGET_VERSION` (detected in Step 2) as the target version. Run upgrade scenarios from each of the following source versions:
+- `7.17.x` (last minor of 7.x)
+- `8.19` (last minor of 8.x)
+- `9.2` (last minor before current major cycle)
+
+```gherkin
+@upgrade
+Scenario: Feature works correctly after upgrading from 7.17.x to TARGET_VERSION
+  Given a Kibana instance running version 7.17.x with existing data relevant to this feature
+  When the instance is upgraded to TARGET_VERSION
+  Then the feature is accessible and behaves as expected
+  And existing data or configuration is preserved without errors
+
+@upgrade
+Scenario: Feature works correctly after upgrading from 8.19 to TARGET_VERSION
+  Given a Kibana instance running version 8.19 with existing data relevant to this feature
+  When the instance is upgraded to TARGET_VERSION
+  Then the feature is accessible and behaves as expected
+  And existing data or configuration is preserved without errors
+
+@upgrade
+Scenario: Feature works correctly after upgrading from 9.2 to TARGET_VERSION
+  Given a Kibana instance running version 9.2 with existing data relevant to this feature
+  When the instance is upgraded to TARGET_VERSION
+  Then the feature is accessible and behaves as expected
+  And existing data or configuration is preserved without errors
+```
+
+---
+
+### Cross-cluster Search (CCS) scenarios
+
+```gherkin
+@ccs
+Scenario: Feature returns results from a remote cluster
+  Given a Kibana instance configured with a remote cluster
+  And the remote cluster contains data relevant to this feature
+  When user performs a search or view action using this feature
+  Then results from the remote cluster are included in the output
+  And no errors or empty states are shown due to the remote cluster
+
+@ccs
+Scenario: Feature handles remote cluster unavailability gracefully
+  Given a Kibana instance configured with a remote cluster
+  And the remote cluster is unavailable or unreachable
+  When user performs a search or view action using this feature
+  Then the feature displays results from the local cluster only
+  And an appropriate warning or indicator is shown for the unavailable cluster
+```
+
+---
+
+## Gherkin rules (strictly enforced)
+
+- Always use **third person**: "user", never "I"
+- Each scenario tests **one thing only** — one When/Then pair maximum
+- Maximum **7 steps** per scenario (Given + When + Then + And lines combined)
+- Every scenario must have a **Given**
+- Use **plain, readable language** — non-technical people must understand it
+
+Example of a correctly structured scenario:
+
+```gherkin
+@smoke @navigation
+Scenario: Navigate to feature page from main menu
+  Given user is on any application page
+  When user clicks "Module" in the main navigation
+  And user clicks "Feature" in the submenu
+  Then user is navigated to the Feature page
+  And the URL updates accordingly
+```
+
+---
+
+## Tags
+
+- `@smoke` — critical happy-path scenarios
+- `@navigation`, `@filters`, `@search`, `@workflow` — functional area tags
+- `@rbac` — permission scenarios (only if the issue mentions roles, permissions, or access control)
+- `@edge_case` — boundary and error scenarios
+- `@multi_space`, `@multi_tenant`, `@upgrade`, `@ccs` — optional coverage area tags
+
+---
+
+## Priority levels
+
+- **P0 (Critical):** Core functionality, navigation, data integrity
+- **P1 (High):** Workflows, filtering, search
+- **P2 (Medium):** Edge cases, error handling, integrations
+
+---
+
+## Formatting for GitHub comments
+
+- Write Gherkin blocks inside triple backtick code fences tagged as `gherkin`
+- Use `###` for feature section headers
+- Use `---` horizontal rules between feature sections
+- No emojis except for the `⚠️` assumption flag

--- a/x-pack/solutions/security/.agent/skills/test-plan-generator/references/output-formats
+++ b/x-pack/solutions/security/.agent/skills/test-plan-generator/references/output-formats
@@ -1,0 +1,38 @@
+# Output Formats
+
+This file defines the format of summaries and structured outputs that the agent produces in the chat after completing key operations. Read this file whenever the skill instructs you to output a Sources Summary.
+
+---
+
+## Sources Summary
+
+Output this table in the chat immediately after saving a draft — whether generating from scratch, checking and updating an existing plan, or running an incremental update.
+
+The goal is to give the user full traceability of what the agent read, what it used, and what it could not access.
+
+### Format
+```markdown
+### 📋 Sources used to generate this test plan
+
+| Source | Status |
+|---|---|
+| Issue #<number> — <title> | ✅ Read |
+| Parent issue #<number> — <title> | ✅ Read / ⛔ No parent |
+| Sub-issue #<number> — <title> | ✅ Read |
+| PR #<number> — <title> | ✅ Read / ⚠️ Partially read (N files skipped — too large) / ⛔ Not found |
+| Figma — <file or node name> | ✅ Read / ⚠️ Read with errors / ⛔ Inaccessible |
+| Image — <url or description> | ✅ Analyzed / ⛔ Could not fetch |
+| Google Doc — <title or url> | ✅ Read / ⛔ MCP not available |
+| Parent test plan (issue #<number>) | ✅ Found and used as reference / ➖ Not found |
+| Sub-issue test plan (issue #<number>) | ✅ Found and used as reference / ➖ Not found |
+
+> ⚠️ Items marked ⛔ were not available and may have affected the completeness of the test plan.
+```
+
+### Rules
+
+- Include a row for **every source encountered**, whether successfully read or not. Do not omit sources that failed — they are the most important ones to surface.
+- Use exactly one status per row — pick the most accurate one from the options shown.
+- If there are multiple sub-issues or PRs, include one row per item.
+- If there is no parent issue, include the row anyway with status `⛔ No parent` so the user can see it was checked.
+- If a source was partially read (e.g. a PR with skipped files), use `⚠️` and describe what was skipped in parentheses.

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/test-plan-generator.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/test-plan-generator.md
@@ -1,0 +1,332 @@
+# AI-Powered Test Plan Generator — Cursor Setup Guide
+
+This guide walks you through setting up an AI agent in Cursor that automatically generates comprehensive test plans from GitHub issues. The agent reads the issue description, navigates the parent epic and all sub-issues, fetches linked Figma designs and images, and posts the test plan as a comment directly on the issue.
+
+---
+
+## How It Works
+
+1. A GitHub issue is labeled **`needs Test Plan`** — this is a team convention to identify which issues need a test plan. The agent works on any issue regardless of labels.
+2. You open Cursor and type: `/test-plan-generator generate test plan for issue #1234`
+3. The agent reads the issue, navigates the parent epic (if any), explores all sub-issues, fetches linked Figma designs and images, and generates a structured test plan
+4. The test plan is saved locally as a draft at `.cursor/tmp/test-plan-#<issue_number>.md` for you to review and edit
+5. When you're happy with it, you run: `/test-plan-generator publish test plan for issue #1234`
+6. The agent posts the plan as a comment on the GitHub issue — using the GitHub MCP if available, or the `gh` CLI as fallback
+7. If the issue changes later, run `/test-plan-generator update test plan for issue #1234` — the agent detects only what changed and updates the draft incrementally, without rewriting everything from scratch
+
+---
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- [ ] [Cursor](https://cursor.com) installed and signed in with your `@elastic.co` Google account
+- [ ] Access to [github.com/elastic](https://github.com/elastic)
+- [ ] A Figma account with access to Elastic's Figma workspace
+- [ ] Node.js 18+ installed (`node --version` to check)
+
+---
+
+## Step 1 — Generate Your GitHub Personal Access Token
+
+The agent needs a token to read and comment on GitHub issues via the GitHub MCP server.
+
+1. Go to [github.com/settings/tokens](https://github.com/settings/tokens)
+2. Click **"Generate new token (classic)"**
+3. Give it a descriptive name, e.g., `cursor-test-plan-agent`
+4. Set expiration to **90 days** (or "No expiration" if your org allows it)
+5. Select the `repo` scope (full control of private repositories)
+6. Click **Generate token** and **copy it immediately** — you won't see it again
+
+> ⚠️ Keep this token private. Never commit it to a repository.
+
+### Authorize the token for the Elastic organization (required)
+
+This step is critical. Without it, all GitHub API calls to `elastic` repositories will fail with a `403 SAML enforcement` error.
+
+1. On the [tokens page](https://github.com/settings/tokens), find your newly created token
+2. Click **"Configure SSO"** next to it
+3. Click **"Authorize"** next to the `elastic` organization
+4. Complete any SSO prompts that appear
+
+---
+
+## Step 2 — Generate Your Figma Personal Access Token
+
+1. Open [figma.com](https://figma.com) and log in with your `@elastic.co` account
+2. Click your profile avatar (top-left) → **Settings**
+3. Scroll down to **"Personal access tokens"**
+4. Click **"Generate new token"**, give it a name like `cursor-mcp`, and click **Generate**
+5. **Copy the token** — it will only be shown once
+
+---
+
+## Step 3 — Configure the GitHub and Figma MCP Servers in Cursor
+
+Cursor reads MCP configuration from a file called `mcp.json`. The GitHub MCP is the primary way the agent reads issues and posts comments. The Figma MCP allows the agent to fetch design context from linked Figma files.
+
+### Locate or create the file
+
+- **macOS / Linux:** `~/.cursor/mcp.json`
+- **Windows:** `%APPDATA%\Cursor\mcp.json`
+
+Open the file (create it if it doesn't exist) and paste the following, replacing the placeholder values with your actual tokens:
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_TOKEN_HERE"
+      }
+    },
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--figma-api-key=YOUR_FIGMA_TOKEN_HERE", "--stdio"]
+    }
+  }
+}
+```
+
+> **Why this approach?**
+>
+> - **GitHub** uses a remote HTTP server hosted by GitHub — no local installation needed, and it provides the most complete set of tools (~41 actions including reading issues, posting comments, navigating sub-issues, etc.). The older `@modelcontextprotocol/server-github` npm package was deprecated in April 2025.
+>
+> - **Figma** uses the `figma-developer-mcp` package, which is the officially recommended package for Cursor (optimised for code generation from designs). The token is passed as a CLI argument — not as an environment variable — because that is how this package expects it. The older `@figma/mcp-server` package does not exist, and `@modelcontextprotocol/server-figma` has been deprecated.
+
+### Save the file and restart Cursor
+
+After saving, fully quit and reopen Cursor. The MCP servers start automatically on launch.
+
+### Verify the MCPs are connected
+
+1. Open Cursor Settings → **MCP** tab
+2. You should see `github` and `figma` listed with a green status indicator
+3. Hover over the `github` entry — you should see ~41 available tools listed
+4. Hover over the `figma` entry — you should see 2 available tools listed
+
+> If a server shows as disconnected, double-check the token values and that the JSON has no syntax errors. Use [jsonlint.com](https://jsonlint.com) to validate if needed.
+
+---
+
+## Step 4 — Install the `gh` CLI (recommended)
+
+The `gh` CLI is GitHub's official command-line tool. The agent uses it as a fallback to post comments when the GitHub MCP tools are not available in the session. **Having both the GitHub MCP and `gh` installed ensures the agent can always publish test plans**, even if one of them fails.
+
+### Install
+```bash
+brew install gh
+```
+
+### Authenticate with SSO
+
+Elastic does not allow HTTPS authentication. When running `gh auth login`, select **Login with a web browser** (not HTTPS):
+```bash
+gh auth login
+```
+
+When prompted:
+1. Select **GitHub.com**
+2. Select **Login with a web browser**
+3. Copy the one-time code shown in the terminal
+4. Press Enter — your browser will open automatically
+5. Paste the code and authorize the app
+6. Return to the terminal — authentication completes automatically
+
+### Verify
+```bash
+gh auth status
+```
+
+You should see your username and a valid token with `repo` scope.
+
+---
+
+## Step 5 — Google Drive (optional, deferred)
+
+Google Drive integration requires a Google Cloud OAuth setup that goes beyond a simple token. It is **not required for the pilot** — GitHub and Figma are sufficient to generate high-quality test plans.
+
+To enable it in the future (e.g., when migrating to a GitHub Actions workflow with a company service account), follow the [official MCP Google Drive setup guide](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive).
+
+---
+
+## Step 6 — Check Out the Skill
+
+The skill and its reference files were added to the repository by the Engineering Productivity team. Once you have the repo checked out locally and open in Cursor, the skill is automatically available — no manual file creation needed.
+
+The files live at:
+```
+x-pack/solutions/security/.agent/skills/test-plan-generator/
+├── SKILL.md                          # Agent instructions
+└── references/
+    ├── optional-scenarios.md         # Gherkin templates and formatting rules
+    └── output-formats.md             # Sources Summary template and chat output formats
+```
+
+> **Why a skill and not a Cursor rule?** Skills are the current standard for extending AI agents in Kibana, agreed by Kibana tech leads and the AI guild. They are more efficient than rules (loaded on demand, not on every agent session), portable across agents, and version-controlled like any other code.
+
+### How to invoke it
+
+Since the skill uses `disable-model-invocation: true`, it is **not** applied automatically. You must invoke it explicitly by typing `/test-plan-generator` in the Agent chat, followed by your command:
+```
+/test-plan-generator generate test plan for issue #1234
+```
+```
+/test-plan-generator update test plan for issue #1234
+```
+```
+/test-plan-generator publish test plan for issue #1234
+```
+
+---
+
+## Step 7 — Verify the Setup
+
+1. Open Cursor in your repository
+2. Open the **Agent** panel and make sure it is in **Agent** mode (not Ask or Edit)
+3. Select **`auto`** as the model — this avoids rate-limiting issues that can cause Cursor to hang on complex issues with many sub-issues and PRs
+4. Type:
+```
+   /test-plan-generator generate test plan for issue #1234
+```
+   Replace `1234` with a real issue number that has a description, acceptance criteria, and ideally some sub-issues.
+5. Watch the agent work through the steps — it will show what it reads from GitHub, Figma, and any linked content
+6. When finished, open `.cursor/tmp/test-plan-#1234.md` in the editor to review the draft
+7. When happy with it, run: `/test-plan-generator publish test plan for issue #1234`
+8. Check the GitHub issue — the test plan should appear as a new comment posted with your account
+
+---
+
+## Daily Usage
+
+Once set up, generating a test plan is as simple as:
+```
+/test-plan-generator generate test plan for issue #1234
+```
+
+Or with a full URL:
+```
+/test-plan-generator create a test plan for https://github.com/elastic/kibana/issues/1234
+```
+
+### Updating an existing test plan
+
+If the issue changes and you need to update the plan:
+```
+/test-plan-generator update test plan for issue #1234
+```
+
+The agent fetches the published comment as the current state, re-reads the issue to detect what changed, applies only the differences, and saves the result as a new draft for you to review before publishing.
+
+If you also need to refresh PR context (e.g., new commits were pushed):
+```
+/test-plan-generator update test plan for issue #1234 including PRs
+```
+
+### Publishing a reviewed draft
+```
+/test-plan-generator publish test plan for issue #1234
+```
+
+The agent will use the GitHub MCP if available. If not, it will automatically fall back to the `gh` CLI. Either way, the result is the same: the comment is posted (or updated) on the issue and the local draft is deleted.
+
+---
+
+## Troubleshooting
+
+### "403 SAML enforcement" error when reading issues
+
+Your GitHub token is not authorized for the Elastic organization. Go to [github.com/settings/tokens](https://github.com/settings/tokens), find your token, click **"Configure SSO"**, and authorize it for the `elastic` org. See Step 1 for the full procedure.
+
+### GitHub MCP shows as disconnected in Cursor
+
+Check that the `mcp.json` entry for `github` uses `"type": "http"` and the URL `https://api.githubcopilot.com/mcp/`. Ensure your GitHub token is correctly placed in the `Authorization` header value (after `Bearer `). Fully quit and reopen Cursor after any changes to `mcp.json`.
+
+### Figma MCP not connecting or "package not found"
+
+Make sure you are using `figma-developer-mcp` as the package name — not `@figma/mcp-server` or `@modelcontextprotocol/server-figma` (both are incorrect or deprecated). The token must be passed as a CLI argument in the `args` array (e.g., `--figma-api-key=YOUR_TOKEN`), not as an environment variable. See Step 3 for the exact configuration.
+
+### "Cannot read Figma file"
+
+Make sure the Figma file is shared with your `@elastic.co` account. The token can only access files your account can view.
+
+### The agent says it cannot connect to GitHub and falls back to `gh` CLI
+
+This is expected behaviour — it means the GitHub MCP tools were not exposed to the agent in this particular session. The agent will automatically use `gh` to publish the comment. As long as `gh auth status` shows a valid session, everything will work normally. If `gh` is not installed or not authenticated, see Step 4.
+
+### `gh auth status` fails or shows no valid token
+
+Run `gh auth login` again. When prompted for the authentication method, select **Login with a web browser** — do not select HTTPS, as Elastic does not allow it. See Step 4 for the full procedure.
+
+### `gh auth login` — authentication fails or HTTPS is rejected
+
+Make sure you select **Login with a web browser** when prompted, not the HTTPS option. Elastic enforces SSO and does not allow HTTPS-based authentication for the `elastic` GitHub organization.
+
+### `gh` CLI posts the comment but the update flow is broken on the next run
+
+The agent looks for a comment whose first line is exactly `<!-- test-plan-generated -->` to detect existing test plans and avoid duplicates. If that marker is missing or not on the first line, the agent will create a new comment instead of updating the existing one. Open the published comment on GitHub, make sure `<!-- test-plan-generated -->` is the very first line, save, and the update flow will work correctly from then on.
+
+### The agent created a file instead of posting a comment
+
+The agent did not follow the skill correctly. Check that the skill files exist at `x-pack/solutions/security/.agent/skills/test-plan-generator/` and that Cursor has loaded them (visible in Cursor Settings → Rules, Skills, Subagents under "Skills"). Try explicitly invoking with `/test-plan-generator` before your command.
+
+### The agent skipped sub-issues
+
+The skill explicitly states sub-issue navigation is mandatory. If it is still skipped, add to your prompt: "before generating the test plan, read all sub-issues of this issue in full." Also verify the GitHub MCP shows ~41 tools in Cursor Settings → MCP.
+
+### The agent generates scenarios for things not in the issue
+
+Add to your prompt: "only include scenarios for functionality explicitly described in the issue and its linked documents. Do not infer or assume features that are not mentioned."
+
+### Cursor hangs or stops responding during generation
+
+This happens when the issue has many sub-issues and PRs with large diffs, or when `update` is run in a new chat session without prior context — the agent may attempt to re-read everything from scratch.
+
+**For `update` mode:** avoid adding "including PRs" to the command unless necessary. The default update mode re-reads the issue body, sub-issues, and comments to detect changes — but skips PRs, which are the heaviest part. If you need to refresh PR context, do it as a separate step: `/test-plan-generator update test plan for issue #1234 including PRs`.
+
+**For `generate` mode:** if it hangs, split the work into two commands. First: `/test-plan-generator generate test plan for issue #1234, only read the issue and sub-issues, skip PRs`. Once that finishes: `/test-plan-generator update test plan for issue #1234 including PRs`.
+
+After a hang, close and reopen Cursor. The draft is not lost if it was saved before the hang.
+
+### JSON syntax error in mcp.json
+
+Use [jsonlint.com](https://jsonlint.com) to validate the file. A missing closing brace `}` or an extra comma are the most common causes.
+
+---
+
+## FAQ
+
+**Can I use this for any repository in the elastic org?**
+Yes, as long as your GitHub token has access to that repository and has been SSO-authorized for the `elastic` org.
+
+**What if the issue has no Figma or Google Docs links?**
+The agent skips those steps and works only with the issue text and sub-issues. The quality of the test plan depends on the quality of the issue description.
+
+**Can the agent read screenshots and images in issues?**
+Yes, as long as you are using a vision-capable model in Cursor. Use the **`auto`** model setting — it selects the best available model for each step and avoids rate-limiting issues. The agent fetches and analyzes image URLs found in the issue body and comments — typically screenshots at `user-images.githubusercontent.com`. If an image requires authentication, the agent will note it could not be read.
+
+**What if the issue has a parent epic?**
+The agent automatically reads the parent issue one level up — including its body, images, and Figma designs — and uses it as background context. If the parent already has a published test plan, the agent reads it too and uses it to avoid duplicating scenarios. It does not read the siblings (other sub-issues of the same parent) and does not navigate further up the hierarchy.
+
+**What if a sub-issue already has a published test plan?**
+The agent reads it and uses it to understand what is already covered. It will not duplicate those scenarios in the current issue's test plan. If everything is already covered by sub-issue test plans, the agent will stop and ask how you want to proceed — offering a summary plan with links, a full self-contained plan, or cancellation.
+
+**What if the issue itself already has a published test plan and I run `generate`?**
+The agent will detect the existing test plan and ask whether you want to check if it is still up to date, generate from scratch, or cancel. If you choose to check, it will re-read all sources and add only what is missing — it will not rewrite what is already correct.
+
+**Do I need both the GitHub MCP and `gh` CLI?**
+No, but it is strongly recommended. The GitHub MCP is the primary method and provides the richest context for reading issues and navigating sub-issues. The `gh` CLI is the fallback for publishing when the MCP tools are not available in the agent session. Having both means the workflow is never blocked by a connectivity issue with either tool.
+
+**Who maintains the skill?**
+The skill files live in the repository under `x-pack/solutions/security/.agent/skills/test-plan-generator/`. Any team member can propose changes via PR, just like any other code file.
+
+**Can I run this without being inside the repository folder in Cursor?**
+No — the skill only loads when you have the repository open in Cursor. The MCP servers work globally, but the skill is repo-specific.
+
+**Why is Google Drive not included in the pilot?**
+It requires a Google Cloud OAuth application setup with credentials stored locally, which adds significant complexity for individual developers. When migrating to a GitHub Actions workflow, a company-provided service account can handle it without any local setup.
+
+---
+
+*Guide maintained by the Engineering Productivity team. For questions or improvements, open an issue or reach out on Slack.*


### PR DESCRIPTION
## Summary

Adds an AI-powered Cursor skill that automatically generates, updates, and publishes comprehensive test plans for GitHub issues.

The agent reads the full issue context — parent epic, all sub-issues, linked PRs, Figma designs, and inline images — and produces a structured test plan with Gherkin scenarios and automation coverage traceability. It posts the result as a comment on the GitHub issue using the GitHub MCP or the `gh` CLI as fallback.

The skill operates in three modes:
- **`generate`** — reads all sources and saves a draft locally for review
- **`update`** — incremental update that detects only what changed and applies the diff
- **`publish`** — posts the reviewed draft as a comment on the issue (or updates the existing one)

### Files added

- `x-pack/solutions/security/.agent/skills/test-plan-generator/SKILL.md` — agent instructions
- `x-pack/solutions/security/.agent/skills/test-plan-generator/references/optional-scenarios.md` — Gherkin templates and formatting rules
- `x-pack/solutions/security/.agent/skills/test-plan-generator/references/output-formats` — Sources Summary template
- `x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/test-plan-generator.md` — setup guide and usage documentation

Full documentation, including prerequisites, MCP configuration, troubleshooting, and FAQ, is in the setup guide linked above.

---

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

---

### Identify risks

This PR adds documentation and skill configuration files only. It does not modify any application code, introduce new dependencies, or change any existing behaviour.

- No runtime code changes → no performance or data risk
- No HTTP API changes
- No plugin configuration changes
- Skill files are loaded on demand by Cursor agents only — they have no effect outside of that context

---

### Release Notes

```
release_note:skip
```

