### PR TITLE
Retry es_rejected_execution_exception in streams execution plan

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/retry.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/retry.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { errors, type DiagnosticResult } from '@elastic/elasticsearch';
+import { loggerMock } from '@kbn/logging-mocks';
+import { retryTransientEsErrors } from './retry';
+
+jest.mock('timers/promises', () => ({
+  setTimeout: jest.fn().mockResolvedValue(undefined),
+}));
+
+const createResponseError = (
+  statusCode: number,
+  body: Record<string, unknown>
+): errors.ResponseError => {
+  return new errors.ResponseError({
+    statusCode,
+    body,
+    headers: {},
+    warnings: [],
+    meta: {
+      aborted: false,
+      attempts: 1,
+      connection: null,
+      context: null,
+      name: 'test',
+      request: {} as unknown as DiagnosticResult['meta']['request'],
+    },
+  });
+};
+
+const createEsRejectedExecutionError = () => {
+  return createResponseError(429, {
+    error: {
+      type: 'es_rejected_execution_exception',
+      reason:
+        'rejected execution of coordinating operation [coordinating_and_primary_bytes=0, replica_bytes=0, all_bytes=0, coordinating_operation_bytes=0, max_coordinating_bytes=0]',
+    },
+  });
+};
+
+const createNonRetryableError = () => {
+  return createResponseError(400, {
+    error: {
+      type: 'illegal_argument_exception',
+      reason: 'invalid request',
+    },
+  });
+};
+
+describe('retryTransientEsErrors', () => {
+  const logger = loggerMock.create();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns result when call succeeds on first attempt', async () => {
+    const esCall = jest.fn().mockResolvedValue({ success: true });
+
+    const result = await retryTransientEsErrors(esCall, { logger });
+
+    expect(result).toEqual({ success: true });
+    expect(esCall).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('retries on es_rejected_execution_exception (HTTP 429) and succeeds', async () => {
+    const esCall = jest
+      .fn()
+      .mockRejectedValueOnce(createEsRejectedExecutionError())
+      .mockResolvedValue({ success: true });
+
+    const result = await retryTransientEsErrors(esCall, { logger });
+
+    expect(result).toEqual({ success: true });
+    expect(esCall).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Retrying Elasticsearch operation after [2s]')
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('es_rejected_execution_exception')
+    );
+  });
+
+  it('retries multiple times with exponential backoff before succeeding', async () => {
+    const { setTimeout: setTimeoutMock } = jest.requireMock('timers/promises');
+
+    const esCall = jest
+      .fn()
+      .mockRejectedValueOnce(createEsRejectedExecutionError())
+      .mockRejectedValueOnce(createEsRejectedExecutionError())
+      .mockRejectedValueOnce(createEsRejectedExecutionError())
+      .mockResolvedValue({ success: true });
+
+    const result = await retryTransientEsErrors(esCall, { logger });
+
+    expect(result).toEqual({ success: true });
+    expect(esCall).toHaveBeenCalledTimes(4);
+    expect(logger.warn).toHaveBeenCalledTimes(3);
+
+    expect(setTimeoutMock).toHaveBeenNthCalledWith(1, 2000);
+    expect(setTimeoutMock).toHaveBeenNthCalledWith(2, 4000);
+    expect(setTimeoutMock).toHaveBeenNthCalledWith(3, 8000);
+  });
+
+  it('throws after exhausting max retry attempts', async () => {
+    const error = createEsRejectedExecutionError();
+    const esCall = jest.fn().mockRejectedValue(error);
+
+    await expect(retryTransientEsErrors(esCall, { logger })).rejects.toThrow(error);
+
+    expect(esCall).toHaveBeenCalledTimes(6);
+    expect(logger.warn).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    const error = createNonRetryableError();
+    const esCall = jest.fn().mockRejectedValue(error);
+
+    await expect(retryTransientEsErrors(esCall, { logger })).rejects.toThrow(error);
+
+    expect(esCall).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('works without a logger', async () => {
+    const esCall = jest
+      .fn()
+      .mockRejectedValueOnce(createEsRejectedExecutionError())
+      .mockResolvedValue({ success: true });
+
+    const result = await retryTransientEsErrors(esCall);
+
+    expect(result).toEqual({ success: true });
+    expect(esCall).toHaveBeenCalledTimes(2);
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
@@ -29,6 +29,7 @@ import {
 } from '../../ingest_pipelines/manage_ingest_pipelines';
 import { getErrorMessage } from '../../errors/parse_error';
 import { upsertEsqlView, deleteEsqlView } from '../../esql_views/manage_esql_views';
+import { retryTransientEsErrors } from '../../helpers/retry';
 import { FailedToExecuteElasticsearchActionsError } from '../errors/failed_to_execute_elasticsearch_actions_error';
 import { FailedToPlanElasticsearchActionsError } from '../errors/failed_to_plan_elasticsearch_actions_error';
 import { InsufficientPermissionsError } from '../../errors/insufficient_permissions_error';
@@ -475,11 +476,15 @@ export class ExecutionPlan {
   private async upsertAndDeleteDotStreamsDocuments(
     actions: Array<UpsertDotStreamsDocumentAction | DeleteDotStreamsDocumentAction>
   ) {
-    return this.dependencies.storageClient.bulk({
-      operations: actions.map(dotDocumentActionToBulkOperation),
-      refresh: true,
-      throwOnFail: true,
-    });
+    return retryTransientEsErrors(
+      () =>
+        this.dependencies.storageClient.bulk({
+          operations: actions.map(dotDocumentActionToBulkOperation),
+          refresh: true,
+          throwOnFail: true,
+        }),
+      { logger: this.dependencies.logger }
+    );
   }
 
   private async updateIngestSettings(actions: UpdateIngestSettingsAction[]) {


### PR DESCRIPTION
## Summary

Wraps the `storageClient.bulk()` call in `upsertAndDeleteDotStreamsDocuments` with `retryTransientEsErrors` to automatically retry when Elasticsearch returns transient errors (like `es_rejected_execution_exception` / HTTP 429) during stream state management operations.

This was identified as a gap where other execution plan operations already use retry logic, but the bulk document operations did not.

## Test plan

- [x] Added unit tests for `retryTransientEsErrors` helper covering:
  - Success on first attempt
  - Retry on `es_rejected_execution_exception` (HTTP 429) and success
  - Multiple retries with exponential backoff (2s, 4s, 8s...)
  - Max retry exhaustion (6 total attempts)
  - Non-retryable errors (HTTP 400) not being retried
  - Operation without a logger

Refs: elastic/observability-error-backlog#503

Made with [Cursor](https://cursor.com)