### PR TITLE
Fix high-cardinality page-load transaction names in kibana-frontend

### DIFF
--- a/src/core/packages/root/browser-internal/src/apm_system.test.ts
+++ b/src/core/packages/root/browser-internal/src/apm_system.test.ts
@@ -158,6 +158,31 @@ describe('ApmSystem', () => {
           'cached-resources': 0,
         });
       });
+
+      it('updates page-load transaction name to /app/{appId} before closing', async () => {
+        const apmSystem = new ApmSystem({ active: true });
+        const currentAppId$ = new Subject<string>();
+        const mockTransaction: MockedKeys<Transaction> = {
+          type: 'page-load',
+          name: '/app/apm/services/my-service/overview',
+          // @ts-expect-error 2345
+          block: jest.fn(),
+          mark: jest.fn(),
+          end: jest.fn(),
+          addLabels: jest.fn(),
+        };
+        apmMock.getCurrentTransaction.mockReturnValue(mockTransaction);
+        await apmSystem.setup();
+        await apmSystem.start({
+          application: {
+            currentAppId$,
+          } as any as InternalApplicationStart,
+          executionContext: executionContextServiceMock.createInternalStartContract(),
+        });
+        currentAppId$.next('apm');
+
+        expect(mockTransaction.name).toBe('/app/apm');
+      });
     });
 
     describe('http request normalization', () => {
@@ -282,6 +307,133 @@ describe('ApmSystem', () => {
             name: 'GET /alpha/beta/',
           } as Transaction)
         ).toEqual({ type: 'http-request', name: 'GET /beta/' });
+      });
+    });
+
+    describe('route-change normalization', () => {
+      const returnArg = <T>(func: (input: T) => any): ((input: T) => T) => {
+        return (input) => {
+          func(input);
+          return input;
+        };
+      };
+
+      it('updates page-load transaction name from execution context when page is available', async () => {
+        const apmSystem = new ApmSystem({ active: true });
+
+        const executionContext = executionContextServiceMock.createInternalStartContract();
+        executionContext.get.mockReturnValue({
+          name: 'apm',
+          page: '/services/:serviceName/overview',
+        });
+
+        await apmSystem.setup();
+        await apmSystem.start({
+          application: {
+            currentAppId$: new Subject<string>(),
+          } as any as InternalApplicationStart,
+          executionContext,
+        });
+
+        const routeChangeObserver = apmMock.observe.mock.calls[1][1];
+        const wrappedObserver = returnArg(routeChangeObserver);
+
+        expect(
+          wrappedObserver({
+            type: 'page-load',
+            name: '/app/apm/services/my-service/overview',
+          } as Transaction)
+        ).toEqual({
+          type: 'page-load',
+          name: 'apm /services/:serviceName/overview',
+        });
+      });
+
+      it('does not modify page-load transaction name when execution context has no page', async () => {
+        const apmSystem = new ApmSystem({ active: true });
+
+        const executionContext = executionContextServiceMock.createInternalStartContract();
+        executionContext.get.mockReturnValue({ name: 'apm' });
+
+        await apmSystem.setup();
+        await apmSystem.start({
+          application: {
+            currentAppId$: new Subject<string>(),
+          } as any as InternalApplicationStart,
+          executionContext,
+        });
+
+        const routeChangeObserver = apmMock.observe.mock.calls[1][1];
+        const wrappedObserver = returnArg(routeChangeObserver);
+
+        expect(
+          wrappedObserver({
+            type: 'page-load',
+            name: '/app/apm',
+          } as Transaction)
+        ).toEqual({
+          type: 'page-load',
+          name: '/app/apm',
+        });
+      });
+
+      it('still updates route-change transaction names from execution context', async () => {
+        const apmSystem = new ApmSystem({ active: true });
+
+        const executionContext = executionContextServiceMock.createInternalStartContract();
+        executionContext.get.mockReturnValue({
+          name: 'security',
+          page: '/rules/:id/edit',
+        });
+
+        await apmSystem.setup();
+        await apmSystem.start({
+          application: {
+            currentAppId$: new Subject<string>(),
+          } as any as InternalApplicationStart,
+          executionContext,
+        });
+
+        const routeChangeObserver = apmMock.observe.mock.calls[1][1];
+        const wrappedObserver = returnArg(routeChangeObserver);
+
+        expect(
+          wrappedObserver({
+            type: 'route-change',
+            name: 'Click - a',
+          } as Transaction)
+        ).toEqual({
+          type: 'route-change',
+          name: 'security /rules/:id/edit',
+        });
+      });
+
+      it('falls back to /app/{appId} for page-load when execution context has no page', async () => {
+        const apmSystem = new ApmSystem({ active: true });
+        const executionContext = executionContextServiceMock.createInternalStartContract();
+        executionContext.get.mockReturnValue({ name: 'apm' });
+
+        const currentAppId$ = new Subject<string>();
+        const mockTransaction: MockedKeys<Transaction> = {
+          type: 'page-load',
+          name: '/app/apm/services/my-service/overview',
+          // @ts-expect-error 2345
+          block: jest.fn(),
+          mark: jest.fn(),
+          end: jest.fn(),
+          addLabels: jest.fn(),
+        };
+        apmMock.getCurrentTransaction.mockReturnValue(mockTransaction);
+        await apmSystem.setup();
+        await apmSystem.start({
+          application: {
+            currentAppId$,
+          } as any as InternalApplicationStart,
+          executionContext,
+        });
+        currentAppId$.next('apm');
+
+        expect(mockTransaction.name).toBe('/app/apm');
       });
     });
 

