### PR TITLE
[Search] Conditionally show callouts for cloud connected mode 

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo } from 'react';
+
+export interface CloudConnectStatus {
+  isCloudConnected: boolean;
+  isCloudConnectEisEnabled: boolean;
+  isCloudConnectAutoopsEnabled: boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export type UseCloudConnectStatusHook = () => CloudConnectStatus;
+
+const defaultCloudConnectStatusHook: UseCloudConnectStatusHook = () => ({
+  isCloudConnected: false,
+  isCloudConnectEisEnabled: false,
+  isCloudConnectAutoopsEnabled: false,
+  isLoading: false,
+  error: null,
+});
+
+export const useCloudConnectStatus = (hook?: UseCloudConnectStatusHook) => {
+  const cloudConnectStatusHook = useMemo(() => hook ?? defaultCloudConnectStatusHook, [hook]);
+
+  return cloudConnectStatusHook();
+};

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
@@ -8,14 +8,15 @@
  */
 
 import { useMemo } from 'react';
-
 export interface CloudConnectStatus {
   isCloudConnected: boolean;
   isCloudConnectEisEnabled: boolean;
   isCloudConnectAutoopsEnabled: boolean;
-  isCloudConnectedWithEisEnabled?: boolean;
   isLoading: boolean;
   error: Error | null;
+}
+export interface CloudConnectStatusWithDerived extends CloudConnectStatus {
+  isCloudConnectedWithEisEnabled: boolean;
 }
 
 export type UseCloudConnectStatusHook = () => CloudConnectStatus;
@@ -24,12 +25,13 @@ const defaultCloudConnectStatusHook: UseCloudConnectStatusHook = () => ({
   isCloudConnected: false,
   isCloudConnectEisEnabled: false,
   isCloudConnectAutoopsEnabled: false,
-  isCloudConnectedWithEisEnabled: false,
   isLoading: false,
   error: null,
 });
 
-export const useCloudConnectStatus = (hook?: UseCloudConnectStatusHook) => {
+export const useCloudConnectStatus = (
+  hook?: UseCloudConnectStatusHook
+): CloudConnectStatusWithDerived => {
   const cloudConnectStatusHook = useMemo(() => hook ?? defaultCloudConnectStatusHook, [hook]);
 
   const status = cloudConnectStatusHook();

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
@@ -13,6 +13,7 @@ export interface CloudConnectStatus {
   isCloudConnected: boolean;
   isCloudConnectEisEnabled: boolean;
   isCloudConnectAutoopsEnabled: boolean;
+  isCloudConnectedWithEisEnabled?: boolean;
   isLoading: boolean;
   error: Error | null;
 }
@@ -23,6 +24,7 @@ const defaultCloudConnectStatusHook: UseCloudConnectStatusHook = () => ({
   isCloudConnected: false,
   isCloudConnectEisEnabled: false,
   isCloudConnectAutoopsEnabled: false,
+  isCloudConnectedWithEisEnabled: false,
   isLoading: false,
   error: null,
 });
@@ -30,5 +32,10 @@ const defaultCloudConnectStatusHook: UseCloudConnectStatusHook = () => ({
 export const useCloudConnectStatus = (hook?: UseCloudConnectStatusHook) => {
   const cloudConnectStatusHook = useMemo(() => hook ?? defaultCloudConnectStatusHook, [hook]);
 
-  return cloudConnectStatusHook();
+  const status = cloudConnectStatusHook();
+
+  return {
+    ...status,
+    isCloudConnectedWithEisEnabled: status.isCloudConnected && status.isCloudConnectEisEnabled,
+  };
 };

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_cloud_connect_status.ts
@@ -21,14 +21,21 @@ export interface CloudConnectStatusWithDerived extends CloudConnectStatus {
 
 export type UseCloudConnectStatusHook = () => CloudConnectStatus;
 
+// Fallback when the cloudConnect plugin is not available
 const defaultCloudConnectStatusHook: UseCloudConnectStatusHook = () => ({
   isCloudConnected: false,
   isCloudConnectEisEnabled: false,
   isCloudConnectAutoopsEnabled: false,
-  isLoading: false,
+  isLoading: true,
   error: null,
 });
 
+// Accepts the UseCloudConnectStatusHook from the cloudConnect plugin via dependency injection.
+// This package can't access plugin start contracts directly (packages have no plugin lifecycle),
+// and cannot depend on x-pack plugins, so consumer plugins pass in cloudConnect?.hooks.useCloudConnectStatus.
+
+// This wrapper centralizes the default status and derives combined values like
+// isCloudConnectedWithEisEnabled to avoid repeating that logic across consumers.
 export const useCloudConnectStatus = (
   hook?: UseCloudConnectStatusHook
 ): CloudConnectStatusWithDerived => {

--- a/src/platform/packages/shared/kbn-search-api-panels/index.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/index.tsx
@@ -16,5 +16,6 @@ export * from './components/eis_update_callout';
 export * from './components/eis_ccm_promotional_tour';
 export * from './components/eis_ccm_promotional_callout';
 
+export * from './hooks/use_cloud_connect_status';
 export * from './types';
 export * from './utils';

--- a/x-pack/platform/plugins/shared/index_management/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/index_management/kibana.jsonc
@@ -25,6 +25,7 @@
       "usageCollection",
       "fleet",
       "cloud",
+      "cloudConnect",
       "ml",
       "streams",
       "console",

--- a/x-pack/platform/plugins/shared/index_management/moon.yml
+++ b/x-pack/platform/plugins/shared/index_management/moon.yml
@@ -78,6 +78,7 @@ dependsOn:
   - '@kbn/core-elasticsearch-server'
   - '@kbn/cloud'
   - '@kbn/search-index-documents'
+  - '@kbn/cloud-connect-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/index_management/public/application/app_context.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/app_context.tsx
@@ -25,6 +25,7 @@ import type { MlPluginStart } from '@kbn/ml-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { CloudSetup } from '@kbn/cloud-plugin/public';
+import type { CloudConnectedPluginStart } from '@kbn/cloud-connect-plugin/public';
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { StreamsPluginStart } from '@kbn/streams-plugin/public';
 import type { ReindexServicePublicStart } from '@kbn/reindex-service-plugin/public';
@@ -54,6 +55,7 @@ export interface AppDependencies {
     isFleetEnabled: boolean;
     share: SharePluginStart;
     cloud?: CloudSetup;
+    cloudConnect?: CloudConnectedPluginStart;
     console?: ConsolePluginStart;
     licensing?: LicensingPluginStart;
     ml?: MlPluginStart;

--- a/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
@@ -91,6 +91,7 @@ export function getIndexManagementDependencies({
       isFleetEnabled,
       share: startDependencies.share,
       cloud,
+      cloudConnect: startDependencies.cloudConnect,
       console: startDependencies.console,
       ml: startDependencies.ml,
       streams: startDependencies.streams,

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
@@ -57,7 +57,7 @@ export const MappingsInformationPanels = ({
   const {
     isLoading: isCloudConnectStatusLoading,
     isCloudConnected,
-    isCloudConnectEisEnabled,
+    isCloudConnectedWithEisEnabled,
   } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
 
   const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
@@ -70,9 +70,8 @@ export const MappingsInformationPanels = ({
 
   const hasSemanticText = hasSemanticTextField(state.mappingViewFields);
   const hasElserOnMlNodeSemanticText = hasElserOnMlNodeSemanticTextField(state.mappingViewFields);
-  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
   const shouldShowEisUpdateCallout =
-    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEisEnabled) &&
       (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
     false;
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
@@ -23,6 +23,7 @@ import {
   EisCloudConnectPromoCallout,
   EisPromotionalCallout,
   EisUpdateCallout,
+  useCloudConnectStatus,
 } from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 
@@ -48,11 +49,16 @@ export const MappingsInformationPanels = ({
   refetchMapping,
 }: MappingsInformationPanelsProps) => {
   const {
-    plugins: { cloud },
+    plugins: { cloud, cloudConnect },
     core: { application },
   } = useAppContext();
   const state = useMappingsState();
   const { isAtLeastEnterprise } = useLicense();
+  const {
+    isLoading: isCloudConnectStatusLoading,
+    isCloudConnected,
+    isCloudConnectEisEnabled,
+  } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
 
   const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
 
@@ -64,8 +70,11 @@ export const MappingsInformationPanels = ({
 
   const hasSemanticText = hasSemanticTextField(state.mappingViewFields);
   const hasElserOnMlNodeSemanticText = hasElserOnMlNodeSemanticTextField(state.mappingViewFields);
+  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
   const shouldShowEisUpdateCallout =
-    (cloud?.isCloudEnabled && (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ?? false;
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+      (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
+    false;
 
   return (
     <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
@@ -100,18 +109,20 @@ export const MappingsInformationPanels = ({
             )}
           </>
         )}
-        <EisCloudConnectPromoCallout
-          promoId="indexDetailsMappings"
-          isSelfManaged={!cloud?.isCloudEnabled}
-          direction="column"
-          navigateToApp={() =>
-            application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
-          }
-        />
+        {!isCloudConnectStatusLoading && !isCloudConnected && (
+          <EisCloudConnectPromoCallout
+            promoId="indexDetailsMappings"
+            isSelfManaged={!cloud?.isCloudEnabled}
+            direction="column"
+            navigateToApp={() =>
+              application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+            }
+          />
+        )}
         <EuiPanel grow={false} paddingSize="l" hasShadow={false} hasBorder>
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="info" />
+              <EuiIcon aria-hidden={true} type="info" />
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiTitle size="xs">
@@ -151,7 +162,7 @@ export const MappingsInformationPanels = ({
         <EuiPanel grow={false} paddingSize="l" hasShadow={false} hasBorder>
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="info" />
+              <EuiIcon aria-hidden={true} type="info" />
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiTitle size="xs">

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
@@ -99,13 +99,11 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
   const {
     isLoading: isCloudConnectStatusLoading,
     isCloudConnected,
-    isCloudConnectEisEnabled,
+    isCloudConnectedWithEisEnabled,
   } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
 
-  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
-
   const shouldShowEisUpdateCallout =
-    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEisEnabled) &&
       (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
     false;
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
@@ -29,6 +29,7 @@ import {
   getConsoleRequest,
   EisCloudConnectPromoCallout,
   EisUpdateCallout,
+  useCloudConnectStatus,
 } from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 import { type Index } from '../../../../../../../common';
@@ -70,7 +71,7 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
   } = indexDetails;
   const {
     core,
-    plugins: { cloud, share },
+    plugins: { cloud, cloudConnect, share },
     services: { extensionsService },
   } = useAppContext();
   const state = useMappingsState();
@@ -95,9 +96,18 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
   };
 
   const isLarge = useIsWithinBreakpoints(['xl']);
+  const {
+    isLoading: isCloudConnectStatusLoading,
+    isCloudConnected,
+    isCloudConnectEisEnabled,
+  } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
+
+  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
 
   const shouldShowEisUpdateCallout =
-    (cloud?.isCloudEnabled && (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ?? false;
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+      (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
+    false;
 
   const { parsedDefaultValue } = useMemo(
     () => parseMappings(mappingsData ?? undefined),
@@ -114,15 +124,17 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
 
   return (
     <>
-      <EisCloudConnectPromoCallout
-        promoId="indexDetailsOverview"
-        isSelfManaged={!cloud?.isCloudEnabled}
-        direction="row"
-        navigateToApp={() =>
-          core.application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
-        }
-        addSpacer="bottom"
-      />
+      {!isCloudConnectStatusLoading && !isCloudConnected && (
+        <EisCloudConnectPromoCallout
+          promoId="indexDetailsOverview"
+          isSelfManaged={!cloud?.isCloudEnabled}
+          direction="row"
+          navigateToApp={() =>
+            core.application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+          }
+          addSpacer="bottom"
+        />
+      )}
       {hasElserOnMlNodeSemanticText && (
         <EisUpdateCallout
           ctaLink={documentationService.docLinks.enterpriseSearch.elasticInferenceService}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview_v2.tsx
@@ -29,6 +29,7 @@ import {
   getConsoleRequest,
   EisCloudConnectPromoCallout,
   EisUpdateCallout,
+  useCloudConnectStatus,
 } from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
@@ -80,7 +81,7 @@ export const DetailsPageOverviewV2: React.FunctionComponent<Props> = ({
   } = indexDetails;
   const {
     core,
-    plugins: { cloud, share },
+    plugins: { cloud, cloudConnect, share },
     services: { extensionsService },
   } = useAppContext();
   const state = useMappingsState();
@@ -105,9 +106,18 @@ export const DetailsPageOverviewV2: React.FunctionComponent<Props> = ({
   };
 
   const isLarge = useIsWithinBreakpoints(['xl']);
+  const {
+    isLoading: isCloudConnectStatusLoading,
+    isCloudConnected,
+    isCloudConnectEisEnabled,
+  } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
+
+  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
 
   const shouldShowEisUpdateCallout =
-    (cloud?.isCloudEnabled && (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ?? false;
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+      (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
+    false;
 
   const { parsedDefaultValue } = useMemo(
     () => parseMappings(mappingsData ?? undefined),
@@ -124,15 +134,17 @@ export const DetailsPageOverviewV2: React.FunctionComponent<Props> = ({
 
   return (
     <>
-      <EisCloudConnectPromoCallout
-        promoId="indexDetailsOverview"
-        isSelfManaged={!cloud?.isCloudEnabled}
-        direction="row"
-        navigateToApp={() =>
-          core.application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
-        }
-        addSpacer="bottom"
-      />
+      {!isCloudConnectStatusLoading && !isCloudConnected && (
+        <EisCloudConnectPromoCallout
+          promoId="indexDetailsOverview"
+          isSelfManaged={!cloud?.isCloudEnabled}
+          direction="row"
+          navigateToApp={() =>
+            core.application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+          }
+          addSpacer="bottom"
+        />
+      )}
       {hasElserOnMlNodeSemanticText && (
         <EisUpdateCallout
           ctaLink={documentationService.docLinks.enterpriseSearch.elasticInferenceService}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview_v2.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview_v2.tsx
@@ -109,13 +109,11 @@ export const DetailsPageOverviewV2: React.FunctionComponent<Props> = ({
   const {
     isLoading: isCloudConnectStatusLoading,
     isCloudConnected,
-    isCloudConnectEisEnabled,
+    isCloudConnectedWithEisEnabled,
   } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
 
-  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
-
   const shouldShowEisUpdateCallout =
-    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEisEnabled) &&
       (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
     false;
 

--- a/x-pack/platform/plugins/shared/index_management/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/plugin.ts
@@ -208,8 +208,17 @@ export class IndexMgmtUIPlugin
     plugins: StartDependencies,
     deps: { history: ScopedHistory<unknown> }
   ) {
-    const { fleet, usageCollection, cloud, share, console, ml, licensing, reindexService } =
-      plugins;
+    const {
+      fleet,
+      usageCollection,
+      cloud,
+      cloudConnect,
+      share,
+      console,
+      ml,
+      licensing,
+      reindexService,
+    } = plugins;
     const { docLinks, fatalErrors, application, uiSettings, executionContext, settings, http } =
       core;
     const { monitor, manageEnrich, monitorEnrich, manageIndexTemplates } =
@@ -231,6 +240,7 @@ export class IndexMgmtUIPlugin
         isFleetEnabled: Boolean(fleet),
         share,
         cloud,
+        cloudConnect,
         console,
         ml,
         licensing,

--- a/x-pack/platform/plugins/shared/index_management/public/types.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/types.ts
@@ -13,6 +13,7 @@ import type {
   UserProfileService,
 } from '@kbn/core/public';
 import type { CloudSetup } from '@kbn/cloud-plugin/public';
+import type { CloudConnectedPluginStart } from '@kbn/cloud-connect-plugin/public';
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { ManagementSetup } from '@kbn/management-plugin/public';
 import type { MlPluginStart } from '@kbn/ml-plugin/public';
@@ -44,6 +45,7 @@ export interface SetupDependencies {
 
 export interface StartDependencies {
   cloud?: CloudSetup;
+  cloudConnect?: CloudConnectedPluginStart;
   console?: ConsolePluginStart;
   share: SharePluginStart;
   fleet?: unknown;

--- a/x-pack/platform/plugins/shared/index_management/tsconfig.json
+++ b/x-pack/platform/plugins/shared/index_management/tsconfig.json
@@ -73,6 +73,7 @@
     "@kbn/core-elasticsearch-server",
     "@kbn/cloud",
     "@kbn/search-index-documents",
+    "@kbn/cloud-connect-plugin",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/kibana.jsonc
@@ -22,6 +22,7 @@
     ],
     "optionalPlugins": [
       "cloud",
+      "cloudConnect",
       "console",
       "serverless",
     ],

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/moon.yml
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/moon.yml
@@ -49,6 +49,7 @@ dependsOn:
   - '@kbn/search-api-panels'
   - '@kbn/cloud-plugin'
   - '@kbn/logging-mocks'
+  - '@kbn/cloud-connect-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -87,15 +87,12 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
   const {
     services: { cloud, cloudConnect, application },
   } = useKibana();
-  const {
-    isLoading: isCloudConnectStatusLoading,
-    isCloudConnected,
-    isCloudConnectEisEnabled,
-  } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
+  const { isLoading: isCloudConnectStatusLoading, isCloudConnected } = useCloudConnectStatus(
+    cloudConnect?.hooks.useCloudConnectStatus
+  );
   const [searchKey, setSearchKey] = useState('');
   const [groupBy, setGroupBy] = useState<GroupByOptions>(initializeGroupBy);
   const [filterOptions, setFilterOptions] = useState<FilterOptions>(DEFAULT_FILTER_OPTIONS);
-  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
 
   const {
     showDeleteAction,

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -16,7 +16,11 @@ import type {
   InferenceTaskType,
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
-import { EisCloudConnectPromoCallout, EisPromotionalCallout } from '@kbn/search-api-panels';
+import {
+  EisCloudConnectPromoCallout,
+  EisPromotionalCallout,
+  useCloudConnectStatus,
+} from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 
 import { docLinks } from '../../../common/doc_links';
@@ -81,11 +85,17 @@ interface TabularPageProps {
 
 export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) => {
   const {
-    services: { cloud, application },
+    services: { cloud, cloudConnect, application },
   } = useKibana();
+  const {
+    isLoading: isCloudConnectStatusLoading,
+    isCloudConnected,
+    isCloudConnectEisEnabled,
+  } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
   const [searchKey, setSearchKey] = useState('');
   const [groupBy, setGroupBy] = useState<GroupByOptions>(initializeGroupBy);
   const [filterOptions, setFilterOptions] = useState<FilterOptions>(DEFAULT_FILTER_OPTIONS);
+  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
 
   const {
     showDeleteAction,
@@ -210,14 +220,16 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
           ctaLink={docLinks.elasticInferenceService}
           direction="row"
         />
-        <EisCloudConnectPromoCallout
-          promoId="inferenceEndpointManagement"
-          isSelfManaged={!cloud?.isCloudEnabled}
-          direction="row"
-          navigateToApp={() =>
-            application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
-          }
-        />
+        {!isCloudConnectStatusLoading && !isCloudConnected && (
+          <EisCloudConnectPromoCallout
+            promoId="inferenceEndpointManagement"
+            isSelfManaged={!cloud?.isCloudEnabled}
+            direction="row"
+            navigateToApp={() =>
+              application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+            }
+          />
+        )}
         <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
           <EuiFlexItem css={searchContainerStyles} grow={false}>
             <TableSearch searchKey={searchKey} setSearchKey={setSearchKey} />

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/types.ts
@@ -16,6 +16,7 @@ import type { MlPluginSetup, MlPluginStart } from '@kbn/ml-plugin/public';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
 import type { LicensingPluginSetup, LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import type { CloudConnectedPluginStart } from '@kbn/cloud-connect-plugin/public';
 import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 
@@ -34,6 +35,7 @@ export interface AppPluginStartDependencies {
   ml: MlPluginStart;
   serverless?: ServerlessPluginStart;
   cloud?: CloudStart;
+  cloudConnect?: CloudConnectedPluginStart;
 }
 
 export interface AppPluginSetupDependencies {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/tsconfig.json
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/tsconfig.json
@@ -40,7 +40,8 @@
     "@kbn/react-query",
     "@kbn/search-api-panels",
     "@kbn/cloud-plugin",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/cloud-connect-plugin"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/solutions/search/plugins/search_indices/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_indices/kibana.jsonc
@@ -19,6 +19,7 @@
     ],
     "optionalPlugins": [
       "cloud",
+      "cloudConnect",
       "console",
       "usageCollection",
       "serverless",

--- a/x-pack/solutions/search/plugins/search_indices/moon.yml
+++ b/x-pack/solutions/search/plugins/search_indices/moon.yml
@@ -56,6 +56,7 @@ dependsOn:
   - '@kbn/search-api-panels'
   - '@kbn/deeplinks-management'
   - '@kbn/index-management-plugin'
+  - '@kbn/cloud-connect-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
@@ -15,7 +15,11 @@ import {
   EuiSpacer,
   EuiHorizontalRule,
 } from '@elastic/eui';
-import { EisCloudConnectPromoCallout, EisUpdateCallout } from '@kbn/search-api-panels';
+import {
+  EisCloudConnectPromoCallout,
+  EisUpdateCallout,
+  useCloudConnectStatus,
+} from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
@@ -47,14 +51,22 @@ export const IndexDetailsData = ({
   userPrivileges,
   mappingData,
 }: IndexDetailsDataProps) => {
-  const { application, cloud } = useKibana().services;
+  const { application, cloud, cloudConnect } = useKibana().services;
   const { isAtLeastEnterprise } = useLicense();
+  const {
+    isLoading: isCloudConnectStatusLoading,
+    isCloudConnected,
+    isCloudConnectEisEnabled,
+  } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
   const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
 
   const documents = indexDocuments?.results?.data ?? [];
 
+  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
   const shouldShowEisUpdateCallout =
-    (cloud?.isCloudEnabled && (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ?? false;
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+      (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
+    false;
 
   const fieldsForUpdate = useMemo<NormalizedFields['byId'] | undefined>(() => {
     const properties = mappingData?.mappings?.properties;
@@ -79,15 +91,17 @@ export const IndexDetailsData = ({
 
   return (
     <>
-      <EisCloudConnectPromoCallout
-        promoId="indexDetailsData"
-        isSelfManaged={!cloud?.isCloudEnabled}
-        direction="row"
-        navigateToApp={() =>
-          application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
-        }
-        addSpacer="top"
-      />
+      {!isCloudConnectStatusLoading && !isCloudConnected && (
+        <EisCloudConnectPromoCallout
+          promoId="indexDetailsData"
+          isSelfManaged={!cloud?.isCloudEnabled}
+          direction="row"
+          navigateToApp={() =>
+            application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+          }
+          addSpacer="top"
+        />
+      )}
       {fieldsForUpdate && (
         <EisUpdateCallout
           ctaLink={docLinks.elasticInferenceService}

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
@@ -56,15 +56,14 @@ export const IndexDetailsData = ({
   const {
     isLoading: isCloudConnectStatusLoading,
     isCloudConnected,
-    isCloudConnectEisEnabled,
+    isCloudConnectedWithEisEnabled,
   } = useCloudConnectStatus(cloudConnect?.hooks.useCloudConnectStatus);
   const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
 
   const documents = indexDocuments?.results?.data ?? [];
 
-  const isCloudConnectedWithEis = isCloudConnected && isCloudConnectEisEnabled;
   const shouldShowEisUpdateCallout =
-    ((cloud?.isCloudEnabled || isCloudConnectedWithEis) &&
+    ((cloud?.isCloudEnabled || isCloudConnectedWithEisEnabled) &&
       (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ??
     false;
 

--- a/x-pack/solutions/search/plugins/search_indices/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/types.ts
@@ -7,6 +7,7 @@
 
 import type { RetrieverContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
+import type { CloudConnectedPluginStart } from '@kbn/cloud-connect-plugin/public';
 import type { ConsolePluginSetup, ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
@@ -52,6 +53,7 @@ export interface SearchIndicesAppPluginStartDependencies {
   sampleDataIngest?: SampleDataIngestPluginStart;
   indexManagement: IndexManagementPluginStart;
   searchNavigation?: SearchNavigationPluginStart;
+  cloudConnect?: CloudConnectedPluginStart;
 }
 
 export interface SearchIndicesServicesContextDeps {

--- a/x-pack/solutions/search/plugins/search_indices/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_indices/tsconfig.json
@@ -49,6 +49,7 @@
     "@kbn/search-api-panels",
     "@kbn/deeplinks-management",
     "@kbn/index-management-plugin",
+    "@kbn/cloud-connect-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This PR extends the update to ELSER on EIS callouts and one-click mapping update functionality to self-managed Kibana deployments that are cloud-connected with EIS enabled.

Previously, the EIS update callout was only shown on Elastic Cloud deployments (`cloud.isCloudEnabled`). This PR integrates the `cloudConnect` plugin to detect cloud-connected self-managed environments and:

- Shows the ELSER update callout (with update modal) when a cloud-connected deployment has EIS enabled and the index has ELSER on ML nodes semantic text fields
- Hides the Cloud Connect (CCM) promotional callout when the deployment is already cloud-connected

#### Changes
- Adds a `useCloudConnectStatus `hook in `kbn-search-api-panels` that wraps the cloud connect plugin's status hook with safe defaults when the plugin isn't available
- Adds `cloudConnect` as an optional plugin dependency in `index_management`, `search_indices`, and `search_inference_endpoints`
- Updates callout visibility logic across 5 pages:
  - Index details overview page (v1 and v2) (platform index_management)
  - Index details mappings panel (platform index_management)
  - Index details data page (search_indices)
  - Inference endpoints management page

### Screenshots

**CCM promo callout**
<img width="1236" height="289" alt="Screenshot 2026-03-04 at 17 39 44" src="https://github.com/user-attachments/assets/23685aab-e059-4ee4-87d7-f8645b2a12bb" />

**ELSER update callout**
<img width="1246" height="306" alt="Screenshot 2026-03-04 at 17 41 11" src="https://github.com/user-attachments/assets/17e7e082-e4fa-4de7-b44b-6053d5c88e5f" />

### Testing

To test this PR, ensure you are running a self-managed deployment and you have created an index with a semantic text field mapping using the ELSER on ML nodes inference endpoint (`.elser-2-elasticsearch`).

The following pages have both the ELSER update and CCM promo callout:
  - Index details overview tab (Classic space)
  - Index details mappings tab 
  - Index details data tab (Elasticsearch solution space)

The following page only has the CCM promo callout:
  - Inference endpoints management page

-------------------------------

Confirm the following on each of the pages mentioned above:

**Self-managed deployment without cloud connect:**
- [ ] CCM promo callout should be visible
- [ ] EIS update callout should not shown even when there are semantic text field mappings using ELSER on ML nodes (`.elser-2-elasticsearch`)

**Self-managed deployment with cloud connect + EIS enabled:** 
- [ ] CCM promo callout hidden 
- [ ] ELSER update callout visible

**Self-managed deployment with cloud connect but EIS not enabled:** 
- [ ] CCM promo hidden
- [ ] EIS update callout hidden

**Cloud deployment:** 
- [ ] EIS update callout visible for enterprise/serverless
- [ ] CCM promo hidden

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud Connect status detection added across Index Management, Search Inference, and Search Indices UIs to adapt messaging.

* **Bug Fixes**
  * Promo callouts now display only when Cloud Connect is not active, preventing redundant prompts.

* **Accessibility**
  * Improved icon accessibility by marking decorative icons appropriately.

* **Chores**
  * Cloud Connect declared as an optional plugin and exposed to relevant plugin contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->