### PR TITLE
[Dataset Quality] Fix flaky test for degraded fields flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams/moon.yml
+++ b/x-pack/platform/plugins/shared/streams/moon.yml
@@ -79,6 +79,7 @@ dependsOn:
   - '@kbn/esql-language'
   - '@kbn/core-elasticsearch-server-mocks'
   - '@kbn/core-logging-server-mocks'
+  - '@kbn/logging-mocks'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
@@ -963,6 +963,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             expandedDegradedField: 'cloud.project',
           });
 
+          await PageObjects.header.waitUntilLoadingHasFinished();
+
           // Field Limit Mitigation Section should exist
           await testSubjects.existOrFail(
             'datasetQualityDetailsDegradedFieldFlyoutFieldLimitMitigationAccordion'


### PR DESCRIPTION
## Summary
This PR should fix a flaky test that was discovered after a recent serverless build. The fix is similar to [this PR](https://github.com/elastic/kibana/pull/202288) where assertions of UI element presence were occurring without a proper await for all the neccessary data to be loaded.  

```
69 passing (8.0m)
--
1 failing
 
1)    serverless observability UI
Dataset Quality
Degraded fields flyout
detecting root cause for ignored fields
current field limit issues
should display increase field limit as a possible mitigation for special packages like apm app:
 
Error: expected testSubject(datasetQualityDetailsDegradedFieldFlyoutFieldLimitMitigationAccordion) to exist
at TestSubjects.existOrFail (test_subjects.ts:76:13)
at Context.<anonymous> (degraded_field_flyout.ts:967:11)
at Object.apply (wrap_function.js:74:16)
```