### PR TITLE
Skip flaky Dataset Quality test

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
@@ -957,7 +957,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           expect(linkURL?.includes('mapping')).to.be(true);
         });
 
-        it('should display increase field limit as a possible mitigation for special packages like apm app', async () => {
+        it.skip('should display increase field limit as a possible mitigation for special packages like apm app', async () => {
           await PageObjects.datasetQuality.navigateToDetails({
             dataStream: apmAppDataStreamName,
             expandedDegradedField: 'cloud.project',


### PR DESCRIPTION
This skips the test that fails on the latest serverless image (see [🔒 slack thread](https://elastic.slack.com/archives/C05V4QQ4ASY/p1772637138923519)).

The issue seems to be related to the apm index mappings: `cloud.project` field does not appear in the list of ignored on the mentioned serveless image which is behind `main`, and changing is to `expandedDegradedField: 'cloud'` fixes the issue but then is fails on `main`.

Skipping the test to unblock the serverless release.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->