### PR TITLE
chore(NA): apply common retry strategy for scout

### DIFF
--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -96,8 +96,8 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
             },
             retry: {
               automatic: [
-                { exit_status: '10', limit: 1 },
-                { exit_status: '*', limit: 3 },
+                { exit_status: '-1', limit: 3 },
+                { exit_status: '*', limit: 1 },
               ],
             },
           })


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-operations/issues/464

I could be missing something but I think it makes more sense for the retry strategy on Scout to match what we currently do in other test frameworks we are using:

- retry up until 3 times for agent loss
- in any other situations retry once

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->