### PR TITLE
Remove propTypes and defaultTypes for .tsx files owned by kibana-visualizations

### DIFF
--- a/examples/expressions_explorer/public/inspector/expressions_inspector_view.tsx
+++ b/examples/expressions_explorer/public/inspector/expressions_inspector_view.tsx
@@ -8,7 +8,6 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiEmptyPrompt } from '@elastic/eui';
 import type { InspectorViewProps, Adapters } from '@kbn/inspector-plugin/public';
@@ -23,11 +22,6 @@ class ExpressionsInspectorViewComponent extends Component<
   InspectorViewProps,
   ExpressionsInspectorViewComponentState
 > {
-  static propTypes = {
-    adapters: PropTypes.object.isRequired,
-    title: PropTypes.string.isRequired,
-  };
-
   state = {} as ExpressionsInspectorViewComponentState;
 
   static getDerivedStateFromProps(

--- a/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/data_table.tsx
+++ b/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/data_table.tsx
@@ -8,7 +8,6 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import {
   EuiButtonIcon,
@@ -60,14 +59,6 @@ class DataTableFormatClass extends Component<
   DataTableFormatProps & EuiTablePersistInjectedProps<DatatableRow>,
   DataTableFormatState
 > {
-  static propTypes: Record<string, PropTypes.Validator<unknown>> = {
-    data: PropTypes.object.isRequired,
-    uiSettings: PropTypes.object.isRequired,
-    fieldFormats: PropTypes.object.isRequired,
-    uiActions: PropTypes.object.isRequired,
-    isFilterable: PropTypes.func.isRequired,
-  };
-
   csvSeparator = this.props.uiSettings.get('csv:separator', ',');
   quoteValues = this.props.uiSettings.get('csv:quoteValues', true);
   state = {} as DataTableFormatState;

--- a/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/download_options.tsx
+++ b/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/download_options.tsx
@@ -9,7 +9,6 @@
 
 import React, { Component } from 'react';
 import { memoize } from 'lodash';
-import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
@@ -43,13 +42,6 @@ const detectFormulasInTables = memoize((datatables: Datatable[]) =>
 );
 
 class DataDownloadOptions extends Component<DataDownloadOptionsProps, DataDownloadOptionsState> {
-  static propTypes = {
-    title: PropTypes.string.isRequired,
-    uiSettings: PropTypes.object.isRequired,
-    datatables: PropTypes.array,
-    fieldFormats: PropTypes.object.isRequired,
-  };
-
   state = {
     isPopoverOpen: false,
   };


### PR DESCRIPTION
## Summary

This PR removes `propTypes` and `defaultTypes` as they're being removed for functional components in React 19.

Context: https://github.com/elastic/kibana/issues/256125


