### PR TITLE
[8.19] Pass alerts data view to buildEsQuery for correct wildcard queries on keyword fields (#255225)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar.tsx
@@ -10,6 +10,7 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { AlertFilterControls } from '@kbn/alerts-ui-shared/src/alert_filter_controls';
 import { useFetchAlertsIndexNamesQuery } from '@kbn/alerts-ui-shared';
 import { ControlGroupRenderer } from '@kbn/controls-plugin/public';
+import { useAlertsDataView } from '@kbn/alerts-ui-shared/src/common/hooks/use_alerts_data_view';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { Filter, TimeRange } from '@kbn/es-query';
@@ -74,6 +75,12 @@ export function ObservabilityAlertSearchBar({
     http,
     ruleTypeIds: OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
   });
+  const { dataView } = useAlertsDataView({
+    http,
+    dataViewsService: dataViews,
+    toasts: notifications.toasts,
+    ruleTypeIds: OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
+  });
 
   const clearSavedQuery = useCallback(
     () => (setSavedQuery ? setSavedQuery(undefined) : null),
@@ -111,6 +118,7 @@ export function ObservabilityAlertSearchBar({
           kuery,
           filters: [...filters, ...(filterControls ?? []), ...defaultFilters],
           config: getEsQueryConfig(uiSettings),
+          indexPattern: dataView,
         })
       );
       setTimeFilter(
@@ -136,6 +144,7 @@ export function ObservabilityAlertSearchBar({
     uiSettings,
     toasts,
     onKueryChange,
+    dataView,
   ]);
 
   useEffect(() => {

--- a/x-pack/solutions/observability/plugins/observability/public/utils/build_es_query/build_es_query.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/build_es_query/build_es_query.ts
@@ -5,13 +5,8 @@
  * 2.0.
  */
 
-import {
-  buildEsQuery as kbnBuildEsQuery,
-  EsQueryConfig,
-  Filter,
-  Query,
-  TimeRange,
-} from '@kbn/es-query';
+import type { DataViewBase, EsQueryConfig, Filter, Query, TimeRange } from '@kbn/es-query';
+import { buildEsQuery as kbnBuildEsQuery } from '@kbn/es-query';
 import { ALERT_TIME_RANGE } from '@kbn/rule-data-utils';
 import { getTime } from '@kbn/data-plugin/common';
 
@@ -21,6 +16,7 @@ interface BuildEsQueryArgs {
   config?: EsQueryConfig;
   queries?: Query[];
   filters?: Filter[];
+  indexPattern?: DataViewBase;
 }
 
 export function buildEsQuery({
@@ -29,6 +25,7 @@ export function buildEsQuery({
   config = {},
   queries = [],
   filters = [],
+  indexPattern,
 }: BuildEsQueryArgs) {
   const timeFilter =
     timeRange &&
@@ -38,5 +35,5 @@ export function buildEsQuery({
   const filtersToUse: Filter[] = timeFilter ? [timeFilter, ...filters] : filters;
   const kueryFilter = kuery ? [{ query: kuery, language: 'kuery' }] : [];
   const queryToUse = [...kueryFilter, ...queries];
-  return kbnBuildEsQuery(undefined, queryToUse, filtersToUse, config);
+  return kbnBuildEsQuery(indexPattern, queryToUse, filtersToUse, config);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Pass alerts data view to buildEsQuery for correct wildcard queries on keyword fields (#255225)](https://github.com/elastic/kibana/pull/255225)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jason Rhodes","email":"jason.rhodes@elastic.co"},"sourceCommit":{"committedDate":"2026-02-27T18:33:42Z","message":"Pass alerts data view to buildEsQuery for correct wildcard queries on keyword fields (#255225)\n\nFixes #255223\n\n## Summary\n\nThe Observability Alerts page doesn't handle keyword searches correctly\nif the search value contains a space. It uses a `query_string` query\ninstead of a `wildcard` query, which breaks because `query_string`\nsplits on whitespace. Discover uses `wildcard` which handles the space\nseparation correctly.\n\nThis PR threads the alerts data view (already fetched elsewhere for\nautocomplete) into the `buildEsQuery` call so that field types like\n`keyword` are known at query-build time, producing the correct\n`wildcard` ES query.\n\n### Before\n\nDiscover---\n<img width=\"1512\" height=\"639\" alt=\"Screenshot 2026-02-26 at 9 39 29 PM\"\nsrc=\"https://github.com/user-attachments/assets/041142c7-304f-4711-8a02-d3f6eb82e3ca\"\n/>\n\nObservability alerts page---\n<img width=\"1509\" height=\"713\" alt=\"Screenshot 2026-02-26 at 9 39 06 PM\"\nsrc=\"https://github.com/user-attachments/assets/afab17c2-46ec-4ae3-821a-213de1d5ab24\"\n/>\n\n### After\n\nObservability alerts page---\n<img width=\"1512\" height=\"746\" alt=\"Screenshot 2026-02-26 at 9 40 09 PM\"\nsrc=\"https://github.com/user-attachments/assets/a9f55b23-9138-4aaf-8baa-dfeaaad3f874\"\n/>\n\n### Summary of changes\n\n- **`build_es_query.ts`** — Added an optional `indexPattern` parameter\nto the observability `buildEsQuery` wrapper and passes it through to\n`kbnBuildEsQuery` (previously hardcoded to `undefined`)\n- **`alert_search_bar.tsx`** — Added a `useAlertsDataView` call (same\nhook that `AlertsSearchBar` already uses internally for autocomplete)\nand passes the resulting data view as `indexPattern` to `buildEsQuery`\n- **`build_es_query.test.ts`** — Added two test cases demonstrating the\nbehavior difference: with an index pattern containing a keyword field, a\nwildcard value with a space produces a `wildcard` query; without one,\nthe same value produces a `query_string` query\n\n## Test plan\n\n- [ ] Create an alerting rule with a multi-word name (e.g. \"Custom\nthreshold rule\")\n- [ ] Navigate to `/app/observability/alerts`\n- [ ] Search for `kibana.alert.rule.name: *threshold rule` — should now\nreturn results\n- [ ] Verify that `kibana.alert.rule.name: *threshold*` and\n`kibana.alert.rule.name: *rule` still work as before\n- [ ] Verify no regressions in alert search bar behavior (filters, date\nrange, saved queries)\n\nMade with [Cursor](https://cursor.com)","sha":"8723a51b11c0916dd4ffacbd71ed36c494f144c3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","backport:version","v9.4.0","author:actionable-obs","Team:obs-ux-management","v8.19.13","v9.3.2"],"title":"Pass alerts data view to buildEsQuery for correct wildcard queries on keyword fields","number":255225,"url":"https://github.com/elastic/kibana/pull/255225","mergeCommit":{"message":"Pass alerts data view to buildEsQuery for correct wildcard queries on keyword fields (#255225)\n\nFixes #255223\n\n## Summary\n\nThe Observability Alerts page doesn't handle keyword searches correctly\nif the search value contains a space. It uses a `query_string` query\ninstead of a `wildcard` query, which breaks because `query_string`\nsplits on whitespace. Discover uses `wildcard` which handles the space\nseparation correctly.\n\nThis PR threads the alerts data view (already fetched elsewhere for\nautocomplete) into the `buildEsQuery` call so that field types like\n`keyword` are known at query-build time, producing the correct\n`wildcard` ES query.\n\n### Before\n\nDiscover---\n<img width=\"1512\" height=\"639\" alt=\"Screenshot 2026-02-26 at 9 39 29 PM\"\nsrc=\"https://github.com/user-attachments/assets/041142c7-304f-4711-8a02-d3f6eb82e3ca\"\n/>\n\nObservability alerts page---\n<img width=\"1509\" height=\"713\" alt=\"Screenshot 2026-02-26 at 9 39 06 PM\"\nsrc=\"https://github.com/user-attachments/assets/afab17c2-46ec-4ae3-821a-213de1d5ab24\"\n/>\n\n### After\n\nObservability alerts page---\n<img width=\"1512\" height=\"746\" alt=\"Screenshot 2026-02-26 at 9 40 09 PM\"\nsrc=\"https://github.com/user-attachments/assets/a9f55b23-9138-4aaf-8baa-dfeaaad3f874\"\n/>\n\n### Summary of changes\n\n- **`build_es_query.ts`** — Added an optional `indexPattern` parameter\nto the observability `buildEsQuery` wrapper and passes it through to\n`kbnBuildEsQuery` (previously hardcoded to `undefined`)\n- **`alert_search_bar.tsx`** — Added a `useAlertsDataView` call (same\nhook that `AlertsSearchBar` already uses internally for autocomplete)\nand passes the resulting data view as `indexPattern` to `buildEsQuery`\n- **`build_es_query.test.ts`** — Added two test cases demonstrating the\nbehavior difference: with an index pattern containing a keyword field, a\nwildcard value with a space produces a `wildcard` query; without one,\nthe same value produces a `query_string` query\n\n## Test plan\n\n- [ ] Create an alerting rule with a multi-word name (e.g. \"Custom\nthreshold rule\")\n- [ ] Navigate to `/app/observability/alerts`\n- [ ] Search for `kibana.alert.rule.name: *threshold rule` — should now\nreturn results\n- [ ] Verify that `kibana.alert.rule.name: *threshold*` and\n`kibana.alert.rule.name: *rule` still work as before\n- [ ] Verify no regressions in alert search bar behavior (filters, date\nrange, saved queries)\n\nMade with [Cursor](https://cursor.com)","sha":"8723a51b11c0916dd4ffacbd71ed36c494f144c3"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255225","number":255225,"mergeCommit":{"message":"Pass alerts data view to buildEsQuery for correct wildcard queries on keyword fields (#255225)\n\nFixes #255223\n\n## Summary\n\nThe Observability Alerts page doesn't handle keyword searches correctly\nif the search value contains a space. It uses a `query_string` query\ninstead of a `wildcard` query, which breaks because `query_string`\nsplits on whitespace. Discover uses `wildcard` which handles the space\nseparation correctly.\n\nThis PR threads the alerts data view (already fetched elsewhere for\nautocomplete) into the `buildEsQuery` call so that field types like\n`keyword` are known at query-build time, producing the correct\n`wildcard` ES query.\n\n### Before\n\nDiscover---\n<img width=\"1512\" height=\"639\" alt=\"Screenshot 2026-02-26 at 9 39 29 PM\"\nsrc=\"https://github.com/user-attachments/assets/041142c7-304f-4711-8a02-d3f6eb82e3ca\"\n/>\n\nObservability alerts page---\n<img width=\"1509\" height=\"713\" alt=\"Screenshot 2026-02-26 at 9 39 06 PM\"\nsrc=\"https://github.com/user-attachments/assets/afab17c2-46ec-4ae3-821a-213de1d5ab24\"\n/>\n\n### After\n\nObservability alerts page---\n<img width=\"1512\" height=\"746\" alt=\"Screenshot 2026-02-26 at 9 40 09 PM\"\nsrc=\"https://github.com/user-attachments/assets/a9f55b23-9138-4aaf-8baa-dfeaaad3f874\"\n/>\n\n### Summary of changes\n\n- **`build_es_query.ts`** — Added an optional `indexPattern` parameter\nto the observability `buildEsQuery` wrapper and passes it through to\n`kbnBuildEsQuery` (previously hardcoded to `undefined`)\n- **`alert_search_bar.tsx`** — Added a `useAlertsDataView` call (same\nhook that `AlertsSearchBar` already uses internally for autocomplete)\nand passes the resulting data view as `indexPattern` to `buildEsQuery`\n- **`build_es_query.test.ts`** — Added two test cases demonstrating the\nbehavior difference: with an index pattern containing a keyword field, a\nwildcard value with a space produces a `wildcard` query; without one,\nthe same value produces a `query_string` query\n\n## Test plan\n\n- [ ] Create an alerting rule with a multi-word name (e.g. \"Custom\nthreshold rule\")\n- [ ] Navigate to `/app/observability/alerts`\n- [ ] Search for `kibana.alert.rule.name: *threshold rule` — should now\nreturn results\n- [ ] Verify that `kibana.alert.rule.name: *threshold*` and\n`kibana.alert.rule.name: *rule` still work as before\n- [ ] Verify no regressions in alert search bar behavior (filters, date\nrange, saved queries)\n\nMade with [Cursor](https://cursor.com)","sha":"8723a51b11c0916dd4ffacbd71ed36c494f144c3"}},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->