### PR TITLE
Remove propTypes and defaultTypes for .tsx files owned by kibana-data-discovery

### DIFF
--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/confirmation_modal.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/confirmation_modal.tsx
@@ -8,8 +8,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
-
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiConfirmModal, EUI_MODAL_CONFIRM_BUTTON, useGeneratedHtmlId } from '@elastic/eui';
 
@@ -63,10 +61,4 @@ export const DeleteFilterConfirmationModal = ({
       defaultFocusedButton={EUI_MODAL_CONFIRM_BUTTON}
     />
   );
-};
-
-DeleteFilterConfirmationModal.propTypes = {
-  filterToDeleteValue: PropTypes.string.isRequired,
-  onCancelConfirmationModal: PropTypes.func.isRequired,
-  onDeleteFilter: PropTypes.func.isRequired,
 };

--- a/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
+++ b/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
@@ -8,7 +8,6 @@
  */
 
 import { debounce } from 'lodash';
-import PropTypes from 'prop-types';
 import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import { getTagFindReferences, parseQuery } from '@kbn/saved-objects-management-plugin/public';
@@ -107,14 +106,6 @@ class SavedObjectFinderUiClass extends React.Component<
   SavedObjectFinderProps & EuiTablePersistInjectedProps<SavedObjectFinderItem>,
   SavedObjectFinderState
 > {
-  public static propTypes: Record<string, PropTypes.Validator<unknown>> = {
-    onChoose: PropTypes.func,
-    noItemsMessage: PropTypes.node,
-    savedObjectMetaData: PropTypes.array.isRequired,
-    initialPageSize: PropTypes.oneOf([5, 10, 15, 25]),
-    fixedPageSize: PropTypes.number,
-    showFilter: PropTypes.bool,
-  };
   private isComponentMounted: boolean = false;
 
   private debouncedFetch = debounce(async (query: Query) => {


### PR DESCRIPTION
## Summary

This PR removes `propTypes` and `defaultTypes` as they're being removed for functional components in React 19.

Context: https://github.com/elastic/kibana/issues/256125
