### PR TITLE
OAuth 2.0 Protected Resource Metadata endpoint 

### DIFF
--- a/src/platform/packages/private/kbn-mock-idp-utils/src/index.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/index.ts
@@ -45,4 +45,5 @@ export {
   generateCosmosDBApiRequestHeaders,
   getSAMLRequestId,
   createUiamSessionTokens,
+  createUiamOAuthAccessToken,
 } from './utils';

--- a/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
@@ -408,9 +408,7 @@ export async function createUiamSessionTokens({
  * Creates a UIAM OAuth access token that can be used to test the OAuth token exchange flow.
  *
  * Unlike {@link createUiamSessionTokens}, this creates a token with `typ: 'oauth-access-token'`
- * that includes OAuth-specific claims (audience, scope, client_id, connection_id). The UIAM
- * `_authenticate` endpoint requires the `audience` query parameter for OAuth tokens and validates
- * it against the token's `aud` claim.
+ * that includes OAuth-specific claims (audience, scope, client_id, connection_id).
  */
 export async function createUiamOAuthAccessToken({
   username,

--- a/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
@@ -404,6 +404,99 @@ export async function createUiamSessionTokens({
   };
 }
 
+/**
+ * Creates a UIAM OAuth access token that can be used to test the OAuth token exchange flow.
+ *
+ * Unlike {@link createUiamSessionTokens}, this creates a token with `typ: 'oauth-access-token'`
+ * that includes OAuth-specific claims (audience, scope, client_id, connection_id). The UIAM
+ * `_authenticate` endpoint requires the `audience` query parameter for OAuth tokens and validates
+ * it against the token's `aud` claim.
+ */
+export async function createUiamOAuthAccessToken({
+  username,
+  organizationId,
+  projectType,
+  roles,
+  audience,
+  fullName,
+  email,
+  accessTokenLifetimeSec = 3600,
+}: {
+  username: string;
+  organizationId: string;
+  projectType: string;
+  roles: string[];
+  audience: string;
+  fullName?: string;
+  email?: string;
+  accessTokenLifetimeSec?: number;
+}) {
+  const iat = Math.floor(Date.now() / 1000);
+
+  const givenName = fullName ? fullName.split(' ')[0] : 'Test';
+  const familyName = fullName ? fullName.split(' ').slice(1).join(' ') : 'User';
+
+  const userSeedResult = await seedTestUser({
+    userId: username,
+    organizationId,
+    roleId: 'cloud-role-id',
+    projectType,
+    applicationRoles: roles,
+    email,
+    firstName: givenName,
+    lastName: familyName,
+  });
+  if (!userSeedResult.success) {
+    throw userSeedResult.response;
+  }
+
+  const accessTokenBody = Buffer.from(
+    JSON.stringify({
+      typ: 'oauth-access-token',
+      var: 'oauth',
+      iss: 'elastic-cloud',
+      sjt: 'user',
+
+      oid: organizationId,
+      sub: username,
+      given_name: givenName,
+      family_name: familyName,
+      email,
+
+      aud: audience,
+      scope: 'all',
+      client_id: 'test-oauth-client',
+      connection_id: 'test-oauth-connection',
+
+      ras: {
+        platform: [],
+        organization: [],
+        user: [],
+        project: [
+          {
+            role_id: 'cloud-role-id',
+            organization_id: organizationId,
+            project_type: projectType,
+            application_roles: roles,
+            project_scope: { scope: 'all' },
+          },
+        ],
+      },
+
+      nbf: iat,
+      exp: iat + accessTokenLifetimeSec,
+      iat,
+      jti: randomBytes(16).toString('hex'),
+    })
+  ).toString('base64url');
+
+  const tokenHeader = Buffer.from(JSON.stringify({ typ: 'JWT', alg: 'HS256' })).toString(
+    'base64url'
+  );
+
+  return prepareJwtForUiam(`${tokenHeader}.${accessTokenBody}`);
+}
+
 function prepareJwtForUiam(unsignedJwt: string): string {
   const signedAccessToken = signJwt(unsignedJwt);
   return wrapSignedJwt(signedAccessToken);

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
@@ -64,7 +64,7 @@ export function registerMCPRoutes({ router, getInternalServices, logger }: Route
 > This endpoint is designed for MCP clients (Claude Desktop, Cursor, VS Code, etc.) and should not be used directly via REST APIs. Use MCP Inspector or native MCP clients instead.
 To learn more, refer to the [MCP documentation](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server).`,
       options: {
-        tags: ['mcp', 'oas-tag:agent builder'],
+        tags: ['mcp', 'oas-tag:agent builder', 'security:acceptUiamOAuth'],
         xsrfRequired: false,
         availability: {
           since: '9.2.0',

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
@@ -396,6 +396,7 @@ export class AuthenticationService {
       config: {
         authc: config.authc,
         accessAgreement: config.accessAgreement,
+        uiam: config.uiam,
       },
       getCurrentUser,
       featureUsageService,

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
@@ -94,7 +94,7 @@ export interface AuthenticatorOptions {
   featureUsageService: SecurityFeatureUsageServiceStart;
   userProfileService: UserProfileServiceStartInternal;
   getCurrentUser: (request: KibanaRequest) => AuthenticatedUser | null;
-  config: Pick<ConfigType, 'authc' | 'accessAgreement'>;
+  config: Pick<ConfigType, 'authc' | 'accessAgreement' | 'uiam'>;
   basePath: IBasePath;
   license: SecurityLicense;
   loggers: LoggerFactory;
@@ -698,6 +698,7 @@ export class Authenticator {
       new HTTPAuthenticationProvider(options, {
         supportedSchemes,
         jwt: this.options.config.authc.http.jwt,
+        acceptUiamOAuth: this.options.config.uiam?.enabled,
       })
     );
   }

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/http.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/http.test.ts
@@ -13,9 +13,10 @@ import { elasticsearchServiceMock, httpServerMock } from '@kbn/core/server/mocks
 import type { MockAuthenticationProviderOptions } from './base.mock';
 import { mockAuthenticationProviderOptions } from './base.mock';
 import { HTTPAuthenticationProvider } from './http';
+import { ES_CLIENT_AUTHENTICATION_HEADER } from '../../../common/constants';
 import { mockAuthenticatedUser } from '../../../common/model/authenticated_user.mock';
 import { securityMock } from '../../mocks';
-import { ROUTE_TAG_ACCEPT_JWT } from '../../routes/tags';
+import { ROUTE_TAG_ACCEPT_JWT, ROUTE_TAG_ACCEPT_UIAM_OAUTH } from '../../routes/tags';
 import { AuthenticationResult } from '../authentication_result';
 import { DeauthenticationResult } from '../deauthentication_result';
 
@@ -282,6 +283,225 @@ describe('HTTPAuthenticationProvider', () => {
 
         expect(request.headers.authorization).toBe(header);
       }
+    });
+  });
+
+  describe('UIAM OAuth authentication', () => {
+    let mockOptionsWithUiam: MockAuthenticationProviderOptions;
+
+    beforeEach(() => {
+      mockOptionsWithUiam = mockAuthenticationProviderOptions({ name: 'http', uiam: true });
+    });
+
+    it('exchanges UIAM OAuth token and authenticates successfully on tagged route.', async () => {
+      const header = 'Bearer essu_oauth_access_token';
+      const user = mockAuthenticatedUser();
+      const expectedAudience = mockOptionsWithUiam.getServerBaseURL();
+
+      mockOptionsWithUiam.uiam!.exchangeOAuthToken.mockResolvedValue({
+        ephemeralToken: 'essu_ephemeral_token',
+        audience: expectedAudience,
+      });
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: header },
+        routeTags: [ROUTE_TAG_ACCEPT_UIAM_OAUTH],
+      });
+
+      const mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      mockScopedClusterClient.asCurrentUser.security.authenticate.mockResponse(user);
+      mockOptionsWithUiam.client.asScoped.mockReturnValue(mockScopedClusterClient);
+
+      const provider = new HTTPAuthenticationProvider(mockOptionsWithUiam, {
+        supportedSchemes: new Set(['bearer']),
+        acceptUiamOAuth: true,
+      });
+
+      await expect(provider.authenticate(request)).resolves.toEqual(
+        AuthenticationResult.succeeded(
+          { ...user, authentication_provider: { type: 'http', name: 'http' } },
+          {
+            authHeaders: {
+              authorization: 'Bearer essu_ephemeral_token',
+              [ES_CLIENT_AUTHENTICATION_HEADER]: 'some-shared-secret',
+            },
+          }
+        )
+      );
+
+      expect(mockOptionsWithUiam.uiam!.exchangeOAuthToken).toHaveBeenCalledWith(
+        'essu_oauth_access_token',
+        expectedAudience
+      );
+
+      expect(mockOptionsWithUiam.client.asScoped).toHaveBeenCalledWith({
+        headers: {
+          ...request.headers,
+          authorization: 'Bearer essu_ephemeral_token',
+          [ES_CLIENT_AUTHENTICATION_HEADER]: 'some-shared-secret',
+        },
+      });
+    });
+
+    it('fails authentication when audience does not match.', async () => {
+      const header = 'Bearer essu_oauth_access_token';
+      const expectedAudience = mockOptionsWithUiam.getServerBaseURL();
+
+      mockOptionsWithUiam.uiam!.exchangeOAuthToken.mockResolvedValue({
+        ephemeralToken: 'essu_ephemeral_token',
+        audience: 'https://wrong-kibana.example.com',
+      });
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: header },
+        routeTags: [ROUTE_TAG_ACCEPT_UIAM_OAUTH],
+      });
+
+      const provider = new HTTPAuthenticationProvider(mockOptionsWithUiam, {
+        supportedSchemes: new Set(['bearer']),
+        acceptUiamOAuth: true,
+      });
+
+      const result = await provider.authenticate(request);
+
+      expect(result.failed()).toBe(true);
+      expect(result.error?.message).toContain(
+        'OAuth access token audience does not match Kibana audience.'
+      );
+
+      expect(mockOptionsWithUiam.uiam!.exchangeOAuthToken).toHaveBeenCalledWith(
+        'essu_oauth_access_token',
+        expectedAudience
+      );
+
+      expect(mockOptionsWithUiam.client.asScoped).not.toHaveBeenCalled();
+    });
+
+    it('fails authentication when UIAM token exchange fails.', async () => {
+      const header = 'Bearer essu_oauth_access_token';
+      const exchangeError = new Error('UIAM service unavailable');
+
+      mockOptionsWithUiam.uiam!.exchangeOAuthToken.mockRejectedValue(exchangeError);
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: header },
+        routeTags: [ROUTE_TAG_ACCEPT_UIAM_OAUTH],
+      });
+
+      const provider = new HTTPAuthenticationProvider(mockOptionsWithUiam, {
+        supportedSchemes: new Set(['bearer']),
+        acceptUiamOAuth: true,
+      });
+
+      await expect(provider.authenticate(request)).resolves.toEqual(
+        AuthenticationResult.failed(exchangeError)
+      );
+    });
+
+    it('does not intercept essu_ tokens on non-tagged routes (falls through to ES).', async () => {
+      const header = 'Bearer essu_some_token';
+      const user = mockAuthenticatedUser();
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: header },
+      });
+
+      const mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      mockScopedClusterClient.asCurrentUser.security.authenticate.mockResponse(user);
+      mockOptionsWithUiam.client.asScoped.mockReturnValue(mockScopedClusterClient);
+
+      const provider = new HTTPAuthenticationProvider(mockOptionsWithUiam, {
+        supportedSchemes: new Set(['bearer']),
+        acceptUiamOAuth: true,
+      });
+
+      await expect(provider.authenticate(request)).resolves.toEqual(
+        AuthenticationResult.succeeded(
+          { ...user, authentication_provider: { type: 'http', name: 'http' } },
+          { authHeaders: { authorization: header } }
+        )
+      );
+
+      expect(mockOptionsWithUiam.uiam!.exchangeOAuthToken).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning when essu_ token is used on a non-tagged route.', async () => {
+      const header = 'Bearer essu_some_token';
+      const user = mockAuthenticatedUser();
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: header },
+      });
+
+      const mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      mockScopedClusterClient.asCurrentUser.security.authenticate.mockResponse(user);
+      mockOptionsWithUiam.client.asScoped.mockReturnValue(mockScopedClusterClient);
+
+      const provider = new HTTPAuthenticationProvider(mockOptionsWithUiam, {
+        supportedSchemes: new Set(['bearer']),
+        acceptUiamOAuth: true,
+      });
+
+      await provider.authenticate(request);
+
+      expect(mockOptionsWithUiam.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Detected UIAM OAuth token on a non-MCP endpoint')
+      );
+    });
+
+    it('does not intercept essu_ tokens when acceptUiamOAuth is not enabled.', async () => {
+      const header = 'Bearer essu_some_token';
+      const user = mockAuthenticatedUser();
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: header },
+        routeTags: [ROUTE_TAG_ACCEPT_UIAM_OAUTH],
+      });
+
+      const mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      mockScopedClusterClient.asCurrentUser.security.authenticate.mockResponse(user);
+      mockOptionsWithUiam.client.asScoped.mockReturnValue(mockScopedClusterClient);
+
+      const provider = new HTTPAuthenticationProvider(mockOptionsWithUiam, {
+        supportedSchemes: new Set(['bearer']),
+      });
+
+      await expect(provider.authenticate(request)).resolves.toEqual(
+        AuthenticationResult.succeeded(
+          { ...user, authentication_provider: { type: 'http', name: 'http' } },
+          { authHeaders: { authorization: header } }
+        )
+      );
+
+      expect(mockOptionsWithUiam.uiam!.exchangeOAuthToken).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept non-essu_ Bearer tokens on tagged routes.', async () => {
+      const header = 'Bearer regular_jwt_token';
+      const user = mockAuthenticatedUser();
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { authorization: header },
+        routeTags: [ROUTE_TAG_ACCEPT_UIAM_OAUTH],
+      });
+
+      const mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      mockScopedClusterClient.asCurrentUser.security.authenticate.mockResponse(user);
+      mockOptionsWithUiam.client.asScoped.mockReturnValue(mockScopedClusterClient);
+
+      const provider = new HTTPAuthenticationProvider(mockOptionsWithUiam, {
+        supportedSchemes: new Set(['bearer']),
+        acceptUiamOAuth: true,
+      });
+
+      await expect(provider.authenticate(request)).resolves.toEqual(
+        AuthenticationResult.succeeded(
+          { ...user, authentication_provider: { type: 'http', name: 'http' } },
+          { authHeaders: { authorization: header } }
+        )
+      );
+
+      expect(mockOptionsWithUiam.uiam!.exchangeOAuthToken).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/http.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/http.ts
@@ -6,12 +6,12 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
-import { HTTPAuthorizationHeader } from '@kbn/core-security-server';
+import { HTTPAuthorizationHeader, isUiamCredential } from '@kbn/core-security-server';
 
 import type { AuthenticationProviderOptions } from './base';
 import { BaseAuthenticationProvider } from './base';
 import { getDetailedErrorMessage } from '../../errors';
-import { ROUTE_TAG_ACCEPT_JWT } from '../../routes/tags';
+import { ROUTE_TAG_ACCEPT_JWT, ROUTE_TAG_ACCEPT_UIAM_OAUTH } from '../../routes/tags';
 import { AuthenticationResult } from '../authentication_result';
 import { DeauthenticationResult } from '../deauthentication_result';
 
@@ -26,6 +26,8 @@ interface HTTPAuthenticationProviderOptions {
     // When set, only routes marked with `ROUTE_TAG_ACCEPT_JWT` tag will accept JWT as a means of authentication.
     taggedRoutesOnly: boolean;
   };
+  // When set, only routes marked  with `ROUTE_TAG_ACCEPT_UIAM_OAUTH` tag will accept UIAM OAuth access tokens.
+  acceptUiamOAuth?: boolean;
 }
 
 /**
@@ -48,6 +50,11 @@ export class HTTPAuthenticationProvider extends BaseAuthenticationProvider {
    */
   private readonly jwt: HTTPAuthenticationProviderOptions['jwt'];
 
+  /**
+   * Indicates whether the HTTP authentication provider will accept UIAM OAuth access tokens for authentication.
+   */
+  private readonly acceptUiamOAuth: boolean;
+
   constructor(
     protected readonly options: Readonly<AuthenticationProviderOptions>,
     httpOptions: Readonly<HTTPAuthenticationProviderOptions>
@@ -61,6 +68,7 @@ export class HTTPAuthenticationProvider extends BaseAuthenticationProvider {
       [...httpOptions.supportedSchemes].map((scheme) => scheme.toLowerCase())
     );
     this.jwt = httpOptions.jwt;
+    this.acceptUiamOAuth = httpOptions.acceptUiamOAuth ?? false;
   }
 
   /**
@@ -89,6 +97,23 @@ export class HTTPAuthenticationProvider extends BaseAuthenticationProvider {
     if (!this.supportedSchemes.has(authorizationHeader.scheme.toLowerCase())) {
       this.logger.warn(`Unsupported authentication scheme: ${authorizationHeader.scheme}`);
       return AuthenticationResult.notHandled();
+    }
+
+    if (
+      this.acceptUiamOAuth &&
+      authorizationHeader.scheme.toLowerCase() === 'bearer' &&
+      isUiamCredential(authorizationHeader)
+    ) {
+      if (request.route.options.tags.includes(ROUTE_TAG_ACCEPT_UIAM_OAUTH)) {
+        return this.authenticateViaUiamOAuth(request, authorizationHeader);
+      }
+
+      this.logger.warn(
+        `Detected UIAM OAuth token on a non-MCP endpoint: ` +
+          `${request.route.method.toUpperCase()} ${request.route.path}. ` +
+          `OAuth tokens are only accepted on routes tagged with "${ROUTE_TAG_ACCEPT_UIAM_OAUTH}". ` +
+          `This may indicate a misconfigured MCP client or token misuse.`
+      );
     }
 
     try {
@@ -145,5 +170,55 @@ export class HTTPAuthenticationProvider extends BaseAuthenticationProvider {
    */
   public getHTTPAuthenticationScheme() {
     return null;
+  }
+
+  /**
+   * Exchanges a UIAM OAuth access token for an ephemeral token via the UIAM service, verifies
+   * the audience, and resolves the user via Elasticsearch using the ephemeral token.
+   */
+  private async authenticateViaUiamOAuth(
+    request: KibanaRequest,
+    authorizationHeader: HTTPAuthorizationHeader
+  ): Promise<AuthenticationResult> {
+    if (!this.options.uiam) {
+      this.logger.error(
+        'UIAM OAuth authentication is enabled but the UIAM service is not available.'
+      );
+      return AuthenticationResult.failed(
+        new Error('UIAM service is not available for OAuth token exchange.')
+      );
+    }
+
+    const expectedAudience = this.options.getServerBaseURL();
+
+    try {
+      const { ephemeralToken, audience } = await this.options.uiam.exchangeOAuthToken(
+        authorizationHeader.credentials,
+        expectedAudience
+      );
+
+      if (audience !== expectedAudience) {
+        this.logger.error(
+          `OAuth token audience mismatch. Expected "${expectedAudience}", ` +
+            `but UIAM returned "${audience}". Rejecting authentication.`
+        );
+        return AuthenticationResult.failed(
+          new Error('OAuth access token audience does not match Kibana audience.')
+        );
+      }
+
+      const authHeaders = this.options.uiam.getAuthenticationHeaders(ephemeralToken);
+
+      const user = await this.getUser(request, authHeaders);
+
+      this.logger.debug('Request authenticated via UIAM OAuth token exchange.');
+
+      return AuthenticationResult.succeeded(user, { authHeaders });
+    } catch (err) {
+      this.logger.error(
+        `Failed to authenticate via UIAM OAuth token exchange: ${getDetailedErrorMessage(err)}`
+      );
+      return AuthenticationResult.failed(err);
+    }
   }
 }

--- a/x-pack/platform/plugins/shared/security/server/config.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.ts
@@ -371,12 +371,39 @@ export const ConfigSchema = schema.object({
       ),
     }),
   }),
+  mcp: offeringBasedSchema({
+    serverless: schema.maybe(
+      schema.object({
+        oauth2: schema.object({
+          metadata: schema.object({
+            authorization_servers: schema.arrayOf(schema.uri({ scheme: ['https', 'http'] }), {
+              minSize: 1,
+            }),
+            resource: schema.maybe(schema.uri({ scheme: ['https', 'http'] })),
+            bearer_methods_supported: schema.maybe(
+              schema.arrayOf(
+                schema.oneOf([
+                  schema.literal('header'),
+                  schema.literal('body'),
+                  schema.literal('query'),
+                ]),
+                { minSize: 1 }
+              )
+            ),
+            scopes_supported: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+            resource_documentation: schema.maybe(schema.uri({ scheme: ['https', 'http'] })),
+          }),
+        }),
+      })
+    ),
+  }),
   fipsMode: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
   }),
 });
 
 export type UiamConfigType = TypeOf<typeof ConfigSchema>['uiam'];
+export type McpConfigType = TypeOf<typeof ConfigSchema>['mcp'];
 
 export function createConfig(
   config: RawConfigType,

--- a/x-pack/platform/plugins/shared/security/server/routes/index.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/index.mock.ts
@@ -28,9 +28,12 @@ import type { SecurityRequestHandlerContext } from '../types';
 import { userProfileServiceMock } from '../user_profile/user_profile_service.mock';
 
 export const routeDefinitionParamsMock = {
-  create: (rawConfig: Record<string, unknown> = {}) => {
+  create: (
+    rawConfig: Record<string, unknown> = {},
+    validationContext: Record<string, unknown> = {}
+  ) => {
     const config = createConfig(
-      ConfigSchema.validate(rawConfig),
+      ConfigSchema.validate(rawConfig, validationContext),
       loggingSystemMock.create().get(),
       { isTLSEnabled: false }
     );

--- a/x-pack/platform/plugins/shared/security/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/index.ts
@@ -21,6 +21,7 @@ import { defineAuthorizationRoutes } from './authorization';
 import { defineDeprecationsRoutes } from './deprecations';
 import { defineSecurityFeatureRoutes } from './feature_check';
 import { defineIndicesRoutes } from './indices';
+import { defineOAuthMetadataRoutes } from './oauth_metadata';
 import { defineRoleMappingRoutes } from './role_mapping';
 import { defineSecurityCheckupGetStateRoutes } from './security_checkup';
 import { defineSessionManagementRoutes } from './session_management';
@@ -67,6 +68,7 @@ export function defineRoutes(params: RouteDefinitionParams) {
   defineApiKeysRoutes(params);
   defineAuthenticationRoutes(params);
   defineAuthorizationRoutes(params);
+  defineOAuthMetadataRoutes(params);
   defineSessionManagementRoutes(params);
   defineUserProfileRoutes(params);
   defineUsersRoutes(params); // Temporarily allow user APIs (ToDo: move to non-serverless block below)

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineOAuthProtectedResourceRoute } from './protected_resource';
+import type { RouteDefinitionParams } from '..';
+
+export function defineOAuthMetadataRoutes(params: RouteDefinitionParams) {
+  defineOAuthProtectedResourceRoute(params);
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/protected_resource.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/protected_resource.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { httpServerMock } from '@kbn/core/server/mocks';
+
+import { defineOAuthProtectedResourceRoute } from './protected_resource';
+import { routeDefinitionParamsMock, securityRequestHandlerContextMock } from '../index.mock';
+
+describe('GET /.well-known/oauth-protected-resource', () => {
+  it('does not register the route when mcp config is not set', () => {
+    const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
+    defineOAuthProtectedResourceRoute(mockRouteDefinitionParams);
+
+    expect(mockRouteDefinitionParams.router.get).not.toHaveBeenCalled();
+  });
+
+  describe('when mcp config is set', () => {
+    const mcpConfig = {
+      mcp: {
+        oauth2: {
+          metadata: {
+            authorization_servers: ['https://auth.example.com'],
+          },
+        },
+      },
+    };
+
+    it('registers the route', () => {
+      const mockRouteDefinitionParams = routeDefinitionParamsMock.create(mcpConfig, {
+        serverless: true,
+      });
+      defineOAuthProtectedResourceRoute(mockRouteDefinitionParams);
+
+      expect(mockRouteDefinitionParams.router.get).toHaveBeenCalledTimes(1);
+      const [[routeConfig]] = mockRouteDefinitionParams.router.get.mock.calls;
+      expect(routeConfig.path).toBe('/.well-known/oauth-protected-resource');
+      expect(routeConfig.security?.authc).toEqual({
+        enabled: false,
+        reason: expect.any(String),
+      });
+      expect(routeConfig.security?.authz).toEqual({
+        enabled: false,
+        reason: expect.any(String),
+      });
+    });
+
+    it('returns only authorization_servers when no optional fields are set', async () => {
+      const mockRouteDefinitionParams = routeDefinitionParamsMock.create(mcpConfig, {
+        serverless: true,
+      });
+      defineOAuthProtectedResourceRoute(mockRouteDefinitionParams);
+
+      const [[, handler]] = mockRouteDefinitionParams.router.get.mock.calls;
+      const mockContext = securityRequestHandlerContextMock.create();
+      const mockRequest = httpServerMock.createKibanaRequest({ method: 'get' });
+
+      const response = await handler(mockContext, mockRequest, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        authorization_servers: ['https://auth.example.com'],
+      });
+    });
+
+    it('returns all configured metadata fields', async () => {
+      const fullMcpConfig = {
+        mcp: {
+          oauth2: {
+            metadata: {
+              authorization_servers: ['https://auth1.example.com', 'https://auth2.example.com'],
+              resource: 'https://kibana.example.com',
+              bearer_methods_supported: ['header'] as const,
+              scopes_supported: ['read', 'write'],
+              resource_documentation: 'https://docs.example.com',
+            },
+          },
+        },
+      };
+
+      const mockRouteDefinitionParams = routeDefinitionParamsMock.create(fullMcpConfig, {
+        serverless: true,
+      });
+      defineOAuthProtectedResourceRoute(mockRouteDefinitionParams);
+
+      const [[, handler]] = mockRouteDefinitionParams.router.get.mock.calls;
+      const mockContext = securityRequestHandlerContextMock.create();
+      const mockRequest = httpServerMock.createKibanaRequest({ method: 'get' });
+
+      const response = await handler(mockContext, mockRequest, kibanaResponseFactory);
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        authorization_servers: ['https://auth1.example.com', 'https://auth2.example.com'],
+        resource: 'https://kibana.example.com',
+        bearer_methods_supported: ['header'],
+        scopes_supported: ['read', 'write'],
+        resource_documentation: 'https://docs.example.com',
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/protected_resource.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth_metadata/protected_resource.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RouteDefinitionParams } from '..';
+
+export function defineOAuthProtectedResourceRoute({ router, config }: RouteDefinitionParams) {
+  if (!config.mcp?.oauth2) {
+    return;
+  }
+
+  const { metadata } = config.mcp.oauth2;
+
+  router.get(
+    {
+      path: '/.well-known/oauth-protected-resource',
+      security: {
+        authc: {
+          enabled: false,
+          reason:
+            'This endpoint must be publicly accessible for OAuth 2 Protected Resource Metadata discovery.',
+        },
+        authz: {
+          enabled: false,
+          reason:
+            'This endpoint must be publicly accessible for OAuth 2 Protected Resource Metadata discovery.',
+        },
+      },
+      options: { access: 'public' },
+      validate: false,
+    },
+    (_context, _request, response) => {
+      const body: Record<string, unknown> = {
+        authorization_servers: metadata.authorization_servers,
+        ...(metadata.resource ? { resource: metadata.resource } : {}),
+        ...(metadata.bearer_methods_supported
+          ? { bearer_methods_supported: metadata.bearer_methods_supported }
+          : {}),
+        ...(metadata.scopes_supported ? { scopes_supported: metadata.scopes_supported } : {}),
+        ...(metadata.resource_documentation
+          ? { resource_documentation: metadata.resource_documentation }
+          : {}),
+      };
+
+      return response.ok({
+        body,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/tags.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/tags.ts
@@ -31,3 +31,10 @@ export const ROUTE_TAG_AUTH_FLOW = 'security:authFlow';
  * JWT as a means of authentication.
  */
 export const ROUTE_TAG_ACCEPT_JWT = 'security:acceptJWT';
+
+/**
+ * If the route is marked with this tag, the HTTP authentication provider will accept UIAM OAuth access tokens for authentication.
+ * HTTP authentication provider will exchange the UIAM OAuth access token for an ephemeral UIAM token
+ * via the UIAM service before authenticating with Elasticsearch.
+ */
+export const ROUTE_TAG_ACCEPT_UIAM_OAUTH = 'security:acceptUiamOAuth';

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
@@ -24,6 +24,9 @@ export const uiamServiceMock = {
       key: 'mock-api-key-value',
       description: 'mock-api-key-name',
     }),
+    exchangeOAuthToken: jest
+      .fn()
+      .mockResolvedValue({ ephemeralToken: 'mock-ephemeral-token', audience: 'mock-audience' }),
     revokeApiKey: jest.fn().mockResolvedValue(undefined),
     convertApiKeys: jest.fn().mockResolvedValue({ results: [] }),
   }),

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -359,7 +359,11 @@ describe('UiamService', () => {
     it('properly calls UIAM service to exchange an OAuth token for an ephemeral token', async () => {
       const mockResponse = {
         token: 'essu_ephemeral_token_value',
-        audience: 'https://my-project.kb.us-east-1.cloud.es.io',
+        credentials: {
+          oauth: {
+            audience: 'https://my-project.kb.us-east-1.cloud.es.io',
+          },
+        },
       };
 
       fetchSpy.mockResolvedValue({
@@ -379,7 +383,7 @@ describe('UiamService', () => {
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://uiam.service/uiam/api/v1/authentication/_authenticate?include_token=true',
+        'https://uiam.service/uiam/api/v1/authentication/_authenticate?include_token=true&audience=https%3A%2F%2Fmy-project.kb.us-east-1.cloud.es.io',
         {
           method: 'POST',
           headers: {
@@ -387,9 +391,6 @@ describe('UiamService', () => {
             [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
             Authorization: 'Bearer essu_oauth_access_token',
           },
-          body: JSON.stringify({
-            audience: 'https://my-project.kb.us-east-1.cloud.es.io',
-          }),
           dispatcher: AGENT_MOCK,
         }
       );

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -355,6 +355,60 @@ describe('UiamService', () => {
     });
   });
 
+  describe('#exchangeOAuthToken', () => {
+    it('properly calls UIAM service to exchange an OAuth token for an ephemeral token', async () => {
+      const mockResponse = {
+        token: 'essu_ephemeral_token_value',
+        audience: 'https://my-project.kb.us-east-1.cloud.es.io',
+      };
+
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await expect(
+        uiamService.exchangeOAuthToken(
+          'essu_oauth_access_token',
+          'https://my-project.kb.us-east-1.cloud.es.io'
+        )
+      ).resolves.toEqual({
+        ephemeralToken: 'essu_ephemeral_token_value',
+        audience: 'https://my-project.kb.us-east-1.cloud.es.io',
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/authentication/_authenticate?include_token=true',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer essu_oauth_access_token',
+          },
+          body: JSON.stringify({
+            audience: 'https://my-project.kb.us-east-1.cloud.es.io',
+          }),
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('throws and logs error when UIAM service returns an error', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: { message: 'Invalid token' } }),
+        headers: new Headers(),
+      });
+
+      await expect(
+        uiamService.exchangeOAuthToken('essu_invalid_token', 'https://kibana.example.com')
+      ).rejects.toThrow();
+    });
+  });
+
   describe('#grantApiKey', () => {
     it('properly calls UIAM service to grant an API key with Bearer scheme and name', async () => {
       const mockResponse: GrantUiamApiKeyResponse = {

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -275,26 +275,26 @@ export class UiamService implements UiamServicePublic {
     this.#logger.debug('Attempting to exchange OAuth access token for ephemeral token.');
 
     try {
+      const url = new URL(`${this.#config.url}/uiam/api/v1/authentication/_authenticate`);
+      url.searchParams.set('include_token', 'true');
+      url.searchParams.set('audience', expectedAudience);
+
       const response = await UiamService.#parseUiamResponse(
-        await fetch(
-          `${this.#config.url}/uiam/api/v1/authentication/_authenticate?include_token=true`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
-              Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({ audience: expectedAudience }),
-            // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
-            dispatcher: this.#dispatcher,
-          }
-        )
+        await fetch(url.toString(), {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+            Authorization: `Bearer ${accessToken}`,
+          },
+          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+          dispatcher: this.#dispatcher,
+        })
       );
 
       return {
         ephemeralToken: response.token,
-        audience: response.audience,
+        audience: response.credentials.oauth.audience,
       };
     } catch (err) {
       this.#logger.error(

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -133,6 +133,17 @@ export interface UiamServicePublic {
   ): Promise<GrantUiamApiKeyResponse>;
 
   /**
+   * Exchanges an OAuth access token for an ephemeral UIAM token.
+   * @param accessToken The OAuth access token.
+   * @param expectedAudience The audience value Kibana expects.
+   * @returns The ephemeral token and the audience returned by UIAM.
+   */
+  exchangeOAuthToken(
+    accessToken: string,
+    expectedAudience: string
+  ): Promise<{ ephemeralToken: string; audience: string }>;
+
+  /**
    * Revokes a UIAM API key by its ID.
    * @param apiKeyId The ID of the API key to revoke.
    * @param apiKey The API key to revoke; will be used for authentication on this request.
@@ -248,6 +259,46 @@ export class UiamService implements UiamServicePublic {
     } catch (err) {
       this.#logger.error(
         () => `Failed to invalidate session tokens: ${getDetailedErrorMessage(err)}`
+      );
+
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.exchangeOAuthToken}.
+   */
+  async exchangeOAuthToken(
+    accessToken: string,
+    expectedAudience: string
+  ): Promise<{ ephemeralToken: string; audience: string }> {
+    this.#logger.debug('Attempting to exchange OAuth access token for ephemeral token.');
+
+    try {
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(
+          `${this.#config.url}/uiam/api/v1/authentication/_authenticate?include_token=true`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+              Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify({ audience: expectedAudience }),
+            // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+            dispatcher: this.#dispatcher,
+          }
+        )
+      );
+
+      return {
+        ephemeralToken: response.token,
+        audience: response.audience,
+      };
+    } catch (err) {
+      this.#logger.error(
+        () => `Failed to exchange OAuth access token: ${getDetailedErrorMessage(err)}`
       );
 
       throw err;

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_local/api/parallel_tests/uiam_oauth_token_exchange.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_local/api/parallel_tests/uiam_oauth_token_exchange.spec.ts
@@ -20,7 +20,6 @@ apiTest.describe(
     let oauthAccessToken: string;
 
     apiTest.beforeAll(async ({ kbnUrl, config: { organizationId, projectType } }) => {
-      // The audience must match what Kibana's getServerBaseURL() returns (protocol://hostname:port).
       const audience = new URL(kbnUrl.get()).origin;
 
       oauthAccessToken = await createUiamOAuthAccessToken({
@@ -57,8 +56,6 @@ apiTest.describe(
           },
         });
 
-        console.log('response', response);
-
         expect(response.statusCode).toBe(200);
       }
     );
@@ -78,8 +75,9 @@ apiTest.describe(
     });
 
     apiTest('should reject an invalid OAuth token on MCP endpoint', async ({ apiClient }) => {
-      // Use a tampered token — remove the last character to make it invalid.
-      const invalidToken = oauthAccessToken.slice(0, -1);
+      const mid = Math.floor(oauthAccessToken.length / 2);
+      const invalidToken =
+        oauthAccessToken.slice(0, mid) + 'CORRUPTED' + oauthAccessToken.slice(mid);
 
       const response = await apiClient.post(MCP_ENDPOINT, {
         headers: {
@@ -125,7 +123,6 @@ apiTest.describe(
           },
         });
 
-        // ES will reject the invalid token.
         expect(response.statusCode).toBe(401);
       }
     );

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_local/api/parallel_tests/uiam_oauth_token_exchange.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_local/api/parallel_tests/uiam_oauth_token_exchange.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createUiamOAuthAccessToken } from '@kbn/mock-idp-utils';
+import { apiTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+
+import { COMMON_HEADERS } from '../fixtures';
+
+const MCP_ENDPOINT = 'api/agent_builder/mcp';
+
+apiTest.describe(
+  '[NON-MKI] UIAM OAuth token exchange on MCP endpoint',
+  { tag: [...tags.serverless.security.complete] },
+  () => {
+    let oauthAccessToken: string;
+
+    apiTest.beforeAll(async ({ kbnUrl, config: { organizationId, projectType } }) => {
+      // The audience must match what Kibana's getServerBaseURL() returns (protocol://hostname:port).
+      const audience = new URL(kbnUrl.get()).origin;
+
+      oauthAccessToken = await createUiamOAuthAccessToken({
+        username: '1234567890',
+        organizationId: organizationId!,
+        projectType: projectType!,
+        roles: ['admin'],
+        email: 'elastic_admin@elastic.co',
+        audience,
+      });
+    });
+
+    apiTest(
+      'should exchange OAuth token and authenticate successfully on MCP endpoint',
+      async ({ apiClient }) => {
+        // The MCP endpoint is tagged with `security:acceptUiamOAuth`, so the HTTP authentication
+        // provider should detect the `essu_` Bearer token, exchange it via UIAM for an ephemeral
+        // token, and authenticate the request.
+        const response = await apiClient.post(MCP_ENDPOINT, {
+          headers: {
+            ...COMMON_HEADERS,
+            Authorization: `Bearer ${oauthAccessToken}`,
+          },
+          responseType: 'json',
+          body: {
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              clientInfo: { name: 'test-client', version: '1.0.0' },
+            },
+            id: 1,
+          },
+        });
+
+        console.log('response', response);
+
+        expect(response.statusCode).toBe(200);
+      }
+    );
+
+    apiTest('should reject OAuth token on a non-MCP endpoint', async ({ apiClient }) => {
+      // Sending an `essu_` OAuth token to a non-tagged endpoint should fall through
+      // to ES authentication which will reject it (the token is not a valid ES credential).
+      const response = await apiClient.get('internal/security/me', {
+        headers: {
+          ...COMMON_HEADERS,
+          Authorization: `Bearer ${oauthAccessToken}`,
+        },
+        responseType: 'json',
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    apiTest('should reject an invalid OAuth token on MCP endpoint', async ({ apiClient }) => {
+      // Use a tampered token — remove the last character to make it invalid.
+      const invalidToken = oauthAccessToken.slice(0, -1);
+
+      const response = await apiClient.post(MCP_ENDPOINT, {
+        headers: {
+          ...COMMON_HEADERS,
+          Authorization: `Bearer ${invalidToken}`,
+        },
+        responseType: 'json',
+        body: {
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+          },
+          id: 1,
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    apiTest(
+      'should reject a non-essu_ Bearer token on MCP endpoint (falls through to ES)',
+      async ({ apiClient }) => {
+        // A regular Bearer token (not prefixed with `essu_`) on a tagged route should
+        // skip the UIAM OAuth branch and fall through to standard ES authentication.
+        const response = await apiClient.post(MCP_ENDPOINT, {
+          headers: {
+            ...COMMON_HEADERS,
+            Authorization: 'Bearer some-regular-jwt-token',
+          },
+          responseType: 'json',
+          body: {
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              capabilities: {},
+              clientInfo: { name: 'test-client', version: '1.0.0' },
+            },
+            id: 1,
+          },
+        });
+
+        // ES will reject the invalid token.
+        expect(response.statusCode).toBe(401);
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Summary

OAuth 2.0 Protected Resource Metadata endpoint https://datatracker.ietf.org/doc/rfc9728/

```yml
xpack.security.mcp.oauth2.metadata:
  authorization_servers:
    - <server1>
    - <server2>
  resource: <resource_uri>
  bearer_methods_supported:
    - header
    - body
    - query
  scopes_supported:
    - all
  resource_documentation: <resource_documentation_uri>
```


### Checklist

- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

__Closes: https://github.com/elastic/kibana-team/issues/2750__
__Relates: https://github.com/elastic/kibana/pull/256182__