### PR TITLE
[8.19] chore(NA): adjust retries for cypress suites (#256106)

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -334,3 +334,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -17,6 +17,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
@@ -34,6 +36,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
@@ -51,6 +55,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
@@ -68,6 +74,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
@@ -85,6 +93,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
@@ -102,6 +112,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
@@ -119,6 +131,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
@@ -136,6 +150,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
@@ -153,6 +169,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
@@ -170,6 +188,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
@@ -187,6 +207,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
@@ -204,6 +226,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
@@ -221,6 +245,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
@@ -240,6 +266,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/profiling_cypress.sh
@@ -259,6 +287,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/apm_cypress.sh
@@ -276,4 +306,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/kbn_handlebars.yml
+++ b/.buildkite/pipelines/pull_request/kbn_handlebars.yml
@@ -10,5 +10,7 @@ steps:
     timeout_in_minutes: 5
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -11,5 +11,7 @@ steps:
     parallelism: 11
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -10,5 +10,7 @@ steps:
     timeout_in_minutes: 60
     retry:
       automatic:
+        - exit_status: '-1'
+          limit: 3
         - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
@@ -12,6 +12,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/cloud_security_posture_serverless.sh
@@ -27,4 +29,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
@@ -12,6 +12,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
@@ -27,4 +29,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/explore.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/explore.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -10,4 +10,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/playwright.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/playwright.yml
@@ -12,4 +12,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -12,6 +12,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
@@ -27,6 +29,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
@@ -42,6 +46,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
@@ -57,6 +63,8 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
@@ -72,4 +80,6 @@ steps:
     retry:
       automatic:
         - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
           limit: 1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(NA): adjust retries for cypress suites (#256106)](https://github.com/elastic/kibana/pull/256106)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2026-03-04T21:20:03Z","message":"chore(NA): adjust retries for cypress suites (#256106)\n\nCloses https://github.com/elastic/kibana-operations/issues/465\n\nThis PR just adjusts the retries of Cypress based tests to be inline\nwith what we have in other FTR. This is now a good move since we have\nretry checkpoints on Cypress added at\nhttps://github.com/elastic/kibana/pull/255709\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4bc5505d663d91169ac375ac1c6e33ada52d04d3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v9.4.0"],"title":"chore(NA): adjust retries for cypress suites","number":256106,"url":"https://github.com/elastic/kibana/pull/256106","mergeCommit":{"message":"chore(NA): adjust retries for cypress suites (#256106)\n\nCloses https://github.com/elastic/kibana-operations/issues/465\n\nThis PR just adjusts the retries of Cypress based tests to be inline\nwith what we have in other FTR. This is now a good move since we have\nretry checkpoints on Cypress added at\nhttps://github.com/elastic/kibana/pull/255709\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4bc5505d663d91169ac375ac1c6e33ada52d04d3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256106","number":256106,"mergeCommit":{"message":"chore(NA): adjust retries for cypress suites (#256106)\n\nCloses https://github.com/elastic/kibana-operations/issues/465\n\nThis PR just adjusts the retries of Cypress based tests to be inline\nwith what we have in other FTR. This is now a good move since we have\nretry checkpoints on Cypress added at\nhttps://github.com/elastic/kibana/pull/255709\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4bc5505d663d91169ac375ac1c6e33ada52d04d3"}},{"url":"https://github.com/elastic/kibana/pull/256113","number":256113,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->