### PR TITLE
[8.19] Update ETag hashing algorithm (#240974)

### DIFF
--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/fields.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/fields.ts
@@ -17,7 +17,7 @@ import { parseFields, IBody, IQuery, querySchema, validate } from './fields_for'
 import { DEFAULT_FIELD_CACHE_FRESHNESS } from '../../constants';
 
 export function calculateHash(srcBuffer: Buffer) {
-  const hash = createHash('sha1');
+  const hash = createHash('sha256');
   hash.update(srcBuffer);
   return hash.digest('hex');
 }


### PR DESCRIPTION
# Backport

Relates #255857

This will backport the following commits from `main` to `8.19`:
 - [Update ETag hashing algorithm (#240974)](https://github.com/elastic/kibana/pull/240974)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alejandro García Parrondo","email":"31973472+AlexGPlay@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-10-31T10:15:44Z","message":"Update ETag hashing algorithm (#240974)\n\nCloses https://github.com/elastic/kibana-team/issues/2027\n\n## Summary\n\nChanges the ETag algorithm from sha1 to sha512 to be FIPS 140-3\ncompliant.\nI guess the only downside to this change is that the browsers that did\nthe requests when it was still done with sha1 will have a cache miss and\nwill need to request again the whole response.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"7234ca2bf5b60dd2ab4067a8c789ca6344838022","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.3.0","v9.4.0","v8.19.13"],"title":"Update ETag hashing algorithm","number":240974,"url":"https://github.com/elastic/kibana/pull/240974","mergeCommit":{"message":"Update ETag hashing algorithm (#240974)\n\nCloses https://github.com/elastic/kibana-team/issues/2027\n\n## Summary\n\nChanges the ETag algorithm from sha1 to sha512 to be FIPS 140-3\ncompliant.\nI guess the only downside to this change is that the browsers that did\nthe requests when it was still done with sha1 will have a cache miss and\nwill need to request again the whole response.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"7234ca2bf5b60dd2ab4067a8c789ca6344838022"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240974","number":240974,"mergeCommit":{"message":"Update ETag hashing algorithm (#240974)\n\nCloses https://github.com/elastic/kibana-team/issues/2027\n\n## Summary\n\nChanges the ETag algorithm from sha1 to sha512 to be FIPS 140-3\ncompliant.\nI guess the only downside to this change is that the browsers that did\nthe requests when it was still done with sha1 will have a cache miss and\nwill need to request again the whole response.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"7234ca2bf5b60dd2ab4067a8c789ca6344838022"}},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->