### PR TITLE
[ES|QL] Track time spent in callbacks while doing validations

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -72,6 +72,7 @@ import {
   esqlEditorStyles,
 } from './esql_editor.styles';
 import { ESQLEditorTelemetryService } from './telemetry/telemetry_service';
+import { createTimedCallbacks } from './telemetry/timed_callbacks';
 import { useEsqlEditorActionsRegistration } from './editor_actions_context';
 import {
   filterDataErrors,
@@ -807,11 +808,15 @@ const ESQLEditorInternal = function ESQLEditor({
   const parseMessages = useCallback(
     async (options?: { invalidateColumnsCache?: boolean }) => {
       if (editorModel.current) {
-        return await ESQLLang.validate(editorModel.current, code, esqlCallbacks, options);
+        const { callbacks: timedCallbacks, getCallbacksDuration } =
+          createTimedCallbacks(esqlCallbacks);
+        const result = await ESQLLang.validate(editorModel.current, code, timedCallbacks, options);
+        return { ...result, callbacksDuration: getCallbacksDuration() };
       }
       return {
         errors: [],
         warnings: [],
+        callbacksDuration: 0,
       };
     },
     [esqlCallbacks, code]
@@ -821,10 +826,10 @@ const ESQLEditorInternal = function ESQLEditor({
     const setQueryToTheCache = async () => {
       if (editorRef?.current) {
         try {
-          const parserMessages = await parseMessages();
-          const clientParserStatus = parserMessages.errors?.length
+          const { errors, warnings } = await parseMessages();
+          const clientParserStatus = errors?.length
             ? 'error'
-            : parserMessages.warnings.length
+            : warnings.length
             ? 'warning'
             : 'success';
 
@@ -856,7 +861,11 @@ const ESQLEditorInternal = function ESQLEditor({
     }) => {
       if (!editorModel.current || editorModel.current.isDisposed()) return;
       monaco.editor.setModelMarkers(editorModel.current, 'Unified search', []);
-      const { warnings: parserWarnings, errors: parserErrors } = await parseMessages({
+      const {
+        warnings: parserWarnings,
+        errors: parserErrors,
+        callbacksDuration,
+      } = await parseMessages({
         invalidateColumnsCache,
       });
 
@@ -887,7 +896,7 @@ const ESQLEditorInternal = function ESQLEditor({
         markers.push(...underlinedMessages);
       }
 
-      trackValidationLatencyEnd(active);
+      trackValidationLatencyEnd(active, callbacksDuration);
 
       if (active) {
         const uniqueWarnings = filterDuplicatedWarnings(allWarnings);

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.performance.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.performance.test.ts
@@ -166,22 +166,4 @@ describe('ESQLEditorTelemetryService performance metrics', () => {
       })
     );
   });
-
-  it('omits callbacks_duration when not provided', () => {
-    const analytics = {
-      reportEvent: jest.fn(),
-    } as Pick<AnalyticsServiceStart, 'reportEvent'> as AnalyticsServiceStart;
-    const service = new ESQLEditorTelemetryService(analytics);
-
-    service.trackValidationLatency({
-      duration: 20,
-      queryLength: 10,
-      queryLines: 1,
-      sessionId: 'session-3',
-    });
-
-    const reported = mockMetricEvent.mock.calls[0][0];
-    expect(reported).not.toHaveProperty('key3');
-    expect(reported).not.toHaveProperty('value3');
-  });
 });

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.performance.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.performance.test.ts
@@ -133,4 +133,55 @@ describe('ESQLEditorTelemetryService performance metrics', () => {
       })
     );
   });
+
+  it('reports validation latency with callbacks duration', () => {
+    const analytics = {
+      reportEvent: jest.fn(),
+    } as Pick<AnalyticsServiceStart, 'reportEvent'> as AnalyticsServiceStart;
+    const service = new ESQLEditorTelemetryService(analytics);
+
+    service.trackValidationLatency({
+      duration: 50,
+      queryLength: 30,
+      queryLines: 2,
+      sessionId: 'session-2',
+      isInitialLoad: true,
+      callbacksDuration: 36,
+    });
+
+    expect(mockMetricEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: 'esql_editor_validation_latency',
+        duration: 50,
+        key1: 'query_length',
+        value1: 30,
+        key2: 'query_lines',
+        value2: 2,
+        key3: 'callbacks_duration',
+        value3: 36,
+        meta: expect.objectContaining({
+          session_id: 'session-2',
+          is_initial_load: true,
+        }),
+      })
+    );
+  });
+
+  it('omits callbacks_duration when not provided', () => {
+    const analytics = {
+      reportEvent: jest.fn(),
+    } as Pick<AnalyticsServiceStart, 'reportEvent'> as AnalyticsServiceStart;
+    const service = new ESQLEditorTelemetryService(analytics);
+
+    service.trackValidationLatency({
+      duration: 20,
+      queryLength: 10,
+      queryLines: 1,
+      sessionId: 'session-3',
+    });
+
+    const reported = mockMetricEvent.mock.calls[0][0];
+    expect(reported).not.toHaveProperty('key3');
+    expect(reported).not.toHaveProperty('value3');
+  });
 });

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
@@ -76,6 +76,11 @@ export class ESQLEditorTelemetryService {
       value1: payload.queryLength,
       key2: 'query_lines' as const,
       value2: payload.queryLines,
+
+      ...(payload.callbacksDuration !== undefined
+        ? { key3: 'callbacks_duration' as const, value3: Math.round(payload.callbacksDuration) }
+        : {}),
+
       meta: {
         ...(payload.sessionId ? { session_id: payload.sessionId } : {}),
         ...(payload.isInitialLoad !== undefined ? { is_initial_load: payload.isInitialLoad } : {}),

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/timed_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/timed_callbacks.ts
@@ -56,14 +56,15 @@ export const createTimedCallbacks = (
     }
 
     timedCallbacks[key] = (...args: unknown[]) => {
+      onStart();
       const result = (value as Function)(...args);
 
       // If the result is a promise, wrap it in the onStart and onEnd logic
       if (result instanceof Promise) {
-        onStart();
-        result.finally(onEnd);
+        return result.finally(onEnd);
       }
 
+      onEnd();
       return result;
     };
   }

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/timed_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/timed_callbacks.ts
@@ -59,18 +59,9 @@ export const createTimedCallbacks = (
       const result = (value as Function)(...args);
 
       // If the result is a promise, wrap it in the onStart and onEnd logic
-      if (result != null && typeof (result as { then?: unknown }).then === 'function') {
+      if (result instanceof Promise) {
         onStart();
-        return (result as Promise<unknown>).then(
-          (res) => {
-            onEnd();
-            return res;
-          },
-          (err) => {
-            onEnd();
-            throw err;
-          }
-        );
+        result.finally(onEnd);
       }
 
       return result;

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/timed_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/timed_callbacks.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ESQLCallbacks } from '@kbn/esql-types';
+
+/**
+ * Wraps each function in an ESQLCallbacks object with timing instrumentation.
+ *
+ * Parallel callbacks are not double-counted: only time where at
+ * least one callback is being executed is accumulated.
+ *
+ * Returns the wrapped callbacks and a getter for the total time
+ * spent inside callback invocations.
+ */
+export const createTimedCallbacks = (
+  callbacks: ESQLCallbacks
+): {
+  callbacks: ESQLCallbacks;
+  getCallbacksDuration: () => number;
+} => {
+  let totalDuration = 0;
+  let activeCount = 0;
+  let activeStart = 0;
+
+  /**
+   *  How this two (onStart, onEnd) works?
+   *  If many callbacks are called in parallel, the first one starting (activeCount === 0) sets the start time.
+   *  The last one ending ( when activeCount reachs 0 again) is the one that closes the totalDuration.
+   */
+  const onStart = () => {
+    if (activeCount === 0) {
+      activeStart = performance.now();
+    }
+    activeCount++;
+  };
+  const onEnd = () => {
+    activeCount--;
+    if (activeCount === 0) {
+      totalDuration += performance.now() - activeStart;
+    }
+  };
+
+  const timedCallbacks: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(callbacks)) {
+    // Don't wrap non-function callbacks (e.g. `isServerless`)
+    if (typeof value !== 'function') {
+      timedCallbacks[key] = value;
+      continue;
+    }
+
+    timedCallbacks[key] = (...args: unknown[]) => {
+      const result = (value as Function)(...args);
+
+      // If the result is a promise, wrap it in the onStart and onEnd logic
+      if (result != null && typeof (result as { then?: unknown }).then === 'function') {
+        onStart();
+        return (result as Promise<unknown>).then(
+          (res) => {
+            onEnd();
+            return res;
+          },
+          (err) => {
+            onEnd();
+            throw err;
+          }
+        );
+      }
+
+      return result;
+    };
+  }
+
+  return {
+    callbacks: timedCallbacks as ESQLCallbacks,
+    getCallbacksDuration: () => totalDuration,
+  };
+};

--- a/src/platform/packages/private/kbn-esql-editor/src/use_latency_tracking.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/use_latency_tracking.ts
@@ -185,7 +185,7 @@ export const useValidationLatencyTracking = ({
   );
 
   const trackValidationLatencyEnd = useCallback(
-    (active: boolean) => {
+    (active: boolean, callbacksDuration?: number) => {
       if (!active) {
         return;
       }
@@ -198,6 +198,7 @@ export const useValidationLatencyTracking = ({
       telemetryService.trackValidationLatency({
         ...result,
         sessionId: sessionIdRef.current,
+        callbacksDuration,
       });
     },
     [sessionIdRef, telemetryService]

--- a/src/platform/packages/shared/kbn-esql-types/src/esql_telemetry_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/esql_telemetry_types.ts
@@ -49,4 +49,5 @@ export interface TelemetryLatencyProps {
   queryLines: number; // Query length in lines.
   sessionId: string; // Editor mount session id.
   isInitialLoad?: boolean; // True for the first sampled event of each metric.
+  callbacksDuration?: number; // Duration spent running callbacks during the execution.
 }


### PR DESCRIPTION
## Summary
This PR adds the `timeSpentInCallbacks` property to the validation tracking events.

It measures the total time spent inside callbacks that are promises.
If two or more callbacks are executed in parallel it will only track the time of the largest one, it will not duplicate the duration measurement.
Meaning:
```ts
await promise.all([
  await callbacks.getSources, //50ms
  await callbacks.getPolicies // 70ms
])
```
Will track as `70ms`.

```ts
await callbacks.getSources(...); //50ms
await callbacks.getPolicies(...); // 70ms
```
Will track as `120ms`

This is the less invasive way of instrumenting this I found, wanted to avoid putting tracking code within the validaiton routine, or having to manually add tracking to to every callback in particular.
