### PR TITLE
Fix input package data stream type override in agent policy

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.test.ts
@@ -827,6 +827,112 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
     ]);
   });
 
+  it('returns agent inputs with overridden data_stream.type from stream vars', async () => {
+    expect(
+      await storedPackagePoliciesToAgentInputs(
+        [
+          {
+            ...mockPackagePolicy,
+            package: {
+              name: 'mock_package',
+              title: 'Mock package',
+              version: '0.0.0',
+            },
+            inputs: [
+              {
+                ...mockInput,
+                streams: [
+                  {
+                    ...mockInput.streams[0],
+                    vars: {
+                      ...mockInput.streams[0].vars,
+                      'data_stream.type': { value: 'metrics' },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        packageInfoCache
+      )
+    ).toEqual([
+      {
+        id: 'test-logs-some-uuid',
+        name: 'mock_package-policy',
+        package_policy_id: 'some-uuid',
+        revision: 1,
+        type: 'test-logs',
+        data_stream: { namespace: 'default' },
+        use_output: 'default',
+        meta: {
+          package: {
+            name: 'mock_package',
+            version: '0.0.0',
+            release: 'beta',
+          },
+        },
+        streams: [
+          {
+            id: 'test-logs-foo',
+            data_stream: { dataset: 'foo', type: 'metrics' },
+            fooKey: 'fooValue1',
+            fooKey2: ['fooValue2'],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('does not override data_stream.type when stream var is not set', async () => {
+    expect(
+      await storedPackagePoliciesToAgentInputs(
+        [
+          {
+            ...mockPackagePolicy,
+            package: {
+              name: 'mock_package',
+              title: 'Mock package',
+              version: '0.0.0',
+            },
+            inputs: [
+              {
+                ...mockInput,
+                streams: [mockInput.streams[0]],
+              },
+            ],
+          },
+        ],
+        packageInfoCache
+      )
+    ).toEqual([
+      {
+        id: 'test-logs-some-uuid',
+        name: 'mock_package-policy',
+        package_policy_id: 'some-uuid',
+        revision: 1,
+        type: 'test-logs',
+        data_stream: { namespace: 'default' },
+        use_output: 'default',
+        meta: {
+          package: {
+            name: 'mock_package',
+            version: '0.0.0',
+            release: 'beta',
+          },
+        },
+        streams: [
+          {
+            id: 'test-logs-foo',
+            data_stream: { dataset: 'foo', type: 'logs' },
+            fooKey: 'fooValue1',
+            fooKey2: ['fooValue2'],
+          },
+        ],
+      },
+    ]);
+  });
+
   it('returns agent inputs with add fields process if global data tags are defined', async () => {
     const excludedInputs: PackagePolicyInput[] = [];
     const expectedExcluded = [];

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_inputs.ts
@@ -162,16 +162,22 @@ export const getFullInputStreams = (
                   return acc;
                 }, {} as { [k: string]: any }),
               };
-              if (input.type === OTEL_COLLECTOR_INPUT_TYPE) {
-                // otelcol inputs are not going to have the data_stream type and dataset in
-                // the compiled stream, get them directly from the user-defined variables.
-                const dsTypeVar = stream.vars?.[DATA_STREAM_TYPE_VAR_NAME]?.value;
-                const datasetVar = stream.vars?.[DATASET_VAR_NAME]?.value;
+              const dsTypeVar = stream.vars?.[DATA_STREAM_TYPE_VAR_NAME]?.value;
+              if (dsTypeVar) {
                 fullStream.data_stream = {
                   ...fullStream.data_stream,
-                  ...(dsTypeVar ? { type: dsTypeVar } : {}),
-                  ...(datasetVar ? { dataset: datasetVar } : {}),
+                  type: dsTypeVar,
                 };
+              }
+
+              if (input.type === OTEL_COLLECTOR_INPUT_TYPE) {
+                const datasetVar = stream.vars?.[DATASET_VAR_NAME]?.value;
+                if (datasetVar) {
+                  fullStream.data_stream = {
+                    ...fullStream.data_stream,
+                    dataset: datasetVar,
+                  };
+                }
 
                 const useAPMVar = stream.vars?.[USE_APM_VAR_NAME]?.value;
                 if (useAPMVar !== undefined) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/255486

In the logic to get input streams for an agent policy, the code that reads the `data_stream.type variable` from stream vars and applies it to the `output data_stream.type` was gated behind `if (input.type === OTEL_COLLECTOR_INPUT_TYPE)`, so it only worked for OTEL collector inputs, not for regular input packages like filestream or sql. This PR fixes that.

### Testing

1. Add an input package, e.g. filestream. When adding it, expand "Change defaults", then expand "Advanced options" at the bottom and change the data stream type to metrics or traces. Save and continue.
2. View the agent policy: the stream should have the correct type, e.g.
```yml
streams:
      - id: filestream-filestream.filestream-0d12a69b-c70c-4962-9f0a-13a0a656d1d8
        data_stream:
          dataset: filestream.generic
          type: metrics # <--- correct
          elasticsearch:
            dynamic_dataset: true
            dynamic_namespace: true
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Very low: narrow fix for input package stream type in Fleet agent policies. Integration packages should be unaffected and the OTEL-specific code path is preserved.