### PR TITLE
fix invalid describe.skip call

### DIFF
--- a/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
@@ -9,7 +9,6 @@
 
 import type { RoleApiCredentials } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
-import { tags } from '@kbn/scout';
 import { apiTest, DASHBOARD_API_PATH } from '../fixtures';
 
 /**
@@ -22,7 +21,8 @@ import { apiTest, DASHBOARD_API_PATH } from '../fixtures';
  * See README.md for usage instructions.
  */
 // Failing: See https://github.com/elastic/kibana/issues/256140
-describe.skip('dashboard REST schema', { tag: tags.stateful.all }, () => {
+// eslint-disable-next-line playwright/no-skipped-test
+describe.skip('dashboard REST schema', () => {
   let viewerCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ requestAuth }) => {

--- a/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
@@ -21,6 +21,7 @@ import { apiTest, DASHBOARD_API_PATH } from '../fixtures';
  * See README.md for usage instructions.
  */
 // Failing: See https://github.com/elastic/kibana/issues/256140
+// describe('dashboard REST schema', { tag: tags.stateful.all }, () => {
 // eslint-disable-next-line playwright/no-skipped-test
 describe.skip('dashboard REST schema', () => {
   let viewerCredentials: RoleApiCredentials;


### PR DESCRIPTION
TypeScript error introduced by [c92f2f2](https://github.com/elastic/kibana/commit/c92f2f2968795aa274308d83ad9f26aa8bc22fd6) when skipping the failing test suite in [#256140](https://github.com/elastic/kibana/issues/256140).