### PR TITLE
[Entity Store] [Asset Mgr] Upgrade Entity Store v1 to v2 when feature flag is flipped 

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.test.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.test.tsx
@@ -52,7 +52,7 @@ describe('useInstallEntityStoreV2', () => {
     const mockServices = createMockServices();
     mockServices.uiSettings.get.mockReturnValue(true);
     mockServices.spaces.getActiveSpace.mockResolvedValue({ id: 'custom-space' });
-    mockServices.http.get.mockResolvedValueOnce({ status: EntityStoreStatus.Values.not_installed });
+    mockServices.http.get.mockResolvedValueOnce({ status: EntityStoreStatus.enum.not_installed });
 
     renderHook(() => useInstallEntityStoreV2(asServices(mockServices)));
 
@@ -71,8 +71,8 @@ describe('useInstallEntityStoreV2', () => {
     mockServices.uiSettings.get.mockReturnValue(true);
     mockServices.spaces.getActiveSpace.mockResolvedValue({ id: 'custom-space' });
     mockServices.http.get
-      .mockResolvedValueOnce({ status: EntityStoreStatus.Values.running })
-      .mockResolvedValueOnce({ status: EntityStoreStatus.Values.not_installed });
+      .mockResolvedValueOnce({ status: EntityStoreStatus.enum.running })
+      .mockResolvedValueOnce({ status: EntityStoreStatus.enum.not_installed });
     mockServices.http.post.mockResolvedValueOnce({});
 
     renderHook(() => useInstallEntityStoreV2(asServices(mockServices)));
@@ -182,7 +182,7 @@ describe('isEntityStoreV1Installed', () => {
   it('returns true when status is not_installed is false', async () => {
     const mockServices = createMockServices();
     mockServices.http.get.mockResolvedValueOnce({
-      status: EntityStoreStatus.Values.running,
+      status: EntityStoreStatus.enum.running,
     });
 
     await expect(
@@ -196,7 +196,7 @@ describe('isEntityStoreV1Installed', () => {
   it('returns false when status is not_installed', async () => {
     const mockServices = createMockServices();
     mockServices.http.get.mockResolvedValueOnce({
-      status: EntityStoreStatus.Values.not_installed,
+      status: EntityStoreStatus.enum.not_installed,
     });
 
     await expect(

--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.test.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.test.tsx
@@ -6,7 +6,11 @@
  */
 
 import { renderHook, waitFor } from '@testing-library/react';
-import { useInstallEntityStoreV2, type Services } from './useInstallEntityStoreV2';
+import {
+  isEntityStoreV1Installed,
+  useInstallEntityStoreV2,
+  type Services,
+} from './useInstallEntityStoreV2';
 import { ENTITY_STORE_ROUTES, EntityStoreStatus, FF_ENABLE_ENTITY_STORE_V2 } from '../../common';
 
 interface MockServices {
@@ -44,18 +48,46 @@ describe('useInstallEntityStoreV2', () => {
     expect(mockServices.http.post).not.toHaveBeenCalled();
   });
 
-  it('should not install when not in default space', async () => {
+  it('should not install when not in default space and v1 is not installed', async () => {
     const mockServices = createMockServices();
     mockServices.uiSettings.get.mockReturnValue(true);
     mockServices.spaces.getActiveSpace.mockResolvedValue({ id: 'custom-space' });
+    mockServices.http.get.mockResolvedValueOnce({ status: EntityStoreStatus.Values.not_installed });
 
     renderHook(() => useInstallEntityStoreV2(asServices(mockServices)));
 
     await waitFor(() => {
-      expect(mockServices.spaces.getActiveSpace).toHaveBeenCalled();
+      expect(mockServices.http.get).toHaveBeenCalledWith({
+        path: '/api/entity_store/status',
+      });
     });
 
+    expect(mockServices.http.get).toHaveBeenCalledTimes(1);
     expect(mockServices.http.post).not.toHaveBeenCalled();
+  });
+
+  it('should proceed when not in default space and v1 is installed', async () => {
+    const mockServices = createMockServices();
+    mockServices.uiSettings.get.mockReturnValue(true);
+    mockServices.spaces.getActiveSpace.mockResolvedValue({ id: 'custom-space' });
+    mockServices.http.get
+      .mockResolvedValueOnce({ status: EntityStoreStatus.Values.running })
+      .mockResolvedValueOnce({ status: EntityStoreStatus.Values.not_installed });
+    mockServices.http.post.mockResolvedValueOnce({});
+
+    renderHook(() => useInstallEntityStoreV2(asServices(mockServices)));
+
+    await waitFor(() => {
+      expect(mockServices.http.post).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockServices.http.get).toHaveBeenNthCalledWith(1, {
+      path: '/api/entity_store/status',
+    });
+    expect(mockServices.http.get).toHaveBeenNthCalledWith(2, {
+      path: ENTITY_STORE_ROUTES.STATUS,
+      query: { apiVersion: '2', include_components: false },
+    });
   });
 
   it("should not install when entity store status is 'running'", async () => {
@@ -143,5 +175,32 @@ describe('useInstallEntityStoreV2', () => {
       body: JSON.stringify({}),
       query: { apiVersion: '2' },
     });
+  });
+});
+
+describe('isEntityStoreV1Installed', () => {
+  it('returns true when status is not_installed is false', async () => {
+    const mockServices = createMockServices();
+    mockServices.http.get.mockResolvedValueOnce({
+      status: EntityStoreStatus.Values.running,
+    });
+
+    await expect(
+      isEntityStoreV1Installed(mockServices.http as unknown as Services['http'])
+    ).resolves.toBe(true);
+    expect(mockServices.http.get).toHaveBeenCalledWith({
+      path: '/api/entity_store/status',
+    });
+  });
+
+  it('returns false when status is not_installed', async () => {
+    const mockServices = createMockServices();
+    mockServices.http.get.mockResolvedValueOnce({
+      status: EntityStoreStatus.Values.not_installed,
+    });
+
+    await expect(
+      isEntityStoreV1Installed(mockServices.http as unknown as Services['http'])
+    ).resolves.toBe(false);
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
@@ -54,6 +54,7 @@ export const useInstallEntityStoreV2 = (services: Services) => {
         if (!isEntityStoreV2Enabled) return;
 
         const space = await services.spaces.getActiveSpace();
+        // Install v2 and remove v1 in default namespace AND every namespace where v1 is currently installed
         if (space.id !== 'default' && !(await isEntityStoreV1Installed(services.http))) return;
 
         const statusResponse = await services.http.get<{ status: EntityStoreStatus }>(

--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
@@ -19,6 +19,10 @@ export interface Services {
   spaces: SpacesPluginStart;
 }
 
+interface EntityStoreV1StatusResponse {
+  status: EntityStoreStatus;
+}
+
 const statusRequestQuery = {
   include_components: false,
 } as const satisfies StatusRequestQuery;
@@ -26,6 +30,10 @@ const statusRequestQuery = {
 const getStatusRequest: HttpFetchOptionsWithPath = {
   path: ENTITY_STORE_ROUTES.STATUS,
   query: { apiVersion: '2', ...statusRequestQuery },
+};
+
+const getStatusV1Request: HttpFetchOptionsWithPath = {
+  path: '/api/entity_store/status',
 };
 
 const installAllEntitiesRequest: HttpFetchOptionsWithPath = {
@@ -46,7 +54,7 @@ export const useInstallEntityStoreV2 = (services: Services) => {
         if (!isEntityStoreV2Enabled) return;
 
         const space = await services.spaces.getActiveSpace();
-        if (space.id !== 'default') return;
+        if (space.id !== 'default' && !(await isEntityStoreV1Installed(services.http))) return;
 
         const statusResponse = await services.http.get<{ status: EntityStoreStatus }>(
           getStatusRequest
@@ -65,3 +73,9 @@ export const useInstallEntityStoreV2 = (services: Services) => {
 
 const isEntityStoreInstalled = (status: EntityStoreStatus): boolean =>
   status !== EntityStoreStatus.enum.not_installed;
+
+export const isEntityStoreV1Installed = async (http: HttpSetup): Promise<boolean> => {
+  const response = await http.get<EntityStoreV1StatusResponse>(getStatusV1Request);
+
+  return response.status !== EntityStoreStatus.enum.not_installed;
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -515,6 +515,7 @@ export class AssetManagerClient {
     const resetIndex = `.entities.v1.reset.${definitionId}`;
     const updatesDataStream = `.entities.v1.updates.${definitionId}`;
     const enrichPolicyName = `entity_store_field_retention_${type}_${this.namespace}_v1.0.0`;
+    const v1EngineDescriptorId = `entity-engine-descriptor-${type}-${this.namespace}`;
 
     await Promise.all(
       transformIds.map((transformId) =>
@@ -575,6 +576,19 @@ export class AssetManagerClient {
           }
           throw error;
         })
+      ),
+      this.tryAsBoolean(
+        this.savedObjectsClient
+          .delete('entity-engine-status', v1EngineDescriptorId)
+          .catch((error) => {
+            if (
+              SavedObjectsErrorHelpers.isNotFoundError(error) ||
+              SavedObjectsErrorHelpers.isForbiddenError(error)
+            ) {
+              return;
+            }
+            throw error;
+          })
       ),
     ]);
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -113,7 +113,6 @@ export class AssetManagerClient {
       await Promise.all([
         this.globalStateClient.init({ historySnapshot, logsExtraction }),
 
-        ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
         ...entityTypes.map((type) =>
           stopAndRemoveV1({
             type,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -58,6 +58,7 @@ import {
   ENTITY_STORE_INITIALIZATION_FAILURE_EVENT,
 } from '../../telemetry/events';
 import { getErrorMessage } from '../../../common';
+import { stopAndRemoveV1, stopAndRemoveV1SharedTasks } from '../../infra/remove_v1';
 
 interface AssetManagerDependencies {
   logger: Logger;
@@ -112,9 +113,18 @@ export class AssetManagerClient {
       await Promise.all([
         this.globalStateClient.init({ historySnapshot, logsExtraction }),
 
-        ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
-        ...entityTypes.map((type) => this.stopAndRemoveV1(type)),
-        this.stopAndRemoveV1SharedTasks(),
+        ...entityTypes.map((type) => this.initEntity(request, type, logExtractionParams)),
+        ...entityTypes.map((type) =>
+          stopAndRemoveV1({
+            type,
+            namespace: this.namespace,
+            logger: this.logger,
+            esClient: this.esClient,
+            taskManager: this.taskManager,
+            savedObjectsClient: this.savedObjectsClient,
+          })
+        ),
+        stopAndRemoveV1SharedTasks({ namespace: this.namespace, taskManager: this.taskManager }),
 
         ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
 
@@ -489,120 +499,5 @@ export class AssetManagerClient {
     }
 
     return ENTITY_STORE_STATUS.RUNNING;
-  }
-
-  private async stopAndRemoveV1(type: EntityType) {
-    const definitionId = `security_${type}_${this.namespace}`;
-    const logger = this.logger.get(type);
-    const transformIds = [
-      `entities-v1-latest-${definitionId}`,
-      `entities-v1-history-${definitionId}`,
-    ];
-    const taskIds = [`entity_store:snapshot:${type}:${this.namespace}:1.0.0`];
-    const ingestPipelineIds = [
-      `entities-v1-latest-${definitionId}`,
-      `entities-v1-history-${definitionId}`,
-      `${definitionId}-latest@platform`,
-    ];
-    const indexTemplateIds = [
-      `entities_v1_reset_${definitionId}_index_template`,
-      `entities_v1_updates_${definitionId}_index_template`,
-    ];
-    const componentTemplateIds = [
-      `${definitionId}-updates@platform`,
-      `${definitionId}-updates@custom`,
-    ];
-    const resetIndex = `.entities.v1.reset.${definitionId}`;
-    const updatesDataStream = `.entities.v1.updates.${definitionId}`;
-    const enrichPolicyName = `entity_store_field_retention_${type}_${this.namespace}_v1.0.0`;
-    const v1EngineDescriptorId = `entity-engine-descriptor-${type}-${this.namespace}`;
-
-    await Promise.all(
-      transformIds.map((transformId) =>
-        this.tryAsBoolean(
-          this.esClient.transform.stopTransform(
-            { transform_id: transformId, wait_for_completion: true, force: true },
-            { ignore: [404, 409] }
-          )
-        )
-      )
-    );
-
-    await Promise.all(
-      taskIds.map((taskId) => this.tryAsBoolean(this.taskManager.removeIfExists(taskId)))
-    );
-
-    await Promise.all([
-      ...transformIds.map((transformId) =>
-        this.tryAsBoolean(
-          this.esClient.transform.deleteTransform(
-            { transform_id: transformId, force: true },
-            { ignore: [404] }
-          )
-        )
-      ),
-      ...ingestPipelineIds.map((pipelineId) =>
-        this.tryAsBoolean(
-          this.esClient.ingest.deletePipeline({ id: pipelineId }, { ignore: [404] })
-        )
-      ),
-      ...indexTemplateIds.map((templateId) =>
-        this.tryAsBoolean(
-          this.esClient.indices.deleteIndexTemplate({ name: templateId }, { ignore: [404] })
-        )
-      ),
-      ...componentTemplateIds.map((componentTemplateId) =>
-        this.tryAsBoolean(
-          this.esClient.cluster.deleteComponentTemplate(
-            { name: componentTemplateId },
-            { ignore: [404] }
-          )
-        )
-      ),
-      this.tryAsBoolean(
-        this.esClient.enrich.deletePolicy({ name: enrichPolicyName }, { ignore: [404] })
-      ),
-      this.tryAsBoolean(this.esClient.indices.delete({ index: resetIndex }, { ignore: [404] })),
-      this.tryAsBoolean(
-        this.esClient.indices.deleteDataStream({ name: updatesDataStream }, { ignore: [404] })
-      ),
-      this.tryAsBoolean(
-        this.savedObjectsClient.delete('entity-definition', definitionId).catch((error) => {
-          if (
-            SavedObjectsErrorHelpers.isNotFoundError(error) ||
-            SavedObjectsErrorHelpers.isForbiddenError(error)
-          ) {
-            return;
-          }
-          throw error;
-        })
-      ),
-      this.tryAsBoolean(
-        this.savedObjectsClient
-          .delete('entity-engine-status', v1EngineDescriptorId)
-          .catch((error) => {
-            if (
-              SavedObjectsErrorHelpers.isNotFoundError(error) ||
-              SavedObjectsErrorHelpers.isForbiddenError(error)
-            ) {
-              return;
-            }
-            throw error;
-          })
-      ),
-    ]);
-
-    logger.debug(`Stopped and removed entity store v1 resources for type: ${type}`);
-  }
-
-  private async stopAndRemoveV1SharedTasks() {
-    const taskIds = [
-      `entity_store:field_retention:enrichment:${this.namespace}:1.0.0`,
-      `entity_store:data_view:refresh:${this.namespace}:1.0.0`,
-      `entity_store:health:${this.namespace}:1.0.0`,
-    ];
-    await Promise.all(
-      taskIds.map((taskId) => this.tryAsBoolean(this.taskManager.removeIfExists(taskId)))
-    );
   }
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -124,7 +124,11 @@ export class AssetManagerClient {
             savedObjectsClient: this.savedObjectsClient,
           })
         ),
-        stopAndRemoveV1SharedTasks({ namespace: this.namespace, taskManager: this.taskManager }),
+        stopAndRemoveV1SharedTasks({
+          namespace: this.namespace,
+          logger: this.logger,
+          taskManager: this.taskManager,
+        }),
 
         ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -113,7 +113,7 @@ export class AssetManagerClient {
       await Promise.all([
         this.globalStateClient.init({ historySnapshot, logsExtraction }),
 
-        ...entityTypes.map((type) => this.initEntity(request, type, logExtractionParams)),
+        ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
         ...entityTypes.map((type) =>
           stopAndRemoveV1({
             type,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -6,7 +6,11 @@
  */
 
 import type { Logger } from '@kbn/logging';
-import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
+import type {
+  ElasticsearchClient,
+  KibanaRequest,
+  SavedObjectsClientContract,
+} from '@kbn/core/server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { CheckPrivilegesResponse } from '@kbn/security-plugin-types-server';
@@ -66,6 +70,7 @@ interface AssetManagerDependencies {
   logsExtractionClient: LogsExtractionClient;
   security: SecurityPluginStart;
   analytics: TelemetryReporter;
+  savedObjectsClient: SavedObjectsClientContract;
 }
 
 export class AssetManagerClient {
@@ -79,6 +84,7 @@ export class AssetManagerClient {
   private readonly logsExtractionClient: LogsExtractionClient;
   private readonly security: SecurityPluginStart;
   private readonly analytics: TelemetryReporter;
+  private readonly savedObjectsClient: SavedObjectsClientContract;
 
   constructor(deps: AssetManagerDependencies) {
     this.logger = deps.logger;
@@ -91,6 +97,7 @@ export class AssetManagerClient {
     this.logsExtractionClient = deps.logsExtractionClient;
     this.security = deps.security;
     this.analytics = deps.analytics;
+    this.savedObjectsClient = deps.savedObjectsClient;
   }
 
   public async init(
@@ -102,9 +109,12 @@ export class AssetManagerClient {
     try {
       const logsExtraction = LogExtractionConfig.parse(logsExtractionParams ?? {});
       const historySnapshot = HistorySnapshotState.parse(historySnapshotParams ?? {});
-
       await Promise.all([
         this.globalStateClient.init({ historySnapshot, logsExtraction }),
+
+        ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
+        ...entityTypes.map((type) => this.stopAndRemoveV1(type)),
+        this.stopAndRemoveV1SharedTasks(),
 
         ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
 
@@ -479,5 +489,106 @@ export class AssetManagerClient {
     }
 
     return ENTITY_STORE_STATUS.RUNNING;
+  }
+
+  private async stopAndRemoveV1(type: EntityType) {
+    const definitionId = `security_${type}_${this.namespace}`;
+    const logger = this.logger.get(type);
+    const transformIds = [
+      `entities-v1-latest-${definitionId}`,
+      `entities-v1-history-${definitionId}`,
+    ];
+    const taskIds = [`entity_store:snapshot:${type}:${this.namespace}:1.0.0`];
+    const ingestPipelineIds = [
+      `entities-v1-latest-${definitionId}`,
+      `entities-v1-history-${definitionId}`,
+      `${definitionId}-latest@platform`,
+    ];
+    const indexTemplateIds = [
+      `entities_v1_reset_${definitionId}_index_template`,
+      `entities_v1_updates_${definitionId}_index_template`,
+    ];
+    const componentTemplateIds = [
+      `${definitionId}-updates@platform`,
+      `${definitionId}-updates@custom`,
+    ];
+    const resetIndex = `.entities.v1.reset.${definitionId}`;
+    const updatesDataStream = `.entities.v1.updates.${definitionId}`;
+    const enrichPolicyName = `entity_store_field_retention_${type}_${this.namespace}_v1.0.0`;
+
+    await Promise.all(
+      transformIds.map((transformId) =>
+        this.tryAsBoolean(
+          this.esClient.transform.stopTransform(
+            { transform_id: transformId, wait_for_completion: true, force: true },
+            { ignore: [404, 409] }
+          )
+        )
+      )
+    );
+
+    await Promise.all(
+      taskIds.map((taskId) => this.tryAsBoolean(this.taskManager.removeIfExists(taskId)))
+    );
+
+    await Promise.all([
+      ...transformIds.map((transformId) =>
+        this.tryAsBoolean(
+          this.esClient.transform.deleteTransform(
+            { transform_id: transformId, force: true },
+            { ignore: [404] }
+          )
+        )
+      ),
+      ...ingestPipelineIds.map((pipelineId) =>
+        this.tryAsBoolean(
+          this.esClient.ingest.deletePipeline({ id: pipelineId }, { ignore: [404] })
+        )
+      ),
+      ...indexTemplateIds.map((templateId) =>
+        this.tryAsBoolean(
+          this.esClient.indices.deleteIndexTemplate({ name: templateId }, { ignore: [404] })
+        )
+      ),
+      ...componentTemplateIds.map((componentTemplateId) =>
+        this.tryAsBoolean(
+          this.esClient.cluster.deleteComponentTemplate(
+            { name: componentTemplateId },
+            { ignore: [404] }
+          )
+        )
+      ),
+      this.tryAsBoolean(
+        this.esClient.enrich.deletePolicy({ name: enrichPolicyName }, { ignore: [404] })
+      ),
+      this.tryAsBoolean(this.esClient.indices.delete({ index: resetIndex }, { ignore: [404] })),
+      this.tryAsBoolean(
+        this.esClient.indices.deleteDataStream({ name: updatesDataStream }, { ignore: [404] })
+      ),
+      this.tryAsBoolean(
+        this.savedObjectsClient.delete('entity-definition', definitionId).catch((error) => {
+          if (
+            SavedObjectsErrorHelpers.isNotFoundError(error) ||
+            SavedObjectsErrorHelpers.isForbiddenError(error)
+          ) {
+            return;
+          }
+          throw error;
+        })
+      ),
+    ]);
+
+    logger.debug(`Stopped and removed entity store v1 resources for type: ${type}`);
+  }
+
+  private async stopAndRemoveV1SharedTasks() {
+    const taskIds = [
+      `entity_store:field_retention:enrichment:${this.namespace}:1.0.0`,
+      `entity_store:data_view:refresh:${this.namespace}:1.0.0`,
+      `entity_store:health:${this.namespace}:1.0.0`,
+    ];
+    await Promise.all(
+      taskIds.map((taskId) => this.tryAsBoolean(this.taskManager.removeIfExists(taskId)))
+    );
   }
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { EntityType } from '../../common';
+
+interface StopAndRemoveV1Params {
+  type: EntityType;
+  namespace: string;
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  taskManager: TaskManagerStartContract;
+  savedObjectsClient: SavedObjectsClientContract;
+}
+
+interface StopAndRemoveV1SharedTasksParams {
+  namespace: string;
+  taskManager: TaskManagerStartContract;
+}
+
+export async function stopAndRemoveV1({
+  type,
+  namespace,
+  logger,
+  esClient,
+  taskManager,
+  savedObjectsClient,
+}: StopAndRemoveV1Params) {
+  const definitionId = `security_${type}_${namespace}`;
+  const scopedLogger = logger.get(type);
+  const transformIds = [
+    `entities-v1-latest-${definitionId}`,
+    `entities-v1-history-${definitionId}`,
+  ];
+  const taskIds = [`entity_store:snapshot:${type}:${namespace}:1.0.0`];
+  const ingestPipelineIds = [
+    `entities-v1-latest-${definitionId}`,
+    `entities-v1-history-${definitionId}`,
+    `${definitionId}-latest@platform`,
+  ];
+  const indexTemplateIds = [
+    `entities_v1_reset_${definitionId}_index_template`,
+    `entities_v1_updates_${definitionId}_index_template`,
+  ];
+  const componentTemplateIds = [
+    `${definitionId}-updates@platform`,
+    `${definitionId}-updates@custom`,
+  ];
+  const resetIndex = `.entities.v1.reset.${definitionId}`;
+  const updatesDataStream = `.entities.v1.updates.${definitionId}`;
+  const enrichPolicyName = `entity_store_field_retention_${type}_${namespace}_v1.0.0`;
+  const v1EngineDescriptorId = `entity-engine-descriptor-${type}-${namespace}`;
+
+  await Promise.all(
+    transformIds.map((transformId) =>
+      tryAsBoolean(
+        esClient.transform.stopTransform(
+          { transform_id: transformId, wait_for_completion: true, force: true },
+          { ignore: [404, 409] }
+        )
+      )
+    )
+  );
+
+  await Promise.all(taskIds.map((taskId) => tryAsBoolean(taskManager.removeIfExists(taskId))));
+
+  await Promise.all([
+    ...transformIds.map((transformId) =>
+      tryAsBoolean(
+        esClient.transform.deleteTransform(
+          { transform_id: transformId, force: true },
+          { ignore: [404] }
+        )
+      )
+    ),
+    ...ingestPipelineIds.map((pipelineId) =>
+      tryAsBoolean(esClient.ingest.deletePipeline({ id: pipelineId }, { ignore: [404] }))
+    ),
+    ...indexTemplateIds.map((templateId) =>
+      tryAsBoolean(esClient.indices.deleteIndexTemplate({ name: templateId }, { ignore: [404] }))
+    ),
+    ...componentTemplateIds.map((componentTemplateId) =>
+      tryAsBoolean(
+        esClient.cluster.deleteComponentTemplate({ name: componentTemplateId }, { ignore: [404] })
+      )
+    ),
+    tryAsBoolean(esClient.enrich.deletePolicy({ name: enrichPolicyName }, { ignore: [404] })),
+    tryAsBoolean(esClient.indices.delete({ index: resetIndex }, { ignore: [404] })),
+    tryAsBoolean(esClient.indices.deleteDataStream({ name: updatesDataStream }, { ignore: [404] })),
+    tryAsBoolean(
+      savedObjectsClient.delete('entity-definition', definitionId).catch((error) => {
+        if (
+          SavedObjectsErrorHelpers.isNotFoundError(error) ||
+          SavedObjectsErrorHelpers.isForbiddenError(error)
+        ) {
+          return;
+        }
+        throw error;
+      })
+    ),
+    tryAsBoolean(
+      savedObjectsClient.delete('entity-engine-status', v1EngineDescriptorId).catch((error) => {
+        if (
+          SavedObjectsErrorHelpers.isNotFoundError(error) ||
+          SavedObjectsErrorHelpers.isForbiddenError(error)
+        ) {
+          return;
+        }
+        throw error;
+      })
+    ),
+  ]);
+
+  scopedLogger.debug(`Stopped and removed entity store v1 resources for type: ${type}`);
+}
+
+export async function stopAndRemoveV1SharedTasks({
+  namespace,
+  taskManager,
+}: StopAndRemoveV1SharedTasksParams) {
+  const taskIds = [
+    `entity_store:field_retention:enrichment:${namespace}:1.0.0`,
+    `entity_store:data_view:refresh:${namespace}:1.0.0`,
+    `entity_store:health:${namespace}:1.0.0`,
+  ];
+  await Promise.all(taskIds.map((taskId) => tryAsBoolean(taskManager.removeIfExists(taskId))));
+}
+
+async function tryAsBoolean(promise: Promise<unknown>): Promise<boolean> {
+  try {
+    await promise;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.ts
@@ -22,10 +22,45 @@ interface StopAndRemoveV1Params {
 
 interface StopAndRemoveV1SharedTasksParams {
   namespace: string;
+  logger: Logger;
   taskManager: TaskManagerStartContract;
 }
 
+const RETRY_ON_FAILURE_TIMES = 3;
+
 export async function stopAndRemoveV1({
+  type,
+  namespace,
+  logger,
+  esClient,
+  taskManager,
+  savedObjectsClient,
+}: StopAndRemoveV1Params) {
+  const scopedLogger = logger.get(type);
+  for (let attempt = 1; attempt <= RETRY_ON_FAILURE_TIMES; attempt++) {
+    try {
+      await stopAndRemoveV1Once({
+        type,
+        namespace,
+        logger,
+        esClient,
+        taskManager,
+        savedObjectsClient,
+      });
+      return;
+    } catch (error) {
+      if (attempt === RETRY_ON_FAILURE_TIMES) {
+        throw error;
+      }
+      scopedLogger.warn(
+        `Failed to remove entity store v1 resources for type: ${type}. Retrying (${attempt}/${RETRY_ON_FAILURE_TIMES}).`,
+        error
+      );
+    }
+  }
+}
+
+async function stopAndRemoveV1Once({
   type,
   namespace,
   logger,
@@ -58,7 +93,7 @@ export async function stopAndRemoveV1({
   const enrichPolicyName = `entity_store_field_retention_${type}_${namespace}_v1.0.0`;
   const v1EngineDescriptorId = `entity-engine-descriptor-${type}-${namespace}`;
 
-  await Promise.all(
+  const stoppedTransforms = await Promise.all(
     transformIds.map((transformId) =>
       tryAsBoolean(
         esClient.transform.stopTransform(
@@ -68,10 +103,18 @@ export async function stopAndRemoveV1({
       )
     )
   );
+  if (stoppedTransforms.includes(false)) {
+    throw new Error(`Failed to stop one or more entity store v1 transforms for type: ${type}`);
+  }
 
-  await Promise.all(taskIds.map((taskId) => tryAsBoolean(taskManager.removeIfExists(taskId))));
+  const removedTasks = await Promise.all(
+    taskIds.map((taskId) => tryAsBoolean(taskManager.removeIfExists(taskId)))
+  );
+  if (removedTasks.includes(false)) {
+    throw new Error(`Failed to remove one or more entity store v1 tasks for type: ${type}`);
+  }
 
-  await Promise.all([
+  const removedResources = await Promise.all([
     ...transformIds.map((transformId) =>
       tryAsBoolean(
         esClient.transform.deleteTransform(
@@ -117,11 +160,35 @@ export async function stopAndRemoveV1({
       })
     ),
   ]);
+  if (removedResources.includes(false)) {
+    throw new Error(`Failed to remove one or more entity store v1 resources for type: ${type}`);
+  }
 
   scopedLogger.debug(`Stopped and removed entity store v1 resources for type: ${type}`);
 }
 
 export async function stopAndRemoveV1SharedTasks({
+  namespace,
+  logger,
+  taskManager,
+}: StopAndRemoveV1SharedTasksParams) {
+  for (let attempt = 1; attempt <= RETRY_ON_FAILURE_TIMES; attempt++) {
+    try {
+      await stopAndRemoveV1SharedTasksOnce({ namespace, logger, taskManager });
+      return;
+    } catch (error) {
+      if (attempt === RETRY_ON_FAILURE_TIMES) {
+        throw error;
+      }
+      logger.warn(
+        `Failed to remove shared entity store v1 tasks in namespace: ${namespace}. Retrying (${attempt}/${RETRY_ON_FAILURE_TIMES}).`,
+        error
+      );
+    }
+  }
+}
+
+async function stopAndRemoveV1SharedTasksOnce({
   namespace,
   taskManager,
 }: StopAndRemoveV1SharedTasksParams) {
@@ -130,7 +197,14 @@ export async function stopAndRemoveV1SharedTasks({
     `entity_store:data_view:refresh:${namespace}:1.0.0`,
     `entity_store:health:${namespace}:1.0.0`,
   ];
-  await Promise.all(taskIds.map((taskId) => tryAsBoolean(taskManager.removeIfExists(taskId))));
+  const removedTasks = await Promise.all(
+    taskIds.map((taskId) => tryAsBoolean(taskManager.removeIfExists(taskId)))
+  );
+  if (removedTasks.includes(false)) {
+    throw new Error(
+      `Failed to remove one or more shared entity store v1 tasks in namespace: ${namespace}`
+    );
+  }
 }
 
 async function tryAsBoolean(promise: Promise<unknown>): Promise<boolean> {

--- a/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/request_context_factory.ts
@@ -99,6 +99,7 @@ export async function createRequestHandlerContext({
       logsExtractionClient,
       security: startPlugins.security,
       analytics,
+      savedObjectsClient: core.savedObjects.client,
     }),
     entityMaintainersClient: new EntityMaintainersClient({
       logger,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/245244

The aim of this PR is to provide a smooth transition from Entity Store v1 to v2. This is achieved by a hook that runs when user visits any Security page. Entity Store v2 is installed if either the namespace is `default` or there are Entity Store v1 engines installed in current namespace. In addition v1 artifacts will be removed (Transforms stopped and deleted, Tasks stopped and removed, helper indices gone) while preserving the data (`latest` and `history` indices preserved).

<img width="4056" height="1480" alt="image" src="https://github.com/user-attachments/assets/5f5064c7-e31f-4946-8081-6c3fd71e4637" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


