### PR TITLE
[Lens as API] Add a label to all esql columns, fix time axis in-flight

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/datatable.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/datatable.ts
@@ -10,7 +10,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { DEFAULT_HEADER_ROW_HEIGHT_LINES, DEFAULT_ROW_HEIGHT_LINES } from '@kbn/lens-common';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnWithFormatSchema, esqlColumnSchema } from '../metric_ops';
 import { applyColorToSchema, colorByValueSchema, colorMappingSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -424,7 +424,7 @@ export const datatableStateSchemaESQL = schema.object(
      */
     metrics: schema.maybe(
       schema.arrayOf(
-        esqlColumnOperationWithLabelAndFormatSchema.extends(datatableStateMetricsOptionsSchema, {
+        esqlColumnWithFormatSchema.extends(datatableStateMetricsOptionsSchema, {
           meta: { id: 'datatableESQLMetric', title: 'Datatable Metric (ES|QL)' },
         }),
         {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/gauge.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/gauge.ts
@@ -10,7 +10,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import {
-  esqlColumnOperationWithLabelAndFormatSchema,
+  esqlColumnWithFormatSchema,
   esqlColumnSchema,
   metricOperationDefinitionSchema,
 } from '../metric_ops';
@@ -154,7 +154,7 @@ export const gaugeStateSchemaESQL = schema.object(
     /**
      * Primary value configuration, must define operation.
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema.extends({
+    metric: esqlColumnWithFormatSchema.extends({
       ...gaugeStateMetricOptionsSchema,
       ...gaugeStateMetricInnerESQLOpsSchema,
     }),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/legacy_metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/legacy_metric.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema } from '../metric_ops';
+import { esqlColumnWithFormatSchema } from '../metric_ops';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import { layerSettingsSchema, sharedPanelInfoSchema, dslOnlyPanelInfoSchema } from '../shared';
 import {
@@ -104,9 +104,7 @@ const esqlLegacyMetricState = schema.object(
     /**
      * Metric configuration, must define operation.
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema.extends(
-      legacyMetricStateMetricOptionsSchema
-    ),
+    metric: esqlColumnWithFormatSchema.extends(legacyMetricStateMetricOptionsSchema),
   },
   { meta: { id: 'legacyMetricESQL', title: 'Legacy Metric Chart (ES|QL)' } }
 );

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/metric.ts
@@ -16,7 +16,7 @@ import {
 import {
   metricOperationDefinitionSchema,
   esqlColumnSchema,
-  esqlColumnOperationWithLabelAndFormatSchema,
+  esqlColumnWithFormatSchema,
 } from '../metric_ops';
 import { staticColorSchema, applyColorToSchema, colorByValueSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
@@ -345,11 +345,11 @@ export const metricStateSchemaNoESQL = schema.object({
   ),
 });
 
-const primaryMetricESQL = esqlColumnOperationWithLabelAndFormatSchema
+const primaryMetricESQL = esqlColumnWithFormatSchema
   .extends(metricStatePrimaryMetricOptionsSchema)
   .extends(metricStateBackgroundChartSchemaESQL);
 
-const secondaryMetricESQL = esqlColumnOperationWithLabelAndFormatSchema.extends(
+const secondaryMetricESQL = esqlColumnWithFormatSchema.extends(
   metricStateSecondaryMetricOptionsSchema
 );
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/mosaic.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/mosaic.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnWithFormatSchema, esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -161,15 +161,12 @@ const mosaicStateSchemaESQL = schema.object(
      * Primary value configuration, must define operation. In ES|QL mode, uses column-based configuration.
      */
     metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(
-        partitionStatePrimaryMetricOptionsSchema,
-        {
-          meta: {
-            description:
-              'Metric configuration for ES|QL mode, combining generic options, primary metric options, and column selection',
-          },
-        }
-      ),
+      esqlColumnWithFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema, {
+        meta: {
+          description:
+            'Metric configuration for ES|QL mode, combining generic options, primary metric options, and column selection',
+        },
+      }),
       {
         minSize: 1,
         maxSize: 1,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/pie.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/pie.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnWithFormatSchema, esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema, staticColorSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -169,10 +169,9 @@ const pieStateSchemaESQL = schema.object(
     ...datasetEsqlTableSchema,
     ...pieStateSharedSchema,
     metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(
-        partitionStatePrimaryMetricOptionsSchema,
-        { meta: { description: 'ES|QL column reference for primary metric' } }
-      ),
+      esqlColumnWithFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema, {
+        meta: { description: 'ES|QL column reference for primary metric' },
+      }),
       {
         minSize: 1,
         maxSize: 100,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.ts
@@ -12,7 +12,7 @@ import { schema } from '@kbn/config-schema';
 import {
   fieldMetricOrFormulaOperationDefinitionSchema,
   esqlColumnSchema,
-  esqlColumnOperationWithLabelAndFormatSchema,
+  esqlColumnWithFormatSchema,
 } from '../metric_ops';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import { dslOnlyPanelInfoSchema, layerSettingsSchema, sharedPanelInfoSchema } from '../shared';
@@ -55,7 +55,7 @@ export const regionMapStateSchemaESQL = schema.object(
     /**
      * Metric configuration
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema,
+    metric: esqlColumnWithFormatSchema,
     /**
      * Configure how to break down to regions
      */

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.ts
@@ -10,7 +10,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { LENS_TAGCLOUD_DEFAULT_STATE } from '@kbn/lens-common';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnWithFormatSchema, esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import { dslOnlyPanelInfoSchema, layerSettingsSchema, sharedPanelInfoSchema } from '../shared';
@@ -97,7 +97,7 @@ export const tagcloudStateSchemaESQL = schema.object(
     /**
      * Primary value configuration, must define operation.
      */
-    metric: esqlColumnOperationWithLabelAndFormatSchema.extends(tagcloudStateMetricOptionsSchema),
+    metric: esqlColumnWithFormatSchema.extends(tagcloudStateMetricOptionsSchema),
     /**
      * Configure how to break down the metric (e.g. show one metric per term).
      */

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/treemap.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/treemap.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnWithFormatSchema, esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema, staticColorSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 
@@ -170,7 +170,7 @@ const treemapStateSchemaESQL = schema.object(
      * Primary value configuration, must define operation. In ES|QL mode, uses column-based configuration.
      */
     metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema),
+      esqlColumnWithFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema),
       {
         minSize: 1,
         maxSize: 100,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/waffle.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/waffle.ts
@@ -9,7 +9,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { esqlColumnOperationWithLabelAndFormatSchema, esqlColumnSchema } from '../metric_ops';
+import { esqlColumnWithFormatSchema, esqlColumnSchema } from '../metric_ops';
 import { colorMappingSchema, staticColorSchema } from '../color';
 import { datasetSchema, datasetEsqlTableSchema } from '../dataset';
 import {
@@ -136,7 +136,7 @@ const waffleStateSchemaESQL = schema.object(
     ...datasetEsqlTableSchema,
     ...waffleStateSharedSchema,
     metrics: schema.arrayOf(
-      esqlColumnOperationWithLabelAndFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema),
+      esqlColumnWithFormatSchema.extends(partitionStatePrimaryMetricOptionsSchema),
       {
         minSize: 1,
         maxSize: 100,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
@@ -42,6 +42,27 @@ describe('Metric Operations Schemas', () => {
       const validated = esqlColumnSchema.validate(input);
       expect(validated).toEqual(input);
     });
+
+    it('validates with an optional label', () => {
+      const input = {
+        operation: 'value',
+        column: 'sum' as const,
+        label: 'My custom label',
+      };
+
+      const validated = esqlColumnSchema.validate(input);
+      expect(validated).toEqual(input);
+    });
+
+    it('validates without a label', () => {
+      const input = {
+        operation: 'value',
+        column: 'sum' as const,
+      };
+
+      const validated = esqlColumnSchema.validate(input);
+      expect(validated).not.toHaveProperty('label');
+    });
   });
 
   describe('staticOperationDefinition', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.ts
@@ -126,10 +126,12 @@ const esqlColumn = {
   }),
 };
 
-export const esqlColumnSchema = schema.object(esqlColumn);
+export const esqlColumnSchema = schema.object({
+  ...esqlColumn,
+  ...labelSharedProp,
+});
 
-export const esqlColumnOperationWithLabelAndFormatSchema =
-  genericOperationOptionsSchema.extends(esqlColumn);
+export const esqlColumnWithFormatSchema = esqlColumnSchema.extends(formatSchema);
 
 export const metricOperationSharedSchema =
   genericOperationOptionsSchema.extends(advancedOperationSettings);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.test.ts
@@ -106,5 +106,31 @@ describe('Datatable ES|QL column ordering', () => {
         },
       ]);
     });
+
+    test('passes label and customLabel through when label is provided', () => {
+      const config = {
+        type: 'datatable',
+        metrics: [{ operation: 'value', column: 'bytes', label: 'Total Bytes' }],
+        rows: [{ operation: 'value', column: 'host' }],
+      } as unknown as DatatableStateESQL;
+
+      const result = getValueColumns(config);
+
+      expect(result).toEqual([
+        {
+          columnId: 'datatable_accessor_row_0',
+          fieldName: 'host',
+          meta: { type: 'string' },
+        },
+        {
+          columnId: 'datatable_accessor_metric_0',
+          fieldName: 'bytes',
+          inMetricDimension: true,
+          meta: { type: 'number' },
+          label: 'Total Bytes',
+          customLabel: true,
+        },
+      ]);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/datatable/to_state/index.ts
@@ -75,13 +75,13 @@ export function buildFormBasedLayer(
 export function getValueColumns(config: DatatableStateESQL) {
   return [
     ...(config.rows ?? []).map((row, index) =>
-      getValueColumn(getAccessorName(ROW_ACCESSOR_PREFIX, index), row.column)
+      getValueColumn(getAccessorName(ROW_ACCESSOR_PREFIX, index), row)
     ),
     ...(config.split_metrics_by ?? []).map((splitBy, index) =>
-      getValueColumn(getAccessorName(SPLIT_METRIC_BY_ACCESSOR_PREFIX, index), splitBy.column)
+      getValueColumn(getAccessorName(SPLIT_METRIC_BY_ACCESSOR_PREFIX, index), splitBy)
     ),
     ...(config.metrics ?? []).map((metric, index) =>
-      getValueColumn(getAccessorName(METRIC_ACCESSOR_PREFIX, index), metric.column, 'number', true)
+      getValueColumn(getAccessorName(METRIC_ACCESSOR_PREFIX, index), metric, 'number', true)
     ),
   ];
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/gauge.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/gauge.ts
@@ -211,12 +211,10 @@ function buildFormBasedLayer(layer: GaugeStateNoESQL): FormBasedPersistedState['
 
 function getValueColumns(layer: GaugeStateESQL) {
   return [
-    getValueColumn(getAccessorName('metric'), layer.metric.column, 'number'),
-    ...(layer.metric.max ? [getValueColumn(getAccessorName('max'), layer.metric.max.column)] : []),
-    ...(layer.metric.min ? [getValueColumn(getAccessorName('min'), layer.metric.min.column)] : []),
-    ...(layer.metric.goal
-      ? [getValueColumn(getAccessorName('goal'), layer.metric.goal.column)]
-      : []),
+    getValueColumn(getAccessorName('metric'), layer.metric, 'number'),
+    ...(layer.metric.max ? [getValueColumn(getAccessorName('max'), layer.metric.max)] : []),
+    ...(layer.metric.min ? [getValueColumn(getAccessorName('min'), layer.metric.min)] : []),
+    ...(layer.metric.goal ? [getValueColumn(getAccessorName('goal'), layer.metric.goal)] : []),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/from_api.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/from_api.ts
@@ -128,9 +128,9 @@ function buildFormBasedLayer(layer: HeatmapStateNoESQL): FormBasedPersistedState
 
 function getValueColumns(layer: HeatmapStateESQL) {
   return [
-    getValueColumn(getAccessorName('value'), layer.metric.column, 'number'),
-    ...(layer.xAxis ? [getValueColumn(getAccessorName('x'), layer.xAxis.column)] : []),
-    ...(layer.yAxis ? [getValueColumn(getAccessorName('y'), layer.yAxis.column)] : []),
+    getValueColumn(getAccessorName('value'), layer.metric, 'number'),
+    ...(layer.xAxis ? [getValueColumn(getAccessorName('x'), layer.xAxis)] : []),
+    ...(layer.yAxis ? [getValueColumn(getAccessorName('y'), layer.yAxis)] : []),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/legacy_metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/legacy_metric.ts
@@ -137,7 +137,7 @@ function buildFormBasedLayer(layer: LegacyMetricStateNoESQL): FormBasedPersisted
 }
 
 function getValueColumns(layer: LegacyMetricStateESQL) {
-  return [getValueColumn(ACCESSOR, layer.metric.column, 'number')];
+  return [getValueColumn(ACCESSOR, layer.metric, 'number')];
 }
 
 type LegacyMetricAttributes = Extract<

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/metric.ts
@@ -565,21 +565,13 @@ function getValueColumns(layer: MetricStateESQL) {
   }
   return [
     ...(layer.breakdown_by
-      ? [getValueColumn(getAccessorName('breakdown'), layer.breakdown_by.column)]
+      ? [getValueColumn(getAccessorName('breakdown'), layer.breakdown_by)]
       : []),
-    getValueColumn(getAccessorName('metric'), primaryMetric.column, 'number'),
+    getValueColumn(getAccessorName('metric'), primaryMetric, 'number'),
     ...(primaryMetric.background_chart?.type === 'bar'
-      ? [
-          getValueColumn(
-            getAccessorName('max'),
-            primaryMetric.background_chart.max_value.column,
-            'number'
-          ),
-        ]
+      ? [getValueColumn(getAccessorName('max'), primaryMetric.background_chart.max_value, 'number')]
       : []),
-    ...(secondaryMetric
-      ? [getValueColumn(getAccessorName('secondary'), secondaryMetric.column)]
-      : []),
+    ...(secondaryMetric ? [getValueColumn(getAccessorName('secondary'), secondaryMetric)] : []),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/partition.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/partition.ts
@@ -148,12 +148,12 @@ export function getValueColumns(layer: unknown) {
 
   const esqlMetricColumns =
     layer.metrics?.map((metric, index) =>
-      getValueColumn(getAccessorName('metric', index), metric.column, 'number')
+      getValueColumn(getAccessorName('metric', index), metric, 'number')
     ) ?? [];
 
   const esqlBucketColumns =
     layer.group_by?.map((bucket, index) =>
-      getValueColumn(getAccessorName('group_by', index), bucket.column)
+      getValueColumn(getAccessorName('group_by', index), bucket)
     ) ?? [];
   return esqlMetricColumns.concat(esqlBucketColumns);
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/region_map.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/region_map.ts
@@ -155,8 +155,8 @@ function buildFormBasedLayer(layer: RegionMapStateNoESQL): FormBasedPersistedSta
 
 function getValueColumns(layer: RegionMapStateESQL) {
   return [
-    getValueColumn(getAccessorName('metric'), layer.metric.column, 'number'),
-    getValueColumn(getAccessorName('region'), layer.region.column),
+    getValueColumn(getAccessorName('metric'), layer.metric, 'number'),
+    getValueColumn(getAccessorName('region'), layer.region),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/tagcloud.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/tagcloud.ts
@@ -180,8 +180,8 @@ function buildFormBasedLayer(layer: TagcloudStateNoESQL): FormBasedPersistedStat
 
 function getValueColumns(layer: TagcloudStateESQL) {
   return [
-    getValueColumn(getAccessorName('metric'), layer.metric.column, 'number'),
-    getValueColumn(getAccessorName('tag'), layer.tag_by.column),
+    getValueColumn(getAccessorName('metric'), layer.metric, 'number'),
+    getValueColumn(getAccessorName('tag'), layer.tag_by),
   ];
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
@@ -50,18 +50,16 @@ export function getValueColumns(layer: unknown, i: number) {
   }
   if (isAPIReferenceLineLayer(layer)) {
     return [
-      ...layer.thresholds.map((t, index) =>
-        getValueColumn(`referenceLine${index}`, t.column, 'number')
-      ),
+      ...layer.thresholds.map((t, index) => getValueColumn(`referenceLine${index}`, t, 'number')),
     ];
   }
   return [
-    ...(layer.x ? [getValueColumn(getAccessorNameForXY(layer, X_ACCESSOR), layer.x.column)] : []),
+    ...(layer.x ? [getValueColumn(getAccessorNameForXY(layer, X_ACCESSOR), layer.x)] : []),
     ...layer.y.map((y, index) =>
-      getValueColumn(getAccessorNameForXY(layer, METRIC_ACCESSOR_PREFIX, index), y.column, 'number')
+      getValueColumn(getAccessorNameForXY(layer, METRIC_ACCESSOR_PREFIX, index), y, 'number')
     ),
     ...(layer.breakdown_by
-      ? [getValueColumn(getAccessorNameForXY(layer, BREAKDOWN_ACCESSOR), layer.breakdown_by.column)]
+      ? [getValueColumn(getAccessorNameForXY(layer, BREAKDOWN_ACCESSOR), layer.breakdown_by)]
       : []),
   ];
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TextBasedLayer } from '@kbn/lens-common';
+import { getValueColumn, getValueApiColumn } from './esql_column';
+
+describe('getValueColumn', () => {
+  it('should set correct columnId and fieldName', () => {
+    const result = getValueColumn('col1', { column: 'my_field' });
+    expect(result.columnId).toBe('col1');
+    expect(result.fieldName).toBe('my_field');
+  });
+
+  it('should use id as fieldName when column is empty', () => {
+    const result = getValueColumn('col1', { column: '' });
+    expect(result.fieldName).toBe('col1');
+  });
+
+  it('should set meta.type from fieldType parameter', () => {
+    const result = getValueColumn('col1', { column: 'my_field' }, 'number');
+    expect(result.meta).toEqual({ type: 'number' });
+  });
+
+  it('should default meta.type to string', () => {
+    const result = getValueColumn('col1', { column: 'my_field' });
+    expect(result.meta).toEqual({ type: 'string' });
+  });
+
+  it('should set label and customLabel when label is provided', () => {
+    const result = getValueColumn('col1', { column: 'my_field', label: 'My Label' });
+    expect(result.label).toBe('My Label');
+    expect(result.customLabel).toBe(true);
+  });
+
+  it('should not set label or customLabel when label is not provided', () => {
+    const result = getValueColumn('col1', { column: 'my_field' });
+    expect(result).not.toHaveProperty('label');
+    expect(result).not.toHaveProperty('customLabel');
+  });
+
+  it('should set inMetricDimension when provided', () => {
+    const result = getValueColumn('col1', { column: 'my_field' }, 'number', true);
+    expect(result.inMetricDimension).toBe(true);
+  });
+
+  it('should not set inMetricDimension when not provided', () => {
+    const result = getValueColumn('col1', { column: 'my_field' });
+    expect(result).not.toHaveProperty('inMetricDimension');
+  });
+});
+
+describe('getValueApiColumn', () => {
+  const makeLayer = (columns: TextBasedLayer['columns']): TextBasedLayer =>
+    ({ columns } as TextBasedLayer);
+
+  it('should return basic API column shape', () => {
+    const layer = makeLayer([{ columnId: 'col1', fieldName: 'my_field' }]);
+    const result = getValueApiColumn('col1', layer);
+    expect(result).toEqual({ operation: 'value', column: 'my_field' });
+  });
+
+  it('should include label when customLabel is true and label is set', () => {
+    const layer = makeLayer([
+      { columnId: 'col1', fieldName: 'my_field', label: 'My Label', customLabel: true },
+    ]);
+    const result = getValueApiColumn('col1', layer);
+    expect(result).toEqual({ operation: 'value', column: 'my_field', label: 'My Label' });
+  });
+
+  it('should not include label when customLabel is false', () => {
+    const layer = makeLayer([
+      { columnId: 'col1', fieldName: 'my_field', label: 'My Label', customLabel: false },
+    ]);
+    const result = getValueApiColumn('col1', layer);
+    expect(result).not.toHaveProperty('label');
+  });
+
+  it('should not include label when customLabel is absent', () => {
+    const layer = makeLayer([{ columnId: 'col1', fieldName: 'my_field', label: 'My Label' }]);
+    const result = getValueApiColumn('col1', layer);
+    expect(result).not.toHaveProperty('label');
+  });
+
+  it('should round-trip label correctly', () => {
+    const col = getValueColumn('col1', { column: 'my_field', label: 'Custom' });
+    const layer = makeLayer([col]);
+    const apiCol = getValueApiColumn('col1', layer);
+    expect(apiCol.label).toBe('Custom');
+  });
+});

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/esql_column.ts
@@ -12,21 +12,24 @@ import type { DatatableColumnType } from '@kbn/expressions-plugin/common';
 
 export const getValueColumn = (
   id: string,
-  fieldName?: string,
+  apiColumn: { column: string; label?: string },
   fieldType: DatatableColumnType = 'string',
   inMetricDimension?: boolean
 ): TextBasedLayerColumn => {
   return {
     columnId: id,
-    fieldName: fieldName || id,
+    fieldName: apiColumn.column || id,
     ...(fieldType ? { meta: { type: fieldType } } : {}),
+    ...(apiColumn.label != null ? { label: apiColumn.label, customLabel: true } : {}),
     ...(inMetricDimension != null ? { inMetricDimension } : {}),
   };
 };
 
 export const getValueApiColumn = (accessor: string, layer: TextBasedLayer) => {
+  const col = layer.columns.find((c) => c.columnId === accessor)!;
   return {
     operation: 'value' as const,
-    column: layer.columns.find((c) => c.columnId === accessor)!.fieldName,
+    column: col.fieldName,
+    ...(col.customLabel && col.label != null ? { label: col.label } : {}),
   };
 };

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer.test.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer.test.ts
@@ -27,7 +27,7 @@ describe('extendedDataLayerConfig', () => {
     palette: mockPaletteOutput,
   };
 
-  test('produces the correct arguments', async () => {
+  test('produces the correct arguments for a line chart with a date x-axis accessor', async () => {
     const { data } = sampleArgs();
     const fullArgs: ExtendedDataLayerArgs = {
       ...args,
@@ -43,9 +43,35 @@ describe('extendedDataLayerConfig', () => {
       type: 'extendedDataLayer',
       layerType: LayerTypes.DATA,
       ...fullArgs,
+      xScaleType: 'time',
+      isHistogram: true,
       table: data,
       showLines: true,
     });
+  });
+
+  test('preserves ordinal xScaleType when x-axis column is a string', async () => {
+    const { data } = sampleArgs();
+    const result = await extendedDataLayerFunction.fn(
+      data,
+      { ...args, xAccessor: 'd', xScaleType: 'ordinal' },
+      createMockExecutionContext()
+    );
+
+    expect(result.xScaleType).toBe('ordinal');
+    expect(result.isHistogram).toBe(false);
+  });
+
+  test('preserves linear xScaleType when x-axis column is numeric', async () => {
+    const { data } = sampleArgs();
+    const result = await extendedDataLayerFunction.fn(
+      data,
+      { ...args, xAccessor: 'a', xScaleType: 'linear' },
+      createMockExecutionContext()
+    );
+
+    expect(result.xScaleType).toBe('linear');
+    expect(result.isHistogram).toBe(false);
   });
 
   test('throws the error if markSizeAccessor is provided to the not line/area chart', async () => {

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer_fn.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/common/expression_functions/extended_data_layer_fn.ts
@@ -8,9 +8,10 @@
  */
 
 import type { ExpressionValueVisDimension } from '@kbn/chart-expressions-common';
-import { validateAccessor } from '@kbn/chart-expressions-common';
-import type { ExtendedDataLayerArgs, ExtendedDataLayerFn } from '../types';
-import { EXTENDED_DATA_LAYER, LayerTypes } from '../constants';
+import { getColumnByAccessor, validateAccessor } from '@kbn/chart-expressions-common';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import type { ExtendedDataLayerArgs, ExtendedDataLayerFn, XScaleType } from '../types';
+import { EXTENDED_DATA_LAYER, LayerTypes, XScaleTypes } from '../constants';
 import { getAccessors, normalizeTable, getShowLines } from '../helpers';
 import {
   validateLinesVisibilityForChartType,
@@ -19,6 +20,36 @@ import {
   validatePointsRadiusForChartType,
   validateShowPointsForChartType,
 } from './validate';
+
+/**
+ * Reconciles xScaleType and isHistogram with the actual Datatable column metadata.
+ * This ensures that date columns are always rendered with a time scale and histogram
+ * behavior (enabling brush/zoom), even when the pre-computed values from the expression
+ * builder are stale (e.g. after restoring a saved ES|QL visualization that lost column
+ * type info).
+ */
+function resolveXAxisMeta(
+  args: Pick<ExtendedDataLayerArgs, 'xScaleType' | 'isHistogram'>,
+  xAccessor: string | ExpressionValueVisDimension | undefined,
+  columns: Datatable['columns']
+): Pick<ExtendedDataLayerArgs, 'xScaleType' | 'isHistogram'> {
+  if (!xAccessor) {
+    return args;
+  }
+  const column = getColumnByAccessor(xAccessor, columns);
+  if (!column) {
+    return args;
+  }
+
+  let { xScaleType, isHistogram } = args;
+
+  if (column.meta?.type === 'date') {
+    xScaleType = XScaleTypes.TIME as XScaleType;
+    isHistogram = true;
+  }
+
+  return { xScaleType, isHistogram };
+}
 
 export const extendedDataLayerFn: ExtendedDataLayerFn['fn'] = async (data, args, context) => {
   const table = data;
@@ -40,10 +71,13 @@ export const extendedDataLayerFn: ExtendedDataLayerFn['fn'] = async (data, args,
   const normalizedTable = normalizeTable(table, accessors.xAccessor);
 
   const showLines = getShowLines(args);
+  const { xScaleType, isHistogram } = resolveXAxisMeta(args, accessors.xAccessor, table.columns);
 
   return {
     type: EXTENDED_DATA_LAYER,
     ...args,
+    xScaleType,
+    isHistogram,
     layerType: LayerTypes.DATA,
     ...accessors,
     table: normalizedTable,

--- a/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
@@ -35,26 +35,33 @@ export const isDatatable = (datatable: unknown): datatable is Datatable =>
   (datatable as ExpressionValueBoxed | undefined)?.type === 'datatable';
 
 /**
+ * All valid column types for a `DatatableColumn`. Duplicated from KBN_FIELD_TYPES.
+ * Exported as a const array so downstream packages can build schemas from it.
+ */
+export const DATATABLE_COLUMN_TYPES = [
+  '_source',
+  'attachment',
+  'boolean',
+  'date',
+  'geo_point',
+  'geo_shape',
+  'ip',
+  'murmur3',
+  'number',
+  'string',
+  'unknown',
+  'conflict',
+  'object',
+  'nested',
+  'histogram',
+  'null',
+] as const;
+
+/**
  * This type represents the `type` of any `DatatableColumn` in a `Datatable`.
  * its duplicated from KBN_FIELD_TYPES
  */
-export type DatatableColumnType =
-  | '_source'
-  | 'attachment'
-  | 'boolean'
-  | 'date'
-  | 'geo_point'
-  | 'geo_shape'
-  | 'ip'
-  | 'murmur3'
-  | 'number'
-  | 'string'
-  | 'unknown'
-  | 'conflict'
-  | 'object'
-  | 'nested'
-  | 'histogram'
-  | 'null';
+export type DatatableColumnType = (typeof DATATABLE_COLUMN_TYPES)[number];
 
 /**
  * This type represents a row in a `Datatable`.

--- a/src/platform/plugins/shared/expressions/common/index.ts
+++ b/src/platform/plugins/shared/expressions/common/index.ts
@@ -108,6 +108,7 @@ export type {
   ExpressionValue,
   Render,
   ExpressionImage,
+  DATATABLE_COLUMN_TYPES,
   DatatableColumnType,
   DatatableRow,
   Datatable,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/dnd/on_drop.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/dnd/on_drop.ts
@@ -36,12 +36,16 @@ export const onDrop = (props: DatasourceDimensionDropHandlerProps<TextBasedPriva
   const allColumns = retrieveLayerColumnsFromCache(layer.columns, layer.query);
   const sourceField = allColumns.find((f) => f.columnId === source.id || f.variable === source.id);
   const targetField = allColumns.find((f) => f.columnId === target.columnId);
+  const sourceLayerColumn = layer.columns.find((c) => c.columnId === source.id);
   const newColumn = {
     columnId: target.columnId,
     fieldName: sourceField?.variable ? `??${sourceField.variable}` : sourceField?.fieldName ?? '',
     meta: sourceField?.meta,
     variable: sourceField?.variable,
     ...(target.isMetricDimension && { inMetricDimension: true }),
+    ...(sourceLayerColumn?.customLabel && sourceLayerColumn.label != null
+      ? { label: sourceLayerColumn.label, customLabel: true }
+      : {}),
   };
   let columns: TextBasedLayerColumn[] | undefined;
 
@@ -59,6 +63,7 @@ export const onDrop = (props: DatasourceDimensionDropHandlerProps<TextBasedPriva
       columns = [...layer.columns, newColumn];
       break;
     case 'swap_compatible':
+      const targetLayerColumn = layer.columns.find((c) => c.columnId === target.columnId);
       const swapTwoColumns = (c: TextBasedLayerColumn) =>
         c.columnId === target.columnId
           ? newColumn
@@ -67,6 +72,9 @@ export const onDrop = (props: DatasourceDimensionDropHandlerProps<TextBasedPriva
               columnId: source.columnId,
               fieldName: targetField?.fieldName ?? '',
               meta: targetField?.meta,
+              ...(targetLayerColumn?.customLabel && targetLayerColumn.label != null
+                ? { label: targetLayerColumn.label, customLabel: true }
+                : {}),
             }
           : c;
       columns = layer.columns.map(swapTwoColumns);


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/253009
Fixes brushing through ESQL time charts
Fixes the label part from https://github.com/elastic/kibana/issues/248464
Fixes using an ESQL column via dnd - if the custom label was set, it was lost on duplicating.

1. Fixes brushing through ESQL charts and time axis problem: https://github.com/elastic/kibana/issues/253009 

A `resolveXAxisMeta` function has been added to `extended_data_layer_fn.ts` that reconciles xScaleType and isHistogram based on actual column metadata — ensuring date columns use a time scale and histogram behavior even when pre-computed values are stale. 

2. Adds a label to all ESQL columns schema

