### PR TITLE
Add search_tool mode for RAG evaluators and extractor fallback

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/README.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/README.md
@@ -135,10 +135,16 @@ SELECTED_EVALUATORS="Precision@K,Recall@K,F1@K,Factuality" RAG_EVAL_K=5,10,20 no
 # Override RAG evaluator K value (supports comma-separated values for multi-K evaluation)
 RAG_EVAL_K=5,10,20 node scripts/playwright test --config x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/playwright.config.ts
 
+# Run RAG evaluators directly on platform.core.search instead of /converse
+RAG_EVAL_EXECUTION_MODE=search_tool SELECTED_EVALUATORS="Precision@K,Recall@K,F1@K" node scripts/playwright test --config x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/playwright.config.ts
+
 # Retrieve traces from another (monitoring) cluster
 TRACING_ES_URL=http://elastic:changeme@localhost:9200 EVALUATION_CONNECTOR_ID=llm-judge-connector-id node scripts/playwright test --config x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/playwright.config.ts
 
 ```
+
+`RAG_EVAL_EXECUTION_MODE` defaults to `converse`. Set it to `search_tool` to evaluate retrieval metrics against direct search tool execution.
+When `search_tool` is enabled, non-RAG evaluators still run on the `converse` response.
 
 > **Tip:** When using preconfigured connectors, set `KBN_EVALS_SKIP_CONNECTOR_SETUP=true` to skip automatic connector setup/teardown, causing instability running evaluations.
 

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.test.ts
@@ -94,6 +94,31 @@ describe('extractSearchRetrievedDocs', () => {
     ]);
   });
 
+  it('falls back to steps and direct results when searchToolResults is undefined', () => {
+    const output = {
+      searchToolResults: undefined,
+      steps: [
+        {
+          type: 'tool_call',
+          tool_id: 'platform.core.search',
+          results: [{ data: { reference: { index: 'elastic_knowledge_base', id: 'step-doc' } } }],
+        },
+      ],
+      results: [
+        {
+          data: {
+            resources: [{ reference: { index: 'wix_knowledge_base', id: 'direct-doc' } }],
+          },
+        },
+      ],
+    } satisfies TaskOutput;
+
+    expect(extractSearchRetrievedDocs(output)).toEqual([
+      { index: 'elastic_knowledge_base', id: 'step-doc' },
+      { index: 'wix_knowledge_base', id: 'direct-doc' },
+    ]);
+  });
+
   it('handles mixed result shapes and ignores malformed references', () => {
     const output = {
       steps: [

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.test.ts
@@ -51,6 +51,49 @@ describe('extractSearchRetrievedDocs', () => {
     ]);
   });
 
+  it('extracts docs from direct tool execution output results', () => {
+    const output = {
+      results: [
+        {
+          data: {
+            resources: [
+              { reference: { index: 'elastic_knowledge_base', id: '3325_1' } },
+              { reference: { index: 'elastic_knowledge_base', id: '3325_3' } },
+            ],
+          },
+        },
+      ],
+    } satisfies TaskOutput;
+
+    expect(extractSearchRetrievedDocs(output)).toEqual([
+      { index: 'elastic_knowledge_base', id: '3325_1' },
+      { index: 'elastic_knowledge_base', id: '3325_3' },
+    ]);
+  });
+
+  it('prefers dedicated searchToolResults when provided', () => {
+    const output = {
+      searchToolResults: [
+        {
+          data: {
+            resources: [{ reference: { index: 'wix_knowledge_base', id: 'direct-doc' } }],
+          },
+        },
+      ],
+      steps: [
+        {
+          type: 'tool_call',
+          tool_id: 'platform.core.search',
+          results: [{ data: { reference: { index: 'elastic_knowledge_base', id: 'step-doc' } } }],
+        },
+      ],
+    } satisfies TaskOutput;
+
+    expect(extractSearchRetrievedDocs(output)).toEqual([
+      { index: 'wix_knowledge_base', id: 'direct-doc' },
+    ]);
+  });
+
   it('handles mixed result shapes and ignores malformed references', () => {
     const output = {
       steps: [

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.ts
@@ -31,6 +31,7 @@ import {
   getStringMeta,
   getToolCallSteps,
 } from '@kbn/evals';
+import { platformCoreTools } from '@kbn/agent-builder-common';
 import type { AgentBuilderEvaluationChatClient } from './chat_client';
 import { extractSearchRetrievedDocs } from './rag_extractor';
 
@@ -59,6 +60,29 @@ export type EvaluateDataset = ({
 
 export type EvaluateExternalDataset = (datasetName: string) => Promise<void>;
 
+const RAG_EVAL_EXECUTION_MODE_ENV_VAR = 'RAG_EVAL_EXECUTION_MODE';
+const RAG_EVAL_EXECUTION_MODES = ['converse', 'search_tool'] as const;
+export type RagEvaluationExecutionMode = (typeof RAG_EVAL_EXECUTION_MODES)[number];
+
+export function getRagEvaluationExecutionMode(
+  env: Record<string, string | undefined> = process.env
+): RagEvaluationExecutionMode {
+  const value = env[RAG_EVAL_EXECUTION_MODE_ENV_VAR];
+  if (!value) {
+    return 'converse';
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'converse' || normalized === 'search_tool') {
+    return normalized;
+  }
+
+  throw new Error(
+    `Invalid ${RAG_EVAL_EXECUTION_MODE_ENV_VAR} value: "${value}". ` +
+      `Expected one of: ${RAG_EVAL_EXECUTION_MODES.join(', ')}.`
+  );
+}
+
 function configureExperiment({
   evaluators,
   chatClient,
@@ -73,7 +97,13 @@ function configureExperiment({
   task: ExperimentTask<DatasetExample, TaskOutput>;
   evaluators: ReturnType<typeof selectEvaluators>;
 } {
-  const task: ExperimentTask<DatasetExample, TaskOutput> = async ({ input, output, metadata }) => {
+  const ragExecutionMode = getRagEvaluationExecutionMode();
+
+  const converseTask: ExperimentTask<DatasetExample, TaskOutput> = async ({
+    input,
+    output,
+    metadata,
+  }) => {
     const agentId = getStringMeta(metadata, 'agentId');
     const response = await chatClient.converse({
       messages: [{ message: input.question }],
@@ -110,6 +140,62 @@ function configureExperiment({
       groundednessAnalysis: groundednessResult?.metadata,
     };
   };
+
+  const searchToolTask: ExperimentTask<DatasetExample, TaskOutput> = async ({
+    input,
+    output,
+    metadata,
+  }) => {
+    const agentId = getStringMeta(metadata, 'agentId');
+    const searchIndex = getStringMeta(metadata, 'searchIndex');
+    const [converseResponse, searchResponse] = await Promise.all([
+      chatClient.converse({
+        messages: [{ message: input.question }],
+        options: agentId ? { agentId } : undefined,
+      }),
+      chatClient.executeTool({
+        toolId: platformCoreTools.search,
+        toolParams: {
+          query: input.question,
+          ...(searchIndex ? { index: searchIndex } : {}),
+        },
+      }),
+    ]);
+
+    // In search_tool mode, non-RAG evaluators should still rely on converse output.
+    const [correctnessResult, groundednessResult] = await Promise.all([
+      withEvaluatorSpan('CorrectnessAnalysis', {}, () =>
+        evaluators.correctnessAnalysis().evaluate({
+          input,
+          expected: output,
+          output: converseResponse,
+          metadata,
+        })
+      ),
+      withEvaluatorSpan('GroundednessAnalysis', {}, () =>
+        evaluators.groundednessAnalysis().evaluate({
+          input,
+          expected: output,
+          output: converseResponse,
+          metadata,
+        })
+      ),
+    ]);
+
+    return {
+      errors: converseResponse.errors,
+      messages: converseResponse.messages,
+      steps: converseResponse.steps,
+      traceId: converseResponse.traceId,
+      correctnessAnalysis: correctnessResult?.metadata,
+      groundednessAnalysis: groundednessResult?.metadata,
+      // Dedicated direct-search output consumed by RAG extractor in search_tool mode.
+      searchToolResults: searchResponse.results,
+      searchToolErrors: searchResponse.errors,
+    };
+  };
+
+  const task = ragExecutionMode === 'search_tool' ? searchToolTask : converseTask;
 
   const ragEvaluators = createRagEvaluators({
     k: 10,
@@ -191,7 +277,10 @@ function configureExperiment({
     }),
   ]);
 
-  return { task, evaluators: selectedEvaluators };
+  return {
+    task,
+    evaluators: selectedEvaluators,
+  };
 }
 
 export function createEvaluateDataset({

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset_execution_mode.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset_execution_mode.test.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DefaultEvaluators, EvalsExecutorClient, Evaluator } from '@kbn/evals';
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import type { EsClient } from '@kbn/scout';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { AgentBuilderEvaluationChatClient } from './chat_client';
+import { createEvaluateDataset, getRagEvaluationExecutionMode } from './evaluate_dataset';
+
+const createCodeEvaluator = (name: string): Evaluator => {
+  return {
+    name,
+    kind: 'CODE',
+    evaluate: jest.fn().mockResolvedValue({ score: 1 }),
+  };
+};
+
+const createMockEvaluators = () => {
+  const correctnessEvaluate = jest.fn().mockResolvedValue({ metadata: { pass: true } });
+  const groundednessEvaluate = jest.fn().mockResolvedValue({ metadata: { pass: true } });
+
+  const evaluators: DefaultEvaluators = {
+    criteria: () => createCodeEvaluator('Criteria'),
+    correctnessAnalysis: () =>
+      ({
+        name: 'Correctness Analysis',
+        kind: 'LLM',
+        evaluate: correctnessEvaluate,
+      } as Evaluator),
+    groundednessAnalysis: () =>
+      ({
+        name: 'Groundedness Analysis',
+        kind: 'LLM',
+        evaluate: groundednessEvaluate,
+      } as Evaluator),
+    traceBasedEvaluators: {
+      inputTokens: createCodeEvaluator('Input Tokens'),
+      outputTokens: createCodeEvaluator('Output Tokens'),
+      cachedTokens: createCodeEvaluator('Cached Tokens'),
+      toolCalls: createCodeEvaluator('Tool Calls'),
+      latency: createCodeEvaluator('Latency'),
+    },
+  };
+
+  return {
+    evaluators,
+    correctnessEvaluate,
+    groundednessEvaluate,
+  };
+};
+
+const createExecutorClient = () => {
+  const runExperiment = jest.fn().mockResolvedValue({ id: 'exp', runs: {}, evaluationRuns: [] });
+  const executorClient = {
+    runExperiment,
+    getRanExperiments: jest.fn().mockResolvedValue([]),
+  } as unknown as EvalsExecutorClient;
+
+  return { executorClient, runExperiment };
+};
+
+const createChatClient = () => {
+  return {
+    converse: jest.fn(),
+    executeTool: jest.fn(),
+  } as unknown as jest.Mocked<AgentBuilderEvaluationChatClient>;
+};
+
+describe('RAG evaluation execution mode', () => {
+  const originalRagEvalExecutionMode = process.env.RAG_EVAL_EXECUTION_MODE;
+  const originalSelectedEvaluators = process.env.SELECTED_EVALUATORS;
+  const originalRagEvalK = process.env.RAG_EVAL_K;
+
+  afterEach(() => {
+    if (originalRagEvalExecutionMode === undefined) {
+      delete process.env.RAG_EVAL_EXECUTION_MODE;
+    } else {
+      process.env.RAG_EVAL_EXECUTION_MODE = originalRagEvalExecutionMode;
+    }
+
+    if (originalSelectedEvaluators === undefined) {
+      delete process.env.SELECTED_EVALUATORS;
+    } else {
+      process.env.SELECTED_EVALUATORS = originalSelectedEvaluators;
+    }
+
+    if (originalRagEvalK === undefined) {
+      delete process.env.RAG_EVAL_K;
+    } else {
+      process.env.RAG_EVAL_K = originalRagEvalK;
+    }
+  });
+
+  it('defaults to converse mode when env var is unset', () => {
+    expect(getRagEvaluationExecutionMode({})).toBe('converse');
+  });
+
+  it('throws for unsupported execution mode values', () => {
+    expect(() =>
+      getRagEvaluationExecutionMode({
+        RAG_EVAL_EXECUTION_MODE: 'invalid_mode',
+      })
+    ).toThrow(
+      'Invalid RAG_EVAL_EXECUTION_MODE value: "invalid_mode". Expected one of: converse, search_tool.'
+    );
+  });
+
+  it('uses converse task and full evaluator set by default', async () => {
+    delete process.env.RAG_EVAL_EXECUTION_MODE;
+    delete process.env.SELECTED_EVALUATORS;
+    delete process.env.RAG_EVAL_K;
+
+    const { evaluators, correctnessEvaluate, groundednessEvaluate } = createMockEvaluators();
+    const { executorClient, runExperiment } = createExecutorClient();
+    const chatClient = createChatClient();
+
+    chatClient.converse.mockResolvedValue({
+      conversationId: 'conversation-id',
+      messages: [{ message: 'assistant answer' }],
+      errors: [],
+      steps: [{ type: 'tool_call', tool_id: platformCoreTools.search, results: [] }],
+      traceId: 'trace-id',
+    });
+
+    const evaluateDataset = createEvaluateDataset({
+      evaluators,
+      executorClient,
+      chatClient,
+      traceEsClient: {} as EsClient,
+      log: {} as ToolingLog,
+    });
+
+    const example = {
+      input: { question: 'Where can I update my billing details?' },
+      output: {
+        expected: 'You can update billing details from account settings.',
+        groundTruth: {
+          wix_knowledge_base: {
+            'doc-1': 1,
+          },
+        },
+      },
+      metadata: {},
+    };
+
+    await evaluateDataset({
+      dataset: {
+        name: 'test dataset',
+        description: 'dataset description',
+        examples: [example],
+      },
+    });
+
+    const [options, selectedEvaluators] = runExperiment.mock.calls[0];
+    const taskOutput = await options.task(example);
+
+    expect(chatClient.converse).toHaveBeenCalledTimes(1);
+    expect(chatClient.executeTool).not.toHaveBeenCalled();
+    expect(taskOutput).toMatchObject({
+      traceId: 'trace-id',
+      messages: [{ message: 'assistant answer' }],
+      steps: [{ type: 'tool_call', tool_id: platformCoreTools.search }],
+      correctnessAnalysis: { pass: true },
+      groundednessAnalysis: { pass: true },
+    });
+    expect(correctnessEvaluate).toHaveBeenCalledTimes(1);
+    expect(groundednessEvaluate).toHaveBeenCalledTimes(1);
+
+    const evaluatorNames = selectedEvaluators.map((e: Evaluator) => e.name);
+    expect(evaluatorNames).toContain('Factuality');
+    expect(evaluatorNames).toContain('Groundedness');
+    expect(evaluatorNames).toContain('Precision@10');
+  });
+
+  it('uses search tool for RAG while keeping converse-based evaluators', async () => {
+    process.env.RAG_EVAL_EXECUTION_MODE = 'search_tool';
+    delete process.env.SELECTED_EVALUATORS;
+    delete process.env.RAG_EVAL_K;
+
+    const { evaluators, correctnessEvaluate, groundednessEvaluate } = createMockEvaluators();
+    const { executorClient, runExperiment } = createExecutorClient();
+    const chatClient = createChatClient();
+
+    chatClient.converse.mockResolvedValue({
+      conversationId: 'conversation-id',
+      messages: [{ message: 'assistant answer from converse' }],
+      errors: [],
+      steps: [
+        {
+          type: 'tool_call',
+          tool_id: platformCoreTools.getDocumentById,
+          results: [],
+        },
+      ],
+      traceId: 'trace-id-from-converse',
+    });
+
+    chatClient.executeTool.mockResolvedValue({
+      results: [
+        {
+          type: 'resource_list',
+          data: {
+            resources: [{ reference: { index: 'wix_knowledge_base', id: 'doc-1' } }],
+          },
+        },
+      ],
+      errors: [],
+    });
+
+    const evaluateDataset = createEvaluateDataset({
+      evaluators,
+      executorClient,
+      chatClient,
+      traceEsClient: {} as EsClient,
+      log: {} as ToolingLog,
+    });
+
+    const example = {
+      input: { question: 'Can I use Wix Payments before account verification?' },
+      output: {
+        expected: 'Yes, with verification required for full activation.',
+        groundTruth: {
+          wix_knowledge_base: {
+            'doc-1': 1,
+          },
+        },
+      },
+      metadata: {
+        searchIndex: 'wix_knowledge_base',
+      },
+    };
+
+    await evaluateDataset({
+      dataset: {
+        name: 'test dataset',
+        description: 'dataset description',
+        examples: [example],
+      },
+    });
+
+    const [options, selectedEvaluators] = runExperiment.mock.calls[0];
+    const taskOutput = await options.task(example);
+
+    expect(chatClient.executeTool).toHaveBeenCalledTimes(1);
+    expect(chatClient.executeTool).toHaveBeenCalledWith({
+      toolId: platformCoreTools.search,
+      toolParams: {
+        query: 'Can I use Wix Payments before account verification?',
+        index: 'wix_knowledge_base',
+      },
+    });
+    expect(chatClient.converse).toHaveBeenCalledTimes(1);
+    expect(taskOutput).toMatchObject({
+      errors: [],
+      traceId: 'trace-id-from-converse',
+      messages: [{ message: 'assistant answer from converse' }],
+      steps: [
+        {
+          type: 'tool_call',
+          tool_id: platformCoreTools.getDocumentById,
+        },
+      ],
+      correctnessAnalysis: { pass: true },
+      groundednessAnalysis: { pass: true },
+      searchToolResults: [
+        {
+          type: 'resource_list',
+          data: {
+            resources: [{ reference: { index: 'wix_knowledge_base', id: 'doc-1' } }],
+          },
+        },
+      ],
+    });
+    expect(correctnessEvaluate).toHaveBeenCalledTimes(1);
+    expect(groundednessEvaluate).toHaveBeenCalledTimes(1);
+
+    const evaluatorNames = selectedEvaluators.map((e: Evaluator) => e.name);
+    expect(evaluatorNames).toContain('Factuality');
+    expect(evaluatorNames).toContain('Groundedness');
+    expect(evaluatorNames).toContain('Precision@10');
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/rag_extractor.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/rag_extractor.ts
@@ -61,9 +61,10 @@ const extractRetrievedDocsFromResults = (results: SearchToolResult[] = []): Retr
 
 export const extractSearchRetrievedDocs = (output: TaskOutput): RetrievedDoc[] => {
   const outputValue = output as SearchToolOutput | undefined;
+  const searchToolResults = outputValue?.searchToolResults;
 
-  if (outputValue && 'searchToolResults' in outputValue) {
-    return extractRetrievedDocsFromResults(outputValue.searchToolResults);
+  if (Array.isArray(searchToolResults)) {
+    return extractRetrievedDocsFromResults(searchToolResults);
   }
 
   const stepResults = (outputValue?.steps ?? [])

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/rag_extractor.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/rag_extractor.ts
@@ -29,31 +29,50 @@ interface SearchToolStep {
   results?: SearchToolResult[];
 }
 
+interface SearchToolOutput {
+  steps?: SearchToolStep[];
+  results?: SearchToolResult[];
+  searchToolResults?: SearchToolResult[];
+}
+
 const toRetrievedDoc = (reference?: SearchToolReference): RetrievedDoc | null => {
   const { id, index } = reference ?? {};
   return id && index ? { id, index } : null;
 };
 
+const extractRetrievedDocsFromResults = (results: SearchToolResult[] = []): RetrievedDoc[] => {
+  return results.flatMap((result) => {
+    const docs: RetrievedDoc[] = [];
+    const directReferenceDoc = toRetrievedDoc(result.data?.reference);
+    if (directReferenceDoc) {
+      docs.push(directReferenceDoc);
+    }
+
+    for (const resource of result.data?.resources ?? []) {
+      const resourceDoc = toRetrievedDoc(resource.reference);
+      if (resourceDoc) {
+        docs.push(resourceDoc);
+      }
+    }
+
+    return docs;
+  });
+};
+
 export const extractSearchRetrievedDocs = (output: TaskOutput): RetrievedDoc[] => {
-  const steps = (output as { steps?: SearchToolStep[] } | undefined)?.steps ?? [];
+  const outputValue = output as SearchToolOutput | undefined;
 
-  return steps
+  if (outputValue && 'searchToolResults' in outputValue) {
+    return extractRetrievedDocsFromResults(outputValue.searchToolResults);
+  }
+
+  const stepResults = (outputValue?.steps ?? [])
     .filter((step) => step.type === 'tool_call' && step.tool_id === 'platform.core.search')
-    .flatMap((step) => step.results ?? [])
-    .flatMap((result) => {
-      const docs: RetrievedDoc[] = [];
-      const directReferenceDoc = toRetrievedDoc(result.data?.reference);
-      if (directReferenceDoc) {
-        docs.push(directReferenceDoc);
-      }
+    .flatMap((step) => step.results ?? []);
+  const directResults = outputValue?.results ?? [];
 
-      for (const resource of result.data?.resources ?? []) {
-        const resourceDoc = toRetrievedDoc(resource.reference);
-        if (resourceDoc) {
-          docs.push(resourceDoc);
-        }
-      }
-
-      return docs;
-    });
+  return [
+    ...extractRetrievedDocsFromResults(stepResults),
+    ...extractRetrievedDocsFromResults(directResults),
+  ];
 };


### PR DESCRIPTION
## Summary
- Add `RAG_EVAL_EXECUTION_MODE` with `converse` (default) and `search_tool` modes for dataset evaluation.
- In `search_tool` mode, run RAG evaluators on direct `platform.core.search` results while keeping non-RAG evaluators on `converse` output.
- Extend RAG extraction to read direct search results and correctly fall back to `steps`/`results` when `searchToolResults` is undefined; add README updates and regression tests.

## Test plan
- [x] Run external dataset evaluation with `RAG_EVAL_EXECUTION_MODE=search_tool`, `SELECTED_EVALUATORS="Precision@K,Recall@K,F1@K"`, and `RAG_EVAL_K=10,20,30` via Playwright (`external_dataset.spec.ts`) and confirm experiment/evaluator completion.

Made with Cursor + 5.3-codex

## Results:
<img width="1204" height="243" alt="Screenshot 2026-03-02 at 11 44 08 PM" src="https://github.com/user-attachments/assets/753a70d2-5b8f-49a7-86c7-01e4884237fc" />
<img width="1176" height="664" alt="Screenshot 2026-03-02 at 11 45 09 PM" src="https://github.com/user-attachments/assets/f38e33ff-bb27-4bbe-b32b-207dbc77b0d6" />

