### PR TITLE
[Agent Builder] fix flattenMappings ignoring nested fields

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.test.ts
@@ -100,6 +100,71 @@ describe('flattenMapping', () => {
     ]);
   });
 
+  it('flattens multi-fields defined under the fields property', () => {
+    const mapping: MappingTypeMapping = {
+      properties: {
+        body: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              ignore_above: 256,
+            },
+            semantic_elser: {
+              type: 'semantic_text',
+            },
+          },
+        },
+        title: {
+          type: 'text',
+          fields: {
+            raw: {
+              type: 'keyword',
+            },
+          },
+          properties: {
+            sub: { type: 'integer' },
+          },
+        },
+      },
+    };
+
+    const flattened = flattenMapping(mapping).sort((a, b) => a.path.localeCompare(b.path));
+
+    expect(flattened).toEqual([
+      {
+        meta: {},
+        path: 'body',
+        type: 'text',
+      },
+      {
+        meta: {},
+        path: 'body.keyword',
+        type: 'keyword',
+      },
+      {
+        meta: {},
+        path: 'body.semantic_elser',
+        type: 'semantic_text',
+      },
+      {
+        meta: {},
+        path: 'title',
+        type: 'text',
+      },
+      {
+        meta: {},
+        path: 'title.raw',
+        type: 'keyword',
+      },
+      {
+        meta: {},
+        path: 'title.sub',
+        type: 'integer',
+      },
+    ]);
+  });
+
   it('keeps internal fields', () => {
     const mapping: MappingTypeMapping = {
       properties: {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.ts
@@ -12,6 +12,7 @@ interface MappingProperties {
   [key: string]: {
     type?: string; // Leaf field (e.g., "text", "keyword", etc.)
     properties?: MappingProperties; // Nested object fields
+    fields?: MappingProperties; // Multi-fields (alternative analyzers/types)
     meta?: Record<string, string>; // meta
   };
 }
@@ -37,8 +38,10 @@ export const flattenMapping = (mapping: MappingTypeMapping): MappingField[] => {
         });
       }
       if (value.properties) {
-        // If it's an object or has nested props, go deeper
         fields = fields.concat(extractFields(value.properties, fieldPath));
+      }
+      if (value.fields) {
+        fields = fields.concat(extractFields(value.fields, fieldPath));
       }
     }
 


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/12238

Fix a flaw in the `flattenMapping` logic where we were recursing on `properties` but not on `fields`, causing mappings such as 

```
"body": {
        "type": "text",
        "fields": {
          "semantic_elser": {
            "type": "semantic_text",
            "inference_id": ".elser-2-elastic",
            "model_settings": {
              "service": "elastic",
              "task_type": "sparse_embedding"
            }
          },
          }
        }
      },
```

to be ignored

## Release Note

Fix a bug in the `platform.core.search` tool and `index_search` tool type which was causing some nested fields to be ignored when searching for matching documents. 

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->