### PR TITLE
Add git helpers to kbn-dev-utils

### DIFF
--- a/src/platform/packages/shared/kbn-dev-utils/index.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/index.ts
@@ -31,4 +31,5 @@ export * from './src/plugin_list';
 export * from './src/streams';
 export * from './src/extract';
 export * from './src/diff_strings';
+export * from './src/git';
 export * from './src/worker';

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/count_commits_between_refs.test.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/count_commits_between_refs.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { countCommitsBetweenRefs } from './count_commits_between_refs';
+
+jest.mock('execa');
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/repo',
+}));
+
+const mockExeca = execa as unknown as jest.Mock;
+
+describe('countCommitsBetweenRefs', () => {
+  beforeEach(() => {
+    mockExeca.mockReset();
+  });
+
+  it('parses commit count from git rev-list output', async () => {
+    mockExeca.mockResolvedValue({ stdout: '7\n' });
+
+    await expect(
+      countCommitsBetweenRefs({
+        base: 'base-sha',
+        head: 'head-sha',
+      })
+    ).resolves.toBe(7);
+    expect(mockExeca).toHaveBeenCalledWith(
+      'git',
+      ['rev-list', '--count', 'base-sha..head-sha'],
+      expect.objectContaining({ stdin: 'ignore' })
+    );
+  });
+
+  it('throws when git output is not numeric', async () => {
+    mockExeca.mockResolvedValue({ stdout: 'not-a-number\n' });
+
+    await expect(
+      countCommitsBetweenRefs({
+        base: 'base-sha',
+        head: 'head-sha',
+      })
+    ).rejects.toThrow("git rev-list returned a non-numeric commit count: 'not-a-number'");
+  });
+});

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/count_commits_between_refs.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/count_commits_between_refs.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+
+/** Counts commits reachable from `head` that are not reachable from `base`. */
+export const countCommitsBetweenRefs = async ({
+  base,
+  head,
+}: {
+  base: string;
+  head: string;
+}): Promise<number> => {
+  const { stdout } = await execa('git', ['rev-list', '--count', `${base}..${head}`], {
+    cwd: REPO_ROOT,
+    stdin: 'ignore',
+  });
+
+  const commitCount = Number.parseInt(stdout.trim(), 10);
+  if (Number.isNaN(commitCount)) {
+    throw new Error(`git rev-list returned a non-numeric commit count: '${stdout.trim()}'`);
+  }
+
+  return commitCount;
+};

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/create_index_snapshot_commit.test.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/create_index_snapshot_commit.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { createIndexSnapshotCommit } from './create_index_snapshot_commit';
+
+jest.mock('execa');
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/repo',
+}));
+
+const mockExeca = execa as unknown as jest.Mock;
+
+describe('createIndexSnapshotCommit', () => {
+  beforeEach(() => {
+    mockExeca.mockReset();
+  });
+
+  it('creates a temporary commit from the current index', async () => {
+    mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === 'write-tree') {
+        return { stdout: 'tree-sha\n' };
+      }
+
+      if (args[0] === 'commit-tree') {
+        return { stdout: 'commit-sha\n' };
+      }
+
+      throw new Error(`Unexpected command args: ${args.join(' ')}`);
+    });
+
+    await expect(createIndexSnapshotCommit()).resolves.toBe('commit-sha');
+    expect(mockExeca).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['commit-tree', 'tree-sha', '-p', 'HEAD'],
+      expect.objectContaining({ input: expect.any(String) })
+    );
+    expect(mockExeca.mock.calls[1][2].stdin).toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/create_index_snapshot_commit.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/create_index_snapshot_commit.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+
+/**
+ * Creates an ephemeral commit from the current Git index without updating any refs.
+ * Used by staged-scope affected checks where tooling needs a real `head` SHA for
+ * index contents (for example Moon comparisons with `base=HEAD` and `head=<index snapshot>`).
+ */
+export const createIndexSnapshotCommit = async ({
+  parentRef = 'HEAD',
+  message = 'Temporary commit for staged-scope tooling\n',
+}: {
+  parentRef?: string;
+  message?: string;
+} = {}): Promise<string> => {
+  const { stdout: treeStdout } = await execa('git', ['write-tree'], {
+    cwd: REPO_ROOT,
+    stdin: 'ignore',
+  });
+  const treeSha = treeStdout.trim();
+  if (!treeSha) {
+    throw new Error('git write-tree returned an empty tree SHA');
+  }
+
+  const { stdout: commitStdout } = await execa('git', ['commit-tree', treeSha, '-p', parentRef], {
+    cwd: REPO_ROOT,
+    input: message,
+  });
+  const commitSha = commitStdout.trim();
+  if (!commitSha) {
+    throw new Error('git commit-tree returned an empty commit SHA');
+  }
+
+  return commitSha;
+};

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/get_remote_default_branch_refs.test.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/get_remote_default_branch_refs.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { getRemoteDefaultBranchRefs } from './get_remote_default_branch_refs';
+
+jest.mock('execa');
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/repo',
+}));
+
+const mockExeca = execa as unknown as jest.Mock;
+
+describe('getRemoteDefaultBranchRefs', () => {
+  beforeEach(() => {
+    mockExeca.mockReset();
+  });
+
+  it('resolves and deduplicates remote default branch refs', async () => {
+    mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        return {
+          stdout:
+            'refs/remotes/origin/HEAD\nrefs/remotes/upstream/HEAD\nrefs/remotes/origin/HEAD\n',
+        };
+      }
+
+      if (args[0] === 'symbolic-ref' && args[2] === 'refs/remotes/origin/HEAD') {
+        return { stdout: 'origin/main\n' };
+      }
+
+      if (args[0] === 'symbolic-ref' && args[2] === 'refs/remotes/upstream/HEAD') {
+        return { stdout: 'upstream/main\n' };
+      }
+
+      throw new Error(`Unexpected command args: ${args.join(' ')}`);
+    });
+
+    await expect(getRemoteDefaultBranchRefs()).resolves.toEqual(['origin/main', 'upstream/main']);
+  });
+
+  it('ignores remotes that cannot be resolved', async () => {
+    mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        return {
+          stdout: 'refs/remotes/origin/HEAD\nrefs/remotes/broken/HEAD\nrefs/remotes/empty/HEAD\n',
+        };
+      }
+
+      if (args[0] === 'symbolic-ref' && args[2] === 'refs/remotes/origin/HEAD') {
+        return { stdout: 'origin/main\n' };
+      }
+
+      if (args[0] === 'symbolic-ref' && args[2] === 'refs/remotes/broken/HEAD') {
+        throw new Error('broken remote');
+      }
+
+      if (args[0] === 'symbolic-ref' && args[2] === 'refs/remotes/empty/HEAD') {
+        return { stdout: '   \n' };
+      }
+
+      throw new Error(`Unexpected command args: ${args.join(' ')}`);
+    });
+
+    await expect(getRemoteDefaultBranchRefs()).resolves.toEqual(['origin/main']);
+  });
+
+  it('resolves default branches for remotes with nested names', async () => {
+    mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        return {
+          stdout:
+            'refs/remotes/origin/HEAD\nrefs/remotes/foo/bar/HEAD\nrefs/remotes/foo/bar/main\n',
+        };
+      }
+
+      if (args[0] === 'symbolic-ref' && args[2] === 'refs/remotes/origin/HEAD') {
+        return { stdout: 'origin/main\n' };
+      }
+
+      if (args[0] === 'symbolic-ref' && args[2] === 'refs/remotes/foo/bar/HEAD') {
+        return { stdout: 'foo/bar/main\n' };
+      }
+
+      throw new Error(`Unexpected command args: ${args.join(' ')}`);
+    });
+
+    await expect(getRemoteDefaultBranchRefs()).resolves.toEqual(['origin/main', 'foo/bar/main']);
+  });
+});

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/get_remote_default_branch_refs.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/get_remote_default_branch_refs.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+
+const splitLines = (value: string): string[] =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+export const getRemoteDefaultBranchRefs = async (): Promise<string[]> => {
+  const { stdout } = await execa('git', ['for-each-ref', '--format=%(refname)', 'refs/remotes'], {
+    cwd: REPO_ROOT,
+    stdin: 'ignore',
+  });
+
+  const remoteHeadRefs = splitLines(stdout).filter((ref) => ref.endsWith('/HEAD'));
+  const resolvedRefs = await Promise.all(
+    remoteHeadRefs.map(async (remoteHeadRef) => {
+      try {
+        const { stdout: baseRefStdout } = await execa(
+          'git',
+          ['symbolic-ref', '--short', remoteHeadRef],
+          {
+            cwd: REPO_ROOT,
+            stdin: 'ignore',
+          }
+        );
+
+        const baseRef = baseRefStdout.trim();
+        return baseRef.length > 0 ? baseRef : undefined;
+      } catch {
+        return undefined;
+      }
+    })
+  );
+
+  return [...new Set(resolvedRefs.filter((ref): ref is string => Boolean(ref)))];
+};

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/has_staged_changes.test.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/has_staged_changes.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { hasStagedChanges } from './has_staged_changes';
+
+jest.mock('execa');
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/repo',
+}));
+
+const mockExeca = execa as unknown as jest.Mock;
+
+describe('hasStagedChanges', () => {
+  beforeEach(() => {
+    mockExeca.mockReset();
+  });
+
+  it('returns false when the index matches HEAD', async () => {
+    mockExeca.mockResolvedValue({ stdout: '' });
+
+    await expect(hasStagedChanges()).resolves.toBe(false);
+  });
+
+  it('returns true when git diff exits with status 1', async () => {
+    mockExeca.mockRejectedValue({ exitCode: 1 });
+
+    await expect(hasStagedChanges()).resolves.toBe(true);
+  });
+
+  it('rethrows unexpected git failures', async () => {
+    const error = new Error('git failed');
+    mockExeca.mockRejectedValue(error);
+
+    await expect(hasStagedChanges()).rejects.toBe(error);
+  });
+});

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/has_staged_changes.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/has_staged_changes.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ExecaError } from 'execa';
+import execa from 'execa';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+
+/** Returns true when the Git index contains staged changes relative to HEAD. */
+export const hasStagedChanges = async (): Promise<boolean> => {
+  try {
+    await execa('git', ['diff', '--cached', '--quiet'], {
+      cwd: REPO_ROOT,
+      stdin: 'ignore',
+    });
+    return false;
+  } catch (error) {
+    if ((error as ExecaError).exitCode === 1) {
+      return true;
+    }
+
+    throw error;
+  }
+};

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/index.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { getRemoteDefaultBranchRefs } from './get_remote_default_branch_refs';
+export { createIndexSnapshotCommit } from './create_index_snapshot_commit';
+export { countCommitsBetweenRefs } from './count_commits_between_refs';
+export { hasStagedChanges } from './has_staged_changes';
+export { resolveNearestMergeBase } from './resolve_nearest_merge_base';
+export type { NearestMergeBaseCandidate } from './resolve_nearest_merge_base';

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/resolve_nearest_merge_base.test.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/resolve_nearest_merge_base.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { resolveNearestMergeBase } from './resolve_nearest_merge_base';
+
+jest.mock('execa');
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/repo',
+}));
+
+const mockExeca = execa as unknown as jest.Mock;
+
+describe('resolveNearestMergeBase', () => {
+  beforeEach(() => {
+    mockExeca.mockReset();
+  });
+
+  it('returns the merge-base candidate with the smallest ahead count', async () => {
+    mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === 'merge-base' && args[1] === 'HEAD' && args[2] === 'origin/main') {
+        return { stdout: 'base-origin\n' };
+      }
+
+      if (args[0] === 'merge-base' && args[1] === 'HEAD' && args[2] === 'upstream/main') {
+        return { stdout: 'base-upstream\n' };
+      }
+
+      if (args[0] === 'rev-list' && args[2] === 'base-origin..HEAD') {
+        return { stdout: '12\n' };
+      }
+
+      if (args[0] === 'rev-list' && args[2] === 'base-upstream..HEAD') {
+        return { stdout: '4\n' };
+      }
+
+      throw new Error(`Unexpected command args: ${args.join(' ')}`);
+    });
+
+    await expect(
+      resolveNearestMergeBase({ baseRefs: ['origin/main', 'upstream/main'] })
+    ).resolves.toEqual({
+      baseRef: 'upstream/main',
+      mergeBase: 'base-upstream',
+      aheadCount: 4,
+    });
+  });
+
+  it('returns undefined when no merge-base can be resolved', async () => {
+    mockExeca.mockRejectedValue(new Error('git failed'));
+
+    await expect(resolveNearestMergeBase({ baseRefs: ['origin/main'] })).resolves.toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/kbn-dev-utils/src/git/resolve_nearest_merge_base.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/git/resolve_nearest_merge_base.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import execa from 'execa';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+
+export interface NearestMergeBaseCandidate {
+  baseRef: string;
+  mergeBase: string;
+  aheadCount: number;
+}
+
+/**
+ * Resolves the closest merge-base candidate between `headRef` and the provided base refs.
+ * "Closest" is the candidate with the smallest ahead count from the merge base to head.
+ */
+export const resolveNearestMergeBase = async ({
+  baseRefs,
+  headRef = 'HEAD',
+}: {
+  baseRefs: string[];
+  headRef?: string;
+}): Promise<NearestMergeBaseCandidate | undefined> => {
+  let bestCandidate: NearestMergeBaseCandidate | undefined;
+
+  for (const baseRef of baseRefs) {
+    try {
+      const { stdout: mergeBaseStdout } = await execa('git', ['merge-base', headRef, baseRef], {
+        cwd: REPO_ROOT,
+        stdin: 'ignore',
+      });
+
+      const mergeBase = mergeBaseStdout.trim();
+      if (!mergeBase) {
+        continue;
+      }
+
+      const { stdout: aheadCountStdout } = await execa(
+        'git',
+        ['rev-list', '--count', `${mergeBase}..${headRef}`],
+        {
+          cwd: REPO_ROOT,
+          stdin: 'ignore',
+        }
+      );
+
+      const aheadCount = Number.parseInt(aheadCountStdout.trim(), 10);
+      if (Number.isNaN(aheadCount)) {
+        continue;
+      }
+
+      if (!bestCandidate || aheadCount < bestCandidate.aheadCount) {
+        bestCandidate = {
+          baseRef,
+          mergeBase,
+          aheadCount,
+        };
+      }
+    } catch {
+      // Ignore refs we cannot compare against.
+    }
+  }
+
+  return bestCandidate;
+};


### PR DESCRIPTION
Introduce shared Git utilities for staged-change detection, index snapshot commits, remote default-branch refs, commit counting, and nearest merge-base resolution, with unit tests and exports.

In preparation for https://github.com/elastic/kibana/pull/255048

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->