### PR TITLE
[Workplace AI][PoC] MCP Client access in v2 Connectors framework

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/api_key_header.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/api_key_header.ts
@@ -38,6 +38,18 @@ type NormalizedAuthSchemaType = Record<string, string>;
 export const ApiKeyHeaderAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'api_key_header',
   schema: authSchema,
+  getHeaders: async (
+    _: AuthContext,
+    secret: NormalizedAuthSchemaType
+  ): Promise<Record<string, string>> => {
+    const headers: Record<string, string> = {};
+    Object.keys(secret)
+      .filter((key) => key !== 'authType')
+      .forEach((key) => {
+        headers[key] = secret[key];
+      });
+    return headers;
+  },
   normalizeSchema: (defaults?: Record<string, unknown>) => {
     const existingMeta = authSchema.meta() ?? {};
     const schemaToUse = z.object({

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/api_key_header.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/api_key_header.ts
@@ -8,7 +8,6 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import type { AxiosInstance } from 'axios';
 import { isString } from 'lodash';
 import type { AuthContext, AuthTypeSpec } from '../connector_spec';
 import * as i18n from './translations';
@@ -38,7 +37,7 @@ type NormalizedAuthSchemaType = Record<string, string>;
 export const ApiKeyHeaderAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'api_key_header',
   schema: authSchema,
-  getHeaders: async (
+  authenticate: async (
     _: AuthContext,
     secret: NormalizedAuthSchemaType
   ): Promise<Record<string, string>> => {
@@ -57,7 +56,6 @@ export const ApiKeyHeaderAuth: AuthTypeSpec<AuthSchemaType> = {
     });
 
     if (defaults) {
-      // get the default values for the headerField
       const headerField: string =
         defaults.headerField && isString(defaults.headerField)
           ? defaults.headerField
@@ -68,19 +66,5 @@ export const ApiKeyHeaderAuth: AuthTypeSpec<AuthSchemaType> = {
     }
 
     return schemaToUse.meta(existingMeta);
-  },
-  configure: async (
-    _: AuthContext,
-    axiosInstance: AxiosInstance,
-    secret: NormalizedAuthSchemaType
-  ): Promise<AxiosInstance> => {
-    // set global defaults
-    Object.keys(secret)
-      .filter((key) => key !== 'authType')
-      .forEach((key) => {
-        axiosInstance.defaults.headers.common[key] = secret[key];
-      });
-
-    return axiosInstance;
   },
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/basic.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/basic.ts
@@ -34,12 +34,15 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const BasicAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'basic',
   schema: authSchema,
+  getHeaders: async (_: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
+    const encoded = Buffer.from(`${secret.username}:${secret.password}`).toString('base64');
+    return { Authorization: `Basic ${encoded}` };
+  },
   configure: async (
     _: AuthContext,
     axiosInstance: AxiosInstance,
     secret: AuthSchemaType
   ): Promise<AxiosInstance> => {
-    // set global defaults
     axiosInstance.defaults.auth = {
       username: secret.username,
       password: secret.password,

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/basic.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/basic.ts
@@ -8,7 +8,6 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import type { AxiosInstance } from 'axios';
 import type { AuthContext, AuthTypeSpec } from '../connector_spec';
 import * as i18n from './translations';
 
@@ -34,20 +33,8 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const BasicAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'basic',
   schema: authSchema,
-  getHeaders: async (_: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
+  authenticate: async (_: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
     const encoded = Buffer.from(`${secret.username}:${secret.password}`).toString('base64');
     return { Authorization: `Basic ${encoded}` };
-  },
-  configure: async (
-    _: AuthContext,
-    axiosInstance: AxiosInstance,
-    secret: AuthSchemaType
-  ): Promise<AxiosInstance> => {
-    axiosInstance.defaults.auth = {
-      username: secret.username,
-      password: secret.password,
-    };
-
-    return axiosInstance;
   },
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.ts
@@ -30,12 +30,14 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const BearerAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'bearer',
   schema: authSchema,
+  getHeaders: async (_: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
+    return { Authorization: `Bearer ${secret.token}` };
+  },
   configure: async (
     _: AuthContext,
     axiosInstance: AxiosInstance,
     secret: AuthSchemaType
   ): Promise<AxiosInstance> => {
-    // set global defaults
     axiosInstance.defaults.headers.common.Authorization = `Bearer ${secret.token}`;
 
     return axiosInstance;

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.ts
@@ -8,7 +8,6 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import type { AxiosInstance } from 'axios';
 import type { AuthContext, AuthTypeSpec } from '../connector_spec';
 import * as i18n from './translations';
 
@@ -30,16 +29,7 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const BearerAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'bearer',
   schema: authSchema,
-  getHeaders: async (_: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
+  authenticate: async (_: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
     return { Authorization: `Bearer ${secret.token}` };
-  },
-  configure: async (
-    _: AuthContext,
-    axiosInstance: AxiosInstance,
-    secret: AuthSchemaType
-  ): Promise<AxiosInstance> => {
-    axiosInstance.defaults.headers.common.Authorization = `Bearer ${secret.token}`;
-
-    return axiosInstance;
   },
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/crt.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/crt.ts
@@ -39,6 +39,10 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const CRT: AuthTypeSpec<AuthSchemaType> = {
   id: 'crt_certificate',
   schema: authSchema,
+  getHeaders: async (): Promise<Record<string, string>> => {
+    // CRT auth uses TLS client certificates, not HTTP headers.
+    return {};
+  },
   configure: async (
     ctx: AuthContext,
     axiosInstance: AxiosInstance,

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/crt.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/crt.ts
@@ -39,8 +39,7 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const CRT: AuthTypeSpec<AuthSchemaType> = {
   id: 'crt_certificate',
   schema: authSchema,
-  getHeaders: async (): Promise<Record<string, string>> => {
-    // CRT auth uses TLS client certificates, not HTTP headers.
+  authenticate: async (): Promise<Record<string, string>> => {
     return {};
   },
   configure: async (

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/none.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/none.ts
@@ -22,6 +22,9 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const NoAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'none',
   schema: authSchema,
+  getHeaders: async (): Promise<Record<string, string>> => {
+    return {};
+  },
   configure: async (_: AuthContext, axiosInstance: AxiosInstance): Promise<AxiosInstance> => {
     return axiosInstance;
   },

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/none.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/none.ts
@@ -8,8 +8,7 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import type { AxiosInstance } from 'axios';
-import type { AuthContext, AuthTypeSpec } from '../connector_spec';
+import type { AuthTypeSpec } from '../connector_spec';
 import * as i18n from './translations';
 
 const authSchema = z.object({}).meta({ label: i18n.NO_AUTH_LABEL });
@@ -22,10 +21,7 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const NoAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'none',
   schema: authSchema,
-  getHeaders: async (): Promise<Record<string, string>> => {
+  authenticate: async (): Promise<Record<string, string>> => {
     return {};
-  },
-  configure: async (_: AuthContext, axiosInstance: AxiosInstance): Promise<AxiosInstance> => {
-    return axiosInstance;
   },
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth.ts
@@ -35,6 +35,25 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const OAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'oauth_client_credentials',
   schema: authSchema,
+  getHeaders: async (ctx: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
+    let token;
+    try {
+      token = await ctx.getToken({
+        tokenUrl: secret.tokenUrl,
+        scope: secret.scope,
+        clientId: secret.clientId,
+        clientSecret: secret.clientSecret,
+      });
+    } catch (error) {
+      throw new Error(`Unable to retrieve/refresh the access token: ${error.message}`);
+    }
+
+    if (!token) {
+      throw new Error(`Unable to retrieve new access token`);
+    }
+
+    return { Authorization: token };
+  },
   configure: async (
     ctx: AuthContext,
     axiosInstance: AxiosInstance,

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth.ts
@@ -8,7 +8,6 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import type { AxiosInstance } from 'axios';
 import type { AuthContext, AuthTypeSpec } from '../connector_spec';
 import * as i18n from './translations';
 
@@ -35,7 +34,10 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const OAuth: AuthTypeSpec<AuthSchemaType> = {
   id: 'oauth_client_credentials',
   schema: authSchema,
-  getHeaders: async (ctx: AuthContext, secret: AuthSchemaType): Promise<Record<string, string>> => {
+  authenticate: async (
+    ctx: AuthContext,
+    secret: AuthSchemaType
+  ): Promise<Record<string, string>> => {
     let token;
     try {
       token = await ctx.getToken({
@@ -53,31 +55,5 @@ export const OAuth: AuthTypeSpec<AuthSchemaType> = {
     }
 
     return { Authorization: token };
-  },
-  configure: async (
-    ctx: AuthContext,
-    axiosInstance: AxiosInstance,
-    secret: AuthSchemaType
-  ): Promise<AxiosInstance> => {
-    let token;
-    try {
-      token = await ctx.getToken({
-        tokenUrl: secret.tokenUrl,
-        scope: secret.scope,
-        clientId: secret.clientId,
-        clientSecret: secret.clientSecret,
-      });
-    } catch (error) {
-      throw new Error(`Unable to retrieve/refresh the access token: ${error.message}`);
-    }
-
-    if (!token) {
-      throw new Error(`Unable to retrieve new access token`);
-    }
-
-    // set global defaults
-    axiosInstance.defaults.headers.common.Authorization = token;
-
-    return axiosInstance;
   },
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/pfx.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/pfx.ts
@@ -38,6 +38,10 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const PFX: AuthTypeSpec<AuthSchemaType> = {
   id: 'pfx_certificate',
   schema: authSchema,
+  getHeaders: async (): Promise<Record<string, string>> => {
+    // PFX auth uses TLS client certificates, not HTTP headers.
+    return {};
+  },
   configure: async (
     ctx: AuthContext,
     axiosInstance: AxiosInstance,

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/pfx.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/pfx.ts
@@ -38,8 +38,7 @@ type AuthSchemaType = z.infer<typeof authSchema>;
 export const PFX: AuthTypeSpec<AuthSchemaType> = {
   id: 'pfx_certificate',
   schema: authSchema,
-  getHeaders: async (): Promise<Record<string, string>> => {
-    // PFX auth uses TLS client certificates, not HTTP headers.
+  authenticate: async (): Promise<Record<string, string>> => {
     return {};
   },
   configure: async (

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -97,6 +97,7 @@ export interface AuthTypeSpec<T extends Record<string, unknown>> {
   schema: z.ZodObject<Record<string, z.ZodType>>;
   normalizeSchema?: (defaults?: Record<string, unknown>) => z.ZodObject<Record<string, z.ZodType>>;
   configure: (ctx: AuthContext, axiosInstance: AxiosInstance, secret: T) => Promise<AxiosInstance>;
+  getHeaders: (ctx: AuthContext, secret: T) => Promise<Record<string, string>>;
 }
 
 export type NormalizedAuthType = AuthTypeSpec<Record<string, unknown>>;
@@ -172,6 +173,45 @@ export interface ConnectorPolicies {
 }
 
 // ============================================================================
+// MCP CLIENT
+// ============================================================================
+
+/** Spec-level declaration that a connector requires an MCP client. */
+export interface McpClientConfig {
+  /** The config field name that contains the MCP server URL (e.g. 'serverUrl'). */
+  urlField: string;
+}
+
+/** Tool descriptor returned by an MCP server. */
+export interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** Parameters for invoking an MCP tool. */
+export interface McpCallToolParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+/** A single content part in an MCP tool response. */
+export interface McpContentPart {
+  type: string;
+  text?: string;
+}
+
+/**
+ * Transport-agnostic MCP client interface exposed to connector action handlers.
+ * Decoupled from the concrete McpClient class so that spec types remain
+ * importable from src/ packages without depending on x-pack.
+ */
+export interface ConnectorMcpClient {
+  listTools(): Promise<{ tools: McpTool[] }>;
+  callTool(params: McpCallToolParams): Promise<{ content: McpContentPart[] }>;
+}
+
+// ============================================================================
 // ACTIONS
 // ============================================================================
 
@@ -188,6 +228,7 @@ export interface ActionDefinition<TInput = unknown, TOutput = unknown, TError = 
 
 export interface ActionContext {
   client: AxiosInstance;
+  mcpClient?: ConnectorMcpClient;
   config?: Record<string, unknown>;
   connectorUsageCollector?: unknown;
   log: Logger;
@@ -256,6 +297,8 @@ export interface ConnectorSpec {
   };
 
   policies?: ConnectorPolicies;
+
+  mcp?: McpClientConfig;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- record of actions with different input types (contravariance)
   actions: Record<string, ActionDefinition<any, any, any>>;

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -96,8 +96,10 @@ export interface AuthTypeSpec<T extends Record<string, unknown>> {
   id: string;
   schema: z.ZodObject<Record<string, z.ZodType>>;
   normalizeSchema?: (defaults?: Record<string, unknown>) => z.ZodObject<Record<string, z.ZodType>>;
-  configure: (ctx: AuthContext, axiosInstance: AxiosInstance, secret: T) => Promise<AxiosInstance>;
-  getHeaders: (ctx: AuthContext, secret: T) => Promise<Record<string, string>>;
+  /** Primary, transport-agnostic auth contract. Returns headers to attach to requests. */
+  authenticate: (ctx: AuthContext, secret: T) => Promise<Record<string, string>>;
+  /** Optional transport-specific setup (e.g. TLS client certificates). When absent, consumers apply authenticate() headers. */
+  configure?: (ctx: AuthContext, axiosInstance: AxiosInstance, secret: T) => Promise<AxiosInstance>;
 }
 
 export type NormalizedAuthType = AuthTypeSpec<Record<string, unknown>>;
@@ -173,14 +175,8 @@ export interface ConnectorPolicies {
 }
 
 // ============================================================================
-// MCP CLIENT
+// MCP CLIENT TYPES
 // ============================================================================
-
-/** Spec-level declaration that a connector requires an MCP client. */
-export interface McpClientConfig {
-  /** The config field name that contains the MCP server URL (e.g. 'serverUrl'). */
-  urlField: string;
-}
 
 /** Tool descriptor returned by an MCP server. */
 export interface McpTool {
@@ -226,9 +222,21 @@ export interface ActionDefinition<TInput = unknown, TOutput = unknown, TError = 
   supportsStreaming?: boolean;
 }
 
+/**
+ * Maps well-known client type IDs to their instance types.
+ * Handlers access clients via `ctx.clients.mcp!.listTools()` etc.
+ * Third-party client types registered at runtime require casting.
+ */
+export interface ClientTypeMap {
+  http: AxiosInstance;
+  mcp: ConnectorMcpClient;
+}
+
 export interface ActionContext {
+  /** HTTP (Axios) client — backward-compat alias for `clients.http`. */
   client: AxiosInstance;
-  mcpClient?: ConnectorMcpClient;
+  /** All clients created for this connector, keyed by client type ID. */
+  clients: Partial<ClientTypeMap>;
   config?: Record<string, unknown>;
   connectorUsageCollector?: unknown;
   log: Logger;
@@ -298,7 +306,13 @@ export interface ConnectorSpec {
 
   policies?: ConnectorPolicies;
 
-  mcp?: McpClientConfig;
+  /**
+   * Declares additional client types this connector needs beyond the implicit
+   * HTTP (Axios) client. Each key is a registered client type ID, each value
+   * is per-client-type configuration (e.g. `{ mcp: { urlField: 'serverUrl' } }`).
+   * HTTP is always created implicitly — no need to declare it here.
+   */
+  clients?: Record<string, Record<string, unknown>>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- record of actions with different input types (contravariance)
   actions: Record<string, ActionDefinition<any, any, any>>;

--- a/x-pack/platform/packages/shared/kbn-mcp-client/index.d.ts
+++ b/x-pack/platform/packages/shared/kbn-mcp-client/index.d.ts
@@ -1,0 +1,4 @@
+export { McpClient } from './mcp/src/client';
+export { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+export { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
+export type { ClientDetails, CallToolParams, CallToolResponse, ContentPart, FetchLike, ListToolsResponse, Tool, ToolProviderMetadata, TextPart, NonTextPart, McpClientOptions, } from './mcp/src/types';

--- a/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.d.ts
+++ b/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.d.ts
@@ -1,0 +1,43 @@
+import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
+import type { Logger } from '@kbn/core/server';
+import type { ClientDetails, CallToolParams, CallToolResponse, ListToolsResponse, McpClientOptions } from './types';
+/**
+ * McpClient is a wrapper around the MCP client SDK.
+ * It provides a simple interface for connecting to an MCP client,
+ * listing tools, and calling tools.
+ */
+export declare class McpClient {
+    private readonly logger;
+    private readonly client;
+    private readonly transport;
+    private connected;
+    name: string;
+    version: string;
+    constructor(logger: Logger, clientDetails: ClientDetails, { headers, fetch: customFetch, maxRetries, reconnectionDelayGrowFactor, initialReconnectionDelay, maxReconnectionDelay, }?: McpClientOptions);
+    /**
+     * Public getter for the connection status.
+     */
+    isConnected(): boolean;
+    /**
+     * Connect to the MCP client and return the connected status and capabilities.
+     */
+    connect(): Promise<{
+        connected: boolean;
+        capabilities?: ServerCapabilities;
+    }>;
+    /**
+     * Disconnect from the MCP client and return the disconnected status.
+     */
+    disconnect(): Promise<void>;
+    /**
+     * List the tools available on the MCP client.
+     */
+    listTools(): Promise<ListToolsResponse>;
+    /**
+     * Call a tool on the MCP client.
+     * This method only returns text content.
+     * It does not support other content types such as images, audio, etc.
+     * @param {CallToolParams} params - The parameters for the tool call.
+     */
+    callTool(params: CallToolParams): Promise<CallToolResponse>;
+}

--- a/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/types.d.ts
+++ b/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/types.d.ts
@@ -1,0 +1,107 @@
+/**
+ * Details about the MCP client.
+ */
+export interface ClientDetails {
+    name: string;
+    version: string;
+    url: string;
+}
+/**
+ * Options for the MCP client.
+ * These map to reconnection options for the StreamableHTTPClientTransport.
+ */
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+export interface McpClientOptions {
+    headers?: Record<string, string>;
+    fetch?: FetchLike;
+    maxRetries?: number;
+    reconnectionDelayGrowFactor?: number;
+    initialReconnectionDelay?: number;
+    maxReconnectionDelay?: number;
+}
+/**
+ * Parameters for calling a tool on the MCP client.
+ */
+export interface CallToolParams {
+    name: string;
+    arguments?: Record<string, unknown>;
+}
+/**
+ * Non-text content as part of a tool call response.
+ */
+export interface NonTextPart {
+    type: string;
+    [key: string]: unknown;
+}
+/**
+ * A text content as part of a tool call response.
+ */
+export interface TextPart {
+    type: 'text';
+    text: string;
+}
+export type ContentPart = TextPart | NonTextPart;
+/**
+ * Type guard to check if a content part is a valid text part.
+ * @param part - The content part to check
+ */
+export declare function isTextPart(part: ContentPart | null | undefined): part is TextPart;
+/**
+ * Response from calling a tool on the MCP client.
+ */
+export interface CallToolResponse {
+    content: ContentPart[];
+    /**
+     * Optional provider metadata for attribution and audit trails.
+     * Included in tool execution results for tracking and logging.
+     */
+    provider?: ToolProviderMetadata;
+}
+/**
+ * Metadata about the provider of a tool.
+ * Used for attribution, audit trails, and UI display.
+ */
+export interface ToolProviderMetadata {
+    /**
+     * Provider identifier (e.g., 'mcp.github')
+     */
+    id: string;
+    /**
+     * Human-readable provider name (e.g., 'GitHub MCP Server')
+     */
+    name: string;
+    /**
+     * Provider type constant
+     */
+    type: 'mcp';
+    /**
+     * Unique ID of the MCP connector (from config.uniqueId)
+     */
+    uniqueId: string;
+    /**
+     * Optional description of when to use this MCP server (for LLM context)
+     */
+    description?: string;
+}
+/**
+ * A tool available on the MCP client.
+ */
+export interface Tool {
+    name: string;
+    description?: string;
+    inputSchema: Record<string, unknown>;
+    /**
+     * Optional provider metadata for attribution and audit trails.
+     * When present, indicates the source of the tool (e.g., which MCP connector).
+     */
+    provider?: ToolProviderMetadata;
+}
+/**
+ * Response from listing the tools available on the MCP client.
+ */
+export interface ListToolsResponse {
+    /**
+     * The tools available on the MCP client.
+     */
+    tools: Tool[];
+}

--- a/x-pack/platform/plugins/shared/actions/server/client_types/client_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/client_types/client_type_registry.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ClientTypeRegistry } from './client_type_registry';
+
+describe('ClientTypeRegistry', () => {
+  let registry: ClientTypeRegistry;
+
+  beforeEach(() => {
+    registry = new ClientTypeRegistry();
+  });
+
+  describe('register', () => {
+    it('registers a client type', () => {
+      registry.register({
+        id: 'http',
+        supportedAuthTypes: '*',
+        create: jest.fn(),
+      });
+
+      expect(registry.has('http')).toBe(true);
+    });
+
+    it('throws when registering a duplicate client type', () => {
+      registry.register({
+        id: 'http',
+        supportedAuthTypes: '*',
+        create: jest.fn(),
+      });
+
+      expect(() =>
+        registry.register({
+          id: 'http',
+          supportedAuthTypes: '*',
+          create: jest.fn(),
+        })
+      ).toThrow(/already registered/);
+    });
+  });
+
+  describe('get', () => {
+    it('returns a registered client type', () => {
+      const mockCreate = jest.fn();
+      registry.register({
+        id: 'mcp',
+        supportedAuthTypes: ['bearer', 'basic'],
+        create: mockCreate,
+      });
+
+      const clientType = registry.get('mcp');
+
+      expect(clientType.id).toBe('mcp');
+      expect(clientType.supportedAuthTypes).toEqual(['bearer', 'basic']);
+      expect(clientType.create).toBe(mockCreate);
+    });
+
+    it('throws for an unregistered client type', () => {
+      expect(() => registry.get('nonexistent')).toThrow(/not registered/);
+    });
+  });
+
+  describe('has', () => {
+    it('returns false for an unregistered client type', () => {
+      expect(registry.has('http')).toBe(false);
+    });
+  });
+
+  describe('getAllTypes', () => {
+    it('returns all registered client type IDs', () => {
+      registry.register({ id: 'http', supportedAuthTypes: '*', create: jest.fn() });
+      registry.register({ id: 'mcp', supportedAuthTypes: ['bearer'], create: jest.fn() });
+
+      expect(registry.getAllTypes()).toEqual(['http', 'mcp']);
+    });
+
+    it('returns empty array when no types registered', () => {
+      expect(registry.getAllTypes()).toEqual([]);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/actions/server/client_types/client_type_registry.ts
+++ b/x-pack/platform/plugins/shared/actions/server/client_types/client_type_registry.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import { i18n } from '@kbn/i18n';
+import type { ConnectorTokenClientContract } from '../types';
+
+export interface RegisteredClientType<TClient = unknown, TConfig = Record<string, unknown>> {
+  id: string;
+  /** Auth type IDs this client supports, or `'*'` for all. */
+  supportedAuthTypes: string[] | '*';
+  create: (opts: CreateClientOpts & { clientConfig: TConfig }) => Promise<TClient>;
+  connect?: (client: TClient) => Promise<void>;
+  disconnect?: (client: TClient) => Promise<void>;
+  isConnected?: (client: TClient) => boolean;
+}
+
+export interface CreateClientOpts {
+  connectorId: string;
+  secrets: Record<string, unknown>;
+  config: Record<string, unknown>;
+  additionalHeaders?: Record<string, string>;
+  connectorTokenClient?: ConnectorTokenClientContract;
+  signal?: AbortSignal;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRegisteredClientType = RegisteredClientType<any, any>;
+
+export class ClientTypeRegistry {
+  private readonly clientTypes: Map<string, AnyRegisteredClientType> = new Map();
+
+  public has(id: string): boolean {
+    return this.clientTypes.has(id);
+  }
+
+  public register(clientType: AnyRegisteredClientType): void {
+    if (this.has(clientType.id)) {
+      throw new Error(
+        i18n.translate('xpack.actions.clientTypeRegistry.register.duplicateClientTypeError', {
+          defaultMessage: 'Client type "{id}" is already registered.',
+          values: { id: clientType.id },
+        })
+      );
+    }
+    this.clientTypes.set(clientType.id, clientType);
+  }
+
+  public get(id: string): AnyRegisteredClientType {
+    if (!this.has(id)) {
+      throw Boom.badRequest(
+        i18n.translate('xpack.actions.clientTypeRegistry.get.missingClientTypeError', {
+          defaultMessage: 'Client type "{id}" is not registered.',
+          values: { id },
+        })
+      );
+    }
+    return this.clientTypes.get(id)!;
+  }
+
+  public getAllTypes(): string[] {
+    return Array.from(this.clientTypes.keys());
+  }
+}

--- a/x-pack/platform/plugins/shared/actions/server/client_types/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/client_types/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { ClientTypeRegistry } from './client_type_registry';
+export type { RegisteredClientType, CreateClientOpts } from './client_type_registry';
+export { registerClientTypes } from './register_client_types';

--- a/x-pack/platform/plugins/shared/actions/server/client_types/register_client_types.ts
+++ b/x-pack/platform/plugins/shared/actions/server/client_types/register_client_types.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AxiosInstance } from 'axios';
+import type { McpClient } from '@kbn/mcp-client';
+import type { GetAxiosInstanceWithAuthFn } from '../lib/get_axios_instance';
+import type { CreateMcpClientFn } from '../lib/get_mcp_client';
+import type { ClientTypeRegistry, RegisteredClientType } from './client_type_registry';
+
+interface McpClientTypeConfig {
+  urlField: string;
+}
+
+const httpClientType = (
+  getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn
+): RegisteredClientType<AxiosInstance> => ({
+  id: 'http',
+  supportedAuthTypes: '*',
+  create: async (opts) =>
+    getAxiosInstanceWithAuth({
+      connectorId: opts.connectorId,
+      secrets: opts.secrets,
+      connectorTokenClient: opts.connectorTokenClient,
+      additionalHeaders: opts.additionalHeaders,
+      signal: opts.signal,
+    }),
+});
+
+const mcpClientType = (
+  createMcpClient: CreateMcpClientFn
+): RegisteredClientType<McpClient, McpClientTypeConfig> => ({
+  id: 'mcp',
+  supportedAuthTypes: ['bearer', 'basic', 'api_key_header', 'none', 'oauth_client_credentials'],
+  create: async (opts) => {
+    const url = opts.config[opts.clientConfig.urlField] as string | undefined;
+    if (!url) {
+      throw new Error(
+        `MCP client requires a URL in config field "${opts.clientConfig.urlField}" but none was provided.`
+      );
+    }
+    return createMcpClient({
+      connectorId: opts.connectorId,
+      url,
+      secrets: opts.secrets,
+      additionalHeaders: opts.additionalHeaders,
+      connectorTokenClient: opts.connectorTokenClient,
+    });
+  },
+  connect: async (client) => {
+    await client.connect();
+  },
+  disconnect: async (client) => {
+    await client.disconnect();
+  },
+  isConnected: (client) => client.isConnected(),
+});
+
+export const registerClientTypes = ({
+  registry,
+  getAxiosInstanceWithAuth,
+  createMcpClient,
+}: {
+  registry: ClientTypeRegistry;
+  getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn;
+  createMcpClient: CreateMcpClientFn;
+}) => {
+  registry.register(httpClientType(getAxiosInstanceWithAuth));
+  registry.register(mcpClientType(createMcpClient));
+};

--- a/x-pack/platform/plugins/shared/actions/server/lib/build_custom_fetch.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/build_custom_fetch.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Agent, ProxyAgent, type Dispatcher } from 'undici';
+import type { Logger } from '@kbn/core/server';
+import type { CustomHostSettings, ProxySettings, SSLSettings } from '@kbn/actions-utils';
+
+import type { ActionsConfigurationUtilities } from '../actions_config';
+
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+
+interface TlsConnectOptions {
+  rejectUnauthorized?: boolean;
+  checkServerIdentity?: () => undefined;
+  ca?: string | Buffer;
+}
+
+function getTlsOptionsFromVerificationMode(
+  logger: Logger,
+  verificationMode?: string
+): Pick<TlsConnectOptions, 'rejectUnauthorized' | 'checkServerIdentity'> {
+  switch (verificationMode) {
+    case undefined:
+      return {};
+    case 'none':
+      return { rejectUnauthorized: false };
+    case 'certificate':
+      return { rejectUnauthorized: true, checkServerIdentity: () => undefined };
+    case 'full':
+      return { rejectUnauthorized: true };
+    default:
+      logger.warn(`Unknown ssl verificationMode: ${verificationMode}`);
+      return { rejectUnauthorized: true };
+  }
+}
+
+function buildTlsConnectOptions(
+  logger: Logger,
+  sslSettings: SSLSettings,
+  customHostSettings?: CustomHostSettings
+): TlsConnectOptions {
+  const options: TlsConnectOptions = {
+    ...getTlsOptionsFromVerificationMode(logger, sslSettings.verificationMode),
+  };
+
+  const hostSsl = customHostSettings?.ssl;
+  if (hostSsl) {
+    logger.debug(`Creating customized connection settings for: ${customHostSettings.url}`);
+
+    if (hostSsl.certificateAuthoritiesData) {
+      options.ca = hostSsl.certificateAuthoritiesData;
+    }
+    if (hostSsl.verificationMode) {
+      Object.assign(options, getTlsOptionsFromVerificationMode(logger, hostSsl.verificationMode));
+    }
+  }
+
+  return options;
+}
+
+function shouldUseProxy(logger: Logger, proxySettings: ProxySettings, targetUrl: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    logger.warn(
+      `error determining proxy state for invalid url "${targetUrl}", using direct connection`
+    );
+    return false;
+  }
+
+  const { hostname } = parsed;
+
+  if (proxySettings.proxyBypassHosts?.has(hostname)) {
+    return false;
+  }
+  if (proxySettings.proxyOnlyHosts && !proxySettings.proxyOnlyHosts.has(hostname)) {
+    return false;
+  }
+
+  return true;
+}
+
+function createFetchWithDispatcher(dispatcher: Dispatcher): FetchLike {
+  return (url: string | URL, init?: RequestInit): Promise<Response> => {
+    return fetch(url, {
+      ...init,
+      dispatcher,
+    } as RequestInit);
+  };
+}
+
+/**
+ * Builds a custom `fetch` that applies the SSL/TLS and proxy settings from
+ * the actions plugin configuration. Allows non-Axios transports (e.g. the MCP
+ * SDK's StreamableHTTPClientTransport) to respect the same
+ * `xpack.actions.ssl`, `xpack.actions.customHostSettings`, and
+ * `xpack.actions.proxyUrl` settings as all other stack connectors.
+ */
+export function buildCustomFetch(
+  configurationUtilities: ActionsConfigurationUtilities,
+  logger: Logger,
+  targetUrl: string
+): FetchLike {
+  const sslSettings = configurationUtilities.getSSLSettings();
+  const proxySettings = configurationUtilities.getProxySettings();
+  const customHostSettings = configurationUtilities.getCustomHostSettings(targetUrl);
+
+  const tlsOptions = buildTlsConnectOptions(logger, sslSettings, customHostSettings);
+
+  let dispatcher: Dispatcher;
+
+  if (proxySettings && shouldUseProxy(logger, proxySettings, targetUrl)) {
+    let proxyUrl: URL;
+    try {
+      proxyUrl = new URL(proxySettings.proxyUrl);
+    } catch {
+      logger.warn(`invalid proxy URL "${proxySettings.proxyUrl}" ignored, using direct connection`);
+      dispatcher = new Agent({ connect: tlsOptions });
+
+      return createFetchWithDispatcher(dispatcher);
+    }
+
+    logger.debug(`Using proxy ${proxySettings.proxyUrl} for ${targetUrl}`);
+
+    const proxyTls = getTlsOptionsFromVerificationMode(
+      logger,
+      proxySettings.proxySSLSettings.verificationMode
+    );
+
+    dispatcher = new ProxyAgent({
+      uri: proxyUrl.toString(),
+      requestTls: tlsOptions,
+      proxyTls,
+      headers: proxySettings.proxyHeaders,
+    });
+  } else {
+    dispatcher = new Agent({ connect: tlsOptions });
+  }
+
+  return createFetchWithDispatcher(dispatcher);
+}

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.test.ts
@@ -87,7 +87,8 @@ describe('getAxiosInstance', () => {
     });
 
     expect(result).not.toBeUndefined();
-    expect(result!.defaults.auth).toEqual({ username: 'user', password: 'pass' });
+    const encoded = Buffer.from('user:pass').toString('base64');
+    expect(result!.defaults.headers.common.Authorization).toEqual(`Basic ${encoded}`);
 
     // @ts-expect-error
     expect(result!.interceptors.request.handlers.length).toBe(1);

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
@@ -127,8 +127,15 @@ export const getAxiosInstanceWithAuth = ({
         sslSettings: configurationUtilities.getSSLSettings(),
       };
 
-      // use the registered auth type to configure authentication for the axios instance
-      return await authType.configure(configureCtx, axiosInstance, secrets);
+      if (authType.configure) {
+        return await authType.configure(configureCtx, axiosInstance, secrets);
+      }
+
+      const authHeaders = await authType.authenticate(configureCtx, secrets);
+      for (const [key, value] of Object.entries(authHeaders)) {
+        axiosInstance.defaults.headers.common[key] = value;
+      }
+      return axiosInstance;
     } catch (err) {
       logger.error(
         `Error getting configured axios instance configured for auth type "${

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_mcp_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_mcp_client.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AxiosHeaderValue } from 'axios';
+import type { Logger } from '@kbn/core/server';
+import { McpClient } from '@kbn/mcp-client';
+import type { GetTokenOpts } from '@kbn/connector-specs';
+
+import type { AuthTypeRegistry } from '../auth_types';
+import type { ActionsConfigurationUtilities } from '../actions_config';
+import type { ConnectorTokenClientContract } from '../types';
+import { buildCustomFetch } from './build_custom_fetch';
+import { getOAuthClientCredentialsAccessToken } from './get_oauth_client_credentials_access_token';
+
+const MCP_CLIENT_VERSION = '0.0.1';
+
+interface GetMcpClientOpts {
+  authTypeRegistry: AuthTypeRegistry;
+  configurationUtilities: ActionsConfigurationUtilities;
+  logger: Logger;
+}
+
+export interface CreateMcpClientFnOpts {
+  connectorId: string;
+  url: string;
+  secrets: Record<string, unknown>;
+  additionalHeaders?: Record<string, AxiosHeaderValue>;
+  connectorTokenClient?: ConnectorTokenClientContract;
+}
+
+export type CreateMcpClientFn = (opts: CreateMcpClientFnOpts) => Promise<McpClient>;
+
+/**
+ * Creates a factory function that produces configured, **unconnected** McpClient
+ * instances. Mirrors the pattern of {@link getAxiosInstanceWithAuth} — the
+ * factory captures long-lived dependencies (auth type registry, config
+ * utilities, logger) and returns a function that callers invoke per-execution
+ * with connector-specific values.
+ *
+ * The returned McpClient is not yet connected; the caller (i.e. the generated
+ * executor) is responsible for calling `connect()` and `disconnect()`. This
+ * separation keeps the door open for a future connection-lifecycle manager that
+ * can sit behind the same factory interface and return pooled / pre-connected
+ * clients without any executor changes.
+ */
+export const getMcpClientFactory = ({
+  authTypeRegistry,
+  configurationUtilities,
+  logger,
+}: GetMcpClientOpts): CreateMcpClientFn => {
+  return async ({
+    connectorId,
+    url,
+    secrets,
+    additionalHeaders,
+    connectorTokenClient,
+  }: CreateMcpClientFnOpts): Promise<McpClient> => {
+    let authTypeId: string | undefined;
+    try {
+      authTypeId = (secrets as { authType?: string }).authType || 'none';
+      const authType = authTypeRegistry.get(authTypeId);
+
+      const authContext = {
+        getCustomHostSettings: (hostUrl: string) =>
+          configurationUtilities.getCustomHostSettings(hostUrl),
+        getToken: async (opts: GetTokenOpts) => {
+          return await getOAuthClientCredentialsAccessToken({
+            connectorId,
+            logger,
+            tokenUrl: opts.tokenUrl,
+            oAuthScope: opts.scope,
+            configurationUtilities,
+            credentials: {
+              config: {
+                clientId: opts.clientId,
+                ...(opts.additionalFields ? { additionalFields: opts.additionalFields } : {}),
+              },
+              secrets: {
+                clientSecret: opts.clientSecret,
+              },
+            },
+            connectorTokenClient,
+          });
+        },
+        logger,
+        proxySettings: configurationUtilities.getProxySettings(),
+        sslSettings: configurationUtilities.getSSLSettings(),
+      };
+
+      const authHeaders = await authType.getHeaders(authContext, secrets);
+
+      const headers: Record<string, string> = { ...authHeaders };
+      if (additionalHeaders) {
+        for (const [key, value] of Object.entries(additionalHeaders)) {
+          if (typeof value === 'string') {
+            headers[key] = value;
+          }
+        }
+      }
+
+      const customFetch = buildCustomFetch(configurationUtilities, logger, url);
+
+      return new McpClient(
+        logger,
+        { name: `kibana-v2-${connectorId}`, version: MCP_CLIENT_VERSION, url },
+        {
+          headers,
+          fetch: customFetch,
+        }
+      );
+    } catch (err) {
+      logger.error(
+        `Error creating MCP client for auth type "${authTypeId ?? 'unknown'}": ${err.message}`
+      );
+      throw err;
+    }
+  };
+};

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_mcp_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_mcp_client.ts
@@ -91,7 +91,7 @@ export const getMcpClientFactory = ({
         sslSettings: configurationUtilities.getSSLSettings(),
       };
 
-      const authHeaders = await authType.getHeaders(authContext, secrets);
+      const authHeaders = await authType.authenticate(authContext, secrets);
 
       const headers: Record<string, string> = { ...authHeaders };
       if (additionalHeaders) {

--- a/x-pack/platform/plugins/shared/actions/server/lib/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/index.ts
@@ -44,3 +44,9 @@ export type { TelemetryMetadata } from './token_tracking/gen_ai_token_tracking';
 export { formatZodV3Error } from './format_zod_v3_error';
 export { createConnectorTypeFromSpec } from './single_file_connectors/create_connector_from_spec';
 export { getDeleteTokenAxiosInterceptor } from './delete_token_axios_interceptor';
+export { buildCustomFetch, type FetchLike } from './build_custom_fetch';
+export {
+  getMcpClientFactory,
+  type CreateMcpClientFn,
+  type CreateMcpClientFnOpts,
+} from './get_mcp_client';

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
@@ -12,14 +12,31 @@ import { createConnectorTypeFromSpec } from './create_connector_from_spec';
 import { WorkflowsConnectorFeatureId } from '../../../common';
 import type { PluginSetupContract as ActionsPluginSetupContract } from '../../plugin';
 import { actionsConfigMock } from '../../actions_config.mock';
+import { ClientTypeRegistry } from '../../client_types';
 
 describe('createConnectorTypeFromSpec', () => {
   const mockGetAxiosInstanceWithAuth = jest.fn();
   const mockActionsConfigUtils = actionsConfigMock.create();
 
+  const createMockClientTypeRegistry = () => {
+    const registry = new ClientTypeRegistry();
+    registry.register({
+      id: 'http',
+      supportedAuthTypes: '*',
+      create: jest.fn(),
+    });
+    registry.register({
+      id: 'mcp',
+      supportedAuthTypes: ['bearer', 'basic', 'api_key_header', 'none', 'oauth_client_credentials'],
+      create: jest.fn(),
+    });
+    return registry;
+  };
+
   const mockActionsPlugin: ActionsPluginSetupContract = {
     getActionsConfigurationUtilities: () => mockActionsConfigUtils,
     getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+    getClientTypeRegistry: () => createMockClientTypeRegistry(),
   } as unknown as ActionsPluginSetupContract;
 
   const createMockSpec = (overrides: Partial<ConnectorSpec> = {}): ConnectorSpec =>
@@ -35,6 +52,7 @@ describe('createConnectorTypeFromSpec', () => {
       auth: overrides.auth || {
         types: ['none'],
       },
+      clients: overrides.clients,
       actions: overrides.actions || {
         testAction: {
           input: z4.object({ test: z4.string() }),
@@ -373,6 +391,64 @@ describe('createConnectorTypeFromSpec', () => {
       expect(connectorType.validate.config.schema.parse(configWithAuthType)).toEqual(
         configWithAuthType
       );
+    });
+  });
+
+  describe('client auth compatibility validation', () => {
+    it('passes when declared client supports all connector auth types', () => {
+      const spec = createMockSpec({
+        auth: { types: ['bearer'] },
+        clients: { mcp: { urlField: 'serverUrl' } },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).not.toThrow();
+    });
+
+    it('passes when declared client supports wildcard auth types', () => {
+      const spec = createMockSpec({
+        auth: { types: ['bearer', 'basic', 'api_key_header'] },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).not.toThrow();
+    });
+
+    it('throws when declared client does not support a connector auth type', () => {
+      const spec = createMockSpec({
+        auth: { types: ['aws_sig_v4'] },
+        clients: { mcp: { urlField: 'serverUrl' } },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).toThrow(
+        'client type "mcp" does not support auth type "aws_sig_v4"'
+      );
+    });
+
+    it('throws when any auth type is unsupported across multiple', () => {
+      const spec = createMockSpec({
+        auth: { types: ['bearer', 'aws_sig_v4'] },
+        clients: { mcp: { urlField: 'serverUrl' } },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).toThrow(
+        'client type "mcp" does not support auth type "aws_sig_v4"'
+      );
+    });
+
+    it('throws for unregistered client type', () => {
+      const spec = createMockSpec({
+        clients: { redis: {} },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).toThrow(/not registered/);
+    });
+
+    it('defaults to auth type "none" when no auth types are declared', () => {
+      const spec = createMockSpec({
+        auth: { types: [] },
+        clients: { mcp: { urlField: 'serverUrl' } },
+      });
+
+      expect(() => createConnectorTypeFromSpec(spec, mockActionsPlugin)).not.toThrow();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
@@ -34,6 +34,8 @@ export const createConnectorTypeFromSpec = (
     ? generateExecutorFunction({
         actions: spec.actions,
         getAxiosInstanceWithAuth: actions.getAxiosInstanceWithAuth,
+        mcp: spec.mcp,
+        createMcpClient: spec.mcp ? actions.createMcpClient : undefined,
       })
     : undefined;
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
@@ -15,17 +15,52 @@ import type {
   ActionType,
 } from '../../types';
 import type { PluginSetupContract as ActionsPluginSetupContract } from '../../plugin';
+import type { ClientTypeRegistry } from '../../client_types';
 
 import { generateParamsSchema } from './generate_params_schema';
 import { generateSecretsSchema } from './generate_secrets_schema';
 import { generateExecutorFunction } from './generate_executor_function';
 import { generateConfigSchema } from './generate_config_schema';
 
+const getSpecAuthTypeIds = (spec: ConnectorSpec): string[] => {
+  if (!spec.auth?.types.length) return ['none'];
+  return spec.auth.types.map((t) => (typeof t === 'string' ? t : t.type));
+};
+
+const validateClientAuthCompatibility = (
+  spec: ConnectorSpec,
+  declaredClients: Record<string, Record<string, unknown>>,
+  registry: ClientTypeRegistry
+): void => {
+  const specAuthTypes = getSpecAuthTypeIds(spec);
+
+  for (const clientId of Object.keys(declaredClients)) {
+    const clientType = registry.get(clientId);
+    if (clientType.supportedAuthTypes === '*') continue;
+
+    for (const authTypeId of specAuthTypes) {
+      if (!clientType.supportedAuthTypes.includes(authTypeId)) {
+        throw new Error(
+          `Connector "${spec.metadata.id}": client type "${clientId}" does not support auth type "${authTypeId}".`
+        );
+      }
+    }
+  }
+};
+
 export const createConnectorTypeFromSpec = (
   spec: ConnectorSpec,
   actions: ActionsPluginSetupContract
 ): ActionType<ActionTypeConfig, ActionTypeSecrets, ActionTypeParams, unknown> => {
   const configUtils = actions.getActionsConfigurationUtilities();
+  const clientTypeRegistry = actions.getClientTypeRegistry();
+
+  const declaredClients: Record<string, Record<string, unknown>> = {
+    http: {},
+    ...(spec.clients ?? {}),
+  };
+
+  validateClientAuthCompatibility(spec, declaredClients, clientTypeRegistry);
 
   const shouldGenerateExecutor = Boolean(spec.actions);
   const shouldGenerateParams = Boolean(spec.actions);
@@ -33,9 +68,8 @@ export const createConnectorTypeFromSpec = (
   const executor = shouldGenerateExecutor
     ? generateExecutorFunction({
         actions: spec.actions,
-        getAxiosInstanceWithAuth: actions.getAxiosInstanceWithAuth,
-        mcp: spec.mcp,
-        createMcpClient: spec.mcp ? actions.createMcpClient : undefined,
+        clientTypeRegistry,
+        declaredClients,
       })
     : undefined;
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -5,22 +5,28 @@
  * 2.0.
  */
 
-import type { ConnectorSpec } from '@kbn/connector-specs';
+import type { ConnectorSpec, McpClientConfig } from '@kbn/connector-specs';
+import type { McpClient } from '@kbn/mcp-client';
 import type { ExecutorParams } from '../../sub_action_framework/types';
 import type {
   ActionTypeExecutorOptions as ConnectorTypeExecutorOptions,
   ActionTypeExecutorResult as ConnectorTypeExecutorResult,
 } from '../../types';
 import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
+import type { CreateMcpClientFn } from '../get_mcp_client';
 
 type RecordUnknown = Record<string, unknown>;
 
 export const generateExecutorFunction = ({
   actions,
   getAxiosInstanceWithAuth,
+  mcp,
+  createMcpClient,
 }: {
   actions: ConnectorSpec['actions'];
   getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn;
+  mcp?: McpClientConfig;
+  createMcpClient?: CreateMcpClientFn;
 }) =>
   async function (
     execOptions: ConnectorTypeExecutorOptions<RecordUnknown, RecordUnknown, RecordUnknown>
@@ -51,14 +57,33 @@ export const generateExecutorFunction = ({
       throw new Error(errorMessage);
     }
 
-    const actionContext = {
-      log: logger,
-      client: axiosInstance,
-      secrets,
-      config,
-    };
+    let mcpClient: McpClient | undefined;
+    if (mcp && createMcpClient) {
+      const url = (config as RecordUnknown)?.[mcp.urlField] as string | undefined;
+      if (!url) {
+        throw new Error(
+          `MCP client requires a URL in config field "${mcp.urlField}" but none was provided.`
+        );
+      }
+      mcpClient = await createMcpClient({
+        connectorId,
+        url,
+        secrets,
+        additionalHeaders: globalAuthHeaders,
+        connectorTokenClient,
+      });
+      await mcpClient.connect();
+    }
 
     try {
+      const actionContext = {
+        log: logger,
+        client: axiosInstance,
+        mcpClient,
+        secrets,
+        config,
+      };
+
       let data = {};
       const res = await actions[subAction].handler(actionContext, subActionParams);
 
@@ -75,5 +100,17 @@ export const generateExecutorFunction = ({
         message: errorMessage,
         actionId: connectorId,
       };
+    } finally {
+      if (mcpClient?.isConnected()) {
+        try {
+          await mcpClient.disconnect();
+        } catch (disconnectError) {
+          logger.warn(
+            `Failed to disconnect MCP client for connector ${connectorId}: ${
+              disconnectError instanceof Error ? disconnectError.message : String(disconnectError)
+            }`
+          );
+        }
+      }
     }
   };

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -5,28 +5,25 @@
  * 2.0.
  */
 
-import type { ConnectorSpec, McpClientConfig } from '@kbn/connector-specs';
-import type { McpClient } from '@kbn/mcp-client';
+import type { AxiosInstance } from 'axios';
+import type { ConnectorSpec } from '@kbn/connector-specs';
 import type { ExecutorParams } from '../../sub_action_framework/types';
 import type {
   ActionTypeExecutorOptions as ConnectorTypeExecutorOptions,
   ActionTypeExecutorResult as ConnectorTypeExecutorResult,
 } from '../../types';
-import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
-import type { CreateMcpClientFn } from '../get_mcp_client';
+import type { ClientTypeRegistry } from '../../client_types';
 
 type RecordUnknown = Record<string, unknown>;
 
 export const generateExecutorFunction = ({
   actions,
-  getAxiosInstanceWithAuth,
-  mcp,
-  createMcpClient,
+  clientTypeRegistry,
+  declaredClients,
 }: {
   actions: ConnectorSpec['actions'];
-  getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn;
-  mcp?: McpClientConfig;
-  createMcpClient?: CreateMcpClientFn;
+  clientTypeRegistry: ClientTypeRegistry;
+  declaredClients: Record<string, Record<string, unknown>>;
 }) =>
   async function (
     execOptions: ConnectorTypeExecutorOptions<RecordUnknown, RecordUnknown, RecordUnknown>
@@ -43,43 +40,40 @@ export const generateExecutorFunction = ({
     } = execOptions;
     const { subAction, subActionParams } = params as ExecutorParams;
 
-    const axiosInstance = await getAxiosInstanceWithAuth({
-      connectorId,
-      connectorTokenClient,
-      additionalHeaders: globalAuthHeaders,
-      secrets,
-      signal,
-    });
-
     if (!actions[subAction]) {
       const errorMessage = `[Action][ExternalService] Unsupported subAction type ${subAction}.`;
       logger.error(errorMessage);
       throw new Error(errorMessage);
     }
 
-    let mcpClient: McpClient | undefined;
-    if (mcp && createMcpClient) {
-      const url = (config as RecordUnknown)?.[mcp.urlField] as string | undefined;
-      if (!url) {
-        throw new Error(
-          `MCP client requires a URL in config field "${mcp.urlField}" but none was provided.`
-        );
-      }
-      mcpClient = await createMcpClient({
+    const createdClients: Record<string, unknown> = {};
+    for (const [clientId, clientConfig] of Object.entries(declaredClients)) {
+      const clientType = clientTypeRegistry.get(clientId);
+      createdClients[clientId] = await clientType.create({
         connectorId,
-        url,
         secrets,
-        additionalHeaders: globalAuthHeaders,
+        config: config as RecordUnknown,
+        additionalHeaders: globalAuthHeaders
+          ? Object.fromEntries(
+              Object.entries(globalAuthHeaders).filter(
+                (entry): entry is [string, string] => typeof entry[1] === 'string'
+              )
+            )
+          : undefined,
         connectorTokenClient,
+        signal,
+        clientConfig,
       });
-      await mcpClient.connect();
+      if (clientType.connect) {
+        await clientType.connect(createdClients[clientId]);
+      }
     }
 
     try {
       const actionContext = {
         log: logger,
-        client: axiosInstance,
-        mcpClient,
+        client: createdClients.http as AxiosInstance,
+        clients: createdClients,
         secrets,
         config,
       };
@@ -101,15 +95,18 @@ export const generateExecutorFunction = ({
         actionId: connectorId,
       };
     } finally {
-      if (mcpClient?.isConnected()) {
-        try {
-          await mcpClient.disconnect();
-        } catch (disconnectError) {
-          logger.warn(
-            `Failed to disconnect MCP client for connector ${connectorId}: ${
-              disconnectError instanceof Error ? disconnectError.message : String(disconnectError)
-            }`
-          );
+      for (const [clientId, client] of Object.entries(createdClients)) {
+        const clientType = clientTypeRegistry.get(clientId);
+        if (clientType.disconnect && clientType.isConnected?.(client)) {
+          try {
+            await clientType.disconnect(client);
+          } catch (disconnectError) {
+            const errMsg =
+              disconnectError instanceof Error ? disconnectError.message : String(disconnectError);
+            logger.warn(
+              `Failed to disconnect ${clientId} client for connector ${connectorId}: ${errMsg}`
+            );
+          }
         }
       }
     }

--- a/x-pack/platform/plugins/shared/actions/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/actions/server/mocks.ts
@@ -33,6 +33,7 @@ const createSetupMock = () => {
     registerType: jest.fn(),
     registerSubActionConnectorType: jest.fn(),
     getAxiosInstanceWithAuth: jest.fn(),
+    createMcpClient: jest.fn(),
     isPreconfiguredConnector: jest.fn(),
     getSubActionConnectorClass: jest.fn(),
     getCaseConnectorClass: jest.fn(),

--- a/x-pack/platform/plugins/shared/actions/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/actions/server/mocks.ts
@@ -34,6 +34,7 @@ const createSetupMock = () => {
     registerSubActionConnectorType: jest.fn(),
     getAxiosInstanceWithAuth: jest.fn(),
     createMcpClient: jest.fn(),
+    getClientTypeRegistry: jest.fn(),
     isPreconfiguredConnector: jest.fn(),
     getSubActionConnectorClass: jest.fn(),
     getCaseConnectorClass: jest.fn(),

--- a/x-pack/platform/plugins/shared/actions/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { McpClient } from '@kbn/mcp-client';
 import type { PublicMethodsOf, Writable } from '@kbn/utility-types';
 import type { UsageCollectionSetup, UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type {
@@ -107,6 +108,8 @@ import { ConnectorUsageReportingTask } from './usage/connector_usage_reporting_t
 import { ConnectorRateLimiter } from './lib/connector_rate_limiter';
 import type { GetAxiosInstanceWithAuthFnOpts } from './lib/get_axios_instance';
 import { getAxiosInstanceWithAuth } from './lib/get_axios_instance';
+import type { CreateMcpClientFnOpts } from './lib/get_mcp_client';
+import { getMcpClientFactory } from './lib/get_mcp_client';
 
 export interface PluginSetupContract {
   registerType<
@@ -126,6 +129,8 @@ export interface PluginSetupContract {
   ): void;
 
   getAxiosInstanceWithAuth(opts: GetAxiosInstanceWithAuthFnOpts): Promise<AxiosInstance>;
+
+  createMcpClient(opts: CreateMcpClientFnOpts): Promise<McpClient>;
 
   isPreconfiguredConnector(connectorId: string): boolean;
 
@@ -429,6 +434,7 @@ export class ActionsPlugin
         subActionFramework.registerConnector(connector);
       },
       getAxiosInstanceWithAuth: this.getAxiosInstanceWithAuthHelper(actionsConfigUtils),
+      createMcpClient: this.createMcpClientHelper(actionsConfigUtils),
       isPreconfiguredConnector: (connectorId: string): boolean => {
         return !!this.inMemoryConnectors.find(
           (inMemoryConnector) =>
@@ -896,6 +902,18 @@ export class ActionsPlugin
 
     return async (getAxiosParams: GetAxiosInstanceWithAuthFnOpts) => {
       return await getAxiosInstanceFn(getAxiosParams);
+    };
+  };
+
+  private createMcpClientHelper = (actionsConfigUtils: ActionsConfigurationUtilities) => {
+    const mcpClientFactory = getMcpClientFactory({
+      authTypeRegistry: this.authTypeRegistry!,
+      configurationUtilities: actionsConfigUtils,
+      logger: this.logger,
+    });
+
+    return async (opts: CreateMcpClientFnOpts) => {
+      return await mcpClientFactory(opts);
     };
   };
 

--- a/x-pack/platform/plugins/shared/actions/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.ts
@@ -53,6 +53,7 @@ import { events } from './lib/event_based_telemetry';
 import { ActionsClient } from './actions_client/actions_client';
 import { ActionTypeRegistry } from './action_type_registry';
 import { AuthTypeRegistry, registerAuthTypes } from './auth_types';
+import { ClientTypeRegistry, registerClientTypes } from './client_types';
 import { createBulkExecutionEnqueuerFunction } from './create_execute_function';
 import { registerActionsUsageCollector } from './usage';
 import type { ILicenseState } from './lib';
@@ -131,6 +132,8 @@ export interface PluginSetupContract {
   getAxiosInstanceWithAuth(opts: GetAxiosInstanceWithAuthFnOpts): Promise<AxiosInstance>;
 
   createMcpClient(opts: CreateMcpClientFnOpts): Promise<McpClient>;
+
+  getClientTypeRegistry: () => ClientTypeRegistry;
 
   isPreconfiguredConnector(connectorId: string): boolean;
 
@@ -232,6 +235,7 @@ export class ActionsPlugin
   private taskRunnerFactory?: TaskRunnerFactory;
   private actionTypeRegistry?: ActionTypeRegistry;
   private authTypeRegistry?: AuthTypeRegistry;
+  private clientTypeRegistry?: ClientTypeRegistry;
   private actionExecutor?: ActionExecutor;
   private licenseState: ILicenseState | null = null;
   private security?: SecurityPluginSetup;
@@ -328,6 +332,13 @@ export class ActionsPlugin
 
     this.authTypeRegistry = new AuthTypeRegistry();
     registerAuthTypes(this.authTypeRegistry);
+
+    this.clientTypeRegistry = new ClientTypeRegistry();
+    registerClientTypes({
+      registry: this.clientTypeRegistry,
+      getAxiosInstanceWithAuth: this.getAxiosInstanceWithAuthHelper(actionsConfigUtils),
+      createMcpClient: this.createMcpClientHelper(actionsConfigUtils),
+    });
 
     setupSavedObjects(
       core.savedObjects,
@@ -463,6 +474,7 @@ export class ActionsPlugin
           );
         }
       },
+      getClientTypeRegistry: () => this.clientTypeRegistry!,
       isActionTypeEnabled: (id, options = { notifyUsage: false }) => {
         return this.actionTypeRegistry!.isActionTypeEnabled(id, options);
       },

--- a/x-pack/platform/plugins/shared/actions/tsconfig.json
+++ b/x-pack/platform/plugins/shared/actions/tsconfig.json
@@ -59,6 +59,7 @@
     "@kbn/actions-utils",
     "@kbn/encrypted-saved-objects-shared",
     "@kbn/usage-api-plugin",
+    "@kbn/mcp-client",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This rough PoC PR demonstrates the viability of exposing the Kibana MCP client (`kbn-mcp-client`) to v2 connector specs.

## Architecture

_Full disclosure: the following diagram was generated via Claude during its "planning" phase_
```mermaid
flowchart TB
    subgraph specLayer ["ConnectorSpec (author writes)"]
        metadata["metadata, auth, schema, actions"]
        mcpConfig["mcp: { urlField: 'serverUrl' }"]
    end

    subgraph registrationLayer ["Registration (framework)"]
        createFromSpec["createConnectorTypeFromSpec()"]
        genExecutor["generateExecutorFunction()"]
    end

    subgraph runtime ["Execution Runtime"]
        executor["Generated Executor"]
        axiosFactory["getAxiosInstanceWithAuth()"]
        mcpFactory["createMcpClient() — NEW"]
        authHeaders["buildAuthHeaders() — NEW"]
        handler["spec.actions.handler(ctx)"]
    end

    subgraph actionCtx ["ActionContext"]
        client["client: AxiosInstance"]
        mcpClient["mcpClient?: McpClient — NEW"]
        log["log, config, secrets"]
    end

    specLayer --> createFromSpec
    createFromSpec --> genExecutor
    genExecutor --> executor
    executor --> axiosFactory
    executor -->|"if spec.mcp"| mcpFactory
    mcpFactory --> authHeaders
    mcpFactory --> mcpClient
    axiosFactory --> client
    executor --> handler
    actionCtx --> handler
```

## Key takeaways
- Setting a new pattern for Data Sources/Connectors:
  - Previously, Data Sources that required MCP access needed to use the generic v1 MCP connector.
  - Now, with the changes in this PR, _any_ v2 connector can be an MCP connector, because all v2 connectors will have access to an MCP client.
  - We should still aim to eventually replace the generic v1 connector with a generic v2 connector, though, as it still serves the "Bulk import MCP tools" story for Agent Builder
- Auth details are passed via plain HTTP headers that are acquired from the seven different auth types. This being a rough PoC, I figured it's fine, but happy to discuss other/better ways of handling this
- This PR does NOT introduce any connection pooling. We can add this functionality via the MCP factory pattern introduced, where instead of creating a new `McpClient` every time, we can return a pooled, already-connector client
- This PR additionally does not port over any of the tools list caching from the v1 connector, either. If the general approach outlined in this PR is sound, we can either roll that into a final PR or leave it for a fast-follow item. Either way, that *will* be a necessary addition until we get fully-fledged connection pooling going