### PR TITLE
Implement validation run contract parsing in kbn-dev-utils

### DIFF
--- a/src/platform/packages/shared/kbn-dev-utils/src/validation_run_contract.test.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/validation_run_contract.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  parseAndResolveValidationContract,
+  VALIDATION_PROFILE_DEFAULTS,
+} from './validation_run_contract';
+
+describe('VALIDATION_PROFILE_DEFAULTS', () => {
+  it('defines expected defaults for each profile', () => {
+    expect(VALIDATION_PROFILE_DEFAULTS).toEqual({
+      precommit: {
+        scope: 'staged',
+        testMode: 'related',
+        downstream: 'none',
+      },
+      quick: {
+        scope: 'local',
+        testMode: 'related',
+        downstream: 'none',
+      },
+      agent: {
+        scope: 'local',
+        testMode: 'related',
+        downstream: 'none',
+      },
+      branch: {
+        scope: 'branch',
+        testMode: 'affected',
+        downstream: 'none',
+      },
+      pr: {
+        scope: 'branch',
+        testMode: 'affected',
+        downstream: 'deep',
+      },
+      full: {
+        scope: 'full',
+        testMode: 'all',
+        downstream: 'none',
+      },
+    });
+  });
+});
+
+describe('parseAndResolveValidationContract', () => {
+  it('defaults to branch profile/scope when no flags are provided', () => {
+    expect(parseAndResolveValidationContract({})).toEqual({
+      profile: 'branch',
+      scope: 'branch',
+      testMode: 'affected',
+      downstream: 'none',
+      baseRef: undefined,
+      headRef: 'HEAD',
+    });
+  });
+
+  it('applies profile defaults and explicit overrides', () => {
+    expect(
+      parseAndResolveValidationContract({
+        profile: 'quick',
+        downstream: 'direct',
+      })
+    ).toEqual({
+      profile: 'quick',
+      scope: 'local',
+      testMode: 'related',
+      downstream: 'direct',
+      baseRef: undefined,
+      headRef: undefined,
+    });
+  });
+
+  it('supports the agent profile with quick defaults', () => {
+    expect(
+      parseAndResolveValidationContract({
+        profile: 'agent',
+      })
+    ).toEqual({
+      profile: 'agent',
+      scope: 'local',
+      testMode: 'related',
+      downstream: 'none',
+      baseRef: undefined,
+      headRef: undefined,
+    });
+  });
+
+  it('allows any test-mode with any scope independently', () => {
+    expect(
+      parseAndResolveValidationContract({
+        scope: 'branch',
+        testMode: 'all',
+      })
+    ).toEqual({
+      profile: 'branch',
+      scope: 'branch',
+      testMode: 'all',
+      downstream: 'none',
+      baseRef: undefined,
+      headRef: 'HEAD',
+    });
+  });
+
+  it('trims and normalizes ref flags', () => {
+    expect(
+      parseAndResolveValidationContract({
+        scope: 'branch',
+        baseRef: ' origin/main ',
+        headRef: ' HEAD ',
+      })
+    ).toEqual({
+      profile: 'branch',
+      scope: 'branch',
+      testMode: 'affected',
+      downstream: 'none',
+      baseRef: 'origin/main',
+      headRef: 'HEAD',
+    });
+  });
+
+  it('throws for unsupported flag values', () => {
+    expect(() => parseAndResolveValidationContract({ profile: 'fast' })).toThrow(
+      "Unsupported --profile value 'fast'. Expected one of: precommit, quick, agent, branch, pr, full."
+    );
+    expect(() => parseAndResolveValidationContract({ scope: 'workspace' })).toThrow(
+      "Unsupported --scope value 'workspace'. Expected one of: staged, local, branch, full."
+    );
+    expect(() => parseAndResolveValidationContract({ testMode: 'delta' })).toThrow(
+      "Unsupported --test-mode value 'delta'. Expected one of: related, affected, all."
+    );
+    expect(() => parseAndResolveValidationContract({ downstream: 'all' })).toThrow(
+      "Unsupported --downstream value 'all'. Expected one of: none, direct, deep."
+    );
+  });
+
+  it('rejects refs outside branch scope', () => {
+    expect(() =>
+      parseAndResolveValidationContract({
+        scope: 'local',
+        baseRef: 'origin/main',
+      })
+    ).toThrow('--base-ref can only be used when --scope is branch.');
+
+    expect(() =>
+      parseAndResolveValidationContract({
+        scope: 'staged',
+        headRef: 'HEAD~1',
+      })
+    ).toThrow('--head-ref can only be used when --scope is branch.');
+  });
+});

