### PR TITLE
test(serverless): fix flaky relationships API test

### DIFF
--- a/src/platform/test/plugin_functional/test_suites/core/route.ts
+++ b/src/platform/test/plugin_functional/test_suites/core/route.ts
@@ -8,6 +8,8 @@
  */
 
 import expect from '@kbn/expect';
+import type { ClientRequest } from 'http';
+import type { Socket } from 'net';
 import type { Test } from 'supertest';
 import type { PluginFunctionalProviderContext } from '../../services';
 
@@ -16,23 +18,49 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
 
   describe('route', function () {
     describe('timeouts', function () {
+      // Sends `body` one character at a time with `interval` ms between each write.
+      //
+      // The first character is written immediately to initiate the TCP connection.
+      // Subsequent characters are sent via setInterval only after the socket is
+      // connected, preventing writes from being buffered during the TCP handshake
+      // and arriving at the server in a single burst rather than drip-fed.
       const writeBodyCharAtATime = (request: Test, body: string, interval: number) => {
         return new Promise((resolve, reject) => {
-          let i = 0;
-          const intervalId = setInterval(() => {
-            if (i < body.length) {
-              request.write(body[i++]);
-            } else {
-              clearInterval(intervalId);
-              void request.end((err, res) => {
-                resolve(res);
-              });
-            }
-          }, interval);
+          let charIdx = 0;
+          let intervalId: ReturnType<typeof setInterval> | undefined;
+
+          const startInterval = () => {
+            intervalId = setInterval(() => {
+              if (charIdx < body.length) {
+                void request.write(body[charIdx++]);
+              } else {
+                clearInterval(intervalId);
+                void request.end((err, res) => {
+                  resolve(res);
+                });
+              }
+            }, interval);
+          };
+
           void request.on('error', (err) => {
             clearInterval(intervalId);
             reject(err);
           });
+
+          void request.write(body[charIdx++]);
+
+          const underlyingReq = (request as unknown as { req?: ClientRequest }).req;
+          if (underlyingReq !== undefined) {
+            underlyingReq.once('socket', (socket: Socket) => {
+              if (socket.connecting) {
+                socket.once('connect', startInterval);
+              } else {
+                setImmediate(startInterval);
+              }
+            });
+          } else {
+            startInterval();
+          }
         });
       };
 
@@ -48,8 +76,8 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
           const result = writeBodyCharAtATime(request, '{"foo":"bar"}', 20);
 
           await result.then(
-            (res) => {
-              expect(res).to.be(undefined);
+            () => {
+              throw new Error('Expected payload timeout error but request succeeded');
             },
             (err) => {
               expect(err.message).to.be('Request Timeout');
@@ -72,7 +100,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
               expect(res).to.have.property('statusCode', 200);
             },
             (err) => {
-              expect(err).to.be(undefined);
+              throw err;
             }
           );
         });
@@ -90,8 +118,8 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
           const result = writeBodyCharAtATime(request, '{"foo":"bar"}', 50);
 
           await result.then(
-            (res) => {
-              expect(res).to.be(undefined);
+            () => {
+              throw new Error('Expected idle socket timeout error but request succeeded');
             },
             (err) => {
               expect(err.message).to.be('socket hang up');
@@ -114,7 +142,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
               expect(res).to.have.property('statusCode', 200);
             },
             (err) => {
-              expect(err).to.be(undefined);
+              throw err;
             }
           );
         });

--- a/x-pack/platform/test/serverless/api_integration/test_suites/saved_objects_management/relationships.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/saved_objects_management/relationships.ts
@@ -81,6 +81,14 @@ export default function ({ getService }: FtrProviderContext) {
       return `${baseApiUrl}/${type}/${id}?${typesQuery}`;
     };
 
+    const sortRelations = <TRelation extends { relationship: string; type: string; id: string }>(
+      relations: TRelation[]
+    ) =>
+      [...relations].sort((a, b) =>
+        `${a.relationship}:${a.type}:${a.id}`.localeCompare(`${b.relationship}:${b.type}:${b.id}`)
+      );
+
+
     describe('validate response schema', () => {
       it('search', async () => {
         const resp = await supertestWithoutAuth
@@ -146,7 +154,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(svlCommonApi.getInternalRequestHeader())
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: '8963ca30-3224-11e8-a572-ffca06da1357',
             type: 'index-pattern',
@@ -184,7 +192,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
       it('for dashboards', async () => {
         const resp = await supertestWithoutAuth
@@ -192,7 +200,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(svlCommonApi.getInternalRequestHeader())
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: 'add810b0-3224-11e8-a572-ffca06da1357',
             type: 'visualization',
@@ -231,7 +239,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
       it('for visualizations', async () => {
         const resp = await supertestWithoutAuth
@@ -240,7 +248,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: '960372e0-3224-11e8-a572-ffca06da1357',
             type: 'search',
@@ -292,7 +300,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
       it('for index patterns', async () => {
         const resp = await supertestWithoutAuth
@@ -301,7 +309,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: '960372e0-3224-11e8-a572-ffca06da1357',
             type: 'search',
@@ -344,7 +352,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
     });
 
@@ -358,7 +366,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: '8963ca30-3224-11e8-a572-ffca06da1357',
             type: 'index-pattern',
@@ -396,7 +404,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
       it('dashboard', async () => {
         const resp = await supertestWithoutAuth
@@ -405,7 +413,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: 'add810b0-3224-11e8-a572-ffca06da1357',
             type: 'visualization',
@@ -444,7 +452,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
       it('visualization', async () => {
         const resp = await supertestWithoutAuth
@@ -455,7 +463,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: '960372e0-3224-11e8-a572-ffca06da1357',
             type: 'search',
@@ -479,7 +487,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
       it('index-pattern', async () => {
         const resp = await supertestWithoutAuth
@@ -490,7 +498,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(resp.body.relations).to.eql([
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
           {
             id: '960372e0-3224-11e8-a572-ffca06da1357',
             type: 'search',
@@ -514,7 +522,7 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
           },
-        ]);
+        ]));
       });
     });
 
@@ -557,37 +565,36 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(resp.body).to.eql({
-          invalidRelations: [
-            {
-              error: 'Saved object [visualization/invalid-vis] not found',
-              id: 'invalid-vis',
-              relationship: 'child',
-              type: 'visualization',
+        expect(resp.body.invalidRelations).to.eql([
+          {
+            error: 'Saved object [visualization/invalid-vis] not found',
+            id: 'invalid-vis',
+            relationship: 'child',
+            type: 'visualization',
+          },
+        ]);
+
+        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
+          {
+            id: 'add810b0-3224-11e8-a572-ffca06da1357',
+            meta: {
+              icon: 'visualizeApp',
+              namespaceType: 'multiple-isolated',
+              hiddenType: false,
+              title: 'Visualization',
             },
-          ],
-          relations: [
-            {
-              id: 'add810b0-3224-11e8-a572-ffca06da1357',
-              meta: {
-                icon: 'visualizeApp',
-                namespaceType: 'multiple-isolated',
-                hiddenType: false,
-                title: 'Visualization',
+            relationship: 'child',
+            type: 'visualization',
+            managed: false,
+            references: [
+              {
+                id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                type: 'index-pattern',
               },
-              relationship: 'child',
-              type: 'visualization',
-              managed: false,
-              references: [
-                {
-                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                  type: 'index-pattern',
-                },
-              ],
-            },
-          ],
-        });
+            ],
+          },
+        ]));
       });
     });
   });

--- a/x-pack/platform/test/serverless/api_integration/test_suites/saved_objects_management/relationships.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/saved_objects_management/relationships.ts
@@ -88,7 +88,6 @@ export default function ({ getService }: FtrProviderContext) {
         `${a.relationship}:${a.type}:${a.id}`.localeCompare(`${b.relationship}:${b.type}:${b.id}`)
       );
 
-
     describe('validate response schema', () => {
       it('search', async () => {
         const resp = await supertestWithoutAuth
@@ -154,45 +153,48 @@ export default function ({ getService }: FtrProviderContext) {
           .set(svlCommonApi.getInternalRequestHeader())
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: '8963ca30-3224-11e8-a572-ffca06da1357',
-            type: 'index-pattern',
-            relationship: 'child',
-            meta: {
-              title: 'saved_objects*',
-              icon: 'indexPatternApp',
-              editUrl: '/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
-              inAppUrl: {
-                path: '/app/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
-                uiCapabilitiesPath: 'management.kibana.indexPatterns',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: '8963ca30-3224-11e8-a572-ffca06da1357',
+              type: 'index-pattern',
+              relationship: 'child',
+              meta: {
+                title: 'saved_objects*',
+                icon: 'indexPatternApp',
+                editUrl:
+                  '/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
+                inAppUrl: {
+                  path: '/app/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
+                  uiCapabilitiesPath: 'management.kibana.indexPatterns',
+                },
+                namespaceType: 'multiple',
+                hiddenType: false,
               },
-              namespaceType: 'multiple',
-              hiddenType: false,
+              managed: false,
+              references: [],
             },
-            managed: false,
-            references: [],
-          },
-          {
-            id: 'a42c0580-3224-11e8-a572-ffca06da1357',
-            type: 'visualization',
-            relationship: 'parent',
-            meta: {
-              title: 'VisualizationFromSavedSearch',
-              icon: 'visualizeApp',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
-            },
-            managed: false,
-            references: [
-              {
-                id: '960372e0-3224-11e8-a572-ffca06da1357',
-                name: 'search_0',
-                type: 'search',
+            {
+              id: 'a42c0580-3224-11e8-a572-ffca06da1357',
+              type: 'visualization',
+              relationship: 'parent',
+              meta: {
+                title: 'VisualizationFromSavedSearch',
+                icon: 'visualizeApp',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-        ]));
+              managed: false,
+              references: [
+                {
+                  id: '960372e0-3224-11e8-a572-ffca06da1357',
+                  name: 'search_0',
+                  type: 'search',
+                },
+              ],
+            },
+          ])
+        );
       });
       it('for dashboards', async () => {
         const resp = await supertestWithoutAuth
@@ -200,46 +202,48 @@ export default function ({ getService }: FtrProviderContext) {
           .set(svlCommonApi.getInternalRequestHeader())
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: 'add810b0-3224-11e8-a572-ffca06da1357',
-            type: 'visualization',
-            relationship: 'child',
-            meta: {
-              icon: 'visualizeApp',
-              title: 'Visualization',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
-            },
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: 'add810b0-3224-11e8-a572-ffca06da1357',
+              type: 'visualization',
+              relationship: 'child',
+              meta: {
+                icon: 'visualizeApp',
+                title: 'Visualization',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-          {
-            id: 'a42c0580-3224-11e8-a572-ffca06da1357',
-            type: 'visualization',
-            relationship: 'child',
-            meta: {
-              icon: 'visualizeApp',
-              title: 'VisualizationFromSavedSearch',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
             },
-            managed: false,
-            references: [
-              {
-                id: '960372e0-3224-11e8-a572-ffca06da1357',
-                name: 'search_0',
-                type: 'search',
+            {
+              id: 'a42c0580-3224-11e8-a572-ffca06da1357',
+              type: 'visualization',
+              relationship: 'child',
+              meta: {
+                icon: 'visualizeApp',
+                title: 'VisualizationFromSavedSearch',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-        ]));
+              managed: false,
+              references: [
+                {
+                  id: '960372e0-3224-11e8-a572-ffca06da1357',
+                  name: 'search_0',
+                  type: 'search',
+                },
+              ],
+            },
+          ])
+        );
       });
       it('for visualizations', async () => {
         const resp = await supertestWithoutAuth
@@ -248,59 +252,61 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: '960372e0-3224-11e8-a572-ffca06da1357',
-            type: 'search',
-            relationship: 'child',
-            meta: {
-              icon: 'discoverApp',
-              title: 'OneRecord',
-              inAppUrl: {
-                path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
-                uiCapabilitiesPath: 'discover_v2.show',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: '960372e0-3224-11e8-a572-ffca06da1357',
+              type: 'search',
+              relationship: 'child',
+              meta: {
+                icon: 'discoverApp',
+                title: 'OneRecord',
+                inAppUrl: {
+                  path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
+                  uiCapabilitiesPath: 'discover_v2.show',
+                },
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
             },
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
+            {
+              id: 'b70c7ae0-3224-11e8-a572-ffca06da1357',
+              type: 'dashboard',
+              relationship: 'parent',
+              meta: {
+                icon: 'dashboardApp',
+                title: 'Dashboard',
+                inAppUrl: {
+                  path: '/app/dashboards#/view/b70c7ae0-3224-11e8-a572-ffca06da1357',
+                  uiCapabilitiesPath: 'dashboard_v2.show',
+                },
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-          {
-            id: 'b70c7ae0-3224-11e8-a572-ffca06da1357',
-            type: 'dashboard',
-            relationship: 'parent',
-            meta: {
-              icon: 'dashboardApp',
-              title: 'Dashboard',
-              inAppUrl: {
-                path: '/app/dashboards#/view/b70c7ae0-3224-11e8-a572-ffca06da1357',
-                uiCapabilitiesPath: 'dashboard_v2.show',
-              },
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              managed: false,
+              references: [
+                {
+                  id: 'add810b0-3224-11e8-a572-ffca06da1357',
+                  name: 'panel_0',
+                  type: 'visualization',
+                },
+                {
+                  id: 'a42c0580-3224-11e8-a572-ffca06da1357',
+                  name: 'panel_1',
+                  type: 'visualization',
+                },
+              ],
             },
-            managed: false,
-            references: [
-              {
-                id: 'add810b0-3224-11e8-a572-ffca06da1357',
-                name: 'panel_0',
-                type: 'visualization',
-              },
-              {
-                id: 'a42c0580-3224-11e8-a572-ffca06da1357',
-                name: 'panel_1',
-                type: 'visualization',
-              },
-            ],
-          },
-        ]));
+          ])
+        );
       });
       it('for index patterns', async () => {
         const resp = await supertestWithoutAuth
@@ -309,50 +315,52 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: '960372e0-3224-11e8-a572-ffca06da1357',
-            type: 'search',
-            relationship: 'parent',
-            meta: {
-              icon: 'discoverApp',
-              title: 'OneRecord',
-              inAppUrl: {
-                path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
-                uiCapabilitiesPath: 'discover_v2.show',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: '960372e0-3224-11e8-a572-ffca06da1357',
+              type: 'search',
+              relationship: 'parent',
+              meta: {
+                icon: 'discoverApp',
+                title: 'OneRecord',
+                inAppUrl: {
+                  path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
+                  uiCapabilitiesPath: 'discover_v2.show',
+                },
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
             },
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
+            {
+              id: 'add810b0-3224-11e8-a572-ffca06da1357',
+              type: 'visualization',
+              relationship: 'parent',
+              meta: {
+                icon: 'visualizeApp',
+                title: 'Visualization',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-          {
-            id: 'add810b0-3224-11e8-a572-ffca06da1357',
-            type: 'visualization',
-            relationship: 'parent',
-            meta: {
-              icon: 'visualizeApp',
-              title: 'Visualization',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
             },
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
-              },
-            ],
-          },
-        ]));
+          ])
+        );
       });
     });
 
