### PR TITLE
Fix "Elastic Search" branding to "Elasticsearch" in product intercept

### DIFF
--- a/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
@@ -44,7 +44,11 @@ export class ProductInterceptPublicPlugin implements Plugin {
       analytics: core.analytics,
     });
 
-    const productOffering = `Elastic ${capitalize(cloud.serverless.projectType || '')}`.trim();
+    const projectType = cloud.serverless.projectType || '';
+    const productOffering =
+      projectType === 'search'
+        ? 'Elasticsearch'
+        : `Elastic ${capitalize(projectType)}`.trim();
 
     void (async () => {
       const currentUser = await core.security.authc.getCurrentUser();

--- a/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
@@ -46,9 +46,7 @@ export class ProductInterceptPublicPlugin implements Plugin {
 
     const projectType = cloud.serverless.projectType || '';
     const productOffering =
-      projectType === 'search'
-        ? 'Elasticsearch'
-        : `Elastic ${capitalize(projectType)}`.trim();
+      projectType === 'search' ? 'Elasticsearch' : `Elastic ${capitalize(projectType)}`.trim();
 
     void (async () => {
       const currentUser = await core.security.authc.getCurrentUser();


### PR DESCRIPTION
## Summary

Fixes #255991

The product intercept survey (CSAT / ease-of-use) constructed its product name via `` `Elastic ${capitalize(projectType)}` ``, which produced **"Elastic Search"** (two words) for search projects. The correct product name is **"Elasticsearch"** (one word, no space).

This special-cases the `search` project type to use the proper branding while leaving other project types (`security` → "Elastic Security", `observability` → "Elastic Observability") unchanged.

## Test plan

- [ ] Verify the intercept survey displays "Elasticsearch" (not "Elastic Search") for search project types
- [ ] Verify "Elastic Security" and "Elastic Observability" are unaffected


Made with [Cursor](https://cursor.com)