### PR TITLE
[Observability:Streams] Leave strings untrimmed in processor data preview table

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/preview_table_cell.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/preview_table_cell.tsx
@@ -23,6 +23,7 @@ import type { PreviewTableMode } from './preview_table';
 
 const emptyCell = <>&nbsp;</>;
 const EMPTY_IGNORED_FIELDS: IgnoredField[] = [];
+const preserveWhitespaceStyle: React.CSSProperties = { whiteSpace: 'pre' };
 
 export function isDocumentWithIgnoredFields(
   doc: SampleDocument | DocumentWithIgnoredFields
@@ -135,9 +136,10 @@ const PreviewTableCellContent = memo(function PreviewTableCellContent({
     return emptyCell;
   }
   if (typeof value === 'object') {
-    return JSON.stringify(value);
+    return <span style={preserveWhitespaceStyle}>{JSON.stringify(value)}</span>;
   }
-  return String(value) || emptyCell;
+  const stringValue = String(value);
+  return stringValue ? <span style={preserveWhitespaceStyle}>{stringValue}</span> : emptyCell;
 });
 
 interface PreviewTableCellProps extends CellRenderBaseProps {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/248190

## Summary 
This PR adds css styles to preserve leading and trailing whitespaces processor preview table cells. This change will enhance the `trim` processor, as before its effects were not observable as the whitespace was already being cutoff in the table. 

## Demo
https://github.com/user-attachments/assets/edc4edb1-88c9-4880-8219-451113ebe75f