### PR TITLE
[Fleet] show alerts tab for input packages too

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.test.tsx
@@ -366,46 +366,6 @@ describe('AlertingPage', () => {
 
       expect(screen.queryByText('Idle data streams alerting available')).not.toBeInTheDocument();
     });
-
-    it('should show callout for input type package when feature flag is enabled and template is missing', async () => {
-      mockExperimentalFeaturesGet.mockReturnValue({
-        enableIntegrationInactivityAlerting: true,
-      });
-
-      mockUseAlertingAssets.mockReturnValue({
-        alertingAssets: [{ id: 'template-1', type: 'alerting_rule_template' }],
-        alertingAssetsByType: {
-          alerting_rule_template: [{ id: 'template-1', type: 'alerting_rule_template' }],
-        },
-        deferredAlerts: [],
-        assetSavedObjectsByType: {
-          alerting_rule_template: {
-            'template-1': {
-              id: 'template-1',
-              type: 'alerting_rule_template',
-              attributes: { title: '[System] Template' },
-            },
-          },
-        },
-        userCreatedRules: [],
-        isLoading: false,
-        fetchError: undefined,
-        refetch: jest.fn(),
-      });
-
-      const inputPackageInfo = { ...basePackageInfo, type: 'input' as const };
-      renderComponent(inputPackageInfo);
-
-      await waitFor(() => {
-        expect(screen.getByText('Idle data streams alerting available')).toBeInTheDocument();
-      });
-
-      expect(
-        screen.getByText(
-          'Reinstall alerting assets to add an alerting rule template for monitoring idle data streams.'
-        )
-      ).toBeInTheDocument();
-    });
   });
 
   it('should deduplicate Fleet-managed rules from alerting API results', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.test.tsx
@@ -11,6 +11,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { I18nProvider } from '@kbn/i18n-react';
 
 import type { PackageInfo } from '../../../../../types';
+import { InstallStatus } from '../../../../../types';
 
 const mockUseAuthz = jest.fn();
 const mockExperimentalFeaturesGet = jest.fn();
@@ -47,7 +48,13 @@ jest.mock('../../../../../hooks', () => ({
   useAlertingAssets: (...args: any[]) => mockUseAlertingAssets(...args),
 }));
 
+import { useGetPackageInstallStatus } from '../../../../../hooks';
+
 import { AlertingPage } from './alerting_page';
+
+const mockUseGetPackageInstallStatus = useGetPackageInstallStatus as jest.MockedFunction<
+  typeof useGetPackageInstallStatus
+>;
 
 describe('AlertingPage', () => {
   const basePackageInfo = {
@@ -88,6 +95,11 @@ describe('AlertingPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockUseGetPackageInstallStatus.mockReturnValue(() => ({
+      status: InstallStatus.installed,
+      version: '1.0.0',
+    }));
 
     mockUseAlertingAssets.mockReturnValue({
       alertingAssets: [
@@ -354,6 +366,46 @@ describe('AlertingPage', () => {
 
       expect(screen.queryByText('Idle data streams alerting available')).not.toBeInTheDocument();
     });
+
+    it('should show callout for input type package when feature flag is enabled and template is missing', async () => {
+      mockExperimentalFeaturesGet.mockReturnValue({
+        enableIntegrationInactivityAlerting: true,
+      });
+
+      mockUseAlertingAssets.mockReturnValue({
+        alertingAssets: [{ id: 'template-1', type: 'alerting_rule_template' }],
+        alertingAssetsByType: {
+          alerting_rule_template: [{ id: 'template-1', type: 'alerting_rule_template' }],
+        },
+        deferredAlerts: [],
+        assetSavedObjectsByType: {
+          alerting_rule_template: {
+            'template-1': {
+              id: 'template-1',
+              type: 'alerting_rule_template',
+              attributes: { title: '[System] Template' },
+            },
+          },
+        },
+        userCreatedRules: [],
+        isLoading: false,
+        fetchError: undefined,
+        refetch: jest.fn(),
+      });
+
+      const inputPackageInfo = { ...basePackageInfo, type: 'input' as const };
+      renderComponent(inputPackageInfo);
+
+      await waitFor(() => {
+        expect(screen.getByText('Idle data streams alerting available')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(
+          'Reinstall alerting assets to add an alerting rule template for monitoring idle data streams.'
+        )
+      ).toBeInTheDocument();
+    });
   });
 
   it('should deduplicate Fleet-managed rules from alerting API results', async () => {
@@ -404,5 +456,16 @@ describe('AlertingPage', () => {
 
     const fleetRuleElements = screen.getAllByText('[System] Fleet rule');
     expect(fleetRuleElements).toHaveLength(1);
+  });
+
+  it('should not redirect to overview when package type is input', async () => {
+    const inputPackageInfo = { ...basePackageInfo, type: 'input' as const };
+    renderComponent(inputPackageInfo);
+
+    await waitFor(() => {
+      expect(screen.getByText('[System] Logs template')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('fleetAlertingReinstallButton')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
@@ -123,7 +123,7 @@ export const AlertingPage = ({ packageInfo, refetchPackageInfo }: AlertingPagePr
     setIsReinstalling(false);
   }, [notifications.toasts, name, version, forceRefreshAssets]);
 
-  // Redirect to overview if not installed or not an integration package
+  // Redirect to overview if not installed
   if (packageInstallStatus.status !== InstallStatus.installed) {
     return <Redirect to={getPath('integration_details_overview', { pkgkey })} />;
   }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
@@ -85,18 +85,13 @@ export const AlertingPage = ({ packageInfo, refetchPackageInfo }: AlertingPagePr
   // Detect missing inactivity monitoring template
   const { enableIntegrationInactivityAlerting } = ExperimentalFeaturesService.get();
   const hasDataStreams = (packageInfo.data_streams?.length ?? 0) > 0;
-  const isIntegrationPackage = packageInfo.type === 'integration';
   const inactivityTemplateId = getInactivityMonitoringTemplateId(name);
   const hasInactivityTemplate = useMemo(
     () => alertingAssets.some((asset) => asset.id === inactivityTemplateId),
     [alertingAssets, inactivityTemplateId]
   );
   const showInactivityCallout =
-    enableIntegrationInactivityAlerting &&
-    isIntegrationPackage &&
-    hasDataStreams &&
-    !hasInactivityTemplate &&
-    !isLoading;
+    enableIntegrationInactivityAlerting && hasDataStreams && !hasInactivityTemplate && !isLoading;
 
   const handleReinstallAlertingAssets = useCallback(async () => {
     setIsReinstalling(true);
@@ -129,10 +124,7 @@ export const AlertingPage = ({ packageInfo, refetchPackageInfo }: AlertingPagePr
   }, [notifications.toasts, name, version, forceRefreshAssets]);
 
   // Redirect to overview if not installed or not an integration package
-  if (
-    packageInstallStatus.status !== InstallStatus.installed ||
-    packageInfo.type !== 'integration'
-  ) {
+  if (packageInstallStatus.status !== InstallStatus.installed) {
     return <Redirect to={getPath('integration_details_overview', { pkgkey })} />;
   }
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
@@ -85,13 +85,18 @@ export const AlertingPage = ({ packageInfo, refetchPackageInfo }: AlertingPagePr
   // Detect missing inactivity monitoring template
   const { enableIntegrationInactivityAlerting } = ExperimentalFeaturesService.get();
   const hasDataStreams = (packageInfo.data_streams?.length ?? 0) > 0;
+  const isIntegrationPackage = packageInfo.type === 'integration';
   const inactivityTemplateId = getInactivityMonitoringTemplateId(name);
   const hasInactivityTemplate = useMemo(
     () => alertingAssets.some((asset) => asset.id === inactivityTemplateId),
     [alertingAssets, inactivityTemplateId]
   );
   const showInactivityCallout =
-    enableIntegrationInactivityAlerting && hasDataStreams && !hasInactivityTemplate && !isLoading;
+    enableIntegrationInactivityAlerting &&
+    isIntegrationPackage &&
+    hasDataStreams &&
+    !hasInactivityTemplate &&
+    !isLoading;
 
   const handleReinstallAlertingAssets = useCallback(async () => {
     setIsReinstalling(true);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -85,22 +85,64 @@ describe('When on integration detail', () => {
     });
   });
 
-  describe('and the package is input type', () => {
-    beforeEach(async () => {
+  describe('and Alerting tab visibility', () => {
+    it('should show Alerting tab when package has alerting type assets', async () => {
       const baseResponse = mockedApi.responseProvider.epmGetInfo('nginx');
+      const itemWithAlertingAssets = {
+        ...baseResponse.item,
+        assets: {
+          ...baseResponse.item.assets,
+          kibana: {
+            ...baseResponse.item.assets?.kibana,
+            alerting_rule_template: [
+              {
+                pkgkey: 'nginx-0.3.7',
+                service: 'kibana',
+                type: 'alerting_rule_template',
+                file: 'nginx-inactivity.json',
+              },
+            ],
+          },
+        },
+      };
       mockedApi.responseProvider.epmGetInfo.mockReturnValue({
         ...baseResponse,
-        item: { ...baseResponse.item, type: 'input' as const },
+        item: { ...itemWithAlertingAssets, type: 'input' as const } as typeof baseResponse.item,
       });
       await render();
       await act(() => mockedApi.waitForApi());
       await act(() => mockedApi.waitForApi());
       await act(() => mockedApi.waitForApi());
       await act(() => mockedApi.waitForApi());
-    }, TESTS_TIMEOUT);
 
-    it('should show the Alerting tab', async () => {
       expect(await renderResult.findByTestId('tab-alerting')).not.toBeNull();
+    });
+
+    it('should not show Alerting tab when package has no alerting type assets', async () => {
+      const baseResponse = mockedApi.responseProvider.epmGetInfo('nginx');
+      const kibanaAssets = baseResponse.item.assets?.kibana as Record<string, unknown> | undefined;
+      const itemWithoutAlertingAssets = {
+        ...baseResponse.item,
+        assets: {
+          ...baseResponse.item.assets,
+          kibana: {
+            dashboard: kibanaAssets?.dashboard ?? [],
+            search: kibanaAssets?.search ?? [],
+            visualization: kibanaAssets?.visualization ?? [],
+          },
+        },
+      };
+      mockedApi.responseProvider.epmGetInfo.mockReturnValue({
+        ...baseResponse,
+        item: itemWithoutAlertingAssets as typeof baseResponse.item,
+      });
+      await render();
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+
+      expect(renderResult.queryByTestId('tab-alerting')).toBeNull();
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -85,6 +85,25 @@ describe('When on integration detail', () => {
     });
   });
 
+  describe('and the package is input type', () => {
+    beforeEach(async () => {
+      const baseResponse = mockedApi.responseProvider.epmGetInfo('nginx');
+      mockedApi.responseProvider.epmGetInfo.mockReturnValue({
+        ...baseResponse,
+        item: { ...baseResponse.item, type: 'input' as const },
+      });
+      await render();
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+    }, TESTS_TIMEOUT);
+
+    it('should show the Alerting tab', async () => {
+      expect(await renderResult.findByTestId('tab-alerting')).not.toBeNull();
+    });
+  });
+
   function mockGAAndPrereleaseVersions(pkgVersion: string) {
     const unInstalledPackage = mockedApi.responseProvider.epmGetInfo('nginx');
     unInstalledPackage.item.status = 'not_installed';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -705,7 +705,7 @@ export function Detail() {
       });
     }
 
-    if (isInstalled && packageInfo.type === 'integration') {
+    if (isInstalled) {
       tabs.push({
         id: 'alerting',
         name: (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -76,7 +76,7 @@ import {
   AddIntegrationButton,
   EditIntegrationButton,
 } from './components';
-import { AlertingPage } from './alerting';
+import { ALERTING_ASSET_TYPES, AlertingPage } from './alerting';
 import { AssetsPage } from './assets';
 import { OverviewPage } from './overview';
 import { PackagePoliciesPage } from './policies';
@@ -288,6 +288,10 @@ export function Detail() {
     !HIDDEN_API_REFERENCE_PACKAGES.includes(pkgName) &&
     packageInfo &&
     hasDocumentation({ packageInfo, integration });
+
+  const showAlertingTab = Object.keys(packageInfo?.assets?.kibana ?? {}).some((type) =>
+    (ALERTING_ASSET_TYPES as string[]).includes(type)
+  );
 
   // Track install status state
   useEffect(() => {
@@ -705,7 +709,7 @@ export function Detail() {
       });
     }
 
-    if (isInstalled) {
+    if (isInstalled && showAlertingTab) {
       tabs.push({
         id: 'alerting',
         name: (
@@ -796,6 +800,7 @@ export function Detail() {
     showCustomTab,
     showDocumentationTab,
     numOfDeferredInstallations,
+    showAlertingTab,
   ]);
 
   const securityCallout = missingSecurityConfiguration ? (


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/255910

Relates https://github.com/elastic/kibana/pull/253948

Enable Alerting tab to be displayed for input packages too

Tested with CouchDB Content Pack that has alerting rules
https://github.com/elastic/integrations/pull/17631
[couchdb_otel-0.1.0.zip](https://github.com/user-attachments/files/25736442/couchdb_otel-0.1.0.zip)

Uploaded the package, and checked that the Alerting tab is showing up

<img width="1206" height="766" alt="image" src="https://github.com/user-attachments/assets/03ab6049-ddd7-4209-bace-013b9e8d9f3c" />

<img width="1204" height="703" alt="image" src="https://github.com/user-attachments/assets/8c102d38-fbc3-4257-9d08-6ffdebca1839" />

The Alerting tab is only visible if there are alerting type kibana assets in the package

<img width="1218" height="436" alt="image" src="https://github.com/user-attachments/assets/39ddc7e8-4037-4ad3-8a28-1f78871fc36d" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



