### PR TITLE
[streams][features] abort if no sample documents

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification.ts
@@ -102,6 +102,14 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                   size: 20,
                 });
 
+                if (sampleDocuments.length === 0) {
+                  taskContext.logger.debug(
+                    () =>
+                      `No sample documents found for stream ${streamName}, skipping features identification`
+                  );
+                  return getDeleteTaskRunResult();
+                }
+
                 const identifyFeaturesStart = Date.now();
                 const [{ features: inferredBaseFeatures }, computedFeatures] = await Promise.all([
                   identifyFeatures({


### PR DESCRIPTION
## Summary

We don't need to consume tokens if no sample documents were found in the stream


