### PR TITLE
[Synthetics] Fix flaky MonitorEditPage Jest test timeout

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import { render } from '../../utils/testing/rtl_helpers';
 import { MonitorEditPage } from './monitor_edit_page';
 import { useMonitorName } from '../../hooks/use_monitor_name';
@@ -30,7 +30,6 @@ jest.mock('../../../../hooks/use_kibana_space', () => ({
   useKibanaSpace: jest.fn().mockReturnValue({ id: 'default' }),
 }));
 
-// Failing: See https://github.com/elastic/kibana/issues/234711
 describe('MonitorEditPage', () => {
   const { FETCH_STATUS } = observabilitySharedPublic;
 
@@ -243,11 +242,11 @@ describe('MonitorEditPage', () => {
       fireEvent.change(inputField, { target: { value: 'any value' } }); // Hook is made to return duplicate error as true
       fireEvent.blur(inputField);
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(1000);
       });
       if (nameAlreadyExists) {
-        await waitFor(() => getByText('Monitor name already exists'));
+        expect(getByText('Monitor name already exists')).toBeInTheDocument();
       } else {
         expect(queryByText('Monitor name already exists')).not.toBeInTheDocument();
       }


### PR DESCRIPTION
## Summary

Fixes 1 flaky test issue tracked in https://github.com/elastic/kibana/issues/244600

### Root Cause

The `MonitorEditPage` test uses `jest.useFakeTimers()` in `beforeEach`, then calls `waitFor(() => getByText('Monitor name already exists'))` after advancing fake timers. `waitFor` polls using real timers (via `setTimeout`), but with fake timers active, those `setTimeout` calls never fire. The test hangs until the 5000ms Jest timeout.

### Changes

- Replaced `act(() => { jest.advanceTimersByTime(1000) })` + `await waitFor(...)` with `await act(async () => { jest.advanceTimersByTime(1000) })` followed by synchronous assertions
- `await act(async ...)` properly flushes React state updates and effects after advancing fake timers, eliminating the need for `waitFor`
- Removed unused `waitFor` import
- Removed stale "Failing" comment referencing #234711

### Issues Fixed

- Fixes #234710

### Verified locally

All 7 tests pass:
```
✓ renders correctly (1.6s)
✓ renders when loading locations (10ms)
✓ renders when monitor is loading (16ms)
✓ renders a location error (41ms)
✓ renders a monitor loading error (14ms)
✓ shows duplicate error when "nameAlreadyExists" is true (1182ms)
✓ shows duplicate error when "nameAlreadyExists" is false (960ms)
```

## Test plan

- [ ] Run `yarn test:jest x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_edit_page.test.tsx` multiple times to confirm no timeout

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->