### PR TITLE
Improve ID validation in Saved Objects Repository and DataStreamClient

### DIFF
--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_delete.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_delete.ts
@@ -32,6 +32,7 @@ import {
   isMgetDoc,
   rawDocExistsInNamespace,
 } from './utils';
+import { assertValidId } from './helpers/id_utils';
 import type { ApiExecutionContext } from './types';
 import { deleteLegacyUrlAliases } from './internals/delete_legacy_url_aliases';
 import type {
@@ -269,6 +270,11 @@ function presortObjectsByNamespaceType(
         type,
         error: errorContent(SavedObjectsErrorHelpers.createUnsupportedTypeError(type)),
       });
+    }
+    try {
+      assertValidId(id);
+    } catch (e) {
+      return left({ id, type, error: errorContent(e) });
     }
     const requiresNamespacesCheck = registry.isMultiNamespace(type);
 

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_get.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_get.ts
@@ -90,6 +90,7 @@ export const performBulkGet = async <T>(
         error = SavedObjectsErrorHelpers.createUnsupportedTypeError(type);
       } else {
         try {
+          validationHelper.validateId(id);
           validationHelper.validateObjectNamespaces(type, id, object.namespaces);
         } catch (e) {
           error = e;

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_update.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_update.ts
@@ -111,6 +111,7 @@ export const performBulkUpdate = async <T>(
       error = SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
     } else {
       try {
+        helpers.validation.validateId(id);
         if (objectNamespace === ALL_NAMESPACES_STRING) {
           error = SavedObjectsErrorHelpers.createBadRequestError('"namespace" cannot be "*"');
         }

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/check_conflicts.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/check_conflicts.ts
@@ -33,7 +33,7 @@ export const performCheckConflicts = async <T>(
   { objects, options }: PerformCheckConflictsParams<T>,
   { registry, helpers, allowedTypes, client, serializer, extensions = {} }: ApiExecutionContext
 ): Promise<SavedObjectsCheckConflictsResponse> => {
-  const { common: commonHelper } = helpers;
+  const { common: commonHelper, validation: validationHelper } = helpers;
   const { securityExtension } = extensions;
 
   const namespace = commonHelper.getCurrentNamespace(options.namespace);
@@ -56,6 +56,11 @@ export const performCheckConflicts = async <T>(
         type,
         error: errorContent(SavedObjectsErrorHelpers.createUnsupportedTypeError(type)),
       });
+    }
+    try {
+      validationHelper.validateId(id);
+    } catch (e) {
+      return left({ id, type, error: errorContent(e) });
     }
 
     return right({

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/collect_multinamespaces_references.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/collect_multinamespaces_references.ts
@@ -24,9 +24,10 @@ export const performCollectMultiNamespaceReferences = async <T>(
   { objects, options }: PerformCreateParams<T>,
   { registry, helpers, allowedTypes, client, serializer, extensions = {} }: ApiExecutionContext
 ): Promise<SavedObjectsCollectMultiNamespaceReferencesResponse> => {
-  const { common: commonHelper } = helpers;
+  const { common: commonHelper, validation: validationHelper } = helpers;
   const { securityExtension } = extensions;
 
+  objects.forEach(({ id }) => validationHelper.validateId(id));
   const namespace = commonHelper.getCurrentNamespace(options.namespace);
   return collectMultiNamespaceReferences({
     registry,

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/create.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/create.test.ts
@@ -643,7 +643,7 @@ describe('#create', () => {
         await expect(
           repository.create(type, attributes, { id: '../../../attack' })
         ).rejects.toThrowError(
-          createBadRequestErrorPayload("Invalid saved object ID: IDs cannot contain '/'")
+          createBadRequestErrorPayload("Invalid saved object ID: IDs cannot contain '/'.")
         );
         expect(client.create).not.toHaveBeenCalled();
       });

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/create.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/create.test.ts
@@ -638,6 +638,16 @@ describe('#create', () => {
         expect(client.create).not.toHaveBeenCalled();
       });
 
+      it(`throws a BadRequestError when id contains a forward slash (path traversal)`, async () => {
+        const type = 'index-pattern';
+        await expect(
+          repository.create(type, attributes, { id: '../../../attack' })
+        ).rejects.toThrowError(
+          createBadRequestErrorPayload("Invalid saved object ID: IDs cannot contain '/'")
+        );
+        expect(client.create).not.toHaveBeenCalled();
+      });
+
       it(`throws when type is hidden`, async () => {
         await expect(repository.create(HIDDEN_TYPE, attributes)).rejects.toThrowError(
           createUnsupportedTypeErrorPayload(HIDDEN_TYPE)

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/delete.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/delete.ts
@@ -38,13 +38,18 @@ export const performDelete = async <T>(
     mappings,
   }: ApiExecutionContext
 ): Promise<{}> => {
-  const { common: commonHelper, preflight: preflightHelper } = helpers;
+  const {
+    common: commonHelper,
+    preflight: preflightHelper,
+    validation: validationHelper,
+  } = helpers;
   const { securityExtension } = extensions;
   const namespace = commonHelper.getCurrentNamespace(options.namespace);
 
   if (!allowedTypes.includes(type)) {
     throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
   }
+  validationHelper.validateId(id);
 
   const { refresh = DEFAULT_REFRESH_SETTING, force } = options;
 

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.test.ts
@@ -193,7 +193,7 @@ describe('#get', () => {
 
       it(`throws a BadRequestError when the id contains a forward slash (path traversal)`, async () => {
         await expect(repository.get(type, '../../../attack')).rejects.toThrowError(
-          createBadRequestErrorPayload("Invalid saved object ID: IDs cannot contain '/'")
+          createBadRequestErrorPayload("Invalid saved object ID: IDs cannot contain '/'.")
         );
         expect(client.get).not.toHaveBeenCalled();
       });

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.test.ts
@@ -191,6 +191,13 @@ describe('#get', () => {
         expect(client.get).not.toHaveBeenCalled();
       });
 
+      it(`throws a BadRequestError when the id contains a forward slash (path traversal)`, async () => {
+        await expect(repository.get(type, '../../../attack')).rejects.toThrowError(
+          createBadRequestErrorPayload("Invalid saved object ID: IDs cannot contain '/'")
+        );
+        expect(client.get).not.toHaveBeenCalled();
+      });
+
       it(`throws when ES is unable to find the document during get`, async () => {
         client.get.mockResolvedValueOnce(
           elasticsearchClientMock.createSuccessTransportRequestPromise({

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.ts
@@ -25,7 +25,7 @@ export const performGet = async <T>(
   { type, id, options }: PerformGetParams,
   { registry, helpers, allowedTypes, client, serializer, extensions = {} }: ApiExecutionContext
 ): Promise<SavedObject<T>> => {
-  const { common: commonHelper, migration: migrationHelper } = helpers;
+  const { common: commonHelper, migration: migrationHelper, validation: validationHelper } = helpers;
   const { securityExtension } = extensions;
 
   const namespace = commonHelper.getCurrentNamespace(options.namespace);
@@ -34,6 +34,7 @@ export const performGet = async <T>(
   if (!allowedTypes.includes(type)) {
     throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
   }
+  validationHelper.validateId(id);
   const { body, statusCode, headers } = await client.get<SavedObjectsRawDocSource>(
     {
       id: serializer.generateRawId(namespace, type, id),

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/get.ts
@@ -25,7 +25,11 @@ export const performGet = async <T>(
   { type, id, options }: PerformGetParams,
   { registry, helpers, allowedTypes, client, serializer, extensions = {} }: ApiExecutionContext
 ): Promise<SavedObject<T>> => {
-  const { common: commonHelper, migration: migrationHelper, validation: validationHelper } = helpers;
+  const {
+    common: commonHelper,
+    migration: migrationHelper,
+    validation: validationHelper,
+  } = helpers;
   const { securityExtension } = extensions;
 
   const namespace = commonHelper.getCurrentNamespace(options.namespace);

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/common.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/common.ts
@@ -16,6 +16,7 @@ import type {
 import { getIndexForType } from '@kbn/core-saved-objects-base-server-internal';
 import { SavedObjectsUtils } from '@kbn/core-saved-objects-utils-server';
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+import { assertValidId } from './id_utils';
 import { normalizeNamespace } from '../utils';
 import type { CreatePointInTimeFinderFn } from '../../point_in_time_finder';
 
@@ -99,6 +100,9 @@ export class CommonHelper {
     version: string | undefined,
     overwrite: boolean | undefined
   ) {
+    if (id) {
+      assertValidId(id);
+    }
     if (!this.encryptionExtension?.isEncryptableType(type)) {
       return id || SavedObjectsUtils.generateId();
     }

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.test.ts
@@ -36,7 +36,7 @@ describe('assertValidId', () => {
   });
 
   it('error message lists the forbidden character', () => {
-    expect(() => assertValidId('path/traversal')).toThrowError("IDs cannot contain '/'");
+    expect(() => assertValidId('path/traversal')).toThrowError("IDs cannot contain '/'.");
   });
 
   it('FORBIDDEN_ID_CHARS contains forward slash', () => {

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { assertValidId, FORBIDDEN_ID_CHARS } from './id_utils';
+
+describe('assertValidId', () => {
+  describe('valid IDs', () => {
+    it.each([
+      ['UUID', '550e8400-e29b-41d4-a716-446655440000'],
+      ['alphanumeric with dashes', 'my-dashboard-123'],
+      ['ID with colons', 'space:type:doc-id'],
+      ['ID with dots', 'my.dashboard.id'],
+      ['ID with underscores', 'my_dashboard_id'],
+    ])('accepts %s', (_label, id) => {
+      expect(() => assertValidId(id)).not.toThrow();
+    });
+  });
+
+  describe('path traversal attacks', () => {
+    it.each([
+      ['simple path traversal', '../../../etc/passwd'],
+      ['leading slash', '/etc/passwd'],
+      ['embedded slash', 'valid-prefix/attack-suffix'],
+      ['double slash', '//attack'],
+      ['slash at end', 'my-id/'],
+      ['complex traversal', '../../.kibana/_cluster/state'],
+    ])('rejects %s', (_label, id) => {
+      expect(() => assertValidId(id)).toThrowError(/Invalid saved object ID/);
+    });
+  });
+
+  it('error message lists the forbidden character', () => {
+    expect(() => assertValidId('path/traversal')).toThrowError("IDs cannot contain '/'");
+  });
+
+  it('FORBIDDEN_ID_CHARS contains forward slash', () => {
+    expect(FORBIDDEN_ID_CHARS).toContain('/');
+  });
+});

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.ts
@@ -30,7 +30,7 @@ export const assertValidId = (id: string): void => {
   const forbidden = FORBIDDEN_ID_CHARS.filter((char) => id.includes(char));
   if (forbidden.length > 0) {
     throw SavedObjectsErrorHelpers.createBadRequestError(
-      `Invalid saved object ID: IDs cannot contain '${forbidden.join("', '")}'`
+      `Invalid saved object ID: IDs cannot contain '${FORBIDDEN_ID_CHARS.join("', '")}'.`
     );
   }
 };

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+
+/**
+ * Characters that are forbidden in user-provided saved object IDs.
+ * Forward slashes can enable path traversal attacks in Elasticsearch REST API URLs.
+ */
+export const FORBIDDEN_ID_CHARS = ['/'] as const;
+
+/**
+ * Throws a BadRequestError if the given ID contains any character that could enable
+ * path traversal attacks against the Elasticsearch REST API.
+ *
+ * Must be called for all user-provided saved object IDs before they are used in ES requests.
+ */
+export const assertValidId = (id: string): void => {
+  const forbidden = FORBIDDEN_ID_CHARS.filter((char) => id.includes(char));
+  if (forbidden.length > 0) {
+    throw SavedObjectsErrorHelpers.createBadRequestError(
+      `Invalid saved object ID: IDs cannot contain '${forbidden.join("', '")}'`
+    );
+  }
+};

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/id_utils.ts
@@ -20,8 +20,13 @@ export const FORBIDDEN_ID_CHARS = ['/'] as const;
  * path traversal attacks against the Elasticsearch REST API.
  *
  * Must be called for all user-provided saved object IDs before they are used in ES requests.
+ * Non-string IDs (e.g. undefined passed despite the type contract) are skipped; other
+ * validators or Elasticsearch itself will handle those.
  */
 export const assertValidId = (id: string): void => {
+  if (typeof id !== 'string') {
+    return;
+  }
   const forbidden = FORBIDDEN_ID_CHARS.filter((char) => id.includes(char));
   if (forbidden.length > 0) {
     throw SavedObjectsErrorHelpers.createBadRequestError(

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/index.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/index.ts
@@ -18,6 +18,7 @@ import type { UserHelper } from './user';
 export { CommonHelper, type ICommonHelper } from './common';
 export { EncryptionHelper, type IEncryptionHelper } from './encryption';
 export { ValidationHelper, type IValidationHelper } from './validation';
+export { assertValidId, FORBIDDEN_ID_CHARS } from './id_utils';
 export { SerializerHelper, type ISerializerHelper } from './serializer';
 export { MigrationHelper, type IMigrationHelper } from './migration';
 export { UserHelper } from './user';

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/validation.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/validation.test.ts
@@ -76,19 +76,19 @@ describe('Saved Objects type validation helper', () => {
 
     it('throws a BadRequestError when ID contains a forward slash', () => {
       expect(() => helper.validateId('../traversal/attack')).toThrowError(
-        "Invalid saved object ID: IDs cannot contain '/'"
+        "Invalid saved object ID: IDs cannot contain '/'."
       );
     });
 
     it('throws a BadRequestError when ID starts with a slash', () => {
       expect(() => helper.validateId('/leading-slash')).toThrowError(
-        "Invalid saved object ID: IDs cannot contain '/'"
+        "Invalid saved object ID: IDs cannot contain '/'."
       );
     });
 
     it('throws a BadRequestError when ID contains a slash in the middle', () => {
       expect(() => helper.validateId('some/path')).toThrowError(
-        "Invalid saved object ID: IDs cannot contain '/'"
+        "Invalid saved object ID: IDs cannot contain '/'."
       );
     });
   });

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/validation.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/validation.test.ts
@@ -53,6 +53,46 @@ describe('Saved Objects type validation helper', () => {
     jest.resetAllMocks();
   });
 
+  describe('validateId', () => {
+    beforeEach(() => {
+      helper = new ValidationHelper({
+        logger,
+        registry: typeRegistry,
+        kibanaVersion: defaultVersion,
+      });
+    });
+
+    it('accepts a valid UUID', () => {
+      expect(() => helper.validateId('550e8400-e29b-41d4-a716-446655440000')).not.toThrow();
+    });
+
+    it('accepts a regular alphanumeric ID', () => {
+      expect(() => helper.validateId('my-dashboard-123')).not.toThrow();
+    });
+
+    it('accepts an ID with colons (namespace separators)', () => {
+      expect(() => helper.validateId('some:valid:id')).not.toThrow();
+    });
+
+    it('throws a BadRequestError when ID contains a forward slash', () => {
+      expect(() => helper.validateId('../traversal/attack')).toThrowError(
+        "Invalid saved object ID: IDs cannot contain '/'"
+      );
+    });
+
+    it('throws a BadRequestError when ID starts with a slash', () => {
+      expect(() => helper.validateId('/leading-slash')).toThrowError(
+        "Invalid saved object ID: IDs cannot contain '/'"
+      );
+    });
+
+    it('throws a BadRequestError when ID contains a slash in the middle', () => {
+      expect(() => helper.validateId('some/path')).toThrowError(
+        "Invalid saved object ID: IDs cannot contain '/'"
+      );
+    });
+  });
+
   describe('validation helper', () => {
     beforeEach(() => {
       registerType(typeA, typedef);

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/validation.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/validation.ts
@@ -19,6 +19,7 @@ import {
   type SavedObjectSanitizedDoc,
 } from '@kbn/core-saved-objects-server';
 import { ALL_NAMESPACES_STRING } from '@kbn/core-saved-objects-utils-server';
+import { assertValidId } from './id_utils';
 
 export type IValidationHelper = PublicMethodsOf<ValidationHelper>;
 
@@ -40,6 +41,14 @@ export class ValidationHelper {
     this.registry = registry;
     this.logger = logger;
     this.kibanaVersion = kibanaVersion;
+  }
+
+  /**
+   * Validates that a saved object ID does not contain characters that could enable
+   * path traversal attacks against the Elasticsearch REST API.
+   */
+  public validateId(id: string): void {
+    assertValidId(id);
   }
 
   /** The `initialNamespaces` field (create, bulkCreate) is used to create an object in an initial set of spaces. */

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/increment_counter.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/increment_counter.ts
@@ -48,6 +48,7 @@ export const performIncrementCounter = async <T>(
   if (!allowedTypes.includes(type)) {
     throw SavedObjectsErrorHelpers.createUnsupportedTypeError(type);
   }
+  apiExecutionContext.helpers.validation.validateId(id);
 
   return incrementCounterInternal<T>({ type, id, counterFields, options }, apiExecutionContext);
 };

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/change_object_access_control.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/change_object_access_control.ts
@@ -34,6 +34,7 @@ import {
   getExpectedVersionProperties,
   rawDocExistsInNamespace,
 } from '../utils';
+import { assertValidId } from '../helpers/id_utils';
 import type { ApiExecutionContext } from '../types';
 import { type GetBulkOperationErrorRawResponse, isMgetError } from '../utils/internal_utils';
 
@@ -187,6 +188,11 @@ export const changeObjectAccessControl = async (
     if (!allowedTypes.includes(type)) {
       const error = SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
       return left({ id, type, error });
+    }
+    try {
+      assertValidId(id);
+    } catch (e) {
+      return left({ id, type, error: e });
     }
     if (!registry.supportsAccessControl(type)) {
       const error = SavedObjectsErrorHelpers.createBadRequestError(

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/internal_bulk_resolve.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/internal_bulk_resolve.ts
@@ -48,6 +48,7 @@ import {
   normalizeNamespace,
   rawDocExistsInNamespace,
 } from '../utils';
+import { assertValidId } from '../helpers/id_utils';
 import type { ApiExecutionContext } from '../types';
 import type { RepositoryEsClient } from '../../repository_es_client';
 
@@ -281,6 +282,11 @@ function validateObjectTypes(objects: SavedObjectsBulkResolveObject[], allowedTy
         id,
         error: SavedObjectsErrorHelpers.createUnsupportedTypeError(type),
       });
+    }
+    try {
+      assertValidId(id);
+    } catch (e) {
+      return left({ type, id, error: e });
     }
     return right(object);
   });

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/update_objects_spaces.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/update_objects_spaces.ts
@@ -40,6 +40,7 @@ import {
   getExpectedVersionProperties,
   rawDocExistsInNamespace,
 } from '../utils';
+import { assertValidId } from '../helpers/id_utils';
 import { DEFAULT_REFRESH_SETTING } from '../../constants';
 import type { RepositoryEsClient } from '../../repository_es_client';
 import {
@@ -121,6 +122,11 @@ export async function updateObjectsSpaces({
     if (!allowedTypes.includes(type)) {
       const error = errorContent(SavedObjectsErrorHelpers.createGenericNotFoundError(type, id));
       return left({ id, type, spaces: [], error });
+    }
+    try {
+      assertValidId(id);
+    } catch (e) {
+      return left({ id, type, spaces: [], error: errorContent(e) });
     }
     if (!registry.isShareable(type)) {
       const error = errorContent(

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/remove_references_to.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/remove_references_to.ts
@@ -28,9 +28,10 @@ export const performRemoveReferencesTo = async <T>(
   { type, id, options }: PerformRemoveReferencesToParams,
   { registry, helpers, client, mappings, serializer, extensions = {} }: ApiExecutionContext
 ): Promise<SavedObjectsRemoveReferencesToResponse> => {
-  const { common: commonHelper } = helpers;
+  const { common: commonHelper, validation: validationHelper } = helpers;
   const { securityExtension } = extensions;
 
+  validationHelper.validateId(id);
   const namespace = commonHelper.getCurrentNamespace(options.namespace);
   const { refresh = true } = options;
 

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/resolve.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/resolve.ts
@@ -26,7 +26,8 @@ export const performResolve = async <T>(
   { type, id, options }: PerformCreateParams<T>,
   apiExecutionContext: ApiExecutionContext
 ): Promise<SavedObjectsResolveResponse<T>> => {
-  const { common: commonHelper } = apiExecutionContext.helpers;
+  const { common: commonHelper, validation: validationHelper } = apiExecutionContext.helpers;
+  validationHelper.validateId(id);
   const namespace = commonHelper.getCurrentNamespace(options.namespace);
   const { resolved_objects: bulkResults } = await internalBulkResolve<T>(
     {

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/update.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/update.ts
@@ -50,6 +50,7 @@ export const performUpdate = async <T>(
   if (!validRequest && error) {
     throw error;
   }
+  helpers.validation.validateId(id);
 
   const maxAttempts = options.version ? 1 : 1 + DEFAULT_RETRY_COUNT;
 

--- a/src/core/packages/saved-objects/api-server-internal/src/mocks/api_helpers.mocks.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/mocks/api_helpers.mocks.ts
@@ -72,6 +72,7 @@ export type ValidationHelperMock = jest.Mocked<PublicMethodsOf<ValidationHelper>
 
 const createValidationHelperMock = (): ValidationHelperMock => {
   const mock: ValidationHelperMock = {
+    validateId: jest.fn(),
     validateInitialNamespaces: jest.fn(),
     validateObjectNamespaces: jest.fn(),
     validateObjectForCreate: jest.fn(),

--- a/src/platform/packages/private/kbn-data-streams/src/client.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/client.ts
@@ -21,6 +21,7 @@ import { validateClientArgs } from './validate_client_args';
 import {
   generateSpacePrefixedId,
   throwOnIdWithSeparator,
+  throwOnIdWithPathTraversal,
   decorateDocumentWithSpace,
   buildSpaceFilter,
   buildSpaceAgnosticFilter,
@@ -91,6 +92,7 @@ export class DataStreamClient<
       // Validate _id if provided
       if (typeof _id !== 'undefined') {
         throwOnIdWithSeparator(_id);
+        throwOnIdWithPathTraversal(_id);
       }
 
       // Process ID and document based on space

--- a/src/platform/packages/private/kbn-data-streams/src/space_utils.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/space_utils.test.ts
@@ -12,6 +12,8 @@ import {
   SYSTEM_SPACE_PROPERTY,
   containsSpaceSeparator,
   throwOnIdWithSeparator,
+  throwOnIdWithPathTraversal,
+  FORBIDDEN_ID_CHARS,
   generateSpacePrefixedId,
   decorateDocumentWithSpace,
   buildSpaceFilter,
@@ -53,6 +55,38 @@ describe('space_utils', () => {
       expect(() => throwOnIdWithSeparator('doc123')).not.toThrow();
       expect(() => throwOnIdWithSeparator('uuid-with-dashes')).not.toThrow();
       expect(() => throwOnIdWithSeparator('single:colon')).not.toThrow();
+    });
+  });
+
+  describe('FORBIDDEN_ID_CHARS', () => {
+    it('should contain forward slash', () => {
+      expect(FORBIDDEN_ID_CHARS).toContain('/');
+    });
+  });
+
+  describe('throwOnIdWithPathTraversal', () => {
+    it('should throw if ID contains a forward slash', () => {
+      expect(() => throwOnIdWithPathTraversal('../../../attack')).toThrow(
+        /IDs cannot contain '\/'/
+      );
+    });
+
+    it('should throw if ID starts with a slash', () => {
+      expect(() => throwOnIdWithPathTraversal('/leading')).toThrow(/IDs cannot contain '\/'/);
+    });
+
+    it('should throw if ID contains a slash in the middle', () => {
+      expect(() => throwOnIdWithPathTraversal('some/path')).toThrow(/IDs cannot contain '\/'/);
+    });
+
+    it('should not throw for valid IDs', () => {
+      expect(() => throwOnIdWithPathTraversal('valid-id-123')).not.toThrow();
+      expect(() => throwOnIdWithPathTraversal('uuid-4a5b-c6d7')).not.toThrow();
+      expect(() => throwOnIdWithPathTraversal('space::doc-id')).not.toThrow();
+    });
+
+    it('should mention path traversal in the error message', () => {
+      expect(() => throwOnIdWithPathTraversal('a/b')).toThrow(/path traversal/);
     });
   });
 

--- a/src/platform/packages/private/kbn-data-streams/src/space_utils.test.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/space_utils.test.ts
@@ -84,10 +84,6 @@ describe('space_utils', () => {
       expect(() => throwOnIdWithPathTraversal('uuid-4a5b-c6d7')).not.toThrow();
       expect(() => throwOnIdWithPathTraversal('space::doc-id')).not.toThrow();
     });
-
-    it('should mention path traversal in the error message', () => {
-      expect(() => throwOnIdWithPathTraversal('a/b')).toThrow(/path traversal/);
-    });
   });
 
   describe('generateSpacePrefixedId', () => {

--- a/src/platform/packages/private/kbn-data-streams/src/space_utils.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/space_utils.ts
@@ -47,8 +47,7 @@ export function throwOnIdWithPathTraversal(id: string): void {
   const forbidden = FORBIDDEN_ID_CHARS.filter((char) => id.includes(char));
   if (forbidden.length > 0) {
     throw new Error(
-      `Invalid document ID: IDs cannot contain '${forbidden.join("', '")}'. ` +
-        `These characters can enable path traversal attacks.`
+      `Invalid document ID: IDs cannot contain '${FORBIDDEN_ID_CHARS.join("', '")}'.`
     );
   }
 }

--- a/src/platform/packages/private/kbn-data-streams/src/space_utils.ts
+++ b/src/platform/packages/private/kbn-data-streams/src/space_utils.ts
@@ -32,6 +32,27 @@ export function throwOnIdWithSeparator(id: string): void {
   }
 }
 
+/**
+ * Characters forbidden in user-provided document IDs to prevent path traversal attacks
+ * against the Elasticsearch REST API.
+ */
+export const FORBIDDEN_ID_CHARS = ['/'] as const;
+
+/**
+ * Validate that a user-provided ID does NOT contain characters that could enable
+ * path traversal attacks against the Elasticsearch REST API.
+ * Forward slashes in document IDs can be interpreted as URL path separators.
+ */
+export function throwOnIdWithPathTraversal(id: string): void {
+  const forbidden = FORBIDDEN_ID_CHARS.filter((char) => id.includes(char));
+  if (forbidden.length > 0) {
+    throw new Error(
+      `Invalid document ID: IDs cannot contain '${forbidden.join("', '")}'. ` +
+        `These characters can enable path traversal attacks.`
+    );
+  }
+}
+
 /** Generate a space-prefixed ID. Only called when space is defined. */
 export function generateSpacePrefixedId(space: string, id?: string): string {
   const docId = id ?? uuidv4();

--- a/src/platform/plugins/shared/usage_collection/server/report/store_ui_report.ts
+++ b/src/platform/plugins/shared/usage_collection/server/report/store_ui_report.ts
@@ -30,7 +30,9 @@ export async function storeUiReport(
     // User Agent
     ...userAgents.map(async ([key, metric]) => {
       const { userAgent } = metric;
-      const savedObjectId = `${key}:${userAgent}`;
+      // Forward slashes in the user agent string (e.g. "Mozilla/5.0") are replaced before
+      // being embedded in the saved object ID to comply with the SOR path-traversal restriction.
+      const savedObjectId = `${key}:${userAgent.replace(/\//g, '-')}`;
       return await internalRepository.create(
         'ui-metric',
         { count: 1 },

--- a/src/platform/test/api_integration/apis/ui_metric/ui_metric.ts
+++ b/src/platform/test/api_integration/apis/ui_metric/ui_metric.ts
@@ -83,7 +83,11 @@ export default function ({ getService }: FtrProviderContext) {
       const ids = response.hits.hits.map(({ _id }: { _id?: string }) => _id!);
       expect(ids.includes('ui-metric:myApp:myEvent')).to.eql(true);
       expect(ids.includes(`ui-metric:myApp:${uniqueEventName}`)).to.eql(true);
-      expect(ids.includes(`ui-metric:kibana-user_agent:${userAgentMetric.userAgent}`)).to.eql(true);
+      expect(
+        ids.includes(
+          `ui-metric:kibana-user_agent:${userAgentMetric.userAgent.replace(/\//g, '-')}`
+        )
+      ).to.eql(true);
     });
 
     it('aggregates multiple events with same eventID', async () => {

--- a/src/platform/test/api_integration/apis/ui_metric/ui_metric.ts
+++ b/src/platform/test/api_integration/apis/ui_metric/ui_metric.ts
@@ -84,9 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(ids.includes('ui-metric:myApp:myEvent')).to.eql(true);
       expect(ids.includes(`ui-metric:myApp:${uniqueEventName}`)).to.eql(true);
       expect(
-        ids.includes(
-          `ui-metric:kibana-user_agent:${userAgentMetric.userAgent.replace(/\//g, '-')}`
-        )
+        ids.includes(`ui-metric:kibana-user_agent:${userAgentMetric.userAgent.replace(/\//g, '-')}`)
       ).to.eql(true);
     });
 

--- a/x-pack/platform/test/fleet_api_integration/apis/uninstall_token/get.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/uninstall_token/get.ts
@@ -317,8 +317,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('when `search` query param is used', () => {
         let generatedManagedPolicyArray: AgentPolicy[];
         let generatedPolicyArray: AgentPolicy[];
-        const specialCharactersForNameAndId = `!@#$%^&*-=_+()[]{}:;'\`|/<>,.?~`.split('');
-        const specialCharactersForNameOnly = `"\\`.split('');
+        // '/' is excluded from ID-capable characters because saved object IDs cannot contain
+        // forward slashes (they would be interpreted as URL path separators, enabling path traversal).
+        const specialCharactersForNameAndId = `!@#$%^&*-=_+()[]{}:;'\`|<>,.?~`.split('');
+        const specialCharactersForNameOnly = `"/\\`.split('');
 
         before(async () => {
           generatedPolicyArray = [];


### PR DESCRIPTION
## Summary

Strengthens ID validation in the Saved Objects Repository (SOR) and the `DataStreamClient` by rejecting IDs that contain characters which could be misinterpreted by the underlying HTTP layer.

The check is centralised in a new `id_utils` helper and applied consistently across all single-object and bulk APIs in the SOR, as well as the `create` method in `DataStreamClient`.

Made with [Cursor](https://cursor.com)