### PR TITLE
Fix: prevent JSON logger scalar meta field explosion

### DIFF
--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { EcsVersion } from '@elastic/ecs';
+import { test as fcTest, fc } from '@fast-check/jest';
 import type { LogRecord } from '@kbn/logging';
 import { LogLevel } from '@kbn/logging';
 import { JsonLayout } from './json_layout';
@@ -559,41 +560,47 @@ test('format() correctly serializes meta.error after calling meta.toJSON() if me
   });
 });
 
-test.each([
-  ['Request timed out', 'Request timed out'],
-  [0, '0'],
-  [false, 'false'],
-  [['a', 'b'], 'a,b'],
-])('format() serializes non-object meta (%p) as error string', (meta, expectedError) => {
-  const layout = new JsonLayout();
+const nonObjectMetaArb = fc.oneof(
+  fc.string(),
+  fc.boolean(),
+  fc.integer(),
+  fc.float({ noNaN: false, noDefaultInfinity: true }),
+  fc.array(fc.string(), { maxLength: 20 })
+);
 
-  expect(
-    JSON.parse(
-      layout.format({
-        message: 'foo',
-        timestamp,
-        level: LogLevel.Debug,
-        context: 'bar',
+fcTest.prop([nonObjectMetaArb])(
+  'format() serializes non-object meta as plain string in error',
+  (meta) => {
+    const layout = new JsonLayout();
+
+    expect(
+      JSON.parse(
+        layout.format({
+          message: 'foo',
+          timestamp,
+          level: LogLevel.Debug,
+          context: 'bar',
+          pid: 3,
+          // @ts-expect-error validating defensive runtime behavior
+          meta,
+        })
+      )
+    ).toStrictEqual({
+      ecs: { version: expect.any(String) },
+      '@timestamp': '2012-02-01T09:30:22.011-05:00',
+      message: 'foo',
+      log: {
+        level: 'DEBUG',
+        logger: 'bar',
+      },
+      error: String(meta),
+      process: {
         pid: 3,
-        // @ts-expect-error validating defensive runtime behavior
-        meta,
-      })
-    )
-  ).toStrictEqual({
-    ecs: { version: expect.any(String) },
-    '@timestamp': '2012-02-01T09:30:22.011-05:00',
-    message: 'foo',
-    log: {
-      level: 'DEBUG',
-      logger: 'bar',
-    },
-    error: expectedError,
-    process: {
-      pid: 3,
-      uptime: 10,
-    },
-  });
-});
+        uptime: 10,
+      },
+    });
+  }
+);
 
 test('format() does not add error when meta is null', () => {
   const layout = new JsonLayout();
@@ -625,13 +632,18 @@ test('format() does not add error when meta is null', () => {
   });
 });
 
