### PR TITLE
kibana operations should own src/cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1983,8 +1983,7 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/dev/license_checker/config.ts @elastic/kibana-operations
 /src/dev/ @elastic/kibana-operations
 /src/setup_node_env/ @elastic/kibana-operations
-/src/cli/keystore/ @elastic/kibana-operations
-/src/cli/serve/ @elastic/kibana-operations
+/src/cli/ @elastic/kibana-operations
 /src/cli_keystore/ @elastic/kibana-operations
 /.github/workflows/ @elastic/kibana-operations
 /.github/copilot-instructions.md @elastic/kibana-operations


### PR DESCRIPTION
## Summary
After a recent restructure, the codeowners file doesn't seem to cover all the src/cli folders. This PR corrects it.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->