### PR TITLE
[ES|QL] Downsampling based on the panel width both in server and client side

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/constants.ts
@@ -8,3 +8,5 @@
  */
 
 export const ENABLE_ESQL = 'enableESQL';
+
+export const DEFAULT_ESQL_LIMIT = 1000;

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -71,4 +71,4 @@ export {
   type ESQLStatsQueryMeta,
 } from './src';
 
-export { ENABLE_ESQL } from './constants';
+export { ENABLE_ESQL, DEFAULT_ESQL_LIMIT } from './constants';

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -67,6 +67,7 @@ export {
   isComputedColumn,
   getQuerySummary,
   getEsqlControls,
+  applyDownsampling,
   type ESQLStatsQueryMeta,
 } from './src';
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from './utils/query_parsing_helpers';
 export { getIndexPatternFromESQLQuery } from './utils/get_index_pattern_from_query';
 export { queryCannotBeSampled } from './utils/query_cannot_be_sampled';
+export { applyDownsampling } from './utils/apply_downsampling';
 export { appendToESQLQuery } from './utils/append_to_query/utils';
 export { appendStatsByToQuery } from './utils/append_to_query/append_stats_by';
 export { appendWhereClauseToESQLQuery } from './utils/append_to_query/append_where';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.test.ts
@@ -26,7 +26,7 @@ describe('applyDownsampling', () => {
     it('should not treat KEEP as an aggregation (KEEP is field selection, not STATS)', () => {
       const query = 'FROM logs* | KEEP host, @timestamp';
       const result = applyDownsampling(query, 500);
-      expect(result).toBe('FROM logs* | KEEP host, @timestamp\n| SAMPLE 0.5');
+      expect(result).toBe('FROM logs*\n| SAMPLE 0.5 | KEEP host, @timestamp');
     });
   });
 
