### PR TITLE
[Security Solution] render analyzer in new tools flyout in Security Solution and Discover

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -12,6 +12,7 @@ import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { analyzerCellActionRenderer } from '../../../../flyout_v2/analyzer/components/cell_actions';
 import { OverviewTab } from '../../../../flyout_v2/document/tabs/overview_tab';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
 import { useKibana } from '../../../lib/kibana';
@@ -118,7 +119,7 @@ const RowActionComponent = ({
           services,
           store,
           history,
-          children: <OverviewTab hit={hit} />,
+          children: <OverviewTab hit={hit} renderCellActions={analyzerCellActionRenderer} />,
         }),
         {
           ownFocus: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/analyzer_panels/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/analyzer_panels/index.tsx
@@ -8,10 +8,11 @@
 import React, { useCallback } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { analyzerCellActionRenderer } from '../../../flyout_v2/analyzer/components/cell_actions';
 import type { DocumentDetailsAnalyzerPanelKey } from '../shared/constants/panel_keys';
+import { DocumentDetailsPreviewPanelKey } from '../shared/constants/panel_keys';
 import { DetailsPanel } from '../../../resolver/view/details_panel';
 import type { NodeEventOnClick } from '../../../resolver/view/panels/node_events_of_type';
-import { DocumentDetailsPreviewPanelKey } from '../shared/constants/panel_keys';
 import { ALERT_PREVIEW_BANNER, EVENT_PREVIEW_BANNER } from '../preview/constants';
 import { FlyoutBody } from '../../shared/components/flyout_body';
 
@@ -56,6 +57,7 @@ export const AnalyzerPanel: React.FC<AnalyzerPanelProps> = ({ resolverComponentI
         <DetailsPanel
           resolverComponentInstanceID={resolverComponentInstanceID}
           nodeEventOnClick={openPreview}
+          renderCellActions={analyzerCellActionRenderer}
         />
       </div>
     </FlyoutBody>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
@@ -66,6 +66,11 @@ jest.mock('../../../../common/lib/kibana', () => {
 
 const mockUseWhichFlyout = useWhichFlyout as jest.Mock;
 const FLYOUT_KEY = 'securitySolution';
+const mockExperimentalFeatureFlags = (flags: Record<string, boolean>) => {
+  (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
+    (flag: string) => flags[flag] ?? false
+  );
+};
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -114,7 +119,10 @@ describe('<AnalyzeGraph />', () => {
     mockUiSettingsGet.mockReturnValue(true);
     mockUseWhichFlyout.mockReturnValue(FLYOUT_KEY);
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+    mockExperimentalFeatureFlags({
+      newDataViewPickerEnabled: true,
+      newFlyoutSystemEnabled: false,
+    });
     (useSelectedPatterns as jest.Mock).mockReturnValue(['index']);
     (useIsAnalyzerEnabled as jest.Mock).mockReturnValue(true);
     (useDataView as jest.Mock).mockReturnValue({
@@ -286,7 +294,10 @@ describe('<AnalyzeGraph />', () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
-      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+      mockExperimentalFeatureFlags({
+        newDataViewPickerEnabled: false,
+        newFlyoutSystemEnabled: false,
+      });
     });
 
     it('should show loading spinner while sourcerer data view is loading', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -20,6 +20,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { analyzerCellActionRenderer } from '../../../../flyout_v2/analyzer/components/cell_actions';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { PageScope } from '../../../../data_view_manager/constants';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
@@ -209,6 +210,7 @@ export const AnalyzeGraph: FC = () => {
         indices={selectedPatterns}
         shouldUpdate={shouldUpdate}
         filters={filters}
+        renderCellActions={analyzerCellActionRenderer}
       />
     </div>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/analyzer/analyzer_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/analyzer/analyzer_graph.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo } from 'react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { PREFIX } from '../../flyout/shared/test_ids';
+import { PageScope } from '../../data_view_manager/constants';
+import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
+import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import { useSourcererDataView } from '../../sourcerer/containers';
+import { useTimelineDataFilters } from '../../timelines/containers/use_timeline_data_filters';
+import { Resolver } from '../../resolver/view';
+import type { ResolverCellActionRenderer } from '../../resolver/types';
+
+export const ANALYZER_GRAPH_TEST_ID = `${PREFIX}AnalyzerGraph` as const;
+
+export interface AnalyzerGraphProps {
+  /**
+   * The document record that will be used to render the content of the analyzer graph.
+   */
+  hit: DataTableRecord;
+  /**
+   * A function that renders cell actions for the analyzer graph.
+   */
+  renderCellActions: ResolverCellActionRenderer;
+}
+
+const RESOLVER_COMPONENT_INSTANCE_ID = 'flyout_v2_analyzer_graph';
+
+/**
+ * Analyzer graph view displayed in the analyzer tools flyout
+ */
+export const AnalyzerGraph = memo(({ hit, renderCellActions }: AnalyzerGraphProps) => {
+  const eventId = hit.raw._id ?? '';
+
+  const { from, to, shouldUpdate } = useTimelineDataFilters(false);
+  const filters = useMemo(() => ({ from, to }), [from, to]);
+
+  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+  const { selectedPatterns: oldAnalyzerPatterns } = useSourcererDataView(PageScope.analyzer);
+  const experimentalAnalyzerPatterns = useSelectedPatterns(PageScope.analyzer);
+  const selectedPatterns = newDataViewPickerEnabled
+    ? experimentalAnalyzerPatterns
+    : oldAnalyzerPatterns;
+
+  if (!eventId) {
+    return null;
+  }
+
+  return (
+    <div data-test-subj={ANALYZER_GRAPH_TEST_ID}>
+      <Resolver
+        databaseDocumentID={eventId}
+        resolverComponentInstanceID={RESOLVER_COMPONENT_INSTANCE_ID}
+        indices={selectedPatterns}
+        shouldUpdate={shouldUpdate}
+        filters={filters}
+        renderCellActions={renderCellActions}
+      />
+    </div>
+  );
+});
+
+AnalyzerGraph.displayName = 'AnalyzerGraph';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/analyzer/components/cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/analyzer/components/cell_actions.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import type { ResolverCellActionRenderer } from '../../../resolver/types';
+import { CellActionsMode, SecurityCellActions } from '../../../common/components/cell_actions';
+import { getSourcererScopeId } from '../../../helpers';
+
+/**
+ * Default cell action renderer for Security Solution. This component is used to render cell actions for fields in Security Solution.
+ * This is used in the expandable flyout and in the new flyout (though only when used in Security Solution).
+ */
+export const analyzerCellActionRenderer: ResolverCellActionRenderer = ({
+  field,
+  value,
+  children,
+  scopeId,
+}) => (
+  <SecurityCellActions
+    data={{
+      field,
+      value: value ?? [],
+    }}
+    triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
+    mode={CellActionsMode.HOVER_DOWN}
+    visibleCellActions={5}
+    sourcererScopeId={getSourcererScopeId(scopeId)}
+    metadata={{ scopeId }}
+  >
+    {children}
+  </SecurityCellActions>
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.test.tsx
@@ -77,6 +77,7 @@ describe('VisualizationsSection', () => {
   const mockUseIsExperimentalFeatureEnabled = jest.mocked(useIsExperimentalFeatureEnabled);
 
   const openSystemFlyout = jest.fn();
+  const renderCellActions = jest.fn();
   const store = createStore(() => ({}));
   const history = createMemoryHistory();
 
@@ -85,7 +86,7 @@ describe('VisualizationsSection', () => {
       <IntlProvider locale="en">
         <Provider store={store}>
           <Router history={history}>
-            <VisualizationsSection hit={mockHit} />
+            <VisualizationsSection hit={mockHit} renderCellActions={renderCellActions} />
           </Router>
         </Provider>
       </IntlProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
@@ -8,11 +8,17 @@
 import React, { memo, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
+import { useHistory } from 'react-router-dom';
+import { useStore } from 'react-redux';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
+import { useKibana } from '../../../common/lib/kibana';
 import { useExpandSection } from '../../shared/hooks/use_expand_section';
 import { ExpandableSection } from '../../shared/components/expandable_section';
 import { PREFIX } from '../../../flyout/shared/test_ids';
 import { AnalyzerPreviewContainer } from './analyzer_preview_container';
+import { flyoutProviders } from '../../shared/components/flyout_provider';
+import { AnalyzerGraph } from '../../analyzer/analyzer_graph';
+import type { ResolverCellActionRenderer } from '../../../resolver/types';
 
 export const VISUALIZATION_SECTION_TEST_ID = `${PREFIX}Visualizations` as const;
 
@@ -30,39 +36,65 @@ export interface VisualizationsSectionProps {
    * Document to display in the overview tab
    */
   hit: DataTableRecord;
+  /**
+   * Optional prop to pass cell action renderer to the analyzer graph.
+   */
+  renderCellActions: ResolverCellActionRenderer;
 }
 
 /**
  * Third section of the overview tab in details flyout.
  * It contains analyzer preview and session view preview.
  */
-export const VisualizationsSection = memo(({ hit }: VisualizationsSectionProps) => {
-  const expanded = useExpandSection({
-    storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
-    title: LOCAL_STORAGE_SECTION_KEY,
-    defaultValue: false,
-  });
+export const VisualizationsSection = memo(
+  ({ hit, renderCellActions }: VisualizationsSectionProps) => {
+    const { services } = useKibana();
+    const { overlays } = services;
+    const store = useStore();
+    const history = useHistory();
 
-  const onShowAnalyzer = useCallback(() => {}, []);
+    const expanded = useExpandSection({
+      storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
+      title: LOCAL_STORAGE_SECTION_KEY,
+      defaultValue: false,
+    });
 
-  return (
-    <ExpandableSection
-      data-test-subj={VISUALIZATION_SECTION_TEST_ID}
-      expanded={expanded}
-      gutterSize="s"
-      localStorageKey={FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS}
-      sectionId={LOCAL_STORAGE_SECTION_KEY}
-      title={VISUALIZATION_SECTION_TITLE}
-    >
-      <AnalyzerPreviewContainer
-        hit={hit}
-        onShowAnalyzer={onShowAnalyzer}
-        shouldUseAncestor={false}
-        showIcon={false}
-        disableNavigation={false}
-      />
-    </ExpandableSection>
-  );
-});
+    const onShowAnalyzer = useCallback(() => {
+      overlays.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: <AnalyzerGraph hit={hit} renderCellActions={renderCellActions} />,
+        }),
+        {
+          ownFocus: false,
+          resizable: true,
+          size: 'm',
+          type: 'overlay',
+        }
+      );
+    }, [history, hit, overlays, renderCellActions, services, store]);
+
+    return (
+      <ExpandableSection
+        data-test-subj={VISUALIZATION_SECTION_TEST_ID}
+        expanded={expanded}
+        gutterSize="s"
+        localStorageKey={FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS}
+        sectionId={LOCAL_STORAGE_SECTION_KEY}
+        title={VISUALIZATION_SECTION_TITLE}
+      >
+        <AnalyzerPreviewContainer
+          hit={hit}
+          onShowAnalyzer={onShowAnalyzer}
+          shouldUseAncestor={false}
+          showIcon={false}
+          disableNavigation={false}
+        />
+      </ExpandableSection>
+    );
+  }
+);
 
 VisualizationsSection.displayName = 'VisualizationsSection';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab.tsx
@@ -12,6 +12,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { AboutSection } from '../components/about_section';
 import { InvestigationSection } from '../components/investigation_section';
 import { VisualizationsSection } from '../components/visualizations_section';
+import type { ResolverCellActionRenderer } from '../../../resolver/types';
 
 const OVERVIEW_ARIA_LABEL = i18n.translate(
   'xpack.securitySolution.flyout.document.overview.overviewContentAriaLabel',
@@ -23,19 +24,23 @@ export interface OverviewTabProps {
    * Document to display in the overview tab
    */
   hit: DataTableRecord;
+  /**
+   * Pass cell action renderer to the analyzer graph in the visualizations section of the overview tab.
+   */
+  renderCellActions: ResolverCellActionRenderer;
 }
 
 /**
  * Overview view displayed in the document details expandable flyout right section
  */
-export const OverviewTab = memo(({ hit }: OverviewTabProps) => {
+export const OverviewTab = memo(({ hit, renderCellActions }: OverviewTabProps) => {
   return (
     <EuiPanel hasBorder={false} hasShadow={false} aria-label={OVERVIEW_ARIA_LABEL}>
       <AboutSection hit={hit} />
       <EuiHorizontalRule margin="m" />
       <InvestigationSection hit={hit} />
       <EuiHorizontalRule margin="m" />
-      <VisualizationsSection hit={hit} />
+      <VisualizationsSection hit={hit} renderCellActions={renderCellActions} />
     </EuiPanel>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab_wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab_wrapper.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { ElasticRequestState } from '@kbn/unified-doc-viewer';
+import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { TestProviders } from '../../../common/mock';
+import { OverviewTabWrapper } from './overview_tab_wrapper';
+
+jest.mock('@kbn/unified-doc-viewer-plugin/public');
+jest.mock('../../../data_view_manager/hooks/use_data_view');
+
+const mockOverviewTab = jest.fn((props: unknown) => <div data-test-subj="overviewTabStub" />);
+jest.mock('./overview_tab', () => ({
+  OverviewTab: (props: unknown) => mockOverviewTab(props),
+}));
+
+const mockDataView = {
+  hasMatchedIndices: () => true,
+  getIndexPattern: () => 'logs-*',
+};
+
+const renderEventOverviewFlyoutContent = () =>
+  render(
+    <TestProviders>
+      <OverviewTabWrapper documentId="doc-id" indexName="my-index" renderCellActions={jest.fn()} />
+    </TestProviders>
+  );
+
+describe('EventOverviewFlyoutContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: mockDataView,
+    });
+    (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.Loading, null, jest.fn()]);
+  });
+
+  it('fetches clicked document using document id and index', () => {
+    renderEventOverviewFlyoutContent();
+
+    expect(useEsDocSearch).toHaveBeenCalledWith({
+      id: 'doc-id',
+      index: 'my-index',
+      dataView: mockDataView,
+      skip: false,
+    });
+  });
+
+  it('renders loading while data view is loading', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'loading',
+      dataView: mockDataView,
+    });
+
+    const { getByTestId } = renderEventOverviewFlyoutContent();
+
+    expect(getByTestId('analyzer-event-overview-loading')).toBeInTheDocument();
+    expect(useEsDocSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: true,
+      })
+    );
+  });
+
+  it('renders OverviewTab when document is found', () => {
+    const hit = { id: '1' } as DataTableRecord;
+    (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.Found, hit, jest.fn()]);
+
+    const { getByTestId } = renderEventOverviewFlyoutContent();
+
+    expect(getByTestId('overviewTabStub')).toBeInTheDocument();
+    expect(mockOverviewTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hit,
+      })
+    );
+  });
+
+  it('renders not-found state when no document matches', () => {
+    (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.NotFound, null, jest.fn()]);
+
+    const { getByTestId } = renderEventOverviewFlyoutContent();
+
+    expect(getByTestId('analyzer-event-overview-not-found')).toBeInTheDocument();
+  });
+
+  it('renders error state when document fetch fails', () => {
+    (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.Error, null, jest.fn()]);
+
+    const { getByTestId } = renderEventOverviewFlyoutContent();
+
+    expect(getByTestId('analyzer-event-overview-fetch-error')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tabs/overview_tab_wrapper.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiCallOut, EuiLoadingSpinner, EuiPanel } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { ElasticRequestState } from '@kbn/unified-doc-viewer';
+import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
+import type { ResolverCellActionRenderer } from '../../../resolver/types';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../data_view_manager/constants';
+import { OverviewTab } from './overview_tab';
+
+const DATA_VIEW_ERROR = i18n.translate(
+  'xpack.securitySolution.analyzer.eventOverviewFlyout.dataViewError',
+  {
+    defaultMessage: 'Unable to retrieve the data view for analyzer.',
+  }
+);
+
+const DOCUMENT_NOT_FOUND = i18n.translate(
+  'xpack.securitySolution.analyzer.eventOverviewFlyout.documentNotFound',
+  {
+    defaultMessage: 'Cannot find document. No documents match that ID.',
+  }
+);
+
+const FETCH_ERROR = i18n.translate(
+  'xpack.securitySolution.analyzer.eventOverviewFlyout.fetchError',
+  {
+    defaultMessage: 'Unable to fetch document details.',
+  }
+);
+
+export interface OverviewTabWrapperProps {
+  /**
+   * The ID of the document to display in the overview tab. This is required to fetch the document details and render the content of the overview tab.
+   */
+  documentId: string | undefined;
+  /**
+   * The name of the index that contains the document to display in the overview tab. This is required to fetch the document details and render the content of the overview tab.
+   */
+  indexName: string | undefined;
+  /**
+   * A function that renders cell actions for the overview tab. This is required to provide interactive actions for fields displayed in the overview tab, such as adding filters or viewing field details.
+   */
+  renderCellActions: ResolverCellActionRenderer;
+}
+
+/**
+ * OverviewTabWrapper is a React component that serves as a wrapper for the OverviewTab component.
+ * It fetches the document details based on the provided document ID and index name, and manages the loading and error states during the data fetching process.
+ * It is currently used in Analyzer when opening a document from the detail panel.
+ */
+export const OverviewTabWrapper = memo(
+  ({ documentId, indexName, renderCellActions }: OverviewTabWrapperProps) => {
+    const { dataView, status } = useDataView(PageScope.default);
+
+    const isDataViewLoading = status === 'loading' || status === 'pristine';
+    const isDataViewInvalid =
+      status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
+    const shouldSkipSearch =
+      isDataViewLoading || isDataViewInvalid || !documentId || !indexName || !dataView;
+
+    const [requestState, hit] = useEsDocSearch({
+      id: documentId ?? '',
+      index: indexName,
+      dataView,
+      skip: shouldSkipSearch,
+    });
+
+    if (isDataViewLoading) {
+      return (
+        <EuiPanel hasBorder={false} hasShadow={false}>
+          <EuiCallOut announceOnMount data-test-subj="analyzer-event-overview-loading">
+            <EuiLoadingSpinner size="m" />{' '}
+            {i18n.translate('xpack.securitySolution.analyzer.eventOverviewFlyout.loading', {
+              defaultMessage: 'Loading…',
+            })}
+          </EuiCallOut>
+        </EuiPanel>
+      );
+    }
+
+    if (isDataViewInvalid) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          color="danger"
+          iconType="warning"
+          title={DATA_VIEW_ERROR}
+          data-test-subj="analyzer-event-overview-data-view-error"
+        />
+      );
+    }
+
+    if (requestState === ElasticRequestState.Found && hit) {
+      return <OverviewTab hit={hit} renderCellActions={renderCellActions} />;
+    }
+
+    if (requestState === ElasticRequestState.NotFound) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          color="danger"
+          iconType="warning"
+          title={DOCUMENT_NOT_FOUND}
+          data-test-subj="analyzer-event-overview-not-found"
+        />
+      );
+    }
+
+    if (requestState === ElasticRequestState.Error) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          color="danger"
+          iconType="warning"
+          title={FETCH_ERROR}
+          data-test-subj="analyzer-event-overview-fetch-error"
+        />
+      );
+    }
+
+    return (
+      <EuiPanel hasBorder={false} hasShadow={false}>
+        <EuiCallOut data-test-subj="analyzer-event-overview-loading">
+          <EuiLoadingSpinner size="m" />{' '}
+          {i18n.translate('xpack.securitySolution.analyzer.eventOverviewFlyout.loadingFallback', {
+            defaultMessage: 'Loading…',
+          })}
+        </EuiCallOut>
+      </EuiPanel>
+    );
+  }
+);
+
+OverviewTabWrapper.displayName = 'EventOverviewFlyoutContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useLocation } from 'react-router-dom';
 import { createStore } from 'redux';
 import type { StartServices } from '../../../types';
