### PR TITLE
[Security Solution] add upper bounds for array schemas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2717,6 +2717,7 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/sie
 
 /x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover @elastic/security-threat-hunting
 x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/resolver.ts @elastic/security-threat-hunting
 
 ## Security Solution Threat Hunting areas - Threat Hunting Investigations
 

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -18862,23 +18862,25 @@ paths:
                 agent_type:
                   $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
                 alert_ids:
-                  description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+                  description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
                   example:
                     - alert-id-1
                     - alert-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 case_ids:
-                  description: The IDs of cases where the action taken will be logged.
+                  description: The IDs of cases where the action taken will be logged. Max of 50.
                   example:
                     - case-id-1
                     - case-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 comment:
@@ -19209,23 +19211,25 @@ paths:
                 agent_type:
                   $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
                 alert_ids:
-                  description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+                  description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
                   example:
                     - alert-id-1
                     - alert-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 case_ids:
-                  description: The IDs of cases where the action taken will be logged.
+                  description: The IDs of cases where the action taken will be logged. Max of 50.
                   example:
                     - case-id-1
                     - case-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 comment:
@@ -82697,7 +82701,7 @@ components:
       description: Agent ID
       type: string
     Security_Endpoint_Management_API_AgentIds:
-      description: A list of agent IDs. Max of 50.
+      description: A list of agent IDs. Max of 250.
       example:
         - agent-id-1
         - agent-id-2
@@ -82706,7 +82710,7 @@ components:
         - items:
             minLength: 1
             type: string
-          maxItems: 50
+          maxItems: 250
           minItems: 1
           type: array
         - minLength: 1
@@ -82748,23 +82752,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -82830,6 +82836,7 @@ components:
         - unisolate
       items:
         $ref: '#/components/schemas/Security_Endpoint_Management_API_Command'
+      maxItems: 50
       type: array
     Security_Endpoint_Management_API_Comment:
       description: Optional comment
@@ -82850,13 +82857,14 @@ components:
       example: '2023-10-31T23:59:59.999Z'
       type: string
     Security_Endpoint_Management_API_EndpointIds:
-      description: List of endpoint IDs (cannot contain empty strings)
+      description: List of endpoint IDs (cannot contain empty strings). Max of 250.
       example:
         - endpoint-id-1
         - endpoint-id-2
       items:
         minLength: 1
         type: string
+      maxItems: 250
       minItems: 1
       type: array
     Security_Endpoint_Management_API_EndpointMetadataResponse:
@@ -82994,23 +83002,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -83175,23 +83185,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -83254,23 +83266,25 @@ components:
         agent_type:
           $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
         alert_ids:
-          description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+          description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
           example:
             - alert-id-1
             - alert-id-2
           items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         case_ids:
-          description: The IDs of cases where the action taken will be logged.
+          description: The IDs of cases where the action taken will be logged. Max of 50.
           example:
             - case-id-1
             - case-id-2
           items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         comment:
@@ -83335,6 +83349,7 @@ components:
           - inactive
           - unenrolled
         type: string
+      maxItems: 20
       type: array
     Security_Endpoint_Management_API_Isolate:
       allOf:
@@ -83429,23 +83444,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -83614,23 +83631,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -84141,23 +84160,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -84208,23 +84229,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -84379,23 +84402,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -84544,23 +84569,25 @@ components:
             agent_type:
               $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+              description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: The IDs of cases where the action taken will be logged. Max of 50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -84624,7 +84651,7 @@ components:
       type: object
       properties: {}
     Security_Endpoint_Management_API_UserIds:
-      description: A list of user IDs.
+      description: A list of user IDs. Max of 50.
       example:
         - user-id-1
         - user-id-2
@@ -84632,12 +84659,13 @@ components:
         - items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         - minLength: 1
           type: string
     Security_Endpoint_Management_API_WithOutputs:
-      description: A list of action IDs that should include the complete output of the action.
+      description: A list of action IDs that should include the complete output of the action. Max of 50.
       example:
         - action-id-1
         - action-id-2
