### PR TITLE
[Streams] Remove test (duplicated elsewhere)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
@@ -13,8 +13,7 @@ import { generateLogsData } from '../../../fixtures/generators';
 // Note: Processor creation, conditional steps, and nested steps API correctness is covered by
 // API tests in x-pack/platform/plugins/shared/streams/test/scout/api/tests/processing_persistence.spec.ts
 // These UI tests focus on the user experience: validation, button states, cancel flows, and duplication
-// Failing: See https://github.com/elastic/kibana/issues/254435
-test.describe.skip(
+test.describe(
   'Stream data processing - creating steps',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
@@ -190,22 +189,6 @@ test.describe.skip(
 
       await pageObjects.streams.saveStepsListChanges();
       expect(await pageObjects.streams.getProcessorsListItems()).toHaveLength(1);
-    });
-
-    test('should handle insufficient privileges gracefully', async ({
-      page,
-      browserAuth,
-      pageObjects,
-    }) => {
-      // Login as user with limited privileges
-      await browserAuth.loginAsViewer();
-      await pageObjects.streams.gotoProcessingTab('logs-generic-default');
-
-      // Create buttons should be hidden for users without edit privileges
-      const createProcessorButton = page.getByTestId(
-        'streamsAppStreamDetailEnrichmentCreateProcessorButton'
-      );
-      await expect(createProcessorButton).toBeHidden();
     });
 
     test('should duplicate a processor', async ({ pageObjects }) => {


### PR DESCRIPTION
## Summary

This closes https://github.com/elastic/kibana/issues/254435 and unskips tests on `main`. Please read [this comment](https://github.com/elastic/kibana/issues/254435#issuecomment-4004080398) for context on this change. 

I've removed this test as it's actually [duplicated here](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/permissions_viewer.spec.ts#L43).




