### PR TITLE
[Controls] Fix pinned state for ES|QL and range slider controls

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
@@ -11,7 +11,7 @@ import React, { useEffect } from 'react';
 import { BehaviorSubject, combineLatest, debounceTime, map, merge, of, skip } from 'rxjs';
 
 import {
-  apiCanPinPanels,
+  apiHasPinnedPanels,
   apiHasSections,
   apiPublishesViewMode,
   fetch$,
@@ -210,7 +210,7 @@ export const getRangesliderControlFactory = (): EmbeddableFactory<
         ? parentApi.viewMode$
         : new BehaviorSubject<boolean>(true);
 
-      const isPinned = apiCanPinPanels(parentApi) ? parentApi.panelIsPinned(uuid) : false;
+      const isPinned = apiHasPinnedPanels(parentApi) ? parentApi.panelIsPinned(uuid) : false;
 
       return {
         api,

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -15,7 +15,7 @@ import type { EmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import { apiPublishesESQLVariables } from '@kbn/esql-types';
 import {
   type PublishingSubject,
-  apiCanPinPanels,
+  apiHasPinnedPanels,
   initializeStateManager,
   initializeUnsavedChanges,
 } from '@kbn/presentation-publishing';
@@ -200,8 +200,8 @@ export const getESQLControlFactory = (): EmbeddableFactory<
         dataViews$: new BehaviorSubject(undefined) as OptionsListComponentApi['dataViews$'],
       };
 
-      const isPinned = apiCanPinPanels(parentApi) ? parentApi.panelIsPinned(uuid) : false;
-
+      const isPinned = apiHasPinnedPanels(parentApi) ? parentApi.panelIsPinned(uuid) : false;
+      console.log({ parentApi, isPinned });
       return {
         api,
         Component: () => {

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -201,7 +201,7 @@ export const getESQLControlFactory = (): EmbeddableFactory<
       };
 
       const isPinned = apiHasPinnedPanels(parentApi) ? parentApi.panelIsPinned(uuid) : false;
-      console.log({ parentApi, isPinned });
+
       return {
         api,
         Component: () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/255913

## Summary

This PR adjusts the pinned panels type guard for ES|QL + range slider controls so that, when they are rendered via the `ControlGroupRenderer`, the parent API passes.

#### Before
The parent API provided through the `ControlGroupRenderer` did not pass the `apiCanPinPanels` type guard, so `isPinned` defaulted to `false`:

<img width="1380" height="948" alt="image" src="https://github.com/user-attachments/assets/97b1fff9-4308-49e9-bc6a-3e5071e098c1" />


#### After
By switching to the less strict `apiHasPinnedPanels` type guard, the `ControlGroupRenderer` parent API now passes and it calls `panelIsPinned` as expected - which always returns true for the `ControlGroupRenderer`:

<img width="1380" height="948" alt="image" src="https://github.com/user-attachments/assets/130ec5af-47cc-4d27-b9f4-a51e13a47080" />


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
