### PR TITLE
[One Workflow] Fix flaky alert trigger Scout test (obs serverless timeout)

### DIFF
--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/constants.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/constants.ts
@@ -20,3 +20,10 @@ export const LONG_EXECUTION_TIMEOUT = 60_000;
 
 /** Timeout for waiting on asynchronous alert-triggered executions to appear in the list. */
 export const ALERT_PROPAGATION_TIMEOUT = 60_000;
+
+/**
+ * Overall test timeout for alert trigger tests.
+ * These tests involve a multi-hop async chain: rule creation → rule scheduling (15s interval)
+ * → document indexing → alert detection → workflow execution → UI navigation.
+ */
+export const ALERT_TRIGGER_TEST_TIMEOUT = 120_000;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/alert_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/alert_workflows.ts
@@ -141,6 +141,12 @@ steps:
       index: "{{consts.alerts_index_name}}"
     on-failure:
       continue: true
+  - name: create_index
+    type: elasticsearch.indices.create
+    with:
+      index: "{{consts.alerts_index_name}}"
+    on-failure:
+      continue: true
   - name: create_obs_alert_rule
     type: kibana.request
     with:

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/alert_trigger.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/alert_trigger.spec.ts
@@ -11,7 +11,11 @@ import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { spaceTest as test } from '../../fixtures';
 import { cleanupWorkflowsAndRules } from '../../fixtures/cleanup';
-import { ALERT_PROPAGATION_TIMEOUT, EXECUTION_TIMEOUT } from '../../fixtures/constants';
+import {
+  ALERT_PROPAGATION_TIMEOUT,
+  ALERT_TRIGGER_TEST_TIMEOUT,
+  EXECUTION_TIMEOUT,
+} from '../../fixtures/constants';
 import {
   getCreateObsAlertRuleWorkflowYaml,
   getCreateSecurityAlertRuleWorkflowYaml,
@@ -34,8 +38,7 @@ const getCreateAlertRuleWorkflow = (projectType: string | undefined) => {
 
 // Alert trigger tests run on Security and Observability (and ESS), but NOT on Elasticsearch/Search.
 // Security uses the detection engine API; Observability uses the generic alerting API.
-// FLAKY: https://github.com/elastic/kibana/issues/252959
-test.describe.skip(
+test.describe(
   'Workflow execution - Alert triggers',
   {
     tag: [
@@ -81,6 +84,7 @@ test.describe.skip(
       scoutSpace,
       config,
     }) => {
+      test.setTimeout(ALERT_TRIGGER_TEST_TIMEOUT);
       const getCreateAlertRuleYaml = getCreateAlertRuleWorkflow(config.projectType);
 
       const singleWorkflowName = 'Handle single alert';
@@ -211,6 +215,7 @@ test.describe.skip(
       scoutSpace,
       config,
     }) => {
+      test.setTimeout(ALERT_TRIGGER_TEST_TIMEOUT);
       const getCreateAlertRuleYaml = getCreateAlertRuleWorkflow(config.projectType);
 
       const disabledWorkflowName = 'Disabled alert target';


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/16061
Closes https://github.com/elastic/kibana/issues/252959

## Summary

Fixes the flaky alert trigger Scout test that was skipped by CI due to timeouts on `local-serverless-observability_complete`.

**Root cause:** The obs alert rule workflow creates an ES|QL `.es-query` rule that immediately starts querying `test-workflow-alerts-index`. But the index doesn't exist yet — documents are only indexed later by a separate trigger workflow. ES|QL queries against a non-existent index throw `verification_exception: Unknown index`, causing the rule to hit repeated errors and backoff delays that exceed the Playwright timeout.

**Fix:**
- Added a `create_index` step in the obs alert rule workflow (between `delete_index` and `create_obs_alert_rule`) so the index exists (empty) before the rule starts querying it. ES|QL queries now return 0 results instead of throwing exceptions.
- Added `on-failure: continue: true` to the `create_index` step for parallel-worker safety (index may already exist from another worker).
- Added `test.setTimeout(120_000)` to both alert trigger tests to accommodate the multi-hop async chain (rule creation → rule scheduling → document indexing → alert detection → workflow execution → UI navigation).
- Re-enabled the test suite (removed `test.describe.skip` and the FLAKY comment).

**Validation:** 6 consecutive test runs (2 tests each = 12 test executions) all passed on local stateful with the `workflows_ui` config set.