@@ -40,7 +40,7 @@ describe('applyDownsampling', () => {
     it('should compute rate from explicit LIMIT in query', () => {
       const query = 'FROM logs* | LIMIT 10000';
       const result = applyDownsampling(query, 1000);
-      expect(result).toBe('FROM logs* | LIMIT 10000\n| SAMPLE 0.1');
+      expect(result).toBe('FROM logs*\n| SAMPLE 0.1 | LIMIT 10000');
     });
 
     it('should not append SAMPLE when rate >= 1 (maxDataPoints >= limit)', () => {
@@ -52,13 +52,13 @@ describe('applyDownsampling', () => {
     it('should clamp rate to minimum of 0.001', () => {
       const query = 'FROM logs* | LIMIT 10000000';
       const result = applyDownsampling(query, 1);
-      expect(result).toBe('FROM logs* | LIMIT 10000000\n| SAMPLE 0.001');
+      expect(result).toBe('FROM logs*\n| SAMPLE 0.001 | LIMIT 10000000');
     });
 
-    it('should handle queries with WHERE clauses', () => {
+    it('should insert SAMPLE right after the source command, before WHERE', () => {
       const query = 'FROM logs* | WHERE host == "server1"';
       const result = applyDownsampling(query, 100);
-      expect(result).toBe('FROM logs* | WHERE host == "server1"\n| SAMPLE 0.1');
+      expect(result).toBe('FROM logs*\n| SAMPLE 0.1 | WHERE host == "server1"');
     });
   });
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.test.ts
@@ -68,15 +68,6 @@ describe('applyDownsampling', () => {
       expect(applyDownsampling(query, 0)).toBe(query);
     });
 
-    it('should return query unchanged when maxDataPoints is negative', () => {
-      const query = 'FROM logs*';
-      expect(applyDownsampling(query, -100)).toBe(query);
-    });
-
-    it('should return query unchanged when query is empty', () => {
-      expect(applyDownsampling('', 500)).toBe('');
-    });
-
     it('should not add SAMPLE when query already has SAMPLE', () => {
       const query = 'FROM logs* | SAMPLE 0.5';
       expect(applyDownsampling(query, 100)).toBe(query);
@@ -85,16 +76,6 @@ describe('applyDownsampling', () => {
     it('should not add SET approximation when query already has SET approximation', () => {
       const query = 'SET approximation = true;\nFROM logs* | STATS count()';
       expect(applyDownsampling(query, 500)).toBe(query);
-    });
-
-    it('should not add SAMPLE when query contains match()', () => {
-      const query = 'FROM logs* | WHERE match(message, "error")';
-      expect(applyDownsampling(query, 100)).toBe(query);
-    });
-
-    it('should not add SAMPLE when query contains qstr()', () => {
-      const query = 'FROM logs* | WHERE qstr("message:error")';
-      expect(applyDownsampling(query, 100)).toBe(query);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { applyDownsampling } from './apply_downsampling';
+
+describe('applyDownsampling', () => {
+  describe('queries with STATS (aggregations)', () => {
+    it('should prepend SET approximation = true for queries with STATS', () => {
+      const query = 'FROM logs* | STATS count() BY host';
+      const result = applyDownsampling(query, 500);
+      expect(result).toBe(`SET approximation = true;\n${query}`);
+    });
+
+    it('should prepend SET approximation = true for queries with STATS and no BY clause', () => {
+      const query = 'FROM logs* | STATS count()';
+      const result = applyDownsampling(query, 500);
+      expect(result).toBe(`SET approximation = true;\n${query}`);
+    });
+
+    it('should not treat KEEP as an aggregation (KEEP is field selection, not STATS)', () => {
+      const query = 'FROM logs* | KEEP host, @timestamp';
+      const result = applyDownsampling(query, 500);
+      expect(result).toBe('FROM logs* | KEEP host, @timestamp\n| SAMPLE 0.5');
+    });
+  });
+
+  describe('queries without STATS (raw documents)', () => {
+    it('should append SAMPLE when maxDataPoints < currentLimit', () => {
+      const query = 'FROM logs*';
+      const result = applyDownsampling(query, 500);
+      expect(result).toBe('FROM logs*\n| SAMPLE 0.5');
+    });
+
+    it('should compute rate from explicit LIMIT in query', () => {
+      const query = 'FROM logs* | LIMIT 10000';
+      const result = applyDownsampling(query, 1000);
+      expect(result).toBe('FROM logs* | LIMIT 10000\n| SAMPLE 0.1');
+    });
+
+    it('should not append SAMPLE when rate >= 1 (maxDataPoints >= limit)', () => {
+      const query = 'FROM logs*';
+      const result = applyDownsampling(query, 2000);
+      expect(result).toBe('FROM logs*');
+    });
+
+    it('should clamp rate to minimum of 0.001', () => {
+      const query = 'FROM logs* | LIMIT 10000000';
+      const result = applyDownsampling(query, 1);
+      expect(result).toBe('FROM logs* | LIMIT 10000000\n| SAMPLE 0.001');
+    });
+
+    it('should handle queries with WHERE clauses', () => {
+      const query = 'FROM logs* | WHERE host == "server1"';
+      const result = applyDownsampling(query, 100);
+      expect(result).toBe('FROM logs* | WHERE host == "server1"\n| SAMPLE 0.1');
+    });
+  });
+
+  describe('skip cases', () => {
+    it('should return query unchanged when maxDataPoints is 0', () => {
+      const query = 'FROM logs*';
+      expect(applyDownsampling(query, 0)).toBe(query);
+    });
+
+    it('should return query unchanged when maxDataPoints is negative', () => {
+      const query = 'FROM logs*';
+      expect(applyDownsampling(query, -100)).toBe(query);
+    });
+
+    it('should return query unchanged when query is empty', () => {
+      expect(applyDownsampling('', 500)).toBe('');
+    });
+
+    it('should not add SAMPLE when query already has SAMPLE', () => {
+      const query = 'FROM logs* | SAMPLE 0.5';
+      expect(applyDownsampling(query, 100)).toBe(query);
+    });
+
+    it('should not add SET approximation when query already has SET approximation', () => {
+      const query = 'SET approximation = true;\nFROM logs* | STATS count()';
+      expect(applyDownsampling(query, 500)).toBe(query);
+    });
+
+    it('should not add SAMPLE when query contains match()', () => {
+      const query = 'FROM logs* | WHERE match(message, "error")';
+      expect(applyDownsampling(query, 100)).toBe(query);
+    });
+
+    it('should not add SAMPLE when query contains qstr()', () => {
+      const query = 'FROM logs* | WHERE qstr("message:error")';
+      expect(applyDownsampling(query, 100)).toBe(query);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
@@ -7,13 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Parser, Walker, walk, isAssignment } from '@elastic/esql';
+import { Parser, walk, isAssignment } from '@elastic/esql';
 import type { ESQLFunction } from '@elastic/esql/types';
 
 const MIN_SAMPLE_RATE = 0.001;
 const MAX_SAMPLE_RATE = 1.0;
 const DEFAULT_ESQL_LIMIT = 1000;
-const UNSAMPLABLE_FUNCTIONS = ['match', 'qstr'];
 
 /**
  * Applies automatic downsampling to an ES|QL query based on the available
@@ -25,7 +24,6 @@ const UNSAMPLABLE_FUNCTIONS = ['match', 'qstr'];
  *
  * Skips modification when:
  * - The query already contains SET approximation or a SAMPLE command
- * - The query contains functions incompatible with sampling (match, qstr)
  * - maxDataPoints is not a positive number
  * - The computed sample rate is >= 1 (no downsampling needed)
  */
@@ -59,16 +57,6 @@ export const applyDownsampling = (query: string, maxDataPoints: number): string 
 
   if (root.commands.some(({ name }) => name === 'stats')) {
     return `SET approximation = true;\n${query}`;
-  }
-
-  const hasUnsamplableFunction = UNSAMPLABLE_FUNCTIONS.some(
-    (f) =>
-      Walker.hasFunction(root, f) ||
-      root.commands.some((c) => c.text.toLowerCase().includes(`${f}(`))
-  );
-
-  if (hasUnsamplableFunction) {
-    return query;
   }
 
   const limitCommands = root.commands.filter(({ name }) => name === 'limit');

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
@@ -9,10 +9,10 @@
 
 import { Parser, walk, isAssignment } from '@elastic/esql';
 import type { ESQLFunction } from '@elastic/esql/types';
+import { DEFAULT_ESQL_LIMIT } from '../../constants';
 
 const MIN_SAMPLE_RATE = 0.001;
 const MAX_SAMPLE_RATE = 1.0;
-const DEFAULT_ESQL_LIMIT = 1000;
 
 /**
  * Applies automatic downsampling to an ES|QL query based on the available

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
@@ -19,8 +19,9 @@ const MAX_SAMPLE_RATE = 1.0;
  * UI data points (typically derived from chart pixel width).
  *
  * - Queries with STATS: prepends `SET approximation = true;`
- * - Queries without STATS: appends `| SAMPLE <rate>` where rate is
- *   derived from `maxDataPoints / currentLimit`
+ * - Queries without STATS: inserts `| SAMPLE <rate>` right after the
+ *   source command (FROM/TS) so that sampling is pushed down to the
+ *   storage layer for maximum performance
  *
  * Skips modification when:
  * - The query already contains SET approximation or a SAMPLE command
@@ -79,6 +80,12 @@ export const applyDownsampling = (query: string, maxDataPoints: number): string 
 
   if (rate >= MAX_SAMPLE_RATE) {
     return query;
+  }
+
+  const sourceCommand = root.commands.find(({ name }) => ['from', 'ts'].includes(name));
+  if (sourceCommand) {
+    const insertPos = sourceCommand.location.max + 1;
+    return `${query.slice(0, insertPos)}\n| SAMPLE ${rate}${query.slice(insertPos)}`;
   }
 
   return `${query}\n| SAMPLE ${rate}`;

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Parser, isAssignment } from '@elastic/esql';
+import type { ESQLFunction } from '@elastic/esql/types';
+import { getLimitFromESQLQuery } from './query_parsing_helpers';
+import { queryCannotBeSampled } from './query_cannot_be_sampled';
+
+const MIN_SAMPLE_RATE = 0.001;
+const MAX_SAMPLE_RATE = 1.0;
+
+const hasExistingApproximationSetting = (query: string): boolean => {
+  const { root } = Parser.parse(query);
+  if (!root.header?.length) {
+    return false;
+  }
+  return root.header.some((cmd) => {
+    if (cmd.name !== 'set' || !cmd.args?.length) {
+      return false;
+    }
+    return cmd.args.some((arg) => {
+      if (!isAssignment(arg)) {
+        return false;
+      }
+      const fn = arg as ESQLFunction;
+      return fn.args[0] && 'name' in fn.args[0] && fn.args[0].name === 'approximation';
+    });
+  });
+};
+
+const hasExistingSampleCommand = (query: string): boolean => {
+  const { root } = Parser.parse(query);
+  return root.commands.some(({ name }) => name === 'sample');
+};
+
+const hasExistingStatsCommand = (query: string): boolean => {
+  const { root } = Parser.parse(query);
+  return root.commands.some(({ name }) => name === 'stats');
+};
+
+/**
+ * Applies automatic downsampling to an ES|QL query based on the available
+ * UI data points (typically derived from chart pixel width).
+ *
+ * - Queries with STATS: prepends `SET approximation = true;`
+ * - Queries without STATS: appends `| SAMPLE <rate>` where rate is
+ *   derived from `maxDataPoints / currentLimit`
+ *
+ * Skips modification when:
+ * - The query already contains SET approximation or a SAMPLE command
+ * - The query contains functions incompatible with sampling (match, qstr)
+ * - maxDataPoints is not a positive number
+ * - The computed sample rate is >= 1 (no downsampling needed)
+ */
+export const applyDownsampling = (query: string, maxDataPoints: number): string => {
+  if (!query || !maxDataPoints || maxDataPoints <= 0) {
+    return query;
+  }
+
+  if (hasExistingSampleCommand(query)) {
+    return query;
+  }
+
+  if (hasExistingApproximationSetting(query)) {
+    return query;
+  }
+
+  const hasStats = hasExistingStatsCommand(query);
+
+  if (hasStats) {
+    return `SET approximation = true;\n${query}`;
+  }
+
+  if (queryCannotBeSampled({ esql: query })) {
+    return query;
+  }
+
+  const currentLimit = getLimitFromESQLQuery(query);
+  const rate = Math.min(MAX_SAMPLE_RATE, Math.max(MIN_SAMPLE_RATE, maxDataPoints / currentLimit));
+
+  if (rate >= MAX_SAMPLE_RATE) {
+    return query;
+  }
+
+  return `${query}\n| SAMPLE ${rate}`;
+};

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/apply_downsampling.ts
@@ -7,42 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Parser, isAssignment } from '@elastic/esql';
+import { Parser, Walker, walk, isAssignment } from '@elastic/esql';
 import type { ESQLFunction } from '@elastic/esql/types';
-import { getLimitFromESQLQuery } from './query_parsing_helpers';
-import { queryCannotBeSampled } from './query_cannot_be_sampled';
 
 const MIN_SAMPLE_RATE = 0.001;
 const MAX_SAMPLE_RATE = 1.0;
-
-const hasExistingApproximationSetting = (query: string): boolean => {
-  const { root } = Parser.parse(query);
-  if (!root.header?.length) {
-    return false;
-  }
-  return root.header.some((cmd) => {
-    if (cmd.name !== 'set' || !cmd.args?.length) {
-      return false;
-    }
-    return cmd.args.some((arg) => {
-      if (!isAssignment(arg)) {
-        return false;
-      }
-      const fn = arg as ESQLFunction;
-      return fn.args[0] && 'name' in fn.args[0] && fn.args[0].name === 'approximation';
-    });
-  });
-};
-
-const hasExistingSampleCommand = (query: string): boolean => {
-  const { root } = Parser.parse(query);
-  return root.commands.some(({ name }) => name === 'sample');
-};
-
-const hasExistingStatsCommand = (query: string): boolean => {
-  const { root } = Parser.parse(query);
-  return root.commands.some(({ name }) => name === 'stats');
-};
+const DEFAULT_ESQL_LIMIT = 1000;
+const UNSAMPLABLE_FUNCTIONS = ['match', 'qstr'];
 
 /**
  * Applies automatic downsampling to an ES|QL query based on the available
@@ -63,25 +34,59 @@ export const applyDownsampling = (query: string, maxDataPoints: number): string 
     return query;
   }
 
-  if (hasExistingSampleCommand(query)) {
+  const { root } = Parser.parse(query);
+
+  if (root.commands.some(({ name }) => name === 'sample')) {
     return query;
   }
 
-  if (hasExistingApproximationSetting(query)) {
+  const hasApproximation = root.header?.some((cmd) => {
+    if (cmd.name !== 'set' || !cmd.args?.length) {
+      return false;
+    }
+    return cmd.args.some((arg) => {
+      if (!isAssignment(arg)) {
+        return false;
+      }
+      const fn = arg as ESQLFunction;
+      return fn.args[0] && 'name' in fn.args[0] && fn.args[0].name === 'approximation';
+    });
+  });
+
+  if (hasApproximation) {
     return query;
   }
 
-  const hasStats = hasExistingStatsCommand(query);
-
-  if (hasStats) {
+  if (root.commands.some(({ name }) => name === 'stats')) {
     return `SET approximation = true;\n${query}`;
   }
 
-  if (queryCannotBeSampled({ esql: query })) {
+  const hasUnsamplableFunction = UNSAMPLABLE_FUNCTIONS.some(
+    (f) =>
+      Walker.hasFunction(root, f) ||
+      root.commands.some((c) => c.text.toLowerCase().includes(`${f}(`))
+  );
+
+  if (hasUnsamplableFunction) {
     return query;
   }
 
-  const currentLimit = getLimitFromESQLQuery(query);
+  const limitCommands = root.commands.filter(({ name }) => name === 'limit');
+  let currentLimit = DEFAULT_ESQL_LIMIT;
+  if (limitCommands.length) {
+    const limits: number[] = [];
+    walk(root.commands, {
+      visitLiteral: (node) => {
+        if (!isNaN(Number(node.value))) {
+          limits.push(Number(node.value));
+        }
+      },
+    });
+    if (limits.length) {
+      currentLimit = Math.min(...limits);
+    }
+  }
+
   const rate = Math.min(MAX_SAMPLE_RATE, Math.max(MIN_SAMPLE_RATE, maxDataPoints / currentLimit));
 
   if (rate >= MAX_SAMPLE_RATE) {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -30,8 +30,7 @@ import type {
 import { type ESQLControlVariable, ESQLVariableType } from '@kbn/esql-types';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { monaco } from '@kbn/monaco';
-
-const DEFAULT_ESQL_LIMIT = 1000;
+import { DEFAULT_ESQL_LIMIT } from '../../constants';
 
 export function getRemoteClustersFromESQLQuery(esql?: string): string[] | undefined {
   if (!esql) return undefined;

--- a/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
@@ -404,6 +404,8 @@ export type LensInternalApi = Simplify<
       getDisplayOptions: () => VisualizationDisplayOptions;
       updateEditingState: (inProgress: boolean) => void;
       isEditingInProgress: () => boolean;
+      containerWidth$: PublishingSubject<number>;
+      updateContainerWidth: (width: number) => void;
     }
 >;
 

--- a/src/platform/packages/shared/kbn-lens-common/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/types.ts
@@ -779,7 +779,8 @@ export interface Datasource<T = unknown, P = unknown, Q = Query | AggregateQuery
     nowInstant: Date,
     searchSessionId?: string,
     forceDSL?: boolean,
-    projectRouting?: ProjectRouting
+    projectRouting?: ProjectRouting,
+    maxDataPoints?: number
   ) => ExpressionAstExpression | string | null;
 
   getDatasourceSuggestionsForField: (

--- a/src/platform/packages/shared/kbn-lens-common/visualizations/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/visualizations/types.ts
@@ -463,7 +463,7 @@ export interface Visualization<T = unknown, P = T, ExtraAppendLayerArg = unknown
   toExpression: (
     state: T,
     datasourceLayers: DatasourceLayers,
-    attributes?: Partial<{ title: string; description: string }>,
+    attributes?: Partial<{ title: string; description: string; maxDataPoints: number }>,
     datasourceExpressionsByLayers?: Record<string, Ast>
   ) => ExpressionAstExpression | string | null;
   /**

--- a/src/platform/plugins/shared/data/common/query/text_based_query_state_to_ast.ts
+++ b/src/platform/plugins/shared/data/common/query/text_based_query_state_to_ast.ts
@@ -18,6 +18,7 @@ interface Args extends QueryState {
   inputQuery?: Query;
   titleForInspector?: string;
   descriptionForInspector?: string;
+  maxDataPoints?: number;
 }
 
 /**
@@ -38,6 +39,7 @@ export function textBasedQueryStateToExpressionAst({
   timeFieldName,
   titleForInspector,
   descriptionForInspector,
+  maxDataPoints,
 }: Args) {
   const kibana = buildExpressionFunction<ExpressionFunctionKibana>('kibana', {});
   let q;
@@ -57,6 +59,7 @@ export function textBasedQueryStateToExpressionAst({
       timeField: timeFieldName,
       titleForInspector,
       descriptionForInspector,
+      maxDataPoints,
     });
 
     if (esql) {

--- a/src/platform/plugins/shared/data/common/search/expressions/aggregate_query_to_ast.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/aggregate_query_to_ast.ts
@@ -18,11 +18,13 @@ export const aggregateQueryToAst = ({
   timeField,
   titleForInspector,
   descriptionForInspector,
+  maxDataPoints,
 }: {
   query: AggregateQuery;
   timeField?: string;
   titleForInspector?: string;
   descriptionForInspector?: string;
+  maxDataPoints?: number;
 }): undefined | ExpressionAstFunction => {
   return buildExpressionFunction<EsqlExpressionFunctionDefinition>('esql', {
     query: query.esql,
@@ -30,5 +32,6 @@ export const aggregateQueryToAst = ({
     locale: i18n.getLocale(),
     titleForInspector,
     descriptionForInspector,
+    maxDataPoints,
   }).toAst();
 };

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -28,6 +28,7 @@ import {
   mapVariableToColumn,
   isComputedColumn,
   getQuerySummary,
+  applyDownsampling,
 } from '@kbn/esql-utils';
 import { zipObject } from 'lodash';
 import type { Observable } from 'rxjs';
@@ -69,6 +70,7 @@ interface Arguments {
   titleForInspector?: string;
   descriptionForInspector?: string;
   ignoreGlobalFilters?: boolean;
+  maxDataPoints?: number;
 }
 
 export type EsqlExpressionFunctionDefinition = ExpressionFunctionDefinition<
@@ -148,6 +150,13 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
           defaultMessage: 'Whether to ignore or use global query and filters',
         }),
       },
+      maxDataPoints: {
+        types: ['number'],
+        help: i18n.translate('data.search.esql.maxDataPoints.help', {
+          defaultMessage:
+            'Maximum number of data points the UI can display. Used for automatic downsampling.',
+        }),
+      },
     },
     allowCache: {
       withSideEffects: (_, { inspectorAdapters }) => {
@@ -156,7 +165,15 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
     },
     fn(
       input,
-      { query, timeField, locale, titleForInspector, descriptionForInspector, ignoreGlobalFilters },
+      {
+        query,
+        timeField,
+        locale,
+        titleForInspector,
+        descriptionForInspector,
+        ignoreGlobalFilters,
+        maxDataPoints,
+      },
       { abortSignal, inspectorAdapters, getKibanaRequest, getSearchSessionId }
     ) {
       return defer(() =>
@@ -176,7 +193,10 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
           // this is for backward compatibility, if the query is of fields or functions type
           // and the query is not set with ?? in the query, we should set it
           // https://github.com/elastic/elasticsearch/pull/122459
-          const fixedQuery = fixESQLQueryWithVariables(query, input?.esqlVariables ?? []);
+          const variableFixedQuery = fixESQLQueryWithVariables(query, input?.esqlVariables ?? []);
+          const fixedQuery = maxDataPoints
+            ? applyDownsampling(variableFixedQuery, maxDataPoints)
+            : variableFixedQuery;
           const esQueryConfigs = getEsQueryConfig(
             uiSettings as Parameters<typeof getEsQueryConfig>[0]
           );

--- a/x-pack/platform/plugins/shared/lens/common/expressions/defs/downsample/index.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/defs/downsample/index.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+import type { DownsampleExpressionFunction } from './types';
+
+export interface DownsampleArgs {
+  targetPoints: number;
+}
+
+export type { DownsampleExpressionFunction };
+
+/**
+ * Client-side LTTB (Largest Triangle Three Buckets) downsampling.
+ *
+ * Reduces datatable rows to `targetPoints` while preserving the visual shape
+ * of time series data. Automatically detects the date column as x-axis and
+ * numeric columns as metrics, applying multi-metric LTTB so no significant
+ * point for any metric is lost.
+ *
+ * If the datatable has no date column or fewer rows than `targetPoints`,
+ * returns the input unchanged.
+ */
+export const downsample: DownsampleExpressionFunction = {
+  name: 'lens_downsample',
+  type: 'datatable',
+
+  inputTypes: ['datatable'],
+
+  help: i18n.translate('xpack.lens.functions.downsample.help', {
+    defaultMessage:
+      'Reduces datatable rows using LTTB downsampling while preserving the visual shape of time series.',
+  }),
+
+  args: {
+    targetPoints: {
+      help: i18n.translate('xpack.lens.functions.downsample.args.targetPointsHelpText', {
+        defaultMessage: 'Maximum number of data points to keep',
+      }),
+      types: ['number'],
+      required: true,
+    },
+  },
+
+  async fn(...args) {
+    const { downsampleFn } = await import('../../impl/async_fns');
+    return downsampleFn(...args);
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/common/expressions/defs/downsample/types.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/defs/downsample/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Datatable, ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
+import type { DownsampleArgs } from '.';
+
+export type DownsampleExpressionFunction = ExpressionFunctionDefinition<
+  'lens_downsample',
+  Datatable,
+  DownsampleArgs,
+  Datatable | Promise<Datatable>
+>;

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/async_fns.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/async_fns.ts
@@ -9,6 +9,7 @@
 export { collapseFn } from './collapse/collapse_fn';
 export { counterRateFn } from './counter_rate/counter_rate_fn';
 export { datatableFn } from './datatable/datatable_fn';
+export { downsampleFn } from './downsample/downsample_fn';
 export { formatColumnFn } from './format_column/format_column_fn';
 export { mapToOriginalColumns } from './map_to_columns/map_to_columns_fn';
 export { mapToOriginalColumnsTextBased } from './map_to_columns/map_to_columns_fn_textbased';

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/downsample_fn.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/downsample_fn.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import { downsampleFn } from './downsample_fn';
+import type { DownsampleExpressionFunction } from '../../defs/downsample/types';
+
+type FnType = DownsampleExpressionFunction['fn'];
+
+const createDatatable = (rowCount: number): Datatable => {
+  const rows = Array.from({ length: rowCount }, (_, i) => ({
+    timestamp: i * 1000,
+    value: Math.sin(i / 10) * 100,
+    count: i,
+  }));
+
+  return {
+    type: 'datatable',
+    columns: [
+      { id: 'timestamp', name: 'timestamp', meta: { type: 'date' } },
+      { id: 'value', name: 'value', meta: { type: 'number' } },
+      { id: 'count', name: 'count', meta: { type: 'number' } },
+    ],
+    rows,
+  };
+};
+
+describe('downsampleFn', () => {
+  const fn = downsampleFn as FnType;
+
+  it('should return input unchanged when targetPoints <= 0', () => {
+    const input = createDatatable(100);
+    const result = fn(input, { targetPoints: 0 }, {} as never);
+    expect(result).toBe(input);
+  });
+
+  it('should return input unchanged when rows <= targetPoints', () => {
+    const input = createDatatable(10);
+    const result = fn(input, { targetPoints: 20 }, {} as never);
+    expect(result).toBe(input);
+  });
+
+  it('should downsample to approximately targetPoints rows', () => {
+    const input = createDatatable(1000);
+    const result = fn(input, { targetPoints: 100 }, {} as never) as Datatable;
+    expect(result.rows.length).toBeLessThanOrEqual(200);
+    expect(result.rows.length).toBeGreaterThanOrEqual(100);
+  });
+
+  it('should preserve all columns', () => {
+    const input = createDatatable(100);
+    const result = fn(input, { targetPoints: 10 }, {} as never) as Datatable;
+    expect(result.columns).toEqual(input.columns);
+  });
+
+  it('should return input unchanged when there is no date column', () => {
+    const input: Datatable = {
+      type: 'datatable',
+      columns: [
+        { id: 'name', name: 'name', meta: { type: 'string' } },
+        { id: 'value', name: 'value', meta: { type: 'number' } },
+      ],
+      rows: Array.from({ length: 100 }, (_, i) => ({ name: `item_${i}`, value: i })),
+    };
+    const result = fn(input, { targetPoints: 10 }, {} as never);
+    expect(result).toBe(input);
+  });
+
+  it('should preserve the first and last timestamps', () => {
+    const input = createDatatable(100);
+    const result = fn(input, { targetPoints: 10 }, {} as never) as Datatable;
+    const timestamps = result.rows.map((r) => r.timestamp);
+    expect(timestamps[0]).toBe(0);
+    expect(timestamps[timestamps.length - 1]).toBe(99 * 1000);
+  });
+
+  it('should maintain temporal order in output', () => {
+    const input = createDatatable(500);
+    const result = fn(input, { targetPoints: 50 }, {} as never) as Datatable;
+    for (let i = 1; i < result.rows.length; i++) {
+      expect(result.rows[i].timestamp).toBeGreaterThanOrEqual(result.rows[i - 1].timestamp);
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/downsample_fn.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/downsample_fn.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import type { DownsampleExpressionFunction } from '../../defs/downsample/types';
+import { lttbMultiMetric } from './lttb';
+
+export const downsampleFn: DownsampleExpressionFunction['fn'] = (input, args) => {
+  const { targetPoints } = args;
+
+  if (!targetPoints || targetPoints <= 0 || input.rows.length <= targetPoints) {
+    return input;
+  }
+
+  const xCol = input.columns.find((c) => c.meta.type === 'date');
+  if (!xCol) {
+    return input;
+  }
+
+  const numericCols = input.columns.filter(
+    (c) => c.id !== xCol.id && (c.meta.type === 'number' || c.meta.type === 'date')
+  );
+
+  const sortedRows = [...input.rows].sort((a, b) => {
+    const aVal = a[xCol.id];
+    const bVal = b[xCol.id];
+    if (aVal == null) return -1;
+    if (bVal == null) return 1;
+    return Number(aVal) - Number(bVal);
+  });
+
+  const xValues = sortedRows.map((row) => Number(row[xCol.id]) || 0);
+  const yColumns = numericCols.map((col) => sortedRows.map((row) => Number(row[col.id]) || 0));
+
+  const keptIndices = lttbMultiMetric(xValues, yColumns, targetPoints);
+
+  return {
+    ...input,
+    rows: keptIndices.map((i) => sortedRows[i]),
+  } as Datatable;
+};

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/lttb.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/lttb.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lttb, lttbMultiMetric } from './lttb';
+
+describe('lttb', () => {
+  it('should return all indices when data length <= threshold', () => {
+    const x = [1, 2, 3, 4, 5];
+    const y = [10, 20, 30, 40, 50];
+    expect(lttb(x, y, 5)).toEqual([0, 1, 2, 3, 4]);
+    expect(lttb(x, y, 10)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('should return all indices when threshold < 3', () => {
+    const x = [1, 2, 3, 4, 5];
+    const y = [10, 20, 30, 40, 50];
+    expect(lttb(x, y, 2)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('should always include the first and last points', () => {
+    const x = Array.from({ length: 100 }, (_, i) => i);
+    const y = x.map((v) => Math.sin(v));
+    const result = lttb(x, y, 10);
+    expect(result[0]).toBe(0);
+    expect(result[result.length - 1]).toBe(99);
+  });
+
+  it('should return exactly threshold number of indices', () => {
+    const x = Array.from({ length: 1000 }, (_, i) => i);
+    const y = x.map((v) => Math.sin(v / 10));
+    const result = lttb(x, y, 50);
+    expect(result).toHaveLength(50);
+  });
+
+  it('should return sorted indices', () => {
+    const x = Array.from({ length: 200 }, (_, i) => i);
+    const y = x.map((v) => Math.sin(v / 5) * 100);
+    const result = lttb(x, y, 20);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).toBeGreaterThan(result[i - 1]);
+    }
+  });
+
+  it('should preserve peaks in a simple spike pattern', () => {
+    const x = Array.from({ length: 100 }, (_, i) => i);
+    const y = x.map((v) => (v === 50 ? 1000 : 0));
+    const result = lttb(x, y, 10);
+    expect(result).toContain(50);
+  });
+});
+
+describe('lttbMultiMetric', () => {
+  it('should return all indices when data is shorter than threshold', () => {
+    const x = [1, 2, 3];
+    const yColumns = [[10, 20, 30]];
+    expect(lttbMultiMetric(x, yColumns, 5)).toEqual([0, 1, 2]);
+  });
+
+  it('should keep indices significant to any metric', () => {
+    const x = Array.from({ length: 100 }, (_, i) => i);
+    const y1 = x.map((v) => (v === 25 ? 1000 : 0));
+    const y2 = x.map((v) => (v === 75 ? 1000 : 0));
+    const result = lttbMultiMetric(x, [y1, y2], 10);
+    expect(result).toContain(25);
+    expect(result).toContain(75);
+  });
+
+  it('should handle empty yColumns by using x as y', () => {
+    const x = Array.from({ length: 100 }, (_, i) => i);
+    const result = lttbMultiMetric(x, [], 10);
+    expect(result).toHaveLength(10);
+    expect(result[0]).toBe(0);
+    expect(result[result.length - 1]).toBe(99);
+  });
+
+  it('should return sorted indices even with multiple metrics', () => {
+    const x = Array.from({ length: 200 }, (_, i) => i);
+    const y1 = x.map((v) => Math.sin(v / 5));
+    const y2 = x.map((v) => Math.cos(v / 5));
+    const result = lttbMultiMetric(x, [y1, y2], 20);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).toBeGreaterThan(result[i - 1]);
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/lttb.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/downsample/lttb.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Largest Triangle Three Buckets (LTTB) downsampling algorithm.
+ *
+ * Reduces a time series to `threshold` points while preserving the visual
+ * shape by selecting the point in each bucket that forms the largest triangle
+ * with the previously selected point and the average of the next bucket.
+ *
+ * Reference: Sveinn Steinarsson, "Downsampling Time Series for Visual
+ * Representation", University of Iceland, 2013.
+ *
+ * @returns Sorted array of row indices to keep.
+ */
+export function lttb(xValues: number[], yValues: number[], threshold: number): number[] {
+  const dataLength = xValues.length;
+
+  if (dataLength <= threshold || threshold < 3) {
+    return Array.from({ length: dataLength }, (_, i) => i);
+  }
+
+  const sampled: number[] = [0];
+  const bucketSize = (dataLength - 2) / (threshold - 2);
+
+  let prevSelected = 0;
+
+  for (let bucket = 0; bucket < threshold - 2; bucket++) {
+    const rangeStart = Math.floor(bucket * bucketSize) + 1;
+    const rangeEnd = Math.min(Math.floor((bucket + 1) * bucketSize) + 1, dataLength);
+
+    const nextStart = Math.floor((bucket + 1) * bucketSize) + 1;
+    const nextEnd = Math.min(Math.floor((bucket + 2) * bucketSize) + 1, dataLength);
+
+    let avgX = 0;
+    let avgY = 0;
+    const nextLen = nextEnd - nextStart;
+    for (let j = nextStart; j < nextEnd; j++) {
+      avgX += xValues[j];
+      avgY += yValues[j];
+    }
+    avgX /= nextLen;
+    avgY /= nextLen;
+
+    const pX = xValues[prevSelected];
+    const pY = yValues[prevSelected];
+
+    let maxArea = -1;
+    let maxIdx = rangeStart;
+
+    for (let j = rangeStart; j < rangeEnd; j++) {
+      const area = Math.abs((pX - avgX) * (yValues[j] - pY) - (pX - xValues[j]) * (avgY - pY));
+      if (area > maxArea) {
+        maxArea = area;
+        maxIdx = j;
+      }
+    }
+
+    sampled.push(maxIdx);
+    prevSelected = maxIdx;
+  }
+
+  sampled.push(dataLength - 1);
+  return sampled;
+}
+
+/**
+ * Multi-metric LTTB: runs LTTB independently for each y-column and returns
+ * the sorted union of all selected indices, so that no visually significant
+ * point for any metric is lost.
+ */
+export function lttbMultiMetric(
+  xValues: number[],
+  yColumns: number[][],
+  threshold: number
+): number[] {
+  if (yColumns.length === 0) {
+    return lttb(xValues, xValues, threshold);
+  }
+
+  if (yColumns.length === 1) {
+    return lttb(xValues, yColumns[0], threshold);
+  }
+
+  const indexSet = new Set<number>();
+  for (const yValues of yColumns) {
+    for (const idx of lttb(xValues, yValues, threshold)) {
+      indexSet.add(idx);
+    }
+  }
+
+  return [...indexSet].sort((a, b) => a - b);
+}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
@@ -462,8 +462,18 @@ export function getTextBasedDatasource({
 
     removeColumn,
 
-    toExpression: (state, layerId, indexPatterns, dateRange, searchSessionId) => {
-      return toExpression(state, layerId);
+    toExpression: (
+      state,
+      layerId,
+      _indexPatterns,
+      _dateRange,
+      _nowInstant,
+      _searchSessionId,
+      _forceDSL,
+      _projectRouting,
+      maxDataPoints
+    ) => {
+      return toExpression(state, layerId, maxDataPoints);
     },
     getSelectedFields(state) {
       return getSelectedFieldsFromColumns(

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
@@ -15,7 +15,8 @@ import type { OriginalColumn } from '../../../common/types';
 function getExpressionForLayer(
   layer: TextBasedLayer,
   layerId: string,
-  refs: IndexPatternRef[]
+  refs: IndexPatternRef[],
+  maxDataPoints?: number
 ): Ast | null {
   if (!layer.columns || layer.columns?.length === 0) {
     return null;
@@ -94,6 +95,7 @@ function getExpressionForLayer(
         defaultMessage:
           'This request queries Elasticsearch to fetch the data for the visualization.',
       }),
+      maxDataPoints,
     });
 
     textBasedQueryToAst.chain.push({
@@ -131,9 +133,18 @@ function getExpressionForLayer(
   }
 }
 
-export function toExpression(state: TextBasedPrivateState, layerId: string) {
+export function toExpression(
+  state: TextBasedPrivateState,
+  layerId: string,
+  maxDataPoints?: number
+) {
   if (state.layers[layerId]) {
-    return getExpressionForLayer(state.layers[layerId], layerId, state.indexPatternRefs);
+    return getExpressionForLayer(
+      state.layers[layerId],
+      layerId,
+      state.indexPatternRefs,
+      maxDataPoints
+    );
   }
 
   return null;

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
@@ -106,17 +106,6 @@ function getExpressionForLayer(
         isTextBased: [true],
       },
     });
-
-    if (maxDataPoints && maxDataPoints > 0) {
-      textBasedQueryToAst.chain.push({
-        type: 'function',
-        function: 'lens_downsample',
-        arguments: {
-          targetPoints: [maxDataPoints],
-        },
-      });
-    }
-
     textBasedQueryToAst.chain.push(...formatterOverrides);
     return textBasedQueryToAst;
   } else {

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
@@ -106,6 +106,17 @@ function getExpressionForLayer(
         isTextBased: [true],
       },
     });
+
+    if (maxDataPoints && maxDataPoints > 0) {
+      textBasedQueryToAst.chain.push({
+        type: 'function',
+        function: 'lens_downsample',
+        arguments: {
+          targetPoints: [maxDataPoints],
+        },
+      });
+    }
+
     textBasedQueryToAst.chain.push(...formatterOverrides);
     return textBasedQueryToAst;
   } else {

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
@@ -118,6 +118,7 @@ export function buildExpression({
     {
       title,
       description,
+      maxDataPoints,
     },
     datasourceExpressionsByLayers
   );

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
@@ -22,7 +22,8 @@ export function getDatasourceExpressionsByLayers(
   dateRange: DateRange,
   nowInstant: Date,
   searchSessionId?: string,
-  forceDSL?: boolean
+  forceDSL?: boolean,
+  maxDataPoints?: number
 ): undefined | Record<string, Ast> {
   const datasourceExpressions: Array<[string, Ast | string]> = [];
 
@@ -42,7 +43,9 @@ export function getDatasourceExpressionsByLayers(
         dateRange,
         nowInstant,
         searchSessionId,
-        forceDSL
+        forceDSL,
+        undefined,
+        maxDataPoints
       );
       if (result) {
         datasourceExpressions.push([layerId, result]);
@@ -76,6 +79,7 @@ export function buildExpression({
   nowInstant,
   searchSessionId,
   forceDSL,
+  maxDataPoints,
 }: {
   title?: string;
   description?: string;
@@ -89,6 +93,7 @@ export function buildExpression({
   dateRange: DateRange;
   nowInstant: Date;
   forceDSL?: boolean;
+  maxDataPoints?: number;
 }): Ast | null {
   // if an unregistered visualization is passed in the SO
   // then this will be set as "undefined". Relax the check to catch both
@@ -103,7 +108,8 @@ export function buildExpression({
     dateRange,
     nowInstant,
     searchSessionId,
-    forceDSL
+    forceDSL,
+    maxDataPoints
   );
 
   const visualizationExpression = visualization.toExpression(

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/state_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/state_helpers.ts
@@ -369,6 +369,7 @@ export async function persistedStateToExpression(
     nowProvider: DataPublicPluginStart['nowProvider'];
     eventAnnotationService: EventAnnotationServiceType;
     forceDSL?: boolean;
+    maxDataPoints?: number;
   }
 ): Promise<DocumentToExpressionReturnType> {
   const {
@@ -466,6 +467,7 @@ export async function persistedStateToExpression(
       dateRange: { fromDate: currentTimeRange.from, toDate: currentTimeRange.to },
       forceDSL: services.forceDSL,
       nowInstant: services.nowProvider.get(),
+      maxDataPoints: services.maxDataPoints,
     }),
     activeVisualizationState,
     activeDatasourceState: datasourceStates[datasourceId]?.state,

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/service.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/service.tsx
@@ -96,7 +96,7 @@ export class EditorFrameService {
    */
   public documentToExpression = async (
     doc: LensDocument,
-    services: EditorFramePlugins & { forceDSL?: boolean }
+    services: EditorFramePlugins & { forceDSL?: boolean; maxDataPoints?: number }
   ) => {
     const [resolvedDatasources, resolvedVisualizations, { persistedStateToExpression }] =
       await Promise.all([

--- a/x-pack/platform/plugins/shared/lens/public/expressions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/expressions.ts
@@ -14,6 +14,7 @@ import { formatColumn } from '../common/expressions/defs/format_column';
 import { counterRate } from '../common/expressions/defs/counter_rate';
 import { getTimeScale } from '../common/expressions/defs/time_scale/time_scale';
 import { collapse } from '../common/expressions/defs/collapse';
+import { downsample } from '../common/expressions/defs/downsample';
 import {
   formulaIntervalFn,
   formulaNowFn,
@@ -34,6 +35,7 @@ export const setupExpressions = (
     formulaNowFn,
     formulaIntervalFn,
     collapse,
+    downsample,
     counterRate,
     formatColumn,
     mapToColumns,

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -363,7 +363,7 @@ export class LensPlugin {
         coreStart,
         timefilter: plugins.data.query.timefilter.timefilter,
         expressionRenderer: plugins.expressions.ReactExpressionRenderer,
-        documentToExpression: (doc: LensDocument, forceDSL?: boolean) =>
+        documentToExpression: (doc: LensDocument, forceDSL?: boolean, maxDataPoints?: number) =>
           this.editorFrameService!.documentToExpression(doc, {
             dataViews: plugins.dataViews,
             storage: new Storage(localStorage),
@@ -371,6 +371,7 @@ export class LensPlugin {
             timefilter: plugins.data.query.timefilter.timefilter,
             nowProvider: plugins.data.nowProvider,
             forceDSL,
+            maxDataPoints,
             eventAnnotationService,
           }),
         injectFilterReferences: data.query.filterManager.inject.bind(data.query.filterManager),

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
@@ -99,6 +99,7 @@ async function expectRerenderOnDataLoader(
     ...internalApiOverrides,
     attributes$: new BehaviorSubject(runtimeState.attributes),
   });
+  internalApi.updateContainerWidth(800);
   const services = {
     ...makeEmbeddableServices(new BehaviorSubject<string>(''), undefined, {
       visOverrides: { id: 'lnsXY' },

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -28,15 +28,11 @@ import {
   BehaviorSubject,
   debounceTime,
   distinctUntilChanged,
-  filter,
-  firstValueFrom,
   map,
   merge,
-  of,
   pipe,
   skip,
   tap,
-  timeout,
   type Subscription,
 } from 'rxjs';
 import { getEditPath } from '../../common/constants';
@@ -63,7 +59,8 @@ export type ReloadReason =
   | 'overrides'
   | 'disableTriggers'
   | 'viewMode'
-  | 'searchContext';
+  | 'searchContext'
+  | 'containerWidth';
 
 function getSearchContext(parentApi: unknown) {
   const unifiedSearch$ = apiPublishesUnifiedSearch(parentApi)
@@ -231,23 +228,7 @@ export function loadEmbeddableData(
       services
     );
 
-    // Wait for the actual panel width from the ResizeObserver.
-    // On first load the component hasn't mounted yet, so containerWidth$ is 0.
-    // Awaiting here yields to the event loop, letting React render the outer div
-    // and the ResizeObserver to fire. Falls back to window.innerWidth after 500ms
-    // (e.g. panel in a collapsed section that never mounts).
-    let containerWidth = internalApi.containerWidth$.getValue();
-    if (containerWidth === 0) {
-      containerWidth = await firstValueFrom(
-        internalApi.containerWidth$.pipe(
-          filter((w) => w > 0),
-          timeout({
-            first: 500,
-            with: () => of(typeof window !== 'undefined' ? window.innerWidth : 0),
-          })
-        )
-      );
-    }
+    const containerWidth = internalApi.containerWidth$.getValue();
 
     // Go concurrently: build the expression and fetch the dataViews
     const [{ params, abortController, ...rest }, dataViewIds] = await Promise.all([
@@ -334,6 +315,10 @@ export function loadEmbeddableData(
     internalApi.disableTriggers$.pipe(
       waitUntilChanged(),
       map(() => 'disableTriggers' as ReloadReason)
+    ),
+    internalApi.containerWidth$.pipe(
+      waitUntilChanged(),
+      map(() => 'containerWidth' as ReloadReason)
     )
   );
 
@@ -341,7 +326,15 @@ export function loadEmbeddableData(
     // on search context change, reload
     fetch$(api)
       .pipe(debounceTime(0))
-      .subscribe((fetchContext) => reload('searchContext' as ReloadReason, fetchContext)),
+      .subscribe((fetchContext) => {
+        // For ES|QL queries, defer the first reload until the panel width is measured
+        // so that downsampling can be applied. The containerWidth$ trigger handles
+        // the initial load once the ResizeObserver fires.
+        if (api.isTextBasedLanguage() && internalApi.containerWidth$.getValue() === 0) {
+          return;
+        }
+        reload('searchContext' as ReloadReason, fetchContext);
+      }),
     mergedSubscriptions.pipe(debounceTime(0)).subscribe(reload),
     // make sure to reload on viewMode change
     api.viewMode$.subscribe(() => {

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -28,11 +28,15 @@ import {
   BehaviorSubject,
   debounceTime,
   distinctUntilChanged,
+  filter,
+  firstValueFrom,
   map,
   merge,
+  of,
   pipe,
   skip,
   tap,
+  timeout,
   type Subscription,
 } from 'rxjs';
 import { getEditPath } from '../../common/constants';
@@ -227,6 +231,24 @@ export function loadEmbeddableData(
       services
     );
 
+    // Wait for the actual panel width from the ResizeObserver.
+    // On first load the component hasn't mounted yet, so containerWidth$ is 0.
+    // Awaiting here yields to the event loop, letting React render the outer div
+    // and the ResizeObserver to fire. Falls back to window.innerWidth after 500ms
+    // (e.g. panel in a collapsed section that never mounts).
+    let containerWidth = internalApi.containerWidth$.getValue();
+    if (containerWidth === 0) {
+      containerWidth = await firstValueFrom(
+        internalApi.containerWidth$.pipe(
+          filter((w) => w > 0),
+          timeout({
+            first: 500,
+            with: () => of(typeof window !== 'undefined' ? window.innerWidth : 0),
+          })
+        )
+      );
+    }
+
     // Go concurrently: build the expression and fetch the dataViews
     const [{ params, abortController, ...rest }, dataViewIds] = await Promise.all([
       getExpressionRendererParams(currentState, {
@@ -251,6 +273,7 @@ export function loadEmbeddableData(
         updateBlockingErrors,
         forceDSL: (parentApi as { forceDSL?: boolean }).forceDSL,
         getDisplayOptions: internalApi.getDisplayOptions,
+        maxDataPoints: containerWidth > 0 ? containerWidth : undefined,
       }),
       getUsedDataViews(
         currentState.attributes.references,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -28,10 +28,12 @@ import {
   BehaviorSubject,
   debounceTime,
   distinctUntilChanged,
+  filter,
   map,
   merge,
   pipe,
   skip,
+  take,
   tap,
   type Subscription,
 } from 'rxjs';
@@ -315,10 +317,6 @@ export function loadEmbeddableData(
     internalApi.disableTriggers$.pipe(
       waitUntilChanged(),
       map(() => 'disableTriggers' as ReloadReason)
-    ),
-    internalApi.containerWidth$.pipe(
-      waitUntilChanged(),
-      map(() => 'containerWidth' as ReloadReason)
     )
   );
 
@@ -328,8 +326,8 @@ export function loadEmbeddableData(
       .pipe(debounceTime(0))
       .subscribe((fetchContext) => {
         // For ES|QL queries, defer the first reload until the panel width is measured
-        // so that downsampling can be applied. The containerWidth$ trigger handles
-        // the initial load once the ResizeObserver fires.
+        // so that downsampling can be applied. The containerWidth$ one-shot subscription
+        // handles the initial load once the ResizeObserver fires.
         if (api.isTextBasedLanguage() && internalApi.containerWidth$.getValue() === 0) {
           return;
         }
@@ -344,6 +342,23 @@ export function loadEmbeddableData(
       }
     }),
   ];
+
+  // For ES|QL: trigger exactly once when the panel width is first measured,
+  // so the initial query has the correct maxDataPoints for downsampling.
+  // After this, width changes are picked up passively on the next natural
+  // reload (filter/time change) — no re-query on flyout open or window resize.
+  if (internalApi.containerWidth$.getValue() === 0) {
+    subscriptions.push(
+      internalApi.containerWidth$
+        .pipe(
+          filter((w) => w > 0 && Boolean(api.isTextBasedLanguage())),
+          take(1),
+          debounceTime(0),
+          map(() => 'containerWidth' as ReloadReason)
+        )
+        .subscribe(reload)
+    );
+  }
   // There are few key moments when errors are checked and displayed:
   // * at setup time (here) before the first expression evaluation
   // * at runtime => when the expression is running and ES/Kibana server could emit errors)

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/expression_params.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/expression_params.ts
@@ -9,7 +9,6 @@ import type { KibanaExecutionContext } from '@kbn/core-execution-context-common'
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import type { RenderMode } from '@kbn/expressions-plugin/common';
 import type { ExpressionRendererEvent } from '@kbn/expressions-plugin/public';
-import type { Ast } from '@kbn/interpreter';
 import { toExpression } from '@kbn/interpreter';
 import { noop } from 'lodash';
 import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
@@ -62,43 +61,21 @@ interface GetExpressionRendererPropsParams {
   maxDataPoints?: number;
 }
 
-function injectMaxDataPoints(ast: Ast, maxDataPoints: number): Ast {
-  if (!ast.chain) {
-    return ast;
-  }
-  return {
-    ...ast,
-    chain: ast.chain.map((fn) => {
-      if (fn.function === 'esql') {
-        return {
-          ...fn,
-          arguments: {
-            ...fn.arguments,
-            maxDataPoints: [maxDataPoints],
-          },
-        };
-      }
-      return fn;
-    }),
-  };
-}
-
 async function getExpressionFromDocument(
   document: LensDocument,
   documentToExpression: (
     doc: LensDocument,
-    forceDSL?: boolean
+    forceDSL?: boolean,
+    maxDataPoints?: number
   ) => Promise<DocumentToExpressionReturnType>,
   forceDSL?: boolean,
   maxDataPoints?: number
 ) {
   const { ast, indexPatterns, indexPatternRefs, activeVisualizationState, activeDatasourceState } =
-    await documentToExpression(document, forceDSL);
-
-  const finalAst = ast && maxDataPoints ? injectMaxDataPoints(ast, maxDataPoints) : ast;
+    await documentToExpression(document, forceDSL, maxDataPoints);
 
   return {
-    expression: finalAst ? toExpression(finalAst) : null,
+    expression: ast ? toExpression(ast) : null,
     indexPatterns,
     indexPatternRefs,
     activeVisualizationState,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/expression_params.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/expression_params.ts
@@ -9,6 +9,7 @@ import type { KibanaExecutionContext } from '@kbn/core-execution-context-common'
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import type { RenderMode } from '@kbn/expressions-plugin/common';
 import type { ExpressionRendererEvent } from '@kbn/expressions-plugin/public';
+import type { Ast } from '@kbn/interpreter';
 import { toExpression } from '@kbn/interpreter';
 import { noop } from 'lodash';
 import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
@@ -58,6 +59,28 @@ interface GetExpressionRendererPropsParams {
   updateBlockingErrors: (error: Error) => void;
   forceDSL?: boolean;
   getDisplayOptions: () => VisualizationDisplayOptions;
+  maxDataPoints?: number;
+}
+
+function injectMaxDataPoints(ast: Ast, maxDataPoints: number): Ast {
+  if (!ast.chain) {
+    return ast;
+  }
+  return {
+    ...ast,
+    chain: ast.chain.map((fn) => {
+      if (fn.function === 'esql') {
+        return {
+          ...fn,
+          arguments: {
+            ...fn.arguments,
+            maxDataPoints: [maxDataPoints],
+          },
+        };
+      }
+      return fn;
+    }),
+  };
 }
 
 async function getExpressionFromDocument(
@@ -66,12 +89,16 @@ async function getExpressionFromDocument(
     doc: LensDocument,
     forceDSL?: boolean
   ) => Promise<DocumentToExpressionReturnType>,
-  forceDSL?: boolean
+  forceDSL?: boolean,
+  maxDataPoints?: number
 ) {
   const { ast, indexPatterns, indexPatternRefs, activeVisualizationState, activeDatasourceState } =
     await documentToExpression(document, forceDSL);
+
+  const finalAst = ast && maxDataPoints ? injectMaxDataPoints(ast, maxDataPoints) : ast;
+
   return {
-    expression: ast ? toExpression(ast) : null,
+    expression: finalAst ? toExpression(finalAst) : null,
     indexPatterns,
     indexPatternRefs,
     activeVisualizationState,
@@ -161,6 +188,7 @@ export async function getExpressionRendererParams(
     searchContext,
     forceDSL,
     getDisplayOptions,
+    maxDataPoints,
   }: GetExpressionRendererPropsParams
 ): Promise<{
   params: ExpressionWrapperProps | null;
@@ -178,7 +206,12 @@ export async function getExpressionRendererParams(
     indexPatternRefs,
     activeVisualizationState,
     activeDatasourceState,
-  } = await getExpressionFromDocument(state.attributes, documentToExpression, forceDSL);
+  } = await getExpressionFromDocument(
+    state.attributes,
+    documentToExpression,
+    forceDSL,
+    maxDataPoints
+  );
 
   // Apparently this change produces had lots of issues with solutions not using
   // the Embeddable incorrectly. Will comment for now and later on will restore it when

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_internal_api.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_internal_api.ts
@@ -75,6 +75,7 @@ export function initializeInternalApi(
     : new BehaviorSubject<ESQLControlVariable[]>([]);
 
   const isEditingInProgress$ = new BehaviorSubject<boolean>(false);
+  const containerWidth$ = new BehaviorSubject<number>(0);
 
   // No need to expose anything at public API right now, that would happen later on
   // where each initializer will pick what it needs and publish it
@@ -147,6 +148,8 @@ export function initializeInternalApi(
 
       return displayOptions;
     },
+    containerWidth$,
+    updateContainerWidth: (width: number) => containerWidth$.next(width),
     getVisualizationContext: () => visualizationContext$.getValue(),
     updateVisualizationContext: (newVisualizationContext: Partial<VisualizationContext>) => {
       visualizationContext$.next({

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
+import { useResizeObserver } from '@elastic/eui';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { LensInternalApi } from '@kbn/lens-common';
 import type { LensApi } from '@kbn/lens-common-2';
 import { ExpressionWrapper } from '../expression_wrapper';
@@ -14,6 +15,8 @@ import { UserMessages } from '../user_messages/container';
 import { useMessages, useDispatcher } from './hooks';
 import { getViewMode } from '../helper';
 import { addLog } from '../logger';
+
+const WIDTH_CHANGE_THRESHOLD = 100;
 
 export function LensEmbeddableComponent({
   internalApi,
@@ -60,6 +63,20 @@ export function LensEmbeddableComponent({
   // take care of dispatching the event from the DOM node
   const rootRef = useDispatcher(hasRendered, api);
 
+  const [resizeElement, setResizeElement] = useState<HTMLDivElement | null>(null);
+  const { width: containerWidth } = useResizeObserver(resizeElement, 'width');
+  const lastReportedWidth = useRef<number>(0);
+
+  useEffect(() => {
+    if (
+      containerWidth > 0 &&
+      Math.abs(containerWidth - lastReportedWidth.current) > WIDTH_CHANGE_THRESHOLD
+    ) {
+      lastReportedWidth.current = containerWidth;
+      internalApi.updateContainerWidth(containerWidth);
+    }
+  }, [containerWidth, internalApi]);
+
   // Publish the data attributes only if avaialble/visible
   const title = useMemo(
     () =>
@@ -82,7 +99,10 @@ export function LensEmbeddableComponent({
       {...title}
       {...description}
       data-shared-item
-      ref={rootRef}
+      ref={(node) => {
+        rootRef.current = node;
+        setResizeElement(node);
+      }}
     >
       {expressionParams == null || blockingErrors.length ? null : (
         <ExpressionWrapper {...expressionParams} paddingTop={hideTitle || !panelTitle?.length} />

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
@@ -7,7 +7,7 @@
 
 import { useResizeObserver } from '@elastic/eui';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { LensInternalApi } from '@kbn/lens-common';
 import type { LensApi } from '@kbn/lens-common-2';
 import { ExpressionWrapper } from '../expression_wrapper';
@@ -15,8 +15,6 @@ import { UserMessages } from '../user_messages/container';
 import { useMessages, useDispatcher } from './hooks';
 import { getViewMode } from '../helper';
 import { addLog } from '../logger';
-
-const WIDTH_CHANGE_THRESHOLD = 100;
 
 export function LensEmbeddableComponent({
   internalApi,
@@ -65,17 +63,9 @@ export function LensEmbeddableComponent({
 
   const [resizeElement, setResizeElement] = useState<HTMLDivElement | null>(null);
   const { width: containerWidth } = useResizeObserver(resizeElement, 'width');
-  const lastReportedWidth = useRef<number>(0);
 
   useEffect(() => {
-    if (containerWidth <= 0) {
-      return;
-    }
-    const isFirstMeasurement = lastReportedWidth.current === 0;
-    const exceedsThreshold =
-      Math.abs(containerWidth - lastReportedWidth.current) > WIDTH_CHANGE_THRESHOLD;
-    if (isFirstMeasurement || exceedsThreshold) {
-      lastReportedWidth.current = containerWidth;
+    if (containerWidth > 0) {
       internalApi.updateContainerWidth(containerWidth);
     }
   }, [containerWidth, internalApi]);

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
@@ -68,10 +68,13 @@ export function LensEmbeddableComponent({
   const lastReportedWidth = useRef<number>(0);
 
   useEffect(() => {
-    if (
-      containerWidth > 0 &&
-      Math.abs(containerWidth - lastReportedWidth.current) > WIDTH_CHANGE_THRESHOLD
-    ) {
+    if (containerWidth <= 0) {
+      return;
+    }
+    const isFirstMeasurement = lastReportedWidth.current === 0;
+    const exceedsThreshold =
+      Math.abs(containerWidth - lastReportedWidth.current) > WIDTH_CHANGE_THRESHOLD;
+    if (isFirstMeasurement || exceedsThreshold) {
       lastReportedWidth.current = containerWidth;
       internalApi.updateContainerWidth(containerWidth);
     }

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
@@ -31,7 +31,8 @@ export type LensEmbeddableStartServices = Simplify<
     expressionRenderer: ReactExpressionRendererType;
     documentToExpression: (
       doc: LensDocument,
-      forceDSL?: boolean
+      forceDSL?: boolean,
+      maxDataPoints?: number
     ) => Promise<DocumentToExpressionReturnType>;
     injectFilterReferences: FilterManager['inject'];
     visualizationMap: VisualizationMap;

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/to_expression.ts
@@ -95,7 +95,8 @@ export const toExpression = (
   datasourceLayers: DatasourceLayers,
   paletteService: PaletteRegistry,
   datasourceExpressionsByLayers: Record<string, Ast>,
-  eventAnnotationService: EventAnnotationServiceType
+  eventAnnotationService: EventAnnotationServiceType,
+  maxDataPoints?: number
 ): Ast | null => {
   if (!state || !state.layers.length) {
     return null;
@@ -120,7 +121,8 @@ export const toExpression = (
     datasourceLayers,
     paletteService,
     datasourceExpressionsByLayers,
-    eventAnnotationService
+    eventAnnotationService,
+    maxDataPoints
   );
 };
 
@@ -199,7 +201,8 @@ export const buildXYExpression = (
   datasourceLayers: DatasourceLayers,
   paletteService: PaletteRegistry,
   datasourceExpressionsByLayers: Record<string, Ast>,
-  eventAnnotationService: EventAnnotationServiceType
+  eventAnnotationService: EventAnnotationServiceType,
+  maxDataPoints?: number
 ): Ast | null => {
   const validDataLayers: ValidXYDataLayerConfig[] = getDataLayers(state.layers)
     .filter<ValidXYDataLayerConfig>((layer): layer is ValidXYDataLayerConfig =>
@@ -363,7 +366,8 @@ export const buildXYExpression = (
           metadata,
           paletteService,
           datasourceExpressionsByLayers[layer.layerId],
-          state.curveType || 'LINEAR'
+          state.curveType || 'LINEAR',
+          maxDataPoints
         )
       ),
       ...validReferenceLayers.map((layer) =>
@@ -476,7 +480,8 @@ const dataLayerToExpression = (
   metadata: Record<string, Record<string, OperationMetadata | null>>,
   paletteService: PaletteRegistry,
   datasourceExpression: Ast,
-  curveType: XYCurveType
+  curveType: XYCurveType,
+  maxDataPoints?: number
 ): Ast => {
   const columnToLabel = getColumnToLabelMap(layer, datasourceLayer);
 
@@ -537,12 +542,24 @@ const dataLayerToExpression = (
     colorMapping: layer.colorMapping ? JSON.stringify(layer.colorMapping) : undefined,
   });
 
+  const isTextBasedDatasource = datasourceExpression?.chain.some((fn) => fn.function === 'esql');
+
+  const downsampleStep =
+    isTextBasedDatasource && maxDataPoints && maxDataPoints > 0
+      ? [
+          buildExpressionFunction('lens_downsample', {
+            targetPoints: maxDataPoints,
+          }).toAst(),
+        ]
+      : [];
+
   return {
     type: 'expression',
     chain: [
       ...(datasourceExpression
         ? [...datasourceExpression.chain, ...(layer.collapseFn ? [collapseFn.toAst()] : [])]
         : []),
+      ...downsampleStep,
       extendedDataLayerFn.toAst(),
     ],
   };

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
@@ -897,13 +897,14 @@ export const getXyVisualization = ({
       />
     );
   },
-  toExpression: (state, layers, _attributes, datasourceExpressionsByLayers = {}) =>
+  toExpression: (state, layers, attributes, datasourceExpressionsByLayers = {}) =>
     toExpression(
       state,
       layers,
       paletteService,
       datasourceExpressionsByLayers,
-      eventAnnotationService
+      eventAnnotationService,
+      attributes?.maxDataPoints
     ),
 
   toPreviewExpression: (state, layers, datasourceExpressionsByLayers = {}) =>


### PR DESCRIPTION
## Summary

Server side downsampling https://github.com/elastic/kibana/pull/255917

+ Client side downsampling with the LTTB algorithm

LTTB algorithm explained by LLM:


Imagine you have 10,000 data points on a time series but your chart is only 800 pixels wide. Most of those points overlap — you can't visually distinguish them anyway. LTTB picks the ~800 points that best preserve what the chart looks like.

### Here's how it works:
- Always keep the first and last points — the chart must start and end correctly.
- Divide the remaining points into equal-sized buckets — if you want 800 points total, you create 798 buckets (800 minus the first and last).
- For each bucket, pick one point — 
    - the one that creates the largest triangle when connected to:
    - The point you picked from the previous bucket (left anchor)
    - The average of all points in the next bucket (right anchor)
    
That's it. The "largest triangle" part is the key insight: a point that forms a big triangle is one that deviates the most from a straight line between its neighbors. Peaks, valleys, and sharp turns create large triangles, so they're always kept. Points in flat, boring sections create tiny triangles, so they're discarded.


**The result**: the downsampled chart looks virtually identical to the original, because the visually important points (peaks, dips, trend changes) are always preserved, while redundant points in flat regions are removed.
For multiple metrics (e.g., both bytes and count on the same chart), we run LTTB independently for each metric and keep the union of all selected points. This way, a peak that matters for bytes but not for count is still kept.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



