### PR TITLE
[Observability] Migrate Observability Agent to modular Agent Builder skills

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/type_definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/type_definition.ts
@@ -28,7 +28,11 @@ export type SkillsDirectoryStructure = Directory<{
     platform: FileDirectory<{
       dashboard: FileDirectory;
     }>;
-    observability: FileDirectory<{}>;
+    observability: FileDirectory<{
+      services: FileDirectory;
+      logs: FileDirectory;
+      infrastructure: FileDirectory;
+    }>;
     security: FileDirectory<{
       alerts: FileDirectory<{
         rules: FileDirectory;

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/observability/observability_skills.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/observability/observability_skills.spec.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { evaluate as base } from '../../src/evaluate';
+import type { EvaluateDataset } from '../../src/evaluate_dataset';
+import { createEvaluateDataset } from '../../src/evaluate_dataset';
+
+const evaluate = base.extend<{ evaluateDataset: EvaluateDataset }, {}>({
+  evaluateDataset: [
+    ({ chatClient, evaluators, executorClient, traceEsClient, log }, use) => {
+      use(
+        createEvaluateDataset({
+          chatClient,
+          evaluators,
+          executorClient,
+          traceEsClient,
+          log,
+        })
+      );
+    },
+    { scope: 'test' },
+  ],
+});
+
+evaluate.describe('Observability Skills - Service Investigation', () => {
+  evaluate('service investigation queries activate the correct skill and tools', async ({ evaluateDataset }) => {
+    await evaluateDataset({
+      dataset: {
+        name: 'agent builder: o11y-service-investigation-skill',
+        description:
+          'Validates that APM/service investigation queries activate the service-investigation skill',
+        examples: [
+          {
+            input: {
+              question:
+                'My checkout service is experiencing high latency. Help me investigate what is causing the slowdown.',
+            },
+            output: {
+              expected:
+                'I will investigate the checkout service by first retrieving its metrics (latency, throughput, error rate), then drilling into individual transactions and traces to identify where the slowdown is occurring.',
+            },
+            metadata: {
+              query_intent: 'Service Investigation',
+              expectedSkill: 'service-investigation',
+            },
+          },
+          {
+            input: {
+              question:
+                'What services are currently running in my production environment and which ones are unhealthy?',
+            },
+            output: {
+              expected:
+                'I will list all instrumented services and their health metrics to identify any with elevated error rates, high latency, or throughput anomalies.',
+            },
+            metadata: {
+              query_intent: 'Service Discovery',
+              expectedSkill: 'service-investigation',
+              expectedOnlyToolId: 'observability.get_services',
+            },
+          },
+          {
+            input: {
+              question:
+                'Show me the service dependency map for the payments service. What are its upstream and downstream dependencies?',
+            },
+            output: {
+              expected:
+                'I will retrieve the service topology for the payments service to map its upstream callers and downstream dependencies, along with their connection metrics.',
+            },
+            metadata: {
+              query_intent: 'Dependency Analysis',
+              expectedSkill: 'service-investigation',
+              expectedOnlyToolId: 'observability.get_service_topology',
+            },
+          },
+          {
+            input: {
+              question:
+                'The cart-service JVM seems to be having garbage collection issues. Check the runtime metrics.',
+            },
+            output: {
+              expected:
+                'I will check the runtime metrics for cart-service, focusing on JVM heap usage, GC pause times, and thread counts to identify garbage collection pressure.',
+            },
+            metadata: {
+              query_intent: 'Runtime Investigation',
+              expectedSkill: 'service-investigation',
+              expectedOnlyToolId: 'observability.get_runtime_metrics',
+            },
+          },
+          {
+            input: {
+              question:
+                'Find me a sample trace for the POST /api/checkout transaction on the payments service that took more than 2 seconds.',
+            },
+            output: {
+              expected:
+                'I will search for traces of the POST /api/checkout transaction on the payments service to find samples exceeding 2 seconds, allowing us to examine the span breakdown.',
+            },
+            metadata: {
+              query_intent: 'Trace Analysis',
+              expectedSkill: 'service-investigation',
+              expectedOnlyToolId: 'observability.get_traces',
+            },
+          },
+        ],
+      },
+    });
+  });
+});
+
+evaluate.describe('Observability Skills - Log Analysis', () => {
+  evaluate('log analysis queries activate the correct skill and tools', async ({ evaluateDataset }) => {
+    await evaluateDataset({
+      dataset: {
+        name: 'agent builder: o11y-log-analysis-skill',
+        description:
+          'Validates that log investigation queries activate the log-analysis skill',
+        examples: [
+          {
+            input: {
+              question:
+                'There was a sudden spike in error logs around 2pm today. Help me understand what changed.',
+            },
+            output: {
+              expected:
+                'I will analyze the log rate changes around 2pm using log rate analysis to identify which field/value combinations explain the spike, then examine log patterns to understand the error types.',
+            },
+            metadata: {
+              query_intent: 'Log Investigation',
+              expectedSkill: 'log-analysis',
+            },
+          },
+          {
+            input: {
+              question:
+                'What are the most common error patterns in our application logs from the last hour?',
+            },
+            output: {
+              expected:
+                'I will discover recurring log message patterns from the last hour, grouped by similarity, to identify the most frequent error categories and their counts.',
+            },
+            metadata: {
+              query_intent: 'Log Patterns',
+              expectedSkill: 'log-analysis',
+              expectedOnlyToolId: 'observability.get_log_groups',
+            },
+          },
+          {
+            input: {
+              question:
+                'Run a log rate analysis on the frontend service logs to find what is driving the volume increase in the last 30 minutes.',
+            },
+            output: {
+              expected:
+                'I will run log rate analysis on the frontend service logs for the last 30 minutes to statistically identify which fields and values are most responsible for the volume change.',
+            },
+            metadata: {
+              query_intent: 'Log Rate Analysis',
+              expectedSkill: 'log-analysis',
+              expectedOnlyToolId: 'observability.run_log_rate_analysis',
+            },
+          },
+        ],
+      },
+    });
+  });
+});
+
+evaluate.describe('Observability Skills - Infrastructure & Alerting', () => {
+  evaluate('infrastructure and alerting queries activate the correct skill and tools', async ({ evaluateDataset }) => {
+    await evaluateDataset({
+      dataset: {
+        name: 'agent builder: o11y-infrastructure-alerting-skill',
+        description:
+          'Validates that infrastructure monitoring and alert triage queries activate the infrastructure-alerting skill',
+        examples: [
+          {
+            input: {
+              question:
+                'Show me all active observability alerts and help me prioritize which ones need immediate attention.',
+            },
+            output: {
+              expected:
+                'I will fetch active observability alerts, assess their severity, group them by affected entity, and prioritize based on impact and urgency.',
+            },
+            metadata: {
+              query_intent: 'Alert Triage',
+              expectedSkill: 'infrastructure-alerting',
+              expectedOnlyToolId: 'observability.get_alerts',
+            },
+          },
+          {
+            input: {
+              question:
+                'Our web servers seem to be running out of memory. Check the host metrics for the web-* hosts.',
+            },
+            output: {
+              expected:
+                'I will retrieve host metrics for the web-* hosts, focusing on memory usage, CPU, and disk I/O to assess whether they are approaching resource saturation.',
+            },
+            metadata: {
+              query_intent: 'Host Investigation',
+              expectedSkill: 'infrastructure-alerting',
+              expectedOnlyToolId: 'observability.get_hosts',
+            },
+          },
+          {
+            input: {
+              question:
+                'Are there any ML anomaly detection jobs configured for our observability data? What anomalies have been detected recently?',
+            },
+            output: {
+              expected:
+                'I will check configured ML anomaly detection jobs, their health status, and review recent anomaly records for statistically significant deviations in your observability metrics.',
+            },
+            metadata: {
+              query_intent: 'Anomaly Detection',
+              expectedSkill: 'infrastructure-alerting',
+              expectedOnlyToolId: 'observability.get_anomaly_detection_jobs',
+            },
+          },
+        ],
+      },
+    });
+  });
+});
+
+evaluate.describe('Observability Skills - Distractor Queries', () => {
+  evaluate('non-observability queries do not activate observability skills', async ({ evaluateDataset }) => {
+    await evaluateDataset({
+      dataset: {
+        name: 'agent builder: o11y-skills-distractor',
+        description:
+          'Validates that non-observability queries do NOT activate observability skills (negative test)',
+        examples: [
+          {
+            input: {
+              question: 'Help me investigate a credential access alert on host WIN-SRV01.',
+            },
+            output: {
+              expected:
+                'I will investigate this security alert. This is a security investigation task, not an observability task.',
+            },
+            metadata: {
+              query_intent: 'Security',
+              shouldNotActivateSkill: 'service-investigation',
+            },
+          },
+          {
+            input: {
+              question: 'Create a KQL detection rule for suspicious PowerShell execution.',
+            },
+            output: {
+              expected:
+                'I will create a detection rule. This is a security detection engineering task.',
+            },
+            metadata: {
+              query_intent: 'Security',
+              shouldNotActivateSkill: 'log-analysis',
+            },
+          },
+          {
+            input: {
+              question: 'Build me a dashboard showing revenue metrics by product category.',
+            },
+            output: {
+              expected:
+                'I will create a dashboard with revenue visualizations. This is a dashboard management task.',
+            },
+            metadata: {
+              query_intent: 'Dashboard',
+              shouldNotActivateSkill: 'infrastructure-alerting',
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/observability/observability_skills.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/observability/observability_skills.spec.ts
@@ -27,259 +27,270 @@ const evaluate = base.extend<{ evaluateDataset: EvaluateDataset }, {}>({
 });
 
 evaluate.describe('Observability Skills - Service Investigation', () => {
-  evaluate('service investigation queries activate the correct skill and tools', async ({ evaluateDataset }) => {
-    await evaluateDataset({
-      dataset: {
-        name: 'agent builder: o11y-service-investigation-skill',
-        description:
-          'Validates that APM/service investigation queries activate the service-investigation skill',
-        examples: [
-          {
-            input: {
-              question:
-                'My checkout service is experiencing high latency. Help me investigate what is causing the slowdown.',
+  evaluate(
+    'service investigation queries activate the correct skill and tools',
+    async ({ evaluateDataset }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'agent builder: o11y-service-investigation-skill',
+          description:
+            'Validates that APM/service investigation queries activate the service-investigation skill',
+          examples: [
+            {
+              input: {
+                question:
+                  'My checkout service is experiencing high latency. Help me investigate what is causing the slowdown.',
+              },
+              output: {
+                expected:
+                  'I will investigate the checkout service by first retrieving its metrics (latency, throughput, error rate), then drilling into individual transactions and traces to identify where the slowdown is occurring.',
+              },
+              metadata: {
+                query_intent: 'Service Investigation',
+                expectedSkill: 'service-investigation',
+              },
             },
-            output: {
-              expected:
-                'I will investigate the checkout service by first retrieving its metrics (latency, throughput, error rate), then drilling into individual transactions and traces to identify where the slowdown is occurring.',
+            {
+              input: {
+                question:
+                  'What services are currently running in my production environment and which ones are unhealthy?',
+              },
+              output: {
+                expected:
+                  'I will list all instrumented services and their health metrics to identify any with elevated error rates, high latency, or throughput anomalies.',
+              },
+              metadata: {
+                query_intent: 'Service Discovery',
+                expectedSkill: 'service-investigation',
+                expectedOnlyToolId: 'observability.get_services',
+              },
             },
-            metadata: {
-              query_intent: 'Service Investigation',
-              expectedSkill: 'service-investigation',
+            {
+              input: {
+                question:
+                  'Show me the service dependency map for the payments service. What are its upstream and downstream dependencies?',
+              },
+              output: {
+                expected:
+                  'I will retrieve the service topology for the payments service to map its upstream callers and downstream dependencies, along with their connection metrics.',
+              },
+              metadata: {
+                query_intent: 'Dependency Analysis',
+                expectedSkill: 'service-investigation',
+                expectedOnlyToolId: 'observability.get_service_topology',
+              },
             },
-          },
-          {
-            input: {
-              question:
-                'What services are currently running in my production environment and which ones are unhealthy?',
+            {
+              input: {
+                question:
+                  'The cart-service JVM seems to be having garbage collection issues. Check the runtime metrics.',
+              },
+              output: {
+                expected:
+                  'I will check the runtime metrics for cart-service, focusing on JVM heap usage, GC pause times, and thread counts to identify garbage collection pressure.',
+              },
+              metadata: {
+                query_intent: 'Runtime Investigation',
+                expectedSkill: 'service-investigation',
+                expectedOnlyToolId: 'observability.get_runtime_metrics',
+              },
             },
-            output: {
-              expected:
-                'I will list all instrumented services and their health metrics to identify any with elevated error rates, high latency, or throughput anomalies.',
+            {
+              input: {
+                question:
+                  'Find me a sample trace for the POST /api/checkout transaction on the payments service that took more than 2 seconds.',
+              },
+              output: {
+                expected:
+                  'I will search for traces of the POST /api/checkout transaction on the payments service to find samples exceeding 2 seconds, allowing us to examine the span breakdown.',
+              },
+              metadata: {
+                query_intent: 'Trace Analysis',
+                expectedSkill: 'service-investigation',
+                expectedOnlyToolId: 'observability.get_traces',
+              },
             },
-            metadata: {
-              query_intent: 'Service Discovery',
-              expectedSkill: 'service-investigation',
-              expectedOnlyToolId: 'observability.get_services',
-            },
-          },
-          {
-            input: {
-              question:
-                'Show me the service dependency map for the payments service. What are its upstream and downstream dependencies?',
-            },
-            output: {
-              expected:
-                'I will retrieve the service topology for the payments service to map its upstream callers and downstream dependencies, along with their connection metrics.',
-            },
-            metadata: {
-              query_intent: 'Dependency Analysis',
-              expectedSkill: 'service-investigation',
-              expectedOnlyToolId: 'observability.get_service_topology',
-            },
-          },
-          {
-            input: {
-              question:
-                'The cart-service JVM seems to be having garbage collection issues. Check the runtime metrics.',
-            },
-            output: {
-              expected:
-                'I will check the runtime metrics for cart-service, focusing on JVM heap usage, GC pause times, and thread counts to identify garbage collection pressure.',
-            },
-            metadata: {
-              query_intent: 'Runtime Investigation',
-              expectedSkill: 'service-investigation',
-              expectedOnlyToolId: 'observability.get_runtime_metrics',
-            },
-          },
-          {
-            input: {
-              question:
-                'Find me a sample trace for the POST /api/checkout transaction on the payments service that took more than 2 seconds.',
-            },
-            output: {
-              expected:
-                'I will search for traces of the POST /api/checkout transaction on the payments service to find samples exceeding 2 seconds, allowing us to examine the span breakdown.',
-            },
-            metadata: {
-              query_intent: 'Trace Analysis',
-              expectedSkill: 'service-investigation',
-              expectedOnlyToolId: 'observability.get_traces',
-            },
-          },
-        ],
-      },
-    });
-  });
+          ],
+        },
+      });
+    }
+  );
 });
 
 evaluate.describe('Observability Skills - Log Analysis', () => {
-  evaluate('log analysis queries activate the correct skill and tools', async ({ evaluateDataset }) => {
-    await evaluateDataset({
-      dataset: {
-        name: 'agent builder: o11y-log-analysis-skill',
-        description:
-          'Validates that log investigation queries activate the log-analysis skill',
-        examples: [
-          {
-            input: {
-              question:
-                'There was a sudden spike in error logs around 2pm today. Help me understand what changed.',
+  evaluate(
+    'log analysis queries activate the correct skill and tools',
+    async ({ evaluateDataset }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'agent builder: o11y-log-analysis-skill',
+          description: 'Validates that log investigation queries activate the log-analysis skill',
+          examples: [
+            {
+              input: {
+                question:
+                  'There was a sudden spike in error logs around 2pm today. Help me understand what changed.',
+              },
+              output: {
+                expected:
+                  'I will analyze the log rate changes around 2pm using log rate analysis to identify which field/value combinations explain the spike, then examine log patterns to understand the error types.',
+              },
+              metadata: {
+                query_intent: 'Log Investigation',
+                expectedSkill: 'log-analysis',
+              },
             },
-            output: {
-              expected:
-                'I will analyze the log rate changes around 2pm using log rate analysis to identify which field/value combinations explain the spike, then examine log patterns to understand the error types.',
+            {
+              input: {
+                question:
+                  'What are the most common error patterns in our application logs from the last hour?',
+              },
+              output: {
+                expected:
+                  'I will discover recurring log message patterns from the last hour, grouped by similarity, to identify the most frequent error categories and their counts.',
+              },
+              metadata: {
+                query_intent: 'Log Patterns',
+                expectedSkill: 'log-analysis',
+                expectedOnlyToolId: 'observability.get_log_groups',
+              },
             },
-            metadata: {
-              query_intent: 'Log Investigation',
-              expectedSkill: 'log-analysis',
+            {
+              input: {
+                question:
+                  'Run a log rate analysis on the frontend service logs to find what is driving the volume increase in the last 30 minutes.',
+              },
+              output: {
+                expected:
+                  'I will run log rate analysis on the frontend service logs for the last 30 minutes to statistically identify which fields and values are most responsible for the volume change.',
+              },
+              metadata: {
+                query_intent: 'Log Rate Analysis',
+                expectedSkill: 'log-analysis',
+                expectedOnlyToolId: 'observability.run_log_rate_analysis',
+              },
             },
-          },
-          {
-            input: {
-              question:
-                'What are the most common error patterns in our application logs from the last hour?',
-            },
-            output: {
-              expected:
-                'I will discover recurring log message patterns from the last hour, grouped by similarity, to identify the most frequent error categories and their counts.',
-            },
-            metadata: {
-              query_intent: 'Log Patterns',
-              expectedSkill: 'log-analysis',
-              expectedOnlyToolId: 'observability.get_log_groups',
-            },
-          },
-          {
-            input: {
-              question:
-                'Run a log rate analysis on the frontend service logs to find what is driving the volume increase in the last 30 minutes.',
-            },
-            output: {
-              expected:
-                'I will run log rate analysis on the frontend service logs for the last 30 minutes to statistically identify which fields and values are most responsible for the volume change.',
-            },
-            metadata: {
-              query_intent: 'Log Rate Analysis',
-              expectedSkill: 'log-analysis',
-              expectedOnlyToolId: 'observability.run_log_rate_analysis',
-            },
-          },
-        ],
-      },
-    });
-  });
+          ],
+        },
+      });
+    }
+  );
 });
 
 evaluate.describe('Observability Skills - Infrastructure & Alerting', () => {
-  evaluate('infrastructure and alerting queries activate the correct skill and tools', async ({ evaluateDataset }) => {
-    await evaluateDataset({
-      dataset: {
-        name: 'agent builder: o11y-infrastructure-alerting-skill',
-        description:
-          'Validates that infrastructure monitoring and alert triage queries activate the infrastructure-alerting skill',
-        examples: [
-          {
-            input: {
-              question:
-                'Show me all active observability alerts and help me prioritize which ones need immediate attention.',
+  evaluate(
+    'infrastructure and alerting queries activate the correct skill and tools',
+    async ({ evaluateDataset }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'agent builder: o11y-infrastructure-alerting-skill',
+          description:
+            'Validates that infrastructure monitoring and alert triage queries activate the infrastructure-alerting skill',
+          examples: [
+            {
+              input: {
+                question:
+                  'Show me all active observability alerts and help me prioritize which ones need immediate attention.',
+              },
+              output: {
+                expected:
+                  'I will fetch active observability alerts, assess their severity, group them by affected entity, and prioritize based on impact and urgency.',
+              },
+              metadata: {
+                query_intent: 'Alert Triage',
+                expectedSkill: 'infrastructure-alerting',
+                expectedOnlyToolId: 'observability.get_alerts',
+              },
             },
-            output: {
-              expected:
-                'I will fetch active observability alerts, assess their severity, group them by affected entity, and prioritize based on impact and urgency.',
+            {
+              input: {
+                question:
+                  'Our web servers seem to be running out of memory. Check the host metrics for the web-* hosts.',
+              },
+              output: {
+                expected:
+                  'I will retrieve host metrics for the web-* hosts, focusing on memory usage, CPU, and disk I/O to assess whether they are approaching resource saturation.',
+              },
+              metadata: {
+                query_intent: 'Host Investigation',
+                expectedSkill: 'infrastructure-alerting',
+                expectedOnlyToolId: 'observability.get_hosts',
+              },
             },
-            metadata: {
-              query_intent: 'Alert Triage',
-              expectedSkill: 'infrastructure-alerting',
-              expectedOnlyToolId: 'observability.get_alerts',
+            {
+              input: {
+                question:
+                  'Are there any ML anomaly detection jobs configured for our observability data? What anomalies have been detected recently?',
+              },
+              output: {
+                expected:
+                  'I will check configured ML anomaly detection jobs, their health status, and review recent anomaly records for statistically significant deviations in your observability metrics.',
+              },
+              metadata: {
+                query_intent: 'Anomaly Detection',
+                expectedSkill: 'infrastructure-alerting',
+                expectedOnlyToolId: 'observability.get_anomaly_detection_jobs',
+              },
             },
-          },
-          {
-            input: {
-              question:
-                'Our web servers seem to be running out of memory. Check the host metrics for the web-* hosts.',
-            },
-            output: {
-              expected:
-                'I will retrieve host metrics for the web-* hosts, focusing on memory usage, CPU, and disk I/O to assess whether they are approaching resource saturation.',
-            },
-            metadata: {
-              query_intent: 'Host Investigation',
-              expectedSkill: 'infrastructure-alerting',
-              expectedOnlyToolId: 'observability.get_hosts',
-            },
-          },
-          {
-            input: {
-              question:
-                'Are there any ML anomaly detection jobs configured for our observability data? What anomalies have been detected recently?',
-            },
-            output: {
-              expected:
-                'I will check configured ML anomaly detection jobs, their health status, and review recent anomaly records for statistically significant deviations in your observability metrics.',
-            },
-            metadata: {
-              query_intent: 'Anomaly Detection',
-              expectedSkill: 'infrastructure-alerting',
-              expectedOnlyToolId: 'observability.get_anomaly_detection_jobs',
-            },
-          },
-        ],
-      },
-    });
-  });
+          ],
+        },
+      });
+    }
+  );
 });
 
 evaluate.describe('Observability Skills - Distractor Queries', () => {
-  evaluate('non-observability queries do not activate observability skills', async ({ evaluateDataset }) => {
-    await evaluateDataset({
-      dataset: {
-        name: 'agent builder: o11y-skills-distractor',
-        description:
-          'Validates that non-observability queries do NOT activate observability skills (negative test)',
-        examples: [
-          {
-            input: {
-              question: 'Help me investigate a credential access alert on host WIN-SRV01.',
+  evaluate(
+    'non-observability queries do not activate observability skills',
+    async ({ evaluateDataset }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'agent builder: o11y-skills-distractor',
+          description:
+            'Validates that non-observability queries do NOT activate observability skills (negative test)',
+          examples: [
+            {
+              input: {
+                question: 'Help me investigate a credential access alert on host WIN-SRV01.',
+              },
+              output: {
+                expected:
+                  'I will investigate this security alert. This is a security investigation task, not an observability task.',
+              },
+              metadata: {
+                query_intent: 'Security',
+                shouldNotActivateSkill: 'service-investigation',
+              },
             },
-            output: {
-              expected:
-                'I will investigate this security alert. This is a security investigation task, not an observability task.',
+            {
+              input: {
+                question: 'Create a KQL detection rule for suspicious PowerShell execution.',
+              },
+              output: {
+                expected:
+                  'I will create a detection rule. This is a security detection engineering task.',
+              },
+              metadata: {
+                query_intent: 'Security',
+                shouldNotActivateSkill: 'log-analysis',
+              },
             },
-            metadata: {
-              query_intent: 'Security',
-              shouldNotActivateSkill: 'service-investigation',
+            {
+              input: {
+                question: 'Build me a dashboard showing revenue metrics by product category.',
+              },
+              output: {
+                expected:
+                  'I will create a dashboard with revenue visualizations. This is a dashboard management task.',
+              },
+              metadata: {
+                query_intent: 'Dashboard',
+                shouldNotActivateSkill: 'infrastructure-alerting',
+              },
             },
-          },
-          {
-            input: {
-              question: 'Create a KQL detection rule for suspicious PowerShell execution.',
-            },
-            output: {
-              expected:
-                'I will create a detection rule. This is a security detection engineering task.',
-            },
-            metadata: {
-              query_intent: 'Security',
-              shouldNotActivateSkill: 'log-analysis',
-            },
-          },
-          {
-            input: {
-              question: 'Build me a dashboard showing revenue metrics by product category.',
-            },
-            output: {
-              expected:
-                'I will create a dashboard with revenue visualizations. This is a dashboard management task.',
-            },
-            metadata: {
-              query_intent: 'Dashboard',
-              shouldNotActivateSkill: 'infrastructure-alerting',
-            },
-          },
-        ],
-      },
-    });
-  });
+          ],
+        },
+      });
+    }
+  );
 });

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/plugin.ts
@@ -15,6 +15,7 @@ import type {
 import { registerObservabilityAgent } from './agent/register_observability_agent';
 import { registerTools } from './tools/register_tools';
 import { registerAttachments } from './attachments/register_attachments';
+import { registerSkills } from './skills/register_skills';
 import type {
   ObservabilityAgentBuilderPluginSetup,
   ObservabilityAgentBuilderPluginSetupDependencies,
@@ -68,6 +69,10 @@ export class ObservabilityAgentBuilderPlugin
       dataRegistry: this.dataRegistry,
     }).catch((error) => {
       this.logger.error(`Error registering observability attachments: ${error}`);
+    });
+
+    registerSkills(plugins.agentBuilder).catch((error) => {
+      this.logger.error(`Error registering observability skills: ${error}`);
     });
 
     registerServerRoutes({ core, plugins, logger: this.logger, dataRegistry: this.dataRegistry });

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { registerSkills } from './register_skills';
+export { serviceInvestigationSkill } from './service_investigation';
+export { logAnalysisSkill } from './log_analysis';
+export { infrastructureAlertingSkill } from './infrastructure_alerting';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/infrastructure_alerting/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/infrastructure_alerting/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { infrastructureAlertingSkill } from './infrastructure_alerting_skill';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/infrastructure_alerting/infrastructure_alerting_skill.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/infrastructure_alerting/infrastructure_alerting_skill.ts
@@ -12,12 +12,8 @@ import {
   OBSERVABILITY_GET_ALERTS_TOOL_ID,
   OBSERVABILITY_GET_ANOMALY_DETECTION_JOBS_TOOL_ID,
 } from '../../tools';
-import {
-  OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID,
-} from '../../tools/get_metric_change_points/tool';
-import {
-  OBSERVABILITY_GET_TRACE_CHANGE_POINTS_TOOL_ID,
-} from '../../tools/get_trace_change_points/tool';
+import { OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID } from '../../tools/get_metric_change_points/tool';
+import { OBSERVABILITY_GET_TRACE_CHANGE_POINTS_TOOL_ID } from '../../tools/get_trace_change_points/tool';
 
 export const infrastructureAlertingSkill = defineSkillType({
   id: 'infrastructure-alerting',

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/infrastructure_alerting/infrastructure_alerting_skill.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/infrastructure_alerting/infrastructure_alerting_skill.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import {
+  OBSERVABILITY_GET_HOSTS_TOOL_ID,
+  OBSERVABILITY_GET_ALERTS_TOOL_ID,
+  OBSERVABILITY_GET_ANOMALY_DETECTION_JOBS_TOOL_ID,
+} from '../../tools';
+import {
+  OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID,
+} from '../../tools/get_metric_change_points/tool';
+import {
+  OBSERVABILITY_GET_TRACE_CHANGE_POINTS_TOOL_ID,
+} from '../../tools/get_trace_change_points/tool';
+
+export const infrastructureAlertingSkill = defineSkillType({
+  id: 'infrastructure-alerting',
+  name: 'infrastructure-alerting',
+  basePath: 'skills/observability/infrastructure',
+  description:
+    'Infrastructure monitoring and alert investigation: analyze host metrics (CPU, memory, disk, network), ' +
+    'triage observability alerts, review ML anomaly detection jobs, and detect metric/trace change points. ' +
+    'Use when investigating host resource issues, triaging alert queues, or analyzing metric anomalies.',
+  content: `# Infrastructure & Alerting Guide
+
+## When to Use This Skill
+
+Use this skill when:
+- Investigating host-level resource issues (CPU saturation, memory pressure, disk full)
+- Triaging observability alerts to determine severity and required action
+- Reviewing ML anomaly detection job results for unusual patterns
+- Detecting change points in infrastructure metrics or trace performance
+- Correlating infrastructure events with application-level symptoms
+
+## Investigation Workflow
+
+### 1. Alert Triage
+- Use 'observability.get_alerts' to fetch active and recent alerts
+- Assess: severity, affected entity (service, host), rule name, and trigger time
+- Group related alerts by entity or time window to identify incident scope
+- Determine priority: critical infrastructure alerts before warning-level metrics
+
+### 2. Host Investigation
+- Use 'observability.get_hosts' to list hosts and their key metrics
+- Check: CPU usage, memory usage, disk I/O, network throughput, load average
+- Compare current metrics against historical baselines
+- Use kqlFilter to scope to specific host groups, cloud providers, or kubernetes clusters
+- Identify resource saturation patterns (CPU >90%, memory >85%, disk >90%)
+
+### 3. Anomaly Detection
+- Use 'observability.get_anomaly_detection_jobs' to review configured ML jobs
+- Check job health: are jobs running, what's the latest bucket time?
+- Review anomaly records for statistically significant deviations
+- Correlate ML anomalies with alerts and infrastructure metric changes
+
+### 4. Change Point Detection
+- Use 'observability.get_metric_change_points' for infrastructure metric shifts
+- Use 'observability.get_trace_change_points' for application performance shifts
+- Change points pinpoint when behavior changed — correlate with deployments, config changes, or external events
+- Look for concurrent change points across multiple metrics (indicates systemic change)
+
+### 5. Synthesis
+- Correlate infrastructure metrics with application performance (use service-investigation skill if needed)
+- Establish timeline: infrastructure issue → application impact → alert trigger
+- Distinguish between: resource exhaustion, noisy neighbor, configuration drift, and capacity planning issues
+- Recommend: scaling actions, alert tuning, anomaly detection job adjustments, or deeper investigation
+
+## Entity Linking
+When referencing entities, use markdown links for quick navigation:
+- Host: [hostname](/app/metrics/detail/host/hostname)
+- Alert: [alertId](/app/observability/alerts/alertId)
+- Alert Rule: [ruleId](/app/observability/alerts/rules/ruleId)
+
+## Best Practices
+- Be quantitative: cite specific CPU%, memory MB, disk IOPS — avoid vague "high"
+- Check multiple signal types: alerts + host metrics + ML anomalies = stronger diagnosis
+- Consider all infrastructure layers: compute → storage → network → dependencies
+- Correlate infrastructure changes with deployment or configuration events
+- Use change point timestamps to narrow investigation windows precisely`,
+  referencedContent: [
+    {
+      relativePath: './queries',
+      name: 'alert-triage-workflow',
+      content: `# Alert Triage Workflow
+
+1. \`observability.get_alerts\` with start=now-1h — fetch recent alerts
+2. Group by affected entity and severity
+3. For host alerts: \`observability.get_hosts\` with hostName filter — check resource metrics
+4. For metric anomalies: \`observability.get_anomaly_detection_jobs\` — review ML job results
+5. \`observability.get_metric_change_points\` — find when metrics shifted
+6. Cross-reference with service-investigation or log-analysis skills as needed`,
+    },
+  ],
+  getRegistryTools: () => [
+    platformCoreTools.listIndices,
+    platformCoreTools.getDocumentById,
+    OBSERVABILITY_GET_ALERTS_TOOL_ID,
+    OBSERVABILITY_GET_HOSTS_TOOL_ID,
+    OBSERVABILITY_GET_ANOMALY_DETECTION_JOBS_TOOL_ID,
+    OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID,
+    OBSERVABILITY_GET_TRACE_CHANGE_POINTS_TOOL_ID,
+  ],
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/log_analysis/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/log_analysis/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { logAnalysisSkill } from './log_analysis_skill';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/log_analysis/log_analysis_skill.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/log_analysis/log_analysis_skill.ts
@@ -12,9 +12,7 @@ import {
   OBSERVABILITY_RUN_LOG_RATE_ANALYSIS_TOOL_ID,
   OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
 } from '../../tools';
-import {
-  OBSERVABILITY_GET_LOG_CHANGE_POINTS_TOOL_ID,
-} from '../../tools/get_log_change_points/tool';
+import { OBSERVABILITY_GET_LOG_CHANGE_POINTS_TOOL_ID } from '../../tools/get_log_change_points/tool';
 
 export const logAnalysisSkill = defineSkillType({
   id: 'log-analysis',

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/log_analysis/log_analysis_skill.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/log_analysis/log_analysis_skill.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import {
+  OBSERVABILITY_GET_LOG_GROUPS_TOOL_ID,
+  OBSERVABILITY_RUN_LOG_RATE_ANALYSIS_TOOL_ID,
+  OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
+} from '../../tools';
+import {
+  OBSERVABILITY_GET_LOG_CHANGE_POINTS_TOOL_ID,
+} from '../../tools/get_log_change_points/tool';
+
+export const logAnalysisSkill = defineSkillType({
+  id: 'log-analysis',
+  name: 'log-analysis',
+  basePath: 'skills/observability/logs',
+  description:
+    'Log investigation and analysis: discover log patterns, identify log rate anomalies, ' +
+    'detect change points in log volumes, and explore index schemas for field discovery. ' +
+    'Use when investigating log spikes, error patterns, or understanding log data structure.',
+  content: `# Log Analysis Guide
+
+## When to Use This Skill
+
+Use this skill when:
+- Investigating sudden increases or decreases in log volume
+- Identifying recurring error patterns or log message groups
+- Detecting change points where log behavior shifted
+- Discovering available log indices and their field schemas
+- Correlating log patterns with service or infrastructure incidents
+
+## Field Discovery
+
+Before using field names in kqlFilter or groupBy parameters, call 'observability.get_index_info' first.
+Clusters use different naming conventions (ECS vs OpenTelemetry) — discovering fields first prevents errors.
+
+## Log Analysis Process
+
+### 1. Index Discovery
+- Use 'observability.get_index_info' to discover available log indices and their field mappings
+- Identify the correct index patterns for the data source (e.g., logs-*, filebeat-*)
+- Check field types and naming conventions (ECS: message, log.level vs OTel: body.text, severity_text)
+
+### 2. Log Rate Analysis
+- Use 'observability.run_log_rate_analysis' to identify statistically significant changes in log rates
+- This tool automatically finds the most important field/value combinations explaining rate changes
+- Use it when log volume suddenly spikes or drops — it identifies what's different
+- Provide specific time ranges around the anomaly for best results
+
+### 3. Log Pattern Discovery
+- Use 'observability.get_log_groups' to identify recurring log message patterns
+- Patterns are grouped by message similarity, revealing the most frequent log categories
+- Look for error patterns, warning clusters, and unusual message types
+- Use kqlFilter to scope to specific services, hosts, or log levels
+
+### 4. Change Point Detection
+- Use 'observability.get_log_change_points' to find statistical change points in log metrics
+- Change points indicate where behavior shifted — useful for pinpointing incident start times
+- Compare change point timestamps with deployment events or configuration changes
+
+### 5. Synthesis
+- Correlate log anomalies with service metrics and infrastructure events
+- Establish timeline: when did log patterns change? What preceded the change?
+- Identify root cause indicators in log messages (stack traces, connection errors, timeout messages)
+- Recommend: log-based alerts, index pattern adjustments, or investigation with service/infra skills
+
+## KQL Syntax Reference
+- Match: \`field: value\`, \`field: (a OR b OR c)\`
+- Range: \`field > 100\`, \`field >= 10 AND field <= 20\`
+- Wildcards: \`field: prefix*\` (trailing only)
+- Negation: \`NOT field: value\`
+- Logical: combine with AND/OR, use parentheses for precedence
+- Exact phrases: \`message: "connection refused"\`
+
+## Best Practices
+- Always call get_index_info before constructing queries with field names
+- Start with broad time ranges then narrow to anomaly windows
+- Use log rate analysis to find statistically significant changes, not just volume
+- Combine log patterns with service metrics for stronger root cause evidence
+- Look for correlated log groups across multiple services for distributed issues`,
+  referencedContent: [
+    {
+      relativePath: './queries',
+      name: 'log-spike-investigation',
+      content: `# Log Spike Investigation Pattern
+
+1. \`observability.get_index_info\` — discover available log indices and fields
+2. \`observability.run_log_rate_analysis\` with start/end around the spike — find what changed
+3. \`observability.get_log_groups\` with kqlFilter for affected service — identify error patterns
+4. \`observability.get_log_change_points\` — pinpoint when behavior shifted
+5. Cross-reference with service-investigation skill if service metrics are also affected`,
+    },
+  ],
+  getRegistryTools: () => [
+    platformCoreTools.listIndices,
+    platformCoreTools.getIndexMapping,
+    platformCoreTools.productDocumentation,
+    OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
+    OBSERVABILITY_GET_LOG_GROUPS_TOOL_ID,
+    OBSERVABILITY_RUN_LOG_RATE_ANALYSIS_TOOL_ID,
+    OBSERVABILITY_GET_LOG_CHANGE_POINTS_TOOL_ID,
+  ],
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/register_skills.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/register_skills.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import { serviceInvestigationSkill } from './service_investigation';
+import { logAnalysisSkill } from './log_analysis';
+import { infrastructureAlertingSkill } from './infrastructure_alerting';
+
+export async function registerSkills(agentBuilder: AgentBuilderPluginSetup): Promise<void> {
+  await agentBuilder.skills.register(serviceInvestigationSkill);
+  await agentBuilder.skills.register(logAnalysisSkill);
+  await agentBuilder.skills.register(infrastructureAlertingSkill);
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/service_investigation/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/service_investigation/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { serviceInvestigationSkill } from './service_investigation_skill';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/service_investigation/service_investigation_skill.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/service_investigation/service_investigation_skill.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import {
+  OBSERVABILITY_GET_SERVICES_TOOL_ID,
+  OBSERVABILITY_GET_TRACE_METRICS_TOOL_ID,
+  OBSERVABILITY_GET_TRACES_TOOL_ID,
+  OBSERVABILITY_GET_RUNTIME_METRICS_TOOL_ID,
+  OBSERVABILITY_GET_SERVICE_TOPOLOGY_TOOL_ID,
+} from '../../tools';
+
+export const serviceInvestigationSkill = defineSkillType({
+  id: 'service-investigation',
+  name: 'service-investigation',
+  basePath: 'skills/observability/services',
+  description:
+    'APM service investigation: discover services, analyze latency/throughput/error rate metrics, ' +
+    'inspect distributed traces, examine runtime metrics (JVM, Go, .NET), and map service dependencies. ' +
+    'Use when diagnosing service performance issues, tracing requests across microservices, or understanding service topology.',
+  content: `# Service Investigation Guide
+
+## When to Use This Skill
+
+Use this skill when:
+- Investigating service performance degradation (high latency, error spikes, throughput drops)
+- Tracing requests across distributed microservices to find bottlenecks
+- Analyzing runtime metrics (JVM heap, GC, Go goroutines, .NET thread pool) for resource issues
+- Mapping service dependencies to understand blast radius of an incident
+- Comparing service metrics across time periods to identify regressions
+
+## Investigation Workflow
+
+### 1. Service Discovery
+- Start with 'observability.get_services' to list all instrumented services and their health
+- Review key metrics: latency (ms), throughput (tpm), failure rate (0-1)
+- Identify services with anomalous metrics compared to their baselines
+- Use kqlFilter to scope to specific environments (e.g., production)
+
+### 2. Service Metrics Deep Dive
+- Use 'observability.get_trace_metrics' to drill into a specific service's transaction metrics
+- Group by transaction name to find the slowest or most error-prone endpoints
+- Compare current metrics against historical baselines (use different time ranges)
+- Check failure rate: values above 0.05 (5%) typically warrant investigation
+
+### 3. Distributed Trace Analysis
+- Use 'observability.get_traces' to find sample traces for problematic transactions
+- Look for: slow spans, error spans, high span count (N+1 queries), missing spans (dropped traces)
+- Follow the trace across services to identify where latency is introduced
+- Pay attention to span.destination.service.resource for dependency bottlenecks
+
+### 4. Runtime Metrics
+- Use 'observability.get_runtime_metrics' to check application-level resource usage
+- JVM: heap usage, GC pause time, thread count
+- Go: goroutine count, heap allocation rate
+- .NET: thread pool queue length, GC generation sizes
+- Correlate runtime anomalies with service metric degradation
+
+### 5. Dependency Analysis
+- Use 'observability.get_service_topology' to map upstream and downstream dependencies
+- Identify: which services call the affected service, which services it depends on
+- Check dependency metrics (latency, error rate) to determine if the issue originates upstream or downstream
+- Use this to establish blast radius and prioritize remediation
+
+### 6. Synthesis
+- Distinguish the SOURCE (where the problem started) from AFFECTED services (impacted downstream)
+- Correlate timeline: what changed before symptoms appeared?
+- Provide quantitative evidence: cite specific metrics, trace IDs, and time ranges
+- Recommend next steps: check infrastructure, review recent deployments, examine logs
+
+## Metric Format Reference
+- **Latency**: milliseconds (ms)
+- **Throughput**: transactions per minute (tpm)
+- **Failure rate**: 0-1 scale (e.g., 0.05 = 5% failure rate)
+
+## Best Practices
+- Always start broad (service list) then narrow (specific transactions, traces)
+- Quote specific numbers — avoid vague terms like "high" without metric values
+- Use kqlFilter with 'service.environment: production' to focus on production issues
+- Check multiple signal types before concluding: metrics + traces + runtime = stronger signal
+- Consider all layers: infrastructure → application → dependencies`,
+  referencedContent: [
+    {
+      relativePath: './queries',
+      name: 'service-health-check',
+      content: `# Service Health Check Pattern
+
+Start with broad service discovery, then drill into specific services:
+
+1. \`observability.get_services\` with start=now-1h, end=now
+2. For unhealthy services: \`observability.get_trace_metrics\` with serviceName=<name>, groupBy=transaction.name
+3. For slow transactions: \`observability.get_traces\` with serviceName=<name>, transactionName=<name>
+4. For dependency issues: \`observability.get_service_topology\` with serviceName=<name>`,
+    },
+  ],
+  getRegistryTools: () => [
+    platformCoreTools.listIndices,
+    platformCoreTools.getIndexMapping,
+    OBSERVABILITY_GET_SERVICES_TOOL_ID,
+    OBSERVABILITY_GET_TRACE_METRICS_TOOL_ID,
+    OBSERVABILITY_GET_TRACES_TOOL_ID,
+    OBSERVABILITY_GET_RUNTIME_METRICS_TOOL_ID,
+    OBSERVABILITY_GET_SERVICE_TOPOLOGY_TOOL_ID,
+  ],
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/skills.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/skills.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateSkillDefinition } from '@kbn/agent-builder-server/skills/type_definition';
+import { serviceInvestigationSkill } from './service_investigation';
+import { logAnalysisSkill } from './log_analysis';
+import { infrastructureAlertingSkill } from './infrastructure_alerting';
+
+const allSkills = [serviceInvestigationSkill, logAnalysisSkill, infrastructureAlertingSkill];
+
+describe('Observability Skills', () => {
+  describe.each(allSkills)('$id', (skill) => {
+    it('should pass schema validation', async () => {
+      await expect(validateSkillDefinition(skill)).resolves.toBeDefined();
+    });
+
+    it('should have a description under 1024 characters', () => {
+      expect(skill.description.length).toBeLessThanOrEqual(1024);
+    });
+
+    it('should have non-empty content', () => {
+      expect(skill.content.length).toBeGreaterThan(100);
+    });
+
+    it('should have a basePath starting with skills/observability/', () => {
+      expect(skill.basePath).toMatch(/^skills\/observability\//);
+    });
+
+    it('should have registry tools defined', () => {
+      const tools = skill.getRegistryTools?.();
+      expect(tools).toBeDefined();
+      expect(Array.isArray(tools)).toBe(true);
+      expect((tools as string[]).length).toBeGreaterThan(0);
+      expect((tools as string[]).length).toBeLessThanOrEqual(7);
+    });
+  });
+
+  describe('service-investigation', () => {
+    it('should include APM service tools', () => {
+      const tools = serviceInvestigationSkill.getRegistryTools?.() as string[];
+      expect(tools).toContain('observability.get_services');
+      expect(tools).toContain('observability.get_trace_metrics');
+      expect(tools).toContain('observability.get_traces');
+      expect(tools).toContain('observability.get_runtime_metrics');
+      expect(tools).toContain('observability.get_service_topology');
+    });
+
+    it('should have 7 tools (at the limit)', () => {
+      const tools = serviceInvestigationSkill.getRegistryTools?.() as string[];
+      expect(tools.length).toBe(7);
+    });
+  });
+
+  describe('log-analysis', () => {
+    it('should include log investigation tools', () => {
+      const tools = logAnalysisSkill.getRegistryTools?.() as string[];
+      expect(tools).toContain('observability.get_log_groups');
+      expect(tools).toContain('observability.run_log_rate_analysis');
+      expect(tools).toContain('observability.get_index_info');
+      expect(tools).toContain('observability.get_log_change_points');
+    });
+
+    it('should have 7 tools', () => {
+      const tools = logAnalysisSkill.getRegistryTools?.() as string[];
+      expect(tools.length).toBe(7);
+    });
+  });
+
+  describe('infrastructure-alerting', () => {
+    it('should include infrastructure and alerting tools', () => {
+      const tools = infrastructureAlertingSkill.getRegistryTools?.() as string[];
+      expect(tools).toContain('observability.get_hosts');
+      expect(tools).toContain('observability.get_alerts');
+      expect(tools).toContain('observability.get_anomaly_detection_jobs');
+      expect(tools).toContain('observability.get_metric_change_points');
+      expect(tools).toContain('observability.get_trace_change_points');
+    });
+
+    it('should have 7 tools', () => {
+      const tools = infrastructureAlertingSkill.getRegistryTools?.() as string[];
+      expect(tools.length).toBe(7);
+    });
+  });
+
+  describe('cross-skill uniqueness', () => {
+    it('should have unique skill IDs', () => {
+      const ids = allSkills.map((s) => s.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('should have unique base paths', () => {
+      const paths = allSkills.map((s) => `${s.basePath}/${s.name}`);
+      expect(new Set(paths).size).toBe(paths.length);
+    });
+
+    it('should have unique descriptions', () => {
+      const descriptions = allSkills.map((s) => s.description);
+      expect(new Set(descriptions).size).toBe(descriptions.length);
+    });
+
+    it('should cover all 14 observability tools across skills', () => {
+      const allToolIds = new Set<string>();
+      for (const skill of allSkills) {
+        const tools = skill.getRegistryTools?.() as string[];
+        for (const tool of tools) {
+          if (tool.startsWith('observability.')) {
+            allToolIds.add(tool);
+          }
+        }
+      }
+      expect(allToolIds.size).toBe(14);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Decomposes the monolithic `observability.agent` into three focused, modular skills for the Elastic AI Agent. This mirrors the pattern established in #255697 (Security skills migration) and enables on-demand capability loading with reduced token overhead.

### New Skills

| Skill | Purpose | Registry Tools (7 each) |
|---|---|---|
| `service-investigation` | APM service metrics, distributed traces, runtime metrics (JVM/Go/.NET), service topology | get_services, get_trace_metrics, get_traces, get_runtime_metrics, get_service_topology + 2 platform |
| `log-analysis` | Log pattern discovery, log rate analysis, change point detection, field discovery | get_log_groups, run_log_rate_analysis, get_log_change_points, get_index_info + 3 platform |
| `infrastructure-alerting` | Host metrics, alert triage, ML anomaly detection, metric/trace change points | get_hosts, get_alerts, get_anomaly_detection_jobs, get_metric_change_points, get_trace_change_points + 2 platform |

### Key Changes

- Extended `SkillsDirectoryStructure` with observability sub-directories (services, logs, infrastructure)
- Created 3 `SkillDefinition` registrations with curated tool sets and rich skill content
- Each skill includes referenced content with investigation workflow templates
- Wired skill registration into `ObservabilityAgentBuilderPlugin.setup()`
- All 14 observability-specific tools are covered across the 3 skills
- Added comprehensive unit tests for skill validation and cross-skill uniqueness
- Added eval suite for skill activation and tool selection validation

### Architecture Notes

- Skills use only `getRegistryTools()` — no inline tools needed (all O11y tools are already registry tools)
- The existing `observability.agent` continues to work alongside skills
- Dashboard already has a `dashboard-management` skill — no migration needed there
- Skills reuse the same rich instruction patterns from the O11y agent (investigation workflow, reasoning principles, metric formats)

## Test Plan

- [ ] Unit tests pass for all 3 skills (schema validation, content, tool counts, cross-skill uniqueness)
- [ ] All 14 O11y tools covered across the 3 skills
- [ ] Eval suite validates correct skill activation for O11y queries
- [ ] Skills appear in Agent Builder skill listing in Observability spaces
- [ ] Service performance queries activate the service-investigation skill
- [ ] Log investigation queries activate the log-analysis skill
- [ ] Infrastructure/alert queries activate the infrastructure-alerting skill
- [ ] Non-O11y queries (security, dashboard) do NOT activate O11y skills