### PR TITLE
chore: Remove empty codeowner entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1457,7 +1457,6 @@ x-pack/platform/test/serverless/api_integration/test_suites/platform_security @e
 /x-pack/platform/test/accessibility/apps/group3/graph.ts @elastic/kibana-visualizations
 /x-pack/platform/test/accessibility/apps/group2/lens.ts @elastic/kibana-visualizations
 /x-pack/platform/test/functional/apps/visualize @elastic/kibana-visualizations
-/src/plugins/visualize/ @elastic/kibana-visualizations
 /x-pack/platform/test/functional/apps/lens @elastic/kibana-visualizations
 /x-pack/platform/test/api_integration/apis/lens/ @elastic/kibana-visualizations
 /src/platform/test/functional/apps/visualize/ @elastic/kibana-visualizations
@@ -1479,19 +1478,14 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 # Global Experience
 
 ### Reporting
-/x-pack/platform/test/functional/apps/dashboard/reporting/ @elastic/response-ops
 /x-pack/platform/test/functional/apps/reporting/ @elastic/response-ops
 /x-pack/platform/test/functional/apps/reporting_management/ @elastic/response-ops
 /x-pack/platform/test/examples/screenshotting/ @elastic/response-ops
-/x-pack/platform/test/fixtures/es_archives/lens/reporting/ @elastic/response-ops
 /x-pack/platform/test/fixtures/es_archives/reporting/ @elastic/response-ops
 /x-pack/platform/test/functional/fixtures/kbn_archives/reporting/ @elastic/response-ops
 /x-pack/platform/test/reporting_api_integration/ @elastic/response-ops
 /x-pack/platform/test/reporting_functional/ @elastic/response-ops
 /x-pack/platform/test/stack_functional_integration/apps/reporting/ @elastic/response-ops
-/docs/user/reporting @elastic/response-ops
-/docs/settings/reporting-settings.asciidoc @elastic/response-ops
-/docs/setup/configuring-reporting.asciidoc @elastic/response-ops
 /x-pack/platform/test/serverless/**/test_suites/reporting/ @elastic/response-ops
 /x-pack/platform/test/accessibility/apps/group3/reporting.ts @elastic/response-ops
 /x-pack/platform/test/functional/page_objects/reporting_page.ts @elastic/response-ops
@@ -1502,12 +1496,8 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/saved_object_tagging/ @elastic/appex-sharedux
 
 ### Kibana React (to be deprecated)
-/src/plugins/kibana_react/public/ @elastic/appex-sharedux @elastic/kibana-presentation
 
 ### Home Plugin and Packages
-/src/plugins/home/public @elastic/appex-sharedux
-/src/plugins/home/server/*.ts @elastic/appex-sharedux
-/src/plugins/home/server/services/ @elastic/appex-sharedux
 
 ### Code Coverage
 #CC# /src/plugins/home/public @elastic/appex-sharedux
@@ -1530,7 +1520,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/serverless/functional/services/ @elastic/observability-ui
 /x-pack/solutions/observability/test/serverless/functional/page_objects/ @elastic/observability-ui
 /x-pack/solutions/observability/test/serverless/functional/ftr_provider_context.d.ts @elastic/observability-ui
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.logs_essentials.index.ts @elastic/observability-ui
 /x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.logs_essentials.serverless.config.ts @elastic/observability-ui
 /x-pack/solutions/observability/test/kibana.jsonc @elastic/observability-ui
 /x-pack/solutions/observability/test/tsconfig.json @elastic/observability-ui
@@ -1550,7 +1539,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 
 # Observability plugin
 /x-pack/solutions/observability/plugins/observability/common/annotations.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/plugins/observability/common/custom_threshold @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/common/custom_threshold_rule @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/common/locators @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/common/utils/alerting @elastic/actionable-obs-team
@@ -1575,9 +1563,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_delete_rules.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_disable_rule.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_enable_rule.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_alert_data.test.tsx @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_alert_data.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_alert_detail.test.tsx @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_alert_detail.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_bulk_cases.test.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_fetch_bulk_cases.ts @elastic/actionable-obs-team
@@ -1586,7 +1572,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_get_available_rules_with_descriptions.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_get_filtered_rule_types.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_rules_table_filters.test.tsx @elastic/actionable-obs-team
-/x-pack/solutions/observability/plugins/observability/public/hooks/use_rules_table_filters.tsx @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_run_rule.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_summary_time_range.tsx @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/observability/public/hooks/use_update_api_key.ts @elastic/actionable-obs-team
@@ -1616,10 +1601,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/serverless/functional/test_suites/data_usage @elastic/kibana-management
 /x-pack/platform/test/serverless/functional/page_objects/svl_data_usage.ts @elastic/kibana-management
 /x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/obs-ai-team
-/x-pack/solutions/observability/test/fixtures/es_archives/observability/ai_assistant @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant_local.index.ts  @elastic/obs-ai-team
@@ -1667,7 +1649,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/public/containers @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/hooks @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/images @elastic/obs-presentation-team
-/x-pack/solutions/observability/plugins/infra/public/lib @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/pages @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/services @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/test_utils @elastic/obs-presentation-team
@@ -1688,7 +1669,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/functional/services/logs_ui @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/functional/page_objects/observability_logs_explorer.ts @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/api_integration/apis/logs_ui @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/serverless/functional/test_suites/observability_logs_explorer @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/serverless/functional/test_suites/discover @elastic/obs-exploration-team @elastic/kibana-data-discovery
 /src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/api_integration/apis/logs_shared @elastic/obs-exploration-team
@@ -1698,29 +1678,20 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/common/http_api/log_alerts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/http_api/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/log_analysis @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/common/log_search_result @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/common/log_search_summary @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/common/log_text_scale @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/performance_tracing.ts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/search_strategies/log_entries @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/docs/state_machines @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/apps/logs_app.tsx @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/public/components/log_stream @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/components/logging @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/containers/logs @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/public/observability_logs @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/pages/logs @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/lib/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/routes/log_alerts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/routes/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/services/rules @elastic/obs-presentation-team @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/common/utils/synthtrace @elastic/obs-presentation-team @elastic/obs-exploration-team
 /x-pack/platform/test/common/utils/server_route_repository @elastic/obs-onboarding-team @elastic/obs-sig-events-team
-/src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts @elastic/obs-presentation-team @elastic/obs-exploration-team
 
 ## Streams parts owned by Logs UX
-/x-pack/platform/plugins/shared/streams/server/routes/streams/processing @elastic/obs-onboarding-team
-/x-pack/platform/plugins/shared/streams/server/routes/streams/schema @elastic/obs-onboarding-team
 /x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-onboarding-team
 
 # Streams parts owned by Kibana Management
@@ -1736,35 +1707,26 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 
 /src/platform/test/api_integration/apis/suggestions  @elastic/actionable-obs-team # Assigned per https://github.com/elastic/kibana/pull/200950#discussion_r1853705079
 /x-pack/solutions/observability/test/api_integration/services/slo.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/services/slo @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/functional/apps/slo @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/observability_api_integration @elastic/actionable-obs-team # Assigned per https://github.com/elastic/kibana/pull/182243
 /x-pack/solutions/observability/test/functional/services/observability @elastic/actionable-obs-team
-/x-pack/platform/test/accessibility/apps/group1/uptime.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/accessibility/apps/observability.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/functional/services/slo/ @elastic/actionable-obs-team
-/x-pack/packages/observability/alert_details @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/observability_functional @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration/apis/security/ @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/infra/public/alerting @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/infra/server/lib/alerting @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/serverless/api_integration/test_suites/es_query_rule @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/ @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitors.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_params_api.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/ @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.index.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/ensemble @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.index.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.serverless.config.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.index.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.stateful.config.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/incident_management/ @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/functional/page_objects/alert_controls.ts @elastic/actionable-obs-team
 /x-pack/platform/test/serverless/functional/page_objects/svl_custom_roles_page.ts @elastic/actionable-obs-team
@@ -1793,7 +1755,6 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 /x-pack/platform/test/fleet_cypress @elastic/fleet
 /x-pack/platform/test/fleet_functional @elastic/fleet
 /x-pack/platform/test/fleet_multi_cluster @elastic/fleet
-/src/dev/build/tasks/bundle_fleet_packages.ts @elastic/fleet @elastic/kibana-operations
 /x-pack/platform/plugins/shared/fleet/server/services/elastic_agent_manifest.ts @elastic/fleet @elastic/obs-cloudnative-monitoring
 /x-pack/solutions/**/test/serverless/**/test_suites/fleet/ @elastic/fleet
 /x-pack/platform/test/serverless/**/test_suites/fleet/ @elastic/fleet
