### PR TITLE
[Search][Indices][Search Applications] Fix Unbounded arra in schema validation

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -514,14 +514,15 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
         body: schema.object({
           field_mappings: schema.maybe(
             schema.arrayOf(
-              schema.object({ sourceField: schema.string(), targetField: schema.string() })
+              schema.object({ sourceField: schema.string(), targetField: schema.string() }),
+              { maxSize: 10000 }
             )
           ),
           model_id: schema.string(),
           pipeline_definition: schema.maybe(
             schema.object({
               description: schema.maybe(schema.string()),
-              processors: schema.arrayOf(schema.any()),
+              processors: schema.arrayOf(schema.any(), { maxSize: 10000 }),
               version: schema.number(),
             })
           ),
@@ -709,10 +710,10 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
       },
       validate: {
         body: schema.object({
-          docs: schema.arrayOf(schema.any()),
+          docs: schema.arrayOf(schema.any(), { maxSize: 10000 }),
           pipeline: schema.object({
             description: schema.maybe(schema.string()),
-            processors: schema.arrayOf(schema.any()),
+            processors: schema.arrayOf(schema.any(), { maxSize: 10000 }),
           }),
         }),
         params: schema.object({
@@ -777,7 +778,7 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
       },
       validate: {
         body: schema.object({
-          docs: schema.arrayOf(schema.any()),
+          docs: schema.arrayOf(schema.any(), { maxSize: 10000 }),
         }),
         params: schema.object({
           indexName: schema.string(),
@@ -901,7 +902,7 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
       validate: {
         body: schema.object({
           description: schema.maybe(schema.string()),
-          processors: schema.arrayOf(schema.any()),
+          processors: schema.arrayOf(schema.any(), { maxSize: 10000 }),
         }),
         params: schema.object({
           indexName: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
@@ -122,7 +122,7 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
       },
       validate: {
         body: schema.object({
-          indices: schema.arrayOf(schema.string()),
+          indices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
           name: schema.maybe(schema.string()),
           template: schema.maybe(
             schema.object({


### PR DESCRIPTION
## Summary

This PR resolves the following code scanning findings for the enterprise_search plugin - indices routes.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