@@ -84645,6 +84673,7 @@ components:
         - items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         - minLength: 1

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/common/base.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/common/base.ts
@@ -33,6 +33,7 @@ export const BaseActionRequestSchema = {
   /** A list of endpoint IDs whose hosts will be isolated (Fleet Agent IDs will be retrieved for these) */
   endpoint_ids: schema.arrayOf(schema.string({ minLength: 1 }), {
     minSize: 1,
+    maxSize: 250,
     validate: (endpointIds) => {
       if (endpointIds.map((v) => v.trim()).some((v) => !v.length)) {
         return 'endpoint_ids cannot contain empty strings';
@@ -43,6 +44,7 @@ export const BaseActionRequestSchema = {
   alert_ids: schema.maybe(
     schema.arrayOf(schema.string({ minLength: 1 }), {
       minSize: 1,
+      maxSize: 50,
       validate: (alertIds) => {
         if (alertIds.map((v) => v.trim()).some((v) => !v.length)) {
           return 'alert_ids cannot contain empty strings';
@@ -54,6 +56,7 @@ export const BaseActionRequestSchema = {
   case_ids: schema.maybe(
     schema.arrayOf(schema.string({ minLength: 1 }), {
       minSize: 1,
+      maxSize: 50,
       validate: (caseIds) => {
         if (caseIds.map((v) => v.trim()).some((v) => !v.length)) {
           return 'case_ids cannot contain empty strings';

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/list/list.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/actions/list/list.ts
@@ -37,7 +37,7 @@ export const EndpointActionListRequestSchema = {
   query: schema.object({
     agentIds: schema.maybe(
       schema.oneOf([
-        schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1 }),
+        schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1, maxSize: 250 }),
         schema.string({ minLength: 1 }),
       ])
     ),
@@ -48,7 +48,7 @@ export const EndpointActionListRequestSchema = {
       ])
     ),
     commands: schema.maybe(
-      schema.oneOf([schema.arrayOf(commandsSchema, { minSize: 1 }), commandsSchema])
+      schema.oneOf([schema.arrayOf(commandsSchema, { minSize: 1, maxSize: 50 }), commandsSchema])
     ),
     page: schema.maybe(schema.number({ defaultValue: 1, min: 1 })),
     pageSize: schema.maybe(
@@ -64,7 +64,7 @@ export const EndpointActionListRequestSchema = {
     ),
     userIds: schema.maybe(
       schema.oneOf([
-        schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1 }),
+        schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1, maxSize: 50 }),
         schema.string({ minLength: 1 }),
       ])
     ),
@@ -72,6 +72,7 @@ export const EndpointActionListRequestSchema = {
       schema.oneOf([
         schema.arrayOf(schema.string({ minLength: 1 }), {
           minSize: 1,
+          maxSize: 50,
           validate: (actionIds) => {
             if (actionIds.map((v) => v.trim()).some((v) => !v.length)) {
               return 'actionIds cannot contain empty strings';

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/list_metadata.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/list_metadata.ts
@@ -38,7 +38,8 @@ export const GetMetadataListRequestSchema = {
             schema.literal(HostStatus.UPDATING.toString()),
             schema.literal(HostStatus.UNHEALTHY.toString()),
             schema.literal(HostStatus.INACTIVE.toString()),
-          ])
+          ]),
+          { maxSize: 20 }
         )
       ),
     },

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
@@ -62,9 +62,9 @@ export const Kuery = z.string();
  * A set of agent health statuses to filter by.
  */
 export type HostStatuses = z.infer<typeof HostStatuses>;
-export const HostStatuses = z.array(
-  z.enum(['healthy', 'offline', 'updating', 'inactive', 'unenrolled'])
-);
+export const HostStatuses = z
+  .array(z.enum(['healthy', 'offline', 'updating', 'inactive', 'unenrolled']))
+  .max(20);
 
 /**
  * Determines the sort order.
@@ -93,10 +93,10 @@ export type SortFieldEnum = typeof SortField.enum;
 export const SortFieldEnum = SortField.enum;
 
 /**
- * A list of agent IDs. Max of 50.
+ * A list of agent IDs. Max of 250.
  */
 export type AgentIds = z.infer<typeof AgentIds>;
-export const AgentIds = z.union([z.array(z.string().min(1)).min(1).max(50), z.string().min(1)]);
+export const AgentIds = z.union([z.array(z.string().min(1)).min(1).max(250), z.string().min(1)]);
 
 /**
  * The command for the response action
@@ -123,7 +123,7 @@ export const CommandEnum = Command.enum;
  * A list of response action command names.
  */
 export type Commands = z.infer<typeof Commands>;
-export const Commands = z.array(Command);
+export const Commands = z.array(Command).max(50);
 
 /**
  * The maximum timeout value in milliseconds (optional)
@@ -140,16 +140,16 @@ export type Statuses = z.infer<typeof Statuses>;
 export const Statuses = z.array(Status);
 
 /**
- * A list of user IDs.
+ * A list of user IDs. Max of 50.
  */
 export type UserIds = z.infer<typeof UserIds>;
-export const UserIds = z.union([z.array(z.string().min(1)).min(1), z.string().min(1)]);
+export const UserIds = z.union([z.array(z.string().min(1)).min(1).max(50), z.string().min(1)]);
 
 /**
- * A list of action IDs that should include the complete output of the action.
+ * A list of action IDs that should include the complete output of the action. Max of 50.
  */
 export type WithOutputs = z.infer<typeof WithOutputs>;
-export const WithOutputs = z.union([z.array(z.string().min(1)).min(1), z.string().min(1)]);
+export const WithOutputs = z.union([z.array(z.string().min(1)).min(1).max(50), z.string().min(1)]);
 
 /**
  * Type of response action
@@ -166,10 +166,10 @@ export type Types = z.infer<typeof Types>;
 export const Types = z.array(Type);
 
 /**
- * List of endpoint IDs (cannot contain empty strings)
+ * List of endpoint IDs (cannot contain empty strings). Max of 250.
  */
 export type EndpointIds = z.infer<typeof EndpointIds>;
-export const EndpointIds = z.array(z.string().min(1)).min(1);
+export const EndpointIds = z.array(z.string().min(1)).min(1).max(250);
 
 /**
  * Optional comment
@@ -200,13 +200,13 @@ export type BaseActionSchema = z.infer<typeof BaseActionSchema>;
 export const BaseActionSchema = z.object({
   endpoint_ids: EndpointIds,
   /**
-   * If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+   * If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
    */
-  alert_ids: z.array(z.string().min(1)).min(1).optional(),
+  alert_ids: z.array(z.string().min(1)).min(1).max(50).optional(),
   /**
-   * The IDs of cases where the action taken will be logged.
+   * The IDs of cases where the action taken will be logged. Max of 50.
    */
-  case_ids: z.array(z.string().min(1)).min(1).optional(),
+  case_ids: z.array(z.string().min(1)).min(1).max(50).optional(),
   comment: Comment.optional(),
   parameters: Parameters.optional(),
   agent_type: AgentTypes.optional(),

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.schema.yaml
@@ -42,6 +42,7 @@ components:
       type: array
       description: A set of agent health statuses to filter by.
       example: [ "healthy", "updating" ]
+      maxItems: 20
       items:
         type: string
         enum:
@@ -79,10 +80,10 @@ components:
             type: string
             minLength: 1
           minItems: 1
-          maxItems: 50
+          maxItems: 250
         - type: string
           minLength: 1
-      description: A list of agent IDs. Max of 50.
+      description: A list of agent IDs. Max of 250.
       example: [ "agent-id-1", "agent-id-2" ]
       minLength: 1
 
@@ -108,6 +109,7 @@ components:
       type: array
       description: A list of response action command names.
       example: [ "isolate", "unisolate" ]
+      maxItems: 50
       items:
         $ref: '#/components/schemas/Command'
 
@@ -137,9 +139,10 @@ components:
             type: string
             minLength: 1
           minItems: 1
+          maxItems: 50
         - type: string
           minLength: 1
-      description: A list of user IDs.
+      description: A list of user IDs. Max of 50.
       example: [ "user-id-1", "user-id-2" ]
 
     WithOutputs:
@@ -149,9 +152,10 @@ components:
             type: string
             minLength: 1
           minItems: 1
+          maxItems: 50
         - type: string
           minLength: 1
-      description: A list of action IDs that should include the complete output of the action.
+      description: A list of action IDs that should include the complete output of the action. Max of 50.
       example: [ "action-id-1", "action-id-2" ]
 
     Type:
@@ -172,12 +176,13 @@ components:
 
     EndpointIds:
       type: array
-      description: List of endpoint IDs (cannot contain empty strings)
+      description: List of endpoint IDs (cannot contain empty strings). Max of 250.
       example: [ "endpoint-id-1", "endpoint-id-2" ]
       items:
         type: string
         minLength: 1
       minItems: 1
+      maxItems: 250
 
     Comment:
       type: string
@@ -206,17 +211,19 @@ components:
           $ref: '#/components/schemas/EndpointIds'
         alert_ids:
           type: array
-          description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts.
+          description: If this action is associated with any alerts, they can be specified here. The action will be logged in any cases associated with the specified alerts. Max of 50.
           example: [ "alert-id-1", "alert-id-2" ]
           minItems: 1
+          maxItems: 50
           items:
             type: string
             minLength: 1
         case_ids:
           type: array
-          description: The IDs of cases where the action taken will be logged.
+          description: The IDs of cases where the action taken will be logged. Max of 50.
           example: [ "case-id-1", "case-id-2" ]
           minItems: 1
+          maxItems: 50
           items:
             type: string
             minLength: 1

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.gen.ts
@@ -32,7 +32,7 @@ export type GetEndpointSuggestionsRequestBody = z.infer<typeof GetEndpointSugges
 export const GetEndpointSuggestionsRequestBody = z.object({
   field: z.string().optional(),
   query: z.string().optional(),
-  filters: z.unknown(),
+  filters: z.array(z.object({})).max(50).optional(),
   fieldMeta: z.unknown(),
 });
 export type GetEndpointSuggestionsRequestBodyInput = z.input<

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.schema.yaml
@@ -23,7 +23,11 @@ paths:
                   type: string
                 query:
                   type: string
-                filters: {}
+                filters:
+                  type: array
+                  maxItems: 50
+                  items:
+                    type: object
                 fieldMeta: {}
       parameters:
         - name: suggestion_type

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/suggestions/get_suggestions.ts
@@ -12,7 +12,9 @@ export const EndpointSuggestionsSchema = {
   body: schema.object({
     field: schema.string(),
     query: schema.string(),
-    filters: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
+    filters: schema.maybe(
+      schema.arrayOf(schema.object({}, { unknowns: 'allow' }), { maxSize: 50 })
+    ),
     fieldMeta: schema.maybe(schema.any()),
   }),
   params: schema.object({

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.test.ts
@@ -126,6 +126,48 @@ describe('Workflow Insights', () => {
       expect(() => validateQuery(validQuery)).not.toThrow();
     });
 
+    describe('maxSize bounds', () => {
+      it('should not accept more than 50 ids', () => {
+        expect(() => validateQuery({ query: { ids: Array(51).fill('valid-id') } })).toThrow();
+      });
+
+      it('should not accept more than 50 sourceIds', () => {
+        expect(() =>
+          validateQuery({ query: { sourceIds: Array(51).fill('source-id') } })
+        ).toThrow();
+      });
+
+      it('should not accept more than 50 targetIds', () => {
+        expect(() =>
+          validateQuery({ query: { targetIds: Array(51).fill('target-id') } })
+        ).toThrow();
+      });
+
+      it('should not accept more than 20 categories', () => {
+        expect(() =>
+          validateQuery({ query: { categories: Array(21).fill('endpoint') } })
+        ).toThrow();
+      });
+
+      it('should not accept more than 20 types', () => {
+        expect(() =>
+          validateQuery({ query: { types: Array(21).fill('incompatible_antivirus') } })
+        ).toThrow();
+      });
+
+      it('should not accept more than 20 sourceTypes', () => {
+        expect(() =>
+          validateQuery({ query: { sourceTypes: Array(21).fill('llm-connector') } })
+        ).toThrow();
+      });
+
+      it('should not accept more than 20 actionTypes', () => {
+        expect(() =>
+          validateQuery({ query: { actionTypes: Array(21).fill('refreshed') } })
+        ).toThrow();
+      });
+    });
+
     it('should throw an error for unsupported categories or types', () => {
       const invalidQuery = {
         query: {
@@ -380,6 +422,84 @@ describe('Workflow Insights', () => {
         };
 
         expect(() => validateRequest(validRequest)).not.toThrow();
+      });
+    });
+
+    describe('maxSize bounds', () => {
+      const baseRequest = {
+        params: { insightId: 'valid-insight-id' },
+        body: {},
+      };
+
+      it('should not accept more than 50 target ids', () => {
+        expect(() =>
+          validateRequest({
+            ...baseRequest,
+            body: { target: { ids: Array(51).fill('target-id') } },
+          })
+        ).toThrow();
+      });
+
+      it('should not accept more than 100 exception_list_items', () => {
+        const item = {
+          list_id: 'list-id',
+          name: 'Exception',
+          entries: [],
+        };
+        expect(() =>
+          validateRequest({
+            ...baseRequest,
+            body: { remediation: { exception_list_items: Array(101).fill(item) } },
+          })
+        ).toThrow();
+      });
+
+      it('should not accept more than 250 entries in an exception list item', () => {
+        expect(() =>
+          validateRequest({
+            ...baseRequest,
+            body: {
+              remediation: {
+                exception_list_items: [{ list_id: 'list-id', entries: Array(251).fill({}) }],
+              },
+            },
+          })
+        ).toThrow();
+      });
+
+      it('should not accept more than 50 tags in an exception list item', () => {
+        expect(() =>
+          validateRequest({
+            ...baseRequest,
+            body: {
+              remediation: {
+                exception_list_items: [{ list_id: 'list-id', tags: Array(51).fill('tag') }],
+              },
+            },
+          })
+        ).toThrow();
+      });
+
+      it('should not accept more than 20 os_types in an exception list item', () => {
+        expect(() =>
+          validateRequest({
+            ...baseRequest,
+            body: {
+              remediation: {
+                exception_list_items: [{ list_id: 'list-id', os_types: Array(21).fill('windows') }],
+              },
+            },
+          })
+        ).toThrow();
+      });
+
+      it('should not accept more than 50 message_variables', () => {
+        expect(() =>
+          validateRequest({
+            ...baseRequest,
+            body: { metadata: { message_variables: Array(51).fill('var') } },
+          })
+        ).toThrow();
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.ts
@@ -15,7 +15,7 @@ import {
   WORKFLOW_INSIGHT_ACTION_TYPE_VALUES,
 } from '../../../endpoint/types/workflow_insights';
 
-const arrayWithNonEmptyString = (field: string) =>
+const arrayWithNonEmptyString = (field: string, options: { maxSize: number }) =>
   schema.arrayOf(
     schema.string({
       minLength: 1,
@@ -24,7 +24,8 @@ const arrayWithNonEmptyString = (field: string) =>
           return `${field} cannot be an empty string`;
         }
       },
-    })
+    }),
+    options
   );
 
 const schemaOneOfValues = (values: readonly string[]) =>
@@ -63,7 +64,7 @@ export const UpdateWorkflowInsightRequestSchema = {
     target: schema.maybe(
       schema.object({
         type: schema.maybe(targetTypeOneOf),
-        ids: schema.maybe(arrayWithNonEmptyString('target.id')),
+        ids: schema.maybe(arrayWithNonEmptyString('target.id', { maxSize: 50 })),
       })
     ),
     action: schema.maybe(
@@ -81,10 +82,11 @@ export const UpdateWorkflowInsightRequestSchema = {
               list_id: schema.maybe(schema.string()),
               name: schema.maybe(schema.string()),
               description: schema.maybe(schema.string()),
-              entries: schema.maybe(schema.arrayOf(schema.any())),
-              tags: schema.maybe(arrayWithNonEmptyString('tag')),
-              os_types: schema.maybe(arrayWithNonEmptyString('os_type')),
-            })
+              entries: schema.maybe(schema.arrayOf(schema.any(), { maxSize: 250 })),
+              tags: schema.maybe(arrayWithNonEmptyString('tag', { maxSize: 50 })),
+              os_types: schema.maybe(arrayWithNonEmptyString('os_type', { maxSize: 20 })),
+            }),
+            { maxSize: 100 }
           )
         ),
         descriptive: schema.maybe(schema.string()),
@@ -94,7 +96,9 @@ export const UpdateWorkflowInsightRequestSchema = {
     metadata: schema.maybe(
       schema.object({
         notes: schema.maybe(schema.recordOf(schema.string(), schema.string())),
-        message_variables: schema.maybe(arrayWithNonEmptyString('message_variable')),
+        message_variables: schema.maybe(
+          arrayWithNonEmptyString('message_variable', { maxSize: 50 })
+        ),
       })
     ),
   }),
@@ -104,13 +108,13 @@ export const GetWorkflowInsightsRequestSchema = {
   query: schema.object({
     size: schema.maybe(schema.number()),
     from: schema.maybe(schema.number()),
-    ids: schema.maybe(arrayWithNonEmptyString('ids')),
+    ids: schema.maybe(arrayWithNonEmptyString('ids', { maxSize: 50 })),
     categories: schema.maybe(schema.arrayOf(categoryOneOf, { maxSize: 20 })),
     types: schema.maybe(schema.arrayOf(insightTypeOneOf, { maxSize: 20 })),
     sourceTypes: schema.maybe(schema.arrayOf(sourceTypeOneOf, { maxSize: 20 })),
-    sourceIds: schema.maybe(arrayWithNonEmptyString('sourceId')),
+    sourceIds: schema.maybe(arrayWithNonEmptyString('sourceId', { maxSize: 50 })),
     targetTypes: schema.maybe(schema.arrayOf(targetTypeOneOf, { maxSize: 20 })),
-    targetIds: schema.maybe(arrayWithNonEmptyString('targetId')),
+    targetIds: schema.maybe(arrayWithNonEmptyString('targetId', { maxSize: 50 })),
     actionTypes: schema.maybe(schema.arrayOf(actionTypeOneOf, { maxSize: 20 })),
   }),
 };

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/actions.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/actions.test.ts
@@ -128,14 +128,24 @@ describe('actions schemas', () => {
         }).not.toThrow();
       });
 
-      it('should not limit multiple agent IDs', () => {
+      it('should accept up to 250 agent IDs', () => {
         expect(() => {
           EndpointActionListRequestSchema.query.validate({
-            agentIds: Array(255)
+            agentIds: Array(250)
               .fill(1)
               .map(() => uuidv4()),
           });
         }).not.toThrow();
+      });
+
+      it('should not accept more than 250 agent IDs', () => {
+        expect(() => {
+          EndpointActionListRequestSchema.query.validate({
+            agentIds: Array(251)
+              .fill(1)
+              .map(() => uuidv4()),
+          });
+        }).toThrow();
       });
     });
 
@@ -253,6 +263,26 @@ describe('actions schemas', () => {
           });
         }).not.toThrow();
       });
+
+      it('should accept up to 50 userIds', () => {
+        expect(() => {
+          EndpointActionListRequestSchema.query.validate({
+            userIds: Array(50)
+              .fill(1)
+              .map((_, i) => `user-${i}`),
+          });
+        }).not.toThrow();
+      });
+
+      it('should not accept more than 50 userIds', () => {
+        expect(() => {
+          EndpointActionListRequestSchema.query.validate({
+            userIds: Array(51)
+              .fill(1)
+              .map((_, i) => `user-${i}`),
+          });
+        }).toThrow();
+      });
     });
 
     describe('commands', () => {
@@ -305,6 +335,14 @@ describe('actions schemas', () => {
             commands: ['isolate', 'unisolate'],
           });
         }).not.toThrow();
+      });
+
+      it('should not accept more than 50 commands', () => {
+        expect(() => {
+          EndpointActionListRequestSchema.query.validate({
+            commands: Array(51).fill('isolate'),
+          });
+        }).toThrow();
       });
     });
 
