### PR TITLE
[9.3] [Search] Remove license check from inference endpoints in semantic text field (#255781)

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -24,12 +24,6 @@ const createMockLocator = () => ({
   useUrl: jest.fn().mockReturnValue('https://redirect.me/to/inference_endpoints'),
 });
 
-const mockIsAtLeast = jest.fn((level: string) => {
-  // Default: enterprise license, so all levels return true
-  // Individual tests can override this mock implementation
-  return true;
-});
-
 jest.mock('../../../public/application/app_context', () => ({
   ...jest.requireActual('../../../public/application/app_context'),
   useAppContext: jest.fn(() => ({
@@ -136,13 +130,6 @@ const DEFAULT_ENDPOINTS: InferenceAPIConfigResponse[] = [
   { inference_id: 'endpoint-2', task_type: 'sparse_embedding' },
 ] as InferenceAPIConfigResponse[];
 
-jest.mock('../../../public/hooks/use_license', () => ({
-  useLicense: jest.fn(() => ({
-    isLoading: false,
-    isAtLeast: mockIsAtLeast,
-  })),
-}));
-
 function TestFormWrapper({
   children,
   initialValue = '.preconfigured-elser',
@@ -234,8 +221,6 @@ beforeEach(() => {
     '../../../public/application/services/api'
   );
   useLoadInferenceEndpoints.mockReset();
-  // Reset to default: enterprise license (all levels return true)
-  mockIsAtLeast.mockImplementation(() => true);
 });
 
 afterEach(async () => {
@@ -570,7 +555,7 @@ describe('SelectInferenceId', () => {
     });
 
     describe('AND .elser-2-elastic is available', () => {
-      it('SHOULD prioritize .elser-2-elastic over other endpoints IF has enterprise license', async () => {
+      it('SHOULD prioritize .elser-2-elastic over other endpoints', async () => {
         setupMocks([
           { inference_id: '.elser-2-elastic', task_type: 'sparse_embedding' },
           { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
@@ -587,29 +572,6 @@ describe('SelectInferenceId', () => {
 
         const button = screen.getByTestId('inferenceIdButton');
         expect(button).toHaveTextContent('.elser-2-elastic');
-      });
-
-      it('SHOULD fall back to .preconfigured-elser instead of .elser-2-elastic IF has NO enterprise license', async () => {
-        // Mock license to return false for enterprise
-        mockIsAtLeast.mockImplementation((level: string) => level !== 'enterprise');
-
-        setupMocks([
-          { inference_id: '.elser-2-elastic', task_type: 'sparse_embedding' },
-          { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
-          { inference_id: 'endpoint-1', task_type: 'text_embedding' },
-        ] as InferenceAPIConfigResponse[]);
-
-        render(
-          <TestFormWrapper initialValue="">
-            <SelectInferenceId {...defaultProps} />
-          </TestFormWrapper>
-        );
-
-        await flushPendingTimers();
-
-        const button = await screen.findByTestId('inferenceIdButton');
-        expect(button).toHaveTextContent('.preconfigured-elser');
-        expect(button).not.toHaveTextContent('.elser-2-elastic');
       });
     });
   });

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -24,7 +24,6 @@ import {
   EuiLink,
   EuiLoadingSpinner,
   useEuiTheme,
-  EuiBadge,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { InferenceCostsTransparencyTour } from '@kbn/search-api-panels';
@@ -123,25 +122,6 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
           label: endpoint.inference_id,
           'data-test-subj': `custom-inference_${endpoint.inference_id}`,
           checked: value === endpoint.inference_id ? 'on' : undefined,
-          disabled: !endpoint.accessible,
-          append: !endpoint.accessible && endpoint.requiredLicense && (
-            <EuiBadge color="hollow" iconType="lock">
-              {endpoint.requiredLicense[0].toUpperCase() + endpoint.requiredLicense.slice(1)}
-            </EuiBadge>
-          ),
-          'aria-label':
-            !endpoint.accessible && endpoint.requiredLicense
-              ? i18n.translate(
-                  'xpack.idxMgmt.mappingsEditor.parameters.inferenceId.popover.selectable.disabledOption.ariaLabel',
-                  {
-                    defaultMessage: '{inferenceId} endpoint disabled - {license} license required',
-                    values: {
-                      inferenceId: endpoint.inference_id,
-                      license: endpoint.requiredLicense,
-                    },
-                  }
-                )
-              : undefined,
         };
       }) || [];
 

--- a/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
@@ -7,27 +7,14 @@
 
 import { useMemo } from 'react';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
-import type { LicenseType } from '@kbn/licensing-types';
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
-import { useLicense } from './use_license';
 
 const COMPATIBLE_TASK_TYPES = ['text_embedding', 'sparse_embedding'] as const;
 type CompatibleTaskType = (typeof COMPATIBLE_TASK_TYPES)[number];
 
-const LICENSE_TIER_ENTERPRISE = 'enterprise';
-const LICENSE_TIER_PLATINUM = 'platinum';
-const INFERENCE_ENDPOINT_LICENSE_MAP: Record<string, LicenseType> = {
-  [defaultInferenceEndpoints.ELSER]: LICENSE_TIER_PLATINUM,
-  [defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID]: LICENSE_TIER_ENTERPRISE,
-};
-
 interface EndpointDefinition {
   /** The inference id of the endpoint. */
   inference_id: string;
-  /** The license requirement for the endpoint. */
-  requiredLicense: string | undefined;
-  /** Whether the endpoint is accessible to the current license. Defaults to true if no license requirement is specified. */
-  accessible: boolean;
 }
 interface CompatibleEndpointsData {
   defaultInferenceId: string | undefined;
@@ -37,16 +24,14 @@ interface CompatibleEndpointsData {
 /**
  * Transforms the inference endpoints into a format that can be used to build the selectable options for the inference endpoint dropdown.
  *
- * Remains in loading state until the endpoints and license are loaded.
+ * Remains in loading state until the endpoints are loaded.
  */
 export const useCompatibleInferenceEndpoints = (
   endpoints: InferenceAPIConfigResponse[] | null | undefined,
   endpointsLoading: boolean
 ) => {
-  const { isLoading: licenseLoading, isAtLeast } = useLicense();
-
   const compatibleEndpoints = useMemo<CompatibleEndpointsData | undefined>(() => {
-    if (endpointsLoading || licenseLoading) {
+    if (endpointsLoading) {
       return;
     }
     let defaultInferenceId: string | undefined;
@@ -58,29 +43,23 @@ export const useCompatibleInferenceEndpoints = (
       }
       const isElserInEis =
         endpoint.inference_id === defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID;
-      const requiredLicense = INFERENCE_ENDPOINT_LICENSE_MAP[endpoint.inference_id];
-      // If no license requirement is specified, assume access is granted.
-      const accessible = requiredLicense ? isAtLeast(requiredLicense) : true;
-      if (accessible) {
-        if (isElserInEis) {
-          // Prioritize elser in eis endpoint as default.
-          defaultInferenceId = endpoint.inference_id;
-        } else if (!defaultInferenceId) {
-          // Otherwise use the first accessible endpoint as default.
-          defaultInferenceId = endpoint.inference_id;
-        }
+
+      if (isElserInEis) {
+        // Prioritize elser in eis endpoint as default.
+        defaultInferenceId = endpoint.inference_id;
+      } else if (!defaultInferenceId) {
+        // Otherwise use the first compatible endpoint as default.
+        defaultInferenceId = endpoint.inference_id;
       }
       endpointDefinitions.push({
         inference_id: endpoint.inference_id,
-        requiredLicense,
-        accessible,
       });
     });
     return {
       defaultInferenceId,
       endpointDefinitions,
     };
-  }, [endpointsLoading, licenseLoading, endpoints, isAtLeast]);
+  }, [endpointsLoading, endpoints]);
 
   return {
     compatibleEndpoints,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Search] Remove license check from inference endpoints in semantic text field (#255781)](https://github.com/elastic/kibana/pull/255781)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2026-03-04T14:25:28Z","message":"[Search] Remove license check from inference endpoints in semantic text field (#255781)\n\n## Summary\n\nThis PR removes the license check and gating from the inference endpoint\nselector when adding a semantic text field mapping. With the\nintroduction of the new EIS endpoints, this functionality is currently\nincomplete and cannot be finalised until there is further clarity around\nthe licensing of inference endpoints and semantic text.\n\n### Testing\n\nTo test this PR you will need to add a Platinum license to Kibana, and\n[run EIS\nlocally](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md).\n\n- [ ] Create an index\n- [ ] Go to the mapping tab on the index details page for the index you\ncreated\n- [ ] Click the `Add field` button\n- [ ] Select the `Semantic text` field type\n- [ ] Click on the inference endpoint select\n- [ ] Confirm that the `.elser-2-elastic` inference endpoint is not\ndisabled\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [ ] ~Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.~","sha":"8b9828dd8be525ae33fba65e27e2540e21903df7","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Search","v9.4.0"],"title":"[Search] Remove license check from inference endpoints in semantic text field","number":255781,"url":"https://github.com/elastic/kibana/pull/255781","mergeCommit":{"message":"[Search] Remove license check from inference endpoints in semantic text field (#255781)\n\n## Summary\n\nThis PR removes the license check and gating from the inference endpoint\nselector when adding a semantic text field mapping. With the\nintroduction of the new EIS endpoints, this functionality is currently\nincomplete and cannot be finalised until there is further clarity around\nthe licensing of inference endpoints and semantic text.\n\n### Testing\n\nTo test this PR you will need to add a Platinum license to Kibana, and\n[run EIS\nlocally](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md).\n\n- [ ] Create an index\n- [ ] Go to the mapping tab on the index details page for the index you\ncreated\n- [ ] Click the `Add field` button\n- [ ] Select the `Semantic text` field type\n- [ ] Click on the inference endpoint select\n- [ ] Confirm that the `.elser-2-elastic` inference endpoint is not\ndisabled\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [ ] ~Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.~","sha":"8b9828dd8be525ae33fba65e27e2540e21903df7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255781","number":255781,"mergeCommit":{"message":"[Search] Remove license check from inference endpoints in semantic text field (#255781)\n\n## Summary\n\nThis PR removes the license check and gating from the inference endpoint\nselector when adding a semantic text field mapping. With the\nintroduction of the new EIS endpoints, this functionality is currently\nincomplete and cannot be finalised until there is further clarity around\nthe licensing of inference endpoints and semantic text.\n\n### Testing\n\nTo test this PR you will need to add a Platinum license to Kibana, and\n[run EIS\nlocally](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md).\n\n- [ ] Create an index\n- [ ] Go to the mapping tab on the index details page for the index you\ncreated\n- [ ] Click the `Add field` button\n- [ ] Select the `Semantic text` field type\n- [ ] Click on the inference endpoint select\n- [ ] Confirm that the `.elser-2-elastic` inference endpoint is not\ndisabled\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [ ] ~Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.~","sha":"8b9828dd8be525ae33fba65e27e2540e21903df7"}}]}] BACKPORT-->