### PR TITLE
[Cases] Import wokflow steps asynchronously

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/workflows/create_case.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/create_case.test.tsx
@@ -5,22 +5,20 @@
  * 2.0.
  */
 
-import { createCreateCaseStepDefinition } from './create_case';
+import { createCaseStepDefinition } from './create_case';
 import { connectorTypesOptions } from './case_enum_options';
 
-describe('createCreateCaseStepDefinition', () => {
+describe('createCaseStepDefinition', () => {
   it('returns a public step definition with expected metadata', () => {
-    const definition = createCreateCaseStepDefinition();
-
-    expect(definition.id).toBe('cases.createCase');
-    expect(definition.category).toBe('kibana');
-    expect(definition.documentation?.examples?.length).toBeGreaterThan(0);
+    expect(createCaseStepDefinition.id).toBe('cases.createCase');
+    expect(createCaseStepDefinition.category).toBe('kibana');
+    expect(createCaseStepDefinition.documentation?.examples?.length).toBeGreaterThan(0);
   });
 
   it('configures connector-id config selector', () => {
-    const definition = createCreateCaseStepDefinition();
-
-    expect(definition.editorHandlers?.config?.['connector-id']?.connectorIdSelection).toEqual({
+    expect(
+      createCaseStepDefinition.editorHandlers?.config?.['connector-id']?.connectorIdSelection
+    ).toEqual({
       connectorTypes: connectorTypesOptions,
       enableCreation: false,
     });

--- a/x-pack/platform/plugins/shared/cases/public/workflows/create_case.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/create_case.tsx
@@ -10,23 +10,21 @@ import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
 import { createCaseStepCommonDefinition } from '../../common/workflows/steps/create_case';
 import { connectorTypesOptions } from './case_enum_options';
 
-export const createCreateCaseStepDefinition = () => {
-  return createPublicStepDefinition({
-    ...createCaseStepCommonDefinition,
-    icon: React.lazy(() =>
-      import('@elastic/eui/es/components/icon/assets/plus_circle').then(({ icon }) => ({
-        default: icon,
-      }))
-    ),
-    editorHandlers: {
-      config: {
-        'connector-id': {
-          connectorIdSelection: {
-            connectorTypes: connectorTypesOptions,
-            enableCreation: false,
-          },
+export const createCaseStepDefinition = createPublicStepDefinition({
+  ...createCaseStepCommonDefinition,
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/plus_circle').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+  editorHandlers: {
+    config: {
+      'connector-id': {
+        connectorIdSelection: {
+          connectorTypes: connectorTypesOptions,
+          enableCreation: false,
         },
       },
     },
-  });
-};
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/public/workflows/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/index.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import { getCaseStepDefinition } from './get_case';
-import { createCreateCaseStepDefinition } from './create_case';
 // import { createCreateCaseFromTemplateStepDefinition } from './create_case_from_template';
-import { createUpdateCaseStepDefinition } from './update_case';
-import { addCommentStepDefinition } from './add_comment';
 import type { CasesPublicSetupDependencies } from '../types';
 
 export function registerCasesSteps(
@@ -19,10 +15,22 @@ export function registerCasesSteps(
     return;
   }
 
-  workflowsExtensions.registerStepDefinition(getCaseStepDefinition);
-  workflowsExtensions.registerStepDefinition(createCreateCaseStepDefinition());
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./get_case').then((m) => m.getCaseStepDefinition)
+  );
+
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./create_case').then((m) => m.createCaseStepDefinition)
+  );
+
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./update_case').then((m) => m.updateCaseStepDefinition)
+  );
+
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./add_comment').then((m) => m.addCommentStepDefinition)
+  );
+
   // Leaving this in for now. We need to get support for reflective value lookup first.
   // workflowsExtensions.registerStepDefinition(createCreateCaseFromTemplateStepDefinition());
-  workflowsExtensions.registerStepDefinition(createUpdateCaseStepDefinition());
-  workflowsExtensions.registerStepDefinition(addCommentStepDefinition);
 }

--- a/x-pack/platform/plugins/shared/cases/public/workflows/update_case.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/update_case.test.tsx
@@ -5,16 +5,14 @@
  * 2.0.
  */
 
-import { createUpdateCaseStepDefinition } from './update_case';
+import { updateCaseStepDefinition } from './update_case';
 // import { caseIdInputEditorHandlers } from './case_id_selection_handler';
 
 describe('createUpdateCaseStepDefinition', () => {
   it('returns a public step definition with expected metadata', () => {
-    const definition = createUpdateCaseStepDefinition();
-
-    expect(definition.id).toBe('cases.updateCase');
-    expect(definition.category).toBe('kibana');
-    expect(definition.documentation?.examples?.length).toBeGreaterThan(0);
+    expect(updateCaseStepDefinition.id).toBe('cases.updateCase');
+    expect(updateCaseStepDefinition.category).toBe('kibana');
+    expect(updateCaseStepDefinition.documentation?.examples?.length).toBeGreaterThan(0);
   });
 
   // TODO: enable one case_id can be a template AND an inputHandler

--- a/x-pack/platform/plugins/shared/cases/public/workflows/update_case.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/update_case.tsx
@@ -10,15 +10,13 @@ import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
 import { updateCaseStepCommonDefinition } from '../../common/workflows/steps/update_case';
 // import { caseIdInputEditorHandlers } from './case_id_selection_handler';
 
-export const createUpdateCaseStepDefinition = () => {
-  return createPublicStepDefinition({
-    ...updateCaseStepCommonDefinition,
-    icon: React.lazy(() =>
-      import('@elastic/eui/es/components/icon/assets/pencil').then(({ icon }) => ({
-        default: icon,
-      }))
-    ),
-    // TODO: enable one case_id can be a template AND an inputHandler
-    // editorHandlers: caseIdInputEditorHandlers,
-  });
-};
+export const updateCaseStepDefinition = createPublicStepDefinition({
+  ...updateCaseStepCommonDefinition,
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/pencil').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+  // TODO: enable one case_id can be a template AND an inputHandler
+  // editorHandlers: caseIdInputEditorHandlers,
+});


### PR DESCRIPTION
## Summary

Ever since https://github.com/elastic/kibana/pull/255580 got merged, we can now import workflow steps asynchronously. This can shave off a couple kilobytes in bundle size. This PR imports all cases workflow steps asynchronously.