### PR TITLE
[8.19] Upgrade terser-webpack-plugin 5.3.14 → 5.3.17 (#256028)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1923,7 +1923,7 @@
     "table": "6.9.0",
     "tape": "5.9.0",
     "terser": "5.40.0",
-    "terser-webpack-plugin": "5.3.14",
+    "terser-webpack-plugin": "5.3.17",
     "tough-cookie": "5.0.0",
     "tree-kill": "1.2.2",
     "ts-morph": "15.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31405,15 +31405,14 @@ terminal-link@^2.1.1:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@5.3.14, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.10:
-  version "5.3.14"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz#9031d48e57ab27567f02ace85c7d690db66c3e06"
-  integrity sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==
+terser-webpack-plugin@5.3.17, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.10:
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz#75ea98876297fbb190d2fbb395e982582b859a67"
+  integrity sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.25"
     jest-worker "^27.4.5"
     schema-utils "^4.3.0"
-    serialize-javascript "^6.0.2"
     terser "^5.31.1"
 
 terser@5.40.0, terser@^5.10.0, terser@^5.15.1, terser@^5.31.1, terser@^5.9.0:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Upgrade terser-webpack-plugin 5.3.14 → 5.3.17 (#256028)](https://github.com/elastic/kibana/pull/256028)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-03-04T16:55:44Z","message":"Upgrade terser-webpack-plugin 5.3.14 → 5.3.17 (#256028)\n\n## Summary\n\nUpgrades `terser-webpack-plugin` from v5.3.14 to v5.3.17","sha":"f0565722c4b58cdaa6f130b169a54b7e8c60590a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.4.0"],"title":"Upgrade terser-webpack-plugin 5.3.14 → 5.3.17","number":256028,"url":"https://github.com/elastic/kibana/pull/256028","mergeCommit":{"message":"Upgrade terser-webpack-plugin 5.3.14 → 5.3.17 (#256028)\n\n## Summary\n\nUpgrades `terser-webpack-plugin` from v5.3.14 to v5.3.17","sha":"f0565722c4b58cdaa6f130b169a54b7e8c60590a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256028","number":256028,"mergeCommit":{"message":"Upgrade terser-webpack-plugin 5.3.14 → 5.3.17 (#256028)\n\n## Summary\n\nUpgrades `terser-webpack-plugin` from v5.3.14 to v5.3.17","sha":"f0565722c4b58cdaa6f130b169a54b7e8c60590a"}},{"url":"https://github.com/elastic/kibana/pull/256052","number":256052,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/256053","number":256053,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->