@@ -1803,9 +1764,7 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 /x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-presentation-team
 /src/platform/test/api_integration/apis/ui_metric/*.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration/apm/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-presentation-team
-/src/apm.js @elastic/kibana-core @vigneshshanmugam
 /x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-presentation-team
 #CC# /src/plugins/apm_oss/ @elastic/apm-ui
@@ -1822,7 +1781,6 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 /x-pack/solutions/observability/test/functional/services/uptime @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration/apis/uptime @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration/apis/synthetics @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/alerting_api_integration/observability/synthetics_rule.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/alerting_api_integration/observability/index.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/serverless/api_integration/test_suites/synthetics @elastic/actionable-obs-team
 
@@ -1845,19 +1803,15 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 # obs-onboarding-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/configs/config.* @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/serverless/functional/test_suites/landing_page.ts @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/test_suites/navigation.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/functional/page_objects/dataset_quality.ts @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/configs/index* @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/serverless/functional/test_suites/cypress @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/functional/services/infra_source_configuration_form.ts @elastic/obs-presentation-team
 /src/platform/test/functional/services/selectable.ts @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/api_integration/configs/index.feature_flags.ts @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/functional/apps/dataset_quality @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality @elastic/obs-onboarding-team
 /x-pack/solutions/observability/plugins/observability/public/pages/landing @elastic/obs-onboarding-team
-/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/landing.spec.ts @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/data_quality/ @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/onboarding/ @elastic/obs-onboarding-team
 
 # Observability-ui
@@ -1867,11 +1821,8 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 /x-pack/solutions/observability/plugins/observability/server/services/index.ts @elastic/observability-ui
 
 # Observability onboarding tour
-/x-pack/solutions/observability/plugins/observability_shared/public/components/tour @elastic/appex-sharedux
-/x-pack/solutions/observability/test/functional/apps/infra/tour.ts @elastic/appex-sharedux
 
 # Observability settings
-/x-pack/plugins/observability_solution/observability/server/ui_settings.ts @elastic/obs-docs
 
 # Streams
 /x-pack/platform/test/api_integration_deployment_agnostic/apis/streams @elastic/obs-sig-events-team  @elastic/obs-onboarding-team
@@ -1886,7 +1837,6 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 # Presentation
 /src/platform/test/functional/page_objects/markdown_vis.ts @elastic/kibana-presentation
 /src/platform/test/functional/page_objects/unified_search_page.ts @elastic/kibana-presentation
-/src/platform/test/functional/fixtures/kbn_archiver/dashboard_error_cases.json @elastic/kibana-presentation # Assigned per https://github.com/elastic/kibana/pull/201648#discussion_r1859020986
 /x-pack/platform/test/fixtures/es_archives/getting_started/shakespeare @elastic/kibana-presentation # Assigned per https://github.com/elastic/kibana/pull/201648#discussion_r1860319853
 /x-pack/platform/test/upgrade/screenshots @elastic/kibana-presentation
 /x-pack/platform/test/functional/screenshots @elastic/kibana-presentation
@@ -1953,9 +1903,7 @@ x-pack/platform/plugins/shared/streams_app/public/components/data_management/str
 /x-pack/platform/test/functional_basic/apps/ml/ @elastic/ml-ui
 /x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/config.ts @elastic/ml-ui
 /x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/ml/ @elastic/ml-ui
-/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/ml_rule_types/ @elastic/ml-ui
 /x-pack/platform/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
-/x-pack/platform/test/screenshot_creation/services/ml_screenshots.ts @elastic/ml-ui
 /x-pack/solutions/**/test/serverless/**/test_suites/ml/ @elastic/ml-ui
 
 # Security Machine Learning
