### PR TITLE
[Agent Builder] Attachments - small fixes

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -29,6 +29,16 @@ export interface AttachmentRenderProps<TAttachment extends UnknownAttachment = U
 }
 
 /**
+ * Callbacks available to canvas content renderers.
+ */
+export interface CanvasRenderCallbacks {
+  /** Register action buttons to display in the canvas header */
+  registerActionButtons: (buttons: ActionButton[]) => void;
+  /** Update the attachment's origin reference (e.g., after saving to library) */
+  updateOrigin: (origin: unknown) => Promise<UpdateOriginResponse | undefined>;
+}
+
+/**
  * Parameters passed when requesting action buttons for an inline-rendered attachment.
  */
 export interface GetActionButtonsParams<TAttachment extends UnknownAttachment = UnknownAttachment> {
@@ -85,13 +95,13 @@ export interface AttachmentUIDefinition<TAttachment extends UnknownAttachment = 
    * Optional custom content renderer for canvas mode (expanded flyout view).
    * When provided, attachments can be opened in an expanded view via action buttons.
    *
-   * The optional `registerActionButtons` callback allows the rendered content to
-   * dynamically register action buttons that appear in the canvas header. This is
-   * useful when buttons depend on state only available at runtime.
+   * The `callbacks` object provides:
+   * - `registerActionButtons`: dynamically register action buttons in the canvas header
+   * - `updateOrigin`: link by-value attachments to persistent storage after saving
    */
   renderCanvasContent?: (
     props: AttachmentRenderProps<TAttachment>,
-    registerActionButtons: (buttons: ActionButton[]) => void
+    callbacks: CanvasRenderCallbacks
   ) => ReactNode;
   /**
    * Optional function to provide action buttons for inline-rendered attachments.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/index.ts
@@ -9,6 +9,7 @@ export type {
   AttachmentUIDefinition,
   AttachmentServiceStartContract,
   AttachmentRenderProps,
+  CanvasRenderCallbacks,
   GetActionButtonsParams,
   ActionButton,
 } from './contract';

--- a/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
+++ b/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
@@ -506,6 +506,71 @@ export const myAttachmentDefinition: AttachmentUIDefinition<MyAttachment> = {
 };
 ```
 
+#### Linking by-value attachments to persistent storage with updateOrigin
+
+The `getActionButtons` params include an `updateOrigin` callback that allows you to link a by-value attachment to its persistent storage location (e.g., a saved object) after it has been saved.
+
+**When to use `updateOrigin`:**
+
+- When your attachment type supports a "Save" workflow where the user can persist a by-value attachment to external storage (e.g., saving a visualization to the library, saving a dashboard)
+- After successfully saving the attachment to persistent storage, call `updateOrigin` to record the reference back to the attachment
+
+**Why this matters:**
+
+- Enables "Open in [App]" functionality by storing the saved object reference
+- Allows the UI to show that an attachment is linked to a persistent resource
+- Maintains the connection between the conversation attachment and its source
+
+**Example: Save button that links to a saved object**
+
+```tsx
+getActionButtons: ({ attachment, updateOrigin, isCanvas }) => {
+  const buttons = [];
+
+  // Only show save button if not already linked to a saved object
+  if (!attachment.origin && isCanvas) {
+    buttons.push({
+      label: 'Save to library',
+      icon: 'save',
+      type: ActionButtonType.PRIMARY,
+      handler: async () => {
+        // 1. Save to your persistent storage (e.g., saved objects)
+        const savedObjectId = await myApi.saveToLibrary(attachment.data);
+
+        // 2. Link the attachment to the saved object
+        await updateOrigin({ saved_object_id: savedObjectId });
+      },
+    });
+  }
+
+  // Show "Open in App" if already linked
+  if (attachment.origin?.saved_object_id) {
+    buttons.push({
+      label: 'Open in App',
+      icon: 'popout',
+      type: ActionButtonType.SECONDARY,
+      handler: () => {
+        window.open(`/app/myApp/${attachment.origin.saved_object_id}`, '_blank');
+      },
+    });
+  }
+
+  return buttons;
+},
+```
+
+**Origin shape:**
+
+The `origin` parameter accepts any shape - it will be validated by the attachment type's `validateOrigin` function on the server. For saved object references, the common pattern is:
+
+```ts
+{
+  saved_object_id: string;
+  title?: string;
+  description?: string;
+}
+```
+
 ## Registering skills
 
 **Note**: Skills are currently an experimental feature. You need to enable the `agentBuilder:experimentalFeatures` uiSetting to enable and use them.

--- a/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
+++ b/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
@@ -464,15 +464,16 @@ import {
   ActionButtonType,
   type ActionButton,
   type AttachmentRenderProps,
+  type CanvasRenderCallbacks,
 } from '@kbn/agent-builder-browser/attachments';
 
 interface MyCanvasContentProps extends AttachmentRenderProps<MyAttachment> {
-  registerActionButtons?: (buttons: ActionButton[]) => void;
+  callbacks: CanvasRenderCallbacks;
 }
 
 const MyCanvasContent: React.FC<MyCanvasContentProps> = ({
   attachment,
-  registerActionButtons,
+  callbacks: { registerActionButtons, updateOrigin },
 }) => {
   const [api, setApi] = useState<MyApi | undefined>();
 
@@ -487,10 +488,14 @@ const MyCanvasContent: React.FC<MyCanvasContentProps> = ({
         label: 'Save',
         icon: 'save',
         type: ActionButtonType.PRIMARY,
-        handler: () => api.save(),
+        handler: async () => {
+          const savedObjectId = await api.save();
+          // Link the attachment to the saved object
+          await updateOrigin({ saved_object_id: savedObjectId });
+        },
       },
     ]);
-  }, [api, registerActionButtons]);
+  }, [api, registerActionButtons, updateOrigin]);
 
   return (
     <MyEditor onApiReady={setApi} />
@@ -500,15 +505,19 @@ const MyCanvasContent: React.FC<MyCanvasContentProps> = ({
 // In the attachment definition:
 export const myAttachmentDefinition: AttachmentUIDefinition<MyAttachment> = {
   // ...
-  renderCanvasContent: (props, registerActionButtons) => (
-    <MyCanvasContent {...props} registerActionButtons={registerActionButtons} />
+  renderCanvasContent: (props, callbacks) => (
+    <MyCanvasContent {...props} callbacks={callbacks} />
   ),
 };
 ```
 
 #### Linking by-value attachments to persistent storage with updateOrigin
 
-The `getActionButtons` params include an `updateOrigin` callback that allows you to link a by-value attachment to its persistent storage location (e.g., a saved object) after it has been saved.
+The `updateOrigin` callback allows you to link a by-value attachment to its persistent storage location (e.g., a saved object) after it has been saved.
+
+This callback is available in two places:
+- **`getActionButtons` params** - for static action buttons defined at registration time
+- **`renderCanvasContent` callbacks** - for dynamic buttons registered at runtime (see [Registering action buttons dynamically](#registering-action-buttons-dynamically) above)
 
 **When to use `updateOrigin`:**
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_attachment_references.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_attachment_references.tsx
@@ -168,7 +168,7 @@ export const RoundAttachmentReferences: React.FC<RoundAttachmentReferencesProps>
   return (
     <EuiFlexGroup
       gutterSize="s"
-      wrap
+      direction="column"
       responsive={false}
       justifyContent={justifyContent}
       role="list"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -77,7 +77,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
   }
 
   const { attachment, isSidebar } = canvasState;
-  const title = attachment.type.toUpperCase(); // TODO: fix this - it won't scale well for all attachment types
+  const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase();
 
   const flyoutStyles = !isSidebar
     ? css`

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -115,7 +115,10 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         showPreviewBadge
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
-        {uiDefinition.renderCanvasContent({ attachment, isSidebar }, registerActionButtons)}
+        {uiDefinition.renderCanvasContent(
+          { attachment, isSidebar },
+          { registerActionButtons, updateOrigin }
+        )}
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -63,7 +63,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
     return null;
   }
 
-  const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase(); // TODO: fix this - it won't scale well for all attachment types
+  const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase();
 
   return (
     <EuiSplitPanel.Outer grow hasShadow={false} hasBorder={true}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -63,7 +63,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
     return null;
   }
 
-  const title = attachment.type.toUpperCase(); // TODO: fix this - it won't scale well for all attachment types
+  const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase(); // TODO: fix this - it won't scale well for all attachment types
 
   return (
     <EuiSplitPanel.Outer grow hasShadow={false} hasBorder={true}>


### PR DESCRIPTION
See atomic commits, they're really small.

- [x] [Use getLabel method for canvas and inline attachment header](https://github.com/elastic/kibana/commit/9ad35ae1a35fdfa4ffd1cdca795980e1e28b6cdb)

Before
<img width="815" height="942" alt="create me a text attachment and add some lorem ipsum consent so it" src="https://github.com/user-attachments/assets/34a51389-e50a-42e3-b5de-3c7826c6021c" />

After (uses the getLabel method from the UI definition)
<img width="762" height="941" alt="1FROk FROM financial_Melings I NEEP accountS  Belance SORT SORT Belance DESCE LINIT S" src="https://github.com/user-attachments/assets/643bfca9-61fd-46b9-a3cb-f9ac34bb6d0d" />

- [x] [Fix round attachment reference to be column instead of row](https://github.com/elastic/kibana/commit/e84d38923db30d278e0574780e3265cb4270e362)

Before
<img width="722" height="288" alt="ESIOL auery" src="https://github.com/user-attachments/assets/dccb99d2-8513-4989-afc3-a6e4ad0f92f2" />

After
<img width="728" height="324" alt="ESQL query" src="https://github.com/user-attachments/assets/39bd3333-0c37-4413-86bb-e6ddaef45b5f" />

- [x] [Add docs for `updateOrigin`](https://github.com/elastic/kibana/commit/26203f8304568ed33e67483b7e62976d29a45471)


