### PR TITLE
[Build] Pin shadow version for Chainguard image

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -92,7 +92,8 @@ RUN microdnf install --setopt=tsflags=nodocs -y \
       microdnf clean all
 {{/ubi}}
 {{#wolfi}}
-RUN apk --no-cache add bash curl fontconfig font-liberation libstdc++ libnss findutils shadow ca-certificates{{#serverless}} libjemalloc2 mimalloc2{{/serverless}}
+# TODO: Remove pinned shadow version once Wolfi image is updated. Newer releases of shadow require glibc 2.43 which is not available in the current image SHA.
+RUN apk --no-cache add bash curl fontconfig font-liberation libstdc++ libnss findutils shadow=4.19.3-r0 ca-certificates{{#serverless}} libjemalloc2 mimalloc2{{/serverless}}
 {{/wolfi}}
 
 # Bring in Kibana from the initial stage.


### PR DESCRIPTION
## Summary

Newer versions of `shadow` that Chainguard is sending out require `glibc 2.43`. We have reverted the images which contain that version of `glibc` due to OOM issues. So, we need to pin to a slightly older version of `shadow`.



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->