@@ -1970,7 +1918,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/functional/services/aiops @elastic/ml-ui
 
 # Transforms maintained by the Kibana Management team.
-/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/kibana-management
 /x-pack/platform/test/serverless/**/test_suites/management/transforms/ @elastic/kibana-management
 /x-pack/platform/test/accessibility/apps/group2/transform.ts @elastic/kibana-management
 /x-pack/platform/test/functional/apps/transform/ @elastic/kibana-management
@@ -1981,15 +1928,12 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/test/package @elastic/kibana-operations
 /src/platform/test/package/roles @elastic/kibana-operations
 /src/platform/test/common/fixtures/plugins/coverage/kibana.json @elastic/kibana-operations
-/x-pack/platform/test/plugin_functional/screenshots @elastic/kibana-operations # Assigned per https://github.com/elastic/kibana/pull/94370/files
 /src/dev/license_checker/config.ts @elastic/kibana-operations
 /src/dev/ @elastic/kibana-operations
 /src/setup_node_env/ @elastic/kibana-operations
 /src/cli/ @elastic/kibana-operations
 /src/cli_keystore/ @elastic/kibana-operations
 /.github/workflows/ @elastic/kibana-operations
-/.github/copilot-instructions.md @elastic/kibana-operations
-/vars/ @elastic/kibana-operations
 /.buildkite/ @elastic/kibana-operations
 /.coderabbit.yml @elastic/kibana-operations
 
@@ -2009,7 +1953,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /.devcontainer/ @elastic/kibana-operations
 /.eslintrc.js @elastic/kibana-operations
 /.eslintignore @elastic/kibana-operations
-/.ci/.storybook @elastic/kibana-operations
 /src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations @elastic/observability-ui
 
 # QA - Appex QA
@@ -2043,7 +1986,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights* @elastic/appex-qa
 /src/platform/test/functional/fixtures/es_archiver/getting_started/shakespeare @elastic/appex-qa
 /src/platform/test/api_integration/fixtures/es_archiver/elasticsearch @elastic/appex-qa
-/x-pack/platform/test/plugin_functional/services.ts @elastic/appex-qa
 /src/platform/test/server_integration/services/index.js @elastic/appex-qa
 /x-pack/platform/test/stack_functional_integration/configs/config.stack_functional_integration_base.js @elastic/appex-qa
 /x-pack/platform/test/stack_functional_integration/configs/consume_state.js @elastic/appex-qa
@@ -2051,9 +1993,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/test/functional/services/remote_es/remote_es_archiver.ts @elastic/appex-qa
 /x-pack/platform/test/functional_with_es_ssl/ftr_provider_context.d.ts @elastic/appex-qa
 /x-pack/platform/test/stack_functional_integration/apps @elastic/appex-qa
-/x-pack/platform/test/plugin_functional/config.ts @elastic/appex-qa
-/x-pack/platform/test/plugin_functional/ftr_provider_context.d.ts @elastic/appex-qa
-/x-pack/platform/test/plugin_functional/page_objects.ts @elastic/appex-qa
 /x-pack/platform/test/upgrade/services/index.ts @elastic/appex-qa
 /x-pack/platform/test/upgrade/ftr_provider_context.d.ts @elastic/appex-qa
 /x-pack/platform/test/upgrade/config.ts @elastic/appex-qa
@@ -2127,19 +2066,15 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/serverless/functional/page_objects/svl_common_page.ts @elastic/appex-qa
 /x-pack/platform/test/README.md @elastic/appex-qa
 /x-pack/platform/test/serverless/README.md @elastic/appex-qa
-/x-pack/platform/test/serverless/api_integration/test_suites/README.md @elastic/appex-qa
 /src/dev/code_coverage @elastic/appex-qa
 /src/platform/test/functional/services/common @elastic/appex-qa
 /src/platform/test/functional/services/lib @elastic/appex-qa
