### PR TITLE
[SLO] Fix flaky find_slo test: use single-instance groupBy

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/find_slo.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/find_slo.ts
@@ -54,13 +54,14 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     it('searches SLOs using kqlQuery', async () => {
       const testTag = `test-${Date.now()}`;
       const createResponse1 = await sloApi.create(
-        Object.assign({}, DEFAULT_SLO, { tags: ['test', testTag] }),
+        Object.assign({}, DEFAULT_SLO, { tags: ['test', testTag], groupBy: '*' }),
         adminRoleAuthc
       );
       const createResponse2 = await sloApi.create(
         Object.assign({}, DEFAULT_SLO, {
           name: 'something irrelevant foo',
           tags: ['test', testTag],
+          groupBy: '*',
         }),
         adminRoleAuthc
       );


### PR DESCRIPTION
## Summary

Fixes #176763

### Root Cause

The `find_slo` test creates SLOs using `DEFAULT_SLO` which has `groupBy: 'tags'`. The Find SLO API returns one result per **instance** (not per definition). With `groupBy: 'tags'`, each SLO fans out to N instances (one per unique tag value in the data-forge data). The test expects 2 results but gets 2*N (error: `expected 6 to sort of equal 2`).

### Fix

Override `groupBy` to `'*'` in the test's `sloApi.create` calls so each SLO produces exactly one summary instance, making `results.length === 2` deterministic.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->