### PR TITLE
Remove propTypes

### DIFF
--- a/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/index.ts
+++ b/x-pack/platform/plugins/private/canvas/public/expression_types/arg_types/series_style/index.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import PropTypes from 'prop-types';
 import { lifecycle, compose } from 'react-recompose';
 import { get } from 'lodash';
 import { templateFromReactComponent } from '../../../lib/template_from_react_component';
@@ -47,13 +46,6 @@ const EnhancedExtendedTemplate = compose<ExtendedTemplateProps, Props>(
     },
   })
 )(ExtendedTemplate);
-
-EnhancedExtendedTemplate.propTypes = {
-  argValue: PropTypes.any.isRequired,
-  setLabel: PropTypes.func.isRequired,
-  // @ts-expect-error upgrade typescript v5.9.3
-  label: PropTypes.string,
-};
 
 export const seriesStyle = () => ({
   name: 'seriesStyle',


### PR DESCRIPTION
## Summary

Follow-up to: https://github.com/elastic/kibana/pull/256129 - somehow I missed this file.

From files owned by kibana-presentation, `x-pack/platform/plugins/private/canvas/public/components/app/index.tsx` also contains `propTypes`. However this can't be simply removed as it's needed for `childContextTypes` - which is something that also will have to be handled at some point as part of React 19 update (see: https://github.com/elastic/kibana/issues/256181)

