### PR TITLE
[Streams] Fix empty conditions crash when discarding

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang/types/conditions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/conditions.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { z } from '@kbn/zod/v4';
-import { createIsNarrowSchema, NonEmptyString } from '@kbn/zod-helpers/v4';
+import { createIsNarrowSchema, DeepStrict, NonEmptyString } from '@kbn/zod-helpers/v4';
 
 export const stringOrNumberOrBoolean = z
   .union([z.string(), z.number(), z.boolean()])
@@ -226,6 +226,13 @@ export const isAlwaysCondition = createIsNarrowSchema(conditionSchema, alwaysCon
 export const isNotCondition = createIsNarrowSchema(conditionSchema, notConditionSchema);
 
 export const isCondition = createIsNarrowSchema(z.unknown(), conditionSchema);
+
+/**
+ * Strict version of conditionSchema that rejects excess/unknown keys.
+ * Pre-constructed for performance as DeepStrict creates proxy wrappers.
+ */
+export const conditionSchemaStrict = DeepStrict(conditionSchema);
+export const isConditionStrict = createIsNarrowSchema(z.unknown(), conditionSchemaStrict);
 
 export const ALWAYS_CONDITION: AlwaysCondition = Object.freeze({ always: {} });
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.test.tsx
@@ -378,6 +378,62 @@ describe('ConditionEditor', () => {
         screen.getByText(/The condition is invalid or in unrecognized format/i)
       ).toBeInTheDocument();
     });
