### PR TITLE
[Console] Fix incorrect brace autocomplete insertion

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -410,14 +410,28 @@ describe('autocomplete_utils', () => {
       expect(getInsertText({ name: undefined } as ResultTerm, '', mockContext)).toBe('');
     });
 
-    it('handles unclosed quotes correctly', () => {
+    it('does not add quotes around braces and brackets', () => {
       expect(
         getInsertText(
-          { name: 'match_all' } as ResultTerm,
+          { name: '{' } as ResultTerm,
+          '{\n' + '    "query": {\n' + '      ',
+          mockContext
+        )
+      ).toBe('{$0}');
+      expect(
+        getInsertText(
+          { name: '[' } as ResultTerm,
+          '{\n' + '    "query": {\n' + '      ',
+          mockContext
+        )
+      ).toBe('[$0]');
+      expect(
+        getInsertText(
+          { name: '{' } as ResultTerm,
           '{\n' + '    "query": {\n' + '      "match_a',
           mockContext
         )
-      ).toBe('match_all"');
+      ).toBe('{$0}');
     });
 
     it('wraps insertValue with quotes when appropriate', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -405,7 +405,7 @@ describe('autocomplete_utils', () => {
     it('filters structural suggestions in unmatched endpoint quoted context', async () => {
       const mockAutocompleteSet = [
         { name: '{' },
-        { name: 'match_all' },
+        { name: 'match_all', insertValue: '{' },
       ] as unknown as AutoCompleteContext['autoCompleteSet'];
 
       mockPopulateContext.mockImplementation((...args) => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -401,6 +401,39 @@ describe('autocomplete_utils', () => {
         endColumn: 21, // Including the closing quote
       });
     });
+
+    it('filters structural suggestions in unmatched endpoint quoted context', async () => {
+      const mockAutocompleteSet = [
+        { name: '{' },
+        { name: 'match_all' },
+      ] as unknown as AutoCompleteContext['autoCompleteSet'];
+
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = mockAutocompleteSet;
+      });
+
+      const mockModel = {
+        getLineContent: () => 'POST not_a_real_endpoint',
+        getValueInRange: jest.fn((range: any) => {
+          if (range.startLineNumber === 2) {
+            return '{\n  "query": "';
+          }
+          if (range.startLineNumber === 3 && range.startColumn === 1) {
+            return '  "query": "';
+          }
+          return '';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 12, word: '' }),
+        getLineMaxColumn: () => 12,
+      } as unknown as monaco.editor.ITextModel;
+
+      const mockPosition = { lineNumber: 3, column: 12 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items.map((item) => item.label)).toEqual(['match_all']);
+    });
   });
 
   describe('getInsertText', () => {
@@ -437,7 +470,17 @@ describe('autocomplete_utils', () => {
     it('wraps insertValue with quotes when appropriate', () => {
       expect(
         getInsertText(
-          { name: 'match_all' } as ResultTerm,
+          { name: 'query', insertValue: 'match_all' } as ResultTerm,
+          '{\n' + '    "query": {\n' + '      ',
+          mockContext
+        )
+      ).toBe('"match_all"');
+    });
+
+    it('uses name when insertValue is a structural token', () => {
+      expect(
+        getInsertText(
+          { name: 'match_all', insertValue: '{' } as ResultTerm,
           '{\n' + '    "query": {\n' + '      ',
           mockContext
         )

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -402,7 +402,7 @@ describe('autocomplete_utils', () => {
       });
     });
 
-    it('filters structural suggestions in unmatched endpoint quoted context', async () => {
+    it('filters structural suggestions when cursor is inside an unclosed quote (unmatched endpoint)', async () => {
       const mockAutocompleteSet = [
         { name: '{' },
         { name: 'match_all', insertValue: '{' },
@@ -433,6 +433,44 @@ describe('autocomplete_utils', () => {
       const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
 
       expect(items.map((item) => item.label)).toEqual(['match_all']);
+    });
+
+    it('filters structural suggestions when cursor is inside an unclosed quote (matched endpoint)', async () => {
+      const mockAutocompleteSet = [
+        { name: '{' },
+        { name: 'type' },
+      ] as unknown as AutoCompleteContext['autoCompleteSet'];
+
+      const mockEndpoint = {
+        bodyAutocompleteRootComponents: [],
+      };
+
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.endpoint = mockEndpoint;
+        context.autoCompleteSet = mockAutocompleteSet;
+      });
+
+      const mockModel = {
+        getLineContent: () => 'PUT /test',
+        getValueInRange: jest.fn((range: any) => {
+          if (range.startLineNumber === 2) {
+            return '{\n  "mappings": {\n    "properties": {\n      "integer_field": "';
+          }
+          if (range.startLineNumber === 5 && range.startColumn === 1) {
+            return '      "integer_field": "';
+          }
+          return '';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 24, word: '' }),
+        getLineMaxColumn: () => 24,
+      } as unknown as monaco.editor.ITextModel;
+
+      const mockPosition = { lineNumber: 5, column: 24 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items.map((item) => item.label)).toEqual(['type']);
     });
   });
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -472,6 +472,45 @@ describe('autocomplete_utils', () => {
 
       expect(items.map((item) => item.label)).toEqual(['type']);
     });
+
+    it('filters structural suggestions when cursor is before existing content on the line', async () => {
+      const mockAutocompleteSet = [
+        { name: '{' },
+        { name: 'type' },
+      ] as unknown as AutoCompleteContext['autoCompleteSet'];
+
+      const mockEndpoint = {
+        bodyAutocompleteRootComponents: [],
+      };
+
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.endpoint = mockEndpoint;
+        context.autoCompleteSet = mockAutocompleteSet;
+      });
+
+      const mockModel = {
+        getLineContent: () => 'PUT /test_index',
+        getValueInRange: jest.fn((range: any) => {
+          if (range.startLineNumber === 2) {
+            return '{\n  "mappings": {\n    "properties": {\n      "integer_field": ';
+          }
+          if (range.startLineNumber === 5 && range.startColumn === 1) {
+            return '      "integer_field": ';
+          }
+          // content after cursor: existing value
+          return '"keyword"';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 23, word: '' }),
+        getLineMaxColumn: () => 32,
+      } as unknown as monaco.editor.ITextModel;
+
+      const mockPosition = { lineNumber: 5, column: 23 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items.map((item) => item.label)).toEqual(['type']);
+    });
   });
 
   describe('getInsertText', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -358,6 +358,10 @@ const getSuggestions = (
     ? unquotedFieldWithDotMatch[1]
     : null;
   const isQuotedField = !!quotedFieldWithDotMatch;
+  const bodyContentLines = bodyContentBeforePosition.split('\n');
+  const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
+  const isUnmatchedEndpointQuotedContext =
+    !context.endpoint && hasUnclosedQuote(currentContentLine);
 
   // Adjust the range start column if we have a field with a dot
   let startColumn = wordUntilPosition.startColumn;
@@ -389,6 +393,14 @@ const getSuggestions = (
     filterTermsWithoutName(autocompleteSet)
       // Filter suggestions to only show nested fields when there's a field being typed with a dot
       .filter((item) => {
+        if (
+          isUnmatchedEndpointQuotedContext &&
+          ((typeof item.name === 'string' && getStructuralSnippet(item.name)) ||
+            (typeof item.insertValue === 'string' && getStructuralSnippet(item.insertValue)))
+        ) {
+          return false;
+        }
+
         if (fieldBeingTyped) {
           // Only show fields that start with what the user has typed so far
           return typeof item.name === 'string' && item.name.startsWith(fieldBeingTyped);
@@ -411,6 +423,17 @@ const getSuggestions = (
       })
   );
 };
+
+const getStructuralSnippet = (token: string) => {
+  if (token === '{') {
+    return '{$0}';
+  }
+  if (token === '[') {
+    return '[$0]';
+  }
+  return undefined;
+};
+
 export const getInsertText = (
   { name, insertValue, template, value }: ResultTerm,
   bodyContent: string,
@@ -422,10 +445,9 @@ export const getInsertText = (
 
   let insertText = '';
   if (typeof name === 'string') {
-    if (name === '{') {
-      insertText = '{$0}';
-    } else if (name === '[') {
-      insertText = '[$0]';
+    const structuralSnippet = getStructuralSnippet(name);
+    if (structuralSnippet) {
+      insertText = structuralSnippet;
     } else {
       const bodyContentLines = bodyContent.split('\n');
       const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
@@ -436,11 +458,9 @@ export const getInsertText = (
         // The cursor is at the beginning of a field so the insert text should start with a quote
         insertText = '"';
       }
-      if (insertValue && insertValue !== '{' && insertValue !== '[') {
-        insertText += `${insertValue}"`;
-      } else {
-        insertText += `${name}"`;
-      }
+      // insertValue can override the inserted token, but structural tokens are inserted as snippets above
+      const insertableName = insertValue && !getStructuralSnippet(insertValue) ? insertValue : name;
+      insertText += `${insertableName}"`;
     }
   } else {
     insertText = name + '';

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -422,19 +422,25 @@ export const getInsertText = (
 
   let insertText = '';
   if (typeof name === 'string') {
-    const bodyContentLines = bodyContent.split('\n');
-    const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
-    if (hasUnclosedQuote(currentContentLine)) {
-      // The cursor is after an unmatched quote (e.g. '..."abc', '..."')
-      insertText = '';
+    if (name === '{') {
+      insertText = '{$0}';
+    } else if (name === '[') {
+      insertText = '[$0]';
     } else {
-      // The cursor is at the beginning of a field so the insert text should start with a quote
-      insertText = '"';
-    }
-    if (insertValue && insertValue !== '{' && insertValue !== '[') {
-      insertText += `${insertValue}"`;
-    } else {
-      insertText += `${name}"`;
+      const bodyContentLines = bodyContent.split('\n');
+      const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
+      if (hasUnclosedQuote(currentContentLine)) {
+        // The cursor is after an unmatched quote (e.g. '..."abc', '..."')
+        insertText = '';
+      } else {
+        // The cursor is at the beginning of a field so the insert text should start with a quote
+        insertText = '"';
+      }
+      if (insertValue && insertValue !== '{' && insertValue !== '[') {
+        insertText += `${insertValue}"`;
+      } else {
+        insertText += `${name}"`;
+      }
     }
   } else {
     insertText = name + '';

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -312,6 +312,19 @@ export const getBodyCompletionItems = async (
   );
 };
 
+const getStructuralSnippet = (token: string) => {
+  if (token === '{') {
+    return '{$0}';
+  }
+  if (token === '[') {
+    return '[$0]';
+  }
+  return undefined;
+};
+
+const usesStructuralSnippet = ({ name }: Pick<ResultTerm, 'name'>): boolean =>
+  typeof name === 'string' && getStructuralSnippet(name) !== undefined;
+
 const getSuggestions = (
   model: monaco.editor.ITextModel,
   position: monaco.Position,
@@ -393,11 +406,7 @@ const getSuggestions = (
     filterTermsWithoutName(autocompleteSet)
       // Filter suggestions to only show nested fields when there's a field being typed with a dot
       .filter((item) => {
-        if (
-          isUnmatchedEndpointQuotedContext &&
-          ((typeof item.name === 'string' && getStructuralSnippet(item.name)) ||
-            (typeof item.insertValue === 'string' && getStructuralSnippet(item.insertValue)))
-        ) {
+        if (isUnmatchedEndpointQuotedContext && usesStructuralSnippet(item)) {
           return false;
         }
 
@@ -422,16 +431,6 @@ const getSuggestions = (
         return suggestion;
       })
   );
-};
-
-const getStructuralSnippet = (token: string) => {
-  if (token === '{') {
-    return '{$0}';
-  }
-  if (token === '[') {
-    return '[$0]';
-  }
-  return undefined;
 };
 
 export const getInsertText = (

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -405,7 +405,7 @@ const getSuggestions = (
     filterTermsWithoutName(autocompleteSet)
       // Filter suggestions to only show nested fields when there's a field being typed with a dot
       .filter((item) => {
-        if (isInsideQuotedString && usesStructuralSnippet(item)) {
+        if ((isInsideQuotedString || !context.addTemplate) && usesStructuralSnippet(item)) {
           return false;
         }
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -373,8 +373,7 @@ const getSuggestions = (
   const isQuotedField = !!quotedFieldWithDotMatch;
   const bodyContentLines = bodyContentBeforePosition.split('\n');
   const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
-  const isUnmatchedEndpointQuotedContext =
-    !context.endpoint && hasUnclosedQuote(currentContentLine);
+  const isInsideQuotedString = hasUnclosedQuote(currentContentLine);
 
   // Adjust the range start column if we have a field with a dot
   let startColumn = wordUntilPosition.startColumn;
@@ -406,7 +405,7 @@ const getSuggestions = (
     filterTermsWithoutName(autocompleteSet)
       // Filter suggestions to only show nested fields when there's a field being typed with a dot
       .filter((item) => {
-        if (isUnmatchedEndpointQuotedContext && usesStructuralSnippet(item)) {
+        if (isInsideQuotedString && usesStructuralSnippet(item)) {
           return false;
         }
 


### PR DESCRIPTION
Closes #220475

## Summary

- Fixes an issue where autocompleting an opening brace `{` or bracket `[` in the Console request body incorrectly wrapped the suggestion in double quotes.
- Suppresses `{`/`[` structural suggestions when they would corrupt existing content (inside unclosed quotes or before existing values).

## Root Cause

- The autocomplete `getInsertText` logic always assumed suggestions were strings and wrapped them in quotes when inside objects, without treating structural characters like `{` and `[` as special cases.
- The autocomplete `getSuggestions` logic did not guard against offering `{`/`[` in contexts where inserting them would be destructive — specifically:
  1. When the cursor is inside an unclosed quote (matched or unmatched endpoint).
  2. When there is existing content to the right of the cursor (e.g., a string value like `"keyword"`).

## Fix

- Modified `getInsertText` to explicitly handle `{` and `[` by inserting them with the Monaco snippet placeholder `{$0}` and `[$0]` respectively, which bypasses the quote-wrapping logic and properly aligns with existing formatting behavior.
- Added a filter in `getSuggestions` that suppresses structural `{`/`[` suggestions when:
  - The cursor is inside an unclosed quote (`hasUnclosedQuote`), OR
  - There is existing content after the cursor that would be corrupted (`!context.addTemplate`).

## Scenarios Fixed

### 1. Selecting `{` inserted `"{"` instead of `{}`

**Before**

https://github.com/user-attachments/assets/095d6930-0ee2-4b84-ae02-e6dd90ed1e4d

**After**

https://github.com/user-attachments/assets/e563aa4d-6fe2-42b1-94b4-cb5765c6f592

### 2. `{` suggested inside unclosed quote (unmatched endpoint)

`POST not_a_real_endpoint` → `{ "query": "` → Ctrl+Space showed `{`. Now shows "No suggestions."

### 3. `{` suggested inside unclosed quote (matched endpoint)

`PUT /test` → `{ "mappings": { "properties": { "integer_field": "` → Ctrl+Space showed `{`. Now shows "No suggestions."

### 4. `{` suggested before existing content

`PUT /test_index` → `{ "mappings": { "properties": { "integer_field": "keyword"` → move cursor before `"keyword"` → Ctrl+Space showed `{`. Now shows "No suggestions."

## Test Plan

- Open Kibana Console
- **Scenario 1 (insertion):** Type `PUT /test_index` with body `{ "mappings": { "properties": { "field1": ` → Ctrl+Space → select `{` → verify `{}` is inserted (not `"{}"`), cursor placed inside.
- **Scenario 2 (unclosed quote, unmatched):** Type `POST not_a_real_endpoint` with body `{ "query": "` → Ctrl+Space → verify no `{` suggestion.
- **Scenario 3 (unclosed quote, matched):** Type `PUT /test` with body `{ "mappings": { "properties": { "integer_field": "` → Ctrl+Space → verify no `{` suggestion.
- **Scenario 4 (before existing content):** Type `PUT /test_index` with body `{ "mappings": { "properties": { "integer_field": "keyword"` → move cursor before `"keyword"` → Ctrl+Space → verify no `{` suggestion.
- All existing Jest tests pass (46 tests), ESLint clean, type check clean.

## Release Note

Fixes Console autocomplete to insert `{}`/`[]` snippets instead of quoted braces when selecting `{` or `[` suggestions in request bodies, and suppresses these structural suggestions in contexts where they would corrupt existing content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete suggestions for structural tokens (braces and brackets) in complex editing contexts.
  * Fixed quote handling to prevent unnecessary wrapping around structural tokens during insertion.
  * Enhanced context detection for unmatched endpoints to provide more accurate and relevant suggestions.

* **Tests**
  * Expanded test coverage for structural token handling and quote behavior in autocomplete scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->