@@ -23,6 +24,12 @@ const LocationProbe = () => {
   const { pathname, search } = useLocation();
 
   return <div>{`${pathname}${search}`}</div>;
+};
+
+const ExpandableFlyoutApiProbe = () => {
+  const { openPreviewPanel } = useExpandableFlyoutApi();
+
+  return <div>{typeof openPreviewPanel}</div>;
 };
 
 describe('flyoutProviders', () => {
@@ -54,5 +61,19 @@ describe('flyoutProviders', () => {
     );
 
     expect(screen.getByText('NoRouterFallback')).toBeInTheDocument();
+  });
+
+  it('provides expandable flyout context to children', () => {
+    const store = createStore(() => ({}));
+
+    render(
+      flyoutProviders({
+        services,
+        store,
+        children: <ExpandableFlyoutApiProbe />,
+      })
+    );
+
+    expect(screen.getByText('function')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
@@ -11,6 +11,8 @@ import type { History } from 'history';
 import { Router } from '@kbn/shared-ux-router';
 import type { Store } from 'redux';
 import { Provider } from 'react-redux';
+import { CellActionsProvider } from '@kbn/cell-actions';
+import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
 import type { StartServices } from '../../../types';
 import { ReactQueryClientProvider } from '../../../common/containers/query_client/query_client_provider';
 import { KibanaContextProvider } from '../../../common/lib/kibana';
@@ -26,13 +28,25 @@ export const flyoutProviders = ({
   children: ReactNode;
   history?: History;
 }): ReactElement => {
-  const flyoutContent = history ? <Router history={history}>{children}</Router> : children;
+  // This is currently necessary because of Analyzer (which internally has the logic to open other flyouts)
+  // TODO remove ExpandableFlyoutProvider when we're ready to drop the expandable flyout
+  const flyoutContent = history ? (
+    <Router history={history}>
+      <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
+    </Router>
+  ) : (
+    <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
+  );
 
   return (
     <KibanaContextProvider services={services}>
-      <Provider store={store}>
-        <ReactQueryClientProvider>{flyoutContent}</ReactQueryClientProvider>
-      </Provider>
+      <CellActionsProvider
+        getTriggerCompatibleActions={services.uiActions.getTriggerCompatibleActions}
+      >
+        <Provider store={store}>
+          <ReactQueryClientProvider>{flyoutContent}</ReactQueryClientProvider>
+        </Provider>
+      </CellActionsProvider>
     </KibanaContextProvider>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useSelector } from 'react-redux';
 import { OverviewTab } from '../../flyout_v2/document/tabs/overview_tab';
@@ -14,6 +14,7 @@ import type { StartServices } from '../../types';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
 import { useInitDataViewManager } from '../../data_view_manager/hooks/use_init_data_view_manager';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import type { ResolverCellActionRenderer } from '../../resolver/types';
 
 const DataViewManagerBootstrap = () => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
@@ -80,6 +81,13 @@ export const AlertFlyoutOverviewTab = ({
     };
   }, [servicesPromise, storePromise]);
 
+  // For now we are not rendering any cell actions in the overview tab, but we need to provide a renderer to prevent errors in the resolver component.
+  // We will eventually implement the Discover cell actions.
+  const renderCellActions = useCallback<ResolverCellActionRenderer>(
+    ({ children, field, scopeId, value }) => <>{children}</>,
+    []
+  );
+
   if (!services || !store) {
     return null;
   }
@@ -90,7 +98,7 @@ export const AlertFlyoutOverviewTab = ({
     children: (
       <>
         <DataViewManagerBootstrap />
-        <OverviewTab hit={hit} />
+        <OverviewTab hit={hit} renderCellActions={renderCellActions} />
       </>
     ),
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
@@ -6,21 +6,23 @@
  */
 
 import React from 'react';
-import type { Store, AnyAction } from 'redux';
+import type { AnyAction, Store } from 'redux';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 import type { History as HistoryPackageHistoryInterface } from 'history';
 import { coreMock } from '@kbn/core/public/mocks';
+import { analyzerCellActionRenderer } from '../../../flyout_v2/analyzer/components/cell_actions';
 import { spyMiddlewareFactory } from '../spy_middleware_factory';
 import { resolverMiddlewareFactory } from '../../store/middleware';
 import { MockResolver } from './mock_resolver';
-import type { DataAccessLayer, SpyMiddleware, SideEffectSimulator, TimeFilters } from '../../types';
+import type { DataAccessLayer, SideEffectSimulator, SpyMiddleware, TimeFilters } from '../../types';
 import { sideEffectSimulatorFactory } from '../../view/side_effect_simulator_factory';
 import { uiSetting } from '../../mocks/ui_setting';
 import { EMPTY_RESOLVER } from '../../store/helpers';
 import type { State } from '../../../common/store/types';
 import { createMockStore, mockGlobalState } from '../../../common/mock';
 import { createResolver } from '../../store/actions';
+
 /**
  * Test a Resolver instance using jest, enzyme, and a mock data layer.
  */
@@ -149,6 +151,7 @@ export class Simulator {
         indices={indices}
         filters={filters}
         shouldUpdate={shouldUpdate}
+        renderCellActions={analyzerCellActionRenderer}
       />
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
@@ -111,8 +111,12 @@ export const MockResolver = React.memo((props: MockResolverProps) => {
                       indices={props.indices}
                       shouldUpdate={props.shouldUpdate}
                       filters={props.filters}
+                      renderCellActions={props.renderCellActions}
                     />
-                    <DetailsPanel resolverComponentInstanceID={props.resolverComponentInstanceID} />
+                    <DetailsPanel
+                      renderCellActions={props.renderCellActions}
+                      resolverComponentInstanceID={props.resolverComponentInstanceID}
+                    />
                   </>
                 </Provider>
               </SideEffectContext.Provider>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
@@ -9,6 +9,7 @@ import type React from 'react';
 import type { AnyAction, Dispatch, Middleware, Store } from 'redux';
 import type { BBox } from 'rbush';
 import type { Provider } from 'react-redux';
+import type { CellActionFieldValue } from '@kbn/cell-actions';
 import type {
   NewResolverTree,
   ResolverEntityIndex,
@@ -815,6 +816,17 @@ export interface TimeFilters {
   to?: string;
 }
 
+export interface ResolverCellActionRendererProps {
+  children: React.ReactNode;
+  field: string;
+  scopeId: string;
+  value: CellActionFieldValue;
+}
+
+export type ResolverCellActionRenderer = (
+  props: ResolverCellActionRendererProps
+) => React.ReactNode | null;
+
 /**
  * The externally provided React props.
  */
@@ -846,6 +858,11 @@ export interface ResolverProps {
    * A flag to update data from an external source
    */
   shouldUpdate: boolean;
+
+  /**
+   * Renderer used by Resolver panels for field cell actions.
+   */
+  renderCellActions: ResolverCellActionRenderer;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/details_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/details_panel.test.tsx
@@ -10,7 +10,7 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { Router } from '@kbn/shared-ux-router';
 import { I18nProvider } from '@kbn/i18n-react';
-import { TestProviders, createMockStore, mockGlobalState } from '../../common/mock';
+import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
 import type { ResolverState } from '../types';
 import { createMemoryHistory } from 'history';
 import { coreMock } from '@kbn/core/public/mocks';
@@ -18,6 +18,7 @@ import { DetailsPanel } from './details_panel';
 import { EMPTY_RESOLVER } from '../store/helpers';
 import { uiSetting } from '../mocks/ui_setting';
 import '../test_utilities/extend_jest';
+import { analyzerCellActionRenderer } from '../../flyout_v2/analyzer/components/cell_actions';
 
 const defaultInstanceID = 'details-panel-test';
 const parameters = { databaseDocumentID: 'id', indices: [], agentId: '', filters: {} };
@@ -67,7 +68,10 @@ const renderDetailsPanel = ({
       <I18nProvider>
         <Router history={history}>
           <Provider store={store}>
-            <DetailsPanel resolverComponentInstanceID={resolverComponentInstanceID} />
+            <DetailsPanel
+              resolverComponentInstanceID={resolverComponentInstanceID}
+              renderCellActions={analyzerCellActionRenderer}
+            />
           </Provider>
         </Router>
       </I18nProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/details_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/details_panel.tsx
@@ -14,6 +14,7 @@ import { PanelRouter } from './panels';
 import { ResolverNoProcessEvents } from './resolver_no_process_events';
 import type { State } from '../../common/store/types';
 import type { NodeEventOnClick } from './panels/node_events_of_type';
+import type { ResolverCellActionRenderer } from '../types';
 
 interface DetailsPanelProps {
   /**
@@ -24,13 +25,17 @@ interface DetailsPanelProps {
    * Optional callback when a node event is clicked
    */
   nodeEventOnClick?: NodeEventOnClick;
+  /**
+   * Renderer used by Resolver panels for field cell actions.
+   */
+  renderCellActions: ResolverCellActionRenderer;
 }
 
 /**
  * Details panel component
  */
 const DetailsPanelComponent = React.memo(
-  ({ resolverComponentInstanceID, nodeEventOnClick }: DetailsPanelProps) => {
+  ({ resolverComponentInstanceID, nodeEventOnClick, renderCellActions }: DetailsPanelProps) => {
     const isLoading = useSelector((state: State) =>
       selectors.isTreeLoading(state.analyzer[resolverComponentInstanceID])
     );
@@ -56,7 +61,11 @@ const DetailsPanelComponent = React.memo(
         </div>
       </div>
     ) : resolverTreeHasNodes ? (
-      <PanelRouter id={resolverComponentInstanceID} nodeEventOnClick={nodeEventOnClick} />
+      <PanelRouter
+        id={resolverComponentInstanceID}
+        nodeEventOnClick={nodeEventOnClick}
+        renderCellActions={renderCellActions}
+      />
     ) : (
       <ResolverNoProcessEvents />
     );
@@ -68,7 +77,7 @@ DetailsPanelComponent.displayName = 'DetailsPanelComponent';
  * Stand alone details panel to be used when in split panel mode
  */
 export const DetailsPanel = React.memo(
-  ({ resolverComponentInstanceID, nodeEventOnClick }: DetailsPanelProps) => {
+  ({ resolverComponentInstanceID, nodeEventOnClick, renderCellActions }: DetailsPanelProps) => {
     const isAnalyzerInitialized = useSelector((state: State) =>
       Boolean(state.analyzer[resolverComponentInstanceID])
     );
@@ -77,6 +86,7 @@ export const DetailsPanel = React.memo(
       <DetailsPanelComponent
         resolverComponentInstanceID={resolverComponentInstanceID}
         nodeEventOnClick={nodeEventOnClick}
+        renderCellActions={renderCellActions}
       />
     ) : (
       <div data-test-subj="resolver:panel:loading" className="loading-container">

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/event_detail.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/event_detail.tsx
@@ -14,11 +14,8 @@ import type { EuiBreadcrumb, EuiBasicTableColumn, EuiSearchBarProps } from '@ela
 import { EuiSpacer, EuiText, EuiInMemoryTable } from '@elastic/eui';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
-import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { BoldCode, StyledTime } from './styles';
 import { GeneratedText } from '../generated_text';
-import { CellActionsMode, SecurityCellActions } from '../../../common/components/cell_actions';
-import { getSourcererScopeId } from '../../../helpers';
 import { Breadcrumbs } from './breadcrumbs';
 import * as eventModel from '../../../../common/endpoint/models/event';
 import * as selectors from '../../store/selectors';
@@ -32,6 +29,7 @@ import { useFormattedDate } from './use_formatted_date';
 import * as nodeDataModel from '../../models/node_data';
 import { expandDottedObject } from '../../../../common/utils/expand_dotted';
 import type { State } from '../../../common/store/types';
+import type { ResolverCellActionRenderer } from '../../types';
 
 const eventDetailRequestError = i18n.translate(
   'xpack.securitySolution.resolver.panel.eventDetail.requestError',
@@ -44,11 +42,13 @@ export const EventDetail = memo(function EventDetail({
   id,
   nodeID,
   eventCategory: eventType,
+  renderCellActions,
 }: {
   id: string;
   nodeID: string;
   /** The event type to show in the breadcrumbs */
   eventCategory: string;
+  renderCellActions: ResolverCellActionRenderer;
 }) {
   const isEventLoading = useSelector((state: State) =>
     selectors.isCurrentRelatedEventLoading(state.analyzer[id])
@@ -77,6 +77,7 @@ export const EventDetail = memo(function EventDetail({
       event={event}
       processEvent={processEvent}
       eventType={eventType}
+      renderCellActions={renderCellActions}
     />
   ) : (
     <PanelContentError id={id} translatedErrorMessage={eventDetailRequestError} />
@@ -94,6 +95,7 @@ const EventDetailContents = memo(function ({
   event,
   eventType,
   processEvent,
+  renderCellActions,
 }: {
   id: string;
   nodeID: string;
@@ -103,6 +105,7 @@ const EventDetailContents = memo(function ({
    */
   eventType: string;
   processEvent: SafeResolverEvent | undefined;
+  renderCellActions: ResolverCellActionRenderer;
 }) {
   const timestamp = eventModel.timestampSafeVersion(event);
   const formattedDate =
@@ -149,7 +152,7 @@ const EventDetailContents = memo(function ({
         </GeneratedText>
       </StyledDescriptiveName>
       <EuiSpacer size="l" />
-      <EventDetailFields event={event} id={id} />
+      <EventDetailFields event={event} id={id} renderCellActions={renderCellActions} />
     </div>
   );
 });
@@ -159,7 +162,15 @@ interface EventDetailsTableView {
   description: string;
 }
 
-function EventDetailFields({ event, id }: { event: SafeResolverEvent; id: string }) {
+function EventDetailFields({
+  event,
+  id,
+  renderCellActions,
+}: {
+  event: SafeResolverEvent;
+  id: string;
+  renderCellActions: ResolverCellActionRenderer;
+}) {
   const descriptions = useMemo(() => {
     const returnValue: EventDetailsTableView[] = [];
     const expandedEventObject: object = expandDottedObject(event);
@@ -210,21 +221,12 @@ function EventDetailFields({ event, id }: { event: SafeResolverEvent; id: string
         />
       ),
       render(data: EventDetailsTableView) {
-        return (
-          <SecurityCellActions
-            data={{
-              field: data.title,
-              value: data.description,
-            }}
-            visibleCellActions={5}
-            triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
-            mode={CellActionsMode.HOVER_DOWN}
-            sourcererScopeId={getSourcererScopeId(id)}
-            metadata={{ scopeId: id }}
-          >
-            {data.description}
-          </SecurityCellActions>
-        );
+        return renderCellActions({
+          field: data.title,
+          value: data.description,
+          children: data.description,
+          scopeId: id,
+        });
       },
     },
   ];

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/index.tsx
@@ -8,12 +8,12 @@
 import React, { memo } from 'react';
 import { useSelector } from 'react-redux';
 import * as selectors from '../../store/selectors';
-import { NodeEventsInCategory, type NodeEventOnClick } from './node_events_of_type';
+import { type NodeEventOnClick, NodeEventsInCategory } from './node_events_of_type';
 import { NodeEvents } from './node_events';
 import { NodeDetail } from './node_detail';
 import { NodeList } from './node_list';
 import { EventDetail } from './event_detail';
-import type { PanelViewAndParameters } from '../../types';
+import type { PanelViewAndParameters, ResolverCellActionRenderer } from '../../types';
 import type { State } from '../../../common/store/types';
 
 /**
@@ -24,9 +24,11 @@ import type { State } from '../../../common/store/types';
 export const PanelRouter = memo(function ({
   id,
   nodeEventOnClick,
+  renderCellActions,
 }: {
   id: string;
   nodeEventOnClick?: NodeEventOnClick;
+  renderCellActions: ResolverCellActionRenderer;
 }) {
   const params: PanelViewAndParameters = useSelector((state: State) =>
     selectors.panelViewAndParameters(state.analyzer[id])
@@ -37,6 +39,7 @@ export const PanelRouter = memo(function ({
         id={id}
         nodeID={params.panelParameters.nodeID}
         nodeEventOnClick={nodeEventOnClick}
+        renderCellActions={renderCellActions}
       />
     );
   } else if (params.panelView === 'nodeEvents') {
@@ -56,10 +59,11 @@ export const PanelRouter = memo(function ({
         id={id}
         nodeID={params.panelParameters.nodeID}
         eventCategory={params.panelParameters.eventCategory}
+        renderCellActions={renderCellActions}
       />
     );
   } else {
     /* The default 'Event List' / 'List of all processes' view */
-    return <NodeList id={id} />;
+    return <NodeList id={id} renderCellActions={renderCellActions} />;
   }
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/node_detail.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/node_detail.test.tsx
@@ -12,6 +12,7 @@ import { TestProviders } from '../../../common/mock';
 import { NodeDetailView } from './node_detail';
 import { useCubeAssets } from '../use_cube_assets';
 import { useLinkProps } from '../use_link_props';
+import type { ResolverCellActionRendererProps } from '../../types';
 
 const mockUseCubeAssets = useCubeAssets as jest.Mock;
 jest.mock('../use_cube_assets');
@@ -31,6 +32,8 @@ const processEvent = {
 };
 
 describe('<NodeDetailView />', () => {
+  const renderCellActions = jest.fn(({ children }: ResolverCellActionRendererProps) => children);
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseLinkProps.mockReturnValue({ href: '#', onClick: jest.fn() });
@@ -44,7 +47,12 @@ describe('<NodeDetailView />', () => {
   it('should render', () => {
     const { getByTestId, queryByTestId } = render(
       <TestProviders>
-        <NodeDetailView id="test" nodeID="test" processEvent={processEvent} />
+        <NodeDetailView
+          id="test"
+          nodeID="test"
+          processEvent={processEvent}
+          renderCellActions={renderCellActions}
+        />
       </TestProviders>
     );
     expect(getByTestId('resolver:panel:node-detail')).toBeInTheDocument();
@@ -63,6 +71,7 @@ describe('<NodeDetailView />', () => {
           nodeID="test"
           nodeEventOnClick={nodeEventOnClick}
           processEvent={processEvent}
+          renderCellActions={renderCellActions}
         />
       </TestProviders>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/node_detail.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/node_detail.tsx
@@ -20,14 +20,11 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import styled from 'styled-components';
-import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { EventKind } from '../../../flyout/document_details/shared/constants/event_kinds';
 import { StyledTitle } from './styles';
 import * as selectors from '../../store/selectors';
 import * as eventModel from '../../../../common/endpoint/models/event';
 import { GeneratedText } from '../generated_text';
-import { CellActionsMode, SecurityCellActions } from '../../../common/components/cell_actions';
-import { getSourcererScopeId } from '../../../helpers';
 import { Breadcrumbs } from './breadcrumbs';
 import { processPath, processPID } from '../../models/process_event';
 import * as nodeDataModel from '../../models/node_data';
@@ -40,6 +37,7 @@ import { useFormattedDate } from './use_formatted_date';
 import { PanelContentError } from './panel_content_error';
 import type { State } from '../../../common/store/types';
 import type { NodeEventOnClick } from './node_events_of_type';
+import type { ResolverCellActionRenderer } from '../../types';
 
 const StyledCubeForProcess = styled(CubeForProcess)`
   position: relative;
@@ -54,10 +52,12 @@ export const NodeDetail = memo(function ({
   id,
   nodeID,
   nodeEventOnClick,
+  renderCellActions,
 }: {
   id: string;
   nodeID: string;
   nodeEventOnClick?: NodeEventOnClick;
+  renderCellActions: ResolverCellActionRenderer;
 }) {
   const processEvent = useSelector((state: State) =>
     nodeDataModel.firstEvent(selectors.nodeDataForID(state.analyzer[id])(nodeID))
@@ -74,6 +74,7 @@ export const NodeDetail = memo(function ({
       nodeID={nodeID}
       processEvent={processEvent}
       nodeEventOnClick={nodeEventOnClick}
+      renderCellActions={renderCellActions}
     />
   ) : (
     <PanelContentError id={id} translatedErrorMessage={nodeDetailError} />
@@ -95,11 +96,13 @@ export const NodeDetailView = memo(function ({
   processEvent,
   nodeID,
   nodeEventOnClick,
+  renderCellActions,
 }: {
   id: string;
   processEvent: SafeResolverEvent;
   nodeID: string;
   nodeEventOnClick?: NodeEventOnClick;
+  renderCellActions: ResolverCellActionRenderer;
 }) {
   const processName = eventModel.processNameSafeVersion(processEvent);
   const nodeState = useSelector((state: State) =>
@@ -265,21 +268,12 @@ export const NodeDetailView = memo(function ({
       ),
       'data-test-subj': 'resolver:node-detail:entry-description',
       render(data: NodeDetailsTableView) {
-        return (
-          <SecurityCellActions
-            data={{
-              field: data.title,
-              value: data.value ?? data.description,
-            }}
-            triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
-            mode={CellActionsMode.HOVER_DOWN}
-            visibleCellActions={5}
-            sourcererScopeId={getSourcererScopeId(id)}
-            metadata={{ scopeId: id }}
-          >
-            {data.description}
-          </SecurityCellActions>
-        );
+        return renderCellActions({
+          field: data.title,
+          value: data.value ?? data.description,
+          children: data.description,
+          scopeId: id,
+        });
       },
     },
   ];

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/node_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/panels/node_list.tsx
@@ -8,17 +8,16 @@
 /* eslint-disable @elastic/eui/href-or-on-click */
 
 import { useDispatch, useSelector } from 'react-redux';
-import React, { memo, useMemo, useCallback, useContext } from 'react';
+import React, { memo, useCallback, useContext, useMemo } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiBadge, EuiButtonEmpty, EuiSpacer, EuiInMemoryTable } from '@elastic/eui';
+import { EuiBadge, EuiButtonEmpty, EuiInMemoryTable, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { SideEffectContext } from '../side_effect_context';
 import {
-  StyledLabelTitle,
   StyledAnalyzedEvent,
-  StyledLabelContainer,
   StyledButtonTextContainer,
+  StyledLabelContainer,
+  StyledLabelTitle,
 } from './styles';
 import * as nodeModel from '../../../../common/endpoint/models/node';
 import * as selectors from '../../store/selectors';
@@ -29,9 +28,8 @@ import { useLinkProps } from '../use_link_props';
 import { useColors } from '../use_colors';
 import { useFormattedDate } from './use_formatted_date';
 import { userSelectedResolverNode } from '../../store/actions';
-import { CellActionsMode, SecurityCellActions } from '../../../common/components/cell_actions';
-import { getSourcererScopeId } from '../../../helpers';
 import type { State } from '../../../common/store/types';
+import type { ResolverCellActionRenderer } from '../../types';
 
 interface ProcessTableView {
   name?: string;
@@ -42,103 +40,111 @@ interface ProcessTableView {
 /**
  * The "default" view for the panel: A list of all the processes currently in the graph.
  */
-export const NodeList = memo(({ id }: { id: string }) => {
-  const columns = useMemo<Array<EuiBasicTableColumn<ProcessTableView>>>(
-    () => [
-      {
-        field: 'name',
-        name: i18n.translate(
-          'xpack.securitySolution.endpoint.resolver.panel.table.row.processNameTitle',
-          {
-            defaultMessage: 'Process Name',
-          }
-        ),
-        sortable: true,
-        truncateText: true,
-        render(name: string | undefined, item: ProcessTableView) {
-          return <NodeDetailLink id={id} name={name} nodeID={item.nodeID} />;
+export const NodeList = memo(
+  ({ id, renderCellActions }: { id: string; renderCellActions: ResolverCellActionRenderer }) => {
+    const columns = useMemo<Array<EuiBasicTableColumn<ProcessTableView>>>(
+      () => [
+        {
+          field: 'name',
+          name: i18n.translate(
+            'xpack.securitySolution.endpoint.resolver.panel.table.row.processNameTitle',
+            {
+              defaultMessage: 'Process Name',
+            }
+          ),
+          sortable: true,
+          truncateText: true,
+          render(name: string | undefined, item: ProcessTableView) {
+            return <NodeDetailLink id={id} name={name} nodeID={item.nodeID} />;
+          },
         },
-      },
-      {
-        field: 'timestamp',
-        name: i18n.translate(
-          'xpack.securitySolution.endpoint.resolver.panel.table.row.timestampTitle',
-          {
-            defaultMessage: 'Timestamp',
-          }
-        ),
-        dataType: 'date',
-        sortable: true,
-        render(eventDate?: string | number) {
-          return <NodeDetailTimestamp eventDate={eventDate} id={id} />;
+        {
+          field: 'timestamp',
+          name: i18n.translate(
+            'xpack.securitySolution.endpoint.resolver.panel.table.row.timestampTitle',
+            {
+              defaultMessage: 'Timestamp',
+            }
+          ),
+          dataType: 'date',
+          sortable: true,
+          render(eventDate?: string | number) {
+            return (
+              <NodeDetailTimestamp
+                eventDate={eventDate}
+                id={id}
+                renderCellActions={renderCellActions}
+              />
+            );
+          },
         },
-      },
-    ],
-    [id]
-  );
+      ],
+      [id, renderCellActions]
+    );
 
-  const processTableView: ProcessTableView[] = useSelector(
-    useCallback(
-      (state: State) => {
-        const { processNodePositions } = selectors.layout(state.analyzer[id]);
-        const view: ProcessTableView[] = [];
-        for (const treeNode of processNodePositions.keys()) {
-          const name = nodeModel.nodeName(treeNode);
-          const nodeID = nodeModel.nodeID(treeNode);
-          if (nodeID !== undefined) {
-            view.push({
-              name,
-              timestamp: nodeModel.nodeDataTimestamp(treeNode),
-              nodeID,
-            });
+    const processTableView: ProcessTableView[] = useSelector(
+      useCallback(
+        (state: State) => {
+          const { processNodePositions } = selectors.layout(state.analyzer[id]);
+          const view: ProcessTableView[] = [];
+          for (const treeNode of processNodePositions.keys()) {
+            const name = nodeModel.nodeName(treeNode);
+            const nodeID = nodeModel.nodeID(treeNode);
+            if (nodeID !== undefined) {
+              view.push({
+                name,
+                timestamp: nodeModel.nodeDataTimestamp(treeNode),
+                nodeID,
+              });
+            }
           }
-        }
-        return view;
-      },
-      [id]
-    )
-  );
+          return view;
+        },
+        [id]
+      )
+    );
 
-  const numberOfProcesses = processTableView.length;
+    const numberOfProcesses = processTableView.length;
 
-  const breadcrumbs = useMemo(() => {
-    return [
-      {
-        text: i18n.translate('xpack.securitySolution.resolver.panel.nodeList.title', {
-          defaultMessage: 'All Process Events',
-        }),
-      },
-    ];
-  }, []);
+    const breadcrumbs = useMemo(() => {
+      return [
+        {
+          text: i18n.translate('xpack.securitySolution.resolver.panel.nodeList.title', {
+            defaultMessage: 'All Process Events',
+          }),
+        },
+      ];
+    }, []);
 
-  const children = useSelector((state: State) => selectors.hasMoreChildren(state.analyzer[id]));
-  const ancestors = useSelector((state: State) => selectors.hasMoreAncestors(state.analyzer[id]));
-  const generations = useSelector((state: State) =>
-    selectors.hasMoreGenerations(state.analyzer[id])
-  );
-  const showWarning = children === true || ancestors === true || generations === true;
-  const rowProps = useMemo(() => ({ 'data-test-subj': 'resolver:node-list:item' }), []);
-  return (
-    <>
-      <Breadcrumbs breadcrumbs={breadcrumbs} />
-      {showWarning && <LimitWarning numberDisplayed={numberOfProcesses} />}
-      <EuiSpacer size="l" />
-      <EuiInMemoryTable<ProcessTableView>
-        rowProps={rowProps}
-        data-test-subj="resolver:node-list"
-        items={processTableView}
-        columns={columns}
-        sorting
-        tableCaption={i18n.translate(
-          'xpack.securitySolution.endpoint.resolver.panel.nodeList.tableCaption',
-          {
-            defaultMessage: 'Process events',
-          }
-        )}
-      />
-    </>
-  );
-});
+    const children = useSelector((state: State) => selectors.hasMoreChildren(state.analyzer[id]));
+    const ancestors = useSelector((state: State) => selectors.hasMoreAncestors(state.analyzer[id]));
+    const generations = useSelector((state: State) =>
+      selectors.hasMoreGenerations(state.analyzer[id])
+    );
+    const showWarning = children === true || ancestors === true || generations === true;
+    const rowProps = useMemo(() => ({ 'data-test-subj': 'resolver:node-list:item' }), []);
+    return (
+      <>
+        <Breadcrumbs breadcrumbs={breadcrumbs} />
+        {showWarning && <LimitWarning numberDisplayed={numberOfProcesses} />}
+        <EuiSpacer size="l" />
+        <EuiInMemoryTable<ProcessTableView>
+          rowProps={rowProps}
+          data-test-subj="resolver:node-list"
+          items={processTableView}
+          columns={columns}
+          sorting
+          tableCaption={i18n.translate(
+            'xpack.securitySolution.endpoint.resolver.panel.nodeList.tableCaption',
+            {
+              defaultMessage: 'Process events',
+            }
+          )}
+        />
+      </>
+    );
+  }
+);
 
 NodeList.displayName = 'NodeList';
 
@@ -216,23 +222,24 @@ const NodeDetailLink = memo(
 NodeDetailLink.displayName = 'NodeDetailLink';
 
 const NodeDetailTimestamp = memo(
-  ({ eventDate, id }: { eventDate: string | number | undefined; id: string }) => {
+  ({
+    eventDate,
+    id,
+    renderCellActions,
+  }: {
+    eventDate: string | number | undefined;
+    id: string;
+    renderCellActions: ResolverCellActionRenderer;
+  }) => {
     const formattedDate = useFormattedDate(eventDate);
 
     return formattedDate ? (
-      <SecurityCellActions
-        data={{
-          field: '@timestamp',
-          value: eventDate,
-        }}
-        triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
-        visibleCellActions={5}
-        mode={CellActionsMode.HOVER_DOWN}
-        sourcererScopeId={getSourcererScopeId(id)}
-        metadata={{ scopeId: id }}
-      >
-        {formattedDate}
-      </SecurityCellActions>
+      renderCellActions({
+        field: '@timestamp',
+        value: eventDate ?? formattedDate,
+        children: formattedDate,
+        scopeId: id,
+      })
     ) : (
       <span>{'—'}</span>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -6,11 +6,15 @@
  */
 
 import React, { useCallback, useContext } from 'react';
-import { useSelector } from 'react-redux';
-import { EuiLoadingSpinner } from '@elastic/eui';
+import { useSelector, useStore } from 'react-redux';
+import { EuiLoadingSpinner, EuiPanel } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { useHistory } from 'react-router-dom';
+import { PanelRouter } from './panels';
+import { useKibana } from '../../common/lib/kibana';
+import type { NodeEventOnClick } from './panels/node_events_of_type';
 import { useResolverQueryParamCleaner } from './use_resolver_query_params_cleaner';
 import * as selectors from '../store/selectors';
 import { EdgeLine } from './edge_line';
@@ -29,6 +33,9 @@ import { ResolverNoProcessEvents } from './resolver_no_process_events';
 import { useAutotuneTimerange } from './use_autotune_timerange';
 import type { State } from '../../common/store/types';
 import { DocumentDetailsAnalyzerPanelKey } from '../../flyout/document_details/shared/constants/panel_keys';
+import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
+import { OverviewTabWrapper } from '../../flyout_v2/document/tabs/overview_tab_wrapper';
+import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 
 export const ANALYZER_PREVIEW_BANNER = {
   title: i18n.translate(
@@ -56,10 +63,18 @@ export const ResolverWithoutProviders = React.memo(
       indices,
       shouldUpdate,
       filters,
+      renderCellActions,
     }: ResolverProps,
     refToForward
   ) {
+    const newFlyoutSystemEnabled = useIsExperimentalFeatureEnabled('newFlyoutSystemEnabled');
+
+    const { services } = useKibana();
+    const { overlays } = services;
+    const store = useStore();
+    const history = useHistory();
     const { openPreviewPanel } = useExpandableFlyoutApi();
+
     useResolverQueryParamCleaner(resolverComponentInstanceID);
     /**
      * This is responsible for dispatching actions that include any external data.
@@ -121,15 +136,76 @@ export const ResolverWithoutProviders = React.memo(
     );
     const colorMap = useColors();
 
-    const openAnalyzerDetailsPanel = useCallback(() => {
-      openPreviewPanel({
-        id: DocumentDetailsAnalyzerPanelKey,
-        params: {
-          resolverComponentInstanceID,
-          banner: ANALYZER_PREVIEW_BANNER,
-        },
-      });
-    }, [openPreviewPanel, resolverComponentInstanceID]);
+    const onShowEvent = useCallback<NodeEventOnClick>(
+      ({ documentId, indexName }) =>
+        () =>
+          overlays?.openSystemFlyout(
+            flyoutProviders({
+              services,
+              store,
+              history,
+              children: (
+                <OverviewTabWrapper
+                  documentId={documentId}
+                  indexName={indexName}
+                  renderCellActions={renderCellActions}
+                />
+              ),
+            }),
+            {
+              ownFocus: false,
+              resizable: true,
+              session: 'inherit',
+              size: 's',
+            }
+          ),
+      [history, overlays, renderCellActions, services, store]
+    );
+
+    const onShowPanel = useCallback(() => {
+      if (newFlyoutSystemEnabled) {
+        overlays.openSystemFlyout(
+          flyoutProviders({
+            services,
+            store,
+            history,
+            children: (
+              <EuiPanel>
+                <PanelRouter
+                  id={resolverComponentInstanceID}
+                  nodeEventOnClick={onShowEvent}
+                  renderCellActions={renderCellActions}
+                />
+              </EuiPanel>
+            ),
+          }),
+          {
+            ownFocus: false,
+            resizable: true,
+            session: 'inherit',
+            size: 's',
+          }
+        );
+      } else {
+        openPreviewPanel({
+          id: DocumentDetailsAnalyzerPanelKey,
+          params: {
+            resolverComponentInstanceID,
+            banner: ANALYZER_PREVIEW_BANNER,
+          },
+        });
+      }
+    }, [
+      history,
+      newFlyoutSystemEnabled,
+      onShowEvent,
+      openPreviewPanel,
+      overlays,
+      renderCellActions,
+      resolverComponentInstanceID,
+      services,
+      store,
+    ]);
 
     return (
       <StyledMapContainer
@@ -187,7 +263,7 @@ export const ResolverWithoutProviders = React.memo(
                     projectionMatrix={projectionMatrix}
                     node={treeNode}
                     timeAtRender={timeAtRender}
-                    onClick={openAnalyzerDetailsPanel}
+                    onClick={onShowPanel}
                   />
                 );
               })}
@@ -196,7 +272,7 @@ export const ResolverWithoutProviders = React.memo(
         ) : (
           <ResolverNoProcessEvents />
         )}
-        <GraphControls id={resolverComponentInstanceID} onShowPanel={openAnalyzerDetailsPanel} />
+        <GraphControls id={resolverComponentInstanceID} onShowPanel={onShowPanel} />
         <SymbolDefinitions id={resolverComponentInstanceID} />
       </StyledMapContainer>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -23,6 +23,7 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useHistory } from 'react-router-dom';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
 import { buildDataTableRecord } from '@kbn/discover-utils';
+import { analyzerCellActionRenderer } from '../../../../../flyout_v2/analyzer/components/cell_actions';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
 import { useOnExpandableFlyoutClose } from '../../../../../flyout/shared/hooks/use_on_expandable_flyout_close';
@@ -190,7 +191,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
               services,
               store,
               history,
-              children: <OverviewTab hit={hit} />,
+              children: <OverviewTab hit={hit} renderCellActions={analyzerCellActionRenderer} />,
             }),
             {
               ownFocus: false,

--- a/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/public/applications/resolver_test/index.tsx
+++ b/x-pack/solutions/security/test/plugin_functional/plugins/resolver_test/public/applications/resolver_test/index.tsx
@@ -7,10 +7,9 @@
 
 import { Router } from '@kbn/shared-ux-router';
 import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
-import React from 'react';
+import React, { useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
-import { useMemo } from 'react';
 import styled from 'styled-components';
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -87,6 +86,7 @@ const AppRoot = React.memo(
                     indices={[]}
                     shouldUpdate={false}
                     filters={{}}
+                    renderCellActions={() => <></>}
                   />
                 </Wrapper>
               </Provider>


### PR DESCRIPTION
## Summary

### Code changes

The PR focuses on the analyzer component, which is an item opened from the AnalyzerPreview component, under the `Visualizations` section in the alert flyout. Current analyzer is opened in the expanded section of our flyout, but in the new EUI flyout system we will be opening it as a tools flyout.

> [!TIP]
> The Analyzer experience should be absolutely unchanged when the feature flag is off in Security Solution.

Here are the main changes introduced here:
- create a new AnalyzerGraph component that will be used as a tools flyout
- in order to have the new Analyzer tools flyout work in Discover, I had to extract the cell actions logic outside, and pass the rendered component via props. This will allow us to have custom Discover action when the flyout is opened there, and our normal Security Solution actions when we opened it here

> [!NOTE]
> When the Analyzer tools flyout is opened within Security Solution, cell actions are working normally. When opened in Discover, we do not yet have cell actions wired up. This will be done in a follow up PR.

### UI changes

The UI of the current alert/event flyouts (using the expandable flyout framework) in Security Solution should remain unchanged after this PR (when the feature flag is off).

https://github.com/user-attachments/assets/774f6533-16df-4edb-9192-9d522311adc3

Then when the feature flag is on, the new flyout show the analyzer preview:

https://github.com/user-attachments/assets/35f0561f-3aa4-43d1-add2-60371ba495b2

The UI of the current document flyout in Discover should remain unchanged after this PR (when the experimental profile off).
And this is how it looks when the enhanced document profile is on:

Uploading Screen Recording 2026-03-03 at 5.48.04 PM.mov…

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

## What to look for when testing

- verify that the Visualizations section on the Security Solution side has not changed in the expandable flyout (`newFlyoutSystemEnabled` feature flag off)
- verify that analyzer shows up in the new flyout (`newFlyoutSystemEnabled` feature flag on)
- verify that analyzer shows up in Discover only for alert documents

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/251804

_PR developed with Cursor + gpt-5.2_