-/src/platform/test/functional/services/remote @elastic/appex-qa
-/src/platform/test/visual_regression @elastic/appex-qa
 /src/platform/packages/shared/kbn-test/src/functional_test_runner @elastic/appex-qa
 /packages/kbn-performance-testing-dataset-extractor @elastic/appex-qa
 /x-pack/platform/test/serverless/api_integration/test_suites/elasticsearch_api @elastic/appex-qa
 /x-pack/platform/test/serverless/functional/test_suites/home_page/  @elastic/appex-qa
 /src/platform/packages/shared/kbn-es/src/stateful_resources/roles.yml @elastic/appex-qa
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/ftr_provider_context.d.ts @elastic/appex-qa
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/README.md @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/*configs/ @elastic/appex-qa
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/ @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/README.md @elastic/appex-qa
@@ -2212,7 +2147,6 @@ x-pack/platform/test/plugin_api_integration/test_suites/platform/ @elastic/kiban
 /x-pack/platform/test/functional_cors @elastic/kibana-core
 /x-pack/platform/test/stack_functional_integration/apps/telemetry @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/core* @elastic/kibana-core
-/src/platform/test/plugin_functional/platform/plugins/shared/telemetry @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/session_notifications @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/kbn_top_nav/ @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/app_link_test @elastic/kibana-core
@@ -2241,7 +2175,6 @@ x-pack/platform/test/plugin_api_integration/test_suites/platform/ @elastic/kiban
 /src/platform/test/functional/apps/bundles @elastic/kibana-core # Assigned per https://github.com/elastic/kibana/pull/64367
 /src/platform/test/examples/hello_world @elastic/kibana-core
 /src/platform/test/examples/routing/index.ts @elastic/kibana-core # Assigned per https://github.com/elastic/kibana/pull/69581
-/src/platform/test/common/platform/plugins/shared/newsfeed @elastic/kibana-core
 /src/platform/test/common/configure_http2.ts @elastic/kibana-core
 /src/platform/test/api_integration/apis/ui_counters @elastic/kibana-core
 /src/platform/test/api_integration/apis/telemetry @elastic/kibana-core
@@ -2306,7 +2239,6 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 
 # Kibana Localization
 /src/dev/i18n_tools/  @elastic/kibana-localization @elastic/kibana-core
-/src/core/public/i18n/  @elastic/kibana-localization @elastic/kibana-core
 #CC# /x-pack/platform/plugins/private/translations/ @elastic/kibana-localization @elastic/kibana-core
 
 # Inference Plugins (Search Solution)
@@ -2315,7 +2247,6 @@ x-pack/platform/test/functional_gen_ai/inference @elastic/search-kibana
 x-pack/platform/plugins/shared/inference_endpoint @elastic/search-kibana
 
 # AppEx Platform Services Security
-/x-pack/platform/test/serverless/api_integration/test_suites/security_response_headers.ts  @elastic/kibana-security
 /x-pack/platform/test/api_integration/apis/es  @elastic/kibana-security
 /x-pack/platform/test/api_integration/apis/features  @elastic/kibana-security
 
@@ -2354,7 +2285,6 @@ x-pack/platform/plugins/shared/inference_endpoint @elastic/search-kibana
 /.github/codeql @elastic/kibana-security
 /.github/workflows/codeql.yml @elastic/kibana-security
 /.github/workflows/codeql-pr.yml @elastic/kibana-security
-/.github/instructions/encrypted-saved-objects.instructions.md @elastic/kibana-security
 /.github/workflows/evaluate-dependency-health.yml @elastic/kibana-security
 /src/dev/eslint/security_eslint_rule_tests.ts @elastic/kibana-security
 /src/core/server/integration_tests/config/check_dynamic_config.test.ts @elastic/kibana-security
@@ -2387,7 +2317,6 @@ x-pack/platform/plugins/shared/inference_endpoint @elastic/search-kibana
 /x-pack/platform/test/serverless/**/test_suites/platform_security/ @elastic/kibana-security
 /src/core/packages/http/server-internal/src/cdn_config/ @elastic/kibana-security @elastic/kibana-core
 /x-pack/solutions/observability/test/serverless/api_integration/configs/config.feature_flags.ts @elastic/kibana-security
-/x-pack/platform/test/serverless/functional/test_suites/spaces/multiple_spaces_enabled.ts @elastic/kibana-security
 /x-pack/platform/test/serverless/functional/page_objects/svl_management_page.ts @elastic/kibana-security
 
 /x-pack/solutions/security/test/serverless/functional/configs/index.feature_flags.ts @elastic/kibana-security
@@ -2433,8 +2362,6 @@ x-pack/platform/plugins/shared/inference_endpoint @elastic/search-kibana
 /x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/response-ops
 /x-pack/platform/test/functional_with_es_ssl/apps/rules/ @elastic/actionable-obs-team @elastic/response-ops
 /x-pack/platform/test/task_manager_claimer_update_by_query/ @elastic/response-ops
-/docs/user/alerting/ @elastic/response-ops
-/docs/management/connectors/ @elastic/response-ops
 /x-pack/solutions/search/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs @elastic/response-ops
 /x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs @elastic/response-ops
 /x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs @elastic/response-ops
