### PR TITLE
[kbn-evals] Fix Evals CLI running against local kibana.dev.yml connectors

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_requester_error.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_requester_error.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { AxiosError } from 'axios';
+import { KbnClientRequesterError } from './kbn_client_requester_error';
+
+describe('KbnClientRequesterError', () => {
+  it('preserves status when cleaning axios errors (even after stripping response)', () => {
+    const original = new AxiosError('Not Found', 'ERR_BAD_REQUEST', undefined, undefined, {
+      status: 404,
+      statusText: 'Not Found',
+      headers: {},
+      config: {} as any,
+      data: { statusCode: 404 },
+    });
+
+    const wrapped = new KbnClientRequesterError('wrapper message', original);
+
+    expect(wrapped.axiosError).toBeDefined();
+    expect(wrapped.axiosError!.status).toBe(404);
+    expect((wrapped.axiosError as any).response).toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_requester_error.ts
+++ b/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_requester_error.ts
@@ -7,18 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { AxiosError } from 'axios';
+import { AxiosError, isAxiosError } from 'axios';
 
 export class KbnClientRequesterError extends Error {
   axiosError?: AxiosError;
   constructor(message: string, error: unknown) {
     super(message);
     this.name = 'KbnClientRequesterError';
-    if (error instanceof AxiosError) this.axiosError = clean(error);
+    if (isAxiosError(error)) this.axiosError = clean(error);
   }
 }
-function clean(error: Error): AxiosError {
+function clean(error: AxiosError): AxiosError {
+  const originalStatus = error.status ?? error.response?.status;
   const _ = AxiosError.from(error);
+  // We strip `response` to avoid keeping large bodies around, but some callers
+  // depend on `status` to branch (e.g. treating 404 as "not found").
+  if (_.status == null && originalStatus != null) {
+    _.status = originalStatus;
+  }
   delete _.cause;
   delete _.config;
   delete _.request;

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
@@ -123,6 +123,18 @@ const waitForScoutReady = async (repoRoot: string, log: ToolingLog): Promise<voi
 
 const isEisConnectorId = (id: string): boolean => id.startsWith('eis-');
 
+const shellQuote = (value: string): string => {
+  // Prefer single quotes for bash/zsh. If the string contains single quotes, fall back to double quotes.
+  if (!value.includes("'")) {
+    return `'${value}'`;
+  }
+  const escaped = value.replace(/(["\\$`])/g, '\\$1');
+  return `"${escaped}"`;
+};
+
+const formatRerunCommand = (args: string[]): string =>
+  ['node', 'scripts/evals', ...args.map((a) => (a.includes(' ') ? shellQuote(a) : a))].join(' ');
+
 const ensureSuite = (suiteId: string, repoRoot: string, log: ToolingLog) => {
   const suites = resolveEvalSuites(repoRoot, log);
   const match = suites.find((suite) => suite.id === suiteId);
@@ -230,6 +242,36 @@ export const startCmd: Command<void> = {
       log.info(`Models:    all (from KIBANA_TESTING_AI_CONNECTORS)`);
     }
     log.info(`Server:    ${skipServer ? 'skip (using existing)' : 'managed'}`);
+    log.info('');
+
+    const rerunArgs: string[] = [];
+    if (suiteId) {
+      rerunArgs.push('--suite', suiteId);
+    } else if (configPath) {
+      rerunArgs.push('--config', configPath);
+    }
+
+    rerunArgs.push('--judge', evaluationConnectorId);
+
+    if (projects.length > 0) {
+      rerunArgs.push('--model', projects.join(','));
+    }
+
+    const grep = flagsReader.string('grep');
+    if (grep) {
+      rerunArgs.push('--grep', grep);
+    }
+
+    const repetitions = flagsReader.string('repetitions');
+    if (repetitions) {
+      rerunArgs.push('--repetitions', repetitions);
+    }
+
+    if (skipServer) {
+      rerunArgs.push('--skip-server');
+    }
+
+    log.info(`Re-run command: ${formatRerunCommand(['start', ...rerunArgs])}`);
     log.info('');
 
     if (flagsReader.boolean('dry-run')) {
@@ -342,7 +384,6 @@ export const startCmd: Command<void> = {
       log.info(`Evaluation results will export to: ${localEsUrl}`);
     }
 
-    const repetitions = flagsReader.string('repetitions');
     if (repetitions) {
       envOverrides.EVALUATION_REPETITIONS = repetitions;
     }
@@ -352,7 +393,6 @@ export const startCmd: Command<void> = {
       args.push('--project', p);
     }
 
-    const grep = flagsReader.string('grep');
     if (grep) {
       args.push('--grep', grep);
     }

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
@@ -17,7 +17,6 @@ import {
   promptForConnector,
   promptForProject,
   isTTY,
-  parseConnectorsFromEnv,
   getAllAvailableConnectors,
   readLocalEsUrl,
   SCOUT_EVALS_ARGS,
@@ -122,10 +121,7 @@ const waitForScoutReady = async (repoRoot: string, log: ToolingLog): Promise<voi
   throw new Error(`Scout did not become ready within ${SCOUT_READY_TIMEOUT_MS / 1000}s`);
 };
 
-const hasEisConnectors = (): boolean => {
-  const connectors = parseConnectorsFromEnv();
-  return connectors.some((c) => c.id.startsWith('eis-'));
-};
+const isEisConnectorId = (id: string): boolean => id.startsWith('eis-');
 
 const ensureSuite = (suiteId: string, repoRoot: string, log: ToolingLog) => {
   const suites = resolveEvalSuites(repoRoot, log);
@@ -219,6 +215,11 @@ export const startCmd: Command<void> = {
     }
 
     const skipServer = flagsReader.boolean('skip-server');
+    const requiresEisCcm =
+      isEisConnectorId(evaluationConnectorId) ||
+      (projects.length > 0
+        ? projects.some(isEisConnectorId)
+        : getAllAvailableConnectors(repoRoot).some((c) => isEisConnectorId(c.id)));
 
     log.info('');
     log.info(`Suite:     ${suiteId ?? configPath}`);
@@ -290,7 +291,7 @@ export const startCmd: Command<void> = {
       }
 
       // --- Step 3: EIS CCM ---
-      if (hasEisConnectors()) {
+      if (requiresEisCcm) {
         log.info('[3/4] Enabling EIS (Cloud Connected Mode)...');
         const ccmApiKey = fetchCcmApiKey(log);
 
@@ -317,7 +318,7 @@ export const startCmd: Command<void> = {
 
         log.info('[3/4] EIS CCM enabled');
       } else {
-        log.info('[3/4] Skipping EIS CCM (no eis- connectors detected)');
+        log.info('[3/4] Skipping EIS CCM (no eis- judge/models selected)');
       }
     }
 


### PR DESCRIPTION
## Summary

Resolving a few issues around the local evals CLI runner:


* Fixes issue where running against local `kibana.dev.yml` connectors would 404
* Fixes issue where only selecting `kibana.dev.yml` connectors would fail on vault auth (for EIS CCM, even though not used)
* Print `run again` command when running `node scripts/evals start` for easily re-running a config or for sharing


### Checklist

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [X] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

_PR developed with Cursor + GPT 5.2_