@@ -425,6 +463,26 @@ describe('actions schemas', () => {
           });
         }).not.toThrow();
       });
+
+      it('should accept up to 50 withOutputs action IDs', () => {
+        expect(() => {
+          EndpointActionListRequestSchema.query.validate({
+            withOutputs: Array(50)
+              .fill(1)
+              .map(() => uuidv4()),
+          });
+        }).not.toThrow();
+      });
+
+      it('should not accept more than 50 withOutputs action IDs', () => {
+        expect(() => {
+          EndpointActionListRequestSchema.query.validate({
+            withOutputs: Array(51)
+              .fill(1)
+              .map(() => uuidv4()),
+          });
+        }).toThrow();
+      });
     });
   });
 
@@ -467,6 +525,26 @@ describe('actions schemas', () => {
       }).not.toThrow();
     });
 
+    it('should accept up to 250 endpoint ids', () => {
+      expect(() => {
+        NoParametersRequestSchema.body.validate({
+          endpoint_ids: Array(250)
+            .fill(1)
+            .map(() => uuidv4()),
+        });
+      }).not.toThrow();
+    });
+
+    it('should not accept more than 250 endpoint ids', () => {
+      expect(() => {
+        NoParametersRequestSchema.body.validate({
+          endpoint_ids: Array(251)
+            .fill(1)
+            .map(() => uuidv4()),
+        });
+      }).toThrow();
+    });
+
     it('should accept a comment', () => {
       expect(() => {
         NoParametersRequestSchema.body.validate({
@@ -494,6 +572,17 @@ describe('actions schemas', () => {
       }).not.toThrow();
     });
 
+    it('should not accept more than 50 alert ids', () => {
+      expect(() => {
+        NoParametersRequestSchema.body.validate({
+          endpoint_ids: ['ABC-XYZ-000'],
+          alert_ids: Array(51)
+            .fill(1)
+            .map(() => uuidv4()),
+        });
+      }).toThrow();
+    });
+
     it('should not accept empty case IDs', () => {
       expect(() => {
         NoParametersRequestSchema.body.validate({
@@ -510,6 +599,17 @@ describe('actions schemas', () => {
           case_ids: ['000000000-000-000'],
         });
       }).not.toThrow();
+    });
+
+    it('should not accept more than 50 case ids', () => {
+      expect(() => {
+        NoParametersRequestSchema.body.validate({
+          endpoint_ids: ['ABC-XYZ-000'],
+          case_ids: Array(51)
+            .fill(1)
+            .map(() => uuidv4()),
+        });
+      }).toThrow();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/automated_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/automated_actions.ts
@@ -12,6 +12,7 @@ const AutomatedActionListRequestSchema = {
   query: schema.object({
     alertIds: schema.arrayOf(schema.string({ minLength: 1 }), {
       minSize: 1,
+      maxSize: 50,
       validate: (alertIds) => {
         if (alertIds.map((v) => v.trim()).some((v) => !v.length)) {
           return 'alertIds cannot contain empty strings';
@@ -30,7 +31,7 @@ const AutomatedActionResponseRequestSchema = {
     expiration: schema.string(),
     actionId: schema.string(),
     agent: schema.object({
-      id: schema.oneOf([schema.string(), schema.arrayOf(schema.string())]),
+      id: schema.oneOf([schema.string(), schema.arrayOf(schema.string(), { maxSize: 50 })]),
     }),
   }),
 };

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/resolver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/resolver.ts
@@ -45,8 +45,9 @@ export const validateTree = {
     // We use collapsing in our Elasticsearch queries for the tree api
     nodes: schema.arrayOf(schema.oneOf([schema.string({ minLength: 1 }), schema.number()]), {
       minSize: 1,
+      maxSize: 65536,
     }),
-    indexPatterns: schema.arrayOf(schema.string(), { minSize: 1 }),
+    indexPatterns: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
     includeHits: schema.boolean({ defaultValue: false }),
   }),
 };
@@ -67,7 +68,7 @@ export const validateEvents = {
         to: schema.string(),
       })
     ),
-    indexPatterns: schema.arrayOf(schema.string()),
+    indexPatterns: schema.arrayOf(schema.string(), { maxSize: 100 }),
     filter: schema.maybe(schema.string()),
     entityType: schema.maybe(schema.string()),
     eventID: schema.maybe(schema.string()),
@@ -87,6 +88,6 @@ export const validateEntities = {
     /**
      * Indices to search in.
      */
-    indices: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+    indices: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 100 }), schema.string()]),
   }),
 };

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_apps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_apps.test.ts
@@ -158,6 +158,18 @@ describe('When invoking Trusted Apps Schema', () => {
       expect(() => body.validate(createNewTrustedApp({ entries: [] }))).toThrow();
     });
 
+    it('should not accept more than 250 entries', () => {
+      expect(() =>
+        body.validate(
+          createNewTrustedApp({
+            entries: Array(251).fill(
+              createConditionEntry({ field: ConditionEntryField.PATH, value: '/tmp/path' })
+            ),
+          })
+        )
+      ).toThrow();
+    });
+
     describe('when `entries` are defined', () => {
       // Some static hashes for use in validation. Some chr. are in UPPERcase on purpose
       const VALID_HASH_MD5 = '741462ab431a22233C787BAAB9B653C7';
@@ -379,6 +391,51 @@ describe('When invoking Trusted Apps Schema', () => {
           );
         }).toThrow();
       });
+    });
+  });
+
+  describe('effectScope validation', () => {
+    const body = PostTrustedAppCreateRequestSchema.body;
+    const createConditionEntry = <T>(data?: T): TrustedAppConditionEntry => ({
+      field: ConditionEntryField.PATH,
+      type: 'match',
+      operator: 'included',
+      value: 'c:/programs files/Anti-Virus',
+      ...(data || {}),
+    });
+    const createNewTrustedApp = <T>(data?: T): NewTrustedApp =>
+      ({
+        name: 'Some Anti-Virus App',
+        os: OperatingSystem.WINDOWS,
+        effectScope: { type: 'global' },
+        entries: [createConditionEntry()],
+        ...(data || {}),
+      } as NewTrustedApp);
+
+    it('should accept a policy effectScope with up to 1000 policies', () => {
+      expect(() =>
+        body.validate(
+          createNewTrustedApp({
+            effectScope: {
+              type: 'policy',
+              policies: Array(1000).fill('policy-id'),
+            },
+          })
+        )
+      ).not.toThrow();
+    });
+
+    it('should not accept a policy effectScope with more than 1000 policies', () => {
+      expect(() =>
+        body.validate(
+          createNewTrustedApp({
+            effectScope: {
+              type: 'policy',
+              policies: Array(1001).fill('policy-id'),
+            },
+          })
+        )
+      ).toThrow();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_apps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_apps.ts
@@ -93,6 +93,7 @@ const MacEntrySchema = schema.object({
 
 const entriesSchemaOptions = {
   minSize: 1,
+  maxSize: 250,
   validate(entries: TrustedAppConditionEntry[]) {
     return (
       getDuplicateFields(entries)
@@ -137,7 +138,7 @@ const getTrustedAppForOsScheme = () =>
       }),
       schema.object({
         type: schema.literal('policy'),
-        policies: schema.arrayOf(schema.string({ minLength: 1 })),
+        policies: schema.arrayOf(schema.string({ minLength: 1 }), { maxSize: 1000 }),
       }),
     ]),
     entries: EntriesSchema,

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_devices.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_devices.test.ts
@@ -162,6 +162,18 @@ describe('When invoking Trusted Devices Schema', () => {
       expect(() => body.validate(createNewTrustedDevice({ entries: [] }))).toThrow();
     });
 
+    it('should not accept more than 250 entries', () => {
+      expect(() =>
+        body.validate(
+          createNewTrustedDevice({
+            entries: Array(251).fill(
+              createConditionEntry({ field: TrustedDeviceConditionEntryField.DEVICE_ID })
+            ),
+          })
+        )
+      ).toThrow();
+    });
+
     describe('when `entries` are defined', () => {
       it('should validate `entry.field` is required', () => {
         const { field, ...entry } = createConditionEntry();
@@ -290,6 +302,26 @@ describe('When invoking Trusted Devices Schema', () => {
       it('should reject policy effect scope without policies array', () => {
         const bodyMsg = createNewTrustedDevice({
           effectScope: { type: 'policy' },
+        });
+        expect(() => body.validate(bodyMsg)).toThrow();
+      });
+
+      it('should accept a policy effectScope with up to 1000 policies', () => {
+        const bodyMsg = createNewTrustedDevice({
+          effectScope: {
+            type: 'policy',
+            policies: Array(1000).fill('policy-id'),
+          },
+        });
+        expect(() => body.validate(bodyMsg)).not.toThrow();
+      });
+
+      it('should not accept a policy effectScope with more than 1000 policies', () => {
+        const bodyMsg = createNewTrustedDevice({
+          effectScope: {
+            type: 'policy',
+            policies: Array(1001).fill('policy-id'),
+          },
         });
         expect(() => body.validate(bodyMsg)).toThrow();
       });

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_devices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/trusted_devices.ts
@@ -64,6 +64,7 @@ const getTrustedDeviceDuplicateFields = (entries: TrustedDeviceConditionEntry[])
 
 const entriesSchemaOptions = {
   minSize: 1,
+  maxSize: 250,
   validate(entries: TrustedDeviceConditionEntry[]) {
     return (
       getTrustedDeviceDuplicateFields(entries)
@@ -90,7 +91,7 @@ const getTrustedDeviceForOsScheme = () =>
       }),
       schema.object({
         type: schema.literal('policy'),
-        policies: schema.arrayOf(schema.string({ minLength: 1 })),
+        policies: schema.arrayOf(schema.string({ minLength: 1 }), { maxSize: 1000 }),
       }),
     ]),
     entries: EntriesSchema,

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -348,23 +348,27 @@ paths:
                   description: >-
                     If this action is associated with any alerts, they can be
                     specified here. The action will be logged in any cases
-                    associated with the specified alerts.
+                    associated with the specified alerts. Max of 50.
                   example:
                     - alert-id-1
                     - alert-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 case_ids:
-                  description: The IDs of cases where the action taken will be logged.
+                  description: >-
+                    The IDs of cases where the action taken will be logged. Max
+                    of 50.
                   example:
                     - case-id-1
                     - case-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 comment:
@@ -624,23 +628,27 @@ paths:
                   description: >-
                     If this action is associated with any alerts, they can be
                     specified here. The action will be logged in any cases
-                    associated with the specified alerts.
+                    associated with the specified alerts. Max of 50.
                   example:
                     - alert-id-1
                     - alert-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 case_ids:
-                  description: The IDs of cases where the action taken will be logged.
+                  description: >-
+                    The IDs of cases where the action taken will be logged. Max
+                    of 50.
                   example:
                     - case-id-1
                     - case-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 comment:
@@ -884,7 +892,7 @@ components:
       description: Agent ID
       type: string
     AgentIds:
-      description: A list of agent IDs. Max of 50.
+      description: A list of agent IDs. Max of 250.
       example:
         - agent-id-1
         - agent-id-2
@@ -893,7 +901,7 @@ components:
         - items:
             minLength: 1
             type: string
-          maxItems: 50
+          maxItems: 250
           minItems: 1
           type: array
         - minLength: 1
@@ -938,23 +946,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1020,6 +1032,7 @@ components:
         - unisolate
       items:
         $ref: '#/components/schemas/Command'
+      maxItems: 50
       type: array
     Comment:
       description: Optional comment
@@ -1042,13 +1055,14 @@ components:
       example: '2023-10-31T23:59:59.999Z'
       type: string
     EndpointIds:
-      description: List of endpoint IDs (cannot contain empty strings)
+      description: List of endpoint IDs (cannot contain empty strings). Max of 250.
       example:
         - endpoint-id-1
         - endpoint-id-2
       items:
         minLength: 1
         type: string
+      maxItems: 250
       minItems: 1
       type: array
     EndpointMetadataResponse:
@@ -1191,23 +1205,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1377,23 +1395,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1459,23 +1481,25 @@ components:
           description: >-
             If this action is associated with any alerts, they can be specified
             here. The action will be logged in any cases associated with the
-            specified alerts.
+            specified alerts. Max of 50.
           example:
             - alert-id-1
             - alert-id-2
           items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         case_ids:
-          description: The IDs of cases where the action taken will be logged.
+          description: The IDs of cases where the action taken will be logged. Max of 50.
           example:
             - case-id-1
             - case-id-2
           items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         comment:
@@ -1540,6 +1564,7 @@ components:
           - inactive
           - unenrolled
         type: string
+      maxItems: 20
       type: array
     Isolate:
       allOf:
@@ -1639,23 +1664,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1835,23 +1864,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2384,23 +2417,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2454,23 +2491,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2632,23 +2673,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2802,23 +2847,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2882,7 +2931,7 @@ components:
       type: object
       properties: {}
     UserIds:
-      description: A list of user IDs.
+      description: A list of user IDs. Max of 50.
       example:
         - user-id-1
         - user-id-2
@@ -2890,6 +2939,7 @@ components:
         - items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         - minLength: 1
@@ -2897,7 +2947,7 @@ components:
     WithOutputs:
       description: >-
         A list of action IDs that should include the complete output of the
-        action.
+        action. Max of 50.
       example:
         - action-id-1
         - action-id-2
@@ -2905,6 +2955,7 @@ components:
         - items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         - minLength: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -348,23 +348,27 @@ paths:
                   description: >-
                     If this action is associated with any alerts, they can be
                     specified here. The action will be logged in any cases
-                    associated with the specified alerts.
+                    associated with the specified alerts. Max of 50.
                   example:
                     - alert-id-1
                     - alert-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 case_ids:
-                  description: The IDs of cases where the action taken will be logged.
+                  description: >-
+                    The IDs of cases where the action taken will be logged. Max
+                    of 50.
                   example:
                     - case-id-1
                     - case-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 comment:
@@ -624,23 +628,27 @@ paths:
                   description: >-
                     If this action is associated with any alerts, they can be
                     specified here. The action will be logged in any cases
-                    associated with the specified alerts.
+                    associated with the specified alerts. Max of 50.
                   example:
                     - alert-id-1
                     - alert-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 case_ids:
-                  description: The IDs of cases where the action taken will be logged.
+                  description: >-
+                    The IDs of cases where the action taken will be logged. Max
+                    of 50.
                   example:
                     - case-id-1
                     - case-id-2
                   items:
                     minLength: 1
                     type: string
+                  maxItems: 50
                   minItems: 1
                   type: array
                 comment:
@@ -884,7 +892,7 @@ components:
       description: Agent ID
       type: string
     AgentIds:
-      description: A list of agent IDs. Max of 50.
+      description: A list of agent IDs. Max of 250.
       example:
         - agent-id-1
         - agent-id-2
@@ -893,7 +901,7 @@ components:
         - items:
             minLength: 1
             type: string
-          maxItems: 50
+          maxItems: 250
           minItems: 1
           type: array
         - minLength: 1
@@ -938,23 +946,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1020,6 +1032,7 @@ components:
         - unisolate
       items:
         $ref: '#/components/schemas/Command'
+      maxItems: 50
       type: array
     Comment:
       description: Optional comment
@@ -1042,13 +1055,14 @@ components:
       example: '2023-10-31T23:59:59.999Z'
       type: string
     EndpointIds:
-      description: List of endpoint IDs (cannot contain empty strings)
+      description: List of endpoint IDs (cannot contain empty strings). Max of 250.
       example:
         - endpoint-id-1
         - endpoint-id-2
       items:
         minLength: 1
         type: string
+      maxItems: 250
       minItems: 1
       type: array
     EndpointMetadataResponse:
@@ -1191,23 +1205,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1377,23 +1395,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1459,23 +1481,25 @@ components:
           description: >-
             If this action is associated with any alerts, they can be specified
             here. The action will be logged in any cases associated with the
-            specified alerts.
+            specified alerts. Max of 50.
           example:
             - alert-id-1
             - alert-id-2
           items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         case_ids:
-          description: The IDs of cases where the action taken will be logged.
+          description: The IDs of cases where the action taken will be logged. Max of 50.
           example:
             - case-id-1
             - case-id-2
           items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         comment:
@@ -1540,6 +1564,7 @@ components:
           - inactive
           - unenrolled
         type: string
+      maxItems: 20
       type: array
     Isolate:
       allOf:
@@ -1639,23 +1664,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -1835,23 +1864,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2384,23 +2417,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2454,23 +2491,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2632,23 +2673,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2802,23 +2847,27 @@ components:
               description: >-
                 If this action is associated with any alerts, they can be
                 specified here. The action will be logged in any cases
-                associated with the specified alerts.
+                associated with the specified alerts. Max of 50.
               example:
                 - alert-id-1
                 - alert-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             case_ids:
-              description: The IDs of cases where the action taken will be logged.
+              description: >-
+                The IDs of cases where the action taken will be logged. Max of
+                50.
               example:
                 - case-id-1
                 - case-id-2
               items:
                 minLength: 1
                 type: string
+              maxItems: 50
               minItems: 1
               type: array
             comment:
@@ -2882,7 +2931,7 @@ components:
       type: object
       properties: {}
     UserIds:
-      description: A list of user IDs.
+      description: A list of user IDs. Max of 50.
       example:
         - user-id-1
         - user-id-2
@@ -2890,6 +2939,7 @@ components:
         - items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         - minLength: 1
@@ -2897,7 +2947,7 @@ components:
     WithOutputs:
       description: >-
         A list of action IDs that should include the complete output of the
-        action.
+        action. Max of 50.
       example:
         - action-id-1
         - action-id-2
@@ -2905,6 +2955,7 @@ components:
         - items:
             minLength: 1
             type: string
+          maxItems: 50
           minItems: 1
           type: array
         - minLength: 1

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/scripts_library/saved_objects/mappings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/scripts_library/saved_objects/mappings.ts
@@ -14,7 +14,7 @@ import { SCRIPTS_LIBRARY_SAVED_OBJECT_TYPE } from '../constants';
 const ScriptsLibraryAttributesSchemaV1 = schema.object({
   id: schema.string(),
   name: schema.string(),
-  platform: schema.arrayOf(schema.string()),
+  platform: schema.arrayOf(schema.string(), { maxSize: 10 }),
   file_id: schema.string(),
   file_name: schema.string(),
   file_size: schema.number(),
@@ -25,7 +25,7 @@ const ScriptsLibraryAttributesSchemaV1 = schema.object({
   instructions: schema.maybe(schema.string()),
   example: schema.maybe(schema.string()),
   path_to_executable: schema.maybe(schema.string()),
-  tags: schema.maybe(schema.arrayOf(schema.string())),
+  tags: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 50 })),
   created_by: schema.string(),
   created_at: schema.string(),
   updated_by: schema.string(),

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/metadata/index.ts
@@ -38,7 +38,8 @@ export const endpointFilters = schema.object({
         schema.literal(HostStatus.UPDATING.toString()),
         schema.literal(HostStatus.UNHEALTHY.toString()),
         schema.literal(HostStatus.INACTIVE.toString()),
-      ])
+      ]),
+      { maxSize: 20 }
     )
   ),
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
@@ -67,7 +67,7 @@ const CommonEntrySchema = {
         validate: (hash: string) =>
           isValidHash(hash) ? undefined : `invalid hash value [${hash}]`,
       }),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 2000 }
     ),
     schema.conditional(
       schema.siblingRef('field'),
@@ -77,14 +77,14 @@ const CommonEntrySchema = {
           validate: (pathValue: string) =>
             pathValue.length > 0 ? undefined : `invalid path value [${pathValue}]`,
         }),
-        { minSize: 1 }
+        { minSize: 1, maxSize: 2000 }
       ),
       schema.arrayOf(
         schema.string({
           validate: (signerValue: string) =>
             signerValue.length > 0 ? undefined : `invalid signer value [${signerValue}]`,
         }),
-        { minSize: 1 }
+        { minSize: 1, maxSize: 2000 }
       )
     )
   ),
@@ -102,12 +102,12 @@ const WindowsSignerEntrySchema = schema.object({
         schema.siblingRef('type'),
         schema.literal('match'),
         schema.string({ minLength: 1 }),
-        schema.arrayOf(schema.string({ minLength: 1 }))
+        schema.arrayOf(schema.string({ minLength: 1 }), { maxSize: 2000 })
       ),
       type: schema.oneOf([schema.literal('match'), schema.literal('match_any')]),
       operator: schema.literal('included'),
     }),
