### PR TITLE
Fix sync badge helper can throw when agentName is undefined

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/helper.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/helper.test.ts
@@ -157,5 +157,9 @@ describe('getAgentSyncValue', () => {
     it('returns undefined for base otlp without language', () => {
       expect(getAgentSyncValue('otlp')).toBeUndefined();
     });
+
+    it('returns undefined for undefined agentName', () => {
+      expect(getAgentSyncValue(undefined)).toBeUndefined();
+    });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/helper.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/helper.ts
@@ -54,7 +54,11 @@ export const agentsSyncMap = new Map<SyncBadgeAgentName, boolean>([
  * @param agentName - The agent name (e.g., 'nodejs', 'opentelemetry/java', 'otlp/python/elastic')
  * @returns true for sync agents, false for async agents, undefined if unknown
  */
-export function getAgentSyncValue(agentName: AgentName): boolean | undefined {
+export function getAgentSyncValue(agentName?: AgentName): boolean | undefined {
+  if (!agentName) {
+    return undefined;
+  }
+
   if (isSyncBadgeAgentName(agentName)) {
     return agentsSyncMap.get(agentName);
   }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/254203

## Summary

- Add an explicit option for have agentName undefined in the options to not crash the page
- Added unit tests for this case


### Unit tests

`yarn test:jest x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/helper.test.ts`


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios