### PR TITLE
[React@18/Chrome] Migrate dashboard breadcrumb + canvas help extension; clean up ChromeHelpExtension API

### DIFF
--- a/src/core/packages/chrome/browser-components/src/shared/header_help_menu.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/header_help_menu.test.tsx
@@ -54,47 +54,21 @@ describe('HeaderHelpMenu', () => {
     expect(component.find('[data-test-subj="kbnVersionString"]').exists()).toBeFalsy();
   });
 
-  test('it renders reactContent and passes hideHelpMenu action', () => {
-    const reactContent = jest.fn(() => (
+  test('it renders content and passes hideHelpMenu action', () => {
+    const content = jest.fn(() => (
       <span data-test-subj="react-content-node">React Content</span>
     ));
     const component = renderAndOpenMenu({
-      helpExtension$: new BehaviorSubject<ChromeHelpExtension | undefined>({
-        appName: 'Test App',
-        reactContent,
-      }),
-    });
-
-    expect(component.find('[data-test-subj="react-content-node"]').exists()).toBeTruthy();
-    expect(reactContent).toHaveBeenCalledWith(
-      expect.objectContaining({ hideHelpMenu: expect.any(Function) })
-    );
-  });
-
-  test('it renders legacy content when only content is provided', () => {
-    const content = jest.fn(() => () => {});
-    renderAndOpenMenu({
       helpExtension$: new BehaviorSubject<ChromeHelpExtension | undefined>({
         appName: 'Test App',
         content,
       }),
     });
 
-    expect(content).toHaveBeenCalled();
-  });
-
-  test('it prefers reactContent over legacy content when both are provided', () => {
-    const legacyContent = jest.fn(() => () => {});
-    const component = renderAndOpenMenu({
-      helpExtension$: new BehaviorSubject<ChromeHelpExtension | undefined>({
-        appName: 'Test App',
-        reactContent: () => <span data-test-subj="react-content-node">React Content</span>,
-        content: legacyContent,
-      }),
-    });
-
     expect(component.find('[data-test-subj="react-content-node"]').exists()).toBeTruthy();
-    expect(legacyContent).not.toHaveBeenCalled();
+    expect(content).toHaveBeenCalledWith(
+      expect.objectContaining({ hideHelpMenu: expect.any(Function) })
+    );
   });
 
   test('it renders the global custom content + the default content', () => {

--- a/src/core/packages/chrome/browser-components/src/shared/header_help_menu.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/header_help_menu.test.tsx
@@ -55,9 +55,7 @@ describe('HeaderHelpMenu', () => {
   });
 
   test('it renders content and passes hideHelpMenu action', () => {
-    const content = jest.fn(() => (
-      <span data-test-subj="react-content-node">React Content</span>
-    ));
+    const content = jest.fn(() => <span data-test-subj="react-content-node">React Content</span>);
     const component = renderAndOpenMenu({
       helpExtension$: new BehaviorSubject<ChromeHelpExtension | undefined>({
         appName: 'Test App',

--- a/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
@@ -35,7 +35,6 @@ import type {
 import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 
 import { css } from '@emotion/react';
-import { HeaderExtension } from './header_extension';
 import { isModifiedOrPrevented } from './nav_link';
 
 const buildDefaultContentLinks = ({
@@ -125,15 +124,6 @@ export const HeaderHelpMenu = ({
   const closeMenu = useCallback(() => setIsOpen(false), []);
   const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
 
-  const helpExtensionLegacyContent = helpExtension?.content;
-  const helpExtensionMount = useCallback(
-    (domNode: HTMLDivElement) => {
-      const unmount = helpExtensionLegacyContent?.(domNode, { hideHelpMenu: closeMenu });
-      return unmount ?? (() => {});
-    },
-    [helpExtensionLegacyContent, closeMenu]
-  );
-
   const createOnClickHandler = useCallback(
     (href: string) => (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       if (!isModifiedOrPrevented(event) && event.button === 0) {
@@ -198,7 +188,7 @@ export const HeaderHelpMenu = ({
 
   let customContent: React.ReactNode = null;
   if (helpExtension) {
-    const { appName, links, content, reactContent } = helpExtension;
+    const { appName, links, content } = helpExtension;
 
     const customLinks =
       links &&
@@ -234,12 +224,7 @@ export const HeaderHelpMenu = ({
         }
       });
 
-    let extensionContent: React.ReactNode = null;
-    if (reactContent) {
-      extensionContent = reactContent({ hideHelpMenu: closeMenu });
-    } else if (content) {
-      extensionContent = <HeaderExtension extension={helpExtensionMount} />;
-    }
+    const extensionContent = content?.({ hideHelpMenu: closeMenu }) ?? null;
 
     customContent = (
       <>

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
@@ -555,7 +555,7 @@ describe('start', () => {
       const { chrome, service } = await start();
       const promise = firstValueFrom(chrome.getHelpExtension$().pipe(Rx.take(3), toArray()));
 
-      chrome.setHelpExtension({ appName: 'App name', content: () => () => undefined });
+      chrome.setHelpExtension({ appName: 'App name', content: () => null });
       chrome.setHelpExtension(undefined);
       service.stop();
 

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -54,7 +54,7 @@ export interface ChromeSetup {
  * ```tsx
  * core.chrome.setHelpExtension({
  *   appName: 'My App',
-   *   content: ({ hideHelpMenu }) => <MyHelpComponent onClose={hideHelpMenu} />,
+ *   content: ({ hideHelpMenu }) => <MyHelpComponent onClose={hideHelpMenu} />,
  * });
  * ```
  *

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -54,7 +54,7 @@ export interface ChromeSetup {
  * ```tsx
  * core.chrome.setHelpExtension({
  *   appName: 'My App',
- *   reactContent: ({ hideHelpMenu }) => <MyHelpComponent onClose={hideHelpMenu} />,
+   *   content: ({ hideHelpMenu }) => <MyHelpComponent onClose={hideHelpMenu} />,
  * });
  * ```
  *
@@ -227,7 +227,7 @@ export interface ChromeStart {
 
   /**
    * Override the current set of custom help content.
-   * Prefer {@link ChromeHelpExtension.reactContent} over the legacy `content` callback.
+   * Use {@link ChromeHelpExtension.content} to render custom React content below the links.
    */
   setHelpExtension(helpExtension?: ChromeHelpExtension): void;
 

--- a/src/core/packages/chrome/browser/src/help_extension.ts
+++ b/src/core/packages/chrome/browser/src/help_extension.ts
@@ -27,15 +27,17 @@ export interface ChromeHelpExtension {
    */
   links?: ChromeHelpExtensionMenuLink[];
   /**
-   * React-first alternative to `content`. Receives menu actions and returns a ReactNode.
-   * Preferred over `content` which is deprecated.
+   * Custom content to render below the list of links. Receives menu actions and returns a ReactNode.
+   *
+   * @example
+   * ```tsx
+   * core.chrome.setHelpExtension({
+   *   appName: 'My App',
+   *   content: ({ hideHelpMenu }) => <MyHelpComponent onClose={hideHelpMenu} />,
+   * });
+   * ```
    */
-  reactContent?: (menuActions: ChromeHelpMenuActions) => ReactNode;
-  /**
-   * Custom content to occur below the list of links
-   * @deprecated Use `reactContent` instead.
-   */
-  content?: (element: HTMLDivElement, menuActions: ChromeHelpMenuActions) => () => void;
+  content?: (menuActions: ChromeHelpMenuActions) => ReactNode;
 }
 
 /** @public */

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -21,7 +21,6 @@ import {
   EuiScreenReaderOnly,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import type { MountPoint } from '@kbn/core/public';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import type { Query } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -29,7 +28,6 @@ import { getManagedContentBadge } from '@kbn/managed-content-badge';
 import type { TopNavMenuBadgeProps, TopNavMenuProps } from '@kbn/navigation-plugin/public';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import { LazyLabsFlyout, withSuspense } from '@kbn/presentation-util-plugin/public';
-import { MountPointPortal } from '@kbn/react-kibana-mount';
 
 import { AppMenu } from '@kbn/core-chrome-app-menu';
 import { UI_SETTINGS } from '../../common/constants';
@@ -367,17 +365,12 @@ export function InternalDashboardTopNav({
     };
   }, [badges]);
 
-  const setFavoriteButtonMountPoint = useCallback(
-    (mountPoint: MountPoint<HTMLElement> | undefined) => {
-      if (mountPoint) {
-        return coreServices.chrome.setBreadcrumbsAppendExtension({
-          mount: mountPoint,
-          order: 0,
-        });
-      }
-    },
-    []
-  );
+  useEffect(() => {
+    return coreServices.chrome.setBreadcrumbsAppendExtension({
+      content: <DashboardFavoriteButton dashboardId={lastSavedId} />,
+      order: 0,
+    });
+  }, [lastSavedId]);
 
   return (
     <div css={styles.container}>
@@ -432,9 +425,6 @@ export function InternalDashboardTopNav({
       {viewMode !== 'print' ? <DashboardControlsRenderer /> : null}
 
       {showBorderBottom && <EuiHorizontalRule margin="none" />}
-      <MountPointPortal setMountPoint={setFavoriteButtonMountPoint}>
-        <DashboardFavoriteButton dashboardId={lastSavedId} />
-      </MountPointPortal>
     </div>
   );
 }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -21,6 +21,7 @@ import {
   EuiScreenReaderOnly,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import type { MountPoint } from '@kbn/core/public';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import type { Query } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';

--- a/x-pack/platform/plugins/private/canvas/public/application.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/application.tsx
@@ -136,17 +136,11 @@ export const initializeCanvas = async (
         href: docLinks.links.canvas.guide,
       },
     ],
-    content: (domNode, { hideHelpMenu }) => {
-      ReactDOM.render(
-        <KibanaRenderContextProvider {...coreStart}>
-          <Provider store={canvasStore}>
-            <HelpMenu hideHelpMenu={hideHelpMenu} />
-          </Provider>
-        </KibanaRenderContextProvider>,
-        domNode
-      );
-      return () => ReactDOM.unmountComponentAtNode(domNode);
-    },
+    content: ({ hideHelpMenu }) => (
+      <Provider store={canvasStore}>
+        <HelpMenu hideHelpMenu={hideHelpMenu} />
+      </Provider>
+    ),
   });
 
   if (setupPlugins.usageCollection) {


### PR DESCRIPTION
## Summary

Part of #254890 (Phase 2 — PR B: breadcrumb append extension + help extension)
Related: #218083 (React 18 concurrent mode migration for chrome extension points)
Related: #218080 (Kibana root already running concurrent mode)

> **Concurrent mode note**: Kibana's root rendering service is already running React 18 concurrent mode (#218080). By moving these extensions into the core React tree they are **immediately migrated to concurrent mode** — there is no `ReactDOM.render()` root left to migrate separately.

Three changes:

### 1. Dashboard — `setBreadcrumbsAppendExtension`

Replaces `MountPointPortal` + `useCallback` with a single `useEffect`. Also fixes a latent cleanup bug: the old `if (mountPoint)` guard meant the extension was never cleared when the portal unmounted (it called the setter with `undefined`, which the guard silently ignored).

Removes: `MountPoint` type import, `MountPointPortal` import from `@kbn/react-kibana-mount`.

### 2. Canvas — `setHelpExtension`

Replaces the deprecated `content` MountPoint callback with the React-first `content` field (formerly `reactContent`). Removes the inner `ReactDOM.render` + `KibanaRenderContextProvider` wrapper — theme and i18n now flow from the core tree. The redux `Provider` is kept as it's canvas-specific.

### 3. `ChromeHelpExtension` API cleanup

Canvas was the **only** consumer of the deprecated MountPoint-based `content` callback. Now that it's migrated, the API is cleaned up:

- Remove deprecated `content?: (element: HTMLDivElement, menuActions) => () => void`
- Rename `reactContent` → `content` (the single, clean API)
- Remove the legacy renderer path in `HeaderHelpMenu` (`helpExtensionMount` useCallback + `HeaderExtension` fallback)
- Remove the corresponding legacy tests (2 tests covering the now-deleted code path)

The API is now symmetric with the other extension points: `content` holds the React-first value.

Part of #254890
