### PR TITLE
[Search] fix(playground): update routes to bound arrays and query max sizes

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes.ts
@@ -75,7 +75,7 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
       },
       validate: {
         body: schema.object({
-          indices: schema.arrayOf(schema.string()),
+          indices: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
         }),
       },
     },
@@ -227,7 +227,7 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
       validate: {
         query: schema.object({
           search_query: schema.maybe(schema.string()),
-          size: schema.number({ defaultValue: 10, min: 0 }),
+          size: schema.number({ defaultValue: 10, min: 0, max: 1000 }),
           exact: schema.maybe(schema.boolean({ defaultValue: false })),
         }),
       },
@@ -265,8 +265,8 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
         body: schema.object({
           search_query: schema.string(),
           elasticsearch_query: schema.string(),
-          indices: schema.arrayOf(schema.string()),
-          size: schema.maybe(schema.number({ defaultValue: 10, min: 0 })),
+          indices: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
+          size: schema.maybe(schema.number({ defaultValue: 10, min: 0, max: 100 })),
           from: schema.maybe(schema.number({ defaultValue: 0, min: 0 })),
         }),
       },
@@ -348,7 +348,7 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
       },
       validate: {
         body: schema.object({
-          indices: schema.arrayOf(schema.string()),
+          indices: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
         }),
       },
     },
@@ -401,8 +401,8 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
         body: schema.object({
           query: schema.string(),
           elasticsearch_query: schema.string(),
-          indices: schema.arrayOf(schema.string()),
-          size: schema.maybe(schema.number({ defaultValue: 10, min: 0 })),
+          indices: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
+          size: schema.maybe(schema.number({ defaultValue: 10, min: 0, max: 100 })),
           from: schema.maybe(schema.number({ defaultValue: 0, min: 0 })),
           chat_context: schema.maybe(
             schema.object({


### PR DESCRIPTION
## Summary

Updated playground routes to bound the size of input arrays.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note

Fixes Search Playground routes to limit the maximum size of arrays.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->