### PR TITLE
[Dashboard Agent] Let the Agent decide panel layout configuration

### DIFF
--- a/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/index.ts
+++ b/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/index.ts
@@ -12,6 +12,7 @@ export {
 } from './constants';
 
 export {
+  panelGridSchema,
   lensAttachmentPanelSchema,
   genericAttachmentPanelSchema,
   attachmentPanelSchema,

--- a/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
+++ b/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
@@ -37,7 +37,7 @@ export const lensAttachmentPanelSchema = z.object({
   query: z.string().optional(),
   /** ES|QL query used (if applicable) */
   esql: z.string().optional(),
-  /** Optional layout: width and height in grid units. When set, the renderer uses this instead of fixed defaults. */
+  /** Layout: width and height in grid units. When set, the renderer uses this instead of fixed defaults. */
   grid: panelGridSchema.optional(),
 });
 
@@ -60,7 +60,7 @@ export const genericAttachmentPanelSchema = z.object({
   rawConfig: z.record(z.unknown()),
   /** Panel title if available */
   title: z.string().optional(),
-  /** Optional layout: width and height in grid units. When set, the renderer uses this instead of fixed defaults. */
+  /** Layout: width and height in grid units. When set, the renderer uses this instead of fixed defaults. */
   grid: panelGridSchema.optional(),
 });
 

--- a/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
+++ b/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
@@ -15,7 +15,7 @@ import type {
 } from './constants';
 
 /**
- * Optional grid dimensions (in dashboard grid units) for layout.
+ * Grid dimensions (in dashboard grid units) for layout.
  * Dashboard grid is 48 columns wide; height is in same units.
  */
 export const panelGridSchema = z.object({

--- a/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
+++ b/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
@@ -38,7 +38,7 @@ export const lensAttachmentPanelSchema = z.object({
   /** ES|QL query used (if applicable) */
   esql: z.string().optional(),
   /** Layout: width and height in grid units. When set, the renderer uses this instead of fixed defaults. */
-  grid: panelGridSchema.optional(),
+  grid: panelGridSchema,
 });
 
 /**

--- a/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
+++ b/x-pack/platform/packages/shared/dashboard-agent/dashboard-agent-common/types.ts
@@ -15,6 +15,15 @@ import type {
 } from './constants';
 
 /**
+ * Optional grid dimensions (in dashboard grid units) for layout.
+ * Dashboard grid is 48 columns wide; height is in same units.
+ */
+export const panelGridSchema = z.object({
+  w: z.number().int().min(1).max(48),
+  h: z.number().int().min(1).max(24),
+});
+
+/**
  * Zod schema for Lens panel entries.
  */
 export const lensAttachmentPanelSchema = z.object({
@@ -28,6 +37,8 @@ export const lensAttachmentPanelSchema = z.object({
   query: z.string().optional(),
   /** ES|QL query used (if applicable) */
   esql: z.string().optional(),
+  /** Optional layout: width and height in grid units. When set, the renderer uses this instead of fixed defaults. */
+  grid: panelGridSchema.optional(),
 });
 
 /**
@@ -49,6 +60,8 @@ export const genericAttachmentPanelSchema = z.object({
   rawConfig: z.record(z.unknown()),
   /** Panel title if available */
   title: z.string().optional(),
+  /** Optional layout: width and height in grid units. When set, the renderer uses this instead of fixed defaults. */
+  grid: panelGridSchema.optional(),
 });
 
 /**

--- a/x-pack/platform/plugins/shared/dashboard_agent/moon.yml
+++ b/x-pack/platform/plugins/shared/dashboard_agent/moon.yml
@@ -34,7 +34,6 @@ dependsOn:
   - '@kbn/dashboard-markdown'
   - '@kbn/management-settings-ids'
   - '@kbn/lens-plugin'
-  - '@kbn/css-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/dashboard_agent/moon.yml
+++ b/x-pack/platform/plugins/shared/dashboard_agent/moon.yml
@@ -34,6 +34,7 @@ dependsOn:
   - '@kbn/dashboard-markdown'
   - '@kbn/management-settings-ids'
   - '@kbn/lens-plugin'
+  - '@kbn/css-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
@@ -6,259 +6,19 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
-import type { DashboardAttachmentData, AttachmentPanel } from '@kbn/dashboard-agent-common';
-import { isGenericAttachmentPanel, isLensAttachmentPanel } from '@kbn/dashboard-agent-common';
+import type { DashboardAttachmentData } from '@kbn/dashboard-agent-common';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
 import type { DashboardState } from '@kbn/dashboard-plugin/common';
 import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import type { DashboardApi, DashboardCreationOptions } from '@kbn/dashboard-plugin/public';
-import type { DashboardPanel } from '@kbn/dashboard-plugin/server';
-import { MARKDOWN_EMBEDDABLE_TYPE } from '@kbn/dashboard-markdown/public';
 import { i18n } from '@kbn/i18n';
-import {
-  LensConfigBuilder,
-  type LensApiSchemaType,
-  type LensAttributes,
-} from '@kbn/lens-embeddable-utils/config_builder';
-import { isLensLegacyAttributes } from '@kbn/lens-embeddable-utils/config_builder/utils';
-import type { LensSerializedAPIConfig } from '@kbn/lens-common-2';
-import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-plugin/public';
+import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
+import { normalizePanels } from './panel_grid_layout';
 
-const DASHBOARD_GRID_COLUMN_COUNT = 48;
-const DEFAULT_PANEL_HEIGHT = 9;
-const SMALL_PANEL_WIDTH = 12;
-const LARGE_PANEL_WIDTH = 24;
-const MARKDOWN_PANEL_WIDTH = 48;
-const MARKDOWN_MIN_HEIGHT = 6;
-const MARKDOWN_MAX_HEIGHT = 9;
-const SMALL_CHART_TYPES = new Set(['metric', 'legacy_metric', 'gauge']);
-
-export const PANEL_LAYOUT = {
-  defaultPanelHeight: DEFAULT_PANEL_HEIGHT,
-  smallPanelWidth: SMALL_PANEL_WIDTH,
-  largePanelWidth: LARGE_PANEL_WIDTH,
-  markdownPanelWidth: MARKDOWN_PANEL_WIDTH,
-  markdownMinHeight: MARKDOWN_MIN_HEIGHT,
-  markdownMaxHeight: MARKDOWN_MAX_HEIGHT,
-  smallChartTypes: SMALL_CHART_TYPES,
-  dashboardGridColumnCount: DASHBOARD_GRID_COLUMN_COUNT,
-};
-
-export const getLensPanelWidthFromAttributes = (lensAttributes: LensAttributes): number => {
-  const visType = lensAttributes.visualizationType;
-  const isSmallChart =
-    visType === 'lnsMetric' || visType === 'lnsLegacyMetric' || visType === 'lnsGauge';
-  return isSmallChart ? SMALL_PANEL_WIDTH : LARGE_PANEL_WIDTH;
-};
-
-export const getPanelWidth = (chartType: string, layout = PANEL_LAYOUT): number => {
-  return layout.smallChartTypes.has(chartType) ? layout.smallPanelWidth : layout.largePanelWidth;
-};
-
-export const calculateMarkdownPanelHeight = (content: string, layout = PANEL_LAYOUT): number => {
-  const lineCount = content.split('\n').length;
-  const estimatedHeight = lineCount + 2;
-  return Math.max(layout.markdownMinHeight, Math.min(layout.markdownMaxHeight, estimatedHeight));
-};
-
-export const buildLensPanelFromApi = (
-  config: LensApiSchemaType,
-  grid: DashboardPanel['grid'],
-  uid?: string
-): DashboardPanel => {
-  const lensAttributes: LensAttributes = new LensConfigBuilder().fromAPIFormat(config);
-
-  const lensConfig: LensSerializedAPIConfig = {
-    title:
-      lensAttributes.title ??
-      config.title ??
-      i18n.translate('xpack.dashboardAgent.attachments.dashboard.generatedPanelTitle', {
-        defaultMessage: 'Generated panel',
-      }),
-    attributes: lensAttributes,
-  };
-
-  return {
-    type: 'lens',
-    grid,
-    config: lensConfig,
-    uid,
-  };
-};
-
-export const isLensEmbeddableType = (
-  embeddableType: string,
-  rawConfig: unknown
-): rawConfig is LensAttributes => {
-  return embeddableType === LENS_EMBEDDABLE_TYPE && isLensLegacyAttributes(rawConfig);
-};
-
-export interface BuildPanelFromRawConfigOptions {
-  embeddableType: string;
-  rawConfig: Record<string, unknown>;
-  title: string | undefined;
-  position: { currentX: number; currentY: number };
-  layout?: typeof PANEL_LAYOUT;
-  uid?: string;
-  getLensPanelWidth?: (lensAttributes: LensAttributes) => number;
-  /** When set (e.g. from agent-specified layout), use these dimensions instead of layout defaults. */
-  preferredGrid?: { w: number; h: number };
-}
-
-export const buildPanelFromRawConfig = ({
-  layout = PANEL_LAYOUT,
-  embeddableType,
-  rawConfig,
-  title,
-  position,
-  uid,
-  getLensPanelWidth,
-  preferredGrid,
-}: BuildPanelFromRawConfigOptions): DashboardPanel | null => {
-  const { currentX, currentY } = position;
-
-  if (isLensEmbeddableType(embeddableType, rawConfig)) {
-    const lensAttributes = rawConfig;
-    const width =
-      preferredGrid?.w ??
-      (getLensPanelWidth ? getLensPanelWidth(lensAttributes) : layout.largePanelWidth);
-    const height = preferredGrid?.h ?? layout.defaultPanelHeight;
-
-    let x = currentX;
-    let y = currentY;
-    if (x + width > layout.dashboardGridColumnCount) {
-      x = 0;
-      y += layout.defaultPanelHeight;
-    }
-
-    const lensConfig: LensSerializedAPIConfig = {
-      title: title ?? lensAttributes.title ?? 'Panel',
-      attributes: lensAttributes,
-    };
-
-    return {
-      type: 'lens',
-      grid: { x, y, w: width, h: height },
-      config: lensConfig,
-      uid,
-    };
-  }
-
-  if (embeddableType === MARKDOWN_EMBEDDABLE_TYPE) {
-    const content = (rawConfig as { content?: string }).content ?? '';
-    const height = preferredGrid?.h ?? calculateMarkdownPanelHeight(content, layout);
-    const width = preferredGrid?.w ?? layout.markdownPanelWidth;
-
-    let x = currentX;
-    let y = currentY;
-    if (x + width > layout.dashboardGridColumnCount) {
-      x = 0;
-      y += layout.defaultPanelHeight;
-    }
-
-    return {
-      type: MARKDOWN_EMBEDDABLE_TYPE,
-      grid: { x, y, w: width, h: height },
-      config: { content },
-      uid,
-    };
-  }
-
-  const width = preferredGrid?.w ?? layout.largePanelWidth;
-  const panelHeight = preferredGrid?.h ?? layout.defaultPanelHeight;
-  let x = currentX;
-  let y = currentY;
-  if (x + width > layout.dashboardGridColumnCount) {
-    x = 0;
-    y += layout.defaultPanelHeight;
-  }
-
-  return {
-    type: embeddableType,
-    grid: { x, y, w: width, h: panelHeight },
-    config: rawConfig,
-    uid,
-  };
-};
-
-export const normalizePanels = (
-  panels: AttachmentPanel[],
-  yOffset: number = 0,
-  layout: typeof PANEL_LAYOUT = PANEL_LAYOUT,
-  includePanelIdAsUid: boolean = true,
-  getLensPanelWidth: (lensAttributes: LensAttributes) => number = getLensPanelWidthFromAttributes
-): DashboardPanel[] => {
-  const normalizedLayout = layout ?? PANEL_LAYOUT;
-  const panelList = panels ?? [];
-  const dashboardPanels: DashboardPanel[] = [];
-  let currentX = 0;
-  let currentY = yOffset;
-  let rowMaxHeight = 0;
-
-  for (const panel of panelList) {
-    let dashboardPanel: DashboardPanel | null = null;
-
-    if (isLensAttachmentPanel(panel)) {
-      const config = panel.visualization as LensApiSchemaType;
-      const width = panel.grid?.w ?? getPanelWidth(config.type, normalizedLayout);
-      const height = panel.grid?.h ?? normalizedLayout.defaultPanelHeight;
-
-      if (currentX + width > normalizedLayout.dashboardGridColumnCount) {
-        currentX = 0;
-        currentY += rowMaxHeight;
-        rowMaxHeight = 0;
-      }
-      rowMaxHeight = Math.max(rowMaxHeight, height);
-
-      dashboardPanel = buildLensPanelFromApi(
-        config,
-        {
-          x: currentX,
-          y: currentY,
-          w: width,
-          h: height,
-        },
-        includePanelIdAsUid ? panel.panelId : undefined
-      );
-      currentX += width;
-    } else if (isGenericAttachmentPanel(panel)) {
-      dashboardPanel = buildPanelFromRawConfig({
-        embeddableType: panel.type,
-        rawConfig: panel.rawConfig,
-        title: panel.title,
-        position: {
-          currentX,
-          currentY,
-        },
-        layout: normalizedLayout,
-        uid: includePanelIdAsUid ? panel.panelId : undefined,
-        getLensPanelWidth,
-        preferredGrid: panel.grid,
-      });
-
-      if (dashboardPanel) {
-        currentX += dashboardPanel.grid.w;
-        rowMaxHeight = Math.max(rowMaxHeight, dashboardPanel.grid.h);
-        if (currentX >= normalizedLayout.dashboardGridColumnCount) {
-          currentX = 0;
-          currentY += rowMaxHeight;
-          rowMaxHeight = 0;
-        }
-      }
-    }
-
-    if (dashboardPanel) {
-      dashboardPanels.push(dashboardPanel);
-    }
-  }
-
-  return dashboardPanels;
-};
-
-export interface DashboardCanvasInitialInput {
+interface DashboardCanvasInitialInput {
   timeRange: {
     from: string;
     to: string;
@@ -269,7 +29,7 @@ export interface DashboardCanvasInitialInput {
   description?: string;
 }
 
-export const createDashboardRendererInitialInput = (
+const createDashboardRendererInitialInput = (
   data: DashboardAttachmentData
 ): DashboardCanvasInitialInput => ({
   timeRange: { from: 'now-24h', to: 'now' },
@@ -279,7 +39,7 @@ export const createDashboardRendererInitialInput = (
   description: data.description,
 });
 
-export const getDashboardRendererCreationOptions = async ({
+const getDashboardRendererCreationOptions = async ({
   savedObjectId,
   initialDashboardInput,
 }: {
@@ -310,11 +70,7 @@ export const saveDashboardFromApi = async (dashboardApi: DashboardApi): Promise<
   await dashboardApi.runInteractiveSave();
 };
 
-const getDashboardCanvasContentStyles = ({
-  euiTheme,
-}: {
-  euiTheme: ReturnType<typeof useEuiTheme>['euiTheme'];
-}) => ({
+const dashboardCanvasContentStyles = {
   root: css({
     display: 'flex',
     flexDirection: 'column',
@@ -327,24 +83,23 @@ const getDashboardCanvasContentStyles = ({
       display: 'none !important',
     },
   }),
-  actions: css({
-    padding: euiTheme.size.m,
-  }),
+  actions: ({ euiTheme }) =>
+    css({
+      padding: euiTheme.size.m,
+    }),
   renderer: css({
     flex: 1,
     minHeight: 0,
     display: 'flex',
   }),
-});
+};
 
 export const DashboardCanvasContent = ({
-  attachment,
+  attachment: { data },
 }: AttachmentRenderProps<DashboardAttachment>) => {
-  const { euiTheme } = useEuiTheme();
-  const data = attachment.data;
   const [dashboardApi, setDashboardApi] = useState<DashboardApi | undefined>();
   const [isSaveInProgress, setIsSaveInProgress] = useState(false);
-  const styles = useMemo(() => getDashboardCanvasContentStyles({ euiTheme }), [euiTheme]);
+  const styles = useMemoCss(dashboardCanvasContentStyles);
 
   const initialDashboardInput = useMemo(() => createDashboardRendererInitialInput(data), [data]);
 

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import type { UseEuiTheme } from '@elastic/eui';
 import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
@@ -83,7 +84,7 @@ const dashboardCanvasContentStyles = {
       display: 'none !important',
     },
   }),
-  actions: ({ euiTheme }) =>
+  actions: ({ euiTheme }: UseEuiTheme) =>
     css({
       padding: euiTheme.size.m,
     }),

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
@@ -123,7 +123,8 @@ export const buildPanelFromRawConfig = ({
   if (isLensEmbeddableType(embeddableType, rawConfig)) {
     const lensAttributes = rawConfig;
     const width =
-      preferredGrid?.w ?? (getLensPanelWidth ? getLensPanelWidth(lensAttributes) : layout.largePanelWidth);
+      preferredGrid?.w ??
+      (getLensPanelWidth ? getLensPanelWidth(lensAttributes) : layout.largePanelWidth);
     const height = preferredGrid?.h ?? layout.defaultPanelHeight;
 
     let x = currentX;

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
@@ -104,6 +104,8 @@ export interface BuildPanelFromRawConfigOptions {
   layout?: typeof PANEL_LAYOUT;
   uid?: string;
   getLensPanelWidth?: (lensAttributes: LensAttributes) => number;
+  /** When set (e.g. from agent-specified layout), use these dimensions instead of layout defaults. */
+  preferredGrid?: { w: number; h: number };
 }
 
 export const buildPanelFromRawConfig = ({
@@ -114,12 +116,15 @@ export const buildPanelFromRawConfig = ({
   position,
   uid,
   getLensPanelWidth,
+  preferredGrid,
 }: BuildPanelFromRawConfigOptions): DashboardPanel | null => {
   const { currentX, currentY } = position;
 
   if (isLensEmbeddableType(embeddableType, rawConfig)) {
     const lensAttributes = rawConfig;
-    const width = getLensPanelWidth ? getLensPanelWidth(lensAttributes) : layout.largePanelWidth;
+    const width =
+      preferredGrid?.w ?? (getLensPanelWidth ? getLensPanelWidth(lensAttributes) : layout.largePanelWidth);
+    const height = preferredGrid?.h ?? layout.defaultPanelHeight;
 
     let x = currentX;
     let y = currentY;
@@ -135,7 +140,7 @@ export const buildPanelFromRawConfig = ({
 
     return {
       type: 'lens',
-      grid: { x, y, w: width, h: layout.defaultPanelHeight },
+      grid: { x, y, w: width, h: height },
       config: lensConfig,
       uid,
     };
@@ -143,8 +148,8 @@ export const buildPanelFromRawConfig = ({
 
   if (embeddableType === MARKDOWN_EMBEDDABLE_TYPE) {
     const content = (rawConfig as { content?: string }).content ?? '';
-    const height = calculateMarkdownPanelHeight(content, layout);
-    const width = layout.markdownPanelWidth;
+    const height = preferredGrid?.h ?? calculateMarkdownPanelHeight(content, layout);
+    const width = preferredGrid?.w ?? layout.markdownPanelWidth;
 
     let x = currentX;
     let y = currentY;
@@ -161,7 +166,8 @@ export const buildPanelFromRawConfig = ({
     };
   }
 
-  const width = layout.largePanelWidth;
+  const width = preferredGrid?.w ?? layout.largePanelWidth;
+  const panelHeight = preferredGrid?.h ?? layout.defaultPanelHeight;
   let x = currentX;
   let y = currentY;
   if (x + width > layout.dashboardGridColumnCount) {
@@ -171,7 +177,7 @@ export const buildPanelFromRawConfig = ({
 
   return {
     type: embeddableType,
-    grid: { x, y, w: width, h: layout.defaultPanelHeight },
+    grid: { x, y, w: width, h: panelHeight },
     config: rawConfig,
     uid,
   };
@@ -189,18 +195,22 @@ export const normalizePanels = (
   const dashboardPanels: DashboardPanel[] = [];
   let currentX = 0;
   let currentY = yOffset;
+  let rowMaxHeight = 0;
 
   for (const panel of panelList) {
     let dashboardPanel: DashboardPanel | null = null;
 
     if (isLensAttachmentPanel(panel)) {
       const config = panel.visualization as LensApiSchemaType;
-      const width = getPanelWidth(config.type, normalizedLayout);
+      const width = panel.grid?.w ?? getPanelWidth(config.type, normalizedLayout);
+      const height = panel.grid?.h ?? normalizedLayout.defaultPanelHeight;
 
       if (currentX + width > normalizedLayout.dashboardGridColumnCount) {
         currentX = 0;
-        currentY += normalizedLayout.defaultPanelHeight;
+        currentY += rowMaxHeight;
+        rowMaxHeight = 0;
       }
+      rowMaxHeight = Math.max(rowMaxHeight, height);
 
       dashboardPanel = buildLensPanelFromApi(
         config,
@@ -208,7 +218,7 @@ export const normalizePanels = (
           x: currentX,
           y: currentY,
           w: width,
-          h: normalizedLayout.defaultPanelHeight,
+          h: height,
         },
         includePanelIdAsUid ? panel.panelId : undefined
       );
@@ -225,13 +235,16 @@ export const normalizePanels = (
         layout: normalizedLayout,
         uid: includePanelIdAsUid ? panel.panelId : undefined,
         getLensPanelWidth,
+        preferredGrid: panel.grid,
       });
 
       if (dashboardPanel) {
         currentX += dashboardPanel.grid.w;
+        rowMaxHeight = Math.max(rowMaxHeight, dashboardPanel.grid.h);
         if (currentX >= normalizedLayout.dashboardGridColumnCount) {
           currentX = 0;
-          currentY += normalizedLayout.defaultPanelHeight;
+          currentY += rowMaxHeight;
+          rowMaxHeight = 0;
         }
       }
     }

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/panel_grid_layout.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/panel_grid_layout.ts
@@ -28,7 +28,7 @@ const MARKDOWN_MIN_HEIGHT = 6;
 const MARKDOWN_MAX_HEIGHT = 9;
 const SMALL_CHART_TYPES = new Set(['metric', 'legacy_metric', 'gauge']);
 
-export const PANEL_LAYOUT = {
+const PANEL_LAYOUT = {
   defaultPanelHeight: DEFAULT_PANEL_HEIGHT,
   smallPanelWidth: SMALL_PANEL_WIDTH,
   largePanelWidth: LARGE_PANEL_WIDTH,
@@ -39,28 +39,49 @@ export const PANEL_LAYOUT = {
   dashboardGridColumnCount: DASHBOARD_GRID_COLUMN_COUNT,
 };
 
-export const getLensPanelWidthFromAttributes = (lensAttributes: LensAttributes): number => {
-  const visType = lensAttributes.visualizationType;
-  const isSmallChart =
-    visType === 'lnsMetric' || visType === 'lnsLegacyMetric' || visType === 'lnsGauge';
-  return isSmallChart ? SMALL_PANEL_WIDTH : LARGE_PANEL_WIDTH;
+const calculatePanelHeight = (
+  rawConfig: Record<string, unknown>,
+  embeddableType: string,
+  preferredGrid?: { w: number; h: number }
+): number => {
+  if (preferredGrid?.h) {
+    return preferredGrid.h;
+  }
+  if (embeddableType === MARKDOWN_EMBEDDABLE_TYPE) {
+    const content = (rawConfig as { content?: string }).content ?? '';
+    const lineCount = content.split('\n').length;
+    const estimatedHeight = lineCount + 2;
+    return Math.max(
+      PANEL_LAYOUT.markdownMinHeight,
+      Math.min(PANEL_LAYOUT.markdownMaxHeight, estimatedHeight)
+    );
+  }
+  return PANEL_LAYOUT.defaultPanelHeight;
 };
 
-export const getPanelWidth = (chartType: string, layout = PANEL_LAYOUT): number => {
-  return layout.smallChartTypes.has(chartType) ? layout.smallPanelWidth : layout.largePanelWidth;
-};
-
-export const calculateMarkdownPanelHeight = (content: string, layout = PANEL_LAYOUT): number => {
-  const lineCount = content.split('\n').length;
-  const estimatedHeight = lineCount + 2;
-  return Math.max(layout.markdownMinHeight, Math.min(layout.markdownMaxHeight, estimatedHeight));
+const calculatePanelWidth = (
+  rawConfig: Record<string, unknown>,
+  embeddableType: string,
+  preferredGrid?: { w: number; h: number }
+): number => {
+  if (preferredGrid?.w) {
+    return preferredGrid.w;
+  }
+  if (isLensEmbeddableType(embeddableType, rawConfig)) {
+    return PANEL_LAYOUT.smallChartTypes.has(rawConfig.visualizationType)
+      ? PANEL_LAYOUT.smallPanelWidth
+      : PANEL_LAYOUT.largePanelWidth;
+  }
+  if (embeddableType === MARKDOWN_EMBEDDABLE_TYPE) {
+    return PANEL_LAYOUT.markdownPanelWidth;
+  }
+  return PANEL_LAYOUT.largePanelWidth;
 };
 
 export const buildLensPanelFromApi = (
   config: LensApiSchemaType,
-  grid: DashboardPanel['grid'],
   uid?: string
-): DashboardPanel => {
+): Omit<DashboardPanel, 'grid'> => {
   const lensAttributes: LensAttributes = new LensConfigBuilder().fromAPIFormat(config);
 
   const lensConfig: LensSerializedAPIConfig = {
@@ -75,7 +96,6 @@ export const buildLensPanelFromApi = (
 
   return {
     type: 'lens',
-    grid,
     config: lensConfig,
     uid,
   };
@@ -92,84 +112,23 @@ export interface BuildPanelFromRawConfigOptions {
   embeddableType: string;
   rawConfig: Record<string, unknown>;
   title: string | undefined;
-  position: { currentX: number; currentY: number };
   uid?: string;
-  /** When set (e.g. from agent-specified layout), use these dimensions instead of layout defaults. */
-  preferredGrid?: { w: number; h: number };
 }
 
 export const buildPanelFromRawConfig = ({
   embeddableType,
   rawConfig,
   title,
-  position,
   uid,
-  preferredGrid,
-}: BuildPanelFromRawConfigOptions): DashboardPanel | null => {
-  const { currentX, currentY } = position;
-
-  if (isLensEmbeddableType(embeddableType, rawConfig)) {
-    const lensAttributes = rawConfig;
-    const width =
-      preferredGrid?.w ??
-      (getLensPanelWidthFromAttributes
-        ? getLensPanelWidthFromAttributes(lensAttributes)
-        : PANEL_LAYOUT.largePanelWidth);
-    const height = preferredGrid?.h ?? PANEL_LAYOUT.defaultPanelHeight;
-
-    let x = currentX;
-    let y = currentY;
-    if (x + width > PANEL_LAYOUT.dashboardGridColumnCount) {
-      x = 0;
-      y += PANEL_LAYOUT.defaultPanelHeight;
-    }
-
-    const lensConfig: LensSerializedAPIConfig = {
-      title: title ?? lensAttributes.title ?? 'Panel',
-      attributes: lensAttributes,
-    };
-
-    return {
-      type: 'lens',
-      grid: { x, y, w: width, h: height },
-      config: lensConfig,
-      uid,
-    };
-  }
-
-  if (embeddableType === MARKDOWN_EMBEDDABLE_TYPE) {
-    const content = (rawConfig as { content?: string }).content ?? '';
-    const height = preferredGrid?.h ?? calculateMarkdownPanelHeight(content, PANEL_LAYOUT);
-    const width = preferredGrid?.w ?? PANEL_LAYOUT.markdownPanelWidth;
-
-    let x = currentX;
-    let y = currentY;
-    if (x + width > PANEL_LAYOUT.dashboardGridColumnCount) {
-      x = 0;
-      y += PANEL_LAYOUT.defaultPanelHeight;
-    }
-
-    return {
-      type: MARKDOWN_EMBEDDABLE_TYPE,
-      grid: { x, y, w: width, h: height },
-      config: { content },
-      uid,
-    };
-  }
-
-  const width = preferredGrid?.w ?? PANEL_LAYOUT.largePanelWidth;
-  const panelHeight = preferredGrid?.h ?? PANEL_LAYOUT.defaultPanelHeight;
-  let x = currentX;
-  let y = currentY;
-  if (x + width > PANEL_LAYOUT.dashboardGridColumnCount) {
-    x = 0;
-    y += PANEL_LAYOUT.defaultPanelHeight;
-  }
-
+}: BuildPanelFromRawConfigOptions): Omit<DashboardPanel, 'grid'> => {
   return {
     type: embeddableType,
-    grid: { x, y, w: width, h: panelHeight },
-    config: rawConfig,
+    config: isLensEmbeddableType(embeddableType, rawConfig)
+      ? {
+          title: title ?? rawConfig.title ?? 'Panel',
+          attributes: rawConfig,
+        }
+      : rawConfig,
     uid,
   };
 };
@@ -182,59 +141,36 @@ export const normalizePanels = (panels: AttachmentPanel[]): DashboardPanel[] => 
   let rowMaxHeight = 0;
 
   for (const panel of panelList) {
-    let dashboardPanel: DashboardPanel | null = null;
+    let dashboardPanel: Omit<DashboardPanel, 'grid'> | null = null;
 
     if (isLensAttachmentPanel(panel)) {
       const config = panel.visualization as LensApiSchemaType;
-      const width = panel.grid?.w ?? getPanelWidth(config.type);
-      const height = panel.grid?.h ?? PANEL_LAYOUT.defaultPanelHeight;
+      dashboardPanel = buildLensPanelFromApi(config, panel.panelId);
+    } else if (isGenericAttachmentPanel(panel)) {
+      dashboardPanel = buildPanelFromRawConfig({
+        embeddableType: panel.type,
+        rawConfig: panel.rawConfig,
+        title: panel.title,
+        uid: panel.panelId,
+      });
+    }
+
+    if (dashboardPanel) {
+      const height = calculatePanelHeight(dashboardPanel.config, panel.type, panel.grid);
+      const width = calculatePanelWidth(dashboardPanel.config, panel.type, panel.grid);
 
       if (currentX + width > PANEL_LAYOUT.dashboardGridColumnCount) {
         currentX = 0;
         currentY += rowMaxHeight;
         rowMaxHeight = 0;
       }
-      rowMaxHeight = Math.max(rowMaxHeight, height);
-
-      dashboardPanel = buildLensPanelFromApi(
-        config,
-        {
-          x: currentX,
-          y: currentY,
-          w: width,
-          h: height,
-        },
-        panel.panelId
-      );
-      currentX += width;
-    } else if (isGenericAttachmentPanel(panel)) {
-      dashboardPanel = buildPanelFromRawConfig({
-        embeddableType: panel.type,
-        rawConfig: panel.rawConfig,
-        title: panel.title,
-        position: {
-          currentX,
-          currentY,
-        },
-        uid: panel.panelId,
-        preferredGrid: panel.grid,
+      dashboardPanels.push({
+        ...dashboardPanel,
+        grid: { x: currentX, y: currentY, w: width, h: height },
       });
-
-      if (dashboardPanel) {
-        currentX += dashboardPanel.grid.w;
-        rowMaxHeight = Math.max(rowMaxHeight, dashboardPanel.grid.h);
-        if (currentX >= PANEL_LAYOUT.dashboardGridColumnCount) {
-          currentX = 0;
-          currentY += rowMaxHeight;
-          rowMaxHeight = 0;
-        }
-      }
-    }
-
-    if (dashboardPanel) {
-      dashboardPanels.push(dashboardPanel);
+      rowMaxHeight = Math.max(rowMaxHeight, height);
+      currentX += width;
     }
   }
-
   return dashboardPanels;
 };

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/panel_grid_layout.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/panel_grid_layout.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttachmentPanel } from '@kbn/dashboard-agent-common';
+import { isGenericAttachmentPanel, isLensAttachmentPanel } from '@kbn/dashboard-agent-common';
+import type { DashboardPanel } from '@kbn/dashboard-plugin/server';
+import { MARKDOWN_EMBEDDABLE_TYPE } from '@kbn/dashboard-markdown/public';
+import { i18n } from '@kbn/i18n';
+import {
+  LensConfigBuilder,
+  type LensApiSchemaType,
+  type LensAttributes,
+} from '@kbn/lens-embeddable-utils/config_builder';
+import { isLensLegacyAttributes } from '@kbn/lens-embeddable-utils/config_builder/utils';
+import type { LensSerializedAPIConfig } from '@kbn/lens-common-2';
+import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-plugin/public';
+
+const DASHBOARD_GRID_COLUMN_COUNT = 48;
+const DEFAULT_PANEL_HEIGHT = 9;
+const SMALL_PANEL_WIDTH = 12;
+const LARGE_PANEL_WIDTH = 24;
+const MARKDOWN_PANEL_WIDTH = 48;
+const MARKDOWN_MIN_HEIGHT = 6;
+const MARKDOWN_MAX_HEIGHT = 9;
+const SMALL_CHART_TYPES = new Set(['metric', 'legacy_metric', 'gauge']);
+
+export const PANEL_LAYOUT = {
+  defaultPanelHeight: DEFAULT_PANEL_HEIGHT,
+  smallPanelWidth: SMALL_PANEL_WIDTH,
+  largePanelWidth: LARGE_PANEL_WIDTH,
+  markdownPanelWidth: MARKDOWN_PANEL_WIDTH,
+  markdownMinHeight: MARKDOWN_MIN_HEIGHT,
+  markdownMaxHeight: MARKDOWN_MAX_HEIGHT,
+  smallChartTypes: SMALL_CHART_TYPES,
+  dashboardGridColumnCount: DASHBOARD_GRID_COLUMN_COUNT,
+};
+
+export const getLensPanelWidthFromAttributes = (lensAttributes: LensAttributes): number => {
+  const visType = lensAttributes.visualizationType;
+  const isSmallChart =
+    visType === 'lnsMetric' || visType === 'lnsLegacyMetric' || visType === 'lnsGauge';
+  return isSmallChart ? SMALL_PANEL_WIDTH : LARGE_PANEL_WIDTH;
+};
+
+export const getPanelWidth = (chartType: string, layout = PANEL_LAYOUT): number => {
+  return layout.smallChartTypes.has(chartType) ? layout.smallPanelWidth : layout.largePanelWidth;
+};
+
+export const calculateMarkdownPanelHeight = (content: string, layout = PANEL_LAYOUT): number => {
+  const lineCount = content.split('\n').length;
+  const estimatedHeight = lineCount + 2;
+  return Math.max(layout.markdownMinHeight, Math.min(layout.markdownMaxHeight, estimatedHeight));
+};
+
+export const buildLensPanelFromApi = (
+  config: LensApiSchemaType,
+  grid: DashboardPanel['grid'],
+  uid?: string
+): DashboardPanel => {
+  const lensAttributes: LensAttributes = new LensConfigBuilder().fromAPIFormat(config);
+
+  const lensConfig: LensSerializedAPIConfig = {
+    title:
+      lensAttributes.title ??
+      config.title ??
+      i18n.translate('xpack.dashboardAgent.attachments.dashboard.generatedPanelTitle', {
+        defaultMessage: 'Generated panel',
+      }),
+    attributes: lensAttributes,
+  };
+
+  return {
+    type: 'lens',
+    grid,
+    config: lensConfig,
+    uid,
+  };
+};
+
+export const isLensEmbeddableType = (
+  embeddableType: string,
+  rawConfig: unknown
+): rawConfig is LensAttributes => {
+  return embeddableType === LENS_EMBEDDABLE_TYPE && isLensLegacyAttributes(rawConfig);
+};
+
+export interface BuildPanelFromRawConfigOptions {
+  embeddableType: string;
+  rawConfig: Record<string, unknown>;
+  title: string | undefined;
+  position: { currentX: number; currentY: number };
+  uid?: string;
+  /** When set (e.g. from agent-specified layout), use these dimensions instead of layout defaults. */
+  preferredGrid?: { w: number; h: number };
+}
+
+export const buildPanelFromRawConfig = ({
+  embeddableType,
+  rawConfig,
+  title,
+  position,
+  uid,
+  preferredGrid,
+}: BuildPanelFromRawConfigOptions): DashboardPanel | null => {
+  const { currentX, currentY } = position;
+
+  if (isLensEmbeddableType(embeddableType, rawConfig)) {
+    const lensAttributes = rawConfig;
+    const width =
+      preferredGrid?.w ??
+      (getLensPanelWidthFromAttributes
+        ? getLensPanelWidthFromAttributes(lensAttributes)
+        : PANEL_LAYOUT.largePanelWidth);
+    const height = preferredGrid?.h ?? PANEL_LAYOUT.defaultPanelHeight;
+
+    let x = currentX;
+    let y = currentY;
+    if (x + width > PANEL_LAYOUT.dashboardGridColumnCount) {
+      x = 0;
+      y += PANEL_LAYOUT.defaultPanelHeight;
+    }
+
+    const lensConfig: LensSerializedAPIConfig = {
+      title: title ?? lensAttributes.title ?? 'Panel',
+      attributes: lensAttributes,
+    };
+
+    return {
+      type: 'lens',
+      grid: { x, y, w: width, h: height },
+      config: lensConfig,
+      uid,
+    };
+  }
+
+  if (embeddableType === MARKDOWN_EMBEDDABLE_TYPE) {
+    const content = (rawConfig as { content?: string }).content ?? '';
+    const height = preferredGrid?.h ?? calculateMarkdownPanelHeight(content, PANEL_LAYOUT);
+    const width = preferredGrid?.w ?? PANEL_LAYOUT.markdownPanelWidth;
+
+    let x = currentX;
+    let y = currentY;
+    if (x + width > PANEL_LAYOUT.dashboardGridColumnCount) {
+      x = 0;
+      y += PANEL_LAYOUT.defaultPanelHeight;
+    }
+
+    return {
+      type: MARKDOWN_EMBEDDABLE_TYPE,
+      grid: { x, y, w: width, h: height },
+      config: { content },
+      uid,
+    };
+  }
+
+  const width = preferredGrid?.w ?? PANEL_LAYOUT.largePanelWidth;
+  const panelHeight = preferredGrid?.h ?? PANEL_LAYOUT.defaultPanelHeight;
+  let x = currentX;
+  let y = currentY;
+  if (x + width > PANEL_LAYOUT.dashboardGridColumnCount) {
+    x = 0;
+    y += PANEL_LAYOUT.defaultPanelHeight;
+  }
+
+  return {
+    type: embeddableType,
+    grid: { x, y, w: width, h: panelHeight },
+    config: rawConfig,
+    uid,
+  };
+};
+
+export const normalizePanels = (panels: AttachmentPanel[]): DashboardPanel[] => {
+  const panelList = panels ?? [];
+  const dashboardPanels: DashboardPanel[] = [];
+  let currentX = 0;
+  let currentY = 0;
+  let rowMaxHeight = 0;
+
+  for (const panel of panelList) {
+    let dashboardPanel: DashboardPanel | null = null;
+
+    if (isLensAttachmentPanel(panel)) {
+      const config = panel.visualization as LensApiSchemaType;
+      const width = panel.grid?.w ?? getPanelWidth(config.type);
+      const height = panel.grid?.h ?? PANEL_LAYOUT.defaultPanelHeight;
+
+      if (currentX + width > PANEL_LAYOUT.dashboardGridColumnCount) {
+        currentX = 0;
+        currentY += rowMaxHeight;
+        rowMaxHeight = 0;
+      }
+      rowMaxHeight = Math.max(rowMaxHeight, height);
+
+      dashboardPanel = buildLensPanelFromApi(
+        config,
+        {
+          x: currentX,
+          y: currentY,
+          w: width,
+          h: height,
+        },
+        panel.panelId
+      );
+      currentX += width;
+    } else if (isGenericAttachmentPanel(panel)) {
+      dashboardPanel = buildPanelFromRawConfig({
+        embeddableType: panel.type,
+        rawConfig: panel.rawConfig,
+        title: panel.title,
+        position: {
+          currentX,
+          currentY,
+        },
+        uid: panel.panelId,
+        preferredGrid: panel.grid,
+      });
+
+      if (dashboardPanel) {
+        currentX += dashboardPanel.grid.w;
+        rowMaxHeight = Math.max(rowMaxHeight, dashboardPanel.grid.h);
+        if (currentX >= PANEL_LAYOUT.dashboardGridColumnCount) {
+          currentX = 0;
+          currentY += rowMaxHeight;
+          rowMaxHeight = 0;
+        }
+      }
+    }
+
+    if (dashboardPanel) {
+      dashboardPanels.push(dashboardPanel);
+    }
+  }
+
+  return dashboardPanels;
+};

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
@@ -148,7 +148,7 @@ Each entry in \`add_generated_panels.items[]\` accepts:
     ', '
   )}. Set only when you are confident about the right chart type. See the chart type guide below.
 - \`esql\` (optional): a pre-generated ES|QL query. When provided, the visualization generator uses this directly instead of generating a query from scratch.
-- \`grid\` (optional): \`{ w: number, h: number }\` — panel size in grid units. **You should set this to control layout.** The dashboard grid has 48 columns; \`w\` is width (1–48), \`h\` is height in the same units (typically 4–12). Decide \`grid\` for each panel based on the number and type of panels so the dashboard is balanced (see Panel layout below).
+- \`grid\` (**required**): \`{ w: number, h: number }\` — panel size in grid units. **Always set this to control layout.** The dashboard grid has 48 columns; \`w\` is width (1–48), \`h\` is height in the same units (typically 4–12). Decide \`grid\` for each panel based on the number and type of panels so the dashboard is balanced (see Panel layout below).
 
 **Good queries are specific and reference real field names:**
 
@@ -192,7 +192,7 @@ Base panel selection on the fields actually available in the discovered index ma
 
 ## Panel layout (decide per panel)
 
-**You control layout by setting \`grid\` on each item in \`add_generated_panels.items[]\`.** The dashboard has a 48-column grid; each panel uses \`grid: { w, h }\` (width and height in grid units). If you omit \`grid\`, the renderer falls back to fixed defaults, which may not suit the mix of panels.
+**You control layout by setting \`grid\` on each item in \`add_generated_panels.items[]\`.** The dashboard has a 48-column grid; each panel uses \`grid: { w, h }\` (width and height in grid units). Always set \`grid\` — never omit it.
 
 **Decide the best layout from the number and type of panels:**
 

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
@@ -148,6 +148,7 @@ Each entry in \`add_generated_panels.items[]\` accepts:
     ', '
   )}. Set only when you are confident about the right chart type. See the chart type guide below.
 - \`esql\` (optional): a pre-generated ES|QL query. When provided, the visualization generator uses this directly instead of generating a query from scratch.
+- \`grid\` (optional): \`{ w: number, h: number }\` — panel size in grid units. **You should set this to control layout.** The dashboard grid has 48 columns; \`w\` is width (1–48), \`h\` is height in the same units (typically 4–12). Decide \`grid\` for each panel based on the number and type of panels so the dashboard is balanced (see Panel layout below).
 
 **Good queries are specific and reference real field names:**
 
@@ -188,6 +189,20 @@ When the user's request is vague (e.g., "create a dashboard for my logs"), compo
 - One or two breakdowns (top sources, top error types)
 
 Base panel selection on the fields actually available in the discovered index mapping.
+
+## Panel layout (decide per panel)
+
+**You control layout by setting \`grid\` on each item in \`add_generated_panels.items[]\`.** The dashboard has a 48-column grid; each panel uses \`grid: { w, h }\` (width and height in grid units). If you omit \`grid\`, the renderer falls back to fixed defaults, which may not suit the mix of panels.
+
+**Decide the best layout from the number and type of panels:**
+
+- **Metric / Gauge panels:** Use smaller panels so several fit in one row, e.g. \`grid: { w: 12, h: 5 }\` or \`{ w: 16, h: 6 }\`. For 2–4 KPI-style panels, use equal widths that fill the row (e.g. two panels: \`w: 24\` each; four: \`w: 12\` each).
+- **XY (line/bar/area) and Tagcloud:** Use medium or full width for readability, e.g. \`grid: { w: 24, h: 8 }\` or \`{ w: 48, h: 9 }\`. Prefer wider panels for time series with many series or long time ranges.
+- **Heatmap:** Use a taller panel so the matrix is readable, e.g. \`grid: { w: 24, h: 10 }\` or \`{ w: 48, h: 10 }\`.
+- **Mix of panels:** Place metrics in a compact first row (e.g. 3× \`{ w: 16, h: 5 }\`), then use full-width or half-width for trend and breakdown panels below. Keep row heights consistent within a row when possible (e.g. all \`h: 8\` for a row of XY charts).
+- **Single panel:** Use \`grid: { w: 48, h: 9 }\` or similar so it uses the full width.
+
+**Guidelines:** Prefer \`w\` values that divide 48 evenly (e.g. 12, 16, 24, 48) for a clean grid. Use \`h\` between 4 and 12 for most panels; use larger \`h\` for heatmaps or dense charts.
 
 ## Examples
 
@@ -231,42 +246,50 @@ Base panel selection on the fields actually available in the discovered index ma
            {
              "query": "Show total request count as a metric",
              "index": "logs-nginx.access-default",
-             "chartType": "${SupportedChartType.Metric}"
+             "chartType": "${SupportedChartType.Metric}",
+             "grid": { "w": 24, "h": 5 }
            },
            {
              "query": "Show average system.cpu.total.pct as a metric",
              "index": "metrics-system.cpu-default",
-             "chartType": "${SupportedChartType.Metric}"
+             "chartType": "${SupportedChartType.Metric}",
+             "grid": { "w": 24, "h": 5 }
            },
            {
              "query": "Show request count over time",
              "index": "logs-nginx.access-default",
-             "chartType": "${SupportedChartType.XY}"
+             "chartType": "${SupportedChartType.XY}",
+             "grid": { "w": 48, "h": 8 }
            },
            {
              "query": "Show 95th percentile of http.response.body.bytes over time",
              "index": "logs-nginx.access-default",
-             "chartType": "${SupportedChartType.XY}"
+             "chartType": "${SupportedChartType.XY}",
+             "grid": { "w": 24, "h": 8 }
            },
            {
              "query": "Show top 10 url.path values by request count",
              "index": "logs-nginx.access-default",
-             "chartType": "${SupportedChartType.XY}"
+             "chartType": "${SupportedChartType.XY}",
+             "grid": { "w": 24, "h": 8 }
            },
            {
              "query": "Show top source.ip values by request count",
              "index": "logs-nginx.access-default",
-             "chartType": "${SupportedChartType.XY}"
+             "chartType": "${SupportedChartType.XY}",
+             "grid": { "w": 24, "h": 8 }
            },
            {
              "query": "Show system.cpu.total.pct over time grouped by host.name",
              "index": "metrics-system.cpu-default",
-             "chartType": "${SupportedChartType.XY}"
+             "chartType": "${SupportedChartType.XY}",
+             "grid": { "w": 24, "h": 8 }
            },
            {
              "query": "Show top http.response.status_code values by request count",
              "index": "logs-nginx.access-default",
-             "chartType": "${SupportedChartType.XY}"
+             "chartType": "${SupportedChartType.XY}",
+             "grid": { "w": 24, "h": 8 }
            }
          ]
        }
@@ -383,17 +406,20 @@ See \`./examples/manage-dashboard-payloads\` for complete payload examples cover
         {
           "query": "Show the total number of documents as a single metric",
           "index": "logs-nginx.access-default",
-          "chartType": "metric"
+          "chartType": "metric",
+          "grid": { "w": 24, "h": 5 }
         },
         {
           "query": "Show average system.cpu.total.pct as a single metric",
           "index": "metrics-system.cpu-default",
-          "chartType": "metric"
+          "chartType": "metric",
+          "grid": { "w": 24, "h": 5 }
         },
         {
           "query": "Show document count over time as a line chart",
           "index": "logs-nginx.access-default",
-          "chartType": "xy"
+          "chartType": "xy",
+          "grid": { "w": 48, "h": 8 }
         }
       ]
     }

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.test.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.test.ts
@@ -36,6 +36,7 @@ describe('executeDashboardOperations', () => {
           type: 'lens',
           panelId: 'existing-panel',
           visualization: { type: 'metric' },
+          grid: { w: 12, h: 9 },
         },
       ],
     };
@@ -45,6 +46,7 @@ describe('executeDashboardOperations', () => {
       panelId: 'generated-panel',
       visualization: { type: 'xy' },
       title: 'Generated panel',
+      grid: { w: 24, h: 9 },
     };
 
     const operations: DashboardOperation[] = [
@@ -102,11 +104,13 @@ describe('executeDashboardOperations', () => {
       type: 'lens',
       panelId: 'generated-1',
       visualization: { type: 'xy' },
+      grid: { w: 24, h: 9 },
     };
     const attachmentPanel: AttachmentPanel = {
       type: 'lens',
       panelId: 'from-attachment',
       visualization: { type: 'metric' },
+      grid: { w: 12, h: 9 },
     };
 
     const result = await executeDashboardOperations({
@@ -196,6 +200,7 @@ describe('executeDashboardOperations', () => {
             type: 'lens',
             panelId: 'generated-panel-1',
             visualization: { type: 'metric' },
+            grid: { w: 12, h: 9 },
           },
         ],
         failures: [],

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.test.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.test.ts
@@ -52,7 +52,7 @@ describe('executeDashboardOperations', () => {
       { operation: 'remove_panels', panelIds: ['existing-panel'] },
       {
         operation: 'add_generated_panels',
-        items: [{ query: 'Show request count over time' }],
+        items: [{ query: 'Show request count over time', grid: { w: 48, h: 8 } }],
       },
       {
         operation: 'upsert_markdown',
@@ -118,7 +118,10 @@ describe('executeDashboardOperations', () => {
       operations: [
         {
           operation: 'add_generated_panels',
-          items: [{ query: 'Show traffic over time' }, { query: 'Show error rate over time' }],
+          items: [
+            { query: 'Show traffic over time', grid: { w: 48, h: 8 } },
+            { query: 'Show error rate over time', grid: { w: 24, h: 8 } },
+          ],
         },
         {
           operation: 'add_panels_from_attachments',
@@ -183,7 +186,7 @@ describe('executeDashboardOperations', () => {
       operations: [
         {
           operation: 'add_generated_panels',
-          items: [{ query: 'Show count as metric' }],
+          items: [{ query: 'Show count as metric', grid: { w: 24, h: 5 } }],
         },
       ],
       logger,

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.ts
@@ -29,11 +29,9 @@ export const visualizationQueryInputSchema = z.object({
     .optional()
     .describe('(optional) The type of chart to create.'),
   esql: z.string().optional().describe('(optional) An ES|QL query to use for the visualization.'),
-  grid: panelGridInputSchema
-    .optional()
-    .describe(
-      '(optional) Panel size in grid units. Choose based on number and type of panels for a balanced layout.'
-    ),
+  grid: panelGridInputSchema.describe(
+    'Panel size in grid units. Required — always set based on the number and type of panels for a balanced layout.'
+  ),
 }) satisfies z.ZodType<VisualizationQueryInput>;
 
 export const setMetadataOperationSchema = z.object({

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/operations.ts
@@ -16,6 +16,11 @@ import type { Logger } from '@kbn/core/server';
 import { getRemovedPanels, upsertMarkdownPanel, type VisualizationFailure } from './utils';
 import type { VisualizationQueryInput } from './visualization_generation';
 
+const panelGridInputSchema = z.object({
+  w: z.number().int().min(1).max(48).describe('Width in grid units (dashboard has 48 columns).'),
+  h: z.number().int().min(1).max(24).describe('Height in grid units.'),
+});
+
 export const visualizationQueryInputSchema = z.object({
   query: z.string().describe('A natural language query describing the desired visualization.'),
   index: z.string().optional().describe('(optional) Index, alias, or datastream to target.'),
@@ -24,6 +29,11 @@ export const visualizationQueryInputSchema = z.object({
     .optional()
     .describe('(optional) The type of chart to create.'),
   esql: z.string().optional().describe('(optional) An ES|QL query to use for the visualization.'),
+  grid: panelGridInputSchema
+    .optional()
+    .describe(
+      '(optional) Panel size in grid units. Choose based on number and type of panels for a balanced layout.'
+    ),
 }) satisfies z.ZodType<VisualizationQueryInput>;
 
 export const setMetadataOperationSchema = z.object({

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/utils.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/utils.ts
@@ -12,6 +12,7 @@ import type { AttachmentPanel, DashboardAttachmentData } from '@kbn/dashboard-ag
 import {
   DASHBOARD_ATTACHMENT_TYPE,
   isGenericAttachmentPanel,
+  panelGridSchema,
   type GenericAttachmentPanel,
   type LensAttachmentPanel,
 } from '@kbn/dashboard-agent-common';
@@ -40,6 +41,7 @@ export const getErrorMessage = (error: unknown): string => {
 const visualizationAttachmentDataSchema = z.object({
   visualization: z.record(z.unknown()),
   query: z.string().optional(),
+  grid: panelGridSchema,
 });
 
 const resolvePanelsFromVisualizationAttachment = (data: unknown): LensAttachmentPanel[] => {
@@ -48,7 +50,7 @@ const resolvePanelsFromVisualizationAttachment = (data: unknown): LensAttachment
     throw new Error('Visualization attachment does not contain a valid visualization payload.');
   }
 
-  const { visualization, query } = parseResult.data;
+  const { visualization, query, grid } = parseResult.data;
   const title =
     typeof visualization.title === 'string'
       ? visualization.title
@@ -60,6 +62,7 @@ const resolvePanelsFromVisualizationAttachment = (data: unknown): LensAttachment
       panelId: uuidv4(),
       visualization: visualization as LensApiSchemaType,
       title,
+      grid,
       ...(query ? { query } : {}),
     },
   ];

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/visualization_generation.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/visualization_generation.ts
@@ -18,8 +18,8 @@ export interface VisualizationQueryInput {
   index?: string;
   chartType?: SupportedChartType;
   esql?: string;
-  /** Optional panel size in grid units (w, h). When set, stored on the panel for the renderer to use. */
-  grid?: { w: number; h: number };
+  /** Panel size in grid units (w, h). Always set by the agent to control layout. */
+  grid: { w: number; h: number };
 }
 
 export const buildVisualizationsFromQueriesWithLLM = async ({
@@ -71,7 +71,7 @@ export const buildVisualizationsFromQueriesWithLLM = async ({
         title: validatedConfig.title ?? nlQuery.slice(0, 50),
         query: nlQuery,
         esql: esqlQuery,
-        ...(grid ? { grid } : {}),
+        grid,
       };
 
       panels.push(panelEntry);

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/visualization_generation.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/visualization_generation.ts
@@ -18,6 +18,8 @@ export interface VisualizationQueryInput {
   index?: string;
   chartType?: SupportedChartType;
   esql?: string;
+  /** Optional panel size in grid units (w, h). When set, stored on the panel for the renderer to use. */
+  grid?: { w: number; h: number };
 }
 
 export const buildVisualizationsFromQueriesWithLLM = async ({
@@ -46,7 +48,7 @@ export const buildVisualizationsFromQueriesWithLLM = async ({
   const failures: VisualizationFailure[] = [];
 
   for (let i = 0; i < queries.length; i++) {
-    const { query: nlQuery, index, chartType, esql } = queries[i];
+    const { query: nlQuery, index, chartType, esql, grid } = queries[i];
 
     events.reportProgress(`Creating visualization ${i + 1} of ${queries.length}: "${nlQuery}"`);
 
@@ -69,6 +71,7 @@ export const buildVisualizationsFromQueriesWithLLM = async ({
         title: validatedConfig.title ?? nlQuery.slice(0, 50),
         query: nlQuery,
         esql: esqlQuery,
+        ...(grid ? { grid } : {}),
       };
 
       panels.push(panelEntry);

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/utils.test.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/utils.test.ts
@@ -60,6 +60,7 @@ describe('resolvePanelsFromAttachments', () => {
           visualization: { type: 'metric', title: 'Request count' },
           chart_type: 'metric',
           esql: 'FROM logs-* | STATS count(*)',
+          grid: { w: 12, h: 9 },
         },
       }),
     });
@@ -128,6 +129,7 @@ describe('upsertMarkdownPanel', () => {
         type: 'lens',
         panelId: 'panel-1',
         visualization: { type: 'Metric' },
+        grid: { w: 12, h: 9 },
       },
     ];
 
@@ -152,6 +154,7 @@ describe('upsertMarkdownPanel', () => {
         type: 'lens',
         panelId: 'panel-1',
         visualization: { type: 'Metric' },
+        grid: { w: 12, h: 9 },
       },
     ];
 
@@ -191,6 +194,7 @@ describe('upsertMarkdownPanel', () => {
         type: 'lens',
         panelId: 'panel-1',
         visualization: { type: 'Metric' },
+        grid: { w: 12, h: 9 },
       },
     ];
 

--- a/x-pack/platform/plugins/shared/dashboard_agent/tsconfig.json
+++ b/x-pack/platform/plugins/shared/dashboard_agent/tsconfig.json
@@ -20,8 +20,7 @@
     "@kbn/agent-builder-genai-utils",
     "@kbn/dashboard-markdown",
     "@kbn/management-settings-ids",
-    "@kbn/lens-plugin",
-    "@kbn/css-utils"
+    "@kbn/lens-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/dashboard_agent/tsconfig.json
+++ b/x-pack/platform/plugins/shared/dashboard_agent/tsconfig.json
@@ -20,7 +20,8 @@
     "@kbn/agent-builder-genai-utils",
     "@kbn/dashboard-markdown",
     "@kbn/management-settings-ids",
-    "@kbn/lens-plugin"
+    "@kbn/lens-plugin",
+    "@kbn/css-utils"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
This change improves the flexibility and usability of dashboard layouts, allowing the Agent to customize and organize the panels itself.

- Added optional `grid` property to `add_generated_panels.items[]` for specifying panel size in grid units (width and height).
- Updated `buildPanelFromRawConfig` to utilize `preferredGrid` for dynamic panel dimensions.
- Introduced validation for grid dimensions in `visualizationQueryInputSchema`.
- Enhanced documentation to guide users on optimal panel layout strategies based on panel types.
- Ensured backward compatibility by maintaining default layout behavior when `grid` is not specified.


## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





