### PR TITLE
[APM/Infra] Add optional chaining for .find() on potentially undefined arrays

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
@@ -403,7 +403,7 @@ export function FailedTransactionsCorrelations({ onFilter }: { onFilter: () => v
           h.fieldValue === selectedSignificantTerm.fieldValue
       );
     } else if (pinnedSignificantTerm) {
-      return correlationTerms.find(
+      return correlationTerms?.find(
         (h) =>
           h.fieldName === pinnedSignificantTerm.fieldName &&
           h.fieldValue === pinnedSignificantTerm.fieldValue

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/correlations/latency_correlations.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/correlations/latency_correlations.tsx
@@ -298,7 +298,7 @@ export function LatencyCorrelations({ onFilter }: { onFilter: () => void }) {
           h.fieldValue === selectedSignificantTerm.fieldValue
       );
     } else if (pinnedSignificantTerm) {
-      return histogramTerms.find(
+      return histogramTerms?.find(
         (h) =>
           h.fieldName === pinnedSignificantTerm.fieldName &&
           h.fieldValue === pinnedSignificantTerm.fieldValue

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/diagnostics/data_stream_tab.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/diagnostics/data_stream_tab.tsx
@@ -69,5 +69,5 @@ function DataStreamsTable({ data }: { data?: DiagnosticsBundle }) {
 }
 
 export function getIndexTemplateState(diagnosticsBundle: DiagnosticsBundle, templateName: string) {
-  return diagnosticsBundle.apmIndexTemplates.find(({ name }) => templateName === name);
+  return diagnosticsBundle.apmIndexTemplates?.find(({ name }) => templateName === name);
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_dashboards/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_dashboards/index.tsx
@@ -76,7 +76,7 @@ export function ServiceDashboards() {
   useEffect(() => {
     const filteredServiceDashboards = (data?.serviceDashboards ?? []).reduce(
       (result: MergedServiceDashboard[], serviceDashboard: SavedApmCustomDashboard) => {
-        const matchedDashboard = allAvailableDashboards.find(
+        const matchedDashboard = allAvailableDashboards?.find(
           ({ id }) => id === serviceDashboard.dashboardSavedObjectId
         );
         if (matchedDashboard) {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/use_keyboard_navigation.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/use_keyboard_navigation.ts
@@ -56,7 +56,7 @@ export function useKeyboardNavigation({
    */
   const findNodeInDirection = useCallback(
     (currentNodeId: string, direction: ArrowDirection): ServiceMapNode | null => {
-      const currentNode = nodes.find((n) => n.id === currentNodeId);
+      const currentNode = nodes?.find((n) => n.id === currentNodeId);
       if (!currentNode) return null;
 
       const current = currentNode.position;
@@ -105,7 +105,7 @@ export function useKeyboardNavigation({
         if (edgeElement) {
           const edgeElementId = edgeElement.getAttribute('data-id');
           if (!edgeElementId) return;
-          const focusedEdge = edges.find((e) => e.id === edgeElementId);
+          const focusedEdge = edges?.find((e) => e.id === edgeElementId);
           if (!focusedEdge) return;
           event.preventDefault();
 
@@ -128,7 +128,7 @@ export function useKeyboardNavigation({
         const nodeElement = activeElement?.closest('[data-id]');
         if (nodeElement && !edgeElement) {
           const nodeId = nodeElement.getAttribute('data-id');
-          const focusedNode = nodes.find((n) => n.id === nodeId);
+          const focusedNode = nodes?.find((n) => n.id === nodeId);
           if (!focusedNode) return;
 
           event.preventDefault();

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/apm_indices/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/apm_indices/index.tsx
@@ -189,7 +189,7 @@ export function ApmIndices() {
         <EuiFlexItem grow={false}>
           <EuiForm>
             {APM_INDEX_LABELS.map(({ configurationName, label }) => {
-              const matchedConfiguration = data.apmIndexSettings.find(
+              const matchedConfiguration = data.apmIndexSettings?.find(
                 ({ configurationName: configName }) => configName === configurationName
               );
               const defaultValue = matchedConfiguration ? matchedConfiguration.defaultValue : '';

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_flyout.tsx
@@ -36,7 +36,7 @@ export function WaterfallFlyout({ waterfallItemId, waterfall, toggleFlyout }: Pr
     '/traces/explorer/waterfall',
     '/dependencies/operation'
   );
-  const currentItem = waterfall.items.find((item) => item.id === waterfallItemId);
+  const currentItem = waterfall.items?.find((item) => item.id === waterfallItemId);
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -163,7 +163,7 @@ function getErrorItem(
   entryWaterfallTransaction?: IWaterfallTransaction
 ): IWaterfallError {
   const entryTimestamp = entryWaterfallTransaction?.doc.timestamp.us ?? 0;
-  const parent = items.find((waterfallItem) => waterfallItem.id === error.parent?.id) as
+  const parent = items?.find((waterfallItem) => waterfallItem.id === error.parent?.id) as
     | IWaterfallSpanOrTransaction
     | undefined;
 
@@ -387,7 +387,7 @@ const getEntryWaterfallTransaction = (
   entryTransactionId: string,
   waterfallItems: IWaterfallItem[]
 ): IWaterfallTransaction | undefined =>
-  waterfallItems.find(
+  waterfallItems?.find(
     (item) => item.docType === 'transaction' && item.id === entryTransactionId
   ) as IWaterfallTransaction;
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/service_group_template.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/service_group_template.tsx
@@ -77,7 +77,7 @@ export function ServiceGroupTemplate({
   );
 
   const tabs = useTabs(serviceGroupContextTab);
-  const selectedTab = tabs.find(({ isSelected }) => isSelected);
+  const selectedTab = tabs?.find(({ isSelected }) => isSelected);
 
   // this is only used for building the breadcrumbs for the service group page
   useBreadcrumb(
@@ -121,6 +121,13 @@ export function ServiceGroupTemplate({
     }
   );
 
+  const returnToServiceGroupsBreadcrumbLabel = i18n.translate(
+    'xpack.apm.serviceGroups.breadcrumb.return',
+    {
+      defaultMessage: 'Return to service groups',
+    }
+  );
+
   return (
     <ApmIndexSettingsContextProvider>
       <ApmMainTemplate
@@ -132,10 +139,12 @@ export function ServiceGroupTemplate({
                 {
                   text: (
                     <>
-                      <EuiIcon size="s" type="arrowLeft" />{' '}
-                      {i18n.translate('xpack.apm.serviceGroups.breadcrumb.return', {
-                        defaultMessage: 'Return to service groups',
-                      })}
+                      <EuiIcon
+                        aria-label={returnToServiceGroupsBreadcrumbLabel}
+                        size="s"
+                        type="arrowLeft"
+                      />{' '}
+                      {returnToServiceGroupsBreadcrumbLabel}
                     </>
                   ),
                   color: 'primary',

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_error_click_handler.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_error_click_handler.ts
@@ -34,7 +34,7 @@ export function useErrorClickHandler(traceItems: TraceItem[]): OnErrorClick {
 
   return useCallback(
     ({ traceId: errorTraceId, docId }) => {
-      const item = traceItems.find((i) => i.id === docId);
+      const item = traceItems?.find((i) => i.id === docId);
       if (!item) return;
 
       const idField = item.docType === 'span' ? SPAN_ID : TRANSACTION_ID;

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_waterfall.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_waterfall.ts
@@ -253,7 +253,7 @@ export function getRootItemOrFallback(
   }
 
   const entryTransactionRootItem = entryTransactionId
-    ? traceItems.find((item) => item.id === entryTransactionId)
+    ? traceItems?.find((item) => item.id === entryTransactionId)
     : undefined;
 
   const rootItem = entryTransactionRootItem

--- a/x-pack/solutions/observability/plugins/infra/public/alerting/inventory/components/expression.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/inventory/components/expression.tsx
@@ -650,7 +650,7 @@ export const ExpressionRow = (props: PropsWithChildren<ExpressionRowProps>) => {
                   text: ofFields?.find((v) => v?.value === metric)?.text || '',
                 }}
                 metrics={
-                  ofFields.filter((m) => m !== undefined && m.value !== undefined) as Array<{
+                  ofFields?.filter((m) => m !== undefined && m.value !== undefined) as Array<{
                     value: SnapshotMetricType;
                     text: string;
                   }>

--- a/x-pack/solutions/observability/plugins/infra/public/alerting/inventory/components/expression.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/inventory/components/expression.tsx
@@ -647,7 +647,7 @@ export const ExpressionRow = (props: PropsWithChildren<ExpressionRowProps>) => {
               <MetricExpression
                 metric={{
                   value: metric!,
-                  text: ofFields.find((v) => v?.value === metric)?.text || '',
+                  text: ofFields?.find((v) => v?.value === metric)?.text || '',
                 }}
                 metrics={
                   ofFields.filter((m) => m !== undefined && m.value !== undefined) as Array<{

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/dashboards/dashboard_selector.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/dashboards/dashboard_selector.tsx
@@ -36,7 +36,7 @@ export function DashboardSelector({
   });
 
   useEffect(() => {
-    const preselectedDashboard = customDashboards.find(
+    const preselectedDashboard = customDashboards?.find(
       ({ dashboardSavedObjectId }) => dashboardSavedObjectId === currentDashboardId
     );
     // preselect dashboard
@@ -54,8 +54,16 @@ export function DashboardSelector({
     [onRefresh, setUrlState]
   );
 
+  const selectDashboardLabel = i18n.translate(
+    'xpack.infra.customDashboards.selectDashboard.placeholder',
+    {
+      defaultMessage: 'Select dashboard',
+    }
+  );
+
   return (
     <EuiComboBox
+      aria-label={selectDashboardLabel}
       compressed
       style={{ minWidth: '200px' }}
       placeholder={i18n.translate('xpack.infra.customDashboards.selectDashboard.placeholder', {

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/metadata/add_metadata_filter_button.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/metadata/add_metadata_filter_button.tsx
@@ -37,7 +37,7 @@ export const AddMetadataFilterButton = ({ item }: AddMetadataFilterButtonProps) 
   } = useKibanaContextForPlugin();
 
   const existingFilter = useMemo(
-    () => searchCriteria?.filters.find((filter) => filter.meta.key === item.name),
+    () => searchCriteria?.filters?.find((filter) => filter.meta.key === item.name),
     [item.name, searchCriteria?.filters]
   );
 

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/metadata/add_metadata_filter_button.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/metadata/add_metadata_filter_button.tsx
@@ -37,7 +37,7 @@ export const AddMetadataFilterButton = ({ item }: AddMetadataFilterButtonProps) 
   } = useKibanaContextForPlugin();
 
   const existingFilter = useMemo(
-    () => searchCriteria?.filters?.find((filter) => filter.meta.key === item.name),
+    () => searchCriteria?.filters.find((filter) => filter.meta.key === item.name),
     [item.name, searchCriteria?.filters]
   );
 

--- a/x-pack/solutions/observability/plugins/infra/public/pages/logs/log_entry_categories/sections/top_categories/log_entry_count_sparkline.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/logs/log_entry_categories/sections/top_categories/log_entry_count_sparkline.tsx
@@ -20,7 +20,7 @@ export const LogEntryCountSparkline: React.FunctionComponent<{
   const metric = useMemo(
     () =>
       histograms
-        .find((histogram) => histogram.histogramId === 'history')
+        ?.find((histogram) => histogram.histogramId === 'history')
         ?.buckets?.map(({ startTime: timestamp, logEntryCount: value }) => ({
           timestamp,
           value,
@@ -29,7 +29,7 @@ export const LogEntryCountSparkline: React.FunctionComponent<{
   );
   const referenceCount = useMemo(
     () =>
-      histograms.find((histogram) => histogram.histogramId === 'reference')?.buckets?.[0]
+      histograms?.find((histogram) => histogram.histogramId === 'reference')?.buckets?.[0]
         ?.logEntryCount ?? 0,
     [histograms]
   );

--- a/x-pack/solutions/observability/plugins/infra/public/pages/logs/log_entry_rate/sections/anomalies/table.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/logs/log_entry_rate/sections/anomalies/table.tsx
@@ -134,7 +134,7 @@ export const AnomaliesTable: React.FunctionComponent<{
   const expandedIdsRowContents = useMemo(
     () =>
       [...expandedIds].reduce<Record<string, React.ReactNode>>((aggregatedRows, id) => {
-        const anomaly = results.find((_anomaly) => _anomaly.id === id);
+        const anomaly = results?.find((_anomaly) => _anomaly.id === id);
 
         return {
           ...aggregatedRows,

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/nodes_overview.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/nodes_overview.tsx
@@ -83,7 +83,7 @@ export const NodesOverview = ({
   );
 
   const nodeName = useMemo(
-    () => nodes.find((node) => node.path[0].value === detailsItemId)?.name,
+    () => nodes?.find((node) => node.path[0].value === detailsItemId)?.name,
     [detailsItemId, nodes]
   );
 

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/conditional_tooltip.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/conditional_tooltip.tsx
@@ -93,7 +93,7 @@ export const ConditionalToolTip = ({ node, nodeType, currentTime }: Props) => {
           // if custom metric, find field and label from waffleOptionsContext result
           // because useSnapshot does not return it
           const customMetric =
-            name === 'custom' ? customMetrics.find((item) => item.id === metric.name) : null;
+            name === 'custom' ? customMetrics?.find((item) => item.id === metric.name) : null;
           const formatter = customMetric
             ? createFormatterForMetric(customMetric)
             : createInventoryMetricFormatter({ type: metricName });

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/metrics_context_menu.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/metrics_context_menu.tsx
@@ -37,7 +37,7 @@ export const MetricsContextMenu = ({
   const handleClick = useCallback(
     (val: string) => {
       if (!SnapshotMetricTypeRT.is(val)) {
-        const selectedMetric = customMetrics.find((m) => m.id === val);
+        const selectedMetric = customMetrics?.find((m) => m.id === val);
         if (selectedMetric) {
           onChange(selectedMetric);
         }

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_group_by_controls.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_group_by_controls.tsx
@@ -140,7 +140,7 @@ export const WaffleGroupByControls = ({
   const buttonBody =
     groupBy.length > 0 ? (
       groupBy
-        .map((g) => combinedOptions.find((o) => o.field === g.field))
+        .map((g) => combinedOptions?.find((o) => o.field === g.field))
         .filter((o) => o != null)
         // In this map the `o && o.field` is totally unnecessary but Typescript is
         // too stupid to realize that the filter above prevents the next map from being null


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/254200

### Summary
Audited APM and Infra public components for .find() calls on arrays that could be undefined at runtime, causing PageFatalReactError ("Cannot read properties of undefined (reading 'find')").
Added optional chaining (?.find()) across 20 call sites in 16 files to prevent crashes when arrays are undefined during loading states, partial data, or edge-case route params