### PR TITLE
[Search] Add index create modal V2 to platform index management

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/components/index_table.helpers.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/components/index_table.helpers.tsx
@@ -17,6 +17,7 @@ import {
   executionContextServiceMock,
   chromeServiceMock,
 } from '@kbn/core/public/mocks';
+import { settingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import type { AppDependencies } from '../../public/application/app_context';
 import { AppContextProvider } from '../../public/application/app_context';
 import type { Index } from '../../common';
@@ -211,6 +212,7 @@ export const renderIndexApp = async (options?: {
       enableIndexActions: true,
       enableIndexStats: true,
     },
+    settings: settingsServiceMock.createStartContract(),
     privs: {
       monitor: true,
       manageEnrich: true,

--- a/x-pack/platform/plugins/shared/index_management/public/application/hooks/use_is_platform_index_management_v2_enabled.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/hooks/use_is_platform_index_management_v2_enabled.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PLATFORM_INDEX_MGMT_V2 } from '../../../common/constants';
+import { useAppContext } from '../app_context';
+
+export const useIsPlatformIndexManagementV2Enabled = (): boolean => {
+  const { settings } = useAppContext();
+  return settings.client.get<boolean>(PLATFORM_INDEX_MGMT_V2, false);
+};

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_button.tsx
@@ -23,13 +23,14 @@ export interface CreateIndexButtonProps {
 }
 
 export const CreateIndexButton = ({ loadIndices, share, dataTestSubj }: CreateIndexButtonProps) => {
+  const {
+    core: { chrome },
+  } = useAppContext();
   const isPlatformIndexManagementV2Enabled = useIsPlatformIndexManagementV2Enabled();
   const [createIndexModalOpen, setCreateIndexModalOpen] = useState<boolean>(false);
   const createIndexUrl = share?.url.locators.get('SEARCH_CREATE_INDEX')?.useUrl({});
 
-  const {
-    core: { chrome },
-  } = useAppContext();
+  const IndexModal = isPlatformIndexManagementV2Enabled ? CreateIndexModalV2 : CreateIndexModal;
 
   const activeSolutionId = useObservable(chrome.getActiveSolutionNavId$());
 
@@ -53,18 +54,9 @@ export const CreateIndexButton = ({ loadIndices, share, dataTestSubj }: CreateIn
           defaultMessage="Create index"
         />
       </EuiButton>
-      {createIndexModalOpen &&
-        (isPlatformIndexManagementV2Enabled ? (
-          <CreateIndexModalV2
-            closeModal={() => setCreateIndexModalOpen(false)}
-            loadIndices={loadIndices}
-          />
-        ) : (
-          <CreateIndexModal
-            closeModal={() => setCreateIndexModalOpen(false)}
-            loadIndices={loadIndices}
-          />
-        ))}
+      {createIndexModalOpen && (
+        <IndexModal closeModal={() => setCreateIndexModalOpen(false)} loadIndices={loadIndices} />
+      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_button.tsx
@@ -12,7 +12,9 @@ import { EuiButton } from '@elastic/eui';
 
 import useObservable from 'react-use/lib/useObservable';
 import { CreateIndexModal } from './create_index_modal';
+import { CreateIndexModalV2 } from './create_index_modal_v2';
 import { useAppContext } from '../../../../app_context';
+import { useIsPlatformIndexManagementV2Enabled } from '../../../../hooks/use_is_platform_index_management_v2_enabled';
 
 export interface CreateIndexButtonProps {
   loadIndices: () => void;
@@ -21,6 +23,7 @@ export interface CreateIndexButtonProps {
 }
 
 export const CreateIndexButton = ({ loadIndices, share, dataTestSubj }: CreateIndexButtonProps) => {
+  const isPlatformIndexManagementV2Enabled = useIsPlatformIndexManagementV2Enabled();
   const [createIndexModalOpen, setCreateIndexModalOpen] = useState<boolean>(false);
   const createIndexUrl = share?.url.locators.get('SEARCH_CREATE_INDEX')?.useUrl({});
 
@@ -50,12 +53,18 @@ export const CreateIndexButton = ({ loadIndices, share, dataTestSubj }: CreateIn
           defaultMessage="Create index"
         />
       </EuiButton>
-      {createIndexModalOpen && (
-        <CreateIndexModal
-          closeModal={() => setCreateIndexModalOpen(false)}
-          loadIndices={loadIndices}
-        />
-      )}
+      {createIndexModalOpen &&
+        (isPlatformIndexManagementV2Enabled ? (
+          <CreateIndexModalV2
+            closeModal={() => setCreateIndexModalOpen(false)}
+            loadIndices={loadIndices}
+          />
+        ) : (
+          <CreateIndexModal
+            closeModal={() => setCreateIndexModalOpen(false)}
+            loadIndices={loadIndices}
+          />
+        ))}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment, useCallback, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFieldText,
+  EuiSuperSelect,
+  EuiForm,
+  EuiFormRow,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiSpacer,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+
+import { LOOKUP_INDEX_MODE, STANDARD_INDEX_MODE } from '../../../../../../common/constants';
+import { indexModeDescriptions, indexModeLabels } from '../../../../lib/index_mode_labels';
+import { createIndex } from '../../../../services';
+import { notificationService } from '../../../../services/notification';
+
+import { isValidIndexName } from './utils';
+
+const INVALID_INDEX_NAME_ERROR = i18n.translate(
+  'xpack.idxMgmt.createIndex.modal.invalidName.error',
+  { defaultMessage: 'Index name is not valid' }
+);
+
+export interface CreateIndexModalProps {
+  closeModal: () => void;
+  loadIndices: () => void;
+}
+
+export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalProps) => {
+  const modalTitleId = useGeneratedHtmlId();
+
+  const [indexName, setIndexName] = useState<string>('');
+  const [indexMode, setIndexMode] = useState<string>(STANDARD_INDEX_MODE);
+  const [indexNameError, setIndexNameError] = useState<string | undefined>();
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [createError, setCreateError] = useState<string | undefined>();
+
+  const putCreateIndex = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const { error } = await createIndex(indexName, indexMode);
+      setIsSaving(false);
+      if (!error) {
+        notificationService.showSuccessToast(
+          i18n.translate('xpack.idxMgmt.createIndex.successfullyCreatedIndexMessage', {
+            defaultMessage: 'Successfully created index: {indexName}',
+            values: { indexName },
+          })
+        );
+        closeModal();
+        loadIndices();
+        return;
+      }
+      setCreateError(error.message);
+    } catch (e) {
+      setIsSaving(false);
+      setCreateError(e.message);
+    }
+  }, [closeModal, indexMode, indexName, loadIndices]);
+
+  const onSave = () => {
+    if (isValidIndexName(indexName)) {
+      putCreateIndex();
+    }
+  };
+
+  const onNameChange = (name: string) => {
+    setIndexName(name);
+    if (!isValidIndexName(name)) {
+      setIndexNameError(INVALID_INDEX_NAME_ERROR);
+    } else if (indexNameError) {
+      setIndexNameError(undefined);
+    }
+  };
+
+  return (
+    <EuiModal
+      aria-labelledby={modalTitleId}
+      onClose={closeModal}
+      initialFocus="[name=indexName]"
+      css={{ width: 450 }}
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>
+          <FormattedMessage
+            id="xpack.idxMgmt.createIndex.modal.title"
+            defaultMessage="Create index"
+          />
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        {createError && (
+          <>
+            <EuiCallOut
+              announceOnMount
+              color="danger"
+              iconType="error"
+              title={i18n.translate('xpack.idxMgmt.createIndex.modal.error.title', {
+                defaultMessage: 'Error creating index',
+              })}
+            >
+              <EuiText>
+                <FormattedMessage
+                  id="xpack.idxMgmt.createIndex.modal.error.description"
+                  defaultMessage="Error creating index: {errorMessage}"
+                  values={{ errorMessage: createError }}
+                />
+              </EuiText>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
+        <EuiForm id="createIndexModalForm" component="form">
+          <EuiFormRow
+            fullWidth
+            label={i18n.translate('xpack.idxMgmt.createIndex.modal.indexName.label', {
+              defaultMessage: 'Index name',
+            })}
+            isDisabled={isSaving}
+            isInvalid={indexNameError !== undefined}
+            error={indexNameError}
+          >
+            <EuiFieldText
+              isInvalid={indexNameError !== undefined}
+              fullWidth
+              name="indexName"
+              value={indexName}
+              onChange={(e) => onNameChange(e.target.value)}
+              data-test-subj="createIndexNameFieldText"
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            fullWidth
+            label={i18n.translate('xpack.idxMgmt.createIndex.modal.indexMode.label', {
+              defaultMessage: 'Index mode',
+            })}
+            isDisabled={isSaving}
+          >
+            <EuiSuperSelect
+              fullWidth
+              hasDividers
+              name="indexMode"
+              valueOfSelected={indexMode}
+              onChange={(mode) => setIndexMode(mode)}
+              data-test-subj="indexModeField"
+              options={[
+                {
+                  value: STANDARD_INDEX_MODE,
+                  inputDisplay: indexModeLabels[STANDARD_INDEX_MODE],
+                  'data-test-subj': 'indexModeStandardOption',
+                  dropdownDisplay: (
+                    <Fragment>
+                      <strong>{indexModeLabels[STANDARD_INDEX_MODE]}</strong>
+                      <EuiText size="s" color="subdued">
+                        <p>{indexModeDescriptions[STANDARD_INDEX_MODE]}</p>
+                      </EuiText>
+                    </Fragment>
+                  ),
+                },
+                {
+                  value: LOOKUP_INDEX_MODE,
+                  inputDisplay: indexModeLabels[LOOKUP_INDEX_MODE],
+                  'data-test-subj': 'indexModeLookupOption',
+                  dropdownDisplay: (
+                    <Fragment>
+                      <strong>{indexModeLabels[LOOKUP_INDEX_MODE]}</strong>
+                      <EuiText size="s" color="subdued">
+                        <p>{indexModeDescriptions[LOOKUP_INDEX_MODE]}</p>
+                      </EuiText>
+                    </Fragment>
+                  ),
+                },
+              ]}
+            />
+          </EuiFormRow>
+        </EuiForm>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButtonEmpty
+          onClick={closeModal}
+          disabled={isSaving}
+          data-test-subj="createIndexCancelButton"
+          data-telemetry-id="idxMgmt-indexList-createIndex-cancelButton"
+        >
+          <FormattedMessage
+            id="xpack.idxMgmt.createIndex.modal.cancelButton"
+            defaultMessage="Cancel"
+          />
+        </EuiButtonEmpty>
+        <EuiButton
+          fill
+          disabled={indexNameError !== undefined}
+          isLoading={isSaving}
+          type="submit"
+          onClick={onSave}
+          form="createIndexModalForm"
+          data-test-subj="createIndexSaveButton"
+          data-telemetry-id="idxMgmt-indexList-createIndex-saveButton"
+        >
+          <FormattedMessage
+            id="xpack.idxMgmt.createIndex.modal.saveButton"
+            defaultMessage="Create"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
@@ -289,7 +289,7 @@ export const CreateIndexModalV2 = ({ closeModal, loadIndices }: CreateIndexModal
             </EuiFlexGroup>
           </EuiFlexGroup>
           {showApi && (
-            <EuiCodeBlock language="bash" isCopyable>
+            <EuiCodeBlock language="json" isCopyable>
               {apiCode}
             </EuiCodeBlock>
           )}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
@@ -30,6 +30,7 @@ import {
   useEuiTheme,
   EuiHorizontalRule,
   EuiCodeBlock,
+  type UseEuiTheme,
 } from '@elastic/eui';
 
 import { LOOKUP_INDEX_MODE, STANDARD_INDEX_MODE } from '../../../../../../common/constants';
@@ -44,6 +45,12 @@ const INVALID_INDEX_NAME_ERROR = i18n.translate(
   { defaultMessage: 'Index name is not valid' }
 );
 
+const modalHeaderStyles = ({ euiTheme }: UseEuiTheme) => css`
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${euiTheme.size.s};
+`;
+
 export interface CreateIndexModalProps {
   closeModal: () => void;
   loadIndices: () => void;
@@ -53,20 +60,13 @@ export const CreateIndexModalV2 = ({ closeModal, loadIndices }: CreateIndexModal
   const modalTitleId = useGeneratedHtmlId();
   const { euiTheme } = useEuiTheme();
 
-  const defaultIndexName = generateRandomIndexName();
-  const [indexName, setIndexName] = useState<string>(defaultIndexName);
+  const [indexName, setIndexName] = useState<string>(generateRandomIndexName);
 
   const [indexMode, setIndexMode] = useState<string>(STANDARD_INDEX_MODE);
   const [indexNameError, setIndexNameError] = useState<string | undefined>();
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [createError, setCreateError] = useState<string | undefined>();
   const [showApi, setShowApi] = useState(false);
-
-  const modalHeaderStyles = css`
-    flex-direction: column;
-    align-items: flex-start;
-    gap: ${euiTheme.size.s};
-  `;
 
   const apiCode = `PUT ${indexName}
 {
@@ -133,7 +133,7 @@ export const CreateIndexModalV2 = ({ closeModal, loadIndices }: CreateIndexModal
         </EuiModalHeaderTitle>
         <EuiText color="subdued" size="s">
           <FormattedMessage
-            id="xpack.idxMgmt.createYourIndex.modal.header.description"
+            id="xpack.idxMgmt.createIndex.modal.header.description"
             defaultMessage="An index stores and defines the schema of your data."
           />
         </EuiText>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal_v2.tsx
@@ -8,6 +8,7 @@
 import React, { Fragment, useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -24,6 +25,11 @@ import {
   EuiSpacer,
   EuiText,
   useGeneratedHtmlId,
+  EuiFlexGroup,
+  EuiFlexItem,
+  useEuiTheme,
+  EuiHorizontalRule,
+  EuiCodeBlock,
 } from '@elastic/eui';
 
 import { LOOKUP_INDEX_MODE, STANDARD_INDEX_MODE } from '../../../../../../common/constants';
@@ -31,7 +37,7 @@ import { indexModeDescriptions, indexModeLabels } from '../../../../lib/index_mo
 import { createIndex } from '../../../../services';
 import { notificationService } from '../../../../services/notification';
 
-import { isValidIndexName } from './utils';
+import { generateRandomIndexName, isValidIndexName } from './utils';
 
 const INVALID_INDEX_NAME_ERROR = i18n.translate(
   'xpack.idxMgmt.createIndex.modal.invalidName.error',
@@ -43,14 +49,33 @@ export interface CreateIndexModalProps {
   loadIndices: () => void;
 }
 
-export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalProps) => {
+export const CreateIndexModalV2 = ({ closeModal, loadIndices }: CreateIndexModalProps) => {
   const modalTitleId = useGeneratedHtmlId();
+  const { euiTheme } = useEuiTheme();
 
-  const [indexName, setIndexName] = useState<string>('');
+  const defaultIndexName = generateRandomIndexName();
+  const [indexName, setIndexName] = useState<string>(defaultIndexName);
+
   const [indexMode, setIndexMode] = useState<string>(STANDARD_INDEX_MODE);
   const [indexNameError, setIndexNameError] = useState<string | undefined>();
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [createError, setCreateError] = useState<string | undefined>();
+  const [showApi, setShowApi] = useState(false);
+
+  const modalHeaderStyles = css`
+    flex-direction: column;
+    align-items: flex-start;
+    gap: ${euiTheme.size.s};
+  `;
+
+  const apiCode = `PUT ${indexName}
+{
+  "settings": {
+    "index":{
+      "mode":"${indexMode}"
+    }
+  }
+}`;
 
   const putCreateIndex = useCallback(async () => {
     setIsSaving(true);
@@ -95,15 +120,23 @@ export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalPr
       aria-labelledby={modalTitleId}
       onClose={closeModal}
       initialFocus="[name=indexName]"
-      css={{ width: 450 }}
+      css={css`
+        width: calc(${euiTheme.size.xxxl} * 16);
+      `}
     >
-      <EuiModalHeader>
+      <EuiModalHeader css={modalHeaderStyles}>
         <EuiModalHeaderTitle id={modalTitleId}>
           <FormattedMessage
-            id="xpack.idxMgmt.createIndex.modal.title"
-            defaultMessage="Create index"
+            id="xpack.idxMgmt.createIndex.modal.header.title"
+            defaultMessage="Create your index"
           />
         </EuiModalHeaderTitle>
+        <EuiText color="subdued" size="s">
+          <FormattedMessage
+            id="xpack.idxMgmt.createYourIndex.modal.header.description"
+            defaultMessage="An index stores and defines the schema of your data."
+          />
+        </EuiText>
       </EuiModalHeader>
       <EuiModalBody>
         {createError && (
@@ -128,97 +161,139 @@ export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalPr
           </>
         )}
         <EuiForm id="createIndexModalForm" component="form">
-          <EuiFormRow
-            fullWidth
-            label={i18n.translate('xpack.idxMgmt.createIndex.modal.indexName.label', {
-              defaultMessage: 'Index name',
-            })}
-            isDisabled={isSaving}
-            isInvalid={indexNameError !== undefined}
-            error={indexNameError}
-          >
-            <EuiFieldText
-              isInvalid={indexNameError !== undefined}
-              fullWidth
-              name="indexName"
-              value={indexName}
-              onChange={(e) => onNameChange(e.target.value)}
-              data-test-subj="createIndexNameFieldText"
-            />
-          </EuiFormRow>
-          <EuiFormRow
-            fullWidth
-            label={i18n.translate('xpack.idxMgmt.createIndex.modal.indexMode.label', {
-              defaultMessage: 'Index mode',
-            })}
-            isDisabled={isSaving}
-          >
-            <EuiSuperSelect
-              fullWidth
-              hasDividers
-              name="indexMode"
-              valueOfSelected={indexMode}
-              onChange={(mode) => setIndexMode(mode)}
-              data-test-subj="indexModeField"
-              options={[
-                {
-                  value: STANDARD_INDEX_MODE,
-                  inputDisplay: indexModeLabels[STANDARD_INDEX_MODE],
-                  'data-test-subj': 'indexModeStandardOption',
-                  dropdownDisplay: (
-                    <Fragment>
-                      <strong>{indexModeLabels[STANDARD_INDEX_MODE]}</strong>
-                      <EuiText size="s" color="subdued">
-                        <p>{indexModeDescriptions[STANDARD_INDEX_MODE]}</p>
-                      </EuiText>
-                    </Fragment>
-                  ),
-                },
-                {
-                  value: LOOKUP_INDEX_MODE,
-                  inputDisplay: indexModeLabels[LOOKUP_INDEX_MODE],
-                  'data-test-subj': 'indexModeLookupOption',
-                  dropdownDisplay: (
-                    <Fragment>
-                      <strong>{indexModeLabels[LOOKUP_INDEX_MODE]}</strong>
-                      <EuiText size="s" color="subdued">
-                        <p>{indexModeDescriptions[LOOKUP_INDEX_MODE]}</p>
-                      </EuiText>
-                    </Fragment>
-                  ),
-                },
-              ]}
-            />
-          </EuiFormRow>
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiFormRow
+                fullWidth
+                label={i18n.translate('xpack.idxMgmt.createIndex.modal.indexName.label', {
+                  defaultMessage: 'Index name',
+                })}
+                isDisabled={isSaving}
+                isInvalid={indexNameError !== undefined}
+                error={indexNameError}
+              >
+                <EuiFieldText
+                  isInvalid={indexNameError !== undefined}
+                  fullWidth
+                  name="indexName"
+                  value={indexName}
+                  onChange={(e) => onNameChange(e.target.value)}
+                  data-test-subj="createIndexNameFieldText"
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFormRow
+                fullWidth
+                label={i18n.translate('xpack.idxMgmt.createIndex.modal.indexMode.label', {
+                  defaultMessage: 'Index mode',
+                })}
+                isDisabled={isSaving}
+                css={css`
+                  width: calc(${euiTheme.size.xxxl} * 4);
+                `}
+              >
+                <EuiSuperSelect
+                  fullWidth
+                  hasDividers
+                  name="indexMode"
+                  valueOfSelected={indexMode}
+                  onChange={(mode) => setIndexMode(mode)}
+                  data-test-subj="indexModeField"
+                  options={[
+                    {
+                      value: STANDARD_INDEX_MODE,
+                      inputDisplay: indexModeLabels[STANDARD_INDEX_MODE],
+                      'data-test-subj': 'indexModeStandardOption',
+                      dropdownDisplay: (
+                        <Fragment>
+                          <strong>{indexModeLabels[STANDARD_INDEX_MODE]}</strong>
+                          <EuiText size="s" color="subdued">
+                            <p>{indexModeDescriptions[STANDARD_INDEX_MODE]}</p>
+                          </EuiText>
+                        </Fragment>
+                      ),
+                    },
+                    {
+                      value: LOOKUP_INDEX_MODE,
+                      inputDisplay: indexModeLabels[LOOKUP_INDEX_MODE],
+                      'data-test-subj': 'indexModeLookupOption',
+                      dropdownDisplay: (
+                        <Fragment>
+                          <strong>{indexModeLabels[LOOKUP_INDEX_MODE]}</strong>
+                          <EuiText size="s" color="subdued">
+                            <p>{indexModeDescriptions[LOOKUP_INDEX_MODE]}</p>
+                          </EuiText>
+                        </Fragment>
+                      ),
+                    },
+                  ]}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="l" />
+          <EuiHorizontalRule margin="none" />
         </EuiForm>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiButtonEmpty
-          onClick={closeModal}
-          disabled={isSaving}
-          data-test-subj="createIndexCancelButton"
-          data-telemetry-id="idxMgmt-indexList-createIndex-cancelButton"
-        >
-          <FormattedMessage
-            id="xpack.idxMgmt.createIndex.modal.cancelButton"
-            defaultMessage="Cancel"
-          />
-        </EuiButtonEmpty>
-        <EuiButton
-          fill
-          disabled={indexNameError !== undefined}
-          isLoading={isSaving}
-          type="submit"
-          onClick={onSave}
-          form="createIndexModalForm"
-          data-test-subj="createIndexSaveButton"
-          data-telemetry-id="idxMgmt-indexList-createIndex-saveButton"
-        >
-          <FormattedMessage
-            id="xpack.idxMgmt.createIndex.modal.saveButton"
-            defaultMessage="Create"
-          />
-        </EuiButton>
+        <EuiFlexGroup direction="column">
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiButtonEmpty
+              onClick={closeModal}
+              disabled={isSaving}
+              data-test-subj="createIndexCancelButton"
+              data-telemetry-id="idxMgmt-indexList-createIndex-cancelButton"
+            >
+              <FormattedMessage
+                id="xpack.idxMgmt.createIndex.modal.cancelButton"
+                defaultMessage="Cancel"
+              />
+            </EuiButtonEmpty>
+            <EuiFlexGroup justifyContent="flexEnd">
+              <EuiButtonEmpty
+                iconSide="left"
+                iconType="code"
+                disabled={isSaving}
+                onClick={() => setShowApi((prev) => !prev)}
+                data-test-subj="createIndexShowApiButton"
+                data-telemetry-id="idxMgmt-indexList-createIndex-showApiButton"
+              >
+                {showApi ? (
+                  <FormattedMessage
+                    id="xpack.idxMgmt.createIndex.modal.hideApiButton"
+                    defaultMessage="Hide API"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.idxMgmt.createIndex.modal.showApiButton"
+                    defaultMessage="Show API"
+                  />
+                )}
+              </EuiButtonEmpty>
+              <EuiButton
+                fill
+                disabled={indexNameError !== undefined}
+                isLoading={isSaving}
+                type="submit"
+                onClick={onSave}
+                form="createIndexModalForm"
+                data-test-subj="createIndexSaveButton"
+                data-telemetry-id="idxMgmt-indexList-createIndex-saveButton"
+              >
+                <FormattedMessage
+                  id="xpack.idxMgmt.createIndex.modal.saveIndexButton"
+                  defaultMessage="Create my index"
+                />
+              </EuiButton>
+            </EuiFlexGroup>
+          </EuiFlexGroup>
+          {showApi && (
+            <EuiCodeBlock language="bash" isCopyable>
+              {apiCode}
+            </EuiCodeBlock>
+          )}
+        </EuiFlexGroup>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/utils.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/utils.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isValidIndexName } from './utils';
+import { isValidIndexName, generateRandomIndexName } from './utils';
 
 describe('create index utilities', () => {
   describe('isValidIndexName', () => {
@@ -57,6 +57,36 @@ describe('create index utilities', () => {
       )}`;
 
       expect(isValidIndexName(indexName)).toBe(false);
+    });
+  });
+
+  describe('generateRandomIndexName', () => {
+    it('uses the default prefix and suffix length', () => {
+      const name = generateRandomIndexName();
+      expect(name).toMatch(/^search-[a-z0-9]{4}$/);
+    });
+
+    it('uses a custom prefix', () => {
+      const name = generateRandomIndexName('logs-');
+      expect(name).toMatch(/^logs-[a-z0-9]{4}$/);
+    });
+
+    it('uses a custom suffix length', () => {
+      const name = generateRandomIndexName('search-', 8);
+      expect(name).toMatch(/^search-[a-z0-9]{8}$/);
+    });
+
+    it('only contains lowercase alphanumeric characters in the suffix', () => {
+      for (let i = 0; i < 20; i++) {
+        const name = generateRandomIndexName('', 10);
+        expect(name).toMatch(/^[a-z0-9]{10}$/);
+      }
+    });
+
+    it('generates a valid index name', () => {
+      for (let i = 0; i < 20; i++) {
+        expect(isValidIndexName(generateRandomIndexName())).toBe(true);
+      }
     });
   });
 });

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/utils.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/utils.ts
@@ -19,3 +19,20 @@ export function isValidIndexName(name: string) {
 
   return !indexPatternInvalid;
 }
+
+export function generateRandomIndexName(
+  prefix: string = 'search-',
+  randomSuffixLength: number = 4
+) {
+  const suffixCharacters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const charsLength = suffixCharacters.length;
+  let result = prefix;
+
+  let counter = 0;
+  do {
+    result += suffixCharacters.charAt(Math.random() * charsLength);
+    counter++;
+  } while (counter < randomSuffixLength);
+
+  return result;
+}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/utils.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/utils.ts
@@ -28,11 +28,10 @@ export function generateRandomIndexName(
   const charsLength = suffixCharacters.length;
   let result = prefix;
 
-  let counter = 0;
-  do {
-    result += suffixCharacters.charAt(Math.random() * charsLength);
-    counter++;
-  } while (counter < randomSuffixLength);
+  for (let i = 0; i < randomSuffixLength; i++) {
+    const idx = Math.floor(Math.random() * charsLength);
+    result += suffixCharacters.charAt(idx);
+  }
 
   return result;
 }

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
@@ -14,15 +14,11 @@ import { SectionLoading } from '@kbn/es-ui-shared-plugin/public';
 
 import { resetIndexUrlParams } from './reset_index_url_params';
 import type { IndexDetailsTabId } from '../../../../../../common/constants';
-import {
-  IndexDetailsSection,
-  PLATFORM_INDEX_MGMT_V2,
-  Section,
-} from '../../../../../../common/constants';
+import { IndexDetailsSection, Section } from '../../../../../../common/constants';
 import type { Index } from '../../../../../../common';
 import type { Error } from '../../../../../shared_imports';
 import { loadIndex } from '../../../../services';
-import { useAppContext } from '../../../../app_context';
+import { useIsPlatformIndexManagementV2Enabled } from '../../../../hooks/use_is_platform_index_management_v2_enabled';
 import { DetailsPageError } from './details_page_error';
 import { DetailsPageContent } from './details_page_content';
 import { DetailsPageContentV2 } from './details_page_content_v2';
@@ -30,7 +26,7 @@ import { DetailsPageContentV2 } from './details_page_content_v2';
 export const DetailsPage: FunctionComponent<
   RouteComponentProps<{ indexName: string; indexDetailsSection: IndexDetailsSection }>
 > = ({ location: { search }, history }) => {
-  const { settings } = useAppContext();
+  const isPlatformIndexManagementV2Enabled = useIsPlatformIndexManagementV2Enabled();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
   const indexName = queryParams.get('indexName') ?? '';
   const tab: IndexDetailsTabId = queryParams.get('tab') ?? IndexDetailsSection.Overview;
@@ -38,11 +34,6 @@ export const DetailsPage: FunctionComponent<
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [index, setIndex] = useState<Index | null>();
-
-  const isPlatformIndexManagementV2Enabled = settings.client.get<boolean>(
-    PLATFORM_INDEX_MGMT_V2,
-    false
-  );
 
   const navigateToIndicesList = useCallback(() => {
     const paramsString = resetIndexUrlParams(search);


### PR DESCRIPTION
## Summary

- Introduces `CreateIndexModalV2`, a refreshed create-index modal for Platform Index Management.
- Keeps the V2 modal behind the existing Platform Index Management V2 UI feature flag.
- Centralizes flag usage via `useIsPlatformIndexManagementV2Enabled` so V2 gating can be reused consistently across the plugin.
- Updates the create-index flow to use the V2 modal when the flag is enabled, while retaining the existing modal when it is not.
- V2 specific UX updates: 
  - Wider modal, index name and index mode fields on one row, pre-filled generated index name, and a Show/Hide API preview for the create-index request.

### Screenshots

<img width="700" height="604" alt="Screenshot 2026-03-03 at 09 13 35" src="https://github.com/user-attachments/assets/47e47ccf-4f4f-42a7-8f67-d5b39d1352c8" />

<img width="700" height="649" alt="Screenshot 2026-03-03 at 09 13 44" src="https://github.com/user-attachments/assets/934c0dfa-c909-4db4-9534-3d7549b46ab3" />

### Testing

To preview these changes you can either add the following to `kibana.dev.yml`:
```
uiSettings:
  overrides:
    platform:indexManagementV2: true
```
or run this command in the console:

```
POST kbn:/internal/kibana/settings/platform:indexManagementV2
    {"value": true}
```

When testing you should confirm the following:

- [x] With flag off, open Index Management and verify clicking Create index opens the existing modal.
- [ ] With flag on, verify Create index opens `CreateIndexModalV2`.
- [x] In V2, confirm default index name is pre-filled and passes validation.
- [x] In V2, verify invalid names show inline validation and block submit.
- [x] In V2, toggle Show API and confirm the request preview updates when index name/mode changes.
- [x] In V2, create an index successfully and verify success toast + index list refresh.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~