### PR TITLE
[CI] Cache tsbuildinfo files for faster type checking

### DIFF
--- a/.buildkite/scripts/steps/typecheck/check_types.sh
+++ b/.buildkite/scripts/steps/typecheck/check_types.sh
@@ -6,6 +6,37 @@ source .buildkite/scripts/common/util.sh
 
 .buildkite/scripts/bootstrap.sh
 
+echo "--- Restore tsbuildinfo cache"
+
+TSBUILDINFO_CACHE_KEY="tsbuildinfo-$(git rev-parse HEAD~1 2>/dev/null || echo 'none')"
+TSBUILDINFO_CACHE_ARCHIVE="/tmp/tsbuildinfo-cache.tar.gz"
+TSBUILDINFO_CACHE_BUCKET="${KIBANA_CI_CACHE_BUCKET:-kibana-ci-cache}"
+TSBUILDINFO_GCS_PATH="gs://${TSBUILDINFO_CACHE_BUCKET}/tsbuildinfo-cache/main-latest.tar.gz"
+
+if gsutil -q stat "$TSBUILDINFO_GCS_PATH" 2>/dev/null; then
+  echo "Downloading tsbuildinfo cache from GCS"
+  gsutil -q cp "$TSBUILDINFO_GCS_PATH" "$TSBUILDINFO_CACHE_ARCHIVE" 2>/dev/null || true
+  if [[ -f "$TSBUILDINFO_CACHE_ARCHIVE" ]]; then
+    tar -xzf "$TSBUILDINFO_CACHE_ARCHIVE" 2>/dev/null || echo "Failed to extract tsbuildinfo cache, starting fresh"
+    TSBUILDINFO_COUNT=$(find . -name '*.tsbuildinfo' 2>/dev/null | wc -l | tr -d ' ')
+    echo "Restored $TSBUILDINFO_COUNT .tsbuildinfo files"
+  fi
+else
+  echo "No tsbuildinfo cache found, running from scratch"
+fi
+
 echo --- Check Types
 
 node scripts/type_check --with-archive
+
+echo "--- Save tsbuildinfo cache"
+
+TSBUILDINFO_FILES=$(find . -name '*.tsbuildinfo' -not -path '*/node_modules/*' 2>/dev/null)
+if [[ -n "$TSBUILDINFO_FILES" ]]; then
+  TSBUILDINFO_COUNT=$(echo "$TSBUILDINFO_FILES" | wc -l | tr -d ' ')
+  echo "Saving $TSBUILDINFO_COUNT .tsbuildinfo files to cache"
+  echo "$TSBUILDINFO_FILES" | tar -czf "$TSBUILDINFO_CACHE_ARCHIVE" -T - 2>/dev/null || true
+  if [[ -f "$TSBUILDINFO_CACHE_ARCHIVE" ]]; then
+    gsutil -q cp "$TSBUILDINFO_CACHE_ARCHIVE" "$TSBUILDINFO_GCS_PATH" 2>/dev/null || echo "Failed to upload tsbuildinfo cache"
+  fi
+fi


### PR DESCRIPTION
## Summary

Optimize TypeScript type checking on CI by using incremental compilation with persistent `.tsbuildinfo` files cached between builds.

## Approach

- **Before type check**: Download a cached `.tsbuildinfo` archive from GCS (if available) and extract into the workspace
- **Run type check**: Execute `node scripts/type_check --with-archive` as before; TypeScript will use the restored `.tsbuildinfo` files for incremental compilation
- **After type check**: Upload the updated `.tsbuildinfo` files back to GCS for the next build

## Key details

- Uses GCS bucket (`kibana-ci-cache` by default, configurable via `KIBANA_CI_CACHE_BUCKET`)
- Cache path: `gs://${bucket}/tsbuildinfo-cache/main-latest.tar.gz`
- **All cache operations are non-fatal** — builds work correctly without the cache (download/extract/upload failures are logged but do not fail the build)
- Follows the same GCS caching pattern used elsewhere in Kibana CI

## Estimated savings

~2–4 minutes on type check when most files are unchanged (e.g., main branch builds that run after a prior successful type check).

## Testing

- First build on a clean cache: runs full type check, uploads cache
- Subsequent builds: restores cache, incremental type check is faster
- Builds without GCS access or on cache miss: full type check, no failure