--- a/src/core/packages/root/browser-internal/src/apm_system.ts
+++ b/src/core/packages/root/browser-internal/src/apm_system.ts
@@ -118,7 +118,7 @@ export class ApmSystem {
      */
     start.application.currentAppId$.subscribe((appId) => {
       if (appId && this.apm) {
-        this.closePageLoadTransaction();
+        this.closePageLoadTransaction(appId);
         this.apm.startTransaction(appId, 'app-change', {
           managed: true,
           canReuse: true,
@@ -141,8 +141,11 @@ export class ApmSystem {
   }
 
   /* Close and clear the page load transaction */
-  private closePageLoadTransaction() {
+  private closePageLoadTransaction(appId?: string) {
     if (this.pageLoadTransaction) {
+      if (appId) {
+        this.pageLoadTransaction.name = `/app/${appId}`;
+      }
       const loadCounts = this.resourceObserver.getCounts();
       this.pageLoadTransaction.addLabels({
         'loaded-resources': loadCounts.networkOrDisk,
@@ -217,9 +220,9 @@ export class ApmSystem {
   private addRouteChangeNormalization(apm: ApmBase) {
     apm.observe('transaction:end', (t) => {
       const executionContext = this.executionContext?.get();
-      if (executionContext && t.type === 'route-change') {
+      if (executionContext?.page && (t.type === 'route-change' || t.type === 'page-load')) {
         const { name, page } = executionContext;
-        t.name = `${name} ${page || 'unknown'}`;
+        t.name = `${name} ${page}`;
       }
     });
   }


### PR DESCRIPTION
## Summary

Closes #256044

Page-load transactions in the `kibana-frontend` RUM agent were using raw URL paths as transaction names (e.g., `/app/apm/services/my-actual-service/overview`), creating unbounded cardinality proportional to the number of distinct URLs visited.

### Changes

- **`closePageLoadTransaction(appId)`**: Before closing the page-load transaction, set its name to `/app/{appId}` as a low-cardinality fallback.
- **`addRouteChangeNormalization`**: Extend the observer to also handle `page-load` type transactions (not just `route-change`), so the execution context can provide a properly parameterized route name (e.g., `apm /services/:serviceName/overview`) when available. Only overrides the name when the execution context has a `page` property set, preserving the `/app/{appId}` fallback otherwise.

### Transaction name resolution order

1. Server sets `pageLoadTransactionName` to raw URL path (unchanged)
2. `closePageLoadTransaction` overrides to `/app/{appId}` (new)
3. `transaction:end` observer overrides to `{name} {page}` from execution context if `page` is available (new for page-load type)

## Test plan

- [x] New unit tests in `apm_system.test.ts`:
  - Page-load transaction name updated to `/app/{appId}` before closing
  - Observer parameterizes page-load names when execution context page is available
  - Observer leaves page-load name unchanged when execution context has no page
  - Route-change transactions still normalized correctly (no regression)
- [x] Existing tests pass unchanged
- [x] Type check clean
- [x] Lint clean


Made with [Cursor](https://cursor.com)