### PR TITLE
[8.19] [Security Solution] Add support for timestamp overrides to timeline (#251827)

### DIFF
--- a/x-pack/platform/plugins/shared/timelines/common/api/search_strategy/timeline/events_all.ts
+++ b/x-pack/platform/plugins/shared/timelines/common/api/search_strategy/timeline/events_all.ts
@@ -20,6 +20,7 @@ const sort = z.array(extendedSortItem);
 
 export const timelineEventsAllSchema = requestPaginated.extend({
   authFilter: z.object({}).optional(),
+  dateRangeField: z.string().optional(),
   excludeEcsData: z.boolean().optional(),
   fieldRequested: z.array(z.string()),
   sort,

--- a/x-pack/platform/plugins/shared/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.test.ts
+++ b/x-pack/platform/plugins/shared/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.test.ts
@@ -89,4 +89,46 @@ describe('buildTimelineEventsAllQuery', () => {
       }
     `);
   });
+
+  it('uses dateRangeField when provided for timerange, sort, and fields', () => {
+    const query = buildTimelineEventsAllQuery({
+      factoryQueryType: TimelineEventsQueries.all,
+      fields: [],
+      defaultIndex: ['.siem-signals-default'],
+      filterQuery: '',
+      language: 'kuery',
+      dateRangeField: 'event.ingested',
+      pagination: { activePage: 0, querySize: 100 },
+      runtimeMappings: {},
+      sort: [
+        {
+          direction: Direction.asc,
+          field: 'event.ingested',
+          type: 'datetime',
+          esTypes: ['date'],
+        },
+      ],
+      timerange: {
+        from: '2024-01-01T00:00:00.000Z',
+        interval: '5m',
+        to: '2024-01-02T00:00:00.000Z',
+      },
+    });
+    expect(query.body.query.bool.filter).toContainEqual({
+      range: {
+        'event.ingested': {
+          gte: '2024-01-01T00:00:00.000Z',
+          lte: '2024-01-02T00:00:00.000Z',
+          format: 'strict_date_optional_time',
+        },
+      },
+    });
+    expect(query.body.sort).toEqual([
+      { 'event.ingested': { order: 'asc', unmapped_type: 'date' } },
+    ]);
+    expect(query.body.fields).toContainEqual({
+      field: 'event.ingested',
+      format: 'strict_date_optional_time',
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.ts
+++ b/x-pack/platform/plugins/shared/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.ts
@@ -16,8 +16,11 @@ import { TimerangeFilter, TimerangeInput } from '../../../../../../common/search
 import { createQueryFilterClauses } from '../../../../../utils/build_query';
 import { getPreferredEsType } from './helpers';
 
+const DEFAULT_DATE_FIELD = '@timestamp';
+
 export const buildTimelineEventsAllQuery = ({
   authFilter,
+  dateRangeField,
   defaultIndex,
   fields,
   filterQuery,
@@ -27,6 +30,7 @@ export const buildTimelineEventsAllQuery = ({
   timerange,
 }: Omit<TimelineEventsAllOptions, 'fieldRequested'>) => {
   const { activePage, querySize } = pagination;
+  const dateField = dateRangeField ?? DEFAULT_DATE_FIELD;
   const filterClause = [...createQueryFilterClauses(filterQuery)];
   const getTimerangeFilter = (timerangeOption: TimerangeInput | undefined): TimerangeFilter[] => {
     if (timerangeOption) {
@@ -35,7 +39,7 @@ export const buildTimelineEventsAllQuery = ({
         ? [
             {
               range: {
-                '@timestamp': {
+                [dateField]: {
                   gte: from,
                   lte: to,
                   format: 'strict_date_optional_time',
@@ -87,7 +91,7 @@ export const buildTimelineEventsAllQuery = ({
         'kibana.alert.*',
         ...fields,
         {
-          field: '@timestamp',
+          field: dateField,
           format: 'strict_date_optional_time',
         },
       ],

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -148,6 +148,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
       skip: !canQueryTimeline(),
       startDate: start,
       timerangeKind,
+      dateRangeField: experimentalDataView?.getTimeField()?.name ?? '@timestamp',
     });
 
   const { onLoad: loadNotesOnEventsLoad } = useFetchNotes();

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -184,6 +184,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
       startDate: '',
       sort: timelineQuerySortField,
       timerangeKind: undefined,
+      dateRangeField: experimentalDataView?.getTimeField()?.name ?? '@timestamp',
     });
 
   const { onLoad: loadNotesOnEventsLoad } = useFetchNotes();

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
@@ -187,6 +187,7 @@ export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string
     sort: timelineQuerySortField,
     startDate: start,
     timerangeKind,
+    dateRangeField: experimentalDataView?.getTimeField()?.name ?? '@timestamp',
   });
 
   useEffect(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -233,6 +233,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
       sort: timelineQuerySortField,
       startDate: start,
       timerangeKind,
+      dateRangeField: experimentalDataView.getTimeField()?.name ?? '@timestamp',
     });
 
   const { onLoad: loadNotesOnEventsLoad } = useFetchNotes();

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/index.tsx
@@ -7,7 +7,7 @@
 
 import deepEqual from 'fast-deep-equal';
 import { isEmpty } from 'lodash/fp';
-import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Subscription } from 'rxjs';
 
@@ -29,8 +29,8 @@ import { detectionsTimelineIds } from './helpers';
 import { getInspectResponse } from '../../helpers';
 import type {
   PaginationInputPaginated,
-  TimelineEventsAllStrategyResponse,
   TimelineEdges,
+  TimelineEventsAllStrategyResponse,
   TimelineItem,
   TimelineRequestSortField,
 } from '../../../common/search_strategy';
@@ -106,6 +106,7 @@ export interface UseTimelineEventsProps {
   startDate?: string;
   timerangeKind?: 'absolute' | 'relative';
   fetchNotes?: boolean;
+  dateRangeField?: string;
 }
 
 const getTimelineEvents = (timelineEdges: TimelineEdges[]): TimelineItem[] =>
@@ -159,6 +160,7 @@ export const useTimelineEventsHandler = ({
   sort = initSortDefault,
   skip = false,
   timerangeKind,
+  dateRangeField,
 }: UseTimelineEventsProps): [DataLoadingState, TimelineArgs, TimelineEventsSearchHandler] => {
   const [{ pageName }] = useRouteSpy();
   const dispatch = useDispatch();
@@ -395,6 +397,7 @@ export const useTimelineEventsHandler = ({
           timerange: prevRequest?.timerange ?? {},
           runtimeMappings: (prevRequest?.runtimeMappings ?? {}) as unknown as RunTimeMappings,
           ...deStructureEqlOptions(prevEqlRequest),
+          ...(dateRangeField ? { dateRangeField } : {}),
         };
 
         const timerange =
@@ -408,6 +411,7 @@ export const useTimelineEventsHandler = ({
           runtimeMappings: runtimeMappings ?? {},
           ...timerange,
           ...deStructureEqlOptions(eqlOptions),
+          ...(dateRangeField ? { dateRangeField } : {}),
         };
 
         const areSearchParamsSame = deepEqual(prevSearchParameters, currentSearchParameters);
@@ -462,6 +466,7 @@ export const useTimelineEventsHandler = ({
           sort,
           ...timerange,
           ...(eqlOptions ? eqlOptions : {}),
+          ...(dateRangeField ? { dateRangeField } : {}),
         } as const;
 
         if (activeBatch !== newActiveBatch) {
@@ -490,6 +495,7 @@ export const useTimelineEventsHandler = ({
     sort,
     fields,
     runtimeMappings,
+    dateRangeField,
   ]);
 
   /*
@@ -543,6 +549,7 @@ export const useTimelineEvents = ({
   sort = initSortDefault,
   skip = false,
   timerangeKind,
+  dateRangeField,
 }: UseTimelineEventsProps): [DataLoadingState, TimelineArgs] => {
   const [eventsPerPage, setEventsPerPage] = useState<TimelineItem[][]>(defaultEvents);
   const [dataLoadingState, timelineResponse, timelineSearchHandler] = useTimelineEventsHandler({
@@ -560,6 +567,7 @@ export const useTimelineEvents = ({
     sort,
     skip,
     timerangeKind,
+    dateRangeField,
   });
 
   useEffect(() => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Add support for timestamp overrides to timeline (#251827)](https://github.com/elastic/kibana/pull/251827)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-04T05:58:23Z","message":"[Security Solution] Add support for timestamp overrides to timeline (#251827)\n\n## Summary\n\nRelated issue #251825\n\nAdds support for timeline timestamp overrides at a data view level, per\ntimeline support to come in a follow up PR.\n\nWhen a timestamp field is set on a data view, that field is passed to\nthe modified timeline search strategy, generating dsl that looks like:\n\n```\n  \"query\": {\n    \"bool\": {\n      \"filter\": [\n        {\n          \"bool\": {\n            \"must\": [],\n            \"filter\": [\n              {\n                \"bool\": {\n                  \"should\": [\n                    {\n                      \"match_phrase\": {\n                        \"_id\": \"510e0c8db73178deba018968c2bfde28a2cc24ec2e70cb72aa2f1c82895704f0\"\n                      }\n                    }\n                  ],\n                  \"minimum_should_match\": 1\n                }\n              }\n            ],\n            \"should\": [],\n            \"must_not\": []\n          }\n        },\n        {\n          \"range\": {\n            \"event.ingested\": {\n              \"gte\": \"2026-02-05T04:11:26.378Z\",\n              \"lte\": \"2026-02-05T04:13:26.378Z\",\n              \"format\": \"strict_date_optional_time\"\n            }\n          }\n        },\n        {\n          \"match_all\": {}\n        }\n     }  \n```\n\ninstead of the previously hard coded `@timestamp`. This is similar to\nhow discover works today, with this set at a data view level.\n\n### Checklist\n\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>","sha":"c6a011f08d05f7b1a9f267a1288379201f5329f8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:all-open","v9.4.0","v9.2.7","v9.3.2"],"title":"[Security Solution] Add support for timestamp overrides to timeline","number":251827,"url":"https://github.com/elastic/kibana/pull/251827","mergeCommit":{"message":"[Security Solution] Add support for timestamp overrides to timeline (#251827)\n\n## Summary\n\nRelated issue #251825\n\nAdds support for timeline timestamp overrides at a data view level, per\ntimeline support to come in a follow up PR.\n\nWhen a timestamp field is set on a data view, that field is passed to\nthe modified timeline search strategy, generating dsl that looks like:\n\n```\n  \"query\": {\n    \"bool\": {\n      \"filter\": [\n        {\n          \"bool\": {\n            \"must\": [],\n            \"filter\": [\n              {\n                \"bool\": {\n                  \"should\": [\n                    {\n                      \"match_phrase\": {\n                        \"_id\": \"510e0c8db73178deba018968c2bfde28a2cc24ec2e70cb72aa2f1c82895704f0\"\n                      }\n                    }\n                  ],\n                  \"minimum_should_match\": 1\n                }\n              }\n            ],\n            \"should\": [],\n            \"must_not\": []\n          }\n        },\n        {\n          \"range\": {\n            \"event.ingested\": {\n              \"gte\": \"2026-02-05T04:11:26.378Z\",\n              \"lte\": \"2026-02-05T04:13:26.378Z\",\n              \"format\": \"strict_date_optional_time\"\n            }\n          }\n        },\n        {\n          \"match_all\": {}\n        }\n     }  \n```\n\ninstead of the previously hard coded `@timestamp`. This is similar to\nhow discover works today, with this set at a data view level.\n\n### Checklist\n\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>","sha":"c6a011f08d05f7b1a9f267a1288379201f5329f8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251827","number":251827,"mergeCommit":{"message":"[Security Solution] Add support for timestamp overrides to timeline (#251827)\n\n## Summary\n\nRelated issue #251825\n\nAdds support for timeline timestamp overrides at a data view level, per\ntimeline support to come in a follow up PR.\n\nWhen a timestamp field is set on a data view, that field is passed to\nthe modified timeline search strategy, generating dsl that looks like:\n\n```\n  \"query\": {\n    \"bool\": {\n      \"filter\": [\n        {\n          \"bool\": {\n            \"must\": [],\n            \"filter\": [\n              {\n                \"bool\": {\n                  \"should\": [\n                    {\n                      \"match_phrase\": {\n                        \"_id\": \"510e0c8db73178deba018968c2bfde28a2cc24ec2e70cb72aa2f1c82895704f0\"\n                      }\n                    }\n                  ],\n                  \"minimum_should_match\": 1\n                }\n              }\n            ],\n            \"should\": [],\n            \"must_not\": []\n          }\n        },\n        {\n          \"range\": {\n            \"event.ingested\": {\n              \"gte\": \"2026-02-05T04:11:26.378Z\",\n              \"lte\": \"2026-02-05T04:13:26.378Z\",\n              \"format\": \"strict_date_optional_time\"\n            }\n          }\n        },\n        {\n          \"match_all\": {}\n        }\n     }  \n```\n\ninstead of the previously hard coded `@timestamp`. This is similar to\nhow discover works today, with this set at a data view level.\n\n### Checklist\n\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>","sha":"c6a011f08d05f7b1a9f267a1288379201f5329f8"}},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/255915","number":255915,"state":"MERGED","mergeCommit":{"sha":"21a10eb9f4bc85cd862de1fa3d54fc83e088dcdc","message":"[9.2] [Security Solution] Add support for timestamp overrides to timeline (#251827) (#255915)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution] Add support for timestamp overrides to timeline\n(#251827)](https://github.com/elastic/kibana/pull/251827)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Kevin Qualters <56408403+kqualters-elastic@users.noreply.github.com>\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/255916","number":255916,"state":"MERGED","mergeCommit":{"sha":"6acb210721dfe11c005a1995bd4a458e7df8cf8b","message":"[9.3] [Security Solution] Add support for timestamp overrides to timeline (#251827) (#255916)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution] Add support for timestamp overrides to timeline\n(#251827)](https://github.com/elastic/kibana/pull/251827)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Kevin Qualters <56408403+kqualters-elastic@users.noreply.github.com>\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}}]}] BACKPORT-->