### PR TITLE
[APM] Service map: the go to full map button should be present

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -70,6 +70,8 @@ interface GraphProps {
   end: string;
   isFullscreen?: boolean;
   onToggleFullscreen?: () => void;
+  /** When set, shows a "View full service map" button that links to the full map (focused map only) */
+  fullMapHref?: string;
 }
 
 function GraphInner({
@@ -83,6 +85,7 @@ function GraphInner({
   end,
   isFullscreen = false,
   onToggleFullscreen,
+  fullMapHref,
 }: GraphProps) {
   const { euiTheme } = useEuiTheme();
   const { fitView } = useReactFlow();
@@ -253,6 +256,10 @@ function GraphInner({
         defaultMessage: 'Enter fullscreen',
       });
 
+  const viewFullMapButtonLabel = i18n.translate('xpack.apm.serviceMap.viewFullServiceMapButton', {
+    defaultMessage: 'View full service map',
+  });
+
   const containerStyle = useMemo(
     () => ({
       height,
@@ -288,10 +295,23 @@ function GraphInner({
       position: relative;
       margin: ${euiTheme.size.s};
 
-      button {
+      button,
+      a[data-test-subj='serviceMapViewFullMapButton'] {
         background-color: ${euiTheme.colors.backgroundBasePlain};
         border-bottom: ${euiTheme.border.width.thin} solid ${euiTheme.colors.lightShade};
         fill: ${euiTheme.colors.text};
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: ${euiTheme.size.s};
+        cursor: pointer;
+        border-left: none;
+        border-right: none;
+        border-top: none;
+        width: 100%;
+        box-sizing: border-box;
+        color: inherit;
+        text-decoration: none;
 
         &:hover {
           background-color: ${euiTheme.colors.backgroundBaseSubdued};
@@ -382,6 +402,16 @@ function GraphInner({
       >
         <Background gap={24} size={1} color={euiTheme.colors.lightShade} />
         <Controls showInteractive={false} position="top-left" css={controlsStyles}>
+          {fullMapHref && (
+            <a
+              href={fullMapHref}
+              title={viewFullMapButtonLabel}
+              aria-label={viewFullMapButtonLabel}
+              data-test-subj="serviceMapViewFullMapButton"
+            >
+              <EuiIcon type="apps" aria-label={viewFullMapButtonLabel} />
+            </a>
+          )}
           {onToggleFullscreen && (
             <ControlButton
               onClick={onToggleFullscreen}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_controls.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_controls.test.tsx
@@ -32,11 +32,11 @@ jest.mock('@xyflow/react', () => {
   return {
     ...original,
     ReactFlow: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="react-flow">{children}</div>
+      <div data-test-subj="react-flow">{children}</div>
     ),
-    Background: () => <div data-testid="react-flow-background" />,
+    Background: () => <div data-test-subj="react-flow-background" />,
     Controls: ({ children }: { children?: React.ReactNode }) => (
-      <div data-testid="react-flow-controls">{children}</div>
+      <div data-test-subj="serviceMapControls">{children}</div>
     ),
     ControlButton: ({
       children,
@@ -122,7 +122,19 @@ function ServiceMapGraphWithFullscreenState(
   );
 }
 
-describe('ServiceMapGraph - Full screen', () => {
+describe('ServiceMapGraph - Controls', () => {
+  it('renders the controls container', () => {
+    render(
+      <ReactFlowProvider>
+        <ServiceMapGraph {...defaultProps} />
+      </ReactFlowProvider>
+    );
+
+    const controls = screen.getByTestId('serviceMapControls');
+    expect(controls).toBeInTheDocument();
+    expect(screen.getByTestId('serviceMapGraph')).toContainElement(controls);
+  });
+
   it('does not render full screen button when onToggleFullscreen is not provided', () => {
     render(
       <ReactFlowProvider>
@@ -174,5 +186,49 @@ describe('ServiceMapGraph - Full screen', () => {
         'Enter fullscreen'
       );
     });
+  });
+
+  it('renders "View full service map" button when fullMapHref is provided', () => {
+    const fullMapHref = '/app/apm/service-map?rangeFrom=now-24h&rangeTo=now';
+    render(
+      <ReactFlowProvider>
+        <ServiceMapGraph {...defaultProps} fullMapHref={fullMapHref} />
+      </ReactFlowProvider>
+    );
+
+    const viewFullMapButton = screen.getByTestId('serviceMapViewFullMapButton');
+    expect(viewFullMapButton).toBeInTheDocument();
+    expect(viewFullMapButton).toHaveAttribute('href', fullMapHref);
+    expect(viewFullMapButton).toHaveAttribute('title', 'View full service map');
+  });
+
+  it('does not render "View full service map" button when fullMapHref is not provided', () => {
+    render(
+      <ReactFlowProvider>
+        <ServiceMapGraph {...defaultProps} />
+      </ReactFlowProvider>
+    );
+
+    expect(screen.queryByTestId('serviceMapViewFullMapButton')).not.toBeInTheDocument();
+  });
+
+  it('renders both view full map and fullscreen buttons when both fullMapHref and onToggleFullscreen are provided', () => {
+    const fullMapHref = '/app/apm/service-map?rangeFrom=now-24h&rangeTo=now';
+    render(
+      <ReactFlowProvider>
+        <ServiceMapGraph
+          {...defaultProps}
+          fullMapHref={fullMapHref}
+          onToggleFullscreen={() => {}}
+        />
+      </ReactFlowProvider>
+    );
+
+    const controls = screen.getByTestId('serviceMapControls');
+    const viewFullMapButton = screen.getByTestId('serviceMapViewFullMapButton');
+    const fullscreenButton = screen.getByTestId('serviceMapFullScreenButton');
+
+    expect(controls).toContainElement(viewFullMapButton);
+    expect(controls).toContainElement(fullscreenButton);
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/index.tsx
@@ -28,6 +28,7 @@ import { useRefDimensions } from './use_ref_dimensions';
 import { SearchBar } from '../../shared/search_bar/search_bar';
 import { useServiceName } from '../../../hooks/use_service_name';
 import { useApmParams, useAnyOfApmParams } from '../../../hooks/use_apm_params';
+import { useApmRouter } from '../../../hooks/use_apm_router';
 import type { Environment } from '../../../../common/environment_rt';
 import { useTimeRange } from '../../../hooks/use_time_range';
 import { DisabledPrompt } from './disabled_prompt';
@@ -99,6 +100,27 @@ export function ServiceMap({
 }) {
   const license = useLicenseContext();
   const serviceName = useServiceName();
+  const apmRouter = useApmRouter();
+  const { query } = useAnyOfApmParams(
+    '/service-map',
+    '/services/{serviceName}/service-map',
+    '/mobile-services/{serviceName}/service-map'
+  );
+
+  const fullMapHref =
+    serviceName && 'rangeFrom' in query && 'rangeTo' in query && query.rangeFrom && query.rangeTo
+      ? apmRouter.link('/service-map', {
+          query: {
+            rangeFrom: query.rangeFrom,
+            rangeTo: query.rangeTo,
+            environment: query.environment,
+            kuery: query.kuery,
+            comparisonEnabled: query.comparisonEnabled,
+            offset: query.offset,
+            serviceGroup: 'serviceGroup' in query ? query.serviceGroup ?? '' : '',
+          },
+        })
+      : undefined;
 
   const { config } = useApmPluginContext();
   const { onPageReady } = usePerformanceContext();
@@ -244,6 +266,7 @@ export function ServiceMap({
               end={end}
               isFullscreen={isFullscreen}
               onToggleFullscreen={onToggleFullscreen}
+              fullMapHref={fullMapHref}
             />
           </div>
         </EuiPanel>


### PR DESCRIPTION
Closes #256236 

## Summary

This PR fixes the issue with the missing View full map button. 

| Before | After |
| ------ | ------ | 
| <img width="3840" height="1938" alt="image" src="https://github.com/user-attachments/assets/15a5d522-7d46-48f8-9baa-e33c258bfcfc" /> |  <img width="1924" height="971" alt="image" src="https://github.com/user-attachments/assets/b0594d6d-db39-4059-8636-0db4dfb2c854" /> |

## How to test
- Navigate to Service map, click on a service and click on Focus map
- Verify that the View full map button is visible
- Click on the view full map button
- The full service map should be visible 


https://github.com/user-attachments/assets/49236446-0b4b-41ae-b937-84a790ea2e8f