-test.each([
-  ['Request timed out', 'Request timed out'],
-  [null, 'null'],
-  [['x'], 'x'],
-])(
-  'format() serializes non-object meta.toJSON() output (%p) as error string',
-  (toJsonValue, expectedError) => {
+const nonObjectToJsonReturnArb = fc.oneof(
+  fc.string(),
+  fc.boolean(),
+  fc.integer(),
+  fc.constant(null),
+  fc.constant(undefined),
+  fc.array(fc.string(), { maxLength: 20 })
+);
+
+fcTest.prop([nonObjectToJsonReturnArb])(
+  'format() serializes non-object meta.toJSON() output as string in error',
+  (toJsonValue) => {
     const layout = new JsonLayout();
 
     expect(
@@ -658,7 +670,7 @@ test.each([
         level: 'DEBUG',
         logger: 'bar',
       },
-      error: expectedError,
+      error: String(toJsonValue),
       process: {
         pid: 3,
         uptime: 10,

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
@@ -558,3 +558,153 @@ test('format() correctly serializes meta.error after calling meta.toJSON() if me
     },
   });
 });
+
+test.each([
+  ['Request timed out', 'Request timed out'],
+  [0, '0'],
+  [false, 'false'],
+  [['a', 'b'], 'a,b'],
+])('format() serializes non-object meta (%p) as error string', (meta, expectedError) => {
+  const layout = new JsonLayout();
+
+  expect(
+    JSON.parse(
+      layout.format({
+        message: 'foo',
+        timestamp,
+        level: LogLevel.Debug,
+        context: 'bar',
+        pid: 3,
+        // @ts-expect-error validating defensive runtime behavior
+        meta,
+      })
+    )
+  ).toStrictEqual({
+    ecs: { version: expect.any(String) },
+    '@timestamp': '2012-02-01T09:30:22.011-05:00',
+    message: 'foo',
+    log: {
+      level: 'DEBUG',
+      logger: 'bar',
+    },
+    error: expectedError,
+    process: {
+      pid: 3,
+      uptime: 10,
+    },
+  });
+});
+
+test('format() does not add error when meta is null', () => {
+  const layout = new JsonLayout();
+
+  expect(
+    JSON.parse(
+      layout.format({
+        message: 'foo',
+        timestamp,
+        level: LogLevel.Debug,
+        context: 'bar',
+        pid: 3,
+        // @ts-expect-error validating defensive runtime behavior
+        meta: null,
+      })
+    )
+  ).toStrictEqual({
+    ecs: { version: expect.any(String) },
+    '@timestamp': '2012-02-01T09:30:22.011-05:00',
+    message: 'foo',
+    log: {
+      level: 'DEBUG',
+      logger: 'bar',
+    },
+    process: {
+      pid: 3,
+      uptime: 10,
+    },
+  });
+});
+
+test.each([
+  ['Request timed out', 'Request timed out'],
+  [null, 'null'],
+  [['x'], 'x'],
+])(
+  'format() serializes non-object meta.toJSON() output (%p) as error string',
+  (toJsonValue, expectedError) => {
+    const layout = new JsonLayout();
+
+    expect(
+      JSON.parse(
+        layout.format({
+          message: 'foo',
+          timestamp,
+          level: LogLevel.Debug,
+          context: 'bar',
+          pid: 3,
+          meta: {
+            // @ts-expect-error validating defensive runtime behavior
+            toJSON() {
+              return toJsonValue;
+            },
+          },
+        })
+      )
+    ).toStrictEqual({
+      ecs: { version: expect.any(String) },
+      '@timestamp': '2012-02-01T09:30:22.011-05:00',
+      message: 'foo',
+      log: {
+        level: 'DEBUG',
+        logger: 'bar',
+      },
+      error: expectedError,
+      process: {
+        pid: 3,
+        uptime: 10,
+      },
+    });
+  }
+);
+
+test('format() serializes Error from meta.toJSON()', () => {
+  const layout = new JsonLayout();
+  const metaError = new Error('boom');
+  metaError.name = 'BoomError';
+  metaError.stack = 'BoomStack';
+
+  expect(
+    JSON.parse(
+      layout.format({
+        message: 'foo',
+        timestamp,
+        level: LogLevel.Debug,
+        context: 'bar',
+        pid: 3,
+        meta: {
+          // @ts-expect-error validating defensive runtime behavior
+          toJSON() {
+            return { error: metaError };
+          },
+        },
+      })
+    )
+  ).toStrictEqual({
+    ecs: { version: expect.any(String) },
+    '@timestamp': '2012-02-01T09:30:22.011-05:00',
+    message: 'foo',
+    log: {
+      level: 'DEBUG',
+      logger: 'bar',
+    },
+    error: {
+      message: metaError.message,
+      type: metaError.name,
+      stack_trace: metaError.stack,
+    },
+    process: {
+      pid: 3,
+      uptime: 10,
+    },
+  });
+});

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
@@ -27,18 +27,6 @@ const jsonLayoutSchema = object({
 export class JsonLayout implements Layout {
   public static configSchema = jsonLayoutSchema;
 
-  private static errorToSerializableObject(error: Error | undefined) {
-    if (error === undefined) {
-      return error;
-    }
-
-    return {
-      message: error.message,
-      type: error.name,
-      stack_trace: error.stack,
-    };
-  }
-
   public format(record: LogRecord): string {
     const spanId = record.meta?.span?.id ?? record.spanId;
     const traceId = record.meta?.trace?.id ?? record.traceId;
@@ -48,7 +36,7 @@ export class JsonLayout implements Layout {
       ecs: { version: EcsVersion },
       '@timestamp': moment(record.timestamp).format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
       message: record.message,
-      error: JsonLayout.errorToSerializableObject(record.error),
+      error: errorToSerializableObject(record.error),
       log: {
         level: record.level.id.toUpperCase(),
         logger: record.context,
@@ -63,15 +51,47 @@ export class JsonLayout implements Layout {
     };
 
     let output = log;
-    if (record.meta) {
-      // @ts-expect-error toJSON not defined on `LogMeta`, but some structured meta can have it defined
-      const serializedMeta = record.meta.toJSON ? record.meta.toJSON() : { ...record.meta };
+    if (record.meta != null) {
+      const serializedMeta = metaToSerializableObject(record.meta);
       if (serializedMeta.error instanceof Error) {
-        serializedMeta.error = JsonLayout.errorToSerializableObject(serializedMeta.error);
+        serializedMeta.error = errorToSerializableObject(serializedMeta.error);
       }
       output = merge(serializedMeta, log);
     }
 
     return JSON.stringify(output);
   }
+}
+
+/** Assumes non-nullish meta */
+function metaToSerializableObject(meta: unknown): Record<string, unknown> {
+  if (Array.isArray(meta) || typeof meta !== 'object') {
+    return { error: String(meta) };
+  }
+
+  const metaObject = meta as { toJSON?: () => unknown };
+  const serializedMeta =
+    typeof metaObject.toJSON === 'function' ? metaObject.toJSON() : { ...metaObject };
+
+  if (
+    serializedMeta == null ||
+    typeof serializedMeta !== 'object' ||
+    Array.isArray(serializedMeta)
+  ) {
+    return { error: String(serializedMeta) };
+  }
+
+  return serializedMeta as Record<string, unknown>;
+}
+
+function errorToSerializableObject(error: Error | undefined) {
+  if (error === undefined) {
+    return error;
+  }
+
+  return {
+    message: error.message,
+    type: error.name,
+    stack_trace: error.stack,
+  };
 }

--- a/x-pack/platform/plugins/shared/cases/server/tasks/incremental_id/incremental_id_task_manager.ts
+++ b/x-pack/platform/plugins/shared/cases/server/tasks/incremental_id/incremental_id_task_manager.ts
@@ -158,10 +158,11 @@ export class IncrementalIdTaskManager {
             `${CASES_INCREMENTAL_ID_SYNC_TASK_ID} scheduled with interval ${taskInstance.schedule?.interval}`
           );
         },
-        (e) => {
+        (e: unknown) => {
           this.logger.error(
-            `Error scheduling task: ${CASES_INCREMENTAL_ID_SYNC_TASK_ID}: ${e}`,
-            e?.message ?? e
+            `Error scheduling task: ${CASES_INCREMENTAL_ID_SYNC_TASK_ID}: ${
+              e instanceof Error ? e.message : String(e)
+            }`
           );
         }
       );


### PR DESCRIPTION
## Summary

Error metadata can sometimes include include numbered string keys, this is due to instances like:

```ts
this.logger.error(
  `Error scheduling task: ${CASES_INCREMENTAL_ID_SYNC_TASK_ID}: ${e}`,
  e?.message ?? e
);
```

...the result is that JSON layout logs ingested into monitoring overview clusters can sometimes contain many many keyword fields like `0...999`. Example:

```
> { ...'string' }
{ '0': 's', '1': 't', '2': 'r', '3': 'i', '4': 'n', '5': 'g' }
```

## Implementation

- Prevent `JsonLayout` from spreading scalar/array `meta` values into unintended fields by coercing non-object meta to `{ error: String(meta) }`.
- Fix one callsite in the Cases incremental ID task to avoid passing a string as logger meta.
- Add unit coverage for scalar meta, array meta, null handling, `toJSON` primitive outputs, and `Error` serialization.

### Checklist
- [x] Unit or functional tests were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the guidelines
- [x] Review the backport guidelines and apply applicable `backport:*` labels.

### Identify risks
- Low risk: change is isolated to JSON log serialization and one callsite.
- Mitigation: dedicated unit tests in `json_layout.test.ts` covering new coercion behavior and existing `Error` handling.

## Validation
- `yarn test:jest src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts`
- `node scripts/check_changes.ts`

## Release notes

We fixed an issue where the Kibana JSON logger could print a JSON object with a large number of numbered keys like `{ "1": "s", "2": "t", ... }`.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->