--- a/src/platform/packages/shared/kbn-dev-utils/src/validation_run_contract.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/validation_run_contract.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createFailError } from '@kbn/dev-cli-errors';
+
+export type ValidationScope = 'staged' | 'local' | 'branch' | 'full';
+export type ValidationTestMode = 'related' | 'affected' | 'all';
+export type ValidationDownstreamMode = 'none' | 'direct' | 'deep';
+export type ValidationProfile = 'precommit' | 'quick' | 'agent' | 'branch' | 'pr' | 'full';
+
+export interface ValidationProfileDefaults {
+  scope: ValidationScope;
+  testMode: ValidationTestMode;
+  downstream: ValidationDownstreamMode;
+}
+
+export const VALIDATION_PROFILE_DEFAULTS: Readonly<
+  Record<ValidationProfile, Readonly<ValidationProfileDefaults>>
+> = {
+  precommit: {
+    scope: 'staged',
+    testMode: 'related',
+    downstream: 'none',
+  },
+  quick: {
+    scope: 'local',
+    testMode: 'related',
+    downstream: 'none',
+  },
+  agent: {
+    scope: 'local',
+    testMode: 'related',
+    downstream: 'none',
+  },
+  branch: {
+    scope: 'branch',
+    testMode: 'affected',
+    downstream: 'none',
+  },
+  pr: {
+    scope: 'branch',
+    testMode: 'affected',
+    downstream: 'deep',
+  },
+  full: {
+    scope: 'full',
+    testMode: 'all',
+    downstream: 'none',
+  },
+};
+
+export interface ResolvedValidationContract {
+  profile: ValidationProfile;
+  scope: ValidationScope;
+  testMode: ValidationTestMode;
+  downstream: ValidationDownstreamMode;
+  baseRef?: string;
+  headRef?: string;
+}
+
+const normalizeValue = (value: string | undefined): string | undefined => {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+};
+
+const createEnumParser =
+  <T extends string>(flagName: string, validValues: readonly T[]) =>
+  (value: string | undefined): T | undefined => {
+    if (!value) {
+      return undefined;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if ((validValues as readonly string[]).includes(normalized)) {
+      return normalized as T;
+    }
+
+    throw createFailError(
+      `Unsupported --${flagName} value '${value}'. Expected one of: ${validValues.join(', ')}.`
+    );
+  };
+
+const parseValidationScope = createEnumParser<ValidationScope>('scope', [
+  'staged',
+  'local',
+  'branch',
+  'full',
+]);
+
+const parseValidationTestMode = createEnumParser<ValidationTestMode>('test-mode', [
+  'related',
+  'affected',
+  'all',
+]);
+
+const parseValidationDownstreamMode = createEnumParser<ValidationDownstreamMode>('downstream', [
+  'none',
+  'direct',
+  'deep',
+]);
+
+const parseValidationProfile = createEnumParser<ValidationProfile>('profile', [
+  'precommit',
+  'quick',
+  'agent',
+  'branch',
+  'pr',
+  'full',
+]);
+
+/** Applies profile defaults and explicit overrides to build a concrete validation contract. */
+const resolveValidationContract = ({
+  profile,
+  scope,
+  testMode,
+  downstream,
+  baseRef,
+  headRef,
+}: {
+  profile?: ValidationProfile;
+  scope?: ValidationScope;
+  testMode?: ValidationTestMode;
+  downstream?: ValidationDownstreamMode;
+  baseRef?: string;
+  headRef?: string;
+}): ResolvedValidationContract => {
+  const resolvedProfile: ValidationProfile = profile ?? 'branch';
+  const defaults = VALIDATION_PROFILE_DEFAULTS[resolvedProfile];
+  const resolvedScope = scope ?? defaults.scope;
+
+  return {
+    profile: resolvedProfile,
+    scope: resolvedScope,
+    testMode: testMode ?? defaults.testMode,
+    downstream: downstream ?? defaults.downstream,
+    baseRef,
+    headRef: resolvedScope === 'branch' ? headRef ?? 'HEAD' : headRef,
+  };
+};
+
+/** Validates cross-flag invariants for a resolved validation contract. */
+const validateResolvedValidationContract = ({
+  scope,
+  baseRef,
+  headRef,
+}: Pick<ResolvedValidationContract, 'scope' | 'baseRef' | 'headRef'>): void => {
+  if (scope !== 'branch' && baseRef !== undefined) {
+    throw createFailError('--base-ref can only be used when --scope is branch.');
+  }
+  if (scope !== 'branch' && headRef !== undefined) {
+    throw createFailError('--head-ref can only be used when --scope is branch.');
+  }
+};
+
+/** Parses, resolves, and validates validation-contract flags in one call. */
+export const parseAndResolveValidationContract = ({
+  profile,
+  scope,
+  testMode,
+  downstream,
+  baseRef,
+  headRef,
+}: {
+  profile?: string;
+  scope?: string;
+  testMode?: string;
+  downstream?: string;
+  baseRef?: string;
+  headRef?: string;
+}): ResolvedValidationContract => {
+  const resolvedContract = resolveValidationContract({
+    profile: parseValidationProfile(profile),
+    scope: parseValidationScope(scope),
+    testMode: parseValidationTestMode(testMode),
+    downstream: parseValidationDownstreamMode(downstream),
+    baseRef: normalizeValue(baseRef),
+    headRef: normalizeValue(headRef),
+  });
+
+  validateResolvedValidationContract(resolvedContract);
+
+  return resolvedContract;
+};


### PR DESCRIPTION
Add validation contract parsing/resolution with profile defaults, enum validation, and branch-only ref guardrails, plus unit tests for defaults, overrides, normalization, and invalid combinations.

Implements #255391

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->