@@ -366,45 +374,48 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: '8963ca30-3224-11e8-a572-ffca06da1357',
-            type: 'index-pattern',
-            meta: {
-              icon: 'indexPatternApp',
-              title: 'saved_objects*',
-              editUrl: '/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
-              inAppUrl: {
-                path: '/app/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
-                uiCapabilitiesPath: 'management.kibana.indexPatterns',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: '8963ca30-3224-11e8-a572-ffca06da1357',
+              type: 'index-pattern',
+              meta: {
+                icon: 'indexPatternApp',
+                title: 'saved_objects*',
+                editUrl:
+                  '/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
+                inAppUrl: {
+                  path: '/app/management/kibana/dataViews/dataView/8963ca30-3224-11e8-a572-ffca06da1357',
+                  uiCapabilitiesPath: 'management.kibana.indexPatterns',
+                },
+                namespaceType: 'multiple',
+                hiddenType: false,
               },
-              namespaceType: 'multiple',
-              hiddenType: false,
+              relationship: 'child',
+              managed: false,
+              references: [],
             },
-            relationship: 'child',
-            managed: false,
-            references: [],
-          },
-          {
-            id: 'a42c0580-3224-11e8-a572-ffca06da1357',
-            type: 'visualization',
-            meta: {
-              icon: 'visualizeApp',
-              title: 'VisualizationFromSavedSearch',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
-            },
-            relationship: 'parent',
-            managed: false,
-            references: [
-              {
-                id: '960372e0-3224-11e8-a572-ffca06da1357',
-                name: 'search_0',
-                type: 'search',
+            {
+              id: 'a42c0580-3224-11e8-a572-ffca06da1357',
+              type: 'visualization',
+              meta: {
+                icon: 'visualizeApp',
+                title: 'VisualizationFromSavedSearch',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-        ]));
+              relationship: 'parent',
+              managed: false,
+              references: [
+                {
+                  id: '960372e0-3224-11e8-a572-ffca06da1357',
+                  name: 'search_0',
+                  type: 'search',
+                },
+              ],
+            },
+          ])
+        );
       });
       it('dashboard', async () => {
         const resp = await supertestWithoutAuth
@@ -413,46 +424,48 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: 'add810b0-3224-11e8-a572-ffca06da1357',
-            type: 'visualization',
-            meta: {
-              icon: 'visualizeApp',
-              title: 'Visualization',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
-            },
-            relationship: 'child',
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: 'add810b0-3224-11e8-a572-ffca06da1357',
+              type: 'visualization',
+              meta: {
+                icon: 'visualizeApp',
+                title: 'Visualization',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-          {
-            id: 'a42c0580-3224-11e8-a572-ffca06da1357',
-            type: 'visualization',
-            meta: {
-              icon: 'visualizeApp',
-              title: 'VisualizationFromSavedSearch',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              relationship: 'child',
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
             },
-            relationship: 'child',
-            managed: false,
-            references: [
-              {
-                id: '960372e0-3224-11e8-a572-ffca06da1357',
-                name: 'search_0',
-                type: 'search',
+            {
+              id: 'a42c0580-3224-11e8-a572-ffca06da1357',
+              type: 'visualization',
+              meta: {
+                icon: 'visualizeApp',
+                title: 'VisualizationFromSavedSearch',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-            ],
-          },
-        ]));
+              relationship: 'child',
+              managed: false,
+              references: [
+                {
+                  id: '960372e0-3224-11e8-a572-ffca06da1357',
+                  name: 'search_0',
+                  type: 'search',
+                },
+              ],
+            },
+          ])
+        );
       });
       it('visualization', async () => {
         const resp = await supertestWithoutAuth
@@ -463,31 +476,33 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: '960372e0-3224-11e8-a572-ffca06da1357',
-            type: 'search',
-            meta: {
-              icon: 'discoverApp',
-              title: 'OneRecord',
-              inAppUrl: {
-                path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
-                uiCapabilitiesPath: 'discover_v2.show',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: '960372e0-3224-11e8-a572-ffca06da1357',
+              type: 'search',
+              meta: {
+                icon: 'discoverApp',
+                title: 'OneRecord',
+                inAppUrl: {
+                  path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
+                  uiCapabilitiesPath: 'discover_v2.show',
+                },
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              relationship: 'child',
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
             },
-            relationship: 'child',
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
-              },
-            ],
-          },
-        ]));
+          ])
+        );
       });
       it('index-pattern', async () => {
         const resp = await supertestWithoutAuth
@@ -498,31 +513,33 @@ export default function ({ getService }: FtrProviderContext) {
           .set(roleAuthc.apiKeyHeader)
           .expect(200);
 
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: '960372e0-3224-11e8-a572-ffca06da1357',
-            type: 'search',
-            meta: {
-              icon: 'discoverApp',
-              title: 'OneRecord',
-              inAppUrl: {
-                path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
-                uiCapabilitiesPath: 'discover_v2.show',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: '960372e0-3224-11e8-a572-ffca06da1357',
+              type: 'search',
+              meta: {
+                icon: 'discoverApp',
+                title: 'OneRecord',
+                inAppUrl: {
+                  path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
+                  uiCapabilitiesPath: 'discover_v2.show',
+                },
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
               },
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
+              relationship: 'parent',
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
             },
-            relationship: 'parent',
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
-              },
-            ],
-          },
-        ]));
+          ])
+        );
       });
     });
 
