### PR TITLE
[9.3] [APM] Make the transaction name optional and test the navigation (#255277)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TransactionDetails } from '.';
+import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
+import { useApmRoutePath } from '../../../hooks/use_apm_route_path';
+import { useApmRouter } from '../../../hooks/use_apm_router';
+
+jest.mock('../../../hooks/use_apm_params', () => ({
+  useAnyOfApmParams: jest.fn(),
+}));
+
+jest.mock('../../../hooks/use_apm_route_path', () => ({
+  useApmRoutePath: jest.fn(),
+}));
+
+jest.mock('../../../hooks/use_apm_router', () => ({
+  useApmRouter: jest.fn(),
+}));
+
+jest.mock('../../../hooks/use_time_range', () => ({
+  useTimeRange: () => ({ start: '2024-01-01', end: '2024-01-02' }),
+}));
+
+jest.mock('../../../context/apm_service/use_apm_service_context', () => ({
+  useApmServiceContext: () => ({
+    transactionType: 'request',
+    fallbackToTransactions: false,
+    serverlessType: undefined,
+    serviceName: 'test-service',
+  }),
+}));
+
+jest.mock('../../../context/breadcrumbs/use_breadcrumb', () => ({
+  useBreadcrumb: () => {},
+}));
+
+const mockHistory = {
+  replace: jest.fn(),
+  push: jest.fn(),
+  location: { pathname: '/services/test/transactions/view', search: '?transactionName=test' },
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => mockHistory,
+}));
+
+jest.mock('../../shared/charts/transaction_charts', () => ({
+  TransactionCharts: () => null,
+}));
+
+jest.mock('./transaction_details_tabs', () => ({
+  TransactionDetailsTabs: () => null,
+}));
+
+jest.mock('../../../context/chart_pointer_event/chart_pointer_event_context', () => ({
+  ChartPointerEventContextProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const mockUseAnyOfApmParams = useAnyOfApmParams as jest.Mock;
+const mockUseApmRoutePath = useApmRoutePath as jest.Mock;
+const mockUseApmRouter = useApmRouter as jest.Mock;
+
+const baseQuery = {
+  rangeFrom: 'now-15m',
+  rangeTo: 'now',
+  comparisonEnabled: false,
+  showCriticalPath: '',
+  environment: 'ENVIRONMENT_ALL',
+  kuery: '',
+  offset: undefined,
+};
+
+describe('TransactionDetails', () => {
+  const mockLink = jest.fn(
+    (path: string, opts: { path: { serviceName: string }; query: object }) => {
+      const qs = new URLSearchParams(opts.query as Record<string, string>).toString();
+      return `/app/apm${path.replace('{serviceName}', opts.path.serviceName)}${qs ? `?${qs}` : ''}`;
+    }
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApmRouter.mockReturnValue({ link: mockLink });
+  });
+
+  it('redirects to transaction list when transactionName is undefined', () => {
+    mockUseAnyOfApmParams.mockReturnValue({
+      path: { serviceName: 'my-service' },
+      query: { ...baseQuery, transactionName: undefined },
+    });
+    mockUseApmRoutePath.mockReturnValue('/services/{serviceName}/transactions/view');
+
+    render(
+      <MemoryRouter>
+        <TransactionDetails />
+      </MemoryRouter>
+    );
+
+    expect(mockLink).toHaveBeenCalledWith('/services/{serviceName}/transactions', {
+      path: { serviceName: 'my-service' },
+      query: expect.objectContaining({
+        rangeFrom: 'now-15m',
+        rangeTo: 'now',
+        environment: 'ENVIRONMENT_ALL',
+      }),
+    });
+  });
+
+  it('redirects to transaction list when transactionName is empty string', () => {
+    mockUseAnyOfApmParams.mockReturnValue({
+      path: { serviceName: 'my-service' },
+      query: { ...baseQuery, transactionName: '' },
+    });
+    mockUseApmRoutePath.mockReturnValue('/services/{serviceName}/transactions/view');
+
+    render(
+      <MemoryRouter>
+        <TransactionDetails />
+      </MemoryRouter>
+    );
+
+    expect(mockLink).toHaveBeenCalledWith('/services/{serviceName}/transactions', {
+      path: { serviceName: 'my-service' },
+      query: expect.any(Object),
+    });
+  });
+
+  it('redirects to mobile transaction list when on mobile route and transactionName is missing', () => {
+    mockUseAnyOfApmParams.mockReturnValue({
+      path: { serviceName: 'mobile-app' },
+      query: { ...baseQuery, transactionName: undefined },
+    });
+    mockUseApmRoutePath.mockReturnValue('/mobile-services/{serviceName}/transactions/view');
+
+    render(
+      <MemoryRouter>
+        <TransactionDetails />
+      </MemoryRouter>
+    );
+
+    expect(mockLink).toHaveBeenCalledWith('/mobile-services/{serviceName}/transactions', {
+      path: { serviceName: 'mobile-app' },
+      query: expect.any(Object),
+    });
+  });
+
+  it('redirects when transactionName is only whitespace', () => {
+    mockUseAnyOfApmParams.mockReturnValue({
+      path: { serviceName: 'my-service' },
+      query: { ...baseQuery, transactionName: '   ' },
+    });
+    mockUseApmRoutePath.mockReturnValue('/services/{serviceName}/transactions/view');
+
+    render(
+      <MemoryRouter>
+        <TransactionDetails />
+      </MemoryRouter>
+    );
+
+    expect(mockLink).toHaveBeenCalledWith('/services/{serviceName}/transactions', {
+      path: { serviceName: 'my-service' },
+      query: expect.any(Object),
+    });
+  });
+
+  it('does not redirect when transactionName is valid', () => {
+    mockUseAnyOfApmParams.mockReturnValue({
+      path: { serviceName: 'my-service' },
+      query: { ...baseQuery, transactionName: 'GET /api/users' },
+    });
+    mockUseApmRoutePath.mockReturnValue('/services/{serviceName}/transactions/view');
+
+    render(
+      <MemoryRouter>
+        <TransactionDetails />
+      </MemoryRouter>
+    );
+
+    // Should not redirect to transaction list (path without /view)
+    const redirectCalls = mockLink.mock.calls.filter(
+      (call: [string, object]) => call[0] === '/services/{serviceName}/transactions'
+    );
+    expect(redirectCalls).toHaveLength(0);
+    // Should render the transaction name in the heading
+    expect(screen.getByRole('heading', { name: 'GET /api/users', level: 2 })).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.test.tsx
@@ -25,6 +25,10 @@ jest.mock('../../../hooks/use_apm_router', () => ({
   useApmRouter: jest.fn(),
 }));
 
+jest.mock('../../../hooks/use_local_storage', () => ({
+  useLocalStorage: () => [true, jest.fn()],
+}));
+
 jest.mock('../../../hooks/use_time_range', () => ({
   useTimeRange: () => ({ start: '2024-01-01', end: '2024-01-02' }),
 }));

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.tsx
@@ -57,6 +57,11 @@ export function TransactionDetails() {
     [apmRouter, path, query, transactionName]
   );
 
+  const [sloCalloutDismissed, setSloCalloutDismissed] = useLocalStorage(
+    'apm.sloCalloutDismissed',
+    false
+  );
+
   // redirect to transaction list when transactionName is missing (e.g. bad URL, encoding issue)
   if (!transactionName || transactionName.trim() === '') {
     const transactionsListPath = routePath?.includes('mobile-services')
@@ -88,10 +93,6 @@ export function TransactionDetails() {
   }
 
   const isServerless = isServerlessAgentName(serverlessType);
-  const [sloCalloutDismissed, setSloCalloutDismissed] = useLocalStorage(
-    'apm.sloCalloutDismissed',
-    false
-  );
 
   return (
     <>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.tsx
@@ -7,11 +7,12 @@
 
 import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { Redirect, useHistory } from 'react-router-dom';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { useBreadcrumb } from '../../../context/breadcrumbs/use_breadcrumb';
 import { ChartPointerEventContextProvider } from '../../../context/chart_pointer_event/chart_pointer_event_context';
 import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
+import { useApmRoutePath } from '../../../hooks/use_apm_route_path';
 import { useApmRouter } from '../../../hooks/use_apm_router';
 import { useTimeRange } from '../../../hooks/use_time_range';
 import { AggregatedTransactionsBadge } from '../../shared/aggregated_transactions_badge';
@@ -38,19 +39,16 @@ export function TransactionDetails() {
   } = query;
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
   const apmRouter = useApmRouter();
+  const apmRouterNoBasePath = useApmRouter({ prependBasePath: false });
+  const routePath = useApmRoutePath();
   const { transactionType, fallbackToTransactions, serverlessType, serviceName } =
     useApmServiceContext();
 
   const history = useHistory();
 
-  // redirect to first transaction type
-  if (!transactionTypeFromUrl && transactionType) {
-    replace(history, { query: { transactionType } });
-  }
-
   useBreadcrumb(
     () => ({
-      title: transactionName,
+      title: transactionName?.trim() || path.serviceName,
       href: apmRouter.link('/services/{serviceName}/transactions/view', {
         path,
         query,
@@ -58,6 +56,36 @@ export function TransactionDetails() {
     }),
     [apmRouter, path, query, transactionName]
   );
+
+  // redirect to transaction list when transactionName is missing (e.g. bad URL, encoding issue)
+  if (!transactionName || transactionName.trim() === '') {
+    const transactionsListPath = routePath?.includes('mobile-services')
+      ? '/mobile-services/{serviceName}/transactions'
+      : '/services/{serviceName}/transactions';
+
+    // Preserve only safe query params for the transaction list (time range and filters)
+    const safeQuery = {
+      comparisonEnabled: query.comparisonEnabled,
+      environment: query.environment,
+      kuery: query.kuery,
+      latencyAggregationType: query.latencyAggregationType,
+      offset: query.offset,
+      rangeFrom: query.rangeFrom,
+      rangeTo: query.rangeTo,
+      serviceGroup: query.serviceGroup,
+      transactionType: query.transactionType,
+    };
+
+    const redirectPath = apmRouterNoBasePath.link(transactionsListPath, {
+      path: { serviceName: path.serviceName },
+      query: safeQuery,
+    });
+    return <Redirect to={redirectPath} />;
+  }
+
+  if (!transactionTypeFromUrl && transactionType) {
+    replace(history, { query: { transactionType } });
+  }
 
   const isServerless = isServerlessAgentName(serverlessType);
   const [sloCalloutDismissed, setSloCalloutDismissed] = useLocalStorage(

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/top_errors/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/top_errors/index.tsx
@@ -59,7 +59,7 @@ export function TopErrors() {
 
   const { data = INITIAL_STATE_MAIN_STATISTICS, status } = useFetcher(
     (callApmApi) => {
-      if (start && end && transactionType) {
+      if (start && end && transactionType && transactionName) {
         return callApmApi(
           'GET /internal/apm/services/{serviceName}/errors/groups/main_statistics_by_transaction_name',
           {

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/mobile_service_detail/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/mobile_service_detail/index.tsx
@@ -162,11 +162,13 @@ export const mobileServiceDetailRoute = {
             element: <TransactionDetails />,
             params: t.type({
               query: t.intersection([
-                t.type({
-                  transactionName: t.string,
-                  comparisonEnabled: toBooleanRt,
-                  showCriticalPath: toBooleanRt,
-                }),
+                t.intersection([
+                  t.type({
+                    comparisonEnabled: toBooleanRt,
+                    showCriticalPath: toBooleanRt,
+                  }),
+                  t.partial({ transactionName: t.string }),
+                ]),
                 t.partial({
                   traceId: t.string,
                   transactionId: t.string,

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/service_detail/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/service_detail/index.tsx
@@ -192,17 +192,23 @@ export const serviceDetailRoute = {
             element: <TransactionDetails />,
             params: t.type({
               query: t.intersection([
-                t.type({
-                  transactionName: t.string,
-                  comparisonEnabled: toBooleanRt,
-                  showCriticalPath: toBooleanRt,
-                }),
+                t.intersection([
+                  t.type({
+                    comparisonEnabled: toBooleanRt,
+                    showCriticalPath: toBooleanRt,
+                  }),
+                  t.partial({ transactionName: t.string }),
+                ]),
                 t.partial({
                   traceId: t.string,
                   transactionId: t.string,
                   flyoutDetailTab: t.string,
                   sampleRangeTo: toNumberRt,
                   sampleRangeFrom: toNumberRt,
+                  page: toNumberRt,
+                  pageSize: toNumberRt,
+                  sortField: t.string,
+                  sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
                 }),
                 offsetRt,
               ]),

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
@@ -61,7 +61,7 @@ export function LatencyChart({ height, kuery }: Props) {
 
   const { transactionType, serviceName } = useApmServiceContext();
 
-  const transactionName = 'transactionName' in query ? query.transactionName : null;
+  const transactionName = 'transactionName' in query ? query.transactionName ?? null : null;
 
   const { latencyChartsData, latencyChartsStatus, bucketSizeInSeconds, start, end } =
     useTransactionLatencyChartsFetcher({

--- a/x-pack/solutions/observability/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
@@ -20,7 +20,7 @@ export function useTransactionTraceSamplesFetcher({
   rangeFrom,
   rangeTo,
 }: {
-  transactionName: string;
+  transactionName: string | undefined;
   kuery: string;
   environment: string;
   rangeFrom: string;

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/constants.ts
@@ -12,6 +12,10 @@ export const OPBEANS_START_DATE = '2021-10-10T00:00:00.000Z';
 export const OPBEANS_END_DATE = '2021-10-10T00:15:00.000Z';
 export const BIGGER_TIMEOUT = 45000;
 
+export const SERVICE_OPBEANS_NODE = 'opbeans-node';
+export const SERVICE_OPBEANS_JAVA = 'opbeans-java';
+export const SERVICE_OPBEANS_RUM = 'opbeans-rum';
+
 export const PRODUCT_TRANSACTION_NAME = 'GET /api/product';
 // Error constants - based on opbeans synthtrace data
 export const ERROR_MESSAGE = '[MockError] Foo';

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/transaction_details.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/transaction_details.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaUrl, ScoutPage } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
 import { waitForApmSettingsHeaderLink } from '../page_helpers';
 import { BIGGER_TIMEOUT } from '../constants';
 
@@ -35,27 +36,55 @@ export class TransactionDetailsPage {
   }
 
   /**
-   * Navigate to transaction details page
+   * Navigate to transaction view URL without transactionName (invalid URL).
    */
-  async goto(
-    serviceName: string,
-    transactionName: string,
-    timeRange: { rangeFrom: string; rangeTo: string }
-  ) {
+  async goToTransactionViewWithoutTransactionName(params: {
+    serviceName: string;
+    start: string;
+    end: string;
+  }) {
+    const { serviceName, start, end } = params;
     const urlServiceName = encodeURIComponent(serviceName);
 
     await this.page.goto(
       `${this.kbnUrl.app('apm')}/services/${urlServiceName}/transactions/view?${new URLSearchParams(
         {
-          transactionName,
-          rangeFrom: timeRange.rangeFrom,
-          rangeTo: timeRange.rangeTo,
+          rangeFrom: start,
+          rangeTo: end,
+          comparisonEnabled: 'false',
+          showCriticalPath: '',
+          environment: 'ENVIRONMENT_ALL',
+          kuery: '',
+          serviceGroup: '',
         }
       )}`
     );
+    await waitForApmSettingsHeaderLink(this.page);
+  }
+
+  /**
+   * From the current page URL (must be transaction details view), remove the
+   * transactionName query param and navigate to that URL. Used to simulate
+   * a user editing the URL or following a bad link. The app should redirect
+   * to the transaction list instead of showing 404.
+   */
+  async removeTransactionNameFromUrlAndNavigate() {
+    const url = new URL(this.page.url());
+    url.searchParams.delete('transactionName');
+    await this.page.goto(url.toString());
+    await waitForApmSettingsHeaderLink(this.page);
+  }
+
+  /**
+   * Assert the current page is the transaction list (not 404, not view).
+   * Use after removeTransactionNameFromUrlAndNavigate to verify redirect.
+   */
+  async expectTransactionListPageLoaded(serviceName: string) {
     await this.page
-      .getByTestId('apmSettingsHeaderLink')
+      .getByRole('heading', { name: 'Transactions', exact: true })
       .waitFor({ state: 'visible', timeout: BIGGER_TIMEOUT });
+    await expect(this.page.getByTestId('apmMainTemplateHeaderServiceName')).toHaveText(serviceName);
+    await expect(this.page.getByTestId('appNotFoundPageContent')).toBeHidden();
   }
 
   /**

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts
@@ -26,6 +26,28 @@ test.describe(
       });
     });
 
+    test('Redirects to transaction list when transactionName is missing in URL', async ({
+      page,
+      pageObjects: { transactionDetailsPage },
+    }) => {
+      // Start from transaction details (beforeEach already navigated there), then remove
+      // the transactionName param to simulate a bad link or user editing the URL.
+      await test.step('Remove transactionName from URL', async () => {
+        await transactionDetailsPage.removeTransactionNameFromUrlAndNavigate();
+      });
+
+      await test.step('Redirects to transaction list instead of showing 404 or error', async () => {
+        await expect(page).toHaveURL(
+          new RegExp(`/services/${testData.SERVICE_OPBEANS_JAVA}/transactions(?:\\?|$)`)
+        );
+        await expect(page).not.toHaveURL(/\/transactions\/view/);
+      });
+
+      await test.step('Transaction list page loads with Transactions tab and no 404', async () => {
+        await transactionDetailsPage.expectTransactionListPageLoaded(testData.SERVICE_OPBEANS_JAVA);
+      });
+    });
+
     test('Renders the page with expected content', async ({ page }) => {
       await test.step('Renders headings', async () => {
         await expect(page.getByTestId('apmMainTemplateHeaderServiceName')).toHaveText(SERVICE_NAME);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[APM] Make the transaction name optional and test the navigation (#255277)](https://github.com/elastic/kibana/pull/255277)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2026-03-02T10:47:54Z","message":"[APM] Make the transaction name optional and test the navigation (#255277)\n\nCloses #254233\n\n## Summary\n\nWhen navigating to the APM transaction detail page with a URL where\n`transactionName` is missing or becomes `undefined` (e.g. param omitted,\nencoding issue, bookmark), the route schema required `transactionName`\nas a string and the app threw a runtime validation error before the\ncomponent mounted, resulting in a PageFatalReactError.\n\nThis PR:\n\n- Makes `transactionName` **optional** in the transaction view route\nschema for both `/services/{serviceName}/transactions/view` and\n`/mobile-services/{serviceName}/transactions/view`, so the route matches\neven when the param is absent.\n- In `TransactionDetails`, when `transactionName` is missing or empty,\n**redirects** to the transaction list for the service\n(`/services/{serviceName}/transactions` or\n`/mobile-services/{serviceName}/transactions`), preserving time range\nand other safe query params. No transaction detail content is rendered\nin that case.\n- Keeps breadcrumb and hooks order correct (all hooks run\nunconditionally; redirect happens after).\n\n**Files changed:**\n\n-\n`x-pack/solutions/observability/plugins/apm/public/components/routing/service_detail/index.tsx`\n– optional `transactionName` in route params\n-\n`x-pack/solutions/observability/plugins/apm/public/components/routing/mobile_service_detail/index.tsx`\n– same for mobile route\n-\n`x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.tsx`\n– redirect when `transactionName` missing/empty; breadcrumb fallback to\nservice name\n- Unit tests: `public/components/app/transaction_details/index.test.tsx`\n- Scout UI test:\n`test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts`\n+ page object `goToTransactionViewWithoutTransactionName`\n\n## How to test\n\n**Jest**\n\n- Transaction details component (includes redirect tests):  \n`yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.test.tsx`\n- Broader transaction details + routing:  \n`yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details\nx-pack/solutions/observability/plugins/apm/public/components/routing`\n\n**Scout (optional, deployment-agnostic)**\n\n- Run transaction details specs (includes “Redirects to transaction list\nwhen transactionName is missing in URL”):\n`node scripts/scout run-tests --arch stateful --domain classic\n--testFiles\nx-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts`\n\n**Manual**\n\n1. **Valid URL**  \nGo to a service → Transactions → open a transaction (e.g. `GET\n/api/...`).\nConfirm the transaction detail page loads and shows charts, breadcrumb,\nand tabs.\n\n2. **Missing transactionName**  \n   Open:  \n\n`{kibana}/app/apm/services/{serviceName}/transactions/view?rangeFrom=now-15m&rangeTo=now&comparisonEnabled=false&showCriticalPath=&environment=ENVIRONMENT_ALL&kuery=&serviceGroup=`\n   (no `transactionName` in query).  \nConfirm the app redirects to `/services/{serviceName}/transactions` and\nthe transaction list loads (no crash).\n\n3. **Empty or whitespace transactionName**  \n   Same URL with `transactionName=` or `transactionName=%20%20`.  \n   Confirm redirect to transaction list, no crash.\n\n4. **Mobile route**  \nUse `/app/apm/mobile-services/{serviceName}/transactions/view?...`\nwithout `transactionName`.\n   Confirm redirect to `/mobile-services/{serviceName}/transactions`.\n\n5. **Query params preserved**  \nIn step 2, use a custom time range (e.g. `rangeFrom=...&rangeTo=...`).\nAfter redirect, confirm the transaction list still has the same time\nrange (and other safe params).\n\n\n\nhttps://github.com/user-attachments/assets/d4e912ee-991d-4457-9e54-6f677f5adf59\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ecf198ce1a3a1eff81e5454a5045fc8135136f8d","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"[APM] Make the transaction name optional and test the navigation","number":255277,"url":"https://github.com/elastic/kibana/pull/255277","mergeCommit":{"message":"[APM] Make the transaction name optional and test the navigation (#255277)\n\nCloses #254233\n\n## Summary\n\nWhen navigating to the APM transaction detail page with a URL where\n`transactionName` is missing or becomes `undefined` (e.g. param omitted,\nencoding issue, bookmark), the route schema required `transactionName`\nas a string and the app threw a runtime validation error before the\ncomponent mounted, resulting in a PageFatalReactError.\n\nThis PR:\n\n- Makes `transactionName` **optional** in the transaction view route\nschema for both `/services/{serviceName}/transactions/view` and\n`/mobile-services/{serviceName}/transactions/view`, so the route matches\neven when the param is absent.\n- In `TransactionDetails`, when `transactionName` is missing or empty,\n**redirects** to the transaction list for the service\n(`/services/{serviceName}/transactions` or\n`/mobile-services/{serviceName}/transactions`), preserving time range\nand other safe query params. No transaction detail content is rendered\nin that case.\n- Keeps breadcrumb and hooks order correct (all hooks run\nunconditionally; redirect happens after).\n\n**Files changed:**\n\n-\n`x-pack/solutions/observability/plugins/apm/public/components/routing/service_detail/index.tsx`\n– optional `transactionName` in route params\n-\n`x-pack/solutions/observability/plugins/apm/public/components/routing/mobile_service_detail/index.tsx`\n– same for mobile route\n-\n`x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.tsx`\n– redirect when `transactionName` missing/empty; breadcrumb fallback to\nservice name\n- Unit tests: `public/components/app/transaction_details/index.test.tsx`\n- Scout UI test:\n`test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts`\n+ page object `goToTransactionViewWithoutTransactionName`\n\n## How to test\n\n**Jest**\n\n- Transaction details component (includes redirect tests):  \n`yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.test.tsx`\n- Broader transaction details + routing:  \n`yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details\nx-pack/solutions/observability/plugins/apm/public/components/routing`\n\n**Scout (optional, deployment-agnostic)**\n\n- Run transaction details specs (includes “Redirects to transaction list\nwhen transactionName is missing in URL”):\n`node scripts/scout run-tests --arch stateful --domain classic\n--testFiles\nx-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts`\n\n**Manual**\n\n1. **Valid URL**  \nGo to a service → Transactions → open a transaction (e.g. `GET\n/api/...`).\nConfirm the transaction detail page loads and shows charts, breadcrumb,\nand tabs.\n\n2. **Missing transactionName**  \n   Open:  \n\n`{kibana}/app/apm/services/{serviceName}/transactions/view?rangeFrom=now-15m&rangeTo=now&comparisonEnabled=false&showCriticalPath=&environment=ENVIRONMENT_ALL&kuery=&serviceGroup=`\n   (no `transactionName` in query).  \nConfirm the app redirects to `/services/{serviceName}/transactions` and\nthe transaction list loads (no crash).\n\n3. **Empty or whitespace transactionName**  \n   Same URL with `transactionName=` or `transactionName=%20%20`.  \n   Confirm redirect to transaction list, no crash.\n\n4. **Mobile route**  \nUse `/app/apm/mobile-services/{serviceName}/transactions/view?...`\nwithout `transactionName`.\n   Confirm redirect to `/mobile-services/{serviceName}/transactions`.\n\n5. **Query params preserved**  \nIn step 2, use a custom time range (e.g. `rangeFrom=...&rangeTo=...`).\nAfter redirect, confirm the transaction list still has the same time\nrange (and other safe params).\n\n\n\nhttps://github.com/user-attachments/assets/d4e912ee-991d-4457-9e54-6f677f5adf59\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ecf198ce1a3a1eff81e5454a5045fc8135136f8d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255277","number":255277,"mergeCommit":{"message":"[APM] Make the transaction name optional and test the navigation (#255277)\n\nCloses #254233\n\n## Summary\n\nWhen navigating to the APM transaction detail page with a URL where\n`transactionName` is missing or becomes `undefined` (e.g. param omitted,\nencoding issue, bookmark), the route schema required `transactionName`\nas a string and the app threw a runtime validation error before the\ncomponent mounted, resulting in a PageFatalReactError.\n\nThis PR:\n\n- Makes `transactionName` **optional** in the transaction view route\nschema for both `/services/{serviceName}/transactions/view` and\n`/mobile-services/{serviceName}/transactions/view`, so the route matches\neven when the param is absent.\n- In `TransactionDetails`, when `transactionName` is missing or empty,\n**redirects** to the transaction list for the service\n(`/services/{serviceName}/transactions` or\n`/mobile-services/{serviceName}/transactions`), preserving time range\nand other safe query params. No transaction detail content is rendered\nin that case.\n- Keeps breadcrumb and hooks order correct (all hooks run\nunconditionally; redirect happens after).\n\n**Files changed:**\n\n-\n`x-pack/solutions/observability/plugins/apm/public/components/routing/service_detail/index.tsx`\n– optional `transactionName` in route params\n-\n`x-pack/solutions/observability/plugins/apm/public/components/routing/mobile_service_detail/index.tsx`\n– same for mobile route\n-\n`x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.tsx`\n– redirect when `transactionName` missing/empty; breadcrumb fallback to\nservice name\n- Unit tests: `public/components/app/transaction_details/index.test.tsx`\n- Scout UI test:\n`test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts`\n+ page object `goToTransactionViewWithoutTransactionName`\n\n## How to test\n\n**Jest**\n\n- Transaction details component (includes redirect tests):  \n`yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/index.test.tsx`\n- Broader transaction details + routing:  \n`yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details\nx-pack/solutions/observability/plugins/apm/public/components/routing`\n\n**Scout (optional, deployment-agnostic)**\n\n- Run transaction details specs (includes “Redirects to transaction list\nwhen transactionName is missing in URL”):\n`node scripts/scout run-tests --arch stateful --domain classic\n--testFiles\nx-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/transaction_details.spec.ts`\n\n**Manual**\n\n1. **Valid URL**  \nGo to a service → Transactions → open a transaction (e.g. `GET\n/api/...`).\nConfirm the transaction detail page loads and shows charts, breadcrumb,\nand tabs.\n\n2. **Missing transactionName**  \n   Open:  \n\n`{kibana}/app/apm/services/{serviceName}/transactions/view?rangeFrom=now-15m&rangeTo=now&comparisonEnabled=false&showCriticalPath=&environment=ENVIRONMENT_ALL&kuery=&serviceGroup=`\n   (no `transactionName` in query).  \nConfirm the app redirects to `/services/{serviceName}/transactions` and\nthe transaction list loads (no crash).\n\n3. **Empty or whitespace transactionName**  \n   Same URL with `transactionName=` or `transactionName=%20%20`.  \n   Confirm redirect to transaction list, no crash.\n\n4. **Mobile route**  \nUse `/app/apm/mobile-services/{serviceName}/transactions/view?...`\nwithout `transactionName`.\n   Confirm redirect to `/mobile-services/{serviceName}/transactions`.\n\n5. **Query params preserved**  \nIn step 2, use a custom time range (e.g. `rangeFrom=...&rangeTo=...`).\nAfter redirect, confirm the transaction list still has the same time\nrange (and other safe params).\n\n\n\nhttps://github.com/user-attachments/assets/d4e912ee-991d-4457-9e54-6f677f5adf59\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ecf198ce1a3a1eff81e5454a5045fc8135136f8d"}}]}] BACKPORT-->