### PR TITLE
Fix flaky payload timeout functional test (#242750)

### DIFF
--- a/src/platform/test/plugin_functional/test_suites/core/route.ts
+++ b/src/platform/test/plugin_functional/test_suites/core/route.ts
@@ -8,6 +8,8 @@
  */
 
 import expect from '@kbn/expect';
+import type { ClientRequest } from 'http';
+import type { Socket } from 'net';
 import type { Test } from 'supertest';
 import type { PluginFunctionalProviderContext } from '../../services';
 
@@ -16,23 +18,49 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
 
   describe('route', function () {
     describe('timeouts', function () {
+      // Sends `body` one character at a time with `interval` ms between each write.
+      //
+      // The first character is written immediately to initiate the TCP connection.
+      // Subsequent characters are sent via setInterval only after the socket is
+      // connected, preventing writes from being buffered during the TCP handshake
+      // and arriving at the server in a single burst rather than drip-fed.
       const writeBodyCharAtATime = (request: Test, body: string, interval: number) => {
         return new Promise((resolve, reject) => {
-          let i = 0;
-          const intervalId = setInterval(() => {
-            if (i < body.length) {
-              request.write(body[i++]);
-            } else {
-              clearInterval(intervalId);
-              void request.end((err, res) => {
-                resolve(res);
-              });
-            }
-          }, interval);
+          let charIdx = 0;
+          let intervalId: ReturnType<typeof setInterval> | undefined;
+
+          const startInterval = () => {
+            intervalId = setInterval(() => {
+              if (charIdx < body.length) {
+                void request.write(body[charIdx++]);
+              } else {
+                clearInterval(intervalId);
+                void request.end((err, res) => {
+                  resolve(res);
+                });
+              }
+            }, interval);
+          };
+
           void request.on('error', (err) => {
             clearInterval(intervalId);
             reject(err);
           });
+
+          void request.write(body[charIdx++]);
+
+          const underlyingReq = (request as unknown as { req?: ClientRequest }).req;
+          if (underlyingReq !== undefined) {
+            underlyingReq.once('socket', (socket: Socket) => {
+              if (socket.connecting) {
+                socket.once('connect', startInterval);
+              } else {
+                setImmediate(startInterval);
+              }
+            });
+          } else {
+            startInterval();
+          }
         });
       };
 
@@ -48,8 +76,8 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
           const result = writeBodyCharAtATime(request, '{"foo":"bar"}', 20);
 
           await result.then(
-            (res) => {
-              expect(res).to.be(undefined);
+            () => {
+              throw new Error('Expected payload timeout error but request succeeded');
             },
             (err) => {
               expect(err.message).to.be('Request Timeout');
@@ -72,7 +100,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
               expect(res).to.have.property('statusCode', 200);
             },
             (err) => {
-              expect(err).to.be(undefined);
+              throw err;
             }
           );
         });
@@ -90,8 +118,8 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
           const result = writeBodyCharAtATime(request, '{"foo":"bar"}', 50);
 
           await result.then(
-            (res) => {
-              expect(res).to.be(undefined);
+            () => {
+              throw new Error('Expected idle socket timeout error but request succeeded');
             },
             (err) => {
               expect(err.message).to.be('socket hang up');
@@ -114,7 +142,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
               expect(res).to.have.property('statusCode', 200);
             },
             (err) => {
-              expect(err).to.be(undefined);
+              throw err;
             }
           );
         });


### PR DESCRIPTION
## Summary

Fixes the flaky test reported in #242750: `Plugin Functional Tests - core route timeouts payload should timeout if POST payload sending is too slow`.

The root cause was in the `writeBodyCharAtATime` helper used by the plugin functional tests. It started the `setInterval` before any TCP connection to the Kibana server was established. Writes made during the handshake were buffered by Node.js's `http.ClientRequest` and flushed as a single burst once the socket connected, causing the server to receive the complete payload well within the 100ms timeout and return 200 OK instead of 408.

**Fix - `writeBodyCharAtATime`:** write the first character immediately (triggering connection setup), then hook into the underlying socket's `connect` event via the superagent-internal `ClientRequest` reference and only start the interval for remaining characters after the socket is ready. Each subsequent write now hits an already-established socket, so the server sees bytes drip in at the configured interval regardless of how long the TCP handshake took.

**Fix - test assertions:** the timeout tests had a resolve-path `expect(res).to.be(undefined)` that could never be correctly satisfied (when the server closes the connection on timeout, the client gets an error event, not a resolved response), and the non-timeout tests had `expect(err).to.be(undefined)` in their reject paths (an Error is never `undefined`). Both are replaced with explicit throws that surface failures clearly.

Note: the equivalent behavior in `src/core/server/integration_tests/http/router.test.ts` is unaffected - it uses `supertest(innerServer.listener)` which bypasses TCP and does not suffer from this buffering issue.

Made with [Cursor](https://cursor.com)