### PR TITLE
POC: Shared extraction workflow via workflow.execute

### DIFF
--- a/packages/kbn-check-saved-objects-cli/current_fields.json
+++ b/packages/kbn-check-saved-objects-cli/current_fields.json
@@ -331,6 +331,9 @@
     "type",
     "workflowIds"
   ],
+  "data_sources_extraction_config": [
+    "workflowId"
+  ],
   "data_stream-config": [
     "created_by",
     "data_stream_id",

--- a/packages/kbn-check-saved-objects-cli/current_mappings.json
+++ b/packages/kbn-check-saved-objects-cli/current_mappings.json
@@ -1141,6 +1141,14 @@
       }
     }
   },
+  "data_sources_extraction_config": {
+    "dynamic": false,
+    "properties": {
+      "workflowId": {
+        "type": "keyword"
+      }
+    }
+  },
   "data_stream-config": {
     "dynamic": false,
     "properties": {
@@ -3046,8 +3054,8 @@
     "dynamic": false,
     "properties": {
       "content": {
-        "type": "text",
-        "index": false
+        "index": false,
+        "type": "text"
       },
       "description": {
         "type": "text"

--- a/x-pack/platform/plugins/shared/data_sources/server/routes/data_sources_helpers.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/routes/data_sources_helpers.ts
@@ -104,11 +104,7 @@ async function ensureExtractionWorkflowExists(
   }
 
   // Create the extraction workflow (auto-generated UUID)
-  const created = await workflowManagement.management.createWorkflow(
-    { yaml },
-    spaceId,
-    request
-  );
+  const created = await workflowManagement.management.createWorkflow({ yaml }, spaceId, request);
 
   // Persist the workflow ID in the config SO
   await savedObjectsClient.create<ExtractionConfigAttributes>(

--- a/x-pack/platform/plugins/shared/data_sources/server/routes/data_sources_helpers.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/routes/data_sources_helpers.ts
@@ -33,9 +33,13 @@ import type {
   DataSourcesServerSetupDependencies,
   DataSourcesServerStartDependencies,
 } from '../types';
-import { DATA_SOURCE_SAVED_OBJECT_TYPE, type DataSourceAttributes } from '../saved_objects';
-
-const EXTRACTION_WORKFLOW_ID = 'workflow-00000000-0000-0000-0000-000000000001';
+import {
+  DATA_SOURCE_SAVED_OBJECT_TYPE,
+  EXTRACTION_CONFIG_SAVED_OBJECT_TYPE,
+  EXTRACTION_CONFIG_SO_ID,
+  type DataSourceAttributes,
+  type ExtractionConfigAttributes,
+} from '../saved_objects';
 
 interface CreateDataSourceAndResourcesParams {
   name: string;
@@ -61,32 +65,60 @@ function slugify(input: string): string {
 }
 
 /**
- * Ensures the shared extraction workflow exists, creating it if necessary.
- * Uses a well-known ID so all data source download workflows can reference it via workflow.execute.
+ * Ensures the shared extraction workflow exists and returns its ID.
+ * Tracks the workflow ID in a singleton Saved Object so that:
+ * - The workflow uses an auto-generated UUID (no hardcoded IDs)
+ * - If a user deletes the workflow, we detect it and create a fresh one
  */
 async function ensureExtractionWorkflowExists(
   workflowManagement: DataSourcesServerSetupDependencies['workflowsManagement'],
+  savedObjectsClient: SavedObjectsClientContract,
   spaceId: string,
   request: KibanaRequest,
   logger: Logger
-): Promise<void> {
-  const existing = await workflowManagement.management.getWorkflow(
-    EXTRACTION_WORKFLOW_ID,
-    spaceId
-  );
-  if (existing) {
-    return;
-  }
-
+): Promise<string> {
   const yamlPath = join(__dirname, '..', 'workflows', 'extraction.yaml');
   const yaml = await fs.readFile(yamlPath, 'utf-8');
 
-  await workflowManagement.management.createWorkflow(
-    { yaml, id: EXTRACTION_WORKFLOW_ID },
+  // Check if we already have a tracked extraction workflow
+  try {
+    const configSo = await savedObjectsClient.get<ExtractionConfigAttributes>(
+      EXTRACTION_CONFIG_SAVED_OBJECT_TYPE,
+      EXTRACTION_CONFIG_SO_ID
+    );
+    const { workflowId } = configSo.attributes;
+
+    // Verify the workflow still exists and is usable
+    const existing = await workflowManagement.management.getWorkflow(workflowId, spaceId);
+    if (existing && existing.enabled && existing.valid) {
+      return workflowId;
+    }
+
+    // Workflow is gone or unusable — fall through to create a new one
+    logger.info(`Extraction workflow '${workflowId}' is missing or unusable, recreating`);
+  } catch (err) {
+    if (err.output?.statusCode !== 404) {
+      throw err;
+    }
+    // SO doesn't exist yet — first time setup
+  }
+
+  // Create the extraction workflow (auto-generated UUID)
+  const created = await workflowManagement.management.createWorkflow(
+    { yaml },
     spaceId,
     request
   );
-  logger.info(`Created shared extraction workflow with id '${EXTRACTION_WORKFLOW_ID}'`);
+
+  // Persist the workflow ID in the config SO
+  await savedObjectsClient.create<ExtractionConfigAttributes>(
+    EXTRACTION_CONFIG_SAVED_OBJECT_TYPE,
+    { workflowId: created.id },
+    { id: EXTRACTION_CONFIG_SO_ID, overwrite: true }
+  );
+
+  logger.info(`Created shared extraction workflow '${created.id}'`);
+  return created.id;
 }
 
 /**
@@ -214,7 +246,13 @@ export async function createDataSourceAndRelatedResources(
   // Create workflows and tools
   const spaceId = getSpaceId(savedObjectsClient);
 
-  await ensureExtractionWorkflowExists(workflowManagement, spaceId, request, logger);
+  const extractionWorkflowId = await ensureExtractionWorkflowExists(
+    workflowManagement,
+    savedObjectsClient,
+    spaceId,
+    request,
+    logger
+  );
 
   logger.info(`data source workflows: ${JSON.stringify(dataSource.workflows)}`);
 
@@ -228,7 +266,13 @@ export async function createDataSourceAndRelatedResources(
       const nameMatch = workflowInfo.content.match(/^name:\s*['"]?([^'"\n]+)['"]?/m);
       const originalName = nameMatch?.[1]?.trim() ?? 'workflow';
       const prefixedName = `${slugify(name)}.${originalName}`;
-      const prefixedContent = updateYamlField(workflowInfo.content, 'name', prefixedName);
+      let prefixedContent = updateYamlField(workflowInfo.content, 'name', prefixedName);
+
+      // Stamp the extraction workflow ID into download workflows
+      prefixedContent = prefixedContent.replaceAll(
+        '{{extraction_workflow_id}}',
+        extractionWorkflowId
+      );
 
       const workflow = await workflowManagement.management.createWorkflow(
         { yaml: prefixedContent },

--- a/x-pack/platform/plugins/shared/data_sources/server/routes/data_sources_helpers.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/routes/data_sources_helpers.ts
@@ -25,6 +25,8 @@ import { loadWorkflows } from '@kbn/data-catalog-plugin/common/workflow_loader';
 import type { ImportedTool } from '@kbn/data-catalog-plugin/common/data_source_spec';
 import { parse } from 'yaml';
 import type { WorkflowYaml } from '@kbn/workflows';
+import { promises as fs } from 'fs';
+import { join } from 'path';
 import { createStackConnector } from '../utils/create_stack_connector';
 
 import type {
@@ -32,6 +34,8 @@ import type {
   DataSourcesServerStartDependencies,
 } from '../types';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE, type DataSourceAttributes } from '../saved_objects';
+
+const EXTRACTION_WORKFLOW_ID = 'workflow-00000000-0000-0000-0000-000000000001';
 
 interface CreateDataSourceAndResourcesParams {
   name: string;
@@ -54,6 +58,35 @@ function slugify(input: string): string {
     .replace(/[\u0300-\u036f]/g, '') // remove accents
     .replace(/[^a-z0-9]+/g, '-') // replace non-alphanumerics with -
     .replace(/^-+|-+$/g, ''); // trim leading/trailing -
+}
+
+/**
+ * Ensures the shared extraction workflow exists, creating it if necessary.
+ * Uses a well-known ID so all data source download workflows can reference it via workflow.execute.
+ */
+async function ensureExtractionWorkflowExists(
+  workflowManagement: DataSourcesServerSetupDependencies['workflowsManagement'],
+  spaceId: string,
+  request: KibanaRequest,
+  logger: Logger
+): Promise<void> {
+  const existing = await workflowManagement.management.getWorkflow(
+    EXTRACTION_WORKFLOW_ID,
+    spaceId
+  );
+  if (existing) {
+    return;
+  }
+
+  const yamlPath = join(__dirname, '..', 'workflows', 'extraction.yaml');
+  const yaml = await fs.readFile(yamlPath, 'utf-8');
+
+  await workflowManagement.management.createWorkflow(
+    { yaml, id: EXTRACTION_WORKFLOW_ID },
+    spaceId,
+    request
+  );
+  logger.info(`Created shared extraction workflow with id '${EXTRACTION_WORKFLOW_ID}'`);
 }
 
 /**
@@ -180,6 +213,8 @@ export async function createDataSourceAndRelatedResources(
 
   // Create workflows and tools
   const spaceId = getSpaceId(savedObjectsClient);
+
+  await ensureExtractionWorkflowExists(workflowManagement, spaceId, request, logger);
 
   logger.info(`data source workflows: ${JSON.stringify(dataSource.workflows)}`);
 

--- a/x-pack/platform/plugins/shared/data_sources/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/saved_objects/index.ts
@@ -59,6 +59,24 @@ export const dataSourceMappings: SavedObjectsTypeMappingDefinition = {
   },
 };
 
+export const EXTRACTION_CONFIG_SAVED_OBJECT_TYPE = 'data_sources_extraction_config';
+export const EXTRACTION_CONFIG_SO_ID = 'data-sources-extraction-config';
+
+export interface ExtractionConfigAttributes {
+  workflowId: string;
+}
+
+const extractionConfigSchemaV1 = schema.object({
+  workflowId: schema.string(),
+});
+
+const extractionConfigMappings: SavedObjectsTypeMappingDefinition = {
+  dynamic: false,
+  properties: {
+    workflowId: { type: 'keyword' },
+  },
+};
+
 export function setupSavedObjects(savedObjects: SavedObjectsServiceSetup) {
   savedObjects.registerType({
     name: DATA_SOURCE_SAVED_OBJECT_TYPE,
@@ -80,6 +98,22 @@ export function setupSavedObjects(savedObjects: SavedObjectsServiceSetup) {
         schemas: {
           forwardCompatibility: dataSourceSchemaV1.extends({}, { unknowns: 'ignore' }),
           create: dataSourceSchemaV1,
+        },
+      },
+    },
+  });
+
+  savedObjects.registerType({
+    name: EXTRACTION_CONFIG_SAVED_OBJECT_TYPE,
+    hidden: false,
+    namespaceType: 'multiple-isolated',
+    mappings: extractionConfigMappings,
+    modelVersions: {
+      1: {
+        changes: [],
+        schemas: {
+          forwardCompatibility: extractionConfigSchemaV1.extends({}, { unknowns: 'ignore' }),
+          create: extractionConfigSchemaV1,
         },
       },
     },

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/google_drive/workflows/download.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/google_drive/workflows/download.yaml
@@ -38,30 +38,21 @@ steps:
         with:
           fileId: "${{foreach.item}}"
       - name: extract_content
-        type: elasticsearch.request
+        type: workflow.execute
         with:
-          method: POST
-          path: /_ingest/pipeline/_simulate
-          body:
-            pipeline:
-              processors:
-                - attachment:
-                    field: data
-                    indexed_chars: -1
-                    remove_binary: true
-            docs:
-              - _id: "${{foreach.item}}"
-                _source:
-                  filename: "${{steps.download_file.output.name}}"
-                  data: "${{steps.download_file.output.content}}"
+          workflow-id: "workflow-00000000-0000-0000-0000-000000000001"
+          inputs:
+            content: "${{steps.download_file.output.content}}"
+            filename: "${{steps.download_file.output.name}}"
+            docId: "${{foreach.item}}"
       - name: normalize_result
         type: data.set
         with:
           normalized:
             fileId: "${{foreach.item}}"
             filename: "${{steps.download_file.output.name}}"
-            content: "${{steps.extract_content.output.docs[0].doc._source.attachment.content}}"
-            content_type: "${{steps.extract_content.output.docs[0].doc._source.attachment.content_type}}"
+            content: "${{steps.extract_content.output.content}}"
+            content_type: "${{steps.extract_content.output.content_type}}"
       - name: accumulate_result
         type: data.set
         with:

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/google_drive/workflows/download.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/google_drive/workflows/download.yaml
@@ -40,7 +40,7 @@ steps:
       - name: extract_content
         type: workflow.execute
         with:
-          workflow-id: "workflow-00000000-0000-0000-0000-000000000001"
+          workflow-id: "{{extraction_workflow_id}}"
           inputs:
             content: "${{steps.download_file.output.content}}"
             filename: "${{steps.download_file.output.name}}"

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/sharepoint_online/workflows/download.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/sharepoint_online/workflows/download.yaml
@@ -1,6 +1,6 @@
 version: '1'
 name: 'sources.sharepoint.download'
-description: 'Download SharePoint content. Actions and inputs: downloadDriveItem (drive_id, item_id) for markdown/plain-text files; downloadItemFromURL + ingest extract (download_url) for PDFs, .docx, and other files that require preprocessing (extracted text available in simulate response under docs[0].doc._source.attachment.content); getSitePageContents (site_id, page_id) for SharePoint site page content.'
+description: 'Download SharePoint content. Actions and inputs: downloadDriveItem (drive_id, item_id) for markdown/plain-text files; downloadItemFromURL + extract (download_url) for PDFs, .docx, and other files that require preprocessing (extracted text available under output.content); getSitePageContents (site_id, page_id) for SharePoint site page content.'
 tags: ['agent-builder-tool']
 enabled: true
 triggers:
@@ -45,22 +45,13 @@ steps:
         with:
           downloadUrl: "${{ inputs.download_url }}"
       - name: extract-content
-        type: elasticsearch.request
+        type: workflow.execute
         with:
-          method: POST
-          path: /_ingest/pipeline/_simulate
-          body:
-            pipeline:
-              processors:
-                - attachment:
-                    field: data
-                    indexed_chars: -1
-                    remove_binary: true
-            docs:
-              - _id: "${{ inputs.download_url }}"
-                _source:
-                  filename: "${{ inputs.download_url }}"
-                  data: "${{ steps.download-item-from-url.output.base64 }}"
+          workflow-id: "workflow-00000000-0000-0000-0000-000000000001"
+          inputs:
+            content: "${{ steps.download-item-from-url.output.base64 }}"
+            filename: "${{ inputs.download_url }}"
+            docId: "${{ inputs.download_url }}"
   - name: get-site-page-contents
     type: sharepoint-online.getSitePageContents
     if: "${{ inputs.download_action == 'getSitePageContents' }}"

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/sharepoint_online/workflows/download.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/sharepoint_online/workflows/download.yaml
@@ -47,7 +47,7 @@ steps:
       - name: extract-content
         type: workflow.execute
         with:
-          workflow-id: "workflow-00000000-0000-0000-0000-000000000001"
+          workflow-id: "{{extraction_workflow_id}}"
           inputs:
             content: "${{ steps.download-item-from-url.output.base64 }}"
             filename: "${{ inputs.download_url }}"

--- a/x-pack/platform/plugins/shared/data_sources/server/workflows/extraction.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/workflows/extraction.yaml
@@ -1,0 +1,40 @@
+version: '1'
+name: 'sources.shared.extract_content'
+description: 'Shared extraction workflow: extracts text from base64-encoded file data using the ingest attachment processor (Tika). Used by data source download workflows via workflow.execute.'
+enabled: true
+triggers:
+  - type: manual
+inputs:
+  - name: content
+    type: string
+    description: Base64-encoded file content
+  - name: filename
+    type: string
+    description: Filename with extension, used for content type detection
+  - name: docId
+    type: string
+    required: false
+    description: Optional document identifier, passed as _id in the simulated doc
+steps:
+  - name: simulate_extraction
+    type: elasticsearch.request
+    with:
+      method: POST
+      path: /_ingest/pipeline/_simulate
+      body:
+        pipeline:
+          processors:
+            - attachment:
+                field: data
+                indexed_chars: -1
+                remove_binary: true
+        docs:
+          - _id: "${{inputs.docId}}"
+            _source:
+              filename: "${{inputs.filename}}"
+              data: "${{inputs.content}}"
+  - name: normalize_output
+    type: data.set
+    with:
+      content: "${{steps.simulate_extraction.output.docs[0].doc._source.attachment.content}}"
+      content_type: "${{steps.simulate_extraction.output.docs[0].doc._source.attachment.content_type}}"


### PR DESCRIPTION
## Summary

Replaces duplicated Tika extraction logic in data source download workflows (Google Drive, SharePoint) with a shared extraction workflow invoked via `workflow.execute`.

- **New shared extraction workflow** (`extraction.yaml`): encapsulates the `_ingest/pipeline/_simulate` + `attachment` processor logic behind a clean `inputs`/`output` interface (`content`, `filename`, `docId` → `content`, `content_type`).
- **Download workflows simplified**: instead of inlining the ES request + attachment processor config, they call `workflow.execute` with the shared workflow's ID and pass inputs.
- **SO-based ID tracking**: the shared workflow is created with an auto-generated UUID. Its ID is persisted in a singleton Saved Object (`data-sources-extraction-config`), so it can be recovered if a user deletes it. Download workflow YAMLs use a `{{extraction_workflow_id}}` placeholder that gets stamped with the real UUID at data source creation time.

This is a POC toward a configurable extraction abstraction where the extraction backend (Tika, inference endpoint / Gemini, etc.) can be swapped globally or per-data-source without modifying individual download workflows.

### How this looks:

Reference to shared workflow now sit in every workflow from a data source that needs extraction:

<img width="1210" height="372" alt="Screenshot 2026-03-04 at 7 10 28 PM" src="https://github.com/user-attachments/assets/f2d77dcf-a4cc-4fba-b9b3-fe56f7579381" />

The above reference can be replaced with another workflow.


The workflow we generate looks like this:

<img width="1360" height="846" alt="Screenshot 2026-03-04 at 7 11 12 PM" src="https://github.com/user-attachments/assets/474386f7-81a4-4361-816d-2ee665553b48" />

Nothing in the UI shows this as "special" and we don't write protected, it can be edited by design.




Made with [Cursor](https://cursor.com)