### PR TITLE
[Agent Builder] Invalidate conversation after update origin is called

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
@@ -22,6 +22,11 @@ export interface Attachment<
   data: DataType;
   /** should the attachment be hidden from the user - e.g. for screen context */
   hidden?: boolean;
+  /**
+   * Origin/reference info for attachments created from external sources (e.g., saved objects).
+   * Undefined for by-value attachments.
+   */
+  origin?: unknown;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
@@ -17,6 +17,7 @@ interface CanvasContextValue {
   canvasState: CanvasState | null;
   openCanvas: (attachment: UnknownAttachment, isSidebar: boolean) => void;
   closeCanvas: () => void;
+  setCanvasAttachmentOrigin: (origin: unknown) => void;
 }
 
 const CanvasContext = createContext<CanvasContextValue | null>(null);
@@ -36,9 +37,19 @@ export const CanvasProvider: React.FC<CanvasProviderProps> = ({ children }) => {
     setCanvasState(null);
   }, []);
 
+  const setCanvasAttachmentOrigin = useCallback((origin: unknown) => {
+    setCanvasState((prev) => {
+      if (!prev) return null;
+      return {
+        ...prev,
+        attachment: { ...prev.attachment, origin },
+      };
+    });
+  }, []);
+
   const value = useMemo(
-    () => ({ canvasState, openCanvas, closeCanvas }),
-    [canvasState, openCanvas, closeCanvas]
+    () => ({ canvasState, openCanvas, closeCanvas, setCanvasAttachmentOrigin }),
+    [canvasState, openCanvas, closeCanvas, setCanvasAttachmentOrigin]
   );
 
   return <CanvasContext.Provider value={value}>{children}</CanvasContext.Provider>;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -12,6 +12,7 @@ import { i18n } from '@kbn/i18n';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationId } from '../../../../../context/conversation/use_conversation_id';
+import { useConversationContext } from '../../../../../context/conversation/conversation_context';
 import { AttachmentHeader } from './attachment_header';
 import { useCanvasContext } from './canvas_context';
 
@@ -30,17 +31,31 @@ interface CanvasFlyoutProps {
  */
 export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }) => {
   const { euiTheme } = useEuiTheme();
-  const { canvasState, closeCanvas } = useCanvasContext();
+  const { canvasState, closeCanvas, setCanvasAttachmentOrigin } = useCanvasContext();
   const conversationId = useConversationId();
+  const { conversationActions } = useConversationContext();
 
   const updateOrigin = useCallback(
     async (origin: unknown) => {
       if (!conversationId || !canvasState) {
         return;
       }
-      return attachmentsService.updateOrigin(conversationId, canvasState.attachment.id, origin);
+      const result = await attachmentsService.updateOrigin(
+        conversationId,
+        canvasState.attachment.id,
+        origin
+      );
+      setCanvasAttachmentOrigin(origin);
+      conversationActions.invalidateConversation();
+      return result;
     },
-    [attachmentsService, conversationId, canvasState]
+    [
+      attachmentsService,
+      conversationId,
+      canvasState,
+      setCanvasAttachmentOrigin,
+      conversationActions,
+    ]
   );
 
   const uiDefinition = canvasState

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import type { UnknownAttachment } from '@kbn/agent-builder-common/attachments';
 import { EuiSplitPanel } from '@elastic/eui';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
+import { useConversationContext } from '../../../../../context/conversation/conversation_context';
 import { AttachmentHeader } from './attachment_header';
 import { useCanvasContext } from './canvas_context';
 
@@ -29,6 +30,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   conversationId,
 }) => {
   const { openCanvas: openCanvasContext, canvasState } = useCanvasContext();
+  const { conversationActions } = useConversationContext();
 
   const openCanvas = useCallback(() => {
     openCanvasContext(attachment, isSidebar);
@@ -36,9 +38,11 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
 
   const updateOrigin = useCallback(
     async (origin: unknown) => {
-      return attachmentsService.updateOrigin(conversationId, attachment.id, origin);
+      const result = await attachmentsService.updateOrigin(conversationId, attachment.id, origin);
+      conversationActions.invalidateConversation();
+      return result;
     },
-    [attachmentsService, conversationId, attachment.id]
+    [attachmentsService, conversationId, attachment.id, conversationActions]
   );
 
   const uiDefinition = attachmentsService.getAttachmentUiDefinition(attachment.type);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
@@ -95,6 +95,7 @@ export const createRenderAttachmentRenderer = ({
           type: attachment.type,
           data: versionData.data,
           hidden: attachment.hidden,
+          origin: attachment.origin,
         }}
         conversationId={conversationId}
         attachmentsService={attachmentsService}


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/13179

- [x] After consumers call updateOrigin, we should invalidate the conversation cache so that it updates the conversation.attachments
- [x] After consumers call updateOrigin, we should update the attachment stored in the canvas context