### PR TITLE
[kbn-es] Retry ES snapshot manifest download on HTTP 5xx

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/artifact.ts
+++ b/src/platform/packages/shared/kbn-es/src/artifact.ts
@@ -112,7 +112,13 @@ async function fetchSnapshotManifest(url: string, log: ToolingLog) {
   log.info('Downloading snapshot manifest from %s', chalk.bold(url));
 
   const abc = new AbortController();
-  const resp = await retry(log, async () => await fetch(url, { signal: abc.signal }));
+  const resp = await retry(log, async () => {
+    const r = await fetch(url, { signal: abc.signal });
+    if (r.status >= 500) {
+      throw new Error(`Manifest fetch failed: ${r.status} ${r.statusText}`);
+    }
+    return r;
+  });
   const json = await resp.text();
 
   return { abc, resp, json };


### PR DESCRIPTION
## Summary

Fixes #223734

### Root Cause

In `src/platform/packages/shared/kbn-es/src/artifact.ts`, the `retry` function (which retries up to 3 times on thrown errors) wraps `fetch()` in `fetchSnapshotManifest`. However, `fetch()` does **not** throw on HTTP 5xx responses — it returns a `Response` with `ok: false`. The HTTP status was only checked _after_ the retry block, so GCS returning HTTP 500 was never retried. This caused flaky test failures across many CI runs (any Jest integration test that downloads an ES snapshot).

Example error: `Unable to read artifact info from https://storage.googleapis.com/.../manifest-latest-SNAPSHOT.json: 500 Internal Server Error`

### Fix

Add an explicit check for `r.status >= 500` inside the retry callback so that server errors trigger a retry. Only 5xx is retried (not 4xx, which are legitimate failures like 404). The existing 404 fallback logic downstream remains unchanged.

### Test plan

This is platform-level code (`kbn-es`). No FTR config — it affects all Jest integration tests that download ES snapshots. The fix is minimal and safe: it only adds retry behavior for transient server errors that were previously silently swallowed.


Made with [Cursor](https://cursor.com)