@@ -2484,18 +2411,14 @@ src/platform/packages/shared/kbn-connector-specs/src/specs/zendesk/** @elastic/w
 /src/platform/test/functional/fixtures/kbn_archiver/ccs @elastic/search-kibana
 /src/platform/test/functional/fixtures/kbn_archiver/annotation_listing_page_search.json @elastic/search-kibana
 /src/platform/test/functional/fixtures/es_archiver/search/downsampled @elastic/search-kibana
-/x-pack/solutions/search/functional_solution_sidenav/ @elastic/search-kibana
 /x-pack/platform/test/functional/page_objects/search_sessions_management_page.ts @elastic/search-kibana
 x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/search-kibana
-/x-pack/solutions/search/test/functional/apps/search_playground @elastic/search-kibana
 /x-pack/platform/test/serverless/functional/page_objects/svl_ingest_pipelines.ts @elastic/search-kibana
 /x-pack/platform/test/functional/apps/dev_tools/embedded_console.ts @elastic/search-kibana
 /x-pack/platform/test/functional/apps/ingest_pipelines/feature_controls/ingest_pipelines_security.ts @elastic/search-kibana
 /x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/doc_links @elastic/platform-docs
-/x-pack/solutions/search/test/serverless/api_integration/serverless_search @elastic/search-kibana
 /x-pack/solutions/search/test/serverless/functional/test_suites/ @elastic/search-kibana
 /x-pack/solutions/search/test/serverless/functional/configs/config.ts @elastic/search-kibana  @elastic/appex-qa
-/x-pack/platform/test/api_integration/apis/management/index_management/inference_endpoints.ts @elastic/search-kibana
 /x-pack/solutions/search/test/serverless/api_integration @elastic/search-kibana
 /x-pack/platform/test/serverless/functional/page_objects/svl_api_keys.ts @elastic/search-kibana
 /x-pack/solutions/search/test/functional_search/ @elastic/search-kibana
@@ -2552,7 +2475,6 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /src/platform/test/functional/apps/saved_objects_management @elastic/kibana-management
 /src/platform/test/functional/apps/console/*.ts @elastic/kibana-management
 /src/platform/test/api_integration/apis/console/*.ts @elastic/kibana-management
-/x-pack/platform/test/api_integration_deployment_agnostic/apis/console/ @elastic/kibana-management
 /src/platform/test/accessibility/apps/management.ts @elastic/kibana-management
 /src/platform/test/accessibility/apps/console.ts @elastic/kibana-management
 /x-pack/platform/test/api_integration/services/index_management.ts @elastic/kibana-management
@@ -2614,7 +2536,6 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/test/api_integration/services @elastic/security-solution
 /x-pack/solutions/security/test/accessibility/ @elastic/security-solution
 /x-pack/solutions/security/test/fixtures/es_archives/endpoint/ @elastic/security-solution
-/x-pack/platform/test/plugin_functional/test_suites/resolver/ @elastic/security-solution
 /x-pack/solutions/security/test/security_solution_api_integration @elastic/security-solution
 /x-pack/platform/test/fixtures/es_archives/auditbeat/default @elastic/security-solution
 /x-pack/solutions/security/test/serverless/functional/test_suites/constants.ts @elastic/security-solution
@@ -2654,7 +2575,6 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/plugins/security_solution_ess/public/upselling/pages/attack_discovery @elastic/security-generative-ai
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/automatic_import @elastic/integration-experience
 /x-pack/solutions/security/plugins/security_solution/public/configurations @elastic/security-generative-ai
-/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_soc @elastic/security-solution @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/agent_builder @elastic/security-threat-hunting @elastic/security-generative-ai
 /x-pack/solutions/security/plugins/security_solution/server/agent_builder @elastic/security-threat-hunting @elastic/security-generative-ai
 
@@ -2667,17 +2587,14 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/test/security_solution_cypress/cypress/fixtures @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/helpers @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/objects @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
-/x-pack/solutions/security/test/security_solution_cypress/cypress/plugins @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/screens/common @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/support @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-detection-engine
 
-/x-pack/solutions/security/plugins/security_solution/common/ecs @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/common/test @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 
 /x-pack/solutions/security/plugins/security_solution/public/common/components/callouts @elastic/security-detection-rule-management
 
-/x-pack/solutions/security/plugins/security_solution/public/flyout/ai_for_soc/components @elastic/security-threat-hunting-investigations @elastic/security-generative-ai
 
 /x-pack/platform/test/functional/apps/cases_attachments/** @elastic/kibana-cases
 
@@ -2698,7 +2615,6 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/sou
 ## Security Solution sub teams - security-engineering-productivity
 ## NOTE: It's important to keep this above other teams' sections because test automation doesn't process
 ## the CODEOWNERS file correctly. See https://github.com/elastic/kibana/issues/173307#issuecomment-1855858929
-/x-pack/solutions/security/.cursor/bug_validator.mdc @elastic/security-engineering-productivity
 /x-pack/solutions/security/test/security_solution_cypress/.cursor/rules/flaky_test_doctor.mdc @elastic/security-engineering-productivity
 /x-pack/solutions/security/test/security_solution_cypress/* @elastic/security-engineering-productivity
 /x-pack/solutions/security/test/security_solution_cypress/cypress/* @elastic/security-engineering-productivity
@@ -2802,10 +2718,8 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout/shared @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document_details @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout_v2/investigation_guide @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/investigations @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/notes @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/onboarding @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/overview @elastic/security-threat-hunting-investigations
@@ -2821,7 +2735,6 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/cases @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/filters @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/guided_onboarding @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/overview @elastic/security-threat-hunting-investigations
@@ -2831,11 +2744,9 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/screens/expandable_flyout  @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/sourcerer/sourcerer_timeline.cy.ts @elastic/security-threat-hunting-investigations
 
 /x-pack/platform/test/fixtures/es_archives/auditbeat/overview @elastic/security-threat-hunting-investigations
 
-x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigations @elastic/security-threat-hunting-investigations
 
 /x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting-investigations
 
@@ -2843,7 +2754,6 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/inv
 
 ## Security Solution Threat Hunting areas - Kibana Cases
 
-/x-pack/platform/plugins/shared/stack_connectors/common/thehive @elastic/kibana-cases
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/thehive @elastic/kibana-cases
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/thehive @elastic/kibana-cases
 src/platform/packages/shared/kbn-connector-schemas/thehive @elastic/kibana-cases
@@ -2858,10 +2768,8 @@ src/platform/packages/shared/kbn-connector-schemas/thehive @elastic/kibana-cases
 /x-pack/platform/test/functional/fixtures/kbn_archives/cases @elastic/kibana-cases
 /x-pack/platform/test/functional/services/cases/ @elastic/kibana-cases
 /x-pack/platform/test/functional_with_es_ssl/apps/cases/ @elastic/kibana-cases
-/x-pack/platform/test/functional_with_es_ssl/platform/plugins/shared/cases @elastic/kibana-cases
 /x-pack/platform/test/functional_with_es_ssl/plugins/cases @elastic/kibana-cases
 
-/x-pack/solutions/search/test/serverless/api_integration/cases/ @elastic/kibana-cases
 /x-pack/solutions/search/test/serverless/functional/test_suites/cases/ @elastic/kibana-cases
 
 /x-pack/solutions/security/test/api_integration/apis/cases/ @elastic/kibana-cases
@@ -2884,31 +2792,26 @@ src/platform/packages/shared/kbn-connector-schemas/thehive @elastic/kibana-cases
 # OpenAI
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai @elastic/security-generative-ai
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai @elastic/security-generative-ai
-/x-pack/platform/plugins/shared/stack_connectors/common/openai @elastic/security-generative-ai
 /src/platform/packages/shared/kbn-connector-schemas/openai @elastic/security-generative-ai
 
 # Bedrock
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/bedrock @elastic/security-generative-ai
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock @elastic/security-generative-ai
-/x-pack/platform/plugins/shared/stack_connectors/common/bedrock @elastic/security-generative-ai
 /src/platform/packages/shared/kbn-connector-schemas/bedrock @elastic/security-generative-ai
 
 # Gemini
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/gemini @elastic/security-generative-ai
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini @elastic/security-generative-ai
-/x-pack/platform/plugins/shared/stack_connectors/common/gemini @elastic/security-generative-ai
 /src/platform/packages/shared/kbn-connector-schemas/gemini @elastic/security-generative-ai
 
 # MCP
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/mcp @elastic/workchat-eng
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp @elastic/workchat-eng
-/x-pack/platform/plugins/shared/stack_connectors/common/mcp @elastic/workchat-eng
 /src/platform/packages/shared/kbn-connector-schemas/mcp @elastic/workchat-eng
 
 # Inference API
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/obs-ai-team
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/obs-ai-team
-/x-pack/platform/plugins/shared/stack_connectors/common/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/obs-ai-team
 /x-pack/platform/plugins/shared/stack_connectors/server/usage/inference @elastic/search-kibana
 /src/platform/packages/shared/kbn-connector-schemas/inference @elastic/search-kibana @elastic/security-generative-ai @elastic/obs-ai-team
 
@@ -2923,18 +2826,15 @@ x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/securi
 ## Defend Workflows owner connectors
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/sentinelone @elastic/security-defend-workflows
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone @elastic/security-defend-workflows
-/x-pack/platform/plugins/shared/stack_connectors/common/sentinelone @elastic/security-defend-workflows
 /src/platform/packages/shared/kbn-connector-schemas/sentinelone @elastic/security-defend-workflows
 /x-pack/solutions/security/test/api_integration_basic @elastic/security-defend-workflows
 /x-pack/solutions/security/test/alerting_api_integration/security_and_spaces @elastic/security-defend-workflows
 /x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/sentinelone.ts @elastic/security-defend-workflows
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/crowdstrike @elastic/security-defend-workflows
-/x-pack/platform/plugins/shared/stack_connectors/common/crowdstrike @elastic/security-defend-workflows
 /src/platform/packages/shared/kbn-connector-schemas/crowdstrike @elastic/security-defend-workflows
 /x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/crowdstrike.ts @elastic/security-defend-workflows
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/microsoft_defender_endpoint @elastic/security-defend-workflows
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/microsoft_defender_endpoint @elastic/security-defend-workflows
-/x-pack/platform/plugins/shared/stack_connectors/common/microsoft_defender_endpoint @elastic/security-defend-workflows
 /src/platform/packages/shared/kbn-connector-schemas/microsoft_defender_endpoint @elastic/security-defend-workflows
 /x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/microsoft_defender_endpoint.ts @elastic/security-defend-workflows
 
@@ -3042,7 +2942,6 @@ x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/securi
 /x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/isolate_host/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/common/endpoint/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/common/api/endpoint/ @elastic/security-defend-workflows
-x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/endpoint/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lib/license/ @elastic/security-defend-workflows
@@ -3051,13 +2950,9 @@ x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defen
 /x-pack/solutions/security/test/security_solution_endpoint/ @elastic/security-defend-workflows
 /x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/sections/endpoint_management @elastic/security-defend-workflows
-/x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/pages/endpoint_management @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution_serverless/server/endpoint @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution_serverless/server/ai4soc @elastic/security-defend-workflows
 x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/defend_insights @elastic/security-defend-workflows
-x-pack/plugins/elastic_assistant/server/__mocks__/defend_insights_schema.mock.ts @elastic/security-defend-workflows
-x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/defend_insights @elastic/security-defend-workflows
-x-pack/plugins/elastic_assistant/server/routes/defend_insights @elastic/security-defend-workflows
 x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights @elastic/security-defend-workflows
 x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/defend_insights_loader.* @elastic/security-defend-workflows
 x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/defend_insight_prompts.ts @elastic/security-defend-workflows
@@ -3086,7 +2981,6 @@ x-pack/solutions/security/plugins/security_solution/common/entity_analytics @ela
 x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/hosts @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/network @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/risk_score @elastic/security-entity-analytics
-x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/user @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/public/entity_analytics @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/public/explore @elastic/security-entity-analytics
@@ -3095,7 +2989,6 @@ x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details
 x-pack/solutions/security/packages/navigation/src/navigation_tree/entity_analytics_navigation_tree.ts @elastic/security-entity-analytics
 
 x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics @elastic/security-entity-analytics
-x-pack/solutions/security/plugins/security_solution/server/lib/risk_score @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/network @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users @elastic/security-entity-analytics
@@ -3111,7 +3004,6 @@ x-pack/solutions/security/test/security_solution_cypress/cypress/screens/users @
 x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/entity_analytics @elastic/security-entity-analytics
 x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/hosts @elastic/security-entity-analytics
 x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/network @elastic/security-entity-analytics
-x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/users @elastic/security-entity-analytics
 x-pack/platform/test/fixtures/es_archives/auditbeat/hosts @elastic/security-entity-analytics
 x-pack/platform/test/fixtures/es_archives/auditbeat/uncommon_processes @elastic/security-entity-analytics
 x-pack/platform/test/fixtures/es_archives/auditbeat/users @elastic/security-entity-analytics
@@ -3130,7 +3022,6 @@ x-pack/platform/test/automatic_import_v2_api_integration @elastic/integration-ex
 
 # Security Defend Workflows - OSQuery Ownership
 /x-pack/solutions/security/test/osquery_cypress @elastic/security-defend-workflows
-/x-pack/plugins/osquery @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_response_actions @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions @elastic/security-defend-workflows
@@ -3139,11 +3030,7 @@ x-pack/platform/test/automatic_import_v2_api_integration @elastic/integration-ex
 # Cloud Security Posture team
 
 ## Packages
-x-pack/packages/kbn-cloud-security-posture @elastic/contextual-security-apps
 ## Plugins
-x-pack/plugins/cloud_defend @elastic/contextual-security-apps
-x-pack/plugins/cloud_security_posture @elastic/contextual-security-apps
-x-pack/plugins/kubernetes_security @elastic/contextual-security-apps
 ## Security Solution sub teams
 x-pack/solutions/security/plugins/security_solution/public/common/components/sessions_viewer @elastic/contextual-security-apps
 x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture @elastic/contextual-security-apps
@@ -3199,7 +3086,6 @@ x-pack/solutions/security/plugins/security_solution/server/lib/security_integrat
 /x-pack/solutions/search/test/accessibility/ @elastic/search-kibana
 
 # Security design
-/x-pack/plugins/endpoint/**/*.scss @elastic/security-design
 /x-pack/solutions/security/plugins/security_solution/**/*.scss @elastic/security-design
 /x-pack/solutions/security/plugins/security_solution_ess/**/*.scss @elastic/security-design
 /x-pack/solutions/security/plugins/security_solution_serverless/**/*.scss @elastic/security-design
