### PR TITLE
[Scout] Splits the creation timeline test per role

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_creation.spec.ts
@@ -11,11 +11,12 @@ import { expect } from '@kbn/scout-security/ui';
 const DEFAULT_QUERY = 'host.name: *';
 
 spaceTest.describe(
-  'Timelines',
+  'Timeline creation',
   { tag: [...tags.stateful.classic, ...tags.serverless.security.complete] },
   () => {
-    spaceTest.beforeEach(async ({ apiServices }) => {
+    spaceTest.beforeEach(async ({ browserAuth, apiServices }) => {
       await apiServices.timeline.deleteAll();
+      await browserAuth.loginAsPlatformEngineer();
     });
 
     spaceTest.afterAll(async ({ apiServices }) => {
@@ -24,7 +25,7 @@ spaceTest.describe(
 
     spaceTest(
       'should create a timeline from a template and have the same query',
-      async ({ browserAuth, pageObjects, apiServices }) => {
+      async ({ pageObjects, apiServices }) => {
         const { timelinePage } = pageObjects;
 
         await apiServices.timeline.createTimelineTemplate({
@@ -32,7 +33,6 @@ spaceTest.describe(
           description: 'This is the best timeline',
           query: DEFAULT_QUERY,
         });
-        await browserAuth.loginAsPlatformEngineer();
 
         await spaceTest.step('Navigate to templates and select custom tab', async () => {
           await timelinePage.navigateToTemplates();
@@ -49,48 +49,21 @@ spaceTest.describe(
       }
     );
 
-    spaceTest(
-      'should be able to create timeline with crud privileges',
-      async ({ browserAuth, pageObjects }) => {
-        const { timelinePage } = pageObjects;
-
-        await browserAuth.loginAsPlatformEngineer();
-        await timelinePage.navigateToTimelines();
-        await timelinePage.open();
-        await timelinePage.createNew();
-
-        await timelinePage.addNameAndDescription('Security Timeline', 'This is the best timeline');
-
-        await expect(timelinePage.panel).toBeVisible();
-      }
-    );
-
-    spaceTest(
-      'should not be able to create/update timeline with only read privileges',
-      async ({ browserAuth, pageObjects }) => {
-        const { timelinePage } = pageObjects;
-
-        await browserAuth.loginAsT1Analyst();
-        await timelinePage.navigateToTimelines();
-        await timelinePage.open();
-        await timelinePage.createNew();
-
-        await expect(timelinePage.panel).toBeVisible();
-        await expect(timelinePage.saveButton).toBeDisabled();
-
-        await spaceTest.step('Hover save button and verify read-only tooltip', async () => {
-          await timelinePage.hoverSaveButton();
-          await expect(timelinePage.saveTooltip).toContainText(
-            'you do not have the required permissions to save timelines'
-          );
-        });
-      }
-    );
-
-    spaceTest('should show the different timeline states', async ({ browserAuth, pageObjects }) => {
+    spaceTest('should be able to create timeline', async ({ pageObjects }) => {
       const { timelinePage } = pageObjects;
 
-      await browserAuth.loginAsPlatformEngineer();
+      await timelinePage.navigateToTimelines();
+      await timelinePage.open();
+      await timelinePage.createNew();
+
+      await timelinePage.addNameAndDescription('Security Timeline', 'This is the best timeline');
+
+      await expect(timelinePage.panel).toBeVisible();
+    });
+
+    spaceTest('should show the different timeline states', async ({ pageObjects }) => {
+      const { timelinePage } = pageObjects;
+
       await timelinePage.navigateToTimelines();
       await timelinePage.open();
 
@@ -110,10 +83,9 @@ spaceTest.describe(
       });
     });
 
-    spaceTest('should save timelines as new', async ({ browserAuth, pageObjects }) => {
+    spaceTest('should save timelines as new', async ({ pageObjects }) => {
       const { timelinePage } = pageObjects;
 
-      await browserAuth.loginAsPlatformEngineer();
       await timelinePage.navigateToTimelines();
 
       await spaceTest.step('Verify no timelines exist initially', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_creation.spec.ts
@@ -14,9 +14,10 @@ spaceTest.describe(
   'Timeline creation',
   { tag: [...tags.stateful.classic, ...tags.serverless.security.complete] },
   () => {
-    spaceTest.beforeEach(async ({ browserAuth, apiServices }) => {
+    spaceTest.beforeEach(async ({ browserAuth, apiServices, pageObjects }) => {
       await apiServices.timeline.deleteAll();
       await browserAuth.loginAsPlatformEngineer();
+      await pageObjects.timelinePage.navigateToTimelines();
     });
 
     spaceTest.afterAll(async ({ apiServices }) => {
@@ -52,7 +53,6 @@ spaceTest.describe(
     spaceTest('should be able to create timeline', async ({ pageObjects }) => {
       const { timelinePage } = pageObjects;
 
-      await timelinePage.navigateToTimelines();
       await timelinePage.open();
       await timelinePage.createNew();
 
@@ -64,7 +64,6 @@ spaceTest.describe(
     spaceTest('should show the different timeline states', async ({ pageObjects }) => {
       const { timelinePage } = pageObjects;
 
-      await timelinePage.navigateToTimelines();
       await timelinePage.open();
 
       await spaceTest.step('Verify unsaved state on new timeline', async () => {
@@ -85,8 +84,6 @@ spaceTest.describe(
 
     spaceTest('should save timelines as new', async ({ pageObjects }) => {
       const { timelinePage } = pageObjects;
-
-      await timelinePage.navigateToTimelines();
 
       await spaceTest.step('Verify no timelines exist initially', async () => {
         await expect(timelinePage.timelinesTable).toContainText(

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_read_only.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_read_only.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { spaceTest, tags } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/ui';
+
+spaceTest.describe(
+  'Timeline read-only',
+  { tag: [...tags.stateful.classic, ...tags.serverless.security.complete] },
+  () => {
+    spaceTest.beforeEach(async ({ browserAuth, apiServices }) => {
+      await apiServices.timeline.deleteAll();
+      await browserAuth.loginAsT1Analyst();
+    });
+
+    spaceTest.afterAll(async ({ apiServices }) => {
+      await apiServices.timeline.deleteAll();
+    });
+
+    spaceTest(
+      'should not be able to create/update timeline with only read privileges',
+      async ({ pageObjects }) => {
+        const { timelinePage } = pageObjects;
+
+        await timelinePage.navigateToTimelines();
+        await timelinePage.open();
+        await timelinePage.createNew();
+
+        await expect(timelinePage.panel).toBeVisible();
+        await expect(timelinePage.saveButton).toBeDisabled();
+
+        await spaceTest.step('Hover save button and verify read-only tooltip', async () => {
+          await timelinePage.hoverSaveButton();
+          await expect(timelinePage.saveTooltip).toContainText(
+            'you do not have the required permissions to save timelines'
+          );
+        });
+      }
+    );
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_read_only.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/investigations/timeline_read_only.spec.ts
@@ -12,9 +12,10 @@ spaceTest.describe(
   'Timeline read-only',
   { tag: [...tags.stateful.classic, ...tags.serverless.security.complete] },
   () => {
-    spaceTest.beforeEach(async ({ browserAuth, apiServices }) => {
+    spaceTest.beforeEach(async ({ browserAuth, apiServices, pageObjects }) => {
       await apiServices.timeline.deleteAll();
       await browserAuth.loginAsT1Analyst();
+      await pageObjects.timelinePage.navigateToTimelines();
     });
 
     spaceTest.afterAll(async ({ apiServices }) => {
@@ -26,7 +27,6 @@ spaceTest.describe(
       async ({ pageObjects }) => {
         const { timelinePage } = pageObjects;
 
-        await timelinePage.navigateToTimelines();
         await timelinePage.open();
         await timelinePage.createNew();
 


### PR DESCRIPTION
## Summary

- Split `timeline_creation.spec.ts` into two separate spec files, organized by user role:
  - **`timeline_creation.spec.ts`** — CRUD tests using `loginAsPlatformEngineer()` (4 tests)
  - **`timeline_read_only.spec.ts`** — Read-only permission test using `loginAsT1Analyst()` (1 test)
- Each file is self-contained with its own setup/teardown (`deleteAll` in `beforeEach`/`afterAll`) and authentication in `beforeEach`
- Removes the nested `spaceTest.describe` blocks in favor of simpler, flatter file structure

## Motivation

Separating tests by role improves clarity and isolation. Tests with different authentication requirements run independently, making failures easier to diagnose and avoiding unnecessary nesting. This follows @csr [suggestion](https://github.com/elastic/kibana/pull/254539#discussion_r2884399385) to split by file rather than using nested describe blocks. 


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->