### PR TITLE
[Search] [Search Applications] Fix missing tooltip announcement for screen readers

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_applications_list.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_applications_list.tsx
@@ -56,6 +56,7 @@ export const CreateSearchApplicationButton: React.FC<CreateSearchApplicationButt
   return (
     <EuiToolTip
       position="top"
+      disableScreenReaderOutput
       title={
         <EuiFlexGroup justifyContent="center" gutterSize="s">
           <EuiFlexItem grow={false}>
@@ -84,6 +85,13 @@ export const CreateSearchApplicationButton: React.FC<CreateSearchApplicationButt
         data-test-subj="enterprise-search-search-applications-creation-button"
         data-telemetry-id="entSearchApplications-list-createSearchApplication"
         isDisabled={disabled}
+        aria-label={i18n.translate(
+          'xpack.enterpriseSearch.searchApplications.list.createSearchApplicationButton.ariaLabel',
+          {
+            defaultMessage:
+              'Create. Beta: This functionality may be changed or removed completely in a future release.',
+          }
+        )}
         onClick={() => KibanaLogic.values.navigateToUrl(SEARCH_APPLICATION_CREATION_PATH)}
       >
         {i18n.translate(


### PR DESCRIPTION
## Summary

Adds screen reader support for the Beta tooltip on the Create button in the Search Applications list page. Previously, the tooltip content (Beta badge + disclaimer text) was only visible on hover and inaccessible to screen readers.

Changes:
- Added `disableScreenReaderOutput` to `EuiToolTip` to prevent duplicate announcements
- Added `aria-label` with i18n support to the Create button so screen readers announce both the action and Beta status

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No significant risks. This is a minor accessibility improvement that adds an `aria-label` attribute and a tooltip prop — no logic or visual changes.