@@ -3213,7 +3099,6 @@ x-pack/solutions/security/plugins/security_solution/server/lib/security_integrat
 #CC# /x-pack/platform/plugins/private/logstash/ @elastic/logstash
 
 # EUI team
-/src/plugins/kibana_react/public/page_template/ @elastic/eui-team @elastic/appex-sharedux
 
 # Changes to translation files should not ping code reviewers
 x-pack/platform/plugins/private/translations/translations
@@ -3245,14 +3130,11 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /x-pack/platform/test/accessibility/apps/**/config.ts @elastic/appex-sharedux
 /x-pack/platform/test/accessibility/apps/**/index.ts @elastic/appex-sharedux
 /src/platform/test/functional/services/monaco_editor.ts @elastic/appex-sharedux
-/x-pack/platform/test/functional/fixtures/kbn_archives/global_search @elastic/appex-sharedux
 /src/platform/test/api_integration/fixtures/unused_urls_task @elastic/appex-sharedux
-/x-pack/platform/test/plugin_functional/test_suites/global_search @elastic/appex-sharedux
 /src/platform/test/plugin_functional/test_suites/shared_ux @elastic/appex-sharedux
 /src/platform/test/plugin_functional/plugins/kbn_sample_panel_action @elastic/appex-sharedux
 /src/platform/test/plugin_functional/plugins/eui_provider_dev_warning @elastic/appex-sharedux
 /src/platform/test/functional/page_objects/settings_page.ts @elastic/appex-sharedux
