### PR TITLE
[9.3] [Discover] Hide sample size for ES|QL embedabble (#255493)

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
@@ -24,7 +24,7 @@ import type { DiscoverAppState } from '../../state_management/redux';
 import type { DiscoverCustomization } from '../../../../customizations';
 import { createCustomizationService } from '../../../../customizations/customization_service';
 import { DiscoverGrid } from '../../../../components/discover_grid';
-import { createDataViewDataSource } from '../../../../../common/data_sources';
+import { createDataViewDataSource, createEsqlDataSource } from '../../../../../common/data_sources';
 import { type ProfilesManager } from '../../../../context_awareness';
 import { internalStateActions } from '../../state_management/redux';
 import { DiscoverTestProvider } from '../../../../__mocks__/test_provider';
@@ -34,7 +34,8 @@ const customisationService = createCustomizationService();
 async function mountComponent(
   fetchStatus: FetchStatus,
   hits: EsHitRecord[],
-  profilesManager?: ProfilesManager
+  profilesManager?: ProfilesManager,
+  isEsqlMode?: boolean
 ) {
   const services = discoverServiceMock;
 
@@ -49,9 +50,14 @@ async function mountComponent(
   const stateContainer = getDiscoverStateMock({});
   stateContainer.internalState.dispatch(
     stateContainer.injectCurrentTab(internalStateActions.updateAppState)({
-      appState: {
-        dataSource: createDataViewDataSource({ dataViewId: dataViewMock.id! }),
-      },
+      appState: isEsqlMode
+        ? {
+            dataSource: createEsqlDataSource(),
+            query: { esql: 'from *' },
+          }
+        : {
+            dataSource: createDataViewDataSource({ dataViewId: dataViewMock.id! }),
+          },
     })
   );
   stateContainer.internalState.dispatch(
@@ -125,6 +131,18 @@ describe('Discover documents layout', () => {
     expect(findTestSubject(component, 'unifiedDataTableToolbar').exists()).toBe(true);
     expect(findTestSubject(component, 'unifiedDataTableToolbarBottom').exists()).toBe(true);
     expect(findTestSubject(component, 'viewModeToggle').exists()).toBe(true);
+  });
+
+  test('ES|QL: should not pass onUpdateSampleSize to DiscoverGrid', async () => {
+    const component = await mountComponent(FetchStatus.COMPLETE, esHitsMock, undefined, true);
+    const discoverGridComponent = component.find(DiscoverGrid);
+    expect(discoverGridComponent.prop('onUpdateSampleSize')).toBeUndefined();
+  });
+
+  test('should pass onUpdateSampleSize to DiscoverGrid when not in ES|QL mode', async () => {
+    const component = await mountComponent(FetchStatus.COMPLETE, esHitsMock, undefined, false);
+    const discoverGridComponent = component.find(DiscoverGrid);
+    expect(discoverGridComponent.prop('onUpdateSampleSize')).toBeDefined();
   });
 
   test('should set rounded width to state on resize column', () => {

--- a/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.test.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { BehaviorSubject } from 'rxjs';
+import { render, waitFor } from '@testing-library/react';
+import { dataViewMock, esHitsMock } from '@kbn/discover-utils/src/__mocks__';
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import { createSearchSourceMock } from '@kbn/data-plugin/public/mocks';
+import type { AggregateQuery, Query } from '@kbn/es-query';
+import type { SavedSearch, DiscoverGridSettings, VIEW_MODE } from '@kbn/saved-search-plugin/common';
+import type { DataTableColumnsMeta, SortOrder, DataGridDensity } from '@kbn/unified-data-table';
+import type { SearchResponseIncompleteWarning } from '@kbn/search-response-warnings/src/types';
+import type { FetchContext } from '@kbn/presentation-publishing';
+import { createDiscoverServicesMock } from '../../__mocks__/services';
+import { DiscoverTestProvider } from '../../__mocks__/test_provider';
+import type { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../types';
+import { SearchEmbeddableGridComponent } from './search_embeddable_grid_component';
+
+const mockDiscoverGridEmbeddableProps = jest.fn();
+
+jest.mock('./saved_search_grid', () => ({
+  DiscoverGridEmbeddable: (props: Record<string, unknown>) => {
+    mockDiscoverGridEmbeddableProps(props);
+    return <div data-test-subj="mockedDiscoverGridEmbeddable" />;
+  },
+}));
+
+const createStateManager = (): SearchEmbeddableStateManager => ({
+  columns: new BehaviorSubject<string[] | undefined>(['message']),
+  columnsMeta: new BehaviorSubject<DataTableColumnsMeta | undefined>(undefined),
+  grid: new BehaviorSubject<DiscoverGridSettings | undefined>(undefined),
+  rowHeight: new BehaviorSubject<number | undefined>(undefined),
+  headerRowHeight: new BehaviorSubject<number | undefined>(undefined),
+  rowsPerPage: new BehaviorSubject<number | undefined>(undefined),
+  sampleSize: new BehaviorSubject<number | undefined>(100),
+  sort: new BehaviorSubject<SortOrder[] | undefined>(undefined),
+  viewMode: new BehaviorSubject<VIEW_MODE | undefined>(undefined),
+  density: new BehaviorSubject<DataGridDensity | undefined>(undefined),
+  rows: new BehaviorSubject<DataTableRecord[]>([]),
+  totalHitCount: new BehaviorSubject<number | undefined>(undefined),
+  inspectorAdapters: new BehaviorSubject<Record<string, unknown>>({}),
+});
+
+const createSavedSearch = (isEsql: boolean): SavedSearch => {
+  const searchSource = createSearchSourceMock({ index: dataViewMock });
+  if (isEsql) {
+    searchSource.setField('query', { esql: 'FROM test | LIMIT 100' } as AggregateQuery);
+  } else {
+    searchSource.setField('query', { query: '*', language: 'kuery' } as Query);
+  }
+  return {
+    id: 'test-saved-search',
+    title: 'Test Saved Search',
+    searchSource,
+    columns: ['message'],
+    sort: [],
+    managed: false,
+  };
+};
+
+const createApi = (savedSearch: SavedSearch) => {
+  return {
+    dataLoading$: new BehaviorSubject<boolean | undefined>(false),
+    savedSearch$: new BehaviorSubject(savedSearch),
+    savedObjectId$: new BehaviorSubject<string | undefined>(undefined),
+    fetchWarnings$: new BehaviorSubject<SearchResponseIncompleteWarning[]>([]),
+    query$: new BehaviorSubject(savedSearch.searchSource.getField('query')),
+    filters$: new BehaviorSubject([]),
+    fetchContext$: new BehaviorSubject<FetchContext | undefined>(undefined),
+    title$: new BehaviorSubject<string | undefined>('Test'),
+    description$: new BehaviorSubject<string | undefined>(undefined),
+    defaultTitle$: new BehaviorSubject<string | undefined>('Test'),
+    defaultDescription$: new BehaviorSubject<string | undefined>(undefined),
+  } as unknown as SearchEmbeddableApi & {
+    fetchWarnings$: BehaviorSubject<SearchResponseIncompleteWarning[]>;
+    fetchContext$: BehaviorSubject<FetchContext | undefined>;
+  };
+};
+
+describe('SearchEmbeddableGridComponent', () => {
+  const services = createDiscoverServicesMock();
+  const rows = esHitsMock.map((hit) => buildDataTableRecord(hit, dataViewMock));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderComponent = ({ isEsql }: { isEsql: boolean }) => {
+    const savedSearch = createSavedSearch(isEsql);
+    const api = createApi(savedSearch);
+    const stateManager = createStateManager();
+    stateManager.rows.next(rows);
+    stateManager.totalHitCount.next(rows.length);
+
+    return render(
+      <DiscoverTestProvider services={services}>
+        <SearchEmbeddableGridComponent
+          api={api}
+          dataView={dataViewMock}
+          stateManager={stateManager}
+          enableDocumentViewer={true}
+        />
+      </DiscoverTestProvider>
+    );
+  };
+
+  describe('onUpdateSampleSize', () => {
+    it('should pass onUpdateSampleSize as undefined when in ES|QL mode', async () => {
+      renderComponent({ isEsql: true });
+
+      await waitFor(() => {
+        expect(mockDiscoverGridEmbeddableProps).toHaveBeenCalled();
+      });
+
+      const lastCallProps = mockDiscoverGridEmbeddableProps.mock.calls.at(-1)?.[0];
+      expect(lastCallProps?.onUpdateSampleSize).toBeUndefined();
+    });
+
+    it('should pass onUpdateSampleSize as a function when not in ES|QL mode', async () => {
+      renderComponent({ isEsql: false });
+
+      await waitFor(() => {
+        expect(mockDiscoverGridEmbeddableProps).toHaveBeenCalled();
+      });
+
+      const lastCallProps = mockDiscoverGridEmbeddableProps.mock.calls.at(-1)?.[0];
+      expect(lastCallProps?.onUpdateSampleSize).toBeDefined();
+      expect(typeof lastCallProps?.onUpdateSampleSize).toBe('function');
+    });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.tsx
@@ -223,6 +223,7 @@ export function SearchEmbeddableGridComponent({
   return (
     <DiscoverGridEmbeddableMemoized
       {...onStateEditedProps}
+      onUpdateSampleSize={isEsql ? undefined : onStateEditedProps.onUpdateSampleSize}
       columns={columns}
       dataView={dataView}
       interceptedWarnings={interceptedWarnings}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover] Hide sample size for ES|QL embedabble (#255493)](https://github.com/elastic/kibana/pull/255493)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2026-03-04T08:24:45Z","message":"[Discover] Hide sample size for ES|QL embedabble (#255493)\n\n- Resolves https://github.com/elastic/kibana/issues/255398\n\n## Summary\n\nThe PR hides the sample size control for panels when in ES|QL mode.\n\n<img width=\"826\" height=\"578\" alt=\"Screenshot 2026-03-02 at 11 57 23\"\nsrc=\"https://github.com/user-attachments/assets/838b9fdb-6109-40ed-ae9c-9cffa51e8af6\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1922568a23c439287d960e60a9673b73be944db8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.4.0","v9.3.2"],"title":"[Discover] Hide sample size for ES|QL embedabble","number":255493,"url":"https://github.com/elastic/kibana/pull/255493","mergeCommit":{"message":"[Discover] Hide sample size for ES|QL embedabble (#255493)\n\n- Resolves https://github.com/elastic/kibana/issues/255398\n\n## Summary\n\nThe PR hides the sample size control for panels when in ES|QL mode.\n\n<img width=\"826\" height=\"578\" alt=\"Screenshot 2026-03-02 at 11 57 23\"\nsrc=\"https://github.com/user-attachments/assets/838b9fdb-6109-40ed-ae9c-9cffa51e8af6\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1922568a23c439287d960e60a9673b73be944db8"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255493","number":255493,"mergeCommit":{"message":"[Discover] Hide sample size for ES|QL embedabble (#255493)\n\n- Resolves https://github.com/elastic/kibana/issues/255398\n\n## Summary\n\nThe PR hides the sample size control for panels when in ES|QL mode.\n\n<img width=\"826\" height=\"578\" alt=\"Screenshot 2026-03-02 at 11 57 23\"\nsrc=\"https://github.com/user-attachments/assets/838b9fdb-6109-40ed-ae9c-9cffa51e8af6\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1922568a23c439287d960e60a9673b73be944db8"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->