### PR TITLE
[@kbn/scout] Add `--repeatEach` flag to `run-tests` for local flakiness validation

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/cli/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/run_tests.ts
@@ -49,6 +49,9 @@ export const runTestsCmd: Command<void> = {
 
     On Elastic Cloud projects (MKI):
     node scripts/scout run-tests --location cloud --arch serverless --domain search --config <playwright_config_path>
+
+    Local flakiness validation (run each test N times):
+    node scripts/scout run-tests --arch stateful --domain classic --config <playwright_config_path> --repeatEach 5
   `,
   flags: TEST_FLAG_OPTIONS,
   run: async ({ flagsReader, log }) => {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
@@ -151,6 +151,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: undefined,
       headed: false,
+      repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
       serverConfigSet: 'default',
@@ -180,6 +181,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: 'snapshot',
       headed: true,
+      repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
       serverConfigSet: 'default',
@@ -208,6 +210,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: undefined,
       headed: false,
+      repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
       serverConfigSet: 'default',
@@ -237,6 +240,7 @@ describe('parseTestFlags', () => {
       configPath: '/path/to/config',
       esFrom: 'snapshot',
       headed: true,
+      repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
       serverConfigSet: 'default',
@@ -246,6 +250,87 @@ describe('parseTestFlags', () => {
         location: 'cloud',
       },
     });
+  });
+
+  it(`should parse with --repeatEach flag`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      headed: false,
+      repeatEach: '5',
+      serverConfigSet: 'default',
+    });
+    validatePlaywrightConfigMock.mockResolvedValueOnce();
+    const result = await parseTestFlags(flags);
+
+    expect(result).toEqual({
+      configPath: '/path/to/config',
+      esFrom: undefined,
+      headed: false,
+      repeatEach: 5,
+      installDir: undefined,
+      logsDir: undefined,
+      serverConfigSet: 'default',
+      testTarget: {
+        arch: 'stateful',
+        domain: 'classic',
+        location: 'local',
+      },
+    });
+  });
+
+  it(`should throw an error when '--repeatEach' is not a number`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      headed: false,
+      repeatEach: 'abc',
+      serverConfigSet: 'default',
+    });
+
+    await expect(parseTestFlags(flags)).rejects.toThrow(
+      `unable to parse --repeatEach value [abc] as a number`
+    );
+  });
+
+  it(`should throw an error when '--repeatEach' is zero`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      headed: false,
+      repeatEach: '0',
+      serverConfigSet: 'default',
+    });
+
+    await expect(parseTestFlags(flags)).rejects.toThrow(
+      `'--repeatEach' must be a positive integer, got '0'`
+    );
+  });
+
+  it(`should throw an error when '--repeatEach' is a decimal`, async () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'stateful',
+      domain: 'classic',
+      config: '/path/to/config',
+      logToFile: false,
+      headed: false,
+      repeatEach: '2.5',
+      serverConfigSet: 'default',
+    });
+
+    await expect(parseTestFlags(flags)).rejects.toThrow(
+      `'--repeatEach' must be a positive integer, got '2.5'`
+    );
   });
 
   describe('testFiles flag', () => {
@@ -282,6 +367,7 @@ describe('parseTestFlags', () => {
         configPath: derivedConfig,
         esFrom: undefined,
         headed: false,
+        repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,
         serverConfigSet: 'default',
@@ -325,6 +411,7 @@ describe('parseTestFlags', () => {
         configPath: derivedConfig,
         esFrom: undefined,
         headed: false,
+        repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,
         serverConfigSet: 'default',

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.ts
@@ -20,6 +20,7 @@ export interface RunTestsOptions {
   testTarget: ScoutTestTarget;
   configPath: string;
   headed: boolean;
+  repeatEach: number | undefined;
   testFiles?: string[];
   esFrom: 'serverless' | 'source' | 'snapshot' | undefined;
   installDir: string | undefined;
@@ -29,13 +30,14 @@ export interface RunTestsOptions {
 export const TEST_FLAG_OPTIONS: FlagOptions = {
   ...SERVER_FLAG_OPTIONS,
   boolean: [...(SERVER_FLAG_OPTIONS.boolean || []), 'headed'],
-  string: [...(SERVER_FLAG_OPTIONS.string || []), 'config', 'testFiles'],
+  string: [...(SERVER_FLAG_OPTIONS.string || []), 'config', 'testFiles', 'repeatEach'],
   default: { ...SERVER_FLAG_OPTIONS.default, headed: false },
   help: `
     ${SERVER_FLAG_OPTIONS.help}
     --config            Playwright config file path (required if --testFiles not provided)
     --testFiles         Comma-separated list of test file paths or test directory path (required if --config not provided)
     --headed            Run Playwright with browser head
+    --repeatEach        Run each test N times for local flakiness validation (e.g. --repeatEach 5)
   `,
 };
 
@@ -55,6 +57,12 @@ export async function parseTestFlags(flags: FlagsReader) {
   }
 
   const headed = flags.boolean('headed');
+  const repeatEach = flags.number('repeatEach');
+
+  if (repeatEach !== undefined && (repeatEach < 1 || !Number.isInteger(repeatEach))) {
+    throw createFlagError(`'--repeatEach' must be a positive integer, got '${repeatEach}'`);
+  }
+
   let scoutConfigPath: string;
   const testFiles: string[] = [];
 
@@ -77,6 +85,7 @@ export async function parseTestFlags(flags: FlagsReader) {
     ...serverOptions,
     configPath: scoutConfigPath,
     headed,
+    repeatEach,
     ...(testFiles.length > 0 && { testFiles }),
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -183,6 +183,12 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
     log.info(`scout: Running Scout tests located in:\n${pwTestFiles.join('\n')}`);
   }
 
+  if (options.repeatEach) {
+    log.info(
+      `scout: Each test will be repeated ${options.repeatEach} time(s) for flakiness validation`
+    );
+  }
+
   const pwBinPath = resolve(REPO_ROOT, './node_modules/.bin/playwright');
   const pwCmdArgs = [
     'test',
@@ -191,6 +197,7 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
     `--grep=${pwGrepTag}`,
     `--project=${pwProject}`,
     ...(options.headed ? ['--headed'] : []),
+    ...(options.repeatEach ? [`--repeat-each=${options.repeatEach}`] : []),
   ];
 
   await withProcRunner(log, async (procs) => {


### PR DESCRIPTION
## Summary

Adds a `--repeatEach` CLI flag to the `node scripts/scout run-tests` command, forwarding Playwright's `--repeat-each` option. This allows developers to run each test N times locally to validate flakiness without waiting for CI Flaky Test Runner jobs.

## Changes

- Added `--repeatEach` flag parsing and validation in `flags.ts`
- Forward `--repeat-each=N` to Playwright args in `run_tests.ts`
- Updated CLI help text with usage example
- Added unit tests for the new flag

**Usage:**
```
node scripts/scout run-tests --arch stateful --domain classic --config <path> --repeatEach <number>
```

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->