### PR TITLE
[ES|QL] Suggest only shorthands time units

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@elastic/eui-theme-borealis": "6.1.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/kibana-d3-color": "npm:@elastic/kibana-d3-color@2.0.1",
-    "@elastic/monaco-esql": "3.1.18",
+    "@elastic/monaco-esql": "3.1.19",
     "@elastic/node-crypto": "1.2.3",
     "@elastic/numeral": "2.5.1",
     "@elastic/opentelemetry-node": "1.8.0",

--- a/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/autocomplete.ts
@@ -359,8 +359,7 @@ export function getFunctionSignaturesByReturnType(
 export function getLiteralsByType(_type: SupportedDataType | SupportedDataType[]) {
   const type = Array.isArray(_type) ? _type : [_type];
   if (type.includes('time_duration')) {
-    // return only singular
-    return timeUnitsToSuggest.map(({ name }) => `1 ${name}`).filter((s) => !/s$/.test(s));
+    return timeUnitsToSuggest.map(({ name }) => `1 ${name}`);
   }
   return [];
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/constants.ts
@@ -15,137 +15,68 @@ export const EDITOR_MARKER = 'marker_esql_editor';
 // List for suggestions (human-friendly)
 export const timeUnitsToSuggest: Literals[] = [
   {
-    name: 'year',
+    name: 'y',
     description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.year', {
-      defaultMessage: 'Year',
+      defaultMessage: 'Year (y)',
     }),
   },
   {
-    name: 'years',
-    description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.years', {
-      defaultMessage: 'Years (Plural)',
-    }),
-  },
-  {
-    name: 'quarter',
+    name: 'q',
     description: i18n.translate(
       'kbn-esql-language.esql.definitions.dateDurationDefinition.quarter',
       {
-        defaultMessage: 'Quarter',
+        defaultMessage: 'Quarter (q)',
       }
     ),
   },
   {
-    name: 'quarters',
-    description: i18n.translate(
-      'kbn-esql-language.esql.definitions.dateDurationDefinition.quarters',
-      {
-        defaultMessage: 'Quarters (Plural)',
-      }
-    ),
-  },
-  {
-    name: 'month',
+    name: 'mo',
     description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.month', {
-      defaultMessage: 'Month',
+      defaultMessage: 'Month (mo)',
     }),
   },
   {
-    name: 'months',
-    description: i18n.translate(
-      'kbn-esql-language.esql.definitions.dateDurationDefinition.months',
-      {
-        defaultMessage: 'Months (Plural)',
-      }
-    ),
-  },
-  {
-    name: 'week',
+    name: 'w',
     description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.week', {
-      defaultMessage: 'Week',
+      defaultMessage: 'Week (w)',
     }),
   },
   {
-    name: 'weeks',
-    description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.weeks', {
-      defaultMessage: 'Weeks (Plural)',
-    }),
-  },
-  {
-    name: 'day',
+    name: 'd',
     description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.day', {
-      defaultMessage: 'Day',
+      defaultMessage: 'Day (d)',
     }),
   },
   {
-    name: 'days',
-    description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.days', {
-      defaultMessage: 'Days (Plural)',
-    }),
-  },
-  {
-    name: 'hour',
+    name: 'h',
     description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.hour', {
-      defaultMessage: 'Hour',
+      defaultMessage: 'Hour (h)',
     }),
   },
   {
-    name: 'hours',
-    description: i18n.translate('kbn-esql-language.esql.definitions.dateDurationDefinition.hours', {
-      defaultMessage: 'Hours (Plural)',
-    }),
-  },
-  {
-    name: 'minute',
+    name: 'm',
     description: i18n.translate(
       'kbn-esql-language.esql.definitions.dateDurationDefinition.minute',
       {
-        defaultMessage: 'Minute',
+        defaultMessage: 'Minute (m)',
       }
     ),
   },
   {
-    name: 'minutes',
-    description: i18n.translate(
-      'kbn-esql-language.esql.definitions.dateDurationDefinition.minutes',
-      {
-        defaultMessage: 'Minutes (Plural)',
-      }
-    ),
-  },
-  {
-    name: 'second',
+    name: 's',
     description: i18n.translate(
       'kbn-esql-language.esql.definitions.dateDurationDefinition.second',
       {
-        defaultMessage: 'Second',
+        defaultMessage: 'Second (s)',
       }
     ),
   },
   {
-    name: 'seconds',
-    description: i18n.translate(
-      'kbn-esql-language.esql.definitions.dateDurationDefinition.seconds',
-      {
-        defaultMessage: 'Seconds (Plural)',
-      }
-    ),
-  },
-  {
-    name: 'millisecond',
+    name: 'ms',
     description: i18n.translate(
       'kbn-esql-language.esql.definitions.dateDurationDefinition.millisecond',
       {
-        defaultMessage: 'Millisecond',
-      }
-    ),
-  },
-  {
-    name: 'milliseconds',
-    description: i18n.translate(
-      'kbn-esql-language.esql.definitions.dateDurationDefinition.milliseconds',
-      {
-        defaultMessage: 'Milliseconds (Plural)',
+        defaultMessage: 'Millisecond (ms)',
       }
     ),
   },

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/literals.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/literals.ts
@@ -98,11 +98,7 @@ export function getDateLiterals(options?: DateLiteralsOptions) {
 }
 
 export function getUnitDuration(unit: number = 1) {
-  const filteredTimeLiteral = timeUnitsToSuggest.filter(({ name }) => {
-    const result = /s$/.test(name);
-    return unit > 1 ? result : !result;
-  });
-  return filteredTimeLiteral.map(({ name }) => `${unit} ${name}`);
+  return timeUnitsToSuggest.map(({ name }) => `${unit} ${name}`);
 }
 
 /**

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/options/recommended_queries/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/options/recommended_queries/index.ts
@@ -88,7 +88,7 @@ export const getRecommendedQueriesTemplates = ({
                 defaultMessage: 'Count aggregation over time',
               }
             ),
-            queryString: `${fromCommand}| EVAL buckets = DATE_TRUNC(5 minute, ${timeField}) | STATS count = COUNT(*) BY buckets /* try out different intervals */`,
+            queryString: `${fromCommand}| EVAL buckets = DATE_TRUNC(5 m, ${timeField}) | STATS count = COUNT(*) BY buckets /* try out different intervals */`,
           },
         ]
       : []),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,10 +2527,10 @@
     progress "^1.1.8"
     through2 "^2.0.0"
 
-"@elastic/monaco-esql@3.1.18":
-  version "3.1.18"
-  resolved "https://registry.yarnpkg.com/@elastic/monaco-esql/-/monaco-esql-3.1.18.tgz#e6931ca44fb5309275cc3db115d472fd88fa0dab"
-  integrity sha512-3yexduJ2l6RLw2E+uQmO1saO+iWc7zVFyyIcgsZa+Qz2mOCnfMBziUYRdEOuZ+cJdFe1G5HpHisAaYaBSSAIrQ==
+"@elastic/monaco-esql@3.1.19":
+  version "3.1.19"
+  resolved "https://registry.yarnpkg.com/@elastic/monaco-esql/-/monaco-esql-3.1.19.tgz#c48ce612664991423812cc84201af4988b0a7821"
+  integrity sha512-bMds++AYDqkTVARfbwyaOQlW6GdWyHlDyBs6z6MJsyxEbUInkBO5/3GBKPcbrghM/EmZDq92eWg8KV5aSPwtfA==
 
 "@elastic/node-crypto@1.2.3", "@elastic/node-crypto@^1.2.3":
   version "1.2.3"


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/253289

## Summary

This PR changes the time units suggested to their corresponding one-letter shorthands.
<img width="757" height="379" alt="image" src="https://github.com/user-attachments/assets/a1eac8d8-10f9-4dce-aa45-4bb0791e6051" />

### Notes:
'minutes' shorthand 'm' wasn't supported in `@elastic/monaco-esql` hence the version update.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.