### PR TITLE
Adds a new optional `lastEnabledAt` field to the rule SO

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/backfill/transforms/transform_backfill_param_to_ad_hoc_run.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/backfill/transforms/transform_backfill_param_to_ad_hoc_run.test.ts
@@ -70,7 +70,14 @@ describe('transformBackfillParamToAdHocRun', () => {
   });
 
   test('should transform backfill param with start and end', () => {
-    expect(transformBackfillParamToAdHocRun(getMockData(), getMockRule(), [], 'default')).toEqual({
+    const { adHocRunSO, truncated } = transformBackfillParamToAdHocRun(
+      getMockData(),
+      getMockRule(),
+      [],
+      'default'
+    );
+    expect(truncated).toBe(false);
+    expect(adHocRunSO).toEqual({
       apiKeyId: '123',
       apiKeyToUse: 'MTIzOmFiYw==',
       createdAt: '2024-01-30T00:00:00.000Z',
@@ -115,9 +122,14 @@ describe('transformBackfillParamToAdHocRun', () => {
     const actions = [
       { uuid: '123abc', group: 'default', actionRef: 'action_0', actionTypeId: 'test', params: {} },
     ];
-    expect(
-      transformBackfillParamToAdHocRun(getMockData(), getMockRule(), actions, 'default')
-    ).toEqual({
+    const { adHocRunSO, truncated } = transformBackfillParamToAdHocRun(
+      getMockData(),
+      getMockRule(),
+      actions,
+      'default'
+    );
+    expect(truncated).toBe(false);
+    expect(adHocRunSO).toEqual({
       apiKeyId: '123',
       apiKeyToUse: 'MTIzOmFiYw==',
       createdAt: '2024-01-30T00:00:00.000Z',
@@ -163,14 +175,14 @@ describe('transformBackfillParamToAdHocRun', () => {
     const actions = [
       { uuid: '123abc', group: 'default', actionRef: 'action_0', actionTypeId: 'test', params: {} },
     ];
-    expect(
-      transformBackfillParamToAdHocRun(
-        getMockData({ runActions: false }),
-        getMockRule(),
-        actions,
-        'default'
-      )
-    ).toEqual({
+    const { adHocRunSO, truncated } = transformBackfillParamToAdHocRun(
+      getMockData({ runActions: false }),
+      getMockRule(),
+      actions,
+      'default'
+    );
+    expect(truncated).toBe(false);
+    expect(adHocRunSO).toEqual({
       apiKeyId: '123',
       apiKeyToUse: 'MTIzOmFiYw==',
       createdAt: '2024-01-30T00:00:00.000Z',

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/bulk_fill_gaps_by_rule_ids/batch_backfill_rule_gaps.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/bulk_fill_gaps_by_rule_ids/batch_backfill_rule_gaps.test.ts
@@ -76,6 +76,9 @@ describe('batchBackfillRuleGaps', () => {
   beforeEach(() => {
     processGapsBatchMock.mockImplementation((_, { gapsBatch }) => ({
       processedGapsCount: gapsBatch.length,
+      hasErrors: false,
+      results: [],
+      truncatedRuleIds: [],
     }));
     processAllRuleGapsMock.mockImplementation(async ({ processGapsBatch: processFn }) => {
       const results: Awaited<ReturnType<typeof processFn>> = [];
@@ -155,7 +158,12 @@ describe('batchBackfillRuleGaps', () => {
 
   describe('when there is nothing to backfill', () => {
     beforeEach(async () => {
-      processGapsBatchMock.mockResolvedValue(false);
+      processGapsBatchMock.mockResolvedValue({
+        processedGapsCount: 0,
+        hasErrors: false,
+        results: [],
+        truncatedRuleIds: [],
+      });
       await callBatchBackfillRuleGaps();
     });
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/bulk_fill_gaps_by_rule_ids/batch_backfill_rule_gaps.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/methods/bulk_fill_gaps_by_rule_ids/batch_backfill_rule_gaps.ts
@@ -47,18 +47,26 @@ export const batchBackfillRuleGaps = async (
         gapsBatch: Gap[],
         processingLimitsByRuleId: Record<string, number>
       ) => {
-        const { processedGapsCount, hasErrors, results } = await processGapsBatch(context, {
-          range,
-          gapsBatch,
-          maxGapsCountToProcess: processingLimitsByRuleId[rule.id],
-          initiator: backfillInitiator.USER,
-        });
+        const { processedGapsCount, hasErrors, results, truncatedRuleIds } =
+          await processGapsBatch(context, {
+            range,
+            gapsBatch,
+            maxGapsCountToProcess: processingLimitsByRuleId[rule.id],
+            initiator: backfillInitiator.USER,
+          });
         if (processedGapsCount > 0) {
           hasBeenBackfilled = true;
         }
         if (hasErrors) {
           const errorMessage = results[0]?.error;
           throw new Error(errorMessage ?? "Can't schedule gap fill");
+        }
+
+        // When the schedule entry cap was hit, report the full limit so
+        // processAllRuleGaps stops paginating -- the remaining gaps will
+        // be picked up on the next user-triggered run.
+        if (truncatedRuleIds.length > 0) {
+          return { [rule.id]: maxGapCountPerRule };
         }
 
         return { [rule.id]: processedGapsCount };

--- a/x-pack/platform/plugins/shared/alerting/server/application/gaps/types/scheduler.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/gaps/types/scheduler.ts
@@ -11,7 +11,7 @@ export type SchedulerSoAttributes = TypeOf<typeof rawGapAutoFillSchedulerSchemaV
 
 export const GAP_AUTO_FILL_SCHEDULER_TASK_TYPE = 'gap-auto-fill-scheduler-task' as const;
 
-export const DEFAULT_RULES_BATCH_SIZE = 100;
+export const DEFAULT_RULES_BATCH_SIZE = 10;
 export const DEFAULT_GAPS_PER_PAGE = 5000;
 
 export const DEFAULT_GAP_AUTO_FILL_SCHEDULER_TIMEOUT = '60s' as const;

--- a/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.test.ts
@@ -32,6 +32,15 @@ import { updateGaps } from '../lib/rule_gaps/update/update_gaps';
 jest.mock('../lib/rule_gaps/update/update_gaps', () => ({
   updateGaps: jest.fn(),
 }));
+jest.mock('./lib/calculate_schedule', () => {
+  const actual = jest.requireActual('./lib/calculate_schedule');
+  return {
+    ...actual,
+    calculateSchedule: jest.fn(actual.calculateSchedule),
+  };
+});
+import { calculateSchedule } from './lib/calculate_schedule';
+import { SCHEDULE_TRUNCATED_WARNING } from './lib/calculate_schedule';
 import { actionsClientMock } from '@kbn/actions-plugin/server/mocks';
 import type { RawRule, RawRuleAction } from '../types';
 import { createMockConnector } from '@kbn/actions-plugin/server/application/connector/mocks';
@@ -240,6 +249,10 @@ describe('BackfillClient', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    const { calculateSchedule: realCalculateSchedule } = jest.requireActual(
+      './lib/calculate_schedule'
+    );
+    (calculateSchedule as jest.Mock).mockImplementation(realCalculateSchedule);
     isSystemAction = jest.fn().mockReturnValue(false);
     actionsClient.isSystemAction.mockImplementation(isSystemAction);
 
@@ -1553,6 +1566,157 @@ describe('BackfillClient', () => {
       ]);
     });
 
+    test('should correctly attach unsupported actions warning when preceding params produce errors', async () => {
+      actionsClient.getBulk.mockResolvedValue([
+        createMockConnector({
+          id: '987',
+          actionTypeId: 'test',
+          config: {
+            from: 'me@me.com',
+            hasAuth: false,
+            host: 'hello',
+            port: 22,
+            secure: null,
+            service: null,
+          },
+          name: 'email connector',
+        }),
+      ]);
+      // params[0] references a nonexistent rule → error (ndx=0)
+      // params[1] has unsupported actions → warning should land on result[1] (ndx=1)
+      const mockData = [getMockData({ ruleId: 'nonexistent' }), getMockData()];
+      const rule1 = getMockRule({
+        actions: [
+          {
+            group: 'default',
+            id: '987',
+            actionTypeId: 'test',
+            params: {},
+            uuid: '123abc',
+            frequency: { notifyWhen: 'onActiveAlert', summary: false, throttle: null },
+          },
+          {
+            group: 'default',
+            id: '987',
+            actionTypeId: 'test',
+            params: {},
+            uuid: 'xyz987',
+            frequency: { notifyWhen: 'onThrottleInterval', summary: true, throttle: '1h' },
+          },
+        ],
+      });
+      const mockRules = [rule1];
+
+      const mockAttributes = getMockAdHocRunAttributes({
+        overwrites: {
+          start: '2023-11-16T08:00:00.000Z',
+          end: '2023-11-16T20:00:00.000Z',
+          schedule: [
+            {
+              runAt: '2023-11-16T20:00:00.000Z',
+              interval: '12h',
+              status: adHocRunStatus.PENDING,
+            },
+          ],
+        },
+        actions: [],
+      });
+
+      const bulkCreateResult = {
+        saved_objects: [getBulkCreateParam('abc', '1', mockAttributes)],
+      };
+
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(bulkCreateResult);
+
+      const result = await backfillClient.bulkQueue({
+        actionsClient,
+        auditLogger,
+        params: mockData,
+        rules: mockRules,
+        ruleTypeRegistry,
+        spaceId: 'default',
+        unsecuredSavedObjectsClient,
+        eventLogClient,
+        internalSavedObjectsRepository,
+        eventLogger,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        error: {
+          message: 'Saved object [alert/nonexistent] not found',
+          rule: { id: 'nonexistent' },
+        },
+      });
+      expect(result[1]).toEqual(
+        expect.objectContaining({
+          warnings: [
+            'Rule has actions that are not supported for backfill. Those actions will be skipped.',
+          ],
+        })
+      );
+    });
+
+    test('should correctly attach truncation warning when preceding params produce errors', async () => {
+      // params[0] references a nonexistent rule → error (ndx=0)
+      // params[1] will be truncated → warning should land on result[1] (ndx=1)
+      const mockData = [getMockData({ ruleId: 'nonexistent' }), getMockData()];
+      const rule1 = getMockRule();
+      const mockRules = [rule1];
+
+      (calculateSchedule as jest.Mock).mockImplementation((interval: string, ranges: unknown[]) => {
+        const { calculateSchedule: realCalc } = jest.requireActual('./lib/calculate_schedule');
+        const result = realCalc(interval, ranges);
+        return { ...result, truncated: true };
+      });
+
+      const mockAttributes = getMockAdHocRunAttributes({
+        overwrites: {
+          start: '2023-11-16T08:00:00.000Z',
+          end: '2023-11-16T20:00:00.000Z',
+          schedule: [
+            {
+              runAt: '2023-11-16T20:00:00.000Z',
+              interval: '12h',
+              status: adHocRunStatus.PENDING,
+            },
+          ],
+        },
+      });
+
+      const bulkCreateResult = {
+        saved_objects: [getBulkCreateParam('abc', '1', mockAttributes)],
+      };
+
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(bulkCreateResult);
+
+      const result = await backfillClient.bulkQueue({
+        actionsClient,
+        auditLogger,
+        params: mockData,
+        rules: mockRules,
+        ruleTypeRegistry,
+        spaceId: 'default',
+        unsecuredSavedObjectsClient,
+        eventLogClient,
+        internalSavedObjectsRepository,
+        eventLogger,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        error: {
+          message: 'Saved object [alert/nonexistent] not found',
+          rule: { id: 'nonexistent' },
+        },
+      });
+      expect(result[1]).toEqual(
+        expect.objectContaining({
+          warnings: [SCHEDULE_TRUNCATED_WARNING],
+        })
+      );
+    });
+
     test('should successfully create multiple backfill saved objects for a single rule', async () => {
       const mockData = [
         getMockData(),
@@ -1812,11 +1976,15 @@ describe('BackfillClient', () => {
 
       const mockAttributes = getMockAdHocRunAttributes();
 
-      const bulkCreateResult = {
+      const bulkCreateResultChunk1 = {
         saved_objects: [
           getBulkCreateParam('abc', '1', mockAttributes),
           getBulkCreateParam('def', '3', mockAttributes),
           getBulkCreateParam('ghi', '1', mockAttributes),
+        ],
+      };
+      const bulkCreateResultChunk2 = {
+        saved_objects: [
           {
             type: 'ad_hoc_rule_run_params',
             error: {
@@ -1828,9 +1996,9 @@ describe('BackfillClient', () => {
         ],
       };
 
-      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
-        bulkCreateResult as SavedObjectsBulkResponse<AdHocRunSO>
-      );
+      unsecuredSavedObjectsClient.bulkCreate
+        .mockResolvedValueOnce(bulkCreateResultChunk1 as SavedObjectsBulkResponse<AdHocRunSO>)
+        .mockResolvedValueOnce(bulkCreateResultChunk2 as SavedObjectsBulkResponse<AdHocRunSO>);
       const result = await backfillClient.bulkQueue({
         actionsClient,
         auditLogger,
@@ -2574,15 +2742,17 @@ describe('BackfillClient', () => {
       );
     });
 
-    test('should process bulk create in chunks of 10', async () => {
+    test('should process bulk create in chunks of 3', async () => {
       // Create 25 mock rules and backfill params to test chunking
       const mockRules = Array.from({ length: 25 }, (_, i) => getMockRule({ id: `${i + 1}` }));
       const mockData = Array.from({ length: 25 }, (_, i) => getMockData({ ruleId: `${i + 1}` }));
 
+      const chunkSize = 3;
+      const expectedChunkCount = Math.ceil(25 / chunkSize);
       // Create mock responses for each chunk
-      const mockResponses = Array.from({ length: 3 }, (_, chunkIndex) => {
-        const startIdx = chunkIndex * 10;
-        const endIdx = Math.min(startIdx + 10, 25);
+      const mockResponses = Array.from({ length: expectedChunkCount }, (_, chunkIndex) => {
+        const startIdx = chunkIndex * chunkSize;
+        const endIdx = Math.min(startIdx + chunkSize, 25);
         return {
           saved_objects: Array.from({ length: endIdx - startIdx }, (item, i) => {
             const idx = startIdx + i;
@@ -2592,10 +2762,9 @@ describe('BackfillClient', () => {
       });
 
       // Mock bulkCreate to return different responses for each chunk
-      unsecuredSavedObjectsClient.bulkCreate
-        .mockResolvedValueOnce(mockResponses[0])
-        .mockResolvedValueOnce(mockResponses[1])
-        .mockResolvedValueOnce(mockResponses[2]);
+      mockResponses.forEach((response) => {
+        unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(response);
+      });
 
       const result = await backfillClient.bulkQueue({
         actionsClient,
@@ -2610,13 +2779,14 @@ describe('BackfillClient', () => {
         eventLogger,
       });
 
-      // Verify bulkCreate was called 3 times (for chunks of 10, 10, and 5)
-      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(3);
+      // Verify bulkCreate was called 9 times (for chunks of 3 and a final chunk of 1)
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(9);
 
       // Verify each chunk was processed with correct size
-      expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(10);
-      expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[1][0]).toHaveLength(10);
-      expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[2][0]).toHaveLength(5);
+      for (let i = 0; i < 8; i++) {
+        expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[i][0]).toHaveLength(3);
+      }
+      expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[8][0]).toHaveLength(1);
 
       // Verify all results were combined correctly
       expect(result).toHaveLength(25);
@@ -2691,7 +2861,7 @@ describe('BackfillClient', () => {
       );
       const mockData = mockRules.map((rule) => getMockData({ ruleId: rule.id }));
 
-      const firstChunkSavedObjects = Array.from({ length: 10 }, (_, i) =>
+      const firstChunkSavedObjects = Array.from({ length: 3 }, (_, i) =>
         getBulkCreateParam(
           `id-${i + 1}`,
           `${i + 1}`,
@@ -2701,6 +2871,8 @@ describe('BackfillClient', () => {
 
       unsecuredSavedObjectsClient.bulkCreate
         .mockResolvedValueOnce({ saved_objects: firstChunkSavedObjects })
+        .mockRejectedValueOnce(new Error('Second chunk failed'))
+        .mockRejectedValueOnce(new Error('Second chunk failed'))
         .mockRejectedValueOnce(new Error('Second chunk failed'));
 
       const result = await backfillClient.bulkQueue({
@@ -2716,13 +2888,13 @@ describe('BackfillClient', () => {
         eventLogger,
       });
 
-      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(2);
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(4);
       expect(auditLogger.log).toHaveBeenCalledTimes(11);
 
       const firstChunkRequest = unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<
         SavedObjectsBulkCreateObject<AdHocRunSO>
       >;
-      expect(result.slice(0, 10)).toEqual(
+      expect(result.slice(0, 3)).toEqual(
         firstChunkSavedObjects.map((so, index) =>
           transformAdHocRunToBackfillResult({
             adHocRunSO: so,
@@ -2731,14 +2903,14 @@ describe('BackfillClient', () => {
           })
         )
       );
-      expect(result.slice(10)).toEqual([
-        {
+      expect(result.slice(3)).toEqual(
+        Array.from({ length: 8 }, (_, i) => ({
           error: {
             message: 'Second chunk failed',
-            rule: { id: '11', name: 'my rule name' },
+            rule: { id: `${i + 4}`, name: 'my rule name' },
           },
-        },
-      ]);
+        }))
+      );
       expect(taskManagerStart.bulkSchedule).toHaveBeenCalledWith(
         firstChunkSavedObjects.map((so) => ({
           id: so.id,

--- a/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.ts
@@ -45,6 +45,7 @@ import { AD_HOC_RUN_SAVED_OBJECT_TYPE, RULE_SAVED_OBJECT_TYPE } from '../saved_o
 import type { TaskRunnerFactory } from '../task_runner';
 import type { RuleTypeRegistry } from '../types';
 import { createBackfillError } from './lib';
+import { SCHEDULE_TRUNCATED_WARNING } from './lib/calculate_schedule';
 import { updateGaps } from '../lib/rule_gaps/update/update_gaps';
 import { denormalizeActions } from '../rules_client/lib/denormalize_actions';
 import type { DenormalizedAction, NormalizedAlertActionWithGeneratedValues } from '../rules_client';
@@ -250,6 +251,7 @@ export class BackfillClient {
 
     const soToCreateIndexOrErrorMap: Map<number, number | ScheduleBackfillError> = new Map();
     const rulesWithUnsupportedActions = new Set<number>();
+    const truncatedScheduleSOs = new Set<number>();
 
     for (let ndx = 0; ndx < params.length; ndx++) {
       const param = params[ndx];
@@ -278,9 +280,20 @@ export class BackfillClient {
           rulesWithUnsupportedActions.add(ndx);
         }
 
+        const { adHocRunSO, truncated } = transformBackfillParamToAdHocRun(
+          param,
+          rule,
+          actions,
+          spaceId
+        );
+
+        if (truncated) {
+          truncatedScheduleSOs.add(ndx);
+        }
+
         adHocSOsToCreate.push({
           type: AD_HOC_RUN_SAVED_OBJECT_TYPE,
-          attributes: transformBackfillParamToAdHocRun(param, rule, actions, spaceId),
+          attributes: adHocRunSO,
           references: [reference, ...references],
         });
       } else if (error) {
@@ -300,8 +313,9 @@ export class BackfillClient {
       );
     }
 
-    // Bulk create the saved objects in chunks of 10 to manage resource usage
-    const chunkSize = 10;
+    // Bulk create the saved objects in small chunks; each SO is capped at ~10k schedule
+    // entries by calculateSchedule, so a chunk of 3 stays well within memory limits.
+    const chunkSize = 3;
 
     const chunks: Array<{
       startIndex: number;
@@ -322,7 +336,7 @@ export class BackfillClient {
       adHocSOsToCreate.length
     );
 
-    const chunkConcurrency = 10;
+    const chunkConcurrency = 2;
     await pMap(
       chunks,
       async ({ startIndex, items }, idx) => {
@@ -340,6 +354,7 @@ export class BackfillClient {
             })`
           );
         } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
           items.forEach((item, i) => {
             const ruleId = item.references?.[0]?.id;
             if (!ruleId) {
@@ -348,13 +363,13 @@ export class BackfillClient {
             orderedResults[startIndex + i] = {
               ruleId,
               ruleName: item.attributes.rule.name,
-              bulkCreateError: new Error(error.message),
+              bulkCreateError: new Error(errorMessage),
             };
-            this.logger.warn(`Error to schedule backfill for ruleId ${ruleId} - ${error.message}`);
+            this.logger.warn(`Error to schedule backfill for ruleId ${ruleId} - ${errorMessage}`);
             auditLogger?.log(
               adHocRunAuditEvent({
                 action: AdHocRunAuditAction.CREATE,
-                error: new Error(error.message),
+                error: new Error(errorMessage),
               })
             );
           });
@@ -425,13 +440,17 @@ export class BackfillClient {
       if (isNumber(indexOrError)) {
         // This number is the index of the response from the savedObjects bulkCreate function
         const response = transformedResponse[indexOrError];
-        if (rulesWithUnsupportedActions.has(indexOrError)) {
-          return {
-            ...response,
-            warnings: [
-              `Rule has actions that are not supported for backfill. Those actions will be skipped.`,
-            ],
-          };
+        const warnings: string[] = [];
+        if (rulesWithUnsupportedActions.has(ndx)) {
+          warnings.push(
+            'Rule has actions that are not supported for backfill. Those actions will be skipped.'
+          );
+        }
+        if (truncatedScheduleSOs.has(ndx)) {
+          warnings.push(SCHEDULE_TRUNCATED_WARNING);
+        }
+        if (warnings.length) {
+          return { ...response, warnings };
         }
         return response;
       } else {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/task/gap_auto_fill_scheduler_task.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/task/gap_auto_fill_scheduler_task.test.ts
@@ -500,6 +500,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
             { ruleId: 'rule-1', processedGaps: 1, status: GapFillSchedulePerRuleStatus.SUCCESS },
             { ruleId: 'rule-2', processedGaps: 1, status: GapFillSchedulePerRuleStatus.SUCCESS },
           ],
+          truncatedRuleIds: [],
         });
 
         const result = await taskRunner.run();
@@ -612,6 +613,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
                   status: gapsStatus[1],
                 },
               ],
+              truncatedRuleIds: [],
             });
           }
 
@@ -726,6 +728,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
             results: [
               { ruleId: 'rule-1', processedGaps: 1, status: GapFillSchedulePerRuleStatus.SUCCESS },
             ],
+            truncatedRuleIds: [],
           });
 
           const result = await taskRunner.run();
@@ -777,6 +780,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
               error: 'Failed to schedule',
             },
           ],
+          truncatedRuleIds: [],
         });
 
         const result = await taskRunner.run();
@@ -829,6 +833,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
                 status: GapFillSchedulePerRuleStatus.SUCCESS,
               },
             ],
+            truncatedRuleIds: [],
           });
 
           const result = await taskRunner.run();
@@ -882,6 +887,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
             results: [
               { ruleId: 'rule-1', processedGaps: 1, status: GapFillSchedulePerRuleStatus.SUCCESS },
             ],
+            truncatedRuleIds: [],
           });
 
           const result = await taskRunner.run();
@@ -1059,6 +1065,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
               status: GapFillSchedulePerRuleStatus.SUCCESS,
             },
           ],
+          truncatedRuleIds: [],
         })
         .mockResolvedValueOnce({
           processedGapsCount: 1,
@@ -1070,6 +1077,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
               status: GapFillSchedulePerRuleStatus.SUCCESS,
             },
           ],
+          truncatedRuleIds: [],
         });
 
       const result = await processRuleBatches({
@@ -1152,6 +1160,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
             status: GapFillSchedulePerRuleStatus.SUCCESS,
           },
         ],
+        truncatedRuleIds: [],
       });
 
       const result = await processRuleBatches({
@@ -1275,6 +1284,7 @@ describe('Gap Auto Fill Scheduler Task', () => {
             status: GapFillSchedulePerRuleStatus.SUCCESS,
           },
         ],
+        truncatedRuleIds: [],
       });
 
       const result = await processGapsForRules({

--- a/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/task/gap_auto_fill_scheduler_task.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps/task/gap_auto_fill_scheduler_task.ts
@@ -248,14 +248,24 @@ export async function processGapsForRules({
     if (filteredGaps.length) {
       const sortedGaps = filteredGaps.sort((a, b) => a.range.gte.getTime() - b.range.gte.getTime());
 
-      const { results: chunkResults } = await processGapsBatch(rulesClientContext, {
-        gapsBatch: sortedGaps,
-        range: { start: startISO, end: endISO },
-        initiator: backfillInitiator.SYSTEM,
-        initiatorId: taskInstanceId,
-      });
+      const { results: chunkResults, truncatedRuleIds } = await processGapsBatch(
+        rulesClientContext,
+        {
+          gapsBatch: sortedGaps,
+          range: { start: startISO, end: endISO },
+          initiator: backfillInitiator.SYSTEM,
+          initiatorId: taskInstanceId,
+        }
+      );
 
       aggregated = addChunkResultsToAggregation(aggregated, chunkResults);
+
+      if (truncatedRuleIds.length > 0) {
+        toProcessRuleIds = toProcessRuleIds.filter((id) => !truncatedRuleIds.includes(id));
+        if (toProcessRuleIds.length === 0) {
+          break;
+        }
+      }
 
       const chunkScheduledCount = chunkResults.reduce(
         (count, result) =>

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/model_versions/rule_model_versions.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/model_versions/rule_model_versions.ts
@@ -15,6 +15,7 @@ import {
   rawRuleSchemaV6,
   rawRuleSchemaV7,
   rawRuleSchemaV8,
+  rawRuleSchemaV9,
 } from '../schemas/raw_rule';
 
 export const ruleModelVersions: SavedObjectsModelVersionMap = {
@@ -102,6 +103,13 @@ export const ruleModelVersions: SavedObjectsModelVersionMap = {
     schemas: {
       forwardCompatibility: rawRuleSchemaV8.extends({}, { unknowns: 'ignore' }),
       create: rawRuleSchemaV8,
+    },
+  },
+  '9': {
+    changes: [],
+    schemas: {
+      forwardCompatibility: rawRuleSchemaV9.extends({}, { unknowns: 'ignore' }),
+      create: rawRuleSchemaV9,
     },
   },
 };

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/schemas/raw_rule/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/schemas/raw_rule/index.ts
@@ -15,3 +15,4 @@ export { rawRuleSchema as rawRuleSchemaV5 } from './v5';
 export { rawRuleSchema as rawRuleSchemaV6 } from './v6';
 export { rawRuleSchema as rawRuleSchemaV7 } from './v7';
 export { rawRuleSchema as rawRuleSchemaV8 } from './v8';
+export { rawRuleSchema as rawRuleSchemaV9 } from './v9';

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/schemas/raw_rule/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/schemas/raw_rule/latest.ts
@@ -14,7 +14,7 @@ import type {
 } from './v3';
 
 import type { rawRuleMonitoringSchema } from './v4';
-import type { rawRuleSchema } from './v8';
+import type { rawRuleSchema } from './v9';
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] extends object ? Mutable<T[P]> : T[P] };
 

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/schemas/raw_rule/v9.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/schemas/raw_rule/v9.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { rawRuleSchema as rawRuleSchemaV8 } from './v8';
+
+export const rawRuleSchema = rawRuleSchemaV8.extends({
+  lastEnabledAt: schema.maybe(schema.string()),
+});


### PR DESCRIPTION
## Summary

Adds a new optional `lastEnabledAt` field to the rule SO. This is the **intermediate release** for serverless , the schema is registered but no values are written yet.

The field will be used internally by the detection engine to know when a rule was last enabled, in order to detect gap reason.  issue - https://github.com/elastic/security-team/issues/15992



### Changes

- New raw rule schema `v9` extending `v8` with `lastEnabledAt: schema.maybe(schema.string())`
- New model version `9` with forward compatibility schema (no mappings, no migrations)