+
+    it('should NOT call onConditionChange and should report invalid when syntax editor is cleared (empty string)', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      renderWithProviders(
+        <ConditionEditor
+          condition={{ field: 'severity_text', eq: 'info' }}
+          status="enabled"
+          onConditionChange={mockOnConditionChange}
+          onValidityChange={mockOnValidityChange}
+        />
+      );
+
+      const switchButton = screen.getByTestId('streamsAppConditionEditorSwitch');
+      await user.click(switchButton);
+
+      mockOnConditionChange.mockClear();
+      mockOnValidityChange.mockClear();
+
+      const codeEditor = screen.getByTestId('streamsAppConditionEditorCodeEditor');
+
+      fireEvent.change(codeEditor, { target: { value: '' } });
+
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+
+      expect(mockOnConditionChange).not.toHaveBeenCalled();
+      expect(mockOnValidityChange).toHaveBeenCalledWith(false);
+
+      jest.useRealTimers();
+    });
+
+    it('should NOT call onConditionChange on blur when syntax editor is empty', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <ConditionEditor
+          condition={{ field: 'severity_text', eq: 'info' }}
+          status="enabled"
+          onConditionChange={mockOnConditionChange}
+          onValidityChange={mockOnValidityChange}
+        />
+      );
+
+      const switchButton = screen.getByTestId('streamsAppConditionEditorSwitch');
+      await user.click(switchButton);
+
+      mockOnConditionChange.mockClear();
+
+      const codeEditor = screen.getByTestId('streamsAppConditionEditorCodeEditor');
+
+      fireEvent.change(codeEditor, { target: { value: '' } });
+      fireEvent.blur(codeEditor);
+
+      expect(mockOnConditionChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('help text for date math', () => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.test.tsx
@@ -411,6 +411,66 @@ describe('ConditionEditor', () => {
       jest.useRealTimers();
     });
 
+    it('should NOT call onConditionChange and should report invalid when YAML has unrecognized keys', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      renderWithProviders(
+        <ConditionEditor
+          condition={{ field: 'severity_text', eq: 'info' }}
+          status="enabled"
+          onConditionChange={mockOnConditionChange}
+          onValidityChange={mockOnValidityChange}
+        />
+      );
+
+      const switchButton = screen.getByTestId('streamsAppConditionEditorSwitch');
+      await user.click(switchButton);
+
+      mockOnConditionChange.mockClear();
+      mockOnValidityChange.mockClear();
+
+      const codeEditor = screen.getByTestId('streamsAppConditionEditorCodeEditor');
+
+      fireEvent.change(codeEditor, {
+        target: { value: 'field: user.name\neq: user1\nsdfsd: sdf\n' },
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+
+      expect(mockOnConditionChange).not.toHaveBeenCalled();
+      expect(mockOnValidityChange).toHaveBeenCalledWith(false);
+
+      jest.useRealTimers();
+    });
+
+    it('should NOT flush on blur when YAML has unrecognized keys', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <ConditionEditor
+          condition={{ field: 'severity_text', eq: 'info' }}
+          status="enabled"
+          onConditionChange={mockOnConditionChange}
+          onValidityChange={mockOnValidityChange}
+        />
+      );
+
+      const switchButton = screen.getByTestId('streamsAppConditionEditorSwitch');
+      await user.click(switchButton);
+
+      mockOnConditionChange.mockClear();
+
+      const codeEditor = screen.getByTestId('streamsAppConditionEditorCodeEditor');
+
+      fireEvent.change(codeEditor, {
+        target: { value: 'field: user.name\neq: user1\nsdfsd: sdf\n' },
+      });
+      fireEvent.blur(codeEditor);
+
+      expect(mockOnConditionChange).not.toHaveBeenCalled();
+    });
+
     it('should NOT call onConditionChange on blur when syntax editor is empty', async () => {
       const user = userEvent.setup();
       renderWithProviders(

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
@@ -25,6 +25,7 @@ import {
   getFilterValue,
   isArrayOperator,
   isCondition,
+  isConditionStrict,
   type OperatorKeys,
 } from '@kbn/streamlang';
 import type { RoutingStatus } from '@kbn/streams-schema';
@@ -194,7 +195,7 @@ export function ConditionEditor(props: ConditionEditorProps) {
     }
     try {
       const parsed = yaml.parse(currentValue);
-      if (!isCondition(parsed)) {
+      if (!isConditionStrict(parsed)) {
         return;
       }
       debouncedEmitConditionChange.cancel();
@@ -280,7 +281,7 @@ export function ConditionEditor(props: ConditionEditorProps) {
             setSyntaxEditorValue(value);
             try {
               const parsed = yaml.parse(value);
-              if (!isCondition(parsed)) {
+              if (!isConditionStrict(parsed)) {
                 reportValidityChange(false);
                 debouncedEmitConditionChange.cancel();
                 return;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
@@ -24,7 +24,6 @@ import {
   getFilterOperator,
   getFilterValue,
   isArrayOperator,
-  isCondition,
   isConditionStrict,
   type OperatorKeys,
 } from '@kbn/streamlang';
@@ -69,7 +68,7 @@ export function ConditionEditor(props: ConditionEditorProps) {
   } = props;
   const { core } = useKibana();
 
-  const isInvalidCondition = !isCondition(props.condition);
+  const isInvalidCondition = !isConditionStrict(props.condition);
 
   const condition = alwaysToEmptyEquals(props.condition);
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
@@ -193,7 +193,10 @@ export function ConditionEditor(props: ConditionEditorProps) {
       return;
     }
     try {
-      const parsed = yaml.parse(currentValue) as Condition;
+      const parsed = yaml.parse(currentValue);
+      if (!isCondition(parsed)) {
+        return;
+      }
       debouncedEmitConditionChange.cancel();
       handleConditionChange(parsed);
     } catch (error: unknown) {
@@ -276,7 +279,12 @@ export function ConditionEditor(props: ConditionEditorProps) {
             syntaxEditorValueRef.current = value;
             setSyntaxEditorValue(value);
             try {
-              const parsed = yaml.parse(value) as Condition;
+              const parsed = yaml.parse(value);
+              if (!isCondition(parsed)) {
+                reportValidityChange(false);
+                debouncedEmitConditionChange.cancel();
+                return;
+              }
               reportValidityChange(true);
               debouncedEmitConditionChange(parsed);
             } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Fixes an issue where emptying the YAML condition editor would crash the page when discarding the condition.

**Root cause:** When the editor is cleared, `yaml.parse('')` returns `null`, which was incorrectly treated as a valid condition. Downstream code then crashed when trying to access properties on `null`.

**Fix:** The parsed YAML is now validated against the zod schema before emitting condition changes. If the result is not a valid condition (including `null` from empty strings), the condition is marked as invalid and no change is emitted.

## Test plan

- [x] Unit tests added for empty string case (both onChange and onBlur)
- [x] Manual testing: Open condition editor, switch to syntax view, clear the editor, blur - should not crash

Fixes #256070

Made with [Cursor](https://cursor.com)