### PR TITLE
Prevent new connectors from listing mapped pages

### DIFF
--- a/docs/reference/connectors-kibana/abuseipdb-action-type.md
+++ b/docs/reference/connectors-kibana/abuseipdb-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "AbuseIPDB"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/abuseipdb-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/alienvault-otx-action-type.md
+++ b/docs/reference/connectors-kibana/alienvault-otx-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "AlienVault OTX"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/alienvault-otx-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/brave-search-action-type.md
+++ b/docs/reference/connectors-kibana/brave-search-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "Brave Search"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/brave-search-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/google-drive-action-type.md
+++ b/docs/reference/connectors-kibana/google-drive-action-type.md
@@ -2,8 +2,6 @@
 navigation_title: "Google Drive"
 type: reference
 description: "Use the Google Drive connector to search, list, and download files and folders from Google Drive."
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/google-drive-action-type.html
 applies_to:
   stack: preview 9.4
   serverless: preview

--- a/docs/reference/connectors-kibana/greynoise-action-type.md
+++ b/docs/reference/connectors-kibana/greynoise-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "GreyNoise"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/greynoise-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/jina-action-type.md
+++ b/docs/reference/connectors-kibana/jina-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "Jina Reader"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/jina-action-type.html
 applies_to:
   stack: preview 9.4+
   serverless: preview

--- a/docs/reference/connectors-kibana/notion-action-type.md
+++ b/docs/reference/connectors-kibana/notion-action-type.md
@@ -2,8 +2,6 @@
 navigation_title: "Notion"
 type: reference
 description: "Use the Notion connector to search pages and databases, retrieve content, and query databases in your Notion workspace."
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/notion-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/servicenow-search-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-search-action-type.md
@@ -2,8 +2,6 @@
 navigation_title: "ServiceNow"
 type: reference
 description: "Use the ServiceNow connector for federated search across incidents, knowledge articles, change requests, and other ServiceNow tables."
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/servicenow-search-action-type.html
 applies_to:
   stack: preview 9.4
   serverless: preview

--- a/docs/reference/connectors-kibana/sharepoint-online-action-type.md
+++ b/docs/reference/connectors-kibana/sharepoint-online-action-type.md
@@ -2,8 +2,6 @@
 navigation_title: "SharePoint Online"
 type: reference
 description: "Use the SharePoint Online connector to search across SharePoint sites, pages, drives, and lists using the Microsoft Graph API."
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/sharepoint-online-action-type.html
 applies_to:
   stack: preview 9.4
   serverless: preview

--- a/docs/reference/connectors-kibana/shodan-action-type.md
+++ b/docs/reference/connectors-kibana/shodan-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "Shodan"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/shodan-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/slack-v2-action-type.md
+++ b/docs/reference/connectors-kibana/slack-v2-action-type.md
@@ -2,8 +2,6 @@
 navigation_title: "Slack (v2)"
 type: reference
 description: "Use the Slack (v2) connector to search messages, resolve channel IDs, and send messages to Slack channels using the Slack Web API."
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/slack-v2-action-type.html
 applies_to:
   stack: preview 9.4
   serverless: preview

--- a/docs/reference/connectors-kibana/urlvoid-action-type.md
+++ b/docs/reference/connectors-kibana/urlvoid-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "URLVoid"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/urlvoid-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/virustotal-action-type.md
+++ b/docs/reference/connectors-kibana/virustotal-action-type.md
@@ -1,7 +1,5 @@
 ---
 navigation_title: "VirusTotal"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/virustotal-action-type.html
 applies_to:
   stack: preview 9.3
   serverless: preview

--- a/docs/reference/connectors-kibana/zoom-action-type.md
+++ b/docs/reference/connectors-kibana/zoom-action-type.md
@@ -2,8 +2,6 @@
 navigation_title: "Zoom"
 type: reference
 description: "Use the Zoom connector to access meetings, cloud recordings, transcripts, chat logs, and participants using the Zoom REST API."
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/zoom-action-type.html
 applies_to:
   stack: preview 9.4
   serverless: preview

--- a/packages/kbn-generate/templates/connector/docs.md.ejs
+++ b/packages/kbn-generate/templates/connector/docs.md.ejs
@@ -1,7 +1,5 @@
 ---
 navigation_title: "<%= connector.displayName %>"
-mapped_pages:
-  - https://www.elastic.co/guide/en/kibana/current/<%= connector.kebabName %>-action-type.html
 applies_to:
   stack: preview
   serverless: preview


### PR DESCRIPTION
## Summary

See: https://github.com/elastic/kibana/pull/252717#discussion_r2891502591

Our "generate connector" script seeded new connector docs with this frontmatter, and our skills encourage new connectors to follow patterns established by prior ones. So we started some bad momentum. This corrects the mistakes we've made thus far, and hopefully will keep us from making more.