-    { minSize: 1 }
+    { minSize: 1, maxSize: 250 }
   ),
 });
 
@@ -156,6 +156,7 @@ const hashEntriesValidation = (entries: BlocklistConditionEntry[]) => {
 // Validate there is only one entry when signer or path and the allowed entries for hashes
 const entriesSchemaOptions = {
   minSize: 1,
+  maxSize: 250,
   validate(entries: BlocklistConditionEntry[]) {
     if (allowedHashes.includes(entries[0].field)) {
       return hashEntriesValidation(entries);

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
@@ -29,7 +29,7 @@ const EventFilterDataSchema = schema.object(
         },
         { unknowns: 'ignore' }
       ),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 250 }
     ),
   },
   {

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_app_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_app_validator.ts
@@ -145,6 +145,7 @@ const LinuxEntrySchema = schema.object({
 
 const entriesSchemaOptions = {
   minSize: 1,
+  maxSize: 250,
   validate(entries: TrustedAppConditionEntry[]) {
     const dups = getDuplicateFields(entries as ConditionEntry[]);
     return dups.map((field) => `Duplicated entry: ${field}`).join(', ') || undefined;
@@ -200,7 +201,7 @@ const TrustedAppAdvancedModeDataSchema = schema.object(
         },
         { unknowns: 'ignore' }
       ),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 250 }
     ),
   },
   {

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_device_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_device_validator.ts
@@ -58,13 +58,14 @@ const TrustedDeviceEntrySchema = schema.object({
         validate: (value: string) =>
           value.trim().length > 0 ? undefined : TRUSTED_DEVICE_EMPTY_VALUE_ERROR,
       }),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 2000 }
     ),
   ]),
 });
 
 const TrustedDeviceEntriesSchema = schema.arrayOf(TrustedDeviceEntrySchema, {
   minSize: 1,
+  maxSize: 250,
   validate(
     entries: Array<{ field: string; type: string; operator: string; value: string | string[] }>
   ) {


### PR DESCRIPTION
## Summary

Adds `maxSize` to a number of array schemas to enforce an upper bound.

Some of these affect public APIs which can be breaking. I made my best guesses as to a generous upper limit but is worth keeping in mind as you're reviewing.

LLM generated summary of public API changes:
| API | Method | Param | Limit |
|-----|--------|-------|-------|
| `/api/endpoint/action/{action}` | POST | `endpoint_ids` | 250 |
| `/api/endpoint/action/{action}` | POST | `alert_ids` | 50 |
| `/api/endpoint/action/{action}` | POST | `case_ids` | 50 |
| `/api/endpoint/action` | GET | `agentIds` | 250 |
| `/api/endpoint/action` | GET | `commands` | 50 |
| `/api/endpoint/action` | GET | `userIds` | 50 |
| `/api/endpoint/action` | GET | `withOutputs` | 50 |
| `/api/endpoint/metadata` | GET | `hostStatuses` | 20 |
| `/api/endpoint/resolver/tree` | POST | `nodes` | 65536 |
| `/api/endpoint/resolver/tree` | POST | `indexPatterns` | 100 |
| `/api/endpoint/resolver/events` | POST | `indexPatterns` | 100 |
| `/api/endpoint/resolver/entity` | GET | `indices` | 100 |
| `/api/exception_lists/items` (trusted apps) | POST/PUT | `entries` | 250 |
| `/api/exception_lists/items` (trusted apps) | POST/PUT | `effectScope.policies` | 1000 |
| `/api/exception_lists/items` (trusted devices) | POST/PUT | `entries` | 250 |
| `/api/exception_lists/items` (trusted devices) | POST/PUT | `effectScope.policies` | 1000 |
| `/api/exception_lists/items` (blocklists) | POST/PUT | `entries` | 250 |
| `/api/exception_lists/items` (blocklists) | POST/PUT | `value` (per entry) | 2000 |
| `/api/exception_lists/items` (event filters) | POST/PUT | `entries` | 250 |
| `/api/exception_lists/items` (trusted devices) | POST/PUT | `value` (per entry) | 2000 |
| `/api/exception_lists/items` (trusted devices) | POST/PUT | `entries` (top-level) | 250 |

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The release_note:breaking label should be applied in these situations.