### PR TITLE
Remove propTypes and defaultTypes for .tsx files owned by kibana-management

### DIFF
--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_list.tsx
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_list.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ScopedHistory } from '@kbn/core/public';
 
@@ -75,18 +74,6 @@ function getHttpErrorBody(error: unknown): { statusCode: number; error: string }
 }
 
 export class RemoteClusterList extends Component<Props> {
-  static propTypes = {
-    loadClusters: PropTypes.func.isRequired,
-    refreshClusters: PropTypes.func.isRequired,
-    openDetailPanel: PropTypes.func.isRequired,
-    closeDetailPanel: PropTypes.func.isRequired,
-    isDetailPanelOpen: PropTypes.bool,
-    clusters: PropTypes.array,
-    isLoading: PropTypes.bool,
-    isCopyingCluster: PropTypes.bool,
-    isRemovingCluster: PropTypes.bool,
-  };
-
   interval?: ReturnType<typeof setInterval>;
 
   componentDidUpdate() {

--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_table/remote_cluster_table.tsx
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/remote_cluster_list/remote_cluster_table/remote_cluster_table.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -73,11 +72,6 @@ interface State {
 }
 
 export class RemoteClusterTable extends Component<Props, State> {
-  static propTypes = {
-    clusters: PropTypes.array,
-    openDetailPanel: PropTypes.func.isRequired,
-  };
-
   static defaultProps = {
     clusters: [],
   };


### PR DESCRIPTION
## Summary

This PR removes `propTypes` and `defaultTypes` in preparation for React 19. The components are already typed using TypeScript.

Context: https://github.com/elastic/kibana/issues/256125


