### PR TITLE
[Security Solution][Attacks/Alerts][Attack flyout] History

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history_row.test.tsx
@@ -20,6 +20,7 @@ import {
   type FlyoutPanelHistory,
   useExpandableFlyoutApi,
 } from '@kbn/expandable-flyout';
+import { useFindAttackDiscoveries } from '../../../attack_discovery/pages/use_find_attack_discoveries';
 import { useRuleDetails } from '../../rule_details/hooks/use_rule_details';
 import { useBasicDataFromDetailsData } from '../../document_details/shared/hooks/use_basic_data_from_details_data';
 import { useEventDetails } from '../../document_details/shared/hooks/use_event_details';
@@ -27,6 +28,7 @@ import { DocumentDetailsRightPanelKey } from '../../document_details/shared/cons
 import { RulePanelKey } from '../../rule_details/right';
 import { NetworkPanelKey } from '../../network_details';
 import {
+  ATTACK_DETAILS_HISTORY_ROW_TEST_ID,
   DOCUMENT_DETAILS_HISTORY_ROW_TEST_ID,
   GENERIC_HISTORY_ROW_TEST_ID,
   HISTORY_ROW_LOADING_TEST_ID,
@@ -38,6 +40,7 @@ import {
 } from './test_ids';
 import { HostPanelKey, UserPanelKey } from '../../entity_details/shared/constants';
 import { IOCRightPanelKey } from '../../ioc_details/constants/panel_keys';
+import { AttackDetailsRightPanelKey } from '../../attack_details/constants/panel_keys';
 
 jest.mock('@kbn/expandable-flyout', () => ({
   useExpandableFlyoutApi: jest.fn(),
@@ -46,6 +49,9 @@ jest.mock('@kbn/expandable-flyout', () => ({
   ExpandableFlyoutProvider: ({ children }: React.PropsWithChildren<{}>) => <>{children}</>,
 }));
 
+jest.mock('../../../attack_discovery/pages/use_find_attack_discoveries', () => ({
+  useFindAttackDiscoveries: jest.fn(),
+}));
 jest.mock('../../../detection_engine/rule_management/logic/use_rule_with_fallback');
 jest.mock('../../document_details/shared/hooks/use_basic_data_from_details_data');
 jest.mock('../../rule_details/hooks/use_rule_details');
@@ -102,6 +108,13 @@ const rowItems: { [id: string]: FlyoutPanelHistory } = {
       params: { id: 'iocId' },
     },
   },
+  attack: {
+    lastOpen: Date.now(),
+    panel: {
+      id: AttackDetailsRightPanelKey,
+      params: { attackId: 'attack-1', indexName: '.alerts-security.alerts-default' },
+    },
+  },
   unsupported: {
     lastOpen: Date.now(),
     panel: {
@@ -132,6 +145,10 @@ describe('FlyoutHistoryRow', () => {
       loading: false,
     });
     (useBasicDataFromDetailsData as jest.Mock).mockReturnValue({ isAlert: false });
+    (useFindAttackDiscoveries as jest.Mock).mockReturnValue({
+      data: { data: [{ title: 'Attack title' }], total: 1 },
+      isLoading: false,
+    });
   });
 
   it('should render document details history row when key is alert', () => {
@@ -195,6 +212,18 @@ describe('FlyoutHistoryRow', () => {
     );
     expect(getByTestId(`${5}-${IOC_HISTORY_ROW_TEST_ID}`)).toBeInTheDocument();
     expect(getByTestId(`${5}-${IOC_HISTORY_ROW_TEST_ID}`)).toHaveTextContent('Document: Indicator');
+  });
+
+  it('should render attack details history row when key is attack', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <FlyoutHistoryRow item={rowItems.attack} index={6} />
+      </TestProviders>
+    );
+    expect(getByTestId(`${6}-${ATTACK_DETAILS_HISTORY_ROW_TEST_ID}`)).toBeInTheDocument();
+    expect(getByTestId(`${6}-${ATTACK_DETAILS_HISTORY_ROW_TEST_ID}`)).toHaveTextContent(
+      'Attack: Attack title'
+    );
   });
 
   it('should render null when key is not supported', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history_row.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 import type { FlyoutPanelHistory } from '@kbn/expandable-flyout';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useAssistantContext } from '@kbn/elastic-assistant';
 import { IOCRightPanelKey } from '../../ioc_details/constants/panel_keys';
 import { EasePanelKey } from '../../ease/constants/panel_keys';
 import { FormattedRelativePreferenceDate } from '../../../common/components/formatted_date';
@@ -39,10 +40,13 @@ import {
   RULE_HISTORY_ROW_TEST_ID,
   USER_HISTORY_ROW_TEST_ID,
   VULNERABILITY_HISTORY_ROW_TEST_ID,
+  ATTACK_DETAILS_HISTORY_ROW_TEST_ID,
 } from './test_ids';
 import { HostPanelKey, UserPanelKey } from '../../entity_details/shared/constants';
 import { VulnerabilityFindingsPanelKey } from '../../csp_details/vulnerabilities_flyout/constants';
 import { MisconfigurationFindingsPanelKey } from '../../csp_details/findings_flyout/constants';
+import { AttackDetailsRightPanelKey } from '../../attack_details/constants/panel_keys';
+import { useFindAttackDiscoveries } from '../../../attack_discovery/pages/use_find_attack_discoveries';
 
 const MAX_WIDTH = 300; // px
 
@@ -128,6 +132,8 @@ export const FlyoutHistoryRow: FC<FlyoutHistoryRowProps> = memo(({ item, index }
           dataTestSubj={IOC_HISTORY_ROW_TEST_ID}
         />
       );
+    case AttackDetailsRightPanelKey:
+      return <AttackDetailsHistoryRow item={item} index={index} />;
     default:
       return null;
   }
@@ -162,6 +168,43 @@ export const DocumentDetailsHistoryRow: FC<FlyoutHistoryRowProps> = memo(({ item
       name={isAlert ? 'Alert' : 'Event'}
       isLoading={loading}
       dataTestSubj={DOCUMENT_DETAILS_HISTORY_ROW_TEST_ID}
+    />
+  );
+});
+
+/**
+ * Row item for a attack details
+ */
+export const AttackDetailsHistoryRow: FC<FlyoutHistoryRowProps> = memo(({ item, index }) => {
+  const attackId = useMemo(() => {
+    if (item?.panel?.params?.attackId) {
+      return String(item.panel.params.attackId);
+    }
+    return undefined;
+  }, [item]);
+  const { assistantAvailability, http } = useAssistantContext();
+
+  const { data: attackData, isLoading } = useFindAttackDiscoveries({
+    ids: attackId ? [attackId] : [],
+    http,
+    isAssistantEnabled: assistantAvailability.isAssistantEnabled,
+    perPage: 1,
+  });
+
+  const title = useMemo(
+    () => (attackData && attackData.data.length > 0 ? attackData.data[0]?.title : ''),
+    [attackData]
+  );
+
+  return (
+    <GenericHistoryRow
+      item={item}
+      index={index}
+      title={title}
+      icon={'bolt'}
+      name={'Attack'}
+      isLoading={isLoading}
+      dataTestSubj={ATTACK_DETAILS_HISTORY_ROW_TEST_ID}
     />
   );
 });
@@ -305,6 +348,7 @@ export const GenericHistoryRow: FC<GenericHistoryRowProps> = memo(
 
 FlyoutHistoryRow.displayName = 'FlyoutHistoryRow';
 DocumentDetailsHistoryRow.displayName = 'DocumentDetailsHistoryRow';
+AttackDetailsHistoryRow.displayName = 'AttackDetailsHistoryRow';
 RuleHistoryRow.displayName = 'RuleHistoryRow';
 RowTitle.displayName = 'RowTitle';
 GenericHistoryRow.displayName = 'GenericHistoryRow';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history_row.tsx
@@ -173,7 +173,7 @@ export const DocumentDetailsHistoryRow: FC<FlyoutHistoryRowProps> = memo(({ item
 });
 
 /**
- * Row item for a attack details
+ * Row item for attack details
  */
 export const AttackDetailsHistoryRow: FC<FlyoutHistoryRowProps> = memo(({ item, index }) => {
   const attackId = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/test_ids.ts
@@ -49,6 +49,8 @@ export const FLYOUT_HISTORY_CONTEXT_PANEL_TEST_ID =
 
 export const DOCUMENT_DETAILS_HISTORY_ROW_TEST_ID =
   `${FLYOUT_HISTORY_TEST_ID}DocumentDetailsRow` as const;
+export const ATTACK_DETAILS_HISTORY_ROW_TEST_ID =
+  `${FLYOUT_HISTORY_TEST_ID}AttackDetailsRow` as const;
 export const RULE_HISTORY_ROW_TEST_ID = `${FLYOUT_HISTORY_TEST_ID}RuleRow` as const;
 export const HOST_HISTORY_ROW_TEST_ID = `${FLYOUT_HISTORY_TEST_ID}HostRow` as const;
 export const USER_HISTORY_ROW_TEST_ID = `${FLYOUT_HISTORY_TEST_ID}UserRow` as const;


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/kibana/issues/242774

Adds the Attack details right panel to the flyout history so that when users open an attack from the Attacks view or timeline, that panel appears in the history list and they can navigate back to it from the history dropdown.

## What changed
- **`FlyoutHistoryRow`**  
  Handles `AttackDetailsRightPanelKey`: when the current panel is Attack details, it renders an attack history row instead of falling through to “unsupported”.
- **`AttackDetailsHistoryRow`**  
  New row component that:
  - Reads `attackId` from panel params.
  - Uses `useFindAttackDiscoveries` to load the attack and show its title.
  - Renders a `GenericHistoryRow` with bolt icon, name “Attack”, and loading state.
- **Test IDs**  
  Adds `ATTACK_DETAILS_HISTORY_ROW_TEST_ID` for the attack history row.
- **Tests**  
  - Mocks `useFindAttackDiscoveries` in `flyout_history_row.test.tsx`.
  - Adds an `attack` entry to `rowItems` with `AttackDetailsRightPanelKey` and `params: { attackId, indexName }`.
  - Adds a test that the attack details history row is rendered with the correct title when the panel key is attack.
- **Comment**  
  Fixes typo: “Row item for a attack details” → “Row item for attack details”.

## How to verify
1. Open the Attacks view or a timeline with attack discoveries.
2. Open an attack (right panel = Attack details).
3. Open the flyout history (e.g. breadcrumb/history in the flyout).
4. Confirm an “Attack: &lt;title&gt;” entry appears and that clicking it reopens that attack panel.


<img width="511" height="339" alt="Screenshot 2026-03-04 at 12 17 03" src="https://github.com/user-attachments/assets/f8b7d207-e3f1-4569-a8ec-0c0ea2becf47" />
