### PR TITLE
Remove propTypes and defaultTypes for .tsx files owned by SharedUX

### DIFF
--- a/src/platform/plugins/private/kibana_overview/public/components/add_data/add_data.tsx
+++ b/src/platform/plugins/private/kibana_overview/public/components/add_data/add_data.tsx
@@ -9,7 +9,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { FeatureCatalogueEntry } from '@kbn/home-plugin/public';
@@ -73,21 +72,4 @@ export const AddData: FC<Props> = ({ addBasePath, features }) => {
       </EuiFlexGroup>
     </section>
   );
-};
-
-AddData.propTypes = {
-  addBasePath: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  features: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
-      description: PropTypes.string.isRequired,
-      icon: PropTypes.string.isRequired,
-      path: PropTypes.string.isRequired,
-      showOnHomePage: PropTypes.bool.isRequired,
-      category: PropTypes.string.isRequired,
-      order: PropTypes.number as PropTypes.Validator<number | undefined>,
-    }).isRequired
-  ).isRequired,
 };

--- a/src/platform/plugins/private/kibana_overview/public/components/manage_data/manage_data.tsx
+++ b/src/platform/plugins/private/kibana_overview/public/components/manage_data/manage_data.tsx
@@ -9,7 +9,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import type { UseEuiTheme } from '@elastic/eui';
 import {
@@ -84,20 +83,4 @@ export const ManageData: FC<Props> = ({ addBasePath, features }) => {
       ) : null}
     </>
   );
-};
-
-ManageData.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  features: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
-      description: PropTypes.string.isRequired,
-      icon: PropTypes.string.isRequired,
-      path: PropTypes.string.isRequired,
-      showOnHomePage: PropTypes.bool.isRequired,
-      category: PropTypes.string.isRequired,
-      order: PropTypes.number as PropTypes.Validator<number | undefined>,
-    }).isRequired
-  ).isRequired,
 };


### PR DESCRIPTION
## Summary

This PR removes `propTypes` and `defaultTypes` as they're being removed for functional components in React 19.

Context: https://github.com/elastic/kibana/issues/256125