@@ -574,27 +591,29 @@ export default function ({ getService }: FtrProviderContext) {
           },
         ]);
 
-        expect(sortRelations(resp.body.relations)).to.eql(sortRelations([
-          {
-            id: 'add810b0-3224-11e8-a572-ffca06da1357',
-            meta: {
-              icon: 'visualizeApp',
-              namespaceType: 'multiple-isolated',
-              hiddenType: false,
-              title: 'Visualization',
-            },
-            relationship: 'child',
-            type: 'visualization',
-            managed: false,
-            references: [
-              {
-                id: '8963ca30-3224-11e8-a572-ffca06da1357',
-                name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
-                type: 'index-pattern',
+        expect(sortRelations(resp.body.relations)).to.eql(
+          sortRelations([
+            {
+              id: 'add810b0-3224-11e8-a572-ffca06da1357',
+              meta: {
+                icon: 'visualizeApp',
+                namespaceType: 'multiple-isolated',
+                hiddenType: false,
+                title: 'Visualization',
               },
-            ],
-          },
-        ]));
+              relationship: 'child',
+              type: 'visualization',
+              managed: false,
+              references: [
+                {
+                  id: '8963ca30-3224-11e8-a572-ffca06da1357',
+                  name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+                  type: 'index-pattern',
+                },
+              ],
+            },
+          ])
+        );
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/244414

The serverless relationships API integration test was failing intermittently because it was strictly comparing arrays of relations that could be returned from the API in a non-deterministic order. 

This PR introduces a `sortRelations` helper (identical to the one used in the standard stateful relationships test `src/platform/test/api_integration/apis/saved_objects_management/relationships.ts`) to sort both the actual and expected arrays before applying the `eql` assertion, thereby eliminating the flakiness caused by ordering differences.