### PR TITLE
[8.19] updates hashing algorithms to be fips140-3 compliant (#241713)

### DIFF
--- a/src/core/packages/apps/server-internal/src/bundle_routes/dynamic_asset_response.test.ts
+++ b/src/core/packages/apps/server-internal/src/bundle_routes/dynamic_asset_response.test.ts
@@ -82,7 +82,7 @@ describe('headers', () => {
     expect(result.options.headers).toEqual({
       'cache-control': 'must-revalidate',
       'content-type': 'application/javascript; charset=utf-8',
-      etag: expect.stringMatching(/^[a-f0-9]{40}-\/public/i),
+      etag: expect.stringMatching(/^[a-f0-9]{64}-\/public/i),
     });
   });
 });

--- a/src/core/packages/apps/server-internal/src/bundle_routes/utils.ts
+++ b/src/core/packages/apps/server-internal/src/bundle_routes/utils.ts
@@ -13,7 +13,7 @@ import * as Rx from 'rxjs';
 import { map, takeUntil } from 'rxjs';
 
 export const generateFileHash = (fd: number): Promise<string> => {
-  const hash = createHash('sha1');
+  const hash = createHash('sha256');
   const read = createReadStream(null as any, {
     fd,
     start: 0,

--- a/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
@@ -104,7 +104,7 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
       publicPathMap,
     });
 
-    const hash = createHash('sha1');
+    const hash = createHash('sha256');
     hash.update(body);
     const etag = hash.digest('hex');
 


### PR DESCRIPTION
# Backport

Relates https://github.com/elastic/kibana/issues/255857

This will backport the following commits from `main` to `8.19`:
 - [updates hashing algorithms to be fips140-3 compliant (#241713)](https://github.com/elastic/kibana/pull/241713)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brian Do","email":"brian.do@elastic.co"},"sourceCommit":{"committedDate":"2025-11-04T15:02:13Z","message":"updates hashing algorithms to be fips140-3 compliant (#241713)\n\n## Summary\n\nA recent CodeQL scan revealed two locations\n([A](https://github.com/elastic/kibana/security/code-scanning/611) and\n[B](https://github.com/elastic/kibana/security/code-scanning/610)) where\nweak hashing algorithms are used.\n\nThese alerts were initially classified as a false positive, but was\nlater found that while sha1 is currently approved for FIPS 140-2, it\nwon't be approved under FIPS 140-3.\n\n## Implementation\nThis PR updates uses of the weak SHA1 algorithm with the stronger,\nstandard SHA256 algorithm in the two locations identified by the CodeQL\nscan.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nOne thing to consider is that SHA256 is potentially not a drop-in\nreplacement for SHA1. That is because, for the same inputs, these two\nalgorithms produce different hashes, with different lengths. However,\nthese hashes are meant to be generated for etags, which are ephemeral\ncache identifiers. This will simply cause a one-time cache bust as the\netags will change due to the change in algorithm.","sha":"84da85e598f45a1360f5fc7e2f20a00ae5d628cc","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:version","v9.3.0","ci:codeql","v9.4.0","v8.19.13"],"title":"updates hashing algorithms to be fips140-3 compliant","number":241713,"url":"https://github.com/elastic/kibana/pull/241713","mergeCommit":{"message":"updates hashing algorithms to be fips140-3 compliant (#241713)\n\n## Summary\n\nA recent CodeQL scan revealed two locations\n([A](https://github.com/elastic/kibana/security/code-scanning/611) and\n[B](https://github.com/elastic/kibana/security/code-scanning/610)) where\nweak hashing algorithms are used.\n\nThese alerts were initially classified as a false positive, but was\nlater found that while sha1 is currently approved for FIPS 140-2, it\nwon't be approved under FIPS 140-3.\n\n## Implementation\nThis PR updates uses of the weak SHA1 algorithm with the stronger,\nstandard SHA256 algorithm in the two locations identified by the CodeQL\nscan.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nOne thing to consider is that SHA256 is potentially not a drop-in\nreplacement for SHA1. That is because, for the same inputs, these two\nalgorithms produce different hashes, with different lengths. However,\nthese hashes are meant to be generated for etags, which are ephemeral\ncache identifiers. This will simply cause a one-time cache bust as the\netags will change due to the change in algorithm.","sha":"84da85e598f45a1360f5fc7e2f20a00ae5d628cc"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241713","number":241713,"mergeCommit":{"message":"updates hashing algorithms to be fips140-3 compliant (#241713)\n\n## Summary\n\nA recent CodeQL scan revealed two locations\n([A](https://github.com/elastic/kibana/security/code-scanning/611) and\n[B](https://github.com/elastic/kibana/security/code-scanning/610)) where\nweak hashing algorithms are used.\n\nThese alerts were initially classified as a false positive, but was\nlater found that while sha1 is currently approved for FIPS 140-2, it\nwon't be approved under FIPS 140-3.\n\n## Implementation\nThis PR updates uses of the weak SHA1 algorithm with the stronger,\nstandard SHA256 algorithm in the two locations identified by the CodeQL\nscan.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\nOne thing to consider is that SHA256 is potentially not a drop-in\nreplacement for SHA1. That is because, for the same inputs, these two\nalgorithms produce different hashes, with different lengths. However,\nthese hashes are meant to be generated for etags, which are ephemeral\ncache identifiers. This will simply cause a one-time cache bust as the\netags will change due to the change in algorithm.","sha":"84da85e598f45a1360f5fc7e2f20a00ae5d628cc"}},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->