### PR TITLE
Upgrade terser-webpack-plugin 5.3.14 → 5.3.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -2109,7 +2109,7 @@
     "table": "6.9.0",
     "tape": "5.9.0",
     "terser": "5.40.0",
-    "terser-webpack-plugin": "5.3.14",
+    "terser-webpack-plugin": "5.3.17",
     "tough-cookie": "6.0.0",
     "trace": "3.2.0",
     "tree-kill": "1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32949,15 +32949,14 @@ terminal-link@^2.1.1:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@5.3.14, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.10:
-  version "5.3.14"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz#9031d48e57ab27567f02ace85c7d690db66c3e06"
-  integrity sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==
+terser-webpack-plugin@5.3.17, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.10:
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz#75ea98876297fbb190d2fbb395e982582b859a67"
+  integrity sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.25"
     jest-worker "^27.4.5"
     schema-utils "^4.3.0"
-    serialize-javascript "^6.0.2"
     terser "^5.31.1"
 
 terser@5.40.0, terser@^5.10.0, terser@^5.31.1, terser@^5.9.0:


### PR DESCRIPTION
## Summary

Upgrades `terser-webpack-plugin` from v5.3.14 to v5.3.17

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->