### PR TITLE
[Scout] Document feature flags and custom servers configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2012,8 +2012,10 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /.ci/.storybook @elastic/kibana-operations
 /src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations @elastic/observability-ui
 
-# QA - Appex QA
+# QA - AppEx QA
 .buildkite/scout_ci_config.yml @elastic/appex-qa
+/docs/extend/scout.md @elastic/appex-qa
+/docs/extend/scout/** @elastic/appex-qa
 /x-pack/platform/test/index.d.ts @elastic/appex-qa
 /src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/es/roles.yml @elastic/appex-qa
 /src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/oblt/roles.yml @elastic/appex-qa

--- a/docs/extend/scout.md
+++ b/docs/extend/scout.md
@@ -86,4 +86,4 @@ Not directly—use Scout [fixtures](./scout/fixtures.md) instead.
 
 #### Q: Does Scout support feature flags? [scout-faq-feature-flags]
 
-Yes. See [Feature flags](./scout/feature-flags.md) for details on enabling flags at runtime with `apiServices.core.settings()` or via custom server configurations.
+Yes. See [Feature flags](./scout/feature-flags.md) for details on enabling flags at runtime with `apiServices.core.settings()` or using custom server configurations.

--- a/docs/extend/scout.md
+++ b/docs/extend/scout.md
@@ -86,4 +86,4 @@ Not directly—use Scout [fixtures](./scout/fixtures.md) instead.
 
 #### Q: Does Scout support feature flags? [scout-faq-feature-flags]
 
-If your feature is behind a feature flag, you can use the `coreApi` [fixture](https://github.com/elastic/kibana/blob/e4f12d39154fe286ce92217e00a7d8bd758ee02d/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/core/index.ts#L17-L30) to enable it during test execution (recommended). Alternatively, you can create a [custom config directory](https://github.com/elastic/kibana/pull/244306) and link your Scout tests (reach out for more info).
+Yes. See [Feature flags](./scout/feature-flags.md) for details on enabling flags at runtime with `apiServices.core.settings()` or via custom server configurations.

--- a/docs/extend/scout/core-concepts.md
+++ b/docs/extend/scout/core-concepts.md
@@ -13,3 +13,4 @@ These pages explain Scout’s building blocks and how they fit together:
 - [Global setup hook](./global-setup-hook.md)
 - [Deployment tags](./deployment-tags.md)
 - [Skip tests](./skip-tests.md)
+- [Feature flags](./feature-flags.md)

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -6,7 +6,7 @@ navigation_title: Feature flags
 
 Some Kibana features are gated behind feature flags or experimental configuration. Scout provides two ways to enable them: **at runtime** via feature flags (without restarting the server) and **at server startup** (via custom server configurations).
 
-## When to use runtime vs server-level flags [scout-feature-flags-when-to-use]
+## When to use runtime versus server-level flags [scout-feature-flags-when-to-use]
 
 - **Runtime** (`apiServices.core.settings()`): **preferred** for most feature flags. No server restart, flags can be toggled per suite, and your tests keep sharing the default servers with other suites in CI.
 - **Server startup** (custom config `serverArgs`): only when the setting must be present at boot time or is not supported by the runtime settings API.

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -13,7 +13,7 @@ Some Kibana features are gated behind feature flags or experimental configuratio
 
 ## Enabling feature flags at runtime [scout-feature-flags-runtime]
 
-Use `apiServices.core.settings()` to toggle feature flags while the server is running. Changes take effect immediately: no restart is needed.
+Use `apiServices.core.settings()` to toggle feature flags while the server is running. This calls Kibana's internal [config overrides API](https://docs.elastic.dev/kibana-dev-docs/tutorials/feature-flags-service#config-overrides) (Elasticians only). Changes take effect immediately (no restart needed).
 
 ::::::{note}
 Feature flag overrides are **server-wide**: they apply to the entire Kibana instance, not to a single space or worker. In [parallel suites](./parallelism.md) all workers share the same server, so a flag set by one worker is visible to every other worker. For parallel tests, enable flags in the **[global setup hook](./global-setup-hook.md)** so they are set once before any worker starts.

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -66,7 +66,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
 
 When using `feature_flags.overrides`, the keys must match the feature flag IDs registered by the owning plugin in Kibana core.
 
-## Custom server configurations [scout-feature-flags-custom-servers]
+## Custom server configs (reach out to AppEx QA first) [scout-feature-flags-custom-servers]
 
 Some settings cannot be changed at runtime and must be present when Kibana starts. For these cases Scout supports **custom server configuration sets**.
 

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -110,7 +110,7 @@ export const servers: ScoutServerConfig = {
 };
 ```
 
-Start the server with the custom config:
+[Start the server](./run-tests.md#scout-run-tests-server-config-set) with the custom config:
 
 ```bash
 node scripts/scout.js start-server --arch serverless --domain security_complete --serverConfigSet uiam_local

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -4,16 +4,24 @@ navigation_title: Feature flags
 
 # Feature flags [scout-feature-flags]
 
-Some Kibana features are gated behind feature flags or experimental configuration. Scout provides two ways to enable them: **at runtime** via feature flags (without restarting the server) and **at server startup** (via custom server configurations).
+Some Kibana features are gated behind feature flags or experimental configuration. Scout provides two ways to enable them: **at runtime** via feature flags (without restarting the server) and **at server startup** (via custom server configurations). The table below compares the two approaches.
 
 ## When to use runtime versus server-level flags [scout-feature-flags-when-to-use]
 
-- **Runtime** (`apiServices.core.settings()`): **preferred** for most feature flags. No server restart, flags can be toggled per suite, and your tests keep sharing the default servers with other suites in CI.
-- **Test servers startup** (custom config `serverArgs`): only when the setting must be present at boot time or is not supported by the runtime settings API. Reach out to the AppEx QA team first (see below).
+|  | Runtime flags | Custom server configs |
+|---|---|---|
+| **API** | `apiServices.core.settings()` | `ScoutServerConfig` config set |
+| **Restart required** | No — applied while running | Yes — must be present at boot |
+| **Elastic Cloud (QA)** | Supported | Not supported — local only |
+| **CI cost** | Low — shares default servers | Higher — dedicated server instance |
+| **Toggle per suite** | Yes | No — fixed at server start |
+| **When to use** | **Preferred** for most flags | Settings required at boot (e.g., route registration) |
+
+For custom server configs, reach out to the AppEx QA team before creating one (see [below](#scout-feature-flags-custom-servers)).
 
 ## Enabling feature flags at runtime [scout-feature-flags-runtime]
 
-Use `apiServices.core.settings()` to toggle feature flags while the server is running. This calls Kibana's internal [config overrides API](https://docs.elastic.dev/kibana-dev-docs/tutorials/feature-flags-service#config-overrides) (Elasticians only). Changes take effect immediately (no restart needed).
+Use `apiServices.core.settings()` to toggle feature flags while the server is running. Under the hood, this calls Kibana's [config overrides API](https://docs.elastic.dev/kibana-dev-docs/tutorials/feature-flags-service#config-overrides) (Elasticians only), which forces flag values directly — bypassing the feature flag provider — so the same test code works locally and on Elastic Cloud (QA).
 
 ::::::{note}
 Feature flag overrides are **server-wide**: they apply to the entire Kibana instance, not to a single space or worker. In [parallel suites](./parallelism.md) all workers share the same server, so a flag set by one worker is visible to every other worker. For parallel tests, enable flags in the **[global setup hook](./global-setup-hook.md)** so they are set once before any worker starts.
@@ -64,19 +72,19 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
 });
 ```
 
-When using `feature_flags.overrides`, the keys must match the feature flag IDs registered by the owning plugin in Kibana core.
+When using `feature_flags.overrides`, the keys must match the feature flag IDs registered by the owning plugin. Overrides bypass variation and type validation, so ensure the values match what the consuming code expects.
 
 ## Custom server configs (reach out to AppEx QA first) [scout-feature-flags-custom-servers]
 
-Some settings cannot be changed at runtime and must be present when Kibana starts. For these cases Scout supports **custom server configuration sets**.
+Some settings — such as those used during the plugin `setup` lifecycle (e.g., HTTP route registration) — cannot be changed at runtime and must be present when Kibana starts. For these cases Scout supports **custom server configuration sets** that manage a local Kibana process.
 
 ::::::{warning}
-⚠️ Each custom config set requires its own dedicated server instance, which adds CI cost. **Reach out to the AppEx QA team before creating one** to make sure it is the right approach for your use case.
+⚠️ Each custom config set requires its own dedicated local server instance, which adds CI cost. **Reach out to the AppEx QA team before creating one** to make sure it is the right approach for your use case. If the flag you need can be toggled at runtime, prefer the [runtime approach](#scout-feature-flags-runtime) instead — it works everywhere, including Cloud.
 ::::::
 
 ### How custom configs work [scout-feature-flags-custom-configs-how]
 
-By default, Scout starts servers using the `default` configuration set. Custom configs live under:
+By default, Scout starts a local server using the `default` configuration set. Custom configs live under:
 
 ```text
 src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/<name>/
@@ -87,7 +95,7 @@ Inside that directory, create one config file per architecture + domain combinat
 Scout detects a custom config in two ways:
 
 1. **Path convention**: name your test directory `test/scout_<name>/` instead of `test/scout/` and Scout automatically maps it to the `<name>` config set.
-2. **Explicit flag**: pass `--serverConfigSet <name>` when starting the server.
+2. **Explicit flag**: pass `--serverConfigSet <name>` when starting the local server.
 
 ### Example [scout-feature-flags-custom-config-example]
 
@@ -112,7 +120,7 @@ export const servers: ScoutServerConfig = {
 };
 ```
 
-[Start the server](./run-tests.md#scout-run-tests-server-config-set) with the custom config:
+[Start the local server](./run-tests.md#scout-run-tests-server-config-set) with the custom config:
 
 ```bash
 node scripts/scout.js start-server --arch serverless --domain security_complete --serverConfigSet uiam_local

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -1,0 +1,115 @@
+---
+navigation_title: Feature flags
+---
+
+# Feature flags [scout-feature-flags]
+
+Some Kibana features are gated behind feature flags or experimental configuration. Scout provides two ways to enable them: **at runtime** via feature flags (without restarting the server) and **at server startup** (via custom server configurations).
+
+## When to use runtime vs server-level flags [scout-feature-flags-when-to-use]
+
+- **Runtime** (`apiServices.core.settings()`): **preferred** for most feature flags. No server restart, flags can be toggled per suite, and your tests keep sharing the default servers with other suites in CI.
+- **Server startup** (custom config `serverArgs`): only when the setting must be present at boot time or is not supported by the runtime settings API.
+
+## Enabling feature flags at runtime [scout-feature-flags-runtime]
+
+Use `apiServices.core.settings()` to toggle feature flags while the server is running. Changes take effect immediately: no restart is needed.
+
+::::::{note}
+Feature flag overrides are **server-wide**: they apply to the entire Kibana instance, not to a single space or worker. In [parallel suites](./parallelism.md) all workers share the same server, so a flag set by one worker is visible to every other worker. For parallel tests, enable flags in the **[global setup hook](./global-setup-hook.md)** so they are set once before any worker starts.
+::::::
+
+### In a global setup hook (recommended for parallel suites) [scout-feature-flags-global-setup]
+
+Enable the flag once in `global.setup.ts` before any worker starts:
+
+```ts
+import { globalSetupHook } from '@kbn/scout';
+
+globalSetupHook('Enable feature flags', async ({ apiServices, log }) => {
+  log.info('[setup] Enabling my-feature-flag...');
+  await apiServices.core.settings({
+    'feature_flags.overrides': {
+      'my-plugin.my-feature-flag': 'true',
+    },
+  });
+});
+```
+
+### In a test suite (sequential tests) [scout-feature-flags-test-suite]
+
+For sequential suites you can enable flags in `beforeAll` and reset them in `afterAll`:
+
+```ts
+import { tags } from '@kbn/scout';
+import { test } from '../fixtures';
+
+test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
+  test.beforeAll(async ({ apiServices }) => {
+    await apiServices.core.settings({
+      'xpack.fleet.experimentalFeatures': { newBrowseIntegrationUx: true },
+    });
+  });
+
+  test.afterAll(async ({ apiServices }) => {
+    await apiServices.core.settings({
+      'xpack.fleet.experimentalFeatures': { newBrowseIntegrationUx: false },
+    });
+  });
+
+  test('loads the page', async ({ pageObjects, browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+    // ...
+  });
+});
+```
+
+When using `feature_flags.overrides`, the keys must match the feature flag IDs registered by the owning plugin in Kibana core.
+
+## Custom server configurations [scout-feature-flags-custom-servers]
+
+Some settings cannot be changed at runtime and must be present when Kibana starts. For these cases Scout supports **custom server configuration sets**.
+
+::::::{warning}
+Each custom config set requires its own dedicated server instance, which adds CI cost. **Reach out to the AppEx QA team before creating one** to make sure it is the right approach for your use case.
+::::::
+
+### How custom configs work [scout-feature-flags-custom-configs-how]
+
+By default, Scout starts servers using the `default` configuration set. Custom configs live under:
+
+```text
+src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/<name>/
+```
+
+Scout detects a custom config in two ways:
+
+1. **Path convention**: name your test directory `test/scout_<name>/` instead of `test/scout/` and Scout automatically maps it to the `<name>` config set.
+2. **Explicit flag**: pass `--serverConfigSet <name>` when starting the server.
+
+### Example [scout-feature-flags-custom-config-example]
+
+The `evals_entity_analytics` config set adds feature flags and UI settings overrides as server arguments:
+
+```ts
+import { servers as evalsTracingConfig } from '../../evals_tracing/stateful/classic.stateful.config';
+import type { ScoutServerConfig } from '../../../../../types';
+
+export const servers: ScoutServerConfig = {
+  ...evalsTracingConfig,
+  kbnTestServer: {
+    ...evalsTracingConfig.kbnTestServer,
+    serverArgs: [
+      ...evalsTracingConfig.kbnTestServer.serverArgs,
+      '--feature_flags.overrides.aiAssistant.aiAgents.enabled=true',
+      '--uiSettings.overrides.agentBuilder:experimentalFeatures=true',
+    ],
+  },
+};
+```
+
+Start the server with the custom config:
+
+```bash
+node scripts/scout.js start-server --arch stateful --domain classic --serverConfigSet evals_entity_analytics
+```

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -9,7 +9,7 @@ Some Kibana features are gated behind feature flags or experimental configuratio
 ## When to use runtime versus server-level flags [scout-feature-flags-when-to-use]
 
 - **Runtime** (`apiServices.core.settings()`): **preferred** for most feature flags. No server restart, flags can be toggled per suite, and your tests keep sharing the default servers with other suites in CI.
-- **Server startup** (custom config `serverArgs`): only when the setting must be present at boot time or is not supported by the runtime settings API.
+- **Test servers startup** (custom config `serverArgs`): only when the setting must be present at boot time or is not supported by the runtime settings API. Reach out to the AppEx QA team first (see below).
 
 ## Enabling feature flags at runtime [scout-feature-flags-runtime]
 

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -89,20 +89,22 @@ Scout detects a custom config in two ways:
 
 ### Example [scout-feature-flags-custom-config-example]
 
-The `evals_entity_analytics` config set adds feature flags and UI settings overrides as server arguments:
+The `uiam_local` config set extends the default serverless config to enable UIAM authentication with a mock IdP:
 
 ```ts
-import { servers as evalsTracingConfig } from '../../evals_tracing/stateful/classic.stateful.config';
+import { servers as defaultConfig } from '../../default/serverless/security_complete.serverless.config';
 import type { ScoutServerConfig } from '../../../../../types';
 
 export const servers: ScoutServerConfig = {
-  ...evalsTracingConfig,
+  ...defaultConfig,
+  esServerlessOptions: { uiam: true },
   kbnTestServer: {
-    ...evalsTracingConfig.kbnTestServer,
+    ...defaultConfig.kbnTestServer,
     serverArgs: [
-      ...evalsTracingConfig.kbnTestServer.serverArgs,
-      '--feature_flags.overrides.aiAssistant.aiAgents.enabled=true',
-      '--uiSettings.overrides.agentBuilder:experimentalFeatures=true',
+      ...defaultConfig.kbnTestServer.serverArgs,
+      '--xpack.security.uiam.enabled=true',
+      '--xpack.security.uiam.url=<mock-idp-url>',
+      // ... additional UIAM-specific args
     ],
   },
 };
@@ -111,5 +113,5 @@ export const servers: ScoutServerConfig = {
 Start the server with the custom config:
 
 ```bash
-node scripts/scout.js start-server --arch stateful --domain classic --serverConfigSet evals_entity_analytics
+node scripts/scout.js start-server --arch serverless --domain security_complete --serverConfigSet uiam_local
 ```

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -71,7 +71,7 @@ When using `feature_flags.overrides`, the keys must match the feature flag IDs r
 Some settings cannot be changed at runtime and must be present when Kibana starts. For these cases Scout supports **custom server configuration sets**.
 
 ::::::{warning}
-Each custom config set requires its own dedicated server instance, which adds CI cost. **Reach out to the AppEx QA team before creating one** to make sure it is the right approach for your use case.
+⚠️ Each custom config set requires its own dedicated server instance, which adds CI cost. **Reach out to the AppEx QA team before creating one** to make sure it is the right approach for your use case.
 ::::::
 
 ### How custom configs work [scout-feature-flags-custom-configs-how]
@@ -81,6 +81,8 @@ By default, Scout starts servers using the `default` configuration set. Custom c
 ```text
 src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/<name>/
 ```
+
+Inside that directory, create one config file per architecture + domain combination your tests target. Files follow the naming convention `<domain>.<arch>.config.ts` and must export `servers: ScoutServerConfig`.
 
 Scout detects a custom config in two ways:
 

--- a/docs/extend/scout/run-tests.md
+++ b/docs/extend/scout/run-tests.md
@@ -79,6 +79,31 @@ node scripts/scout.js run-tests \
 All `--testFiles` paths must fall under the same Scout root (for example, `scout/ui/tests` vs `scout/ui/parallel_tests`) so Scout can discover the right config.
 :::::::
 
+### Custom server configuration [scout-run-tests-server-config-set]
+
+By default, Scout starts Kibana and Elasticsearch using the built-in `default` configuration set. This works for most tests and requires no extra flags. Because all suites that use the default config share the same servers, they can be grouped together in CI, saving both time and resources.
+
+If your tests need specific server-level settings that must be present at boot time (for example, feature flags that cannot be toggled at runtime), you can point Scout at a **custom configuration set** with `--serverConfigSet`. Each custom config set requires its own dedicated server instance, so prefer [runtime feature flags](./feature-flags.md#scout-feature-flags-runtime) whenever possible.
+
+```bash
+node scripts/scout.js start-server \
+  --arch stateful \
+  --domain classic \
+  --serverConfigSet evals_entity_analytics
+```
+
+Or with `run-tests`:
+
+```bash
+node scripts/scout.js run-tests \
+  --arch stateful \
+  --domain classic \
+  --serverConfigSet evals_entity_analytics \
+  --config <plugin-path>/test/scout/ui/playwright.config.ts
+```
+
+See [Feature flags](./feature-flags.md#scout-feature-flags-custom-servers) for more details on when and how to use custom server configurations.
+
 ## Run tests on Elastic Cloud [scout-run-tests-cloud]
 
 Follow these steps to run your Scout tests on a real ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg 'Supported on Elastic Cloud Hosted') **Elastic Cloud project or deployment**.

--- a/docs/extend/toc.yml
+++ b/docs/extend/toc.yml
@@ -70,6 +70,7 @@ toc:
           - file: scout/global-setup-hook.md
           - file: scout/deployment-tags.md
           - file: scout/skip-tests.md
+          - file: scout/feature-flags.md
       - file: scout/ui-testing.md
         children:
           - file: scout/write-ui-tests.md


### PR DESCRIPTION
This PR updates our existing Scout docs to add a new Feature Flags article under Core Concepts, covering:

- Enabling feature flags at runtime with `apiServices.core.settings()`
- Custom server configurations and when they're needed

This PR also updates the Run Tests page with a `--serverConfigSet` section.