-/src/platform/test/functional/apps/kibana_overviews @elastic/appex-sharedux
 /src/platform/test/examples/ui_actions/*.ts @elastic/appex-sharedux
 /src/platform/test/examples/state_sync/*.ts @elastic/appex-sharedux
 /src/platform/test/examples/error_boundary/index.ts @elastic/appex-sharedux
@@ -3265,8 +3147,6 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /x-pack/platform/plugins/shared/spaces/test/scout/ui/fixtures/ @elastic/appex-sharedux
 /x-pack/platform/plugins/shared/spaces/test/scout/ui/tests/spaces_selection_serverless.spec.ts @elastic/appex-sharedux
 /x-pack/platform/test/serverless/functional/test_suites/spaces/index.ts @elastic/appex-sharedux
-packages/react @elastic/appex-sharedux
-src/platform/testfunctional/page_objects/solution_navigation.ts @elastic/appex-sharedux
 /x-pack/platform/test/serverless/functional/page_objects/svl_common_navigation.ts @elastic/appex-sharedux
 /x-pack/solutions/security/test/serverless/functional/page_objects/svl_sec_landing_page.ts @elastic/appex-sharedux
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/intercepts/*.ts @elastic/appex-sharedux
@@ -3308,7 +3188,6 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 
 # Specialised GitHub workflows for the Observability robots
 /.github/workflows/deploy-my-kibana.yml   @elastic/observablt-robots @elastic/kibana-operations
-/.github/workflows/oblt-github-commands   @elastic/observablt-robots @elastic/kibana-operations
 /.github/workflows/undeploy-my-kibana.yml @elastic/observablt-robots @elastic/kibana-operations
 
 # Moon related configs
@@ -3343,6 +3222,7 @@ x-pack/solutions/security/test/moon.yml @elastic/kibana-operations
 /.agents/skills/codeql/** @elastic/kibana-security
 /.agents/skills/kibana-privilege-deprecation/** @elastic/kibana-security
 /.agents/skills/encrypted-saved-objects/** @elastic/kibana-security
+
 
 ####
 ## These rules are always last so they take ultimate priority over everything else

--- a/packages/kbn-generate/src/commands/codeowners_command.ts
+++ b/packages/kbn-generate/src/commands/codeowners_command.ts
@@ -13,6 +13,7 @@ import Path from 'path';
 import { REPO_ROOT, kibanaPackageJson } from '@kbn/repo-info';
 import { getPackages } from '@kbn/repo-packages';
 
+import { cleanNonGeneratedSection } from '../lib/clean_codeowners';
 import type { GenerateCommand } from '../generate_command';
 
 const REL = '.github/CODEOWNERS';
@@ -54,8 +55,14 @@ const ULTIMATE_PRIORITY_RULES =
 export const CodeownersCommand: GenerateCommand = {
   name: 'codeowners',
   description: 'Update the codeowners file based on the package manifest files',
-  usage: 'node scripts/generate codeowners',
-  async run({ log }) {
+  usage: 'node scripts/generate codeowners [--clean-empty]',
+  flags: {
+    boolean: ['clean-empty'],
+    help: `
+      --clean-empty  Remove entries from the overrides section whose path no longer exists in the repo
+    `,
+  },
+  async run({ log, flags }) {
     const pkgs = getPackages(REPO_ROOT);
     const path = Path.resolve(REPO_ROOT, REL);
     const oldCodeowners = await Fsp.readFile(path, 'utf8');
@@ -71,6 +78,18 @@ export const CodeownersCommand: GenerateCommand = {
     const ultStart = content.indexOf(ULTIMATE_PRIORITY_RULES_COMMENT);
     if (ultStart !== -1) {
       content = content.slice(0, ultStart);
+    }
+
+    if (flags['clean-empty']) {
+      const { cleaned: cleanedContent, removed } = cleanNonGeneratedSection(content, REPO_ROOT);
+      content = cleanedContent;
+      removed.forEach(({ lineNumber, line }) => {
+        log.warning(`  removed line ${lineNumber}: ${line.trim()}`);
+      });
+      if (removed.length > 0) {
+        const word = removed.length === 1 ? 'entry' : 'entries';
+        log.info(`Cleaned ${removed.length} dead CODEOWNERS ${word} from overrides section`);
+      }
     }
 
     // sort genarated entries by directory name

--- a/packages/kbn-generate/src/lib/clean_codeowners.ts
+++ b/packages/kbn-generate/src/lib/clean_codeowners.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Fs from 'fs';
+import Path from 'path';
+
+/**
+ * Get the path (first token) from a CODEOWNERS line, or null if this line
+ * is not an ownership rule (comment, blank, negation, or invalid).
+ */
+function getPathFromLine(line: string): string | null {
+  const trimmed = line.trim();
+  const isCommentOrBlank = !trimmed || trimmed.startsWith('#') || trimmed.startsWith('!');
+  if (isCommentOrBlank) return null;
+
+  const pathToken = trimmed.split(/\s+/)[0];
+  const looksLikePath = pathToken && (pathToken.startsWith('/') || pathToken.includes('/'));
+  if (!looksLikePath) return null;
+
+  return pathToken;
+}
+
+/**
+ * Convert a CODEOWNERS path (e.g. "/src/cli" or "packages/foo") to an absolute
+ * filesystem path under repo root.
+ */
+function toAbsolutePath(ownerPath: string, repoRoot: string): string {
+  const withoutLeadingSlash = ownerPath.startsWith('/') ? ownerPath.slice(1) : ownerPath;
+  return Path.join(repoRoot, withoutLeadingSlash);
+}
+
+/**
+ * For a path that contains no glob: check that the file or directory exists.
+ */
+function existsLiteral(absolutePath: string): boolean {
+  return Fs.existsSync(absolutePath);
+}
+
+/**
+ * For a path that contains * or **: we only check that the parent directory
+ * of the glob segment exists (we don't expand the glob).
+ * E.g. "packages/kbn-asterisk/" -> check that "packages" exists.
+ */
+function existsGlob(ownerPath: string, repoRoot: string): boolean {
+  const withoutLeadingSlash = ownerPath.startsWith('/') ? ownerPath.slice(1) : ownerPath;
+  const upToFirstStar = withoutLeadingSlash.replace(/\*.*$/, '').replace(/\/+$/, '');
+  const parentDir = upToFirstStar.includes('/')
+    ? upToFirstStar.replace(/\/[^/]*$/, '')
+    : upToFirstStar || '.';
+  const absoluteParent = Path.join(repoRoot, parentDir);
+  return Fs.existsSync(absoluteParent);
+}
+
+/**
+ * Return true if the CODEOWNERS path exists in the repo (file, dir, or parent of glob).
+ */
+function pathExistsInRepo(ownerPath: string, repoRoot: string): boolean {
+  const hasGlob = ownerPath.includes('*');
+  if (hasGlob) {
+    return existsGlob(ownerPath, repoRoot);
+  }
+  return existsLiteral(toAbsolutePath(ownerPath, repoRoot));
+}
+
+/**
+ * Remove CODEOWNERS lines that are ownership rules whose path does not exist in the repo.
+ * Only considers lines that look like path + owners; comments and blank lines are kept.
+ * Used to clean the non-generated overrides section.
+ *
+ * @param sectionContent - Raw section text (e.g. the overrides section)
+ * @param repoRoot - Repo root for resolving paths
+ * @returns Cleaned section and list of removed entries (1-based line number within section + line text)
+ */
+export function cleanNonGeneratedSection(
+  sectionContent: string,
+  repoRoot: string
+): { cleaned: string; removed: Array<{ lineNumber: number; line: string }> } {
+  const lines = sectionContent.split('\n');
+  const kept: string[] = [];
+  const removed: Array<{ lineNumber: number; line: string }> = [];
+
+  lines.forEach((line, index) => {
+    const ownerPath = getPathFromLine(line);
+    if (ownerPath === null) {
+      kept.push(line);
+      return;
+    }
+    if (pathExistsInRepo(ownerPath, repoRoot)) {
+      kept.push(line);
+    } else {
+      removed.push({ lineNumber: index + 1, line });
+    }
+  });
+
+  const cleaned = kept.join('\n') + (sectionContent.endsWith('\n') ? '\n' : '');
+  return { cleaned, removed };
+}

--- a/packages/kbn-generate/src/lib/clean_codeowners.ts
+++ b/packages/kbn-generate/src/lib/clean_codeowners.ts
@@ -98,6 +98,8 @@ export function cleanNonGeneratedSection(
     }
   });
 
-  const cleaned = kept.join('\n') + (sectionContent.endsWith('\n') ? '\n' : '');
+  const joined = kept.join('\n');
+  // Not to add an extra \n if the sectionContent already ends with a \n
+  const cleaned = joined + (sectionContent.endsWith('\n') && !joined.endsWith('\n') ? '\n' : '');
   return { cleaned, removed };
 }


### PR DESCRIPTION
## Summary
Over time, we've accumulated manual CODEOWNERS entries that no longer point to valid files/folders. This PR adds an extension to `node scripts/generate codeowners` with `--clean-empty` to remove these lines - I also ran it to remove these lines from the CODEOWNERS.

Made with the help of Cursor


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->