### PR TITLE
[Alerting V2] [UI] Add no-data handling feature to rule form

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_execution_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_execution_field_group.tsx
@@ -12,6 +12,7 @@ import { ScheduleField } from '../fields/schedule_field';
 import { TimeFieldSelect } from '../fields/time_field_select';
 import { LookbackWindowField } from '../fields/lookback_window_field';
 import { GroupFieldSelect } from '../fields/group_field_select';
+import { NoDataHandlingField } from '../fields/no_data_handling_field';
 
 export const RuleExecutionFieldGroup: React.FC = () => {
   return (
@@ -24,6 +25,7 @@ export const RuleExecutionFieldGroup: React.FC = () => {
       <TimeFieldSelect />
       <LookbackWindowField />
       <GroupFieldSelect />
+      <NoDataHandlingField />
     </FieldGroup>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_handling_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_handling_field.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { NoDataHandlingField } from './no_data_handling_field';
+import { createFormWrapper } from '../../test_utils';
+
+describe('NoDataHandlingField', () => {
+  it('does not render for signal rules', () => {
+    render(<NoDataHandlingField />, {
+      wrapper: createFormWrapper({ kind: 'signal' }),
+    });
+
+    expect(screen.queryByText('No-data behavior')).not.toBeInTheDocument();
+  });
+
+  it('renders behavior selector for alert rules', () => {
+    const { container } = render(<NoDataHandlingField />, {
+      wrapper: createFormWrapper({ kind: 'alert' }),
+    });
+
+    expect(screen.getByText('No-data behavior')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-test-subj="ruleNoDataBehaviorSelect"]')
+    ).toBeInTheDocument();
+  });
+
+  it('renders split timeframe controls when behavior is configured', () => {
+    const { container } = render(<NoDataHandlingField />, {
+      wrapper: createFormWrapper({
+        kind: 'alert',
+        noData: { behavior: 'no_data', timeframe: '10h' },
+      }),
+    });
+
+    expect(container.querySelector('[data-test-subj="ruleNoDataTimeframeValueInput"]')).toHaveValue(
+      10
+    );
+    expect(container.querySelector('[data-test-subj="ruleNoDataTimeframeUnitSelect"]')).toHaveValue(
+      'h'
+    );
+  });
+
+  it('defaults timeframe to 5m when enabling no-data behavior', () => {
+    const { container } = render(<NoDataHandlingField />, {
+      wrapper: createFormWrapper({
+        kind: 'alert',
+        noData: undefined,
+      }),
+    });
+
+    fireEvent.change(container.querySelector('[data-test-subj="ruleNoDataBehaviorSelect"]')!, {
+      target: { value: 'no_data' },
+    });
+
+    expect(container.querySelector('[data-test-subj="ruleNoDataTimeframeValueInput"]')).toHaveValue(
+      5
+    );
+    expect(container.querySelector('[data-test-subj="ruleNoDataTimeframeUnitSelect"]')).toHaveValue(
+      'm'
+    );
+  });
+
+  it('clears timeframe controls when behavior is unset', () => {
+    const { container } = render(<NoDataHandlingField />, {
+      wrapper: createFormWrapper({
+        kind: 'alert',
+        noData: { behavior: 'no_data', timeframe: '10m' },
+      }),
+    });
+
+    fireEvent.change(container.querySelector('[data-test-subj="ruleNoDataBehaviorSelect"]')!, {
+      target: { value: '' },
+    });
+
+    expect(
+      container.querySelector('[data-test-subj="ruleNoDataTimeframeValueInput"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-test-subj="ruleNoDataTimeframeUnitSelect"]')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_handling_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_handling_field.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect } from '@elastic/eui';
+import { validateDuration } from '@kbn/alerting-v2-schemas';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import type { FormValues } from '../types';
+import { getTimeOptions } from '../../flyout/utils';
+
+const NO_DATA_BEHAVIOR_OPTIONS = [
+  {
+    value: '',
+    text: i18n.translate('xpack.alertingV2.ruleForm.noDataBehaviorDisabled', {
+      defaultMessage: 'Not configured',
+    }),
+  },
+  {
+    value: 'no_data',
+    text: i18n.translate('xpack.alertingV2.ruleForm.noDataBehaviorNoData', {
+      defaultMessage: 'No data',
+    }),
+  },
+  {
+    value: 'last_status',
+    text: i18n.translate('xpack.alertingV2.ruleForm.noDataBehaviorLastStatus', {
+      defaultMessage: 'Last status',
+    }),
+  },
+  {
+    value: 'recover',
+    text: i18n.translate('xpack.alertingV2.ruleForm.noDataBehaviorRecover', {
+      defaultMessage: 'Recover',
+    }),
+  },
+];
+
+const NO_DATA_BEHAVIOR_ROW_ID = 'ruleV2FormNoDataBehaviorField';
+const NO_DATA_TIMEFRAME_ROW_ID = 'ruleV2FormNoDataTimeframeField';
+const INVALID_KEYS = ['-', '+', '.', 'e', 'E'];
+
+type TimeUnit = 's' | 'm' | 'h';
+
+const getNoDataTimeframeUnitOptions = (value: number): Array<{ value: TimeUnit; text: string }> =>
+  getTimeOptions(value).filter((option): option is { value: TimeUnit; text: string } =>
+    ['s', 'm', 'h'].includes(option.value)
+  );
+
+const getTimeframeParts = (
+  timeframe: string | undefined
+): { timeValue: string; timeUnit: TimeUnit } => {
+  if (!timeframe) {
+    return { timeValue: '', timeUnit: 'm' };
+  }
+
+  const match = timeframe.match(/^(\d+)(s|m|h)$/);
+  if (!match) {
+    return { timeValue: '', timeUnit: 'm' };
+  }
+
+  return {
+    timeValue: match[1],
+    timeUnit: match[2] as TimeUnit,
+  };
+};
+
+export const NoDataHandlingField: React.FC = () => {
+  const { control, setValue } = useFormContext<FormValues>();
+  const kind = useWatch({ control, name: 'kind' });
+  const noDataBehavior = useWatch({ control, name: 'noData.behavior' });
+
+  if (kind !== 'alert') {
+    return null;
+  }
+
+  return (
+    <>
+      <Controller
+        name="noData.behavior"
+        control={control}
+        render={({ field, fieldState: { error } }) => (
+          <EuiFormRow
+            id={NO_DATA_BEHAVIOR_ROW_ID}
+            label={i18n.translate('xpack.alertingV2.ruleForm.noDataBehaviorLabel', {
+              defaultMessage: 'No-data behavior',
+            })}
+            helpText={i18n.translate('xpack.alertingV2.ruleForm.noDataBehaviorHelpText', {
+              defaultMessage:
+                'Choose how rule status changes when no results are returned for the configured timeframe.',
+            })}
+            isInvalid={!!error}
+            error={error?.message}
+          >
+            <EuiSelect
+              {...field}
+              value={field.value ?? ''}
+              onChange={(event) => {
+                const nextValue = event.target.value || undefined;
+                field.onChange(nextValue);
+
+                if (!nextValue) {
+                  setValue('noData.timeframe', undefined, {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  });
+                } else {
+                  setValue('noData.timeframe', '5m', {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  });
+                }
+              }}
+              options={NO_DATA_BEHAVIOR_OPTIONS}
+              isInvalid={!!error}
+              data-test-subj="ruleNoDataBehaviorSelect"
+            />
+          </EuiFormRow>
+        )}
+      />
+      {noDataBehavior ? (
+        <Controller
+          name="noData.timeframe"
+          control={control}
+          rules={{
+            validate: (value) => {
+              if (!value?.trim()) {
+                return i18n.translate('xpack.alertingV2.ruleForm.noDataTimeframeRequired', {
+                  defaultMessage:
+                    'No-data timeframe is required when no-data behavior is configured.',
+                });
+              }
+
+              const timeframeMatch = value.match(/^(\d+)(s|m|h)$/);
+              if (!timeframeMatch) {
+                return i18n.translate('xpack.alertingV2.ruleForm.noDataTimeframeFormatError', {
+                  defaultMessage: 'Timeframe must use seconds, minutes, or hours.',
+                });
+              }
+
+              if (parseInt(timeframeMatch[1], 10) <= 0) {
+                return i18n.translate('xpack.alertingV2.ruleForm.noDataTimeframePositiveError', {
+                  defaultMessage: 'Timeframe value must be a positive number.',
+                });
+              }
+
+              return validateDuration(value) ?? true;
+            },
+          }}
+          render={({ field, fieldState: { error } }) => {
+            const { timeValue, timeUnit } = getTimeframeParts(field.value);
+            const numericTimeValue = timeValue ? parseInt(timeValue, 10) : 1;
+
+            const onTimeValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+              const nextValue = event.target.value.trim();
+              if (!nextValue) {
+                field.onChange(undefined);
+                return;
+              }
+
+              if (/^[1-9][0-9]*$/.test(nextValue)) {
+                field.onChange(`${nextValue}${timeUnit}`);
+              }
+            };
+
+            const onTimeUnitChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+              const nextUnit = event.target.value as TimeUnit;
+              if (!timeValue) {
+                return;
+              }
+
+              field.onChange(`${timeValue}${nextUnit}`);
+            };
+
+            const onTimeValueKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+              if (INVALID_KEYS.includes(event.key)) {
+                event.preventDefault();
+              }
+            };
+
+            return (
+              <EuiFormRow
+                id={NO_DATA_TIMEFRAME_ROW_ID}
+                label={i18n.translate('xpack.alertingV2.ruleForm.noDataTimeframeLabel', {
+                  defaultMessage: 'No-data timeframe',
+                })}
+                helpText={i18n.translate('xpack.alertingV2.ruleForm.noDataTimeframeHelpText', {
+                  defaultMessage:
+                    'Duration after which no data is detected. Enter a positive value and select seconds, minutes, or hours.',
+                })}
+                isInvalid={!!error}
+                error={error?.message}
+              >
+                <EuiFlexGroup gutterSize="s" responsive={false}>
+                  <EuiFlexItem grow={2}>
+                    <EuiFieldNumber
+                      value={timeValue}
+                      onChange={onTimeValueChange}
+                      onKeyDown={onTimeValueKeyDown}
+                      min={1}
+                      step={1}
+                      isInvalid={!!error}
+                      aria-label={i18n.translate('xpack.alertingV2.ruleForm.noDataTimeValueLabel', {
+                        defaultMessage: 'Time value',
+                      })}
+                      placeholder={i18n.translate(
+                        'xpack.alertingV2.ruleForm.noDataTimeframeValuePlaceholder',
+                        {
+                          defaultMessage: '10',
+                        }
+                      )}
+                      data-test-subj="ruleNoDataTimeframeValueInput"
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={3}>
+                    <EuiSelect
+                      value={timeUnit}
+                      onChange={onTimeUnitChange}
+                      options={getNoDataTimeframeUnitOptions(numericTimeValue)}
+                      isInvalid={!!error}
+                      aria-label={i18n.translate('xpack.alertingV2.ruleForm.noDataTimeUnitLabel', {
+                        defaultMessage: 'Time unit',
+                      })}
+                      data-test-subj="ruleNoDataTimeframeUnitSelect"
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFormRow>
+            );
+          }}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
@@ -22,7 +22,7 @@ interface UseCreateRuleProps {
  * and the API contract (CreateRuleData).
  */
 const mapFormValuesToCreateRuleData = (formValues: FormValues): CreateRuleData => {
-  const { kind, metadata, timeField, schedule, evaluation, grouping } = formValues;
+  const { kind, metadata, timeField, schedule, evaluation, grouping, noData } = formValues;
 
   return {
     kind,
@@ -39,10 +39,18 @@ const mapFormValuesToCreateRuleData = (formValues: FormValues): CreateRuleData =
     evaluation: {
       query: {
         base: evaluation.query.base,
-        condition: '', // Required by API but not in form yet
+        condition: undefined,
       },
     },
     ...(grouping?.fields?.length ? { grouping: { fields: grouping.fields } } : {}),
+    ...(noData?.behavior
+      ? {
+          no_data: {
+            behavior: noData.behavior,
+            ...(noData.timeframe ? { timeframe: noData.timeframe } : {}),
+          },
+        }
+      : {}),
   };
 };
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_form_defaults.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_form_defaults.test.ts
@@ -26,6 +26,7 @@ describe('useFormDefaults', () => {
           base: '',
         },
       },
+      noData: { timeframe: '5m' },
       grouping: undefined,
     });
   });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_form_defaults.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_form_defaults.ts
@@ -44,6 +44,7 @@ export const useFormDefaults = ({ query }: UseFormDefaultsProps): FormValues => 
           base: query,
         },
       },
+      noData: { timeframe: '5m' },
       grouping: defaultGroupBy.length
         ? {
             fields: defaultGroupBy,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
@@ -26,6 +26,7 @@ export interface RuleSchedule {
 
 export interface EvaluationQuery {
   base: string;
+  condition?: string;
 }
 
 export interface RuleEvaluation {
@@ -34,6 +35,11 @@ export interface RuleEvaluation {
 
 export interface RuleGrouping {
   fields: string[];
+}
+
+export interface RuleNoData {
+  behavior?: 'no_data' | 'last_status' | 'recover';
+  timeframe?: string;
 }
 
 /**
@@ -48,4 +54,5 @@ export interface FormValues {
   schedule: RuleSchedule;
   evaluation: RuleEvaluation;
   grouping?: RuleGrouping;
+  noData?: RuleNoData;
 }


### PR DESCRIPTION
## 🧹 Summary

Closes #251328

> ℹ️ This PR is going into the `alerting_v2` feature branch, not `main`, for fast iteration. Feedback is welcome, but this may still evolve before anything is merged to `main`.

This PR adds the **No-data handling** UI to the shared V2 rule form (`@kbn/alerting-v2-rule-form`) and wires it into the existing form flow used by Discover.

### What’s included

- Adds a new **No-data handling** control block in Rule Execution.
- No-data controls are **visible for `kind=alert` only** and hidden for `kind=signal`.
- Adds no-data fields:
  - `noData.behavior` (`no_data | last_status | recover`)
  - `noData.timeframe` as split input:
    - time value (positive integer)
    - time unit selector (`seconds`, `minutes`, `hours`)
- Maps form values to API:
  - `noData` -> `no_data`
- Applies agreed default:
  - no-data timeframe defaults to `5m` when no-data behavior is enabled

## 🔑 Key implementation details

### New components

- `no_data_handling_field.tsx`

### Form integration

- `NoDataHandlingField` is rendered in `rule_execution_field_group.tsx`.
- `FormValues` extended with `noData` and optional `evaluation.query.condition`.

## Files changed

| Area | Files | Description |
|------|-------|-------------|
| Form types | `form/types.ts` | Adds `noData` shape and optional `evaluation.query.condition` |
| New field + tests | `form/fields/no_data_handling_field.tsx`, `form/fields/no_data_handling_field.test.tsx` | No-data UI, validation, unit selector, alert-only visibility |
| Form wiring | `form/field_groups/rule_execution_field_group.tsx` | Renders no-data field in rule execution group |
| Defaults | `form/hooks/use_form_defaults.ts`, `form/hooks/use_form_defaults.test.ts` | Sets default no-data timeframe to `5m` |
| API mapping | `form/hooks/use_create_rule.ts`, `form/hooks/use_create_rule.test.tsx` | Maps `no_data`; keeps `condition` undefined |

## 🧪 Testing

- Added/updated unit tests for:
  - no-data visibility by rule kind
  - no-data timeframe split controls
  - default `5m` timeframe when behavior is enabled
  - seconds/minutes/hours unit support
  - payload mapping for `no_data` and `condition: undefined`
  - defaults in `useFormDefaults`

## 🔬 How to test manually

1. Enable: 
```
xpack.alerting_v2.ui.enabled: true
xpack.alerting_v2.enabled: true
``` 
2. Start Kibana and open Discover in ES|QL mode.
3. Open V2 create rule flow.
4. Verify:

- Alert shows no-data behavior/timeframe.
- Signal hides no-data controls.
- Enabling no-data behavior pre-fills timeframe with 5m.
- Timeframe uses split controls (value + unit) and supports seconds/minutes/hours.
- Timeframe value must be a positive integer.

5. Submit and verify payload includes no_data