### PR TITLE
[Index Management] Improve date_range_datatype test

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/__jest__/client_integration/datatypes/date_range_datatype.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/__jest__/client_integration/datatypes/date_range_datatype.test.tsx
@@ -24,9 +24,8 @@ interface Mappings {
   properties: Record<string, Record<string, unknown>>;
 }
 
-// FLAKY: https://github.com/elastic/kibana/issues/253541
-describe.skip('Mappings editor: date range datatype', () => {
-  test('should require a scaling factor to be provided', async () => {
+describe('Mappings editor: date range datatype', () => {
+  test('should append custom format to default formats', async () => {
     const defaultMappings: Mappings = {
       properties: {
         myField: {
@@ -62,7 +61,8 @@ describe.skip('Mappings editor: date range datatype', () => {
     // The label is "Date range" (from TYPE_DEFINITION)
     const fieldSubTypeComboBox = new EuiComboBoxTestHarness('fieldSubType');
     await fieldSubTypeComboBox.select('Date range');
-    await fieldSubTypeComboBox.close();
+    // This is a single-selection combobox, avoid toggle-clicking while it's auto-closing.
+    await fieldSubTypeComboBox.waitForClosed();
 
     const formatParameter = await within(flyout).findByTestId('formatParameter');
     expect(formatParameter).toBeInTheDocument();
@@ -71,23 +71,28 @@ describe.skip('Mappings editor: date range datatype', () => {
     expect(within(flyout).queryByTestId('formatInput')).not.toBeInTheDocument();
 
     // Enable the format parameter toggle
-    const formatToggle = within(formatParameter).getByTestId('formRowToggle');
-    fireEvent.click(formatToggle);
+    fireEvent.click(within(formatParameter).getByTestId('formRowToggle'));
 
     await waitFor(() => {
+      // Re-query to avoid asserting on a stale element after rerenders.
+      const formatToggle = within(formatParameter).getByTestId('formRowToggle');
       expect(formatToggle.getAttribute('aria-checked')).toBe('true');
     });
 
-    await within(flyout).findByTestId('formatParameter');
-
     // Set custom format value using EuiComboBox harness
     const formatComboBox = new EuiComboBoxTestHarness('formatInput');
-    await formatComboBox.select('customDateFormat');
-    await formatComboBox.close();
+    // `select()` spends time looking for an options list, this input is createable/free-form.
+    formatComboBox.addCustomValue('customDateFormat');
+    // This combobox can remain open after Enter, close explicitly for deterministic cleanup.
+    await formatComboBox.close({ timeout: 1000 });
 
     // Save the field and close the flyout
     const updateButton = within(flyout).getByTestId('editFieldUpdateButton');
     fireEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mappingsEditorFieldEdit')).not.toBeInTheDocument();
+    });
 
     await waitFor(() => {
       expect(onChangeHandler).toHaveBeenCalled();


### PR DESCRIPTION
Closes #253541 

## Summary

This PR reduces the runtime of `date_range_datatype.test.tsx` by removing unnecessary slow waits in EUI combobox interactions:

- Switches the custom format entry to the createable/free-form path (`addCustomValue('customDateFormat'))` instead of `select()`, which avoids option-list matching and its built-in waits.
- Uses `waitForClosed()` for the single-selection subtype combobox and an explicit short `close()` for the format combobox to keep portal cleanup deterministic without extra delay.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.