### PR TITLE
[ES|QL] Fixes autocomplete fetches piling up without cancellation

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -729,7 +729,6 @@ const ESQLEditorInternal = function ESQLEditor({
     histogramBarTarget,
     activeSolutionId: activeSolutionId ?? undefined,
     minimalQueryRef,
-    abortControllerRef,
     dataSourcesCache,
     memoizedSources,
     esqlFieldsCache,

--- a/src/platform/packages/private/kbn-esql-editor/src/use_esql_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/use_esql_callbacks.ts
@@ -143,6 +143,8 @@ export const useEsqlCallbacks = ({
           return [];
         }
 
+        previousColumnsQueryRef.current = undefined;
+
         return result || [];
       }
       return [];

--- a/src/platform/packages/private/kbn-esql-editor/src/use_esql_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/use_esql_callbacks.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useCallback, useMemo, type MutableRefObject } from 'react';
+import { useCallback, useMemo, useRef, type MutableRefObject } from 'react';
 import type { CoreStart } from '@kbn/core/public';
 import type { TimeRange } from '@kbn/es-query';
 import type { ESQLCallbacks, ESQLControlVariable } from '@kbn/esql-types';
@@ -71,7 +71,6 @@ interface UseEsqlCallbacksParams {
   histogramBarTarget: number;
   activeSolutionId?: Parameters<typeof getEditorExtensions>[2];
   minimalQueryRef: MutableRefObject<string>;
-  abortControllerRef: MutableRefObject<AbortController>;
   dataSourcesCache: MapCache;
   memoizedSources: MemoizedSources;
   esqlFieldsCache: MapCache;
@@ -92,7 +91,6 @@ export const useEsqlCallbacks = ({
   histogramBarTarget,
   activeSolutionId,
   minimalQueryRef,
-  abortControllerRef,
   dataSourcesCache,
   memoizedSources,
   esqlFieldsCache,
@@ -103,6 +101,9 @@ export const useEsqlCallbacks = ({
   getJoinIndicesCallback,
   enableResourceBrowser,
 }: UseEsqlCallbacksParams): ESQLCallbacks => {
+  const columnsAbortControllerRef = useRef<AbortController | undefined>(undefined);
+  const previousColumnsQueryRef = useRef<string | undefined>(undefined);
+
   const getSources = useCallback(async () => {
     clearCacheWhenOld(dataSourcesCache, minimalQueryRef.current);
     const getLicense = esqlService?.getLicense;
@@ -113,19 +114,36 @@ export const useEsqlCallbacks = ({
   const getColumnsFor = useCallback(
     async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
       if (queryToExecute) {
-        // Check if there's a stale entry and clear it
-        clearCacheWhenOld(esqlFieldsCache, `${queryToExecute} | limit 0`);
+        // Abort any previous in-flight autocomplete column fetch and
+        // remove its potentially stale cache entry
+        if (columnsAbortControllerRef.current) {
+          columnsAbortControllerRef.current.abort();
+          if (previousColumnsQueryRef.current) {
+            esqlFieldsCache.delete(previousColumnsQueryRef.current);
+          }
+        }
+
+        const controller = new AbortController();
+        columnsAbortControllerRef.current = controller;
+        previousColumnsQueryRef.current = queryToExecute;
+
+        clearCacheWhenOld(esqlFieldsCache, queryToExecute);
         const timeRange = data.query.timefilter.timefilter.getTime();
-        return (
-          (await memoizedFieldsFromESQL({
-            esqlQuery: queryToExecute,
-            search: data.search.search,
-            timeRange,
-            signal: abortControllerRef.current.signal,
-            variables: esqlService?.variablesService?.esqlVariables,
-            dropNullColumns: true,
-          }).result) || []
-        );
+        const result = await memoizedFieldsFromESQL({
+          esqlQuery: queryToExecute,
+          search: data.search.search,
+          timeRange,
+          signal: controller.signal,
+          variables: esqlService?.variablesService?.esqlVariables,
+          dropNullColumns: true,
+        }).result;
+
+        if (controller.signal.aborted) {
+          esqlFieldsCache.delete(queryToExecute);
+          return [];
+        }
+
+        return result || [];
       }
       return [];
     },
@@ -134,7 +152,6 @@ export const useEsqlCallbacks = ({
       data.search.search,
       esqlFieldsCache,
       memoizedFieldsFromESQL,
-      abortControllerRef,
       esqlService,
     ]
   );

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/sources.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/sources.test.ts
@@ -25,7 +25,8 @@ describe('getIndicesList', function () {
     ]);
 
     expect(coreMockStartContract.http.get).toHaveBeenCalledWith(
-      `${SOURCES_AUTOCOMPLETE_ROUTE}local`
+      `${SOURCES_AUTOCOMPLETE_ROUTE}local`,
+      { signal: undefined }
     );
   });
 
@@ -72,7 +73,10 @@ describe('getIndicesList with remote indices', function () {
       { name: 'local-index', hidden: false, type: SOURCES_TYPES.INDEX },
     ]);
 
-    expect(coreMockStartContract.http.get).toHaveBeenCalledWith(`${SOURCES_AUTOCOMPLETE_ROUTE}all`);
+    expect(coreMockStartContract.http.get).toHaveBeenCalledWith(
+      `${SOURCES_AUTOCOMPLETE_ROUTE}all`,
+      { signal: undefined }
+    );
   });
 
   it('should not include remote indices when areRemoteIndicesAvailable is false', async function () {
@@ -87,7 +91,8 @@ describe('getIndicesList with remote indices', function () {
     ]);
 
     expect(coreMockStartContract.http.get).toHaveBeenCalledWith(
-      `${SOURCES_AUTOCOMPLETE_ROUTE}local`
+      `${SOURCES_AUTOCOMPLETE_ROUTE}local`,
+      { signal: undefined }
     );
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/sources.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/sources.ts
@@ -28,18 +28,23 @@ interface IntegrationsResponse {
  * Fetches the list of indices, aliases, and data streams from the Elasticsearch cluster.
  * @param core The core start contract to make HTTP requests.
  * @param areRemoteIndicesAvailable A boolean indicating if remote indices should be included.
+ * @param signal Optional AbortSignal to cancel the request.
  * @returns A promise that resolves to an array of ESQLSourceResult objects.
  */
 export const getIndicesList = async (
   core: Pick<CoreStart, 'http'>,
-  areRemoteIndicesAvailable: boolean
+  areRemoteIndicesAvailable: boolean,
+  signal?: AbortSignal
 ): Promise<ESQLSourceResult[]> => {
   const scope = areRemoteIndicesAvailable ? 'all' : 'local';
-  const response = await core.http.get(`${SOURCES_AUTOCOMPLETE_ROUTE}${scope}`).catch((error) => {
-    // eslint-disable-next-line no-console
-    console.error('Failed to fetch the sources', error);
-    return [];
-  });
+  const response = await core.http
+    .get(`${SOURCES_AUTOCOMPLETE_ROUTE}${scope}`, { signal })
+    .catch((error) => {
+      if (signal?.aborted) return [];
+      // eslint-disable-next-line no-console
+      console.error('Failed to fetch the sources', error);
+      return [];
+    });
 
   return response as ESQLSourceResult[];
 };
@@ -50,7 +55,8 @@ export const getIndicesList = async (
  * @returns A promise that resolves to an array of ESQLSourceResult objects.
  */
 const getIntegrations = async (
-  core: Pick<CoreStart, 'application' | 'http'>
+  core: Pick<CoreStart, 'application' | 'http'>,
+  signal?: AbortSignal
 ): Promise<ESQLSourceResult[]> => {
   const fleetCapabilities = core.application.capabilities.fleet;
   if (!fleetCapabilities?.read) {
@@ -62,8 +68,13 @@ const getIntegrations = async (
   // and this needs to be done in various places in the codebase which use the editor
   // https://github.com/elastic/kibana/issues/186061
   const response = (await core.http
-    .get(INTEGRATIONS_API, { query: { showOnlyActiveDataStreams: true }, version: API_VERSION })
+    .get(INTEGRATIONS_API, {
+      query: { showOnlyActiveDataStreams: true },
+      version: API_VERSION,
+      signal,
+    })
     .catch((error) => {
+      if (signal?.aborted) return undefined;
       // eslint-disable-next-line no-console
       console.error('Failed to fetch integrations', error);
     })) as IntegrationsResponse;
@@ -84,18 +95,20 @@ const getIntegrations = async (
 /** Fetches ESQL sources including indices, aliases, data streams, and integrations.
  * @param core The core start contract to make HTTP requests and access application capabilities.
  * @param getLicense An optional function to retrieve the current license information.
+ * @param signal Optional AbortSignal to cancel the request.
  * @returns A promise that resolves to an array of ESQLSourceResult objects.
  */
 export const getESQLSources = async (
   core: Pick<CoreStart, 'application' | 'http'>,
-  getLicense: (() => Promise<ILicense | undefined>) | undefined
+  getLicense: (() => Promise<ILicense | undefined>) | undefined,
+  signal?: AbortSignal
 ): Promise<ESQLSourceResult[]> => {
   const ls = await getLicense?.();
   const ccrFeature = ls?.getFeature('ccr');
   const areRemoteIndicesAvailable = ccrFeature?.isAvailable ?? false;
   const [allIndices, integrations] = await Promise.all([
-    getIndicesList(core, areRemoteIndicesAvailable),
-    getIntegrations(core),
+    getIndicesList(core, areRemoteIndicesAvailable, signal),
+    getIntegrations(core, signal),
   ]);
   return [...allIndices, ...integrations];
 };


### PR DESCRIPTION
## Summary

Fixes a problem where rapid typing in the ES|QL editor (e.g. changing the FROM source) could cause autocomplete column-fetch queries to pile up on the ES side with no way to cancel them.

- getColumnsFor now uses its own AbortController, decoupled from the query-submit lifecycle. Each new autocomplete column fetch aborts the previous in-flight request and cleans up its stale cache entry.
- Fixed a clearCacheWhenOld key mismatch — the TTL check used "query | limit 0" as the key but the memoize cache is keyed by just "query", so entries were never actually evicted.
- Added optional signal parameter to getESQLSources, getIndicesList, and getIntegrations so callers can cancel source fetches when needed.