### PR TITLE
[9.3] [Fleet] Log warning if policy revisions don't match (#255305)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -1791,7 +1791,7 @@ describe('Agent policy', () => {
       } as FullAgentPolicy);
 
       const mockSo = {
-        attributes: {},
+        attributes: { revision: 1 },
         id: 'policy123',
         type: 'mocked',
         references: [],
@@ -1821,6 +1821,12 @@ describe('Agent policy', () => {
       soClient.bulkGet.mockResolvedValue({
         saved_objects: [mockSo],
       });
+      esClient.search.mockResolvedValue({
+        hits: {
+          total: 1,
+          hits: [{ _source: { policy_id: 'policy123', revision_idx: 1 } }],
+        },
+      } as any);
       await agentPolicyService.deployPolicy(soClient, 'policy123');
 
       expect(esClient.bulk).toBeCalledWith(
@@ -1928,6 +1934,13 @@ describe('Agent policy', () => {
         ],
       });
 
+      esClient.search.mockResolvedValue({
+        hits: {
+          total: 1,
+          hits: [{ _source: { policy_id: 'test-agentless-policy', revision_idx: 1 } }],
+        },
+      } as any);
+
       jest.spyOn(agentlessAgentService, 'createAgentlessAgent');
 
       await agentPolicyService.deployPolicy(soClient, 'test-agentless-policy');
@@ -1995,6 +2008,13 @@ describe('Agent policy', () => {
         ],
       });
 
+      esClient.search.mockResolvedValue({
+        hits: {
+          total: 1,
+          hits: [{ _source: { policy_id: 'test-agentless-policy', revision_idx: 1 } }],
+        },
+      } as any);
+
       jest.spyOn(agentlessAgentService, 'createAgentlessAgent');
 
       await expect(
@@ -2002,6 +2022,50 @@ describe('Agent policy', () => {
           throwOnAgentlessError: true,
         })
       ).rejects.toThrow('createAgentlessAgent error');
+    });
+
+    it('should log a warning when .fleet-policies revision does not match .kibana_ingest revision after deploy', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      mockedAppContextService.getInternalUserESClient.mockReturnValue(esClient);
+      mockedOutputService.getDefaultDataOutputId.mockResolvedValue('default-output');
+      mockedGetFullAgentPolicy.mockResolvedValue({
+        id: 'policy123',
+        revision: 2,
+        namespaces: ['default'],
+        inputs: [{ id: 'input-1' }],
+      } as FullAgentPolicy);
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          { attributes: { revision: 2 }, id: 'policy123', type: 'mocked', references: [] },
+        ],
+      });
+      soClient.find.mockResolvedValue({
+        saved_objects: [],
+        page: 0,
+        per_page: 0,
+        total: 0,
+      });
+
+      esClient.search.mockResolvedValue({
+        hits: {
+          total: 1,
+          hits: [{ _source: { policy_id: 'policy123', revision_idx: 1 } }],
+        },
+      } as any);
+
+      await agentPolicyService.deployPolicy(soClient, 'policy123');
+
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Policy [policy123] has mismatched revisions after deploy')
+      );
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('.kibana_ingest revision [2]')
+      );
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('.fleet-policies revision_idx [1]')
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -1742,25 +1742,60 @@ class AgentPolicyService {
 
     logger.debug(`Bulk update against index [${AGENT_POLICY_INDEX}] with deployment updates done`);
 
-    if (bulkResponse.errors) {
-      const erroredDocuments = bulkResponse.items.reduce((acc, item) => {
-        const value: BulkResponseItem | undefined = item.index;
-        if (!value || !value.error) {
+      if (bulkResponse.errors) {
+        const erroredDocuments = bulkResponse.items.reduce((acc, item, idx) => {
+          const value: BulkResponseItem | undefined = item.index;
+          if (!value || !value.error) {
+            return acc;
+          }
+
+          const policy = fleetServerPolicies[idx];
+          acc.push({
+            bulkItem: value,
+            policyId: policy?.policy_id,
+            revisionIdx: policy?.revision_idx,
+          });
           return acc;
+        }, [] as Array<{ bulkItem: BulkResponseItem; policyId?: string; revisionIdx?: number }>);
+
+        const errorMessage = `Failed to deploy ${
+          erroredDocuments.length
+        } policy revision(s) to ${AGENT_POLICY_INDEX}: ${erroredDocuments
+          .map(
+            ({ bulkItem, policyId, revisionIdx }) =>
+              `policy [${policyId}] revision [${revisionIdx}] (${bulkItem.error?.reason})`
+          )
+          .join('; ')}`;
+
+        logger.error(errorMessage);
+
+        if (options?.throwOnAnyError) {
+          throw new Error(errorMessage);
         }
-
-        acc.push(value);
-        return acc;
-      }, [] as BulkResponseItem[]);
-
-      logger.warn(
-        `Failed to index documents with ids ${erroredDocuments
-          .map((doc) => doc._id)
-          .join(', ')} during policy deployment: ${erroredDocuments
-          .map((doc) => doc.error?.reason)
-          .join(', ')}`
-      );
+      }
     }
+
+    // Check for mismatched revisions after deploy (excluding version-specific policies)
+    const deployedPolicyIds = [
+      ...new Set(
+        fleetServerPolicies.map((fsp) => fsp.policy_id).filter((id) => !hasVersionSuffix(id))
+      ),
+    ];
+    await pMap(
+      deployedPolicyIds,
+      async (policyId) => {
+        const latestFleetPolicy = await this.getLatestFleetPolicy(esClient, policyId);
+        const soRevision = policiesMap[policyId]?.revision;
+        if (latestFleetPolicy && soRevision && latestFleetPolicy.revision_idx !== soRevision) {
+          logger.warn(
+            `Policy [${policyId}] has mismatched revisions after deploy: ` +
+              `.kibana_ingest revision [${soRevision}], ` +
+              `.fleet-policies revision_idx [${latestFleetPolicy.revision_idx}]`
+          );
+        }
+      },
+      { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_20 }
+    );
 
     for (const agentPolicy of policies) {
       if (!agentPolicy.supports_agentless) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.test.ts
@@ -79,6 +79,9 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
 
     expect(mockedEnsureDefaultEnrollmentAPIKeyForAgentPolicy).toBeCalledTimes(2);
     expect(mockedAgentPolicyService.deployPolicies).not.toBeCalled();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('has mismatched revisions')
+    );
   });
 
   it('should do deploy policies out of sync', async () => {
@@ -111,6 +114,9 @@ describe('ensureAgentPoliciesFleetServerKeysAndPolicies', () => {
     expect(scheduleDeployAgentPoliciesTask).toBeCalledWith(undefined, [
       { id: 'policy2', spaceId: undefined },
     ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Policy [policy2] has mismatched revisions: .kibana_ingest revision [2], .fleet-policies revision_idx [1]'
+    );
   });
 
   it('should do deploy policies never deployed', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/fleet_server_policies_enrollment_keys.ts
@@ -46,6 +46,14 @@ export async function ensureAgentPoliciesFleetServerKeysAndPolicies({
         ensureDefaultEnrollmentAPIKeyForAgentPolicy(soClient, esClient, agentPolicy.id),
       ]);
 
+      if (latestFleetPolicy && latestFleetPolicy.revision_idx !== agentPolicy.revision) {
+        logger.warn(
+          `Policy [${agentPolicy.id}] has mismatched revisions: ` +
+            `.kibana_ingest revision [${agentPolicy.revision}], ` +
+            `.fleet-policies revision_idx [${latestFleetPolicy.revision_idx}]`
+        );
+      }
+
       if ((latestFleetPolicy?.revision_idx ?? -1) < agentPolicy.revision) {
         outdatedAgentPolicyIds.push({ id: agentPolicy.id, spaceId: agentPolicy.space_ids?.[0] });
       }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Log warning if policy revisions don't match (#255305)](https://github.com/elastic/kibana/pull/255305)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2026-02-27T14:59:36Z","message":"[Fleet] Log warning if policy revisions don't match (#255305)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/248082\n\nThis PR adds warn logging if a mismatch is detected in policy revision\nbetween `.fleet-policies` and `. kibana_ingest`.\n\nChanges summary:\n* Log warning on Fleet setup\n* `ensureAgentPoliciesFleetServerKeysAndPolicies` runs on every Kibana\nstartup and already fetches both the SO revision and the\n`.fleet-policies` revision for every agent policy, so there is no extra\ncost in comparing them. This warns about desyncs that accumulated\nbetween restarts.\n* Changes in policy deploy:\n* Bulk write error handler maps errored items to their `policy_id` and\n`revision_idx`, so the error message should make it clearer which policy\ndeployment failed and what revision was lost..\n   * Log warning after policy deploy\n* Check for mismatch (probably due to write failures or race conditions)\nafter writing to `.fleet-policies`. This costs an extra ES read but\nprobably worth it for this purpose since it seems like a probable moment\nwhere a desync could happen.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of impacting agent policy deploy.","sha":"5949b29e083939db921c0371e907b8617c08da88","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.4.0","v8.19.13","v9.2.7","v9.3.2"],"title":"[Fleet] Log warning if policy revisions don't match","number":255305,"url":"https://github.com/elastic/kibana/pull/255305","mergeCommit":{"message":"[Fleet] Log warning if policy revisions don't match (#255305)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/248082\n\nThis PR adds warn logging if a mismatch is detected in policy revision\nbetween `.fleet-policies` and `. kibana_ingest`.\n\nChanges summary:\n* Log warning on Fleet setup\n* `ensureAgentPoliciesFleetServerKeysAndPolicies` runs on every Kibana\nstartup and already fetches both the SO revision and the\n`.fleet-policies` revision for every agent policy, so there is no extra\ncost in comparing them. This warns about desyncs that accumulated\nbetween restarts.\n* Changes in policy deploy:\n* Bulk write error handler maps errored items to their `policy_id` and\n`revision_idx`, so the error message should make it clearer which policy\ndeployment failed and what revision was lost..\n   * Log warning after policy deploy\n* Check for mismatch (probably due to write failures or race conditions)\nafter writing to `.fleet-policies`. This costs an extra ES read but\nprobably worth it for this purpose since it seems like a probable moment\nwhere a desync could happen.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of impacting agent policy deploy.","sha":"5949b29e083939db921c0371e907b8617c08da88"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.2","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255305","number":255305,"mergeCommit":{"message":"[Fleet] Log warning if policy revisions don't match (#255305)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/248082\n\nThis PR adds warn logging if a mismatch is detected in policy revision\nbetween `.fleet-policies` and `. kibana_ingest`.\n\nChanges summary:\n* Log warning on Fleet setup\n* `ensureAgentPoliciesFleetServerKeysAndPolicies` runs on every Kibana\nstartup and already fetches both the SO revision and the\n`.fleet-policies` revision for every agent policy, so there is no extra\ncost in comparing them. This warns about desyncs that accumulated\nbetween restarts.\n* Changes in policy deploy:\n* Bulk write error handler maps errored items to their `policy_id` and\n`revision_idx`, so the error message should make it clearer which policy\ndeployment failed and what revision was lost..\n   * Log warning after policy deploy\n* Check for mismatch (probably due to write failures or race conditions)\nafter writing to `.fleet-policies`. This costs an extra ES read but\nprobably worth it for this purpose since it seems like a probable moment\nwhere a desync could happen.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of impacting agent policy deploy.","sha":"5949b29e083939db921c0371e907b8617c08da88"}},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->