### PR TITLE
Remove propTypes and defaultTypes for .tsx files owned by kibana-presentation

### DIFF
--- a/src/platform/plugins/shared/inspector/public/ui/inspector_panel.tsx
+++ b/src/platform/plugins/shared/inspector/public/ui/inspector_panel.tsx
@@ -9,7 +9,6 @@
 
 import { i18n } from '@kbn/i18n';
 import React, { Component, Suspense } from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -67,19 +66,6 @@ interface InspectorPanelState {
 export class InspectorPanel extends Component<InspectorPanelProps, InspectorPanelState> {
   static defaultProps = {
     title: inspectorTitle,
-  };
-
-  static propTypes = {
-    adapters: PropTypes.object.isRequired,
-    views: (props: InspectorPanelProps, propName: string, componentName: string) => {
-      if (!Array.isArray(props.views) || props.views.length < 1) {
-        throw new Error(
-          `${propName} prop must be an array of at least one element in ${componentName}.`
-        );
-      }
-    },
-    title: PropTypes.string,
-    options: PropTypes.object,
   };
 
   state: InspectorPanelState = {

--- a/src/platform/plugins/shared/inspector/public/ui/inspector_view_chooser.tsx
+++ b/src/platform/plugins/shared/inspector/public/ui/inspector_view_chooser.tsx
@@ -9,7 +9,6 @@
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiButtonEmpty,
   EuiContextMenuItem,
@@ -30,12 +29,6 @@ interface State {
 }
 
 export class InspectorViewChooser extends Component<Props, State> {
-  static propTypes = {
-    views: PropTypes.array.isRequired,
-    onViewSelected: PropTypes.func.isRequired,
-    selectedView: PropTypes.object.isRequired,
-  };
-
   state: State = {
     isSelectorOpen: false,
   };

--- a/src/platform/plugins/shared/inspector/public/views/requests/components/request_selector.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/request_selector.tsx
@@ -9,7 +9,6 @@
 
 import React, { Component } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import PropTypes from 'prop-types';
 import { i18n } from '@kbn/i18n';
 
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
@@ -32,12 +31,6 @@ interface RequestSelectorProps {
 }
 
 export class RequestSelector extends Component<RequestSelectorProps> {
-  static propTypes = {
-    requests: PropTypes.array.isRequired,
-    selectedRequest: PropTypes.object.isRequired,
-    onRequestChanged: PropTypes.func,
-  };
-
   handleSelected = (selectedOptions: Array<EuiComboBoxOptionOption<string>>) => {
     const selectedOption = this.props.requests.find(
       (request) => request.id === selectedOptions[0].value

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/advanced_filter/component/advanced_filter.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/advanced_filter/component/advanced_filter.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -58,13 +57,3 @@ export const AdvancedFilter: FunctionComponent<Props> = ({ value = '', onChange,
     </EuiFlexGroup>
   </form>
 );
-
-AdvancedFilter.defaultProps = {
-  value: '',
-};
-
-AdvancedFilter.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.string,
-  commit: PropTypes.func.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/dropdown_filter/component/dropdown_filter.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/dropdown_filter/component/dropdown_filter.tsx
@@ -7,7 +7,6 @@
 
 import type { ChangeEvent, FocusEvent, FunctionComponent } from 'react';
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import type { EuiSelectOption } from '@elastic/eui';
 import { EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -87,10 +86,4 @@ export const DropdownFilter: FunctionComponent<Props> = ({
       />
     </div>
   );
-};
-
-DropdownFilter.propTypes = {
-  choices: PropTypes.array,
-  initialValue: PropTypes.string,
-  commit: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/time_filter/components/time_filter.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/filters/time_filter/components/time_filter.tsx
@@ -8,7 +8,6 @@
 import type { OnTimeChangeProps, EuiSuperDatePickerCommonRange } from '@elastic/eui';
 import { EuiSuperDatePicker } from '@elastic/eui';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { fromExpression } from '@kbn/interpreter';
 import { UnitStrings } from '../../../../../i18n/units';
@@ -77,17 +76,4 @@ export const TimeFilter = ({ filter, commit, dateFormat, commonlyUsedRanges = []
       />
     </div>
   );
-};
-
-TimeFilter.propTypes = {
-  filter: PropTypes.string.isRequired,
-  commit: PropTypes.func.isRequired, // Canvas filter
-  dateFormat: PropTypes.string,
-  commonlyUsedRanges: PropTypes.arrayOf(
-    PropTypes.shape({
-      start: PropTypes.string.isRequired,
-      end: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-    })
-  ),
 };

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/axis_config/extended_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/axis_config/extended_template.tsx
@@ -7,7 +7,6 @@
 
 import type { ChangeEvent } from 'react';
 import React, { Fragment, PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { EuiSelect, EuiFormRow, EuiSpacer, EuiText } from '@elastic/eui';
 import { set } from 'object-path-immutable';
 import { get } from 'lodash';
@@ -36,17 +35,6 @@ export interface Props {
 }
 
 export class ExtendedTemplate extends PureComponent<Props> {
-  static propTypes = {
-    onValueChange: PropTypes.func.isRequired,
-    argValue: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.shape({
-        chain: PropTypes.array,
-      }).isRequired,
-    ]),
-    typeInstance: PropTypes.object.isRequired,
-  };
-
   static displayName = 'AxisConfigExtendedInput';
 
   // TODO: this should be in a helper, it's the same code from container_style

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/axis_config/simple_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/axis_config/simple_template.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiSwitch } from '@elastic/eui';
 
 export interface Props {
@@ -25,12 +24,6 @@ export const SimpleTemplate: FunctionComponent<Props> = ({ onValueChange, argVal
       label=""
     />
   );
-};
-
-SimpleTemplate.propTypes = {
-  onValueChange: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  argValue: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]).isRequired,
 };
 
 SimpleTemplate.displayName = 'AxisConfigSimpleInput';

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/color_picker/color_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/color_picker/color_picker.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import type { EuiSetColorMethod } from '@elastic/eui';
 import { EuiColorPicker, EuiFlexGroup, EuiFlexItem, useColorPickerState } from '@elastic/eui';
 import { templateFromReactComponent } from '../../../../public/lib/template_from_react_component';
@@ -36,11 +35,6 @@ const ColorPicker: FC<Props> = ({ onValueChange, argValue }) => {
       </EuiFlexItem>
     </EuiFlexGroup>
   );
-};
-
-ColorPicker.propTypes = {
-  argValue: PropTypes.any.isRequired,
-  onValueChange: PropTypes.func.isRequired,
 };
 
 export const colorPicker = () => ({

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/date_format/date_format.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/date_format/date_format.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FormatSelect } from '../../../../public/components/format_select/format_select';
 import type { ArgumentProps } from '../../../../types/arguments';
 
@@ -43,14 +42,3 @@ export const DateFormatArgInput: FunctionComponent<Props> = ({
     defaultCustomFormat="M/D/YY h:ma"
   />
 );
-
-DateFormatArgInput.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  dateFormats: PropTypes.arrayOf(
-    PropTypes.shape({ value: PropTypes.string, text: PropTypes.string })
-  ).isRequired,
-  onValueChange: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  argValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
-  argId: PropTypes.string.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/number_format/number_format.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/number_format/number_format.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FormatSelect } from '../../../../public/components/format_select/format_select';
 import type { ArgumentProps } from '../../../../types/arguments';
 
@@ -43,14 +42,3 @@ export const NumberFormatArgInput: FunctionComponent<Props> = ({
     defaultCustomFormat="0.0a"
   />
 );
-
-NumberFormatArgInput.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  numberFormats: PropTypes.arrayOf(
-    PropTypes.shape({ value: PropTypes.string, text: PropTypes.string })
-  ).isRequired,
-  onValueChange: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  argValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
-  argId: PropTypes.string.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/palette/palette.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/palette/palette.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import type { ExpressionAstExpression } from '@kbn/expressions-plugin/common';
 import { templateFromReactComponent } from '../../../../public/lib/template_from_react_component';
 import { ArgumentStrings } from '../../../../i18n';
@@ -93,14 +92,6 @@ export const StopsPaletteArgInput: FC<Props> = (props) => (
     }}
   />
 );
-
-PaletteArgInput.propTypes = {
-  argId: PropTypes.string,
-  onValueChange: PropTypes.func.isRequired,
-  argValue: PropTypes.any.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  renderError: PropTypes.func,
-};
 
 const defaultPaletteOptions = {
   default:

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/partition_labels/extended_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/partition_labels/extended_template.tsx
@@ -7,7 +7,6 @@
 
 import type { ChangeEvent, MouseEvent, KeyboardEvent, FunctionComponent } from 'react';
 import React, { useCallback, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import type { EuiSelectOption, EuiSwitchEvent } from '@elastic/eui';
 import { EuiFormRow, EuiRange, EuiSelect, EuiSpacer, EuiSwitch, EuiText } from '@elastic/eui';
 import type { ExpressionAstExpression } from '@kbn/expressions-plugin/common';
@@ -140,12 +139,6 @@ export const ExtendedTemplate: FunctionComponent<Props> = ({ onValueChange, argV
       )}
     </>
   );
-};
-
-ExtendedTemplate.propTypes = {
-  onValueChange: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  argValue: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]).isRequired,
 };
 
 ExtendedTemplate.displayName = 'PartitionLabelsExtendedArg';

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/partition_labels/simple_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/uis/arguments/partition_labels/simple_template.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import type { EuiSwitchEvent } from '@elastic/eui';
 import { EuiSwitch } from '@elastic/eui';
 import type { ExpressionAstExpression } from '@kbn/expressions-plugin/common';
@@ -46,12 +45,6 @@ export const SimpleTemplate: FunctionComponent<Props> = ({ onValueChange, argVal
   return (
     <EuiSwitch compressed checked={showLabels} onChange={onToggle} showLabel={false} label="" />
   );
-};
-
-SimpleTemplate.propTypes = {
-  onValueChange: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  argValue: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]).isRequired,
 };
 
 SimpleTemplate.displayName = 'PartitionLabelsSimpleArg';

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_add/arg_add.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_add/arg_add.tsx
@@ -7,7 +7,6 @@
 
 import type { FC, ReactEventHandler } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiDescriptionList,
   EuiDescriptionListTitle,
@@ -31,10 +30,4 @@ export const ArgAdd: FC<Props> = ({ onValueAdd = () => {}, displayName, help }) 
       </EuiDescriptionList>
     </button>
   );
-};
-
-ArgAdd.propTypes = {
-  displayName: PropTypes.string.isRequired,
-  help: PropTypes.string.isRequired,
-  onValueAdd: PropTypes.func,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_add_popover/arg_add_popover.tsx
@@ -7,7 +7,6 @@
 
 import type { MouseEventHandler, FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Popover } from '../popover';
@@ -63,8 +62,4 @@ export const ArgAddPopover: FC<Props> = ({ options }) => {
       }
     </Popover>
   );
-};
-
-ArgAddPopover.propTypes = {
-  options: PropTypes.array.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_form/arg_simple_form.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_form/arg_simple_form.tsx
@@ -7,7 +7,6 @@
 
 import type { ReactNode, MouseEventHandler } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -64,12 +63,4 @@ export const ArgSimpleForm: React.FunctionComponent<Props> = ({
       )}
     </EuiFlexGroup>
   );
-};
-
-ArgSimpleForm.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  children: PropTypes.node,
-  required: PropTypes.bool,
-  valueMissing: PropTypes.bool,
-  onRemove: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/asset_manager/asset_manager.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/asset_manager/asset_manager.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiButton,
   EuiEmptyPrompt,
@@ -172,11 +171,4 @@ export const AssetManager: FC<Props> = (props) => {
       </EuiModalFooter>
     </EuiModal>
   );
-};
-
-AssetManager.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  assets: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onClose: PropTypes.func.isRequired,
-  onAddAsset: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGrid, EuiFlexItem, EuiLink, EuiImage, EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -26,12 +25,6 @@ interface Props {
 }
 
 export class AssetPicker extends PureComponent<Props> {
-  static propTypes = {
-    assets: PropTypes.array.isRequired,
-    selected: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-  };
-
   componentDidMount() {
     const selectedAsset = document.getElementById('canvasAssetPicker__selectedAsset');
     if (selectedAsset) {

--- a/x-pack/platform/plugins/private/canvas/public/components/clipboard/clipboard.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/clipboard/clipboard.tsx
@@ -6,7 +6,6 @@
  */
 
 import copy from 'copy-to-clipboard';
-import PropTypes from 'prop-types';
 import type { MouseEvent, KeyboardEvent, ReactElement } from 'react';
 import React from 'react';
 
@@ -17,12 +16,6 @@ interface Props {
 }
 
 export class Clipboard extends React.PureComponent<Props> {
-  public static propTypes = {
-    children: PropTypes.element.isRequired,
-    content: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    onCopy: PropTypes.func,
-  };
-
   public render() {
     return (
       <div

--- a/x-pack/platform/plugins/private/canvas/public/components/color_dot/color_dot.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_dot/color_dot.tsx
@@ -7,7 +7,6 @@
 
 import type { FC, ReactNode } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import chroma from 'chroma-js';
 
 interface Props {
@@ -32,10 +31,4 @@ export const ColorDot: FC<Props> = ({ value, children }) => {
       </div>
     </div>
   );
-};
-
-ColorDot.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  children: PropTypes.node,
-  value: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/color_manager/color_manager.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_manager/color_manager.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonIcon, EuiFieldText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import chroma from 'chroma-js';
 import { i18n } from '@kbn/i18n';
@@ -95,12 +94,4 @@ export const ColorManager: FC<Props> = ({
       {buttons}
     </EuiFlexGroup>
   );
-};
-
-ColorManager.propTypes = {
-  hasButtons: PropTypes.bool,
-  onAddColor: PropTypes.func,
-  onChange: PropTypes.func.isRequired,
-  onRemoveColor: PropTypes.func,
-  value: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/color_palette/color_palette.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_palette/color_palette.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiIcon, EuiLink } from '@elastic/eui';
 import chroma from 'chroma-js';
 import { readableColor } from '../../lib/readable_color';
@@ -72,11 +71,4 @@ export const ColorPalette: FC<Props> = ({
       </ItemGrid>
     </div>
   );
-};
-
-ColorPalette.propTypes = {
-  colors: PropTypes.array,
-  colorsPerRow: PropTypes.number,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/color_picker/color_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_picker/color_picker.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import chroma from 'chroma-js';
 
 import type { Props as ColorManagerProps } from '../color_manager';
@@ -57,13 +56,4 @@ export const ColorPicker: FC<Props> = ({
       />
     </div>
   );
-};
-
-ColorPicker.propTypes = {
-  colors: PropTypes.array,
-  hasButtons: PropTypes.bool,
-  onAddColor: PropTypes.func,
-  onChange: PropTypes.func.isRequired,
-  onRemoveColor: PropTypes.func,
-  value: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/color_picker_popover/color_picker_popover.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_picker_popover/color_picker_popover.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import type { PopoverAnchorPosition } from '@elastic/eui';
 import { EuiLink } from '@elastic/eui';
 import chroma from 'chroma-js';
@@ -43,10 +42,4 @@ export const ColorPickerPopover: FC<Props> = (props: Props) => {
       {() => <ColorPicker value={value} {...rest} />}
     </Popover>
   );
-};
-
-ColorPickerPopover.propTypes = {
-  ...ColorPicker.propTypes,
-  // @ts-expect-error upgrade typescript v5.9.3
-  anchorPosition: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/confirm_modal/confirm_modal.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/confirm_modal/confirm_modal.tsx
@@ -6,7 +6,6 @@
  */
 
 import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
-import PropTypes from 'prop-types';
 import type { FunctionComponent } from 'react';
 import React from 'react';
 
@@ -21,19 +20,17 @@ export interface Props {
   className?: string;
 }
 
-export const ConfirmModal: FunctionComponent<Props> = (props) => {
-  const {
-    isOpen,
-    title,
-    message,
-    onConfirm,
-    onCancel,
-    confirmButtonText,
-    cancelButtonText,
-    className,
-    ...rest
-  } = props;
-
+export const ConfirmModal: FunctionComponent<Props> = ({
+  isOpen,
+  title = 'Confirm',
+  message,
+  onConfirm,
+  onCancel,
+  confirmButtonText = 'Confirm',
+  cancelButtonText = 'Cancel',
+  className,
+  ...rest
+}) => {
   const modalTitleId = useGeneratedHtmlId();
 
   // render nothing if this component isn't open
@@ -59,22 +56,4 @@ export const ConfirmModal: FunctionComponent<Props> = (props) => {
       {message}
     </EuiConfirmModal>
   );
-};
-
-ConfirmModal.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  isOpen: PropTypes.bool,
-  title: PropTypes.string,
-  message: PropTypes.string.isRequired,
-  onConfirm: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  cancelButtonText: PropTypes.string,
-  confirmButtonText: PropTypes.string,
-  className: PropTypes.string,
-};
-
-ConfirmModal.defaultProps = {
-  title: 'Confirm',
-  confirmButtonText: 'Confirm',
-  cancelButtonText: 'Cancel',
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/custom_element_modal/custom_element_modal.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/custom_element_modal/custom_element_modal.tsx
@@ -7,7 +7,6 @@
 
 import React, { PureComponent } from 'react';
 import { get } from 'lodash';
-import PropTypes from 'prop-types';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -119,15 +118,6 @@ interface State {
 }
 
 export class CustomElementModal extends PureComponent<Props, State> {
-  public static propTypes = {
-    name: PropTypes.string,
-    description: PropTypes.string,
-    image: PropTypes.string,
-    title: PropTypes.string.isRequired,
-    onSave: PropTypes.func.isRequired,
-    onCancel: PropTypes.func.isRequired,
-  };
-
   public state = {
     name: this.props.name || '',
     description: this.props.description || '',

--- a/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { i18n } from '@kbn/i18n';
 import { EuiIcon, EuiPagination } from '@elastic/eui';
 import moment from 'moment';
@@ -117,11 +116,3 @@ export const Datatable: FC<Props> = ({
     )}
   </Paginate>
 );
-
-Datatable.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  datatable: PropTypes.object.isRequired,
-  paginate: PropTypes.bool,
-  perPage: PropTypes.number,
-  showHeader: PropTypes.bool,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/dom_preview/dom_preview.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/dom_preview/dom_preview.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 
 interface HeightProps {
@@ -21,12 +20,6 @@ interface WidthProps {
 }
 
 export class DomPreview extends PureComponent<HeightProps | WidthProps> {
-  static propTypes = {
-    elementId: PropTypes.string.isRequired,
-    height: PropTypes.number,
-    width: PropTypes.number,
-  };
-
   _container: HTMLDivElement | null = null;
   _content: HTMLDivElement | null = null;
   _observer: MutationObserver | null = null;

--- a/x-pack/platform/plugins/private/canvas/public/components/download/download.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/download/download.tsx
@@ -7,7 +7,6 @@
 
 import { toByteArray } from 'base64-js';
 import fileSaver from 'file-saver';
-import PropTypes from 'prop-types';
 import type { ReactElement } from 'react';
 import React from 'react';
 import { parseDataUrl } from '../../lib';
@@ -19,12 +18,6 @@ interface Props {
 }
 
 export class Download extends React.PureComponent<Props> {
-  public static propTypes = {
-    children: PropTypes.element.isRequired,
-    fileName: PropTypes.string.isRequired,
-    content: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  };
-
   public onClick = () => {
     const { fileName, content } = this.props;
     const asset = parseDataUrl(content, true);

--- a/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiCard, EuiIcon } from '@elastic/eui';
 import { TagList } from '../tag_list';
 
@@ -48,10 +47,3 @@ export const ElementCard = ({ title, description, image, tags = [], onClick, ...
     {...rest}
   />
 );
-
-ElementCard.propTypes = {
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  image: PropTypes.string,
-  onClick: PropTypes.func,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/element_config/element_config.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_config/element_config.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiStat, EuiAccordion } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -85,8 +84,4 @@ export const ElementConfig = ({ elementStats }: Props) => {
       </EuiAccordion>
     </div>
   );
-};
-
-ElementConfig.propTypes = {
-  elementStats: PropTypes.object,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/element_content/invalid_element_type.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_content/invalid_element_type.tsx
@@ -11,8 +11,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
 import React from 'react';
-import PropTypes from 'prop-types';
-
 export interface Props {
   renderableType: string;
   selectElement: () => void;
@@ -21,8 +19,3 @@ export interface Props {
 export const InvalidElementType = ({ renderableType, selectElement }: Props) => (
   <h3 onClick={selectElement}>Element not found: {renderableType}</h3>
 );
-
-InvalidElementType.propTypes = {
-  renderableType: PropTypes.string,
-  selectElement: PropTypes.func,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/element_content/invalid_expression.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_content/invalid_expression.tsx
@@ -11,8 +11,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
 import React from 'react';
-import PropTypes from 'prop-types';
-
 export interface Props {
   selectElement: () => void;
 }
@@ -20,7 +18,3 @@ export interface Props {
 export const InvalidExpression = ({ selectElement }: Props) => (
   <h3 onClick={selectElement}>Invalid expression</h3>
 );
-
-InvalidExpression.propTypes = {
-  selectElement: PropTypes.func,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/enhance/error_boundary.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/enhance/error_boundary.tsx
@@ -8,7 +8,6 @@
 import type { ErrorInfo, FC, ReactElement } from 'react';
 import React from 'react';
 import { withState, withHandlers, lifecycle, mapProps, compose } from 'react-recompose';
-import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 
 interface Props {
@@ -26,14 +25,6 @@ type ChildrenProps = Omit<ComponentProps, 'children'>;
 const ErrorBoundaryComponent: FC<ComponentProps> = (props) => {
   const { children, ...rest } = props;
   return <>{children(rest)}</>;
-};
-
-ErrorBoundaryComponent.propTypes = {
-  children: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  error: PropTypes.object,
-  errorInfo: PropTypes.object,
-  resetErrorState: PropTypes.func.isRequired,
 };
 
 export const errorBoundaryHoc = compose<ComponentProps, Pick<ComponentProps, 'children'>>(

--- a/x-pack/platform/plugins/private/canvas/public/components/export_app/export_app.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/export_app/export_app.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 // @ts-expect-error untyped local
 import { WorkpadPage } from '../workpad_page';
@@ -53,14 +52,4 @@ export const ExportApp: FC<Props> = ({ workpad, selectedPageIndex, initializeWor
       </div>
     </div>
   );
-};
-
-ExportApp.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  workpad: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    pages: PropTypes.array.isRequired,
-  }).isRequired,
-  selectedPageIndex: PropTypes.number.isRequired,
-  initializeWorkpad: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/expression/expression.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/expression/expression.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useRef } from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiPanel,
   EuiButton,
@@ -208,18 +207,4 @@ export const Expression: FC<Props> = ({
     // Portal is required to show above the navigation
     return <EuiPortal>{expressionPanel}</EuiPortal>;
   }
-};
-
-Expression.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  functionDefinitions: PropTypes.array,
-  // @ts-expect-error upgrade typescript v5.9.3
-  formState: PropTypes.object,
-  // @ts-expect-error upgrade typescript v5.9.3
-  updateValue: PropTypes.func,
-  // @ts-expect-error upgrade typescript v5.9.3
-  setExpression: PropTypes.func,
-  // @ts-expect-error upgrade typescript v5.9.3
-  done: PropTypes.func,
-  error: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/file_upload/file_upload.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/file_upload/file_upload.tsx
@@ -6,7 +6,6 @@
  */
 
 import { EuiFilePicker } from '@elastic/eui';
-import PropTypes from 'prop-types';
 import type { FunctionComponent } from 'react';
 import React from 'react';
 
@@ -19,22 +18,10 @@ interface Props {
   onUpload: () => void;
 }
 
-export const FileUpload: FunctionComponent<Props> = (props) => (
-  <EuiFilePicker compressed id={props.id} className={props.className} onChange={props.onUpload} />
-);
-
-FileUpload.defaultProps = {
-  id: '',
-  className: 'canvasFileUpload',
-};
-
-FileUpload.propTypes = {
-  /** Optional ID of the component */
-  id: PropTypes.string,
-  /** Optional className of the component */
-  className: PropTypes.string,
-  /** Function to invoke when the file is successfully uploaded */
-  onUpload: PropTypes.func.isRequired,
-};
+export const FileUpload: FunctionComponent<Props> = ({
+  id = '',
+  className = 'canvasFileUpload',
+  onUpload,
+}) => <EuiFilePicker compressed id={id} className={className} onChange={onUpload} />;
 
 FileUpload.displayName = 'FileUpload';

--- a/x-pack/platform/plugins/private/canvas/public/components/font_picker/font_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/font_picker/font_picker.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiSuperSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { FontValue } from '../../../common/lib/fonts';
@@ -48,14 +47,6 @@ export const FontPicker: FC<Props> = ({ value, onSelect }) => {
       })}
     />
   );
-};
-
-FontPicker.propTypes = {
-  /** Function to execute when a Font is selected. */
-  onSelect: PropTypes.func,
-  /** Initial value of the Font Picker. */
-  // @ts-expect-error upgrade typescript v5.9.3
-  value: PropTypes.string,
 };
 
 FontPicker.displayName = 'FontPicker';

--- a/x-pack/platform/plugins/private/canvas/public/components/format_select/format_select.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/format_select/format_select.tsx
@@ -7,7 +7,6 @@
 
 import type { ChangeEvent } from 'react';
 import React, { Fragment, PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { EuiSelect, EuiSpacer, EuiFieldText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -25,18 +24,6 @@ interface Props {
 }
 
 export class FormatSelect extends PureComponent<Props> {
-  static propTypes = {
-    argId: PropTypes.string,
-    argValue: PropTypes.string,
-    formatOptions: PropTypes.arrayOf(
-      PropTypes.shape({
-        value: PropTypes.string,
-        text: PropTypes.string,
-      })
-    ).isRequired,
-    onValueChange: PropTypes.func,
-  };
-
   state = {
     isCustomFormat: !this.props.formatOptions
       .map(({ value }) => value)

--- a/x-pack/platform/plugins/private/canvas/public/components/function_form/function_unknown.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/function_form/function_unknown.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { i18n } from '@kbn/i18n';
 
 const strings = {
@@ -30,8 +29,3 @@ export const FunctionUnknown: FunctionComponent<Props> = ({ argType }) => (
     {strings.getUnknownArgumentTypeErrorMessage(argType)}
   </div>
 );
-
-FunctionUnknown.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  argType: PropTypes.string,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/item_grid/item_grid.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/item_grid/item_grid.tsx
@@ -6,7 +6,6 @@
  */
 
 import { last } from 'lodash';
-import PropTypes from 'prop-types';
 import type { ReactElement, ValidationMap } from 'react';
 import React, { Fragment } from 'react';
 
@@ -64,12 +63,4 @@ export const ItemGrid: ItemGridType = function ItemGridFunc<T>({
       ))}
     </Fragment>
   );
-};
-
-ItemGrid.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  items: PropTypes.array,
-  // @ts-expect-error upgrade typescript v5.9.3
-  itemsPerRow: PropTypes.number,
-  children: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/keyboard_shortcuts_doc/keyboard_shortcuts_doc.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/keyboard_shortcuts_doc/keyboard_shortcuts_doc.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiFlyout,
   EuiFlyoutHeader,
@@ -113,7 +112,3 @@ export const KeyboardShortcutsDoc: FunctionComponent<Props> = ({ onClose }) => (
     </EuiFlyoutBody>
   </EuiFlyout>
 );
-
-KeyboardShortcutsDoc.propTypes = {
-  onClose: PropTypes.func.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/alignment_guide.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/alignment_guide.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -31,10 +30,3 @@ export const AlignmentGuide: FC<Props> = ({ transformMatrix, width, height }) =>
     }}
   />
 );
-
-AlignmentGuide.propTypes = {
-  height: PropTypes.number.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  width: PropTypes.number.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_connection.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_connection.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -30,10 +29,3 @@ export const BorderConnection: FC<Props> = ({ transformMatrix, width, height }) 
     }}
   />
 );
-
-BorderConnection.propTypes = {
-  height: PropTypes.number.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  width: PropTypes.number.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_resize_handle.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/border_resize_handle.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -24,9 +23,3 @@ export const BorderResizeHandle: FC<Props> = ({ transformMatrix, zoomScale = 1 }
     }}
   />
 );
-
-BorderResizeHandle.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  zoomScale: PropTypes.number,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/dragbox_annotation.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/dragbox_annotation.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -29,10 +28,3 @@ export const DragBoxAnnotation: FC<Props> = ({ transformMatrix, width, height })
     }}
   />
 );
-
-DragBoxAnnotation.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/hover_annotation.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/hover_annotation.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -29,10 +28,3 @@ export const HoverAnnotation: FC<Props> = ({ transformMatrix, width, height }) =
     }}
   />
 );
-
-HoverAnnotation.propTypes = {
-  height: PropTypes.number.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  width: PropTypes.number.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/rotation_handle.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/rotation_handle.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -29,9 +28,3 @@ export const RotationHandle: FC<Props> = ({ transformMatrix, zoomScale = 1 }) =>
     />
   </div>
 );
-
-RotationHandle.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  zoomScale: PropTypes.number,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/tooltip_annotation.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/layout_annotations/tooltip_annotation.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -25,10 +24,4 @@ export const TooltipAnnotation: FC<Props> = ({ transformMatrix, text }) => {
       <p>{text}°</p>
     </div>
   );
-};
-
-TooltipAnnotation.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  text: PropTypes.string.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/loading/loading.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/loading/loading.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiIcon, EuiLoadingSpinner, isColorDark } from '@elastic/eui';
 import { hexToRgb } from '../../../common/lib/hex_to_rgb';
 
@@ -54,16 +53,4 @@ export const Loading: FC<Props> = ({
       <EuiIcon color={color} type="clock" />
     </div>
   );
-};
-
-Loading.propTypes = {
-  animated: PropTypes.bool,
-  backgroundColor: PropTypes.string,
-  text: PropTypes.string,
-};
-
-Loading.defaultProps = {
-  animated: false,
-  backgroundColor: '#000000',
-  text: '',
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.component.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { Fragment, Component } from 'react';
-import PropTypes from 'prop-types';
 import type { DragDropContextProps } from '@elastic/eui';
 import {
   EuiIcon,
@@ -63,18 +62,6 @@ interface State {
 }
 
 export class PageManager extends Component<Props, State> {
-  static propTypes = {
-    isWriteable: PropTypes.bool.isRequired,
-    onAddPage: PropTypes.func.isRequired,
-    onMovePage: PropTypes.func.isRequired,
-    onPreviousPage: PropTypes.func.isRequired,
-    onRemovePage: PropTypes.func.isRequired,
-    pages: PropTypes.array.isRequired,
-    selectedPage: PropTypes.string,
-    workpadCSS: PropTypes.string,
-    workpadId: PropTypes.string.isRequired,
-  };
-
   constructor(props: Props) {
     super(props);
     this.state = {

--- a/x-pack/platform/plugins/private/canvas/public/components/page_preview/page_controls.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_preview/page_controls.tsx
@@ -7,7 +7,6 @@
 
 import type { FC, ReactEventHandler } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -74,10 +73,4 @@ export const PageControls: FC<Props> = ({ pageId, onRemove, onDuplicate }) => {
       </EuiFlexItem>
     </EuiFlexGroup>
   );
-};
-
-PageControls.propTypes = {
-  pageId: PropTypes.string.isRequired,
-  onRemove: PropTypes.func.isRequired,
-  onDuplicate: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/page_preview/page_preview.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_preview/page_preview.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { DomPreview } from '../dom_preview';
 import { PageControls } from './page_controls';
 import type { CanvasPage } from '../../../types';
@@ -28,16 +27,3 @@ export const PagePreview: FC<Props> = ({ isWriteable, page, height, onDuplicate,
     {isWriteable && <PageControls pageId={page.id} onDuplicate={onDuplicate} onRemove={onRemove} />}
   </div>
 );
-
-PagePreview.propTypes = {
-  isWriteable: PropTypes.bool.isRequired,
-  page: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    style: PropTypes.shape({
-      background: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
-  height: PropTypes.number.isRequired,
-  onDuplicate: PropTypes.func.isRequired,
-  onRemove: PropTypes.func.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/paginate/index.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/paginate/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
-import PropTypes from 'prop-types';
 import type { PaginateProps, PaginateChildProps } from './paginate';
 import { Paginate as Component } from './paginate';
 
@@ -76,11 +75,4 @@ export const Paginate: React.FunctionComponent<InPaginateProps> = ({
       children={children}
     />
   );
-};
-
-Paginate.propTypes = {
-  rows: PropTypes.array.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  perPage: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  startPage: PropTypes.number,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/paginate/paginate.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/paginate/paginate.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import type { InPaginateProps } from '.';
 
 export type PaginateProps = Omit<InPaginateProps, 'startPage'> & {
@@ -26,17 +25,4 @@ export const Paginate: React.FunctionComponent<PaginateProps> = ({
   ...childrenProps
 }) => {
   return <React.Fragment>{children(childrenProps)}</React.Fragment>;
-};
-
-Paginate.propTypes = {
-  children: PropTypes.func.isRequired,
-  rows: PropTypes.array.isRequired,
-  perPage: PropTypes.number.isRequired,
-  pageNumber: PropTypes.number.isRequired,
-  totalPages: PropTypes.number.isRequired,
-  nextPageEnabled: PropTypes.bool.isRequired,
-  prevPageEnabled: PropTypes.bool.isRequired,
-  setPage: PropTypes.func.isRequired,
-  nextPage: PropTypes.func.isRequired,
-  prevPage: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/palette_picker/palette_picker/palette_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/palette_picker/palette_picker/palette_picker.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { ClearablePalettePicker } from './clearable_palette_picker';
 import { palettes as defaultPalettes } from '../../../../common/lib/palettes';
 import type { PalettePickerProps } from '../types';
@@ -30,13 +29,4 @@ export const PalettePicker: FC<PalettePickerProps> = (props) => {
   return (
     <DefaultPalettePicker palettes={palettes} palette={props.palette} onChange={props.onChange} />
   );
-};
-
-PalettePicker.propTypes = {
-  id: PropTypes.string,
-  // @ts-expect-error upgrade typescript v5.9.3
-  palette: PropTypes.object,
-  onChange: PropTypes.func,
-  // @ts-expect-error upgrade typescript v5.9.3
-  clearable: PropTypes.bool,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/popover/popover.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/popover/popover.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { EuiPopover, EuiToolTip } from '@elastic/eui';
 
 interface Props {
@@ -30,15 +29,6 @@ interface State {
 }
 
 export class Popover extends Component<Props, State> {
-  static propTypes = {
-    isOpen: PropTypes.bool,
-    ownFocus: PropTypes.bool,
-    button: PropTypes.func.isRequired,
-    children: PropTypes.func.isRequired,
-    tooltip: PropTypes.string,
-    tooltipPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
-  };
-
   static defaultProps = {
     isOpen: false,
     ownFocus: true,

--- a/x-pack/platform/plugins/private/canvas/public/components/positionable/positionable.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/positionable/positionable.tsx
@@ -7,7 +7,6 @@
 
 import type { FC, ReactElement, CSSProperties } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { matrixToCSS } from '../../lib/dom';
 import type { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -40,13 +39,4 @@ export const Positionable: FC<Props> = ({ children, transformMatrix, width, heig
       {childNode}
     </div>
   );
-};
-
-Positionable.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  children: PropTypes.element.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  transformMatrix: PropTypes.arrayOf(PropTypes.number).isRequired,
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/element_controls.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/element_controls.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent, MouseEvent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -70,8 +69,3 @@ export const ElementControls: FunctionComponent<Props> = ({ onDelete, onEdit }) 
     </EuiFlexItem>
   </EuiFlexGroup>
 );
-
-ElementControls.propTypes = {
-  onDelete: PropTypes.func.isRequired,
-  onEdit: PropTypes.func.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/element_grid.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/element_grid.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { map } from 'lodash';
 import { EuiFlexItem, EuiFlexGrid } from '@elastic/eui';
 import { ElementControls } from './element_controls';
@@ -36,7 +35,7 @@ export interface Props {
   onDelete: (element: CustomElement) => void;
 }
 
-export const ElementGrid = ({ elements, filterText, onClick, onEdit, onDelete }: Props) => {
+export const ElementGrid = ({ elements, filterText = '', onClick, onEdit, onDelete }: Props) => {
   filterText = filterText.toLowerCase();
 
   return (
@@ -68,16 +67,4 @@ export const ElementGrid = ({ elements, filterText, onClick, onEdit, onDelete }:
       })}
     </EuiFlexGrid>
   );
-};
-
-ElementGrid.propTypes = {
-  elements: PropTypes.array.isRequired,
-  filterText: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
-  onEdit: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired,
-};
-
-ElementGrid.defaultProps = {
-  filterText: '',
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/shape_picker/shape_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/shape_picker/shape_picker.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGrid, EuiFlexItem, EuiLink } from '@elastic/eui';
 import type { Shape } from '../../../canvas_plugin_src/renderers/shape';
 import { ShapePreview } from '../shape_preview';
@@ -28,9 +27,3 @@ export const ShapePicker: FC<Props> = ({ shapes, onChange = () => {} }) => (
     ))}
   </EuiFlexGrid>
 );
-
-ShapePicker.propTypes = {
-  onChange: PropTypes.func,
-  // @ts-expect-error upgrade typescript v5.9.3
-  shapes: PropTypes.object.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/shape_picker_popover/shape_picker_popover.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/shape_picker_popover/shape_picker_popover.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiLink, EuiPanel } from '@elastic/eui';
 import type { Shape } from '../../../canvas_plugin_src/renderers/shape';
 import { Popover } from '../popover';
@@ -35,13 +34,4 @@ export const ShapePickerPopover: FC<Props> = ({ shapes, onChange, value, ariaLab
       {() => <ShapePicker onChange={onChange} shapes={shapes} />}
     </Popover>
   );
-};
-
-ShapePickerPopover.propTypes = {
-  ariaLabel: PropTypes.string,
-  onChange: PropTypes.func,
-  // @ts-expect-error upgrade typescript v5.9.3
-  shapes: PropTypes.object.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  value: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/shape_preview/shape_preview.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/shape_preview/shape_preview.tsx
@@ -7,7 +7,6 @@
 
 import type { FC, RefCallback } from 'react';
 import React, { useCallback, useState } from 'react';
-import PropTypes from 'prop-types';
 import { ShapeDrawerComponent } from '../../../canvas_plugin_src/renderers/shape/components';
 import type { SvgConfig, ShapeRef, ViewBoxParams } from '../shape_drawer';
 import { getDefaultShapeData } from '../shape_drawer';
@@ -49,8 +48,4 @@ export const ShapePreview: FC<Props> = ({ shape }) => {
       />
     </div>
   );
-};
-
-ShapePreview.propTypes = {
-  shape: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/sidebar/element_settings/element_settings.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/sidebar/element_settings/element_settings.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React, { useMemo, useState } from 'react';
-import PropTypes from 'prop-types';
 import { EuiTab, EuiTabs } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -125,9 +124,4 @@ export const ElementSettings: FunctionComponent<Props> = ({ element }) => {
       {tabsContent}
     </>
   );
-};
-
-ElementSettings.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  element: PropTypes.object,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/tag/tag.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/tag/tag.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiBadge, EuiHealth } from '@elastic/eui';
 
 interface Props {
@@ -45,11 +44,4 @@ export const Tag: FunctionComponent<Props> = ({
         </EuiBadge>
       );
   }
-};
-
-Tag.propTypes = {
-  name: PropTypes.string.isRequired,
-  color: PropTypes.string,
-  // @ts-expect-error upgrade typescript v5.9.3
-  type: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/tag_list/tag_list.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/tag_list/tag_list.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
 import { getId } from '../../lib/get_id';
 import { Tag } from '../tag';
 import type { TagSpec } from '../../lib/tag';
@@ -38,9 +37,3 @@ export const TagList: FunctionComponent<Props> = ({ tags = [], tagType = 'health
       : null}
   </Fragment>
 );
-
-TagList.propTypes = {
-  tags: PropTypes.array,
-  tagType: PropTypes.oneOf(['health', 'badge']),
-  getTag: PropTypes.func.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/text_style_picker/text_style_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/text_style_picker/text_style_picker.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiSelect, EuiSpacer, EuiButtonGroup } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { FontValue } from '@kbn/expressions-plugin/common';
@@ -224,23 +223,4 @@ export const TextStylePicker: FC<Props> = ({
       </EuiFlexGroup>
     </div>
   );
-};
-
-TextStylePicker.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  family: PropTypes.string,
-  size: PropTypes.number,
-  align: PropTypes.oneOf(['left', 'center', 'right']),
-  color: PropTypes.string,
-  weight: PropTypes.oneOf(['normal', 'bold']),
-  underline: PropTypes.bool,
-  italic: PropTypes.bool,
-  onChange: PropTypes.func.isRequired,
-  colors: PropTypes.array,
-};
-
-TextStylePicker.defaultProps = {
-  align: 'left',
-  size: 14,
-  weight: 'normal',
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/tool_tip_shortcut/tool_tip_shortcut.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/tool_tip_shortcut/tool_tip_shortcut.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiText } from '@elastic/eui';
 import type { FunctionComponent } from 'react';
 
@@ -22,7 +21,3 @@ export const ToolTipShortcut: FunctionComponent<Props> = ({ shortcut }) => (
     {shortcut.replace(/\+/g, ' + ')}
   </EuiText>
 );
-
-ToolTipShortcut.propTypes = {
-  shortcut: PropTypes.string.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/components/toolbar/toolbar.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/toolbar/toolbar.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useState, useContext, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -148,13 +147,4 @@ export const Toolbar: FC<Props> = ({
       </div>
     </div>
   );
-};
-
-Toolbar.propTypes = {
-  isWriteable: PropTypes.bool.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  selectedElement: PropTypes.object,
-  selectedPageNumber: PropTypes.number.isRequired,
-  totalPages: PropTypes.number.isRequired,
-  workpadName: PropTypes.string.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/toolbar/tray/tray.tsx
@@ -7,7 +7,6 @@
 
 import type { ReactNode, MouseEventHandler } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -39,9 +38,4 @@ export const Tray = ({ children, done }: Props) => {
       <div className="canvasTray">{children}</div>
     </>
   );
-};
-
-Tray.propTypes = {
-  children: PropTypes.node.isRequired,
-  done: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/tooltip_icon/tooltip_icon.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/tooltip_icon/tooltip_icon.tsx
@@ -8,7 +8,6 @@
 /* eslint react/forbid-elements: 0 */
 import type { FC } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import type { PropsOf } from '@elastic/eui';
 import { EuiIconTip } from '@elastic/eui';
 
@@ -32,9 +31,4 @@ export const TooltipIcon: FC<Props> = ({ icon = IconType.info, ...rest }) => {
   };
 
   return <EuiIconTip {...rest} type={icons[icon].type} color={icons[icon].color} />;
-};
-
-TooltipIcon.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  icon: PropTypes.string,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_app/workpad_app.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_app/workpad_app.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FC, MouseEventHandler } from 'react';
 import React, { useRef, useCallback, useEffect, useMemo } from 'react';
-import PropTypes from 'prop-types';
 import { CANVAS } from '../../../i18n';
 import { Sidebar } from '../sidebar';
 import { Toolbar } from '../toolbar';
@@ -92,9 +91,4 @@ export const WorkpadApp: FC<Props> = ({ deselectElement, isWriteable, workpad })
       </div>
     </div>
   );
-};
-
-WorkpadApp.propTypes = {
-  isWriteable: PropTypes.bool.isRequired,
-  deselectElement: PropTypes.func,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_color_picker/workpad_color_picker.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_color_picker/workpad_color_picker.component.tsx
@@ -40,5 +40,3 @@ export const WorkpadColorPicker = (props: Props) => {
     />
   );
 };
-
-WorkpadColorPicker.propTypes = ColorPickerPopover.propTypes;

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_config/workpad_config.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_config/workpad_config.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiFieldText,
   EuiFieldNumber,
@@ -220,17 +219,4 @@ export const WorkpadConfig: FC<Props> = (props) => {
       </div>
     </div>
   );
-};
-
-WorkpadConfig.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  size: PropTypes.object.isRequired,
-  name: PropTypes.string.isRequired,
-  css: PropTypes.string,
-  // @ts-expect-error upgrade typescript v5.9.3
-  variables: PropTypes.array,
-  setSize: PropTypes.func.isRequired,
-  setName: PropTypes.func.isRequired,
-  setWorkpadCSS: PropTypes.func.isRequired,
-  setWorkpadVariables: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/edit_menu/edit_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/edit_menu/edit_menu.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React, { Fragment, useState } from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonEmpty, EuiContextMenu, EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ClosePopoverFn } from '../../popover';
@@ -510,30 +509,4 @@ export const EditMenu: FunctionComponent<Props> = ({
       ) : null}
     </Fragment>
   );
-};
-
-EditMenu.propTypes = {
-  cutNodes: PropTypes.func.isRequired,
-  copyNodes: PropTypes.func.isRequired,
-  pasteNodes: PropTypes.func.isRequired,
-  deleteNodes: PropTypes.func.isRequired,
-  cloneNodes: PropTypes.func.isRequired,
-  bringToFront: PropTypes.func.isRequired,
-  bringForward: PropTypes.func.isRequired,
-  sendBackward: PropTypes.func.isRequired,
-  sendToBack: PropTypes.func.isRequired,
-  alignLeft: PropTypes.func.isRequired,
-  alignCenter: PropTypes.func.isRequired,
-  alignRight: PropTypes.func.isRequired,
-  alignTop: PropTypes.func.isRequired,
-  alignMiddle: PropTypes.func.isRequired,
-  alignBottom: PropTypes.func.isRequired,
-  distributeHorizontally: PropTypes.func.isRequired,
-  distributeVertically: PropTypes.func.isRequired,
-  createCustomElement: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  selectedNodes: PropTypes.arrayOf(PropTypes.object).isRequired,
-  groupIsSelected: PropTypes.bool.isRequired,
-  groupNodes: PropTypes.func.isRequired,
-  ungroupNodes: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
@@ -8,7 +8,6 @@
 import { sortBy } from 'lodash';
 import type { FunctionComponent } from 'react';
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
 import { EuiContextMenu, EuiIcon } from '@elastic/eui';
 import { ToolbarPopover } from '@kbn/shared-ux-button-toolbar';
@@ -223,10 +222,4 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
       {isSavedElementsModalVisible ? <SavedElementsModal onClose={hideSavedElementsModal} /> : null}
     </>
   );
-};
-
-ElementMenu.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  elements: PropTypes.object,
-  addElement: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/fullscreen_control/fullscreen_control.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/fullscreen_control/fullscreen_control.tsx
@@ -7,7 +7,6 @@
 
 import type { ReactNode, KeyboardEvent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 // @ts-expect-error no @types definition
 import { Shortcuts } from 'react-shortcuts';
 import { isTextInput } from '../../../lib/is_text_input';
@@ -35,12 +34,6 @@ interface Props {
 }
 
 export class FullscreenControl extends React.PureComponent<Props> {
-  static propTypes = {
-    setFullscreen: PropTypes.func.isRequired,
-    isFullscreen: PropTypes.bool.isRequired,
-    children: PropTypes.func.isRequired,
-  };
-
   /*
     We need these instance functions because ReactShortcuts bind the handlers on it's mount, 
     but then does no rebinding if it's props change. Using these instance functions will 

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/refresh_control/refresh_control.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/refresh_control/refresh_control.component.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useDispatch, useSelector } from 'react-redux';
@@ -55,9 +54,4 @@ export const RefreshControl = () => {
       />
     </EuiToolTip>
   );
-};
-
-RefreshControl.propTypes = {
-  doRefresh: PropTypes.func.isRequired,
-  inFlight: PropTypes.bool,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiButtonEmpty, EuiContextMenu, EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { PDF, JSON } from '../../../../i18n/constants';
@@ -106,8 +105,4 @@ export const ShareMenu = ({ ReportingComponent, onExport }: Props) => {
       </Popover>
     </div>
   );
-};
-
-ShareMenu.propTypes = {
-  onExport: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/auto_refresh_controls.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/auto_refresh_controls.tsx
@@ -7,7 +7,6 @@
 
 import type { ReactNode } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -181,10 +180,4 @@ export const AutoRefreshControls = ({ refreshInterval, setRefresh, disableInterv
       </EuiFlexItem>
     </EuiFlexGroup>
   );
-};
-
-AutoRefreshControls.propTypes = {
-  refreshInterval: PropTypes.number,
-  setRefresh: PropTypes.func.isRequired,
-  disableInterval: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/custom_interval.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/custom_interval.tsx
@@ -38,7 +38,7 @@ interface Props {
   gutterSize?: EuiFlexGroupGutterSize;
   buttonSize?: EuiButtonSize;
   onSubmit: (interval: number) => void;
-  defaultValue?: any;
+  defaultValue?: string;
 }
 
 export const CustomInterval = ({

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/custom_interval.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/custom_interval.tsx
@@ -7,7 +7,6 @@
 
 import type { ChangeEvent } from 'react';
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiButton, EuiFieldText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { EuiButtonSize } from '@elastic/eui/src/components/button/button';
@@ -36,13 +35,18 @@ const strings = {
 };
 
 interface Props {
-  gutterSize: EuiFlexGroupGutterSize;
-  buttonSize: EuiButtonSize;
+  gutterSize?: EuiFlexGroupGutterSize;
+  buttonSize?: EuiButtonSize;
   onSubmit: (interval: number) => void;
-  defaultValue: any;
+  defaultValue?: any;
 }
 
-export const CustomInterval = ({ gutterSize, buttonSize, onSubmit, defaultValue }: Props) => {
+export const CustomInterval = ({
+  gutterSize = 's' as EuiFlexGroupGutterSize,
+  buttonSize = 's' as EuiButtonSize,
+  onSubmit,
+  defaultValue = '',
+}: Props) => {
   const [customInterval, setCustomInterval] = useState(defaultValue);
   const refreshInterval = getTimeInterval(customInterval);
   const isInvalid = Boolean(customInterval.length && !refreshInterval);
@@ -84,17 +88,4 @@ export const CustomInterval = ({ gutterSize, buttonSize, onSubmit, defaultValue 
       </EuiFlexGroup>
     </form>
   );
-};
-
-CustomInterval.propTypes = {
-  buttonSize: PropTypes.string,
-  gutterSize: PropTypes.string,
-  defaultValue: PropTypes.string,
-  onSubmit: PropTypes.func.isRequired,
-};
-
-CustomInterval.defaultProps = {
-  buttonSize: 's',
-  gutterSize: 's',
-  defaultValue: '',
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/kiosk_controls.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/kiosk_controls.tsx
@@ -7,7 +7,6 @@
 
 import type { ReactNode } from 'react';
 import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiButtonIcon,
   EuiDescriptionList,
@@ -179,9 +178,4 @@ export const KioskControls = ({ autoplayInterval, onSetInterval }: Props) => {
       </EuiFlexItem>
     </EuiFlexGroup>
   );
-};
-
-KioskControls.propTypes = {
-  autoplayInterval: PropTypes.number.isRequired,
-  onSetInterval: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/view_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/view_menu.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
 import { EuiButtonEmpty, EuiContextMenu, EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -296,22 +295,4 @@ export const ViewMenu: FunctionComponent<Props> = ({
       )}
     </Popover>
   );
-};
-
-ViewMenu.propTypes = {
-  isWriteable: PropTypes.bool.isRequired,
-  zoomScale: PropTypes.number.isRequired,
-  fitToWindow: PropTypes.func.isRequired,
-  setZoomScale: PropTypes.func.isRequired,
-  zoomIn: PropTypes.func.isRequired,
-  zoomOut: PropTypes.func.isRequired,
-  resetZoom: PropTypes.func.isRequired,
-  toggleWriteable: PropTypes.func.isRequired,
-  enterFullscreen: PropTypes.func.isRequired,
-  doRefresh: PropTypes.func.isRequired,
-  refreshInterval: PropTypes.number.isRequired,
-  setRefreshInterval: PropTypes.func.isRequired,
-  autoplayEnabled: PropTypes.bool.isRequired,
-  autoplayInterval: PropTypes.number.isRequired,
-  setAutoplayInterval: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/workpad_header.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/workpad_header.component.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useCallback, useState } from 'react';
-import PropTypes from 'prop-types';
 // @ts-expect-error no @types definition
 import { Shortcuts } from 'react-shortcuts';
 import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
@@ -226,7 +225,6 @@ export const WorkpadHeader: FC<Props> = ({
               </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              {/* @ts-expect-error upgrade typescript v5.9.3 */}
               <RefreshControl />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
@@ -238,17 +236,4 @@ export const WorkpadHeader: FC<Props> = ({
       {isEmbedPanelVisible ? renderEmbedPanel(hideEmbedPanel) : null}
     </>
   );
-};
-
-WorkpadHeader.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  isWriteable: PropTypes.bool,
-  commit: PropTypes.func.isRequired,
-  onSetWriteable: PropTypes.func,
-  // @ts-expect-error upgrade typescript v5.9.3
-  canUserWrite: PropTypes.bool,
-  renderEmbedPanel: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  elements: PropTypes.object.isRequired,
-  addElement: PropTypes.func.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_shortcuts/index.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_shortcuts/index.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import PropTypes from 'prop-types';
 import { withHandlers, compose } from 'react-recompose';
 import type { Props as WorkpadShortcutsProps } from './workpad_shortcuts';
 import { WorkpadShortcuts as Component } from './workpad_shortcuts';
@@ -25,14 +24,3 @@ export const WorkpadShortcuts = compose<WorkpadShortcutsProps, HandlerCreatorPro
   withHandlers(clipboardHandlerCreators),
   withHandlers(positionHandlerCreators)
 )(Component);
-
-WorkpadShortcuts.propTypes = {
-  pageId: PropTypes.string.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  selectedNodes: PropTypes.arrayOf(PropTypes.object),
-  elementLayer: PropTypes.func.isRequired,
-  insertNodes: PropTypes.func.isRequired,
-  removeNodes: PropTypes.func.isRequired,
-  selectToplevelNodes: PropTypes.func.isRequired,
-  commit: PropTypes.func.isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/appearance_form.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/appearance_form.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent, ChangeEvent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect } from '@elastic/eui';
 import { ArgTypesStrings } from '../../../../i18n';
 
@@ -88,19 +87,4 @@ export const AppearanceForm: FunctionComponent<Props> = ({
       </EuiFlexItem>
     </EuiFlexGroup>
   );
-};
-
-AppearanceForm.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  padding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  // @ts-expect-error upgrade typescript v5.9.3
-  opacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  // @ts-expect-error upgrade typescript v5.9.3
-  overflow: PropTypes.oneOf(['hidden', 'visible']),
-  onChange: PropTypes.func.isRequired,
-};
-
-AppearanceForm.defaultProps = {
-  opacity: 1,
-  overflow: 'hidden',
 };

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/border_form.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/border_form.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   EuiFlexGroup,
   EuiFormRow,
@@ -125,13 +124,4 @@ export const BorderForm: FunctionComponent<Props> = ({
       </EuiFlexItem>
     </EuiFlexGroup>
   );
-};
-
-BorderForm.propTypes = {
-  // @ts-expect-error upgrade typescript v5.9.3
-  value: PropTypes.string,
-  // @ts-expect-error upgrade typescript v5.9.3
-  radius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onChange: PropTypes.func.isRequired,
-  colors: PropTypes.array.isRequired,
 };

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/extended_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/extended_template.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import { BorderForm } from './border_form';
 import { AppearanceForm } from './appearance_form';
@@ -63,12 +62,3 @@ export const ExtendedTemplate: FunctionComponent<Props> = ({
 );
 
 ExtendedTemplate.displayName = 'ContainerStyleArgExtendedInput';
-
-ExtendedTemplate.propTypes = {
-  getArgValue: PropTypes.func.isRequired,
-  setArgValue: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  workpad: PropTypes.shape({
-    colors: PropTypes.array.isRequired,
-  }).isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/simple_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/container_style/simple_template.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { ColorPickerPopover } from '../../../components/color_picker_popover';
 import type { CanvasWorkpad } from '../../../../types';
 import { ArgTypesStrings } from '../../../../i18n';
@@ -38,12 +37,3 @@ export const SimpleTemplate: FunctionComponent<Props> = ({ getArgValue, setArgVa
 );
 
 SimpleTemplate.displayName = 'ContainerStyleArgSimpleInput';
-
-SimpleTemplate.propTypes = {
-  getArgValue: PropTypes.func.isRequired,
-  setArgValue: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  workpad: PropTypes.shape({
-    colors: PropTypes.array.isRequired,
-  }),
-};

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/extended_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/extended_template.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent, ChangeEvent } from 'react';
 import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect, EuiSpacer } from '@elastic/eui';
 import { set, del } from 'object-path-immutable';
 import { get } from 'lodash';
@@ -141,13 +140,3 @@ export const ExtendedTemplate: FunctionComponent<Props> = (props) => {
 };
 
 ExtendedTemplate.displayName = 'SeriesStyleArgAdvancedInput';
-
-ExtendedTemplate.propTypes = {
-  onValueChange: PropTypes.func.isRequired,
-  argValue: PropTypes.any.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  typeInstance: PropTypes.object,
-  resolved: PropTypes.shape({
-    labels: PropTypes.array.isRequired,
-  }).isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/simple_template.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/simple_template.tsx
@@ -7,7 +7,6 @@
 
 import type { FunctionComponent } from 'react';
 import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiButtonIcon, EuiText } from '@elastic/eui';
 import { set, del } from 'object-path-immutable';
 import { get } from 'lodash';
@@ -110,15 +109,3 @@ export const SimpleTemplate: FunctionComponent<Props> = (props) => {
 };
 
 SimpleTemplate.displayName = 'SeriesStyleArgSimpleInput';
-
-SimpleTemplate.propTypes = {
-  argValue: PropTypes.any.isRequired,
-  resolved: PropTypes.shape({
-    labels: PropTypes.array.isRequired,
-  }).isRequired,
-  onValueChange: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  workpad: PropTypes.shape({
-    colors: PropTypes.array.isRequired,
-  }).isRequired,
-};

--- a/x-pack/platform/plugins/private/canvas/public/lib/template_from_react_component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/lib/template_from_react_component.tsx
@@ -8,7 +8,6 @@
 import type { ComponentType, ForwardRefRenderFunction } from 'react';
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import { unmountComponentAtNode, createPortal } from 'react-dom';
-import PropTypes from 'prop-types';
 import { I18nProvider } from '@kbn/i18n-react';
 import { ErrorBoundary } from '../components/enhance/error_boundary';
 import type { ArgumentHandlers, UpdatePropsRef } from '../../types/arguments';
@@ -46,11 +45,6 @@ export const templateFromReactComponent = (Component: ComponentType<any>) => {
   };
 
   const ForwardRefWrappedComponent = forwardRef(WrappedComponent);
-
-  ForwardRefWrappedComponent.propTypes = {
-    // @ts-expect-error upgrade typescript v5.9.3
-    renderError: PropTypes.func,
-  };
 
   return (
     domNode: HTMLElement,


### PR DESCRIPTION
## Summary

This PR removes `propTypes` and `defaultTypes` as they're being removed for functional components in React 19.

Context: https://github.com/elastic/kibana/issues/256125
