### PR TITLE
Remove propTypes and defaultTypes for .tsx files owned by elastic/ml-ui

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/annotations/delete_annotation_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/annotations/delete_annotation_modal/index.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { EUI_MODAL_CONFIRM_BUTTON, EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 
@@ -58,10 +57,4 @@ export const DeleteAnnotationModal: React.FC<Props> = ({
       )}
     </Fragment>
   );
-};
-
-DeleteAnnotationModal.propTypes = {
-  cancelAction: PropTypes.func.isRequired,
-  deleteAction: PropTypes.func.isRequired,
-  isVisible: PropTypes.bool.isRequired,
 };


### PR DESCRIPTION
## Summary

This PR removes `propTypes` and `defaultTypes` as they're being removed for functional components in React 19.

Context: https://github.com/elastic/kibana/issues/256125
