### PR TITLE
chore: add missing names to gh workflows

### DIFF
--- a/.github/workflows/alert-failed-test.yml
+++ b/.github/workflows/alert-failed-test.yml
@@ -1,3 +1,5 @@
+name: Alert on failed test comment
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/auto-approve-api-docs.yml
+++ b/.github/workflows/auto-approve-api-docs.yml
@@ -1,3 +1,5 @@
+name: Auto-approve API docs PRs
+
 on:
   pull_request_target:
     branches:

--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -1,3 +1,5 @@
+name: Auto-approve backport PRs
+
 on:
   pull_request_target:
     branches-ignore:

--- a/.github/workflows/auto-approve-bundled-package-updates.yml
+++ b/.github/workflows/auto-approve-bundled-package-updates.yml
@@ -1,3 +1,5 @@
+name: Auto-approve bundled package updates
+
 on:
   pull_request:
     types:

--- a/.github/workflows/auto-approve-machine-prs.yml
+++ b/.github/workflows/auto-approve-machine-prs.yml
@@ -1,5 +1,7 @@
 # Generic auto-approve for machine-created PRs.
 # Add new rules to the whitelist in the check step; approval runs when any rule matches.
+name: Auto-approve machine PRs
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/label-failed-test.yml
+++ b/.github/workflows/label-failed-test.yml
@@ -1,3 +1,5 @@
+name: Label failed-test issues
+
 on:
   issues:
     types:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,3 +1,5 @@
+name: Label and backport on merge
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -1,3 +1,5 @@
+name: Assign issues to project by label
+
 on:
   issues:
     types: [labeled, unlabeled]

--- a/.github/workflows/skip-failed-test.yml
+++ b/.github/workflows/skip-failed-test.yml
@@ -1,3 +1,5 @@
+name: Skip failed test on comment
+
 on:
   issue_comment:
     types:

--- a/.github/workflows/trigger-flaky.yml
+++ b/.github/workflows/trigger-flaky.yml
@@ -1,3 +1,5 @@
+name: Trigger flaky test runner on comment
+
 on:
   issue_comment:
     types:

--- a/.github/workflows/trigger-sync-ci.yml
+++ b/.github/workflows/trigger-sync-ci.yml
@@ -1,3 +1,5 @@
+name: Sync CI on comment
+
 on:
   issue_comment:
     types:


### PR DESCRIPTION
I’ve added names to the workflows so they’re easier to identify and look a bit cleaner in the Actions tab.