### PR TITLE
[Inference] Fix deanonymization offset drift and add regression coverage

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/deanonymize.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/deanonymize.test.ts
@@ -111,6 +111,160 @@ describe('deanonymize', () => {
         ])
       );
     });
+
+    it('ensures deanonymization start/end are correct in the final string when regex is processed before earlier NER', () => {
+      const name = 'john';
+      const email = 'john123@gmail.com';
+
+      // Reflect realistic mask lengths and rule execution order: RegExp before NER.
+      const nameMask = `PER_${'a'.repeat(40)}`;
+      const emailMask = `EMAIL_${'b'.repeat(40)}`;
+
+      const anonymizations: Anonymization[] = [
+        {
+          entity: { class_name: 'EMAIL', value: email, mask: emailMask },
+          rule: { type: 'RegExp' },
+        },
+        { entity: { class_name: 'PER', value: name, mask: nameMask }, rule: { type: 'NER' } },
+      ];
+
+      const originalMsg: UserMessage = {
+        role: MessageRole.User,
+        content: `my name is ${nameMask} and my email is ${emailMask}`,
+      };
+
+      const { message: deanonymized, deanonymizations } = deanonymize(originalMsg, anonymizations);
+
+      const expectedContent = `my name is ${name} and my email is ${email}`;
+      expect(deanonymized.content).toBe(expectedContent);
+
+      for (const deanonymization of deanonymizations) {
+        expect(deanonymization.start).toBeGreaterThanOrEqual(0);
+        expect(deanonymization.end).toBeLessThanOrEqual(expectedContent.length);
+        expect(expectedContent.slice(deanonymization.start, deanonymization.end)).toBe(
+          deanonymization.entity.value
+        );
+      }
+    });
+
+    it('deanonymizes repeated occurrences of the same mask and reports all ranges', () => {
+      const name = 'john';
+      const nameMask = createMask('PER', name);
+      const anonymizations: Anonymization[] = [
+        { entity: { class_name: 'PER', value: name, mask: nameMask }, rule: { type: 'NER' } },
+      ];
+
+      const originalMsg: UserMessage = {
+        role: MessageRole.User,
+        content: `${nameMask} met ${nameMask} and ${nameMask}`,
+      };
+
+      const { message: deanonymized, deanonymizations } = deanonymize(originalMsg, anonymizations);
+      const expectedContent = `${name} met ${name} and ${name}`;
+      expect(deanonymized.content).toBe(expectedContent);
+      expect(deanonymizations).toHaveLength(3);
+
+      for (const deanonymization of deanonymizations) {
+        expect(expectedContent.slice(deanonymization.start, deanonymization.end)).toBe(name);
+      }
+    });
+
+    // Defensive coverage: resolveOverlapsAndMask should prevent this.
+    it('prefers longer mask when two masks match at same start position', () => {
+      const shortMask = 'ENTITY_abc';
+      const longMask = 'ENTITY_abc123';
+      const shortValue = 'SHORT';
+      const longValue = 'LONG_VALUE';
+
+      const anonymizations: Anonymization[] = [
+        {
+          entity: { class_name: 'GENERIC', value: shortValue, mask: shortMask },
+          rule: { type: 'RegExp' },
+        },
+        {
+          entity: { class_name: 'GENERIC', value: longValue, mask: longMask },
+          rule: { type: 'RegExp' },
+        },
+      ];
+
+      const originalMsg: UserMessage = {
+        role: MessageRole.User,
+        content: `A ${longMask} B ${shortMask}`,
+      };
+
+      const { message: deanonymized, deanonymizations } = deanonymize(originalMsg, anonymizations);
+      const expectedContent = `A ${longValue} B ${shortValue}`;
+      expect(deanonymized.content).toBe(expectedContent);
+
+      expect(deanonymizations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ entity: anonymizations[1].entity }),
+          expect.objectContaining({ entity: anonymizations[0].entity }),
+        ])
+      );
+      for (const deanonymization of deanonymizations) {
+        expect(expectedContent.slice(deanonymization.start, deanonymization.end)).toBe(
+          deanonymization.entity.value
+        );
+      }
+    });
+
+    it('deanonymizes both content and tool call arguments without corrupting content ranges', () => {
+      const name = 'john';
+      const email = 'john123@gmail.com';
+      const nameMask = `PER_${'a'.repeat(40)}`;
+      const emailMask = `EMAIL_${'b'.repeat(40)}`;
+
+      const anonymizations: Anonymization[] = [
+        {
+          entity: { class_name: 'EMAIL', value: email, mask: emailMask },
+          rule: { type: 'RegExp' },
+        },
+        { entity: { class_name: 'PER', value: name, mask: nameMask }, rule: { type: 'NER' } },
+      ];
+
+      const assistantMsg: AssistantMessage = {
+        role: MessageRole.Assistant,
+        content: `my name is ${nameMask} and my email is ${emailMask}`,
+        toolCalls: [
+          {
+            function: {
+              name: 'saveProfile',
+              arguments: { user: nameMask, contact: emailMask },
+            },
+            toolCallId: '1',
+          },
+        ],
+      };
+
+      const { message: deanonymized, deanonymizations } = deanonymize(assistantMsg, anonymizations);
+      const expectedContent = `my name is ${name} and my email is ${email}`;
+      expect(deanonymized.content).toBe(expectedContent);
+
+      const args = (
+        deanonymized as AssistantMessage & {
+          toolCalls: [{ function: { arguments: { user: string; contact: string } } }];
+        }
+      ).toolCalls?.[0].function.arguments;
+
+      expect(args.user).toBe(name);
+      expect(args.contact).toBe(email);
+
+      const contentRanges = deanonymizations.filter(
+        (deanonymization) =>
+          deanonymization.start >= 0 &&
+          deanonymization.end <= expectedContent.length &&
+          expectedContent.slice(deanonymization.start, deanonymization.end) ===
+            deanonymization.entity.value
+      );
+
+      expect(contentRanges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ entity: anonymizations[0].entity }),
+          expect.objectContaining({ entity: anonymizations[1].entity }),
+        ])
+      );
+    });
   });
 
   it('handles no anonymizations gracefully (returns identical message)', () => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/deanonymize.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/deanonymize.ts
@@ -9,6 +9,12 @@ import type { Message, Deanonymization, Anonymization } from '@kbn/inference-com
 import { isEmpty } from 'lodash';
 import { getAnonymizableMessageParts } from './get_anonymizable_message_parts';
 
+interface DeanonymizeMaskMatch {
+  start: number;
+  mask: string;
+  entity: Anonymization['entity'];
+}
+
 /**
  * Recursively walks a value and replaces all string leaves using the provided
  * replacement function, collecting deanonymization metadata from every leaf.
@@ -42,29 +48,61 @@ export function deanonymize<TMessage extends Message>(
   anonymizations: Anonymization[]
 ): { message: TMessage; deanonymizations: Deanonymization[] } {
   function replace(content: string) {
-    let next = content;
-    const deanonymizations: Deanonymization[] = [];
-
-    anonymizations.forEach(({ entity }) => {
-      let index = next.indexOf(entity.mask);
-
-      while (index !== -1) {
-        const start = index;
-        const end = start + entity.value.length;
-
-        deanonymizations.push({ start, end, entity });
-
-        // Replace the mask with the original value
-        next = next.slice(0, start) + entity.value + next.slice(start + entity.mask.length);
-
-        // Continue searching after the replaced value to avoid infinite loops
-        index = next.indexOf(entity.mask, start + entity.value.length);
+    // Multiple anonymization entries can point at the same mask.
+    // Scan each unique mask once so we don't duplicate matches/ranges.
+    const entitiesByMask = new Map<string, Anonymization['entity']>();
+    for (const { entity } of anonymizations) {
+      if (!entitiesByMask.has(entity.mask)) {
+        entitiesByMask.set(entity.mask, entity);
       }
+    }
+
+    const matches: DeanonymizeMaskMatch[] = [];
+    // Collect mask occurrences from the original (immutable) content.
+    // We compute ranges from rebuilt output later, so they are final-string offsets.
+    for (const [mask, entity] of entitiesByMask) {
+      let index = content.indexOf(mask);
+      while (index !== -1) {
+        matches.push({ start: index, mask, entity });
+        index = content.indexOf(mask, index + mask.length);
+      }
+    }
+
+    // Sort left-to-right for cursor-based reconstruction.
+    matches.sort((a, b) => {
+      if (a.start !== b.start) {
+        return a.start - b.start;
+      }
+      // Resolve same-start overlaps by preferring the longer mask
+      return b.mask.length - a.mask.length;
     });
+
+    const deanonymizations: Deanonymization[] = [];
+    let cursor = 0;
+    let output = '';
+
+    // Rebuild content in one pass from left to right.
+    // This avoids offset drift caused by mutating and re-indexing the same string.
+    for (const match of matches) {
+      // Ignore overlaps that were made stale by a previous (earlier/longer) match.
+      if (match.start < cursor) {
+        continue;
+      }
+
+      // Copy unchanged span, append replacement, and capture final-output range.
+      output += content.slice(cursor, match.start);
+      const start = output.length;
+      output += match.entity.value;
+      const end = output.length;
+      deanonymizations.push({ start, end, entity: match.entity });
+      cursor = match.start + match.mask.length;
+    }
+
+    output += content.slice(cursor);
 
     return {
       deanonymizations,
-      output: next,
+      output,
     };
   }
 

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/deanonymize_message.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/deanonymize_message.test.ts
@@ -317,4 +317,46 @@ describe('deanonymizeMessage', () => {
       ])
     );
   });
+
+  it('emits final-string-valid deanonymization ranges for input/output when regex ordering differs from text ordering', async () => {
+    const name = 'john';
+    const email = 'john123@gmail.com';
+    const nameMask = `PER_${'a'.repeat(40)}`;
+    const emailMask = `EMAIL_${'b'.repeat(40)}`;
+
+    // Reflect regex-first processing order while PER appears first in text.
+    const anonymizations: Anonymization[] = [
+      { entity: { class_name: 'EMAIL', value: email, mask: emailMask }, rule: { type: 'RegExp' } },
+      { entity: { class_name: 'PER', value: name, mask: nameMask }, rule: { type: 'NER' } },
+    ];
+
+    const maskedContent = `my name is ${nameMask} and my email is ${emailMask}`;
+    const expectedContent = `my name is ${name} and my email is ${email}`;
+
+    const anonymizationOutput: AnonymizationOutput = {
+      messages: [{ role: MessageRole.User, content: maskedContent }],
+      anonymizations,
+    } as AnonymizationOutput;
+
+    const [chunkOut, msgOut] = await lastValueFrom(
+      from([chunkEvent(maskedContent), messageEvent(maskedContent)]).pipe(
+        deanonymizeMessage(anonymizationOutput),
+        toArray()
+      )
+    );
+
+    expect(chunkOut.content).toBe(expectedContent);
+    expect(msgOut.content).toBe(expectedContent);
+
+    const outputDeanonymizations = msgOut.deanonymized_output?.deanonymizations ?? [];
+    const inputDeanonymizations = msgOut.deanonymized_input?.[0].deanonymizations ?? [];
+
+    for (const deanonymization of [...outputDeanonymizations, ...inputDeanonymizations]) {
+      expect(deanonymization.start).toBeGreaterThanOrEqual(0);
+      expect(deanonymization.end).toBeLessThanOrEqual(expectedContent.length);
+      expect(expectedContent.slice(deanonymization.start, deanonymization.end)).toBe(
+        deanonymization.entity.value
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a deanonymization bug that could produce incorrect start/end offsets for highlighted entities in chat messages. The issue happened when entities were replaced in a different order than they appear in the text (for example, regex-based entities before earlier NER entities), which could leave offsets pointing to the wrong positions.
The fix changes deanonymization to build the final message in one pass and compute offsets directly from that final output, so the ranges are always accurate for UI highlighting.



### UI Preview



<details><summary>Screenshot of before</summary>
<img width="749" height="481" alt="Screenshot 2026-03-04 at 16 30 51" src="https://github.com/user-attachments/assets/390d0846-5314-44e7-b49b-61a5ba56284b" />
</details>

<details><summary>Screenshot of after</summary>

<img width="739" height="451" alt="Screenshot 2026-03-04 at 16 30 46" src="https://github.com/user-attachments/assets/aea2e5ca-39d1-4a90-8eee-595c6316d3a0" />

</details>
