### PR TITLE
[Search] Remove license check from inference endpoints in semantic text field

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -19,12 +19,6 @@ import {
 const mockDispatch = jest.fn();
 const mockNavigateToUrl = jest.fn();
 
-const mockIsAtLeast = jest.fn((level: string) => {
-  // Default: enterprise license, so all levels return true
-  // Individual tests can override this mock implementation
-  return true;
-});
-
 jest.mock('../../../public/application/app_context', () => ({
   ...jest.requireActual('../../../public/application/app_context'),
   useAppContext: jest.fn(() => ({
@@ -136,13 +130,6 @@ jest.mock('../../../public/application/services/api', () => ({
   useLoadInferenceEndpoints: jest.fn(),
 }));
 
-jest.mock('../../../public/hooks/use_license', () => ({
-  useLicense: jest.fn(() => ({
-    isLoading: false,
-    isAtLeast: mockIsAtLeast,
-  })),
-}));
-
 let user: ReturnType<typeof userEvent.setup>;
 
 let restoreConsoleErrorFilter: () => void;
@@ -152,8 +139,6 @@ beforeEach(() => {
   jest.clearAllMocks();
   user = userEvent.setup();
   restoreConsoleErrorFilter = installConsoleTruncationWarningFilter();
-  // Reset to default: enterprise license (all levels return true)
-  mockIsAtLeast.mockImplementation(() => true);
 });
 
 afterEach(async () => {
@@ -422,20 +407,20 @@ describe('SelectInferenceId', () => {
     });
 
     describe('AND .elser-2-elastic is available', () => {
-      it('SHOULD prioritize .elser-2-elastic over other endpoints IF has enterprise license', async () => {
+      it('SHOULD prioritize .elser-2-elastic over other endpoints', async () => {
         setupInferenceEndpointsMocks({
           data: [
-            {
-              inference_id: '.elser-2-elastic',
-              task_type: 'sparse_embedding',
-              service: 'elastic',
-              service_settings: { model_id: 'elser-2-elastic' },
-            },
             {
               inference_id: '.preconfigured-elser',
               task_type: 'sparse_embedding',
               service: 'elastic',
               service_settings: { model_id: 'elser' },
+            },
+            {
+              inference_id: '.elser-2-elastic',
+              task_type: 'sparse_embedding',
+              service: 'elastic',
+              service_settings: { model_id: 'elser-2-elastic' },
             },
             {
               inference_id: 'endpoint-1',
@@ -450,40 +435,6 @@ describe('SelectInferenceId', () => {
 
         const button = await screen.findByTestId('inferenceIdButton');
         await waitFor(() => expect(button).toHaveTextContent('.elser-2-elastic'));
-      });
-
-      it('SHOULD fall back to .preconfigured-elser instead of .elser-2-elastic IF has NO enterprise license', async () => {
-        // Mock license to return false for enterprise
-        mockIsAtLeast.mockImplementation((level: string) => level !== 'enterprise');
-
-        setupInferenceEndpointsMocks({
-          data: [
-            {
-              inference_id: '.elser-2-elastic',
-              task_type: 'sparse_embedding',
-              service: 'elastic',
-              service_settings: { model_id: 'elser-2-elastic' },
-            },
-            {
-              inference_id: '.preconfigured-elser',
-              task_type: 'sparse_embedding',
-              service: 'elastic',
-              service_settings: { model_id: 'elser' },
-            },
-            {
-              inference_id: 'endpoint-1',
-              task_type: 'text_embedding',
-              service: 'openai',
-              service_settings: { model_id: 'text-embedding-3-large' },
-            },
-          ] as InferenceAPIConfigResponse[],
-        });
-
-        renderSelectInferenceId({ initialValue: '' });
-
-        const button = await screen.findByTestId('inferenceIdButton');
-        await waitFor(() => expect(button).toHaveTextContent('.preconfigured-elser'));
-        expect(button).not.toHaveTextContent('.elser-2-elastic');
       });
     });
   });

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -24,7 +24,6 @@ import {
   EuiLink,
   EuiLoadingSpinner,
   useEuiTheme,
-  EuiBadge,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { InferenceCostsTransparencyTour } from '@kbn/search-api-panels';
@@ -129,25 +128,6 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
           'data-test-subj': `custom-inference_${endpoint.inference_id}`,
           checked: value === endpoint.inference_id ? 'on' : undefined,
           description: endpoint.description,
-          disabled: !endpoint.accessible,
-          append: !endpoint.accessible && endpoint.requiredLicense && (
-            <EuiBadge color="hollow" iconType="lock">
-              {endpoint.requiredLicense[0].toUpperCase() + endpoint.requiredLicense.slice(1)}
-            </EuiBadge>
-          ),
-          'aria-label':
-            !endpoint.accessible && endpoint.requiredLicense
-              ? i18n.translate(
-                  'xpack.idxMgmt.mappingsEditor.parameters.inferenceId.popover.selectable.disabledOption.ariaLabel',
-                  {
-                    defaultMessage: '{inferenceId} endpoint disabled - {license} license required',
-                    values: {
-                      inferenceId: endpoint.inference_id,
-                      license: endpoint.requiredLicense,
-                    },
-                  }
-                )
-              : undefined,
         };
       }) || [];
 

--- a/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
@@ -7,28 +7,15 @@
 
 import { useMemo } from 'react';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
-import type { LicenseType } from '@kbn/licensing-types';
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
-import { useLicense } from './use_license';
 
 const COMPATIBLE_TASK_TYPES = ['text_embedding', 'sparse_embedding'] as const;
 type CompatibleTaskType = (typeof COMPATIBLE_TASK_TYPES)[number];
 
-const LICENSE_TIER_ENTERPRISE = 'enterprise';
-const LICENSE_TIER_PLATINUM = 'platinum';
-const INFERENCE_ENDPOINT_LICENSE_MAP: Record<string, LicenseType> = {
-  [defaultInferenceEndpoints.ELSER]: LICENSE_TIER_PLATINUM,
-  [defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID]: LICENSE_TIER_ENTERPRISE,
-};
-
 interface EndpointDefinition {
   /** The inference id of the endpoint. */
   inference_id: string;
-  /** The license requirement for the endpoint. */
-  requiredLicense: string | undefined;
-  /** Whether the endpoint is accessible to the current license. Defaults to true if no license requirement is specified. */
-  accessible: boolean;
   description: string;
 }
 interface CompatibleEndpointsData {
@@ -39,16 +26,14 @@ interface CompatibleEndpointsData {
 /**
  * Transforms the inference endpoints into a format that can be used to build the selectable options for the inference endpoint dropdown.
  *
- * Remains in loading state until the endpoints and license are loaded.
+ * Remains in loading state until the endpoints are loaded.
  */
 export const useCompatibleInferenceEndpoints = (
   endpoints: InferenceAPIConfigResponse[] | null | undefined,
   endpointsLoading: boolean
 ) => {
-  const { isLoading: licenseLoading, isAtLeast } = useLicense();
-
   const compatibleEndpoints = useMemo<CompatibleEndpointsData | undefined>(() => {
-    if (endpointsLoading || licenseLoading) {
+    if (endpointsLoading) {
       return;
     }
     let defaultInferenceId: string | undefined;
@@ -65,23 +50,17 @@ export const useCompatibleInferenceEndpoints = (
 
       const isElserInEis =
         endpoint.inference_id === defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID;
-      const requiredLicense = INFERENCE_ENDPOINT_LICENSE_MAP[endpoint.inference_id];
-      // If no license requirement is specified, assume access is granted.
-      const accessible = requiredLicense ? isAtLeast(requiredLicense) : true;
-      if (accessible) {
-        if (isElserInEis) {
-          // Prioritize elser in eis endpoint as default.
-          defaultInferenceId = endpoint.inference_id;
-        } else if (!defaultInferenceId) {
-          // Otherwise use the first accessible endpoint as default.
-          defaultInferenceId = endpoint.inference_id;
-        }
+
+      if (isElserInEis) {
+        // Prioritize elser in eis endpoint as default.
+        defaultInferenceId = endpoint.inference_id;
+      } else if (!defaultInferenceId) {
+        // Otherwise use the first compatible endpoint as default.
+        defaultInferenceId = endpoint.inference_id;
       }
 
       endpointDefinitions.push({
         inference_id: endpoint.inference_id,
-        requiredLicense,
-        accessible,
         description,
       });
     });
@@ -89,7 +68,7 @@ export const useCompatibleInferenceEndpoints = (
       defaultInferenceId,
       endpointDefinitions,
     };
-  }, [endpointsLoading, licenseLoading, endpoints, isAtLeast]);
+  }, [endpointsLoading, endpoints]);
 
   return {
     compatibleEndpoints,


### PR DESCRIPTION
## Summary

This PR removes the license check and gating from the inference endpoint selector when adding a semantic text field mapping. With the introduction of the new EIS endpoints, this functionality is currently incomplete and cannot be finalised until there is further clarity around the licensing of inference endpoints and semantic text.

### Testing

To test this PR you will need to add a Platinum license to Kibana, and [run EIS locally](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md).

- [ ] Create an index
- [ ] Go to the mapping tab on the index details page for the index you created
- [ ] Click the `Add field` button
- [ ] Select the `Semantic text` field type
- [ ] Click on the inference endpoint select
- [ ] Confirm that the `.elser-2-elastic` inference endpoint is not disabled

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~
