### PR TITLE
fix: enable all plugins when generating SO migration baseline snapshots

### DIFF
--- a/src/dev/so_migration/snapshot_plugin_types.ts
+++ b/src/dev/so_migration/snapshot_plugin_types.ts
@@ -75,7 +75,23 @@ async function startServers() {
   });
 
   const esServer = await startES();
-  const kibanaRoot = createRootWithCorePlugins({}, { oss: false });
+  const kibanaRoot = createRootWithCorePlugins(
+    {
+      plugins: {
+        // Must enable all plugins to ensure the snapshot includes SO types from every plugin,
+        // matching the configuration used in the 'Check changes in Saved Objects' CI step.
+        forceEnableAllPlugins: true,
+      },
+      node: {
+        roles: ['ui'],
+      },
+    },
+    {
+      oss: false,
+      // Running in 'dev' mode prevents plugins (e.g. cloud-experiments) from failing due to missing config.
+      dev: true,
+    }
+  );
   await kibanaRoot.preboot();
   await kibanaRoot.setup();
   const coreStart = await kibanaRoot.start();


### PR DESCRIPTION
## Summary

The `Check changes in Saved Objects` CI step was reporting SO types contributed by non-default plugins as new/invalid on PRs that did not introduce those types.

Root cause: the on-merge pipeline generates baseline snapshots via `src/dev/so_migration/snapshot_plugin_types.ts` without enabling all plugins, while the CI check step captures the current snapshot with `forceEnableAllPlugins: true` (see `packages/kbn-check-saved-objects-cli/src/util/servers.ts`). The mismatch means plugin-contributed SO types (e.g. `integration-config`, `data_stream-config`) are absent from the baseline, causing the comparison to flag them as new types on every unrelated PR.

Fix: apply the same Kibana startup configuration used by the check step (`forceEnableAllPlugins`, `dev: true`, `node.roles: ['ui']`) when generating the baseline snapshot, so both sides of the comparison are produced under identical conditions.

## Testing

The correctness of this fix can be verified by re-running the on-merge `archive_so_migration_snapshot` step after merging and confirming that a subsequent PR's `Check changes in Saved Objects` step no longer reports `integration-config` or `data_stream-config` as new types.

Made with [Cursor](https://cursor.com)