### PR TITLE
First pass at connectors in Agent Builder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2371,6 +2371,7 @@ x-pack/platform/plugins/shared/inference_endpoint @elastic/search-kibana
 # Connector Specs
 src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
 src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
+src/platform/packages/shared/kbn-connector-specs/src/get_workflow_templates* @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/**
 src/platform/packages/shared/kbn-connector-specs/src/specs/abuseipdb/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/alienvault_otx/** @elastic/workflows-eng

--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -276,7 +276,7 @@ export function getWebpackConfig(
           type: 'asset/source',
         },
         {
-          test: /\.(html|md|txt|tmpl)$/,
+          test: /\.(html|md|txt|tmpl|yaml|yml)$/,
           type: 'asset/source',
         },
         // automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using url-loader with asset size limit.

--- a/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
+++ b/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
@@ -17,7 +17,7 @@ import { RepoPath } from './repo_path';
 import { inferGroupAttrsFromPath } from './group';
 
 const STATIC_EXTS = new Set(
-  'json|woff|woff2|ttf|eot|svg|ico|png|jpg|gif|jpeg|html|md|txt|tmpl|xml'
+  'json|woff|woff2|ttf|eot|svg|ico|png|jpg|gif|jpeg|html|md|txt|tmpl|xml|yaml|yml'
     .split('|')
     .map((e) => `.${e}`)
 );

--- a/src/dev/build/tasks/build_packages_task.ts
+++ b/src/dev/build/tasks/build_packages_task.ts
@@ -212,6 +212,16 @@ export const BuildPackages: Task = {
                   };
                 }
 
+                case '.yaml':
+                case '.yml': {
+                  const yamlSource = await Fsp.readFile(rec.source.abs, 'utf8');
+                  return {
+                    ...rec,
+                    dest: rec.dest.withName(rec.dest.name + '.js'),
+                    content: `module.exports = ${JSON.stringify(yamlSource)};\n`,
+                  };
+                }
+
                 case '.ts':
                 case '.tsx':
                 case '.js':

--- a/src/platform/packages/private/kbn-ambient-common-types/index.d.ts
+++ b/src/platform/packages/private/kbn-ambient-common-types/index.d.ts
@@ -44,3 +44,20 @@ declare module '*.text' {
   // eslint-disable-next-line import/no-default-export
   export default content;
 }
+
+/**
+ * YAML files are loaded as raw strings via asset/source in webpack,
+ * the yaml transform in kbn-babel-register for Node runtime,
+ * and the raw transform in Jest.
+ */
+declare module '*.yaml' {
+  const content: string;
+  // eslint-disable-next-line import/no-default-export
+  export default content;
+}
+
+declare module '*.yml' {
+  const content: string;
+  // eslint-disable-next-line import/no-default-export
+  export default content;
+}

--- a/src/platform/packages/shared/kbn-babel-register/index.js
+++ b/src/platform/packages/shared/kbn-babel-register/index.js
@@ -136,7 +136,7 @@ function install(options = undefined) {
       return transform(path, code, cache);
     },
     {
-      exts: ['.js', '.ts', '.tsx', '.text', '.peggy'],
+      exts: ['.js', '.ts', '.tsx', '.text', '.peggy', '.yaml', '.yml'],
       ignoreNodeModules: false,
       matcher(path) {
         if (options?.only && !match(path, options.only)) {

--- a/src/platform/packages/shared/kbn-babel-register/transforms/yaml.js
+++ b/src/platform/packages/shared/kbn-babel-register/transforms/yaml.js
@@ -7,20 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-const { peggyTransform } = require('./peggy');
-const { dotTextTransform } = require('./dot_text');
-const { yamlTransform } = require('./yaml');
-const { babelTransform } = require('./babel');
+/** @type {import('./types').Transform} */
+const yamlTransform = (path, source, cache) => {
+  const key = cache.getKey(path, source);
 
-module.exports = {
-  /**
-   * @type {Record<string, import('./types').Transform>}
-   */
-  TRANSFORMS: {
-    '.peggy': peggyTransform,
-    '.text': dotTextTransform,
-    '.yaml': yamlTransform,
-    '.yml': yamlTransform,
-    default: babelTransform,
-  },
+  const cached = cache.getCode(key);
+  if (cached) {
+    return cached;
+  }
+
+  const code = `module.exports = ${JSON.stringify(source)};\n`;
+
+  cache.update(key, {
+    code,
+  });
+
+  return code;
 };
+
+module.exports = { yamlTransform };

--- a/src/platform/packages/shared/kbn-connector-specs/src/get_workflow_templates.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/get_workflow_templates.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getWorkflowTemplatesForConnector } from './get_workflow_templates';
+
+describe('getWorkflowTemplatesForConnector', () => {
+  it('returns empty array for unknown connector type', () => {
+    expect(getWorkflowTemplatesForConnector('.nonexistent')).toEqual([]);
+  });
+
+  it('returns empty array for connector without agentBuilderWorkflows', () => {
+    expect(getWorkflowTemplatesForConnector('.github')).toEqual([]);
+  });
+
+  it('returns workflow YAML strings for .slack2', () => {
+    const templates = getWorkflowTemplatesForConnector('.slack2');
+    expect(templates.length).toBeGreaterThan(0);
+    for (const yaml of templates) {
+      expect(typeof yaml).toBe('string');
+      expect(yaml).toContain('version:');
+    }
+  });
+
+  it('returns YAML with template placeholders intact', () => {
+    const templates = getWorkflowTemplatesForConnector('.slack2');
+    const hasPlaceholder = templates.some((yaml) => yaml.includes('<%='));
+    expect(hasPlaceholder).toBe(true);
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
@@ -12,6 +12,8 @@ import { z } from '@kbn/zod/v4';
 import type { AxiosError, AxiosResponse } from 'axios';
 import type { ConnectorSpec, ActionContext } from '../../connector_spec';
 import type { SlackAssistantSearchContextResponse, SlackErrorFields } from './types';
+import searchMessagesWorkflow from './workflows/search_messages.yaml';
+import sendMessageWorkflow from './workflows/send_message.yaml';
 
 const SLACK_API_BASE = 'https://slack.com/api';
 const ENABLE_TEMPORARY_MANUAL_TOKEN_AUTH = true; // Temporary: remove once OAuth support is unblocked.
@@ -816,4 +818,6 @@ export const Slack: ConnectorSpec = {
       }
     },
   },
+
+  agentBuilderWorkflows: [searchMessagesWorkflow, sendMessageWorkflow],
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/workflows/search_messages.yaml
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/workflows/search_messages.yaml
@@ -1,0 +1,68 @@
+version: "1"
+name: "sources.slack.search_messages"
+description: "Search Slack messages and return compact results suitable for LLM summaries and follow-up navigation. Uses Slack Real-time Search API (assistant.search.context). Actions and inputs: searchMessages (required query, optional in_channel, optional from_user, optional after, optional before, optional sort, optional sort_dir, optional count, optional cursor, optional raw). Output (compact default): matches with text, channel {id,name}, sender, mentions, and permalink."
+tags: ["agent-builder-tool"]
+enabled: true
+triggers:
+  - type: "manual"
+inputs:
+  - name: query
+    type: string
+    required: true
+    description: "Search query. You can include Slack search operators directly (e.g. in:#general from:@user after:2026-02-10)."
+  - name: in_channel
+    type: string
+    required: false
+    description: "Optional constraint. Appends `in:CHANNEL_NAME` to the query (e.g. in:general)."
+  - name: from_user
+    type: string
+    required: false
+    description: "Optional constraint. Appends `from:USER_ID` (e.g. from:U012ABCDEF) or `from:username` to the query."
+  - name: after
+    type: string
+    required: false
+    description: "Optional constraint. Appends `after:YYYY-MM-DD` to the query (e.g. after:2026-02-10)."
+  - name: before
+    type: string
+    required: false
+    description: "Optional constraint. Appends `before:YYYY-MM-DD` to the query (e.g. before:2026-02-10)."
+  - name: sort
+    type: string
+    required: false
+    default: "score"
+    description: "Sort order. Valid values: [score, timestamp]."
+  - name: sort_dir
+    type: string
+    required: false
+    default: "desc"
+    description: "Sort direction. Valid values: [asc, desc]."
+  - name: count
+    type: number
+    required: false
+    default: 20
+    description: "Number of results to return (1-20). Slack returns up to 20 results per page."
+  - name: cursor
+    type: string
+    required: false
+    description: "Pagination cursor from a previous response (response_metadata.next_cursor)."
+  - name: raw
+    type: boolean
+    required: false
+    default: false
+    description: "If true, return the full raw Slack API response (very verbose). If false, return compact results."
+steps:
+  - name: search-messages
+    type: slack2.searchMessages
+    connector-id: <%= slack2-stack-connector-id %>
+    with:
+      query: "${{inputs.query}}"
+      inChannel: "${{inputs.in_channel}}"
+      fromUser: "${{inputs.from_user}}"
+      after: "${{inputs.after}}"
+      before: "${{inputs.before}}"
+      sort: "${{inputs.sort}}"
+      sortDir: "${{inputs.sort_dir}}"
+      count: ${{inputs.count}}
+      cursor: "${{inputs.cursor}}"
+      raw: ${{inputs.raw}}
+

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/workflows/send_message.yaml
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/workflows/send_message.yaml
@@ -1,0 +1,37 @@
+version: "1"
+name: "sources.slack.send_message"
+description: "Send a message to a Slack public channel by channel conversation ID (C...). Actions and inputs: sendMessage (channel, text, optional thread_ts, optional unfurl_links, optional unfurl_media). Use sources.slack.find first to resolve a channel name (e.g. \"#general\") into a channel id (C...). Requires chat:write and access to the channel."
+tags: ["agent-builder-tool"]
+enabled: true
+triggers:
+  - type: "manual"
+inputs:
+  - name: channel
+    type: string
+    description: "Public channel name or conversation ID to send the message to (e.g. #general or C123...)."
+  - name: text
+    type: string
+    description: "Message text."
+  - name: thread_ts
+    type: string
+    required: false
+    description: "Optional thread timestamp to reply in a thread."
+  - name: unfurl_links
+    type: boolean
+    required: false
+    description: "If true, enable unfurling of primarily text-based content."
+  - name: unfurl_media
+    type: boolean
+    required: false
+    description: "If true, enable unfurling of media content."
+steps:
+  - name: send-message
+    type: slack2.sendMessage
+    connector-id: <%= slack2-stack-connector-id %>
+    with:
+      channel: "${{inputs.channel}}"
+      text: "${{inputs.text}}"
+      threadTs: "${{inputs.thread_ts}}"
+      unfurlLinks: ${{inputs.unfurl_links}}
+      unfurlMedia: ${{inputs.unfurl_media}}
+

--- a/src/platform/packages/shared/kbn-connector-specs/tsconfig.json
+++ b/src/platform/packages/shared/kbn-connector-specs/tsconfig.json
@@ -7,6 +7,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
+      "@kbn/ambient-common-types",
     ]
   },
   "include": [

--- a/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
+++ b/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
@@ -63,6 +63,7 @@ export const ACCESSIBILITY_DISABLE_ANIMATIONS_ID = 'accessibility:disableAnimati
 export const AGENT_BUILDER_NAV_ENABLED_SETTING_ID = 'agentBuilder:navEnabled';
 export const AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID = 'agentBuilder:experimentalFeatures';
 export const AGENT_BUILDER_PRE_PROMPT_WORKFLOW_IDS = 'agentBuilder:prePromptWorkflowIds';
+export const AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID = 'agentBuilder:connectorsEnabled';
 
 // Autocomplete settings
 export const AUTOCOMPLETE_USE_TIME_RANGE_ID = 'autocomplete:useTimeRange';

--- a/src/platform/packages/shared/kbn-storybook/src/webpack.config.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/webpack.config.ts
@@ -33,7 +33,7 @@ export default ({ config: storybookConfig }: { config: Configuration }) => {
           type: 'javascript/auto',
         },
         {
-          test: /\.(html|md|txt|tmpl)$/,
+          test: /\.(html|md|txt|tmpl|yaml|yml)$/,
           type: 'asset/source',
         },
         {

--- a/src/platform/packages/shared/kbn-test/jest-preset.js
+++ b/src/platform/packages/shared/kbn-test/jest-preset.js
@@ -116,7 +116,7 @@ module.exports = {
   transform: {
     '^.+\\.(js|tsx?)$':
       '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/babel/index.js',
-    '^.+\\.(txt|html)?$':
+    '^.+\\.(txt|html|yaml|yml)?$':
       '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/raw.js',
     '^.+\\.peggy?$': '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/transforms/peggy.js',
     '^.+\\.text?$':

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -536,6 +536,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'agentBuilder:connectorsEnabled': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'dataSources:enabled': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -54,6 +54,7 @@ export interface UsageStats {
   'agentBuilder:navEnabled': boolean;
   'agentBuilder:externalMcp': boolean;
   'agentBuilder:experimentalFeatures': boolean;
+  'agentBuilder:connectorsEnabled': boolean;
   'dataSources:enabled': boolean;
   'workflows:ui:enabled': boolean;
   'workflows:aiAgent:enabled': boolean;

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11208,6 +11208,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "agentBuilder:connectorsEnabled": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "dataSources:enabled": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/more_actions_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/more_actions_button.tsx
@@ -18,7 +18,10 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
-import { DATA_SOURCES_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
+import {
+  DATA_SOURCES_ENABLED_SETTING_ID,
+  AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID,
+} from '@kbn/management-settings-ids';
 import { DATA_SOURCES_APP_ID } from '@kbn/deeplinks-data-sources';
 import { css } from '@emotion/react';
 import { useIsAgentReadOnly } from '../../../hooks/agents/use_is_agent_read_only';
@@ -77,6 +80,9 @@ const fullscreenLabels = {
   }),
   plugins: i18n.translate('xpack.agentBuilder.conversationActions.plugins', {
     defaultMessage: 'View all plugins',
+  }),
+  connectors: i18n.translate('xpack.agentBuilder.conversationActions.connectors', {
+    defaultMessage: 'View all connectors',
   }),
   sources: i18n.translate('xpack.agentBuilder.conversationActions.sources', {
     defaultMessage: 'View all sources',
@@ -141,6 +147,10 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onRenameCo
   const hasAccessToGenAiSettings = useHasConnectorsAllPrivileges();
   const isExperimentalFeaturesEnabled = useExperimentalFeatures();
   const isDataSourcesEnabled = uiSettings.get<boolean>(DATA_SOURCES_ENABLED_SETTING_ID, false);
+  const isABConnectorsEnabled = uiSettings.get<boolean>(
+    AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID,
+    false
+  );
 
   const closePopover = () => {
     setIsPopoverOpen(false);
@@ -217,7 +227,7 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onRenameCo
     />,
     <EuiContextMenuItem
       key="agents"
-      icon={<EuiIcon type="productAgent" />}
+      icon={<EuiIcon type="productAgent" aria-hidden={true} />}
       onClick={closePopover}
       href={createAgentBuilderUrl(appPaths.agents.list)}
       data-test-subj="agentBuilderActionsAgents"
@@ -252,6 +262,19 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onRenameCo
             data-test-subj="agentBuilderActionsPlugins"
           >
             {fullscreenLabels.plugins}
+          </EuiContextMenuItem>,
+        ]
+      : []),
+    ...(isABConnectorsEnabled
+      ? [
+          <EuiContextMenuItem
+            key="connectors"
+            icon="plugs"
+            onClick={closePopover}
+            href={createAgentBuilderUrl(appPaths.connectors.list)}
+            data-test-subj="agentBuilderActionsConnectors"
+          >
+            {fullscreenLabels.connectors}
           </EuiContextMenuItem>,
         ]
       : []),

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/connectors.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/connectors.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { EuiPageTemplate, EuiBasicTable, EuiButton, EuiLink } from '@elastic/eui';
+import type { ActionConnector } from '@kbn/alerts-ui-shared';
+import { useQueryClient } from '@kbn/react-query';
+import { i18n } from '@kbn/i18n';
+import type { ConnectorItem } from '../../../common/http_api/tools';
+import { useBreadcrumb } from '../hooks/use_breadcrumbs';
+import { useKibana } from '../hooks/use_kibana';
+import { useFlyoutState } from '../hooks/use_flyout_state';
+import { useListConnectors } from '../hooks/tools/use_mcp_connectors';
+import { queryKeys } from '../query_keys';
+
+// Convert ConnectorItem to the ActionConnector shape expected by the edit flyout
+const toActionConnector = (c: ConnectorItem): ActionConnector =>
+  ({
+    id: c.id,
+    name: c.name,
+    actionTypeId: c.actionTypeId,
+    isPreconfigured: c.isPreconfigured,
+    isDeprecated: c.isDeprecated,
+    isSystemAction: c.isSystemAction,
+    isConnectorTypeDeprecated: c.isConnectorTypeDeprecated,
+    config: c.config,
+    isMissingSecrets: c.isMissingSecrets ?? false,
+    secrets: {},
+  } as ActionConnector);
+
+export const AgentBuilderConnectorsPage: React.FC = () => {
+  useBreadcrumb([
+    {
+      text: i18n.translate('xpack.agentBuilder.connectors.breadcrumb', {
+        defaultMessage: 'Connectors',
+      }),
+      path: '/connectors',
+    },
+  ]);
+
+  const {
+    services: {
+      plugins: { triggersActionsUi },
+    },
+  } = useKibana();
+  const queryClient = useQueryClient();
+
+  const createFlyoutState = useFlyoutState();
+  const [editingConnector, setEditingConnector] = useState<ActionConnector | null>(null);
+
+  const { connectors, isLoading } = useListConnectors({});
+
+  const handleConnectorCreated = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.connectors.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tools.connectors.list() });
+    createFlyoutState.closeFlyout();
+  }, [queryClient, createFlyoutState]);
+
+  const handleConnectorUpdated = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.connectors.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tools.connectors.list() });
+    setEditingConnector(null);
+  }, [queryClient]);
+
+  const createFlyout = useMemo(
+    () =>
+      triggersActionsUi.getAddConnectorFlyout({
+        onClose: createFlyoutState.closeFlyout,
+        onConnectorCreated: handleConnectorCreated,
+      }),
+    [createFlyoutState.closeFlyout, handleConnectorCreated, triggersActionsUi]
+  );
+
+  const handleEditClose = useCallback(() => setEditingConnector(null), []);
+
+  const editFlyout = useMemo(() => {
+    if (!editingConnector) return null;
+    return triggersActionsUi.getEditConnectorFlyout({
+      connector: editingConnector,
+      onClose: handleEditClose,
+      onConnectorUpdated: handleConnectorUpdated,
+    });
+  }, [editingConnector, handleEditClose, handleConnectorUpdated, triggersActionsUi]);
+
+  const columns = useMemo(
+    () => [
+      {
+        field: 'name',
+        name: i18n.translate('xpack.agentBuilder.connectors.column.name', {
+          defaultMessage: 'Name',
+        }),
+        render: (name: string, connector: ConnectorItem) => (
+          <EuiLink onClick={() => setEditingConnector(toActionConnector(connector))}>
+            {name}
+          </EuiLink>
+        ),
+      },
+    ],
+    []
+  );
+
+  return (
+    <EuiPageTemplate offset={0} restrictWidth={false}>
+      <EuiPageTemplate.Header
+        pageTitle={i18n.translate('xpack.agentBuilder.connectors.pageTitle', {
+          defaultMessage: 'Connectors',
+        })}
+        description={i18n.translate('xpack.agentBuilder.connectors.pageDescription', {
+          defaultMessage:
+            'Manage connectors for your agents. Connectors with workflow definitions will automatically create tools when configured.',
+        })}
+        rightSideItems={[
+          <EuiButton key="create" fill iconType="plus" onClick={createFlyoutState.openFlyout}>
+            {i18n.translate('xpack.agentBuilder.connectors.createButton', {
+              defaultMessage: 'Create connector',
+            })}
+          </EuiButton>,
+        ]}
+      />
+      <EuiPageTemplate.Section>
+        <EuiBasicTable
+          items={connectors as ConnectorItem[]}
+          columns={columns}
+          loading={isLoading}
+          tableCaption={i18n.translate('xpack.agentBuilder.connectors.tableCaption', {
+            defaultMessage: 'Connectors',
+          })}
+        />
+      </EuiPageTemplate.Section>
+      {createFlyoutState.isOpen && createFlyout}
+      {editFlyout}
+    </EuiPageTemplate>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
@@ -52,4 +52,7 @@ export const queryKeys = {
     all: ['plugins', 'list'] as const,
     byId: (pluginId?: string) => ['plugins', pluginId],
   },
+  connectors: {
+    all: ['connectors'] as const,
+  },
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/routes.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/routes.tsx
@@ -7,6 +7,7 @@
 
 import { Route, Routes } from '@kbn/shared-ux-router';
 import React from 'react';
+import { AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
 import { AgentBuilderAgentsCreate } from './pages/agent_create';
 import { AgentBuilderAgentsEdit } from './pages/agent_edit';
 import { AgentBuilderAgentsPage } from './pages/agents';
@@ -21,9 +22,18 @@ import { AgentBuilderSkillDetailsPage } from './pages/skill_details';
 import { AgentBuilderPluginsPage } from './pages/plugins';
 import { AgentBuilderPluginDetailsPage } from './pages/plugin_details';
 import { useExperimentalFeatures } from './hooks/use_experimental_features';
+import { useKibana } from './hooks/use_kibana';
+import { AgentBuilderConnectorsPage } from './pages/connectors';
 
 export const AgentBuilderRoutes: React.FC<{}> = () => {
   const isExperimentalFeaturesEnabled = useExperimentalFeatures();
+  const {
+    services: { uiSettings },
+  } = useKibana();
+  const isConnectorsEnabled = uiSettings.get<boolean>(
+    AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID,
+    false
+  );
 
   return (
     <Routes>
@@ -58,6 +68,12 @@ export const AgentBuilderRoutes: React.FC<{}> = () => {
       <Route path="/tools">
         <AgentBuilderToolsPage />
       </Route>
+
+      {isConnectorsEnabled ? (
+        <Route path="/connectors">
+          <AgentBuilderConnectorsPage />
+        </Route>
+      ) : null}
 
       {isExperimentalFeaturesEnabled
         ? [

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -25,6 +25,9 @@ export const appPaths = {
       return `/conversations/${conversationId}`;
     },
   },
+  connectors: {
+    list: '/connectors',
+  },
   tools: {
     list: '/tools',
     new: '/tools/new',

--- a/x-pack/platform/plugins/shared/agent_builder/public/register.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/register.ts
@@ -40,6 +40,13 @@ const BASE_DEEP_LINKS = [
     path: '/agents',
     title: i18n.translate('xpack.agentBuilder.agents.title', { defaultMessage: 'Agents' }),
   },
+  {
+    id: 'connectors',
+    path: '/connectors',
+    title: i18n.translate('xpack.agentBuilder.connectors.title', {
+      defaultMessage: 'Connectors',
+    }),
+  },
 ];
 
 const SKILLS_DEEP_LINK = {

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -30,6 +30,7 @@ import { AnalyticsService } from './telemetry';
 import { registerSampleData } from './register_sample_data';
 import { registerBeforeAgentWorkflowsHook } from './hooks/agent_workflows/register_before_agent_workflows_hook';
 import { registerSkillToolsLoaderHook } from './hooks/skills/register_skill_tools_loader_hook';
+import { createConnectorLifecycleHandler } from './services/connector_lifecycle/connector_lifecycle_handler';
 import { registerTaskDefinitions } from './services/execution';
 import { createModelProviderFactory } from './services/runner/model_provider';
 import { createAdminPrivilegeSwitcher } from './capabilities/admin_privilege_switcher';
@@ -149,6 +150,22 @@ export class AgentBuilderPlugin
     });
 
     registerSkillToolsLoaderHook(serviceSetups);
+
+    // Register connector lifecycle listener to auto-create workflows/tools
+    // when connectors with workflow definitions are created.
+    // The handler checks the connectors-enabled feature flag and workflows
+    // availability at runtime, so we always register.
+    const connectorLifecycleHandler = createConnectorLifecycleHandler({
+      serviceManager: this.serviceManager,
+      workflowsManagement: setupDeps.workflowsManagement,
+      logger: this.logger.get('connector-lifecycle'),
+    });
+
+    setupDeps.actions.registerConnectorLifecycleListener({
+      connectorTypes: '*',
+      onPostCreate: connectorLifecycleHandler.onPostCreate,
+      onPostDelete: connectorLifecycleHandler.onPostDelete,
+    });
 
     return {
       tools: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
@@ -1,0 +1,334 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { ToolType } from '@kbn/agent-builder-common';
+import { AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
+import { createConnectorLifecycleHandler } from './connector_lifecycle_handler';
+
+const SIMPLE_WORKFLOW_YAML = `version: "1"
+name: "sources.test.action"
+description: "Test workflow"
+tags: ["agent-builder-tool"]
+enabled: true
+triggers:
+  - type: "manual"
+inputs:
+  - name: query
+    type: string
+steps:
+  - name: do-action
+    type: test.action
+    connector-id: <%= test-stack-connector-id %>
+    with:
+      query: "\${{inputs.query}}"
+`;
+
+const WORKFLOW_YAML_NO_TOOL_TAG = `version: "1"
+name: "sources.test.internal"
+description: "Internal workflow"
+tags: ["internal"]
+enabled: true
+triggers:
+  - type: "manual"
+steps:
+  - name: do-internal
+    type: test.internal
+    connector-id: <%= test-stack-connector-id %>
+`;
+
+const createMockToolRegistry = () => ({
+  create: jest.fn().mockResolvedValue({ id: 'mock-tool-id' }),
+  list: jest.fn().mockResolvedValue([]),
+  delete: jest.fn().mockResolvedValue(undefined),
+});
+
+const createMockWorkflowsManagement = () => ({
+  management: {
+    createWorkflow: jest.fn().mockResolvedValue({ id: 'wf-123', name: 'test-workflow' }),
+    deleteWorkflows: jest.fn().mockResolvedValue(undefined),
+  },
+});
+
+const createMockUiSettingsClient = (connectorsEnabled = true) => ({
+  get: jest.fn().mockImplementation(async (key: string) => {
+    if (key === AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID) return connectorsEnabled;
+    return undefined;
+  }),
+});
+
+const createMockServiceManager = (
+  toolRegistry = createMockToolRegistry(),
+  uiSettingsClient = createMockUiSettingsClient()
+) => ({
+  internalStart: {
+    tools: {
+      getRegistry: jest.fn().mockResolvedValue(toolRegistry),
+    },
+    savedObjects: {
+      getScopedClient: jest.fn().mockReturnValue({}),
+    },
+    uiSettings: {
+      asScopedToClient: jest.fn().mockReturnValue(uiSettingsClient),
+    },
+  },
+});
+
+const createBaseParams = (overrides = {}) => ({
+  connectorId: 'connector-abc',
+  connectorName: 'My Test Connector',
+  connectorType: '.test',
+  config: {},
+  secrets: {},
+  logger: loggingSystemMock.create().get(),
+  request: {} as any,
+  services: { scopedClusterClient: {} as any },
+  wasSuccessful: true,
+  workflowTemplates: [] as string[],
+  ...overrides,
+});
+
+describe('createConnectorLifecycleHandler', () => {
+  const logger = loggingSystemMock.create().get('connector-lifecycle');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onPostCreate', () => {
+    it('skips unsuccessful saves', async () => {
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager() as any,
+        workflowsManagement: createMockWorkflowsManagement() as any,
+        logger,
+      });
+
+      await handler.onPostCreate(
+        createBaseParams({
+          wasSuccessful: false,
+          workflowTemplates: [SIMPLE_WORKFLOW_YAML],
+        }) as any
+      );
+    });
+
+    it('skips connectors without workflows', async () => {
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager() as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostCreate(createBaseParams({ workflowTemplates: [] }) as any);
+
+      expect(workflowsManagement.management.createWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('skips when experimental features are disabled', async () => {
+      const uiSettingsClient = createMockUiSettingsClient(false);
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(createMockToolRegistry(), uiSettingsClient) as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostCreate(
+        createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] }) as any
+      );
+
+      expect(workflowsManagement.management.createWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('creates workflows and tools for connectors with workflow templates', async () => {
+      const toolRegistry = createMockToolRegistry();
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(toolRegistry) as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostCreate(
+        createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] }) as any
+      );
+
+      expect(workflowsManagement.management.createWorkflow).toHaveBeenCalledTimes(1);
+      const createCall = workflowsManagement.management.createWorkflow.mock.calls[0];
+      expect(createCall[0].yaml).toContain('test.my-test-connector.action');
+      expect(createCall[0].yaml).toContain('connector-abc');
+      expect(createCall[1]).toBe('default');
+
+      expect(toolRegistry.create).toHaveBeenCalledTimes(1);
+      expect(toolRegistry.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: ToolType.workflow,
+          description: 'Test workflow',
+          tags: ['connector', 'test', 'connector:connector-abc'],
+          configuration: { workflow_id: 'wf-123' },
+        })
+      );
+    });
+
+    it('substitutes template variables with connector ID', async () => {
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager() as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostCreate(
+        createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] }) as any
+      );
+
+      const yaml = workflowsManagement.management.createWorkflow.mock.calls[0][0].yaml;
+      expect(yaml).toContain('connector-abc');
+      expect(yaml).not.toContain('<%= test-stack-connector-id %>');
+    });
+
+    it('does not create a tool when workflow lacks agent-builder-tool tag', async () => {
+      const toolRegistry = createMockToolRegistry();
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(toolRegistry) as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostCreate(
+        createBaseParams({ workflowTemplates: [WORKFLOW_YAML_NO_TOOL_TAG] }) as any
+      );
+
+      expect(workflowsManagement.management.createWorkflow).toHaveBeenCalledTimes(1);
+      expect(toolRegistry.create).not.toHaveBeenCalled();
+    });
+
+    it('creates workflows in parallel for multiple templates', async () => {
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager() as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostCreate(
+        createBaseParams({
+          workflowTemplates: [SIMPLE_WORKFLOW_YAML, WORKFLOW_YAML_NO_TOOL_TAG],
+        }) as any
+      );
+
+      expect(workflowsManagement.management.createWorkflow).toHaveBeenCalledTimes(2);
+    });
+
+    it('logs error but does not throw when workflow creation fails', async () => {
+      const workflowsManagement = createMockWorkflowsManagement();
+      workflowsManagement.management.createWorkflow.mockRejectedValue(new Error('API error'));
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager() as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await expect(
+        handler.onPostCreate(createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] }) as any)
+      ).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('failed to create workflows/tools')
+      );
+    });
+
+    it('returns early when services are not started', async () => {
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: { internalStart: undefined } as any,
+        workflowsManagement: createMockWorkflowsManagement() as any,
+        logger,
+      });
+
+      await handler.onPostCreate(
+        createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] }) as any
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('services not started yet')
+      );
+    });
+  });
+
+  describe('onPostDelete', () => {
+    it('deletes tools and workflows tagged with the connector ID', async () => {
+      const toolRegistry = createMockToolRegistry();
+      toolRegistry.list.mockResolvedValue([
+        {
+          id: 'tool-1',
+          tags: ['connector', 'test', 'connector:connector-abc'],
+          configuration: { workflow_id: 'wf-1' },
+        },
+        {
+          id: 'tool-2',
+          tags: ['connector', 'test', 'connector:connector-abc'],
+          configuration: { workflow_id: 'wf-2' },
+        },
+        {
+          id: 'tool-other',
+          tags: ['connector', 'test', 'connector:other-id'],
+          configuration: { workflow_id: 'wf-other' },
+        },
+      ]);
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(toolRegistry) as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostDelete(createBaseParams({ connectorType: '.test' }) as any);
+
+      expect(toolRegistry.delete).toHaveBeenCalledTimes(2);
+      expect(toolRegistry.delete).toHaveBeenCalledWith('tool-1');
+      expect(toolRegistry.delete).toHaveBeenCalledWith('tool-2');
+      expect(toolRegistry.delete).not.toHaveBeenCalledWith('tool-other');
+
+      expect(workflowsManagement.management.deleteWorkflows).toHaveBeenCalledWith(
+        ['wf-1', 'wf-2'],
+        'default',
+        expect.anything()
+      );
+    });
+
+    it('handles connectors with no associated tools', async () => {
+      const toolRegistry = createMockToolRegistry();
+      toolRegistry.list.mockResolvedValue([]);
+      const workflowsManagement = createMockWorkflowsManagement();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(toolRegistry) as any,
+        workflowsManagement: workflowsManagement as any,
+        logger,
+      });
+
+      await handler.onPostDelete(createBaseParams() as any);
+
+      expect(toolRegistry.delete).not.toHaveBeenCalled();
+      expect(workflowsManagement.management.deleteWorkflows).not.toHaveBeenCalled();
+    });
+
+    it('logs error but does not throw on failure', async () => {
+      const toolRegistry = createMockToolRegistry();
+      toolRegistry.list.mockRejectedValue(new Error('list failed'));
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(toolRegistry) as any,
+        workflowsManagement: createMockWorkflowsManagement() as any,
+        logger,
+      });
+
+      await expect(handler.onPostDelete(createBaseParams() as any)).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('failed to clean up'));
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { OpeningAndClosingTags } from 'mustache';
+import Mustache from 'mustache';
+import { parse } from 'yaml';
+import { trimStart } from 'lodash';
+import { ToolType } from '@kbn/agent-builder-common';
+import { toolIdMaxLength } from '@kbn/agent-builder-common/tools';
+import type { Logger } from '@kbn/logging';
+import type { WorkflowYaml } from '@kbn/workflows';
+import { AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
+import type {
+  ConnectorLifecyclePostCreateParams,
+  ConnectorLifecyclePostDeleteParams,
+} from '@kbn/actions-plugin/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import type { ServiceManager } from '..';
+
+const TEMPLATE_DELIMITERS: OpeningAndClosingTags = ['<%=', '%>'];
+const CONNECTOR_TAG_PREFIX = 'connector:';
+
+interface ConnectorLifecycleHandlerDeps {
+  serviceManager: ServiceManager;
+  workflowsManagement?: WorkflowsServerPluginSetup;
+  logger: Logger;
+}
+
+function renderWorkflowTemplate(
+  rawYaml: string,
+  templateInputs: Record<string, string>
+): { content: string; shouldGenerateABTool: boolean } {
+  const content = Mustache.render(rawYaml, templateInputs, {}, TEMPLATE_DELIMITERS);
+  const parsed = parse(content);
+  const shouldGenerateABTool = parsed?.tags?.includes('agent-builder-tool') ?? false;
+  return { content, shouldGenerateABTool };
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerDeps) {
+  const { serviceManager, workflowsManagement, logger } = deps;
+
+  return {
+    async onPostCreate(params: ConnectorLifecyclePostCreateParams): Promise<void> {
+      if (!params.wasSuccessful) {
+        logger.error(
+          `Connector lifecycle: onPostCreate called with wasSuccessful=false for connector ${params.connectorId}`
+        );
+        return;
+      }
+
+      const { connectorId, connectorName, connectorType } = params;
+
+      const { workflowTemplates } = params;
+      if (!workflowTemplates.length) return;
+
+      try {
+        const internalServices = serviceManager.internalStart;
+        if (!internalServices) {
+          logger.error('Connector lifecycle: services not started yet, cannot create workflows');
+          return;
+        }
+
+        // Check the feature flag at runtime rather than at registration time,
+        // because UI settings aren't available during plugin setup and the flag
+        // can be toggled without a restart.
+        const request = params.request;
+        const soClient = internalServices.savedObjects.getScopedClient(request);
+        const uiSettingsClient = internalServices.uiSettings.asScopedToClient(soClient);
+        const isConnectorsEnabled = await uiSettingsClient.get<boolean>(
+          AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID
+        );
+        if (!isConnectorsEnabled) return;
+
+        if (!workflowsManagement) {
+          logger.warn('Connector lifecycle: workflows management plugin is not available');
+          return;
+        }
+
+        logger.info(
+          `Connector lifecycle: creating workflows/tools for connector ${connectorId} (type: ${connectorType})`
+        );
+
+        const connectorTypeKey = trimStart(connectorType, '.');
+        const templateInputs: Record<string, string> = {
+          [`${connectorTypeKey}-stack-connector-id`]: connectorId,
+        };
+
+        const workflowInfos = workflowTemplates.map((rawYaml) =>
+          renderWorkflowTemplate(rawYaml, templateInputs)
+        );
+
+        const toolRegistry = await internalServices.tools.getRegistry({ request });
+        const connectorTag = `${CONNECTOR_TAG_PREFIX}${connectorId}`;
+        const slugifiedConnectorName = slugify(connectorName);
+
+        await Promise.all(
+          workflowInfos.map(async (workflowInfo) => {
+            const parsed: WorkflowYaml = parse(workflowInfo.content);
+            const originalName = parsed?.name ?? 'workflow';
+            const workflowBaseName = originalName.split('.').pop() || originalName;
+            const prefixedName = `${connectorTypeKey}.${slugifiedConnectorName}.${workflowBaseName}`;
+
+            const updatedContent = workflowInfo.content.replace(
+              /^name:\s*['"]?[^'"\n]+['"]?/m,
+              `name: "${prefixedName}"`
+            );
+
+            const workflow = await workflowsManagement.management.createWorkflow(
+              { yaml: updatedContent },
+              'default',
+              request
+            );
+
+            logger.info(
+              `Connector lifecycle: created workflow '${workflow.name}' (id: ${workflow.id})`
+            );
+
+            if (workflowInfo.shouldGenerateABTool) {
+              const workflowDescription =
+                typeof parsed?.description === 'string'
+                  ? parsed.description
+                  : `Workflow tool for ${connectorTypeKey} connector`;
+
+              const toolId = `${connectorTypeKey}.${slugifiedConnectorName}.${workflowBaseName}`;
+
+              if (toolId.length > toolIdMaxLength) {
+                logger.warn(
+                  `Connector lifecycle: generated tool ID '${toolId}' exceeds ${toolIdMaxLength} chars (${toolId.length}), skipping tool creation for workflow '${workflow.name}'`
+                );
+                return;
+              }
+
+              const tool = await toolRegistry.create({
+                id: toolId,
+                type: ToolType.workflow,
+                description: workflowDescription,
+                tags: ['connector', connectorTypeKey, connectorTag],
+                configuration: {
+                  workflow_id: workflow.id,
+                },
+              });
+
+              logger.info(
+                `Connector lifecycle: created tool '${tool.id}' for workflow '${workflow.name}'`
+              );
+            }
+          })
+        );
+      } catch (error) {
+        logger.error(
+          `Connector lifecycle: failed to create workflows/tools for connector ${connectorId}: ${error.message}`
+        );
+      }
+    },
+
+    async onPostDelete(params: ConnectorLifecyclePostDeleteParams): Promise<void> {
+      const { connectorId, connectorType } = params;
+
+      logger.info(
+        `Connector lifecycle: cleaning up workflows/tools for deleted connector ${connectorId} (type: ${connectorType})`
+      );
+
+      try {
+        const internalServices = serviceManager.internalStart;
+        if (!internalServices) {
+          logger.error('Connector lifecycle: services not started yet, cannot clean up');
+          return;
+        }
+
+        const request = params.request;
+        const toolRegistry = await internalServices.tools.getRegistry({ request });
+        const connectorTag = `${CONNECTOR_TAG_PREFIX}${connectorId}`;
+
+        const tools = await toolRegistry.list();
+        const connectorTools = tools.filter(
+          (tool) => tool.tags && tool.tags.includes(connectorTag)
+        );
+
+        // Collect workflow IDs before deleting tools, then delete both in parallel
+        const workflowIds = connectorTools
+          .map((tool) => (tool.configuration as Record<string, unknown>)?.workflow_id as string)
+          .filter(Boolean);
+
+        const deleteToolsPromise = Promise.all(
+          connectorTools.map(async (tool) => {
+            await toolRegistry.delete(tool.id);
+            logger.info(`Connector lifecycle: deleted tool '${tool.id}'`);
+          })
+        );
+
+        const deleteWorkflowsPromise =
+          workflowsManagement && workflowIds.length > 0
+            ? workflowsManagement.management
+                .deleteWorkflows(workflowIds, 'default', request)
+                .then(() => {
+                  logger.info(
+                    `Connector lifecycle: deleted ${workflowIds.length} workflow(s) for connector ${connectorId}`
+                  );
+                })
+            : Promise.resolve();
+
+        await Promise.all([deleteToolsPromise, deleteWorkflowsPromise]);
+      } catch (error) {
+        logger.error(
+          `Connector lifecycle: failed to clean up for connector ${connectorId}: ${error.message}`
+        );
+      }
+    },
+  };
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/ui_settings.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/ui_settings.ts
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import {
   AGENT_BUILDER_NAV_ENABLED_SETTING_ID,
   AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID,
+  AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID,
 } from '@kbn/management-settings-ids';
 
 export const registerUISettings = ({ uiSettings }: { uiSettings: UiSettingsServiceSetup }) => {
@@ -44,6 +45,21 @@ export const registerUISettings = ({ uiSettings }: { uiSettings: UiSettingsServi
       technicalPreview: true,
       requiresPageReload: false,
       readonly: false,
+    },
+    [AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID]: {
+      description: i18n.translate('xpack.agentBuilder.uiSettings.connectorsEnabled.description', {
+        defaultMessage:
+          'Enables connectors management in Agent Builder, including automatic workflow and tool creation when connectors are added.',
+      }),
+      name: i18n.translate('xpack.agentBuilder.uiSettings.connectorsEnabled.name', {
+        defaultMessage: 'Elastic Agent Builder: Connectors',
+      }),
+      schema: schema.boolean(),
+      value: false,
+      technicalPreview: true,
+      requiresPageReload: false,
+      readonly: true,
+      readonlyMode: 'ui',
     },
   });
 };


### PR DESCRIPTION
## Summary

Part of  https://github.com/elastic/kibana/issues/255829


This PR exposes Connectors inside Agent Builder, and lays the groundwork for allowing "data source" concerns (like Workflows) to be part of connector specs.

At the code level, this effectively does 3 things:
- https://github.com/elastic/kibana/pull/257820 defines a new lifecycle hook for connectors, 
  - In this PR, those hooks are used by Agent Builder, to allow execution at connector create/delete time
- enables `yaml` resource files to be imported as string content. (This allows us to VCS workflows as YAML files, but avoid file IO at runtime, especially in frontend packages)
- adds some new pages to AgentBuilder, which effectively duplicates the `Alerts & Insights -> Connectors UI` (this UX will get reworked in follow-up PRs)

At the User Experience level, this lets a user connect connectors without leaving Agent Builder, and for some sources, results in Workflows and Tools being created automagically.

To enable:
```
POST kbn://internal/kibana/settings
{
   "changes": {
      "agentBuilder:connectorsEnabled": true
   }
}
```

1. Adds connectors to the Agent Builder navigation "more" 
<img width="863" height="581" alt="Screenshot 2026-03-03 at 1 43 09 PM" src="https://github.com/user-attachments/assets/e37f8e66-b848-4c29-9760-5075039471f3" />

2. Covers a basic table view
<img width="1233" height="437" alt="Screenshot 2026-03-03 at 1 44 16 PM" src="https://github.com/user-attachments/assets/107aa861-cd8d-4562-a648-c734d328b069" />

3. Exports and utilizes type picker, create, and edit flyouts
<img width="1487" height="746" alt="Screenshot 2026-03-03 at 1 45 29 PM" src="https://github.com/user-attachments/assets/087ae878-a0f6-495e-9f9a-aafd7c440ad8" />
<img width="1498" height="801" alt="Screenshot 2026-03-03 at 1 46 23 PM" src="https://github.com/user-attachments/assets/ec312d5b-9fda-46ea-af5f-6d51b45c2a23" />
<img width="1506" height="813" alt="Screenshot 2026-03-03 at 1 45 58 PM" src="https://github.com/user-attachments/assets/9dae2ff0-8143-45d6-b6ed-68dec986cea8" />

4. Allows defining workflows alongside connector specs:
<img width="261" height="199" alt="Screenshot 2026-03-03 at 1 50 05 PM" src="https://github.com/user-attachments/assets/5548c7fe-d876-413f-bbb4-31cee24cd367" />


6. Registers a new lifecycle hook for workflow/tool creation on connector creation:
```
[2026-03-03T13:10:10.715-06:00][INFO ][plugins.agentBuilder.connector-lifecycle] Connector lifecycle: creating workflows/tools for connector 1a2640a2-e7b1-44fa-9cde-d11917adaefd (type: .slack2)
[2026-03-03T13:10:11.236-06:00][INFO ][plugins.agentBuilder.connector-lifecycle] Connector lifecycle: created workflow 'connector.slack2.search_messages' (id: workflow-46a9cfa8-1a99-42db-b584-d9c2be80ce96)
[2026-03-03T13:10:11.864-06:00][INFO ][plugins.agentBuilder.connector-lifecycle] Connector lifecycle: created tool 'slack2.slack2.search_messages' for workflow 'connector.slack2.search_messages'
[2026-03-03T13:10:12.145-06:00][INFO ][plugins.agentBuilder.connector-lifecycle] Connector lifecycle: created workflow 'connector.slack2.send_message' (id: workflow-00a0bffc-4e7a-4232-bb07-34a0e81556e3)
[2026-03-03T13:10:16.885-06:00][INFO ][plugins.agentBuilder.connector-lifecycle] Connector lifecycle: created tool 'slack2.slack2.send_message' for workflow 'connector.slack2.send_message'
```
<img width="1503" height="479" alt="Screenshot 2026-03-03 at 1 50 32 PM" src="https://github.com/user-attachments/assets/6d100bb4-f9fe-4dc9-b99d-de1ff9bb50a6" />




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Connectors management interface in Agent Builder for discovering, viewing, and editing available connectors.
  * Introduced Slack workflow templates for common operations including searching messages and sending messages to channels.
  * Added a feature flag to enable connector integrations (disabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->