### PR TITLE
POC: Agent Builder semantic reranking

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
@@ -27,7 +27,7 @@ const convertMatchResult = (result: MatchResult): Resource => {
     },
     partial: true,
     content: {
-      highlights: result.highlights,
+      contentFragments: result.contentFragments,
     },
   };
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
@@ -27,7 +27,7 @@ const convertMatchResult = (result: MatchResult): Resource => {
     },
     partial: true,
     content: {
-      contentFragments: result.contentFragments,
+      snippets: result.snippets,
     },
   };
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -8,7 +8,7 @@
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
 import type { MappingField } from '../utils/mappings';
-import { executeEsql, interpolateEsqlQuery } from '../utils/esql';
+import { executeEsql } from '../utils/esql';
 import { isCcsTarget } from '../utils/ccs';
 
 export interface MatchResult {
@@ -129,47 +129,58 @@ const buildMvAppendExpr = (fieldPaths: string[]): string => {
   return fieldPaths.reduce((acc, path) => `MV_APPEND(${acc}, ${path})`);
 };
 
-const extractSnippets = async ({
-  docId,
+const extractSnippetsBatch = async ({
+  docIds,
   index,
   term,
   fields,
   esClient,
   logger,
 }: {
-  docId: string;
+  docIds: string[];
   index: string;
   term: string;
   fields: MappingField[];
   esClient: ElasticsearchClient;
   logger: Logger;
-}): Promise<string[]> => {
+}): Promise<Map<string, string[]>> => {
+  const result = new Map<string, string[]>();
+  if (docIds.length === 0) return result;
+
   const fieldPaths = fields.map((field) => field.path);
   const mvAppendExpr = buildMvAppendExpr(fieldPaths);
 
   const snippetCount = rerankSnippets ? snippetRankWindowSize : numSnippets;
 
-  const esqlQuery = interpolateEsqlQuery(
-    `FROM ${index} METADATA _id | WHERE _id == ?docId | EVAL doc = MV_DEDUPE(${mvAppendExpr}) | EVAL snippets = TOP_SNIPPETS(doc, ?term, {"num_snippets": ${snippetCount}, "num_words": ${numWords}}) | MV_EXPAND snippets | KEEP snippets`,
-    { docId, term }
-  );
+  const idList = docIds.map((id) => `"${escapeEsqlString(id)}"`).join(', ');
+  const escapedTerm = escapeEsqlString(term);
 
-  logger.info(`TOP_SNIPPETS query for doc="${docId}": ${esqlQuery}`);
+  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL doc = MV_DEDUPE(${mvAppendExpr}) | EVAL snippets = TOP_SNIPPETS(doc, "${escapedTerm}", {"num_snippets": ${snippetCount}, "num_words": ${numWords}}) | MV_EXPAND snippets | KEEP _id, snippets`;
+
+  logger.info(`TOP_SNIPPETS batch query for ${docIds.length} docs: ${esqlQuery}`);
 
   const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
 
-  const snippets: string[] = [];
+  // Response columns are [_id, snippets]; group snippets by doc ID
   for (const row of esqlResponse.values) {
-    const value = row[0];
-    if (Array.isArray(value)) {
-      for (const item of value) {
+    const docId = row[0];
+    const snippet = row[1];
+    if (typeof docId !== 'string') continue;
+
+    if (!result.has(docId)) {
+      result.set(docId, []);
+    }
+    const snippets = result.get(docId)!;
+    if (Array.isArray(snippet)) {
+      for (const item of snippet) {
         if (typeof item === 'string') snippets.push(item);
       }
-    } else if (typeof value === 'string') {
-      snippets.push(value);
+    } else if (typeof snippet === 'string') {
+      snippets.push(snippet);
     }
   }
-  return snippets;
+
+  return result;
 };
 
 const rerankDocuments = async ({
@@ -311,53 +322,54 @@ export const performMatchSearch = async ({
   const hitsByDocId = new Map(response.hits.hits.map((hit) => [hit._id!, hit]));
 
   if (useSnippets) {
+    let rawSnippetsByDocId = new Map<string, string[]>();
+    try {
+      rawSnippetsByDocId = await extractSnippetsBatch({
+        docIds: hitOrder,
+        index,
+        term,
+        fields,
+        esClient,
+        logger,
+      });
+    } catch (error) {
+      logger.info(
+        `TOP_SNIPPETS batch query failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
     const snippetsByDocId = new Map<string, string[]>();
 
     for (const docId of hitOrder) {
-      try {
-        const rawSnippets = await extractSnippets({
-          docId,
-          index,
-          term,
-          fields,
-          esClient,
-          logger,
-        });
+      const rawSnippets = rawSnippetsByDocId.get(docId) ?? [];
 
-        const seen = new Set<string>();
-        const uniqueSnippets = rawSnippets.filter((s) => {
-          if (seen.has(s)) return false;
-          seen.add(s);
-          return true;
-        });
+      const seen = new Set<string>();
+      const uniqueSnippets = rawSnippets.filter((s) => {
+        if (seen.has(s)) return false;
+        seen.add(s);
+        return true;
+      });
 
-        let finalSnippets = uniqueSnippets;
-        if (rerankSnippets && uniqueSnippets.length > 0) {
-          try {
-            const entries: SnippetEntry[] = uniqueSnippets.map((s) => ({ docId, snippet: s }));
-            const reranked = await rerankSnippetEntries({ entries, term, esClient, logger });
-            logger.info(
-              `RERANK snippets for doc="${docId}": ${uniqueSnippets.length} candidates -> ${reranked.length} returned`
-            );
-            finalSnippets = reranked.map((e) => e.snippet);
-          } catch (error) {
-            logger.info(
-              `RERANK snippets failed for doc="${docId}", keeping original order: ${
-                error instanceof Error ? error.message : String(error)
-              }`
-            );
-            finalSnippets = uniqueSnippets.slice(0, numSnippets);
-          }
+      let finalSnippets = uniqueSnippets;
+      if (rerankSnippets && uniqueSnippets.length > 0) {
+        try {
+          const entries: SnippetEntry[] = uniqueSnippets.map((s) => ({ docId, snippet: s }));
+          const reranked = await rerankSnippetEntries({ entries, term, esClient, logger });
+          logger.info(
+            `RERANK snippets for doc="${docId}": ${uniqueSnippets.length} candidates -> ${reranked.length} returned`
+          );
+          finalSnippets = reranked.map((e) => e.snippet);
+        } catch (error) {
+          logger.info(
+            `RERANK snippets failed for doc="${docId}", keeping original order: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+          finalSnippets = uniqueSnippets.slice(0, numSnippets);
         }
-
-        snippetsByDocId.set(docId, finalSnippets);
-      } catch (error) {
-        logger.info(
-          `TOP_SNIPPETS failed for doc="${docId}": ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
       }
+
+      snippetsByDocId.set(docId, finalSnippets);
     }
 
     const results: MatchResult[] = hitOrder.map((docId) => ({

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -14,7 +14,7 @@ import { isCcsTarget } from '../utils/ccs';
 export interface MatchResult {
   id: string;
   index: string;
-  contentFragments: string[];
+  snippets: string[];
 }
 
 export interface PerformMatchSearchResponse {
@@ -23,12 +23,22 @@ export interface PerformMatchSearchResponse {
 
 // --- Search & extraction configuration ---
 
+// When true, use ES|QL TOP_SNIPPETS command to generate snippets from the documents
+// returned via the RRF retriever. When false, rely on Elasticsearch's highlighter to generate snippets.
 const useSnippets = true;
+// The maximum number of snippets to return for each matching document. The number of returned snippets
+// may be lower than this depending on the content in the returned document.
+// Only applicable when useSnippets = true.
 const numSnippets = 2;
+// The number of words to use when chunking fields for snippet generation.
+// Only applicable when useSnippets = true.
 const numWords = 750;
 
+// The reranker inference ID to use. We assume this reranker is always available.
 const rerankInferenceID = '.jina-reranker-v3';
+// When true, perform RERANK on the documents that were returned via the RRF retriever.
 const rerankCandidateDocs = true;
+// When true, perform an additional rerank operation on the generated snippets for each document.
 const rerankSnippets = true;
 
 // Number of candidate documents to retrieve for doc reranking
@@ -38,6 +48,12 @@ const snippetRankWindowSize = 10;
 
 // --- End configuration ---
 
+/**
+ * Builds the search request body. For local indices, uses the RRF retriever
+ * for best relevance ranking. For CCS targets, falls back to a query-based
+ * approach because the simplified RRF retriever syntax does not support
+ * cross-cluster index patterns.
+ */
 const buildSearchRequest = ({
   index,
   term,
@@ -73,6 +89,7 @@ const buildSearchRequest = ({
     };
   }
 
+  // Here is where we're using the RRF retriever for hybrid retrieval :)
   return {
     index,
     size: requestSize,
@@ -211,6 +228,8 @@ const rerankSnippetEntries = async ({
 
   logger.info(`RERANK snippets: sending ${entries.length} snippets to inference API`);
 
+  // NOTE: ES|QL RERANK doesn't play nicely with the format of the content in our test dataset,
+  // so we're making a direct inference call to rerank snippets.
   const response = await esClient.inference.inference({
     inference_id: rerankInferenceID,
     task_type: 'rerank',
@@ -242,7 +261,7 @@ export const performMatchSearch = async ({
 }): Promise<PerformMatchSearchResponse> => {
   const searchRequest = buildSearchRequest({ index, term, fields, size });
 
-  logger.debug(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
+  logger.info(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
 
   let response;
   try {
@@ -344,7 +363,7 @@ export const performMatchSearch = async ({
     const results: MatchResult[] = hitOrder.map((docId) => ({
       id: docId,
       index: hitsByDocId.get(docId)?._index ?? index,
-      contentFragments: snippetsByDocId.get(docId) ?? [],
+      snippets: snippetsByDocId.get(docId) ?? [],
     }));
 
     return { results };
@@ -355,7 +374,7 @@ export const performMatchSearch = async ({
     return {
       id: docId,
       index: hit?._index ?? index,
-      contentFragments: Object.values(hit?.highlight ?? {}).reduce<string[]>((acc, fragments) => {
+      snippets: Object.values(hit?.highlight ?? {}).reduce<string[]>((acc, fragments) => {
         acc.push(...fragments);
         return acc;
       }, []),

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -224,20 +224,40 @@ interface SnippetEntry {
   snippet: string;
 }
 
-const rerankSnippetEntries = async ({
-  entries,
+/**
+ * Reranks all snippet entries across all documents in a single inference call,
+ * then returns the top snippets per document.
+ */
+const rerankAllSnippets = async ({
+  entriesByDocId,
   term,
   esClient,
   logger,
 }: {
-  entries: SnippetEntry[];
+  entriesByDocId: Map<string, SnippetEntry[]>;
   term: string;
   esClient: ElasticsearchClient;
   logger: Logger;
-}): Promise<SnippetEntry[]> => {
-  if (entries.length === 0) return [];
+}): Promise<Map<string, string[]>> => {
+  const result = new Map<string, string[]>();
 
-  logger.info(`RERANK snippets: sending ${entries.length} snippets to inference API`);
+  // Flatten all entries into a single list, tracking the original index range per doc
+  const allEntries: SnippetEntry[] = [];
+  const docRanges: Array<{ docId: string; start: number; count: number }> = [];
+  for (const [docId, entries] of entriesByDocId) {
+    if (entries.length === 0) {
+      result.set(docId, []);
+      continue;
+    }
+    docRanges.push({ docId, start: allEntries.length, count: entries.length });
+    allEntries.push(...entries);
+  }
+
+  if (allEntries.length === 0) return result;
+
+  logger.info(
+    `RERANK snippets: sending ${allEntries.length} snippets across ${docRanges.length} docs to inference API`
+  );
 
   // NOTE: ES|QL RERANK doesn't play nicely with the format of the content in our test dataset,
   // so we're making a direct inference call to rerank snippets.
@@ -245,14 +265,50 @@ const rerankSnippetEntries = async ({
     inference_id: rerankInferenceID,
     task_type: 'rerank',
     query: term,
-    input: entries.map((e) => e.snippet),
+    input: allEntries.map((e) => e.snippet),
   });
 
   const reranked = (response as { rerank?: Array<{ index: number; relevance_score: number }> })
     .rerank;
-  if (!reranked) return entries.slice(0, numSnippets);
 
-  return reranked.slice(0, numSnippets).map((r) => entries[r.index]);
+  if (!reranked) {
+    // Fallback: take first numSnippets per doc without reranking
+    for (const { docId, start, count } of docRanges) {
+      result.set(
+        docId,
+        allEntries
+          .slice(start, start + count)
+          .slice(0, numSnippets)
+          .map((e) => e.snippet)
+      );
+    }
+    return result;
+  }
+
+  // Build a set of scores indexed by original position for fast lookup
+  const scoreByIndex = new Map<number, number>();
+  for (const r of reranked) {
+    scoreByIndex.set(r.index, r.relevance_score);
+  }
+
+  // For each doc, collect its scored snippets, sort by relevance, take top N
+  for (const { docId, start, count } of docRanges) {
+    const docScored: Array<{ snippet: string; score: number }> = [];
+    for (let i = start; i < start + count; i++) {
+      const score = scoreByIndex.get(i);
+      if (score !== undefined) {
+        docScored.push({ snippet: allEntries[i].snippet, score });
+      }
+    }
+    docScored.sort((a, b) => b.score - a.score);
+    const topSnippets = docScored.slice(0, numSnippets).map((s) => s.snippet);
+    logger.info(
+      `RERANK snippets for doc="${docId}": ${count} candidates -> ${topSnippets.length} returned`
+    );
+    result.set(docId, topSnippets);
+  }
+
+  return result;
 };
 
 export const performMatchSearch = async ({
@@ -338,38 +394,54 @@ export const performMatchSearch = async ({
       );
     }
 
-    const snippetsByDocId = new Map<string, string[]>();
-
+    // Dedup snippets per document
+    const dedupedByDocId = new Map<string, SnippetEntry[]>();
     for (const docId of hitOrder) {
       const rawSnippets = rawSnippetsByDocId.get(docId) ?? [];
-
       const seen = new Set<string>();
       const uniqueSnippets = rawSnippets.filter((s) => {
         if (seen.has(s)) return false;
         seen.add(s);
         return true;
       });
+      dedupedByDocId.set(
+        docId,
+        uniqueSnippets.map((s) => ({ docId, snippet: s }))
+      );
+    }
 
-      let finalSnippets = uniqueSnippets;
-      if (rerankSnippets && uniqueSnippets.length > 0) {
-        try {
-          const entries: SnippetEntry[] = uniqueSnippets.map((s) => ({ docId, snippet: s }));
-          const reranked = await rerankSnippetEntries({ entries, term, esClient, logger });
-          logger.info(
-            `RERANK snippets for doc="${docId}": ${uniqueSnippets.length} candidates -> ${reranked.length} returned`
+    // Rerank all snippets across all docs in a single inference call
+    let snippetsByDocId: Map<string, string[]>;
+    if (rerankSnippets) {
+      try {
+        snippetsByDocId = await rerankAllSnippets({
+          entriesByDocId: dedupedByDocId,
+          term,
+          esClient,
+          logger,
+        });
+      } catch (error) {
+        logger.info(
+          `RERANK snippets failed, keeping original order: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        snippetsByDocId = new Map<string, string[]>();
+        for (const [docId, entries] of dedupedByDocId) {
+          snippetsByDocId.set(
+            docId,
+            entries.slice(0, numSnippets).map((e) => e.snippet)
           );
-          finalSnippets = reranked.map((e) => e.snippet);
-        } catch (error) {
-          logger.info(
-            `RERANK snippets failed for doc="${docId}", keeping original order: ${
-              error instanceof Error ? error.message : String(error)
-            }`
-          );
-          finalSnippets = uniqueSnippets.slice(0, numSnippets);
         }
       }
-
-      snippetsByDocId.set(docId, finalSnippets);
+    } else {
+      snippetsByDocId = new Map<string, string[]>();
+      for (const [docId, entries] of dedupedByDocId) {
+        snippetsByDocId.set(
+          docId,
+          entries.map((e) => e.snippet)
+        );
+      }
     }
 
     const results: MatchResult[] = hitOrder.map((docId) => ({

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -8,24 +8,36 @@
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
 import type { MappingField } from '../utils/mappings';
+import { executeEsql, interpolateEsqlQuery } from '../utils/esql';
 import { isCcsTarget } from '../utils/ccs';
 
 export interface MatchResult {
   id: string;
   index: string;
-  highlights: string[];
+  contentFragments: string[];
 }
 
 export interface PerformMatchSearchResponse {
   results: MatchResult[];
 }
 
-/**
- * Builds the search request body. For local indices, uses the RRF retriever
- * for best relevance ranking. For CCS targets, falls back to a query-based
- * approach because the simplified RRF retriever syntax does not support
- * cross-cluster index patterns.
- */
+// --- Search & extraction configuration ---
+
+const useSnippets = true;
+const numSnippets = 2;
+const numWords = 750;
+
+const rerankInferenceID = '.jina-reranker-v3';
+const rerankCandidateDocs = true;
+const rerankSnippets = true;
+
+// Number of candidate documents to retrieve for doc reranking
+const rankWindowSize = 20;
+// Number of candidate snippets to extract per doc for snippet reranking
+const snippetRankWindowSize = 10;
+
+// --- End configuration ---
+
 const buildSearchRequest = ({
   index,
   term,
@@ -37,54 +49,44 @@ const buildSearchRequest = ({
   fields: MappingField[];
   size: number;
 }): Record<string, any> => {
-  const highlightConfig = {
-    number_of_fragments: 5,
-    fragment_size: 500,
-    pre_tags: [''],
-    post_tags: [''],
-    order: 'score' as const,
-    fields: fields.reduce((memo, field) => ({ ...memo, [field.path]: {} }), {}),
-  };
+  const requestSize = rerankCandidateDocs ? rankWindowSize : size;
 
-  // CCS fallback: the simplified RRF retriever syntax does not support
-  // cross-cluster index patterns, so we use a query-based approach instead.
+  const highlightConfig = !useSnippets
+    ? {
+        highlight: {
+          number_of_fragments: 5,
+          fragment_size: 500,
+          pre_tags: [''],
+          post_tags: [''],
+          order: 'score' as const,
+          fields: fields.reduce((memo, field) => ({ ...memo, [field.path]: {} }), {}),
+        },
+      }
+    : {};
+
   if (isCcsTarget(index)) {
     return {
       index,
-      size,
+      size: requestSize,
       query: buildCcsQuery({ term, fields }),
-      highlight: highlightConfig,
+      ...highlightConfig,
     };
   }
 
-  // Local indices: use the RRF retriever for optimal relevance ranking
-  // TODO: once multi_match supports semantic_text (elastic/search-team#11226),
-  // consider unifying local and CCS paths.
-  // should replace `any` with `SearchRequest` type when the simplified retriever syntax is supported in @elastic/elasticsearch
   return {
     index,
-    size,
+    size: requestSize,
     retriever: {
       rrf: {
-        rank_window_size: size * 2,
+        rank_window_size: requestSize * 2,
         query: term,
         fields: fields.map((field) => field.path),
       },
     },
-    highlight: highlightConfig,
+    ...highlightConfig,
   };
 };
 
-/**
- * Builds the query for a CCS target using a bool/should with one match clause
- * per searchable field.
- *
- * We cannot use multi_match here because it does not support semantic_text
- * fields (elastic/search-team#11226), and _field_caps (our mapping source for
- * CCS) reports semantic_text fields as "text", making them indistinguishable.
- * Individual match queries work correctly with both regular text and
- * semantic_text fields.
- */
 const buildCcsQuery = ({
   term,
   fields,
@@ -98,6 +100,129 @@ const buildCcsQuery = ({
       minimum_should_match: 1,
     },
   };
+};
+
+const escapeEsqlString = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+const buildMvAppendExpr = (fieldPaths: string[]): string => {
+  if (fieldPaths.length === 1) {
+    return fieldPaths[0];
+  }
+  return fieldPaths.reduce((acc, path) => `MV_APPEND(${acc}, ${path})`);
+};
+
+const extractSnippets = async ({
+  docId,
+  index,
+  term,
+  fields,
+  esClient,
+  logger,
+}: {
+  docId: string;
+  index: string;
+  term: string;
+  fields: MappingField[];
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<string[]> => {
+  const fieldPaths = fields.map((field) => field.path);
+  const mvAppendExpr = buildMvAppendExpr(fieldPaths);
+
+  const snippetCount = rerankSnippets ? snippetRankWindowSize : numSnippets;
+
+  const esqlQuery = interpolateEsqlQuery(
+    `FROM ${index} METADATA _id | WHERE _id == ?docId | EVAL doc = MV_DEDUPE(${mvAppendExpr}) | EVAL snippets = TOP_SNIPPETS(doc, ?term, {"num_snippets": ${snippetCount}, "num_words": ${numWords}}) | MV_EXPAND snippets | KEEP snippets`,
+    { docId, term }
+  );
+
+  logger.info(`TOP_SNIPPETS query for doc="${docId}": ${esqlQuery}`);
+
+  const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
+
+  const snippets: string[] = [];
+  for (const row of esqlResponse.values) {
+    const value = row[0];
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string') snippets.push(item);
+      }
+    } else if (typeof value === 'string') {
+      snippets.push(value);
+    }
+  }
+  return snippets;
+};
+
+const rerankDocuments = async ({
+  docIds,
+  index,
+  term,
+  fields,
+  resultSize,
+  esClient,
+  logger,
+}: {
+  docIds: string[];
+  index: string;
+  term: string;
+  fields: MappingField[];
+  resultSize: number;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<string[]> => {
+  logger.info(`rerankDocuments called with ${docIds.length} docs, resultSize=${resultSize}`);
+  if (docIds.length === 0) return [];
+
+  const fieldPaths = fields.map((f) => f.path);
+  const mvAppendExpr = buildMvAppendExpr(fieldPaths);
+
+  const idList = docIds.map((id) => `"${escapeEsqlString(id)}"`).join(', ');
+  const escapedTerm = escapeEsqlString(term);
+
+  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL rerank_input = MV_CONCAT(MV_DEDUPE(${mvAppendExpr}), " ") | RERANK "${escapedTerm}" ON rerank_input WITH {"inference_id": "${rerankInferenceID}"} | KEEP _id | LIMIT ${resultSize}`;
+
+  logger.info(`RERANK candidate docs query: ${esqlQuery}`);
+
+  const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
+  logger.info(`RERANK candidate docs response: ${JSON.stringify(esqlResponse)}`);
+
+  return esqlResponse.values.map((row) => row[0]).filter((v): v is string => typeof v === 'string');
+};
+
+interface SnippetEntry {
+  docId: string;
+  snippet: string;
+}
+
+const rerankSnippetEntries = async ({
+  entries,
+  term,
+  esClient,
+  logger,
+}: {
+  entries: SnippetEntry[];
+  term: string;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<SnippetEntry[]> => {
+  if (entries.length === 0) return [];
+
+  logger.info(`RERANK snippets: sending ${entries.length} snippets to inference API`);
+
+  const response = await esClient.inference.inference({
+    inference_id: rerankInferenceID,
+    task_type: 'rerank',
+    query: term,
+    input: entries.map((e) => e.snippet),
+  });
+
+  const reranked = (response as { rerank?: Array<{ index: number; relevance_score: number }> })
+    .rerank;
+  if (!reranked) return entries.slice(0, numSnippets);
+
+  return reranked.slice(0, numSnippets).map((r) => entries[r.index]);
 };
 
 export const performMatchSearch = async ({
@@ -121,9 +246,9 @@ export const performMatchSearch = async ({
 
   let response;
   try {
-    response = await esClient.search<any>(searchRequest);
+    response = await esClient.search<Record<string, unknown>>(searchRequest);
   } catch (error) {
-    logger.debug(
+    logger.info(
       `Elasticsearch search failed for index="${index}", term="${term}": ${
         error instanceof Error ? error.message : String(error)
       }`
@@ -131,14 +256,109 @@ export const performMatchSearch = async ({
     throw error;
   }
 
-  const results = response.hits.hits.map<MatchResult>((hit) => {
+  let hitOrder = response.hits.hits.map((hit) => hit._id!);
+  logger.info(
+    `Search returned ${hitOrder.length} hits: [${hitOrder.join(
+      ', '
+    )}], rerankCandidateDocs=${rerankCandidateDocs}, useSnippets=${useSnippets}`
+  );
+
+  if (rerankCandidateDocs) {
+    const originalOrder = hitOrder;
+    logger.info(`Entering RERANK candidate docs block with ${hitOrder.length} docs`);
+    try {
+      hitOrder = await rerankDocuments({
+        docIds: hitOrder,
+        index,
+        term,
+        fields,
+        resultSize: size,
+        esClient,
+        logger,
+      });
+      logger.info(
+        `RERANK candidate docs: before=[${originalOrder.join(', ')}] after=[${hitOrder.join(', ')}]`
+      );
+    } catch (error) {
+      logger.info(
+        `RERANK candidate docs failed, keeping original order: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      hitOrder = hitOrder.slice(0, size);
+    }
+  }
+
+  const hitsByDocId = new Map(response.hits.hits.map((hit) => [hit._id!, hit]));
+
+  if (useSnippets) {
+    const snippetsByDocId = new Map<string, string[]>();
+
+    for (const docId of hitOrder) {
+      try {
+        const rawSnippets = await extractSnippets({
+          docId,
+          index,
+          term,
+          fields,
+          esClient,
+          logger,
+        });
+
+        const seen = new Set<string>();
+        const uniqueSnippets = rawSnippets.filter((s) => {
+          if (seen.has(s)) return false;
+          seen.add(s);
+          return true;
+        });
+
+        let finalSnippets = uniqueSnippets;
+        if (rerankSnippets && uniqueSnippets.length > 0) {
+          try {
+            const entries: SnippetEntry[] = uniqueSnippets.map((s) => ({ docId, snippet: s }));
+            const reranked = await rerankSnippetEntries({ entries, term, esClient, logger });
+            logger.info(
+              `RERANK snippets for doc="${docId}": ${uniqueSnippets.length} candidates -> ${reranked.length} returned`
+            );
+            finalSnippets = reranked.map((e) => e.snippet);
+          } catch (error) {
+            logger.info(
+              `RERANK snippets failed for doc="${docId}", keeping original order: ${
+                error instanceof Error ? error.message : String(error)
+              }`
+            );
+            finalSnippets = uniqueSnippets.slice(0, numSnippets);
+          }
+        }
+
+        snippetsByDocId.set(docId, finalSnippets);
+      } catch (error) {
+        logger.info(
+          `TOP_SNIPPETS failed for doc="${docId}": ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
+
+    const results: MatchResult[] = hitOrder.map((docId) => ({
+      id: docId,
+      index: hitsByDocId.get(docId)?._index ?? index,
+      contentFragments: snippetsByDocId.get(docId) ?? [],
+    }));
+
+    return { results };
+  }
+
+  const results: MatchResult[] = hitOrder.map((docId) => {
+    const hit = hitsByDocId.get(docId);
     return {
-      id: hit._id!,
-      index: hit._index!,
-      highlights: Object.entries(hit.highlight ?? {}).reduce((acc, [field, highlights]) => {
-        acc.push(...highlights);
+      id: docId,
+      index: hit?._index ?? index,
+      contentFragments: Object.values(hit?.highlight ?? {}).reduce<string[]>((acc, fragments) => {
+        acc.push(...fragments);
         return acc;
-      }, [] as string[]),
+      }, []),
     };
   });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -22,30 +22,29 @@ export interface PerformMatchSearchResponse {
 }
 
 // --- Search & extraction configuration ---
-// All settings can be overridden via environment variables for eval runs.
 
 // When true, use ES|QL TOP_SNIPPETS command to generate snippets from the documents
 // returned via the RRF retriever. When false, rely on Elasticsearch's highlighter to generate snippets.
-const useSnippets = process.env.USE_SNIPPETS !== 'false';
+const useSnippets = true;
 // The maximum number of snippets to return for each matching document. The number of returned snippets
 // may be lower than this depending on the content in the returned document.
 // Only applicable when useSnippets = true.
-const numSnippets = parseInt(process.env.NUM_SNIPPETS ?? '2', 10);
+const numSnippets = 2;
 // The number of words to use when chunking fields for snippet generation.
 // Only applicable when useSnippets = true.
-const numWords = parseInt(process.env.NUM_WORDS ?? '750', 10);
+const numWords = 750;
 
 // The reranker inference ID to use. We assume this reranker is always available.
-const rerankInferenceID = process.env.RERANK_INFERENCE_ID ?? '.jina-reranker-v3';
+const rerankInferenceID = '.jina-reranker-v3';
 // When true, perform RERANK on the documents that were returned via the RRF retriever.
-const rerankCandidateDocs = process.env.RERANK_CANDIDATE_DOCS !== 'false';
+const rerankCandidateDocs = true;
 // When true, perform an additional rerank operation on the generated snippets for each document.
-const rerankSnippets = process.env.RERANK_SNIPPETS !== 'false';
+const rerankSnippets = true;
 
 // Number of candidate documents to retrieve for doc reranking
-const rankWindowSize = parseInt(process.env.RANK_WINDOW_SIZE ?? '20', 10);
+const rankWindowSize = 20;
 // Number of candidate snippets to extract per doc for snippet reranking
-const snippetRankWindowSize = parseInt(process.env.SNIPPET_RANK_WINDOW_SIZE ?? '10', 10);
+const snippetRankWindowSize = 10;
 
 // --- End configuration ---
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -157,7 +157,7 @@ const extractSnippetsBatch = async ({
 
   const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL doc = MV_DEDUPE(${mvAppendExpr}) | EVAL snippets = TOP_SNIPPETS(doc, "${escapedTerm}", {"num_snippets": ${snippetCount}, "num_words": ${numWords}}) | MV_EXPAND snippets | KEEP _id, snippets`;
 
-  logger.info(`TOP_SNIPPETS batch query for ${docIds.length} docs: ${esqlQuery}`);
+  logger.debug(`TOP_SNIPPETS batch query for ${docIds.length} docs: ${esqlQuery}`);
 
   const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
 
@@ -200,7 +200,7 @@ const rerankDocuments = async ({
   esClient: ElasticsearchClient;
   logger: Logger;
 }): Promise<string[]> => {
-  logger.info(`rerankDocuments called with ${docIds.length} docs, resultSize=${resultSize}`);
+  logger.debug(`rerankDocuments called with ${docIds.length} docs, resultSize=${resultSize}`);
   if (docIds.length === 0) return [];
 
   const fieldPaths = fields.map((f) => f.path);
@@ -211,10 +211,10 @@ const rerankDocuments = async ({
 
   const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL rerank_input = MV_CONCAT(MV_DEDUPE(${mvAppendExpr}), " ") | RERANK "${escapedTerm}" ON rerank_input WITH {"inference_id": "${rerankInferenceID}"} | KEEP _id | LIMIT ${resultSize}`;
 
-  logger.info(`RERANK candidate docs query: ${esqlQuery}`);
+  logger.debug(`RERANK candidate docs query: ${esqlQuery}`);
 
   const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
-  logger.info(`RERANK candidate docs response: ${JSON.stringify(esqlResponse)}`);
+  logger.debug(`RERANK candidate docs response: ${JSON.stringify(esqlResponse)}`);
 
   return esqlResponse.values.map((row) => row[0]).filter((v): v is string => typeof v === 'string');
 };
@@ -302,7 +302,7 @@ const rerankAllSnippets = async ({
     }
     docScored.sort((a, b) => b.score - a.score);
     const topSnippets = docScored.slice(0, numSnippets).map((s) => s.snippet);
-    logger.info(
+    logger.debug(
       `RERANK snippets for doc="${docId}": ${count} candidates -> ${topSnippets.length} returned`
     );
     result.set(docId, topSnippets);
@@ -328,7 +328,7 @@ export const performMatchSearch = async ({
 }): Promise<PerformMatchSearchResponse> => {
   const searchRequest = buildSearchRequest({ index, term, fields, size });
 
-  logger.info(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
+  logger.debug(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
 
   let response;
   try {
@@ -343,7 +343,7 @@ export const performMatchSearch = async ({
   }
 
   let hitOrder = response.hits.hits.map((hit) => hit._id!);
-  logger.info(
+  logger.debug(
     `Search returned ${hitOrder.length} hits: [${hitOrder.join(
       ', '
     )}], rerankCandidateDocs=${rerankCandidateDocs}, useSnippets=${useSnippets}`
@@ -351,7 +351,7 @@ export const performMatchSearch = async ({
 
   if (rerankCandidateDocs) {
     const originalOrder = hitOrder;
-    logger.info(`Entering RERANK candidate docs block with ${hitOrder.length} docs`);
+    logger.debug(`Entering RERANK candidate docs block with ${hitOrder.length} docs`);
     try {
       hitOrder = await rerankDocuments({
         docIds: hitOrder,
@@ -362,7 +362,7 @@ export const performMatchSearch = async ({
         esClient,
         logger,
       });
-      logger.info(
+      logger.debug(
         `RERANK candidate docs: before=[${originalOrder.join(', ')}] after=[${hitOrder.join(', ')}]`
       );
     } catch (error) {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -22,29 +22,30 @@ export interface PerformMatchSearchResponse {
 }
 
 // --- Search & extraction configuration ---
+// All settings can be overridden via environment variables for eval runs.
 
 // When true, use ES|QL TOP_SNIPPETS command to generate snippets from the documents
 // returned via the RRF retriever. When false, rely on Elasticsearch's highlighter to generate snippets.
-const useSnippets = true;
+const useSnippets = process.env.USE_SNIPPETS !== 'false';
 // The maximum number of snippets to return for each matching document. The number of returned snippets
 // may be lower than this depending on the content in the returned document.
 // Only applicable when useSnippets = true.
-const numSnippets = 2;
+const numSnippets = parseInt(process.env.NUM_SNIPPETS ?? '2', 10);
 // The number of words to use when chunking fields for snippet generation.
 // Only applicable when useSnippets = true.
-const numWords = 750;
+const numWords = parseInt(process.env.NUM_WORDS ?? '750', 10);
 
 // The reranker inference ID to use. We assume this reranker is always available.
-const rerankInferenceID = '.jina-reranker-v3';
+const rerankInferenceID = process.env.RERANK_INFERENCE_ID ?? '.jina-reranker-v3';
 // When true, perform RERANK on the documents that were returned via the RRF retriever.
-const rerankCandidateDocs = true;
+const rerankCandidateDocs = process.env.RERANK_CANDIDATE_DOCS !== 'false';
 // When true, perform an additional rerank operation on the generated snippets for each document.
-const rerankSnippets = true;
+const rerankSnippets = process.env.RERANK_SNIPPETS !== 'false';
 
 // Number of candidate documents to retrieve for doc reranking
-const rankWindowSize = 20;
+const rankWindowSize = parseInt(process.env.RANK_WINDOW_SIZE ?? '20', 10);
 // Number of candidate snippets to extract per doc for snippet reranking
-const snippetRankWindowSize = 10;
+const snippetRankWindowSize = parseInt(process.env.SNIPPET_RANK_WINDOW_SIZE ?? '10', 10);
 
 // --- End configuration ---
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -310,6 +310,72 @@ const rerankAllSnippets = async ({
   return result;
 };
 
+/**
+ * Combines RERANK and TOP_SNIPPETS into a single ES|QL query, avoiding
+ * a second index read. Returns the reranked doc order and snippets.
+ */
+const rerankAndExtractSnippets = async ({
+  docIds,
+  index,
+  term,
+  fields,
+  resultSize,
+  esClient,
+  logger,
+}: {
+  docIds: string[];
+  index: string;
+  term: string;
+  fields: MappingField[];
+  resultSize: number;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<{ hitOrder: string[]; snippetsByDocId: Map<string, string[]> }> => {
+  if (docIds.length === 0) return { hitOrder: [], snippetsByDocId: new Map() };
+
+  const idList = docIds.map((id) => `"${escapeEsqlString(id)}"`).join(', ');
+  const escapedTerm = escapeEsqlString(term);
+  const fieldPaths = fields.map((f) => f.path);
+  const mvAppendExpr = buildMvAppendExpr(fieldPaths);
+  const snippetCount = rerankSnippets ? snippetRankWindowSize : numSnippets;
+
+  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | RERANK "${escapedTerm}" ON ${fieldPaths} WITH {"inference_id": "${rerankInferenceID}"} | SORT _score DESC | LIMIT ${resultSize} | EVAL doc = MV_DEDUPE(${mvAppendExpr}) | EVAL snippets = TOP_SNIPPETS(doc, "${escapedTerm}", {"num_snippets": ${snippetCount}, "num_words": ${numWords}}) | MV_EXPAND snippets | KEEP _id, snippets`;
+
+  logger.debug(`RERANK + TOP_SNIPPETS combined query: ${esqlQuery}`);
+
+  const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
+
+  const hitOrder: string[] = [];
+  const snippetsByDocId = new Map<string, string[]>();
+  const seen = new Set<string>();
+
+  for (const row of esqlResponse.values) {
+    const docId = row[0];
+    const snippet = row[1];
+    if (typeof docId !== 'string') continue;
+
+    // Preserve RERANK order for doc IDs
+    if (!seen.has(docId)) {
+      seen.add(docId);
+      hitOrder.push(docId);
+    }
+
+    if (!snippetsByDocId.has(docId)) {
+      snippetsByDocId.set(docId, []);
+    }
+    const snippets = snippetsByDocId.get(docId)!;
+    if (Array.isArray(snippet)) {
+      for (const item of snippet) {
+        if (typeof item === 'string') snippets.push(item);
+      }
+    } else if (typeof snippet === 'string') {
+      snippets.push(snippet);
+    }
+  }
+
+  return { hitOrder, snippetsByDocId };
+};
+
 export const performMatchSearch = async ({
   term,
   fields,
@@ -343,13 +409,38 @@ export const performMatchSearch = async ({
   }
 
   let hitOrder = response.hits.hits.map((hit) => hit._id!);
+  const hitsByDocId = new Map(response.hits.hits.map((hit) => [hit._id!, hit]));
   logger.debug(
     `Search returned ${hitOrder.length} hits: [${hitOrder.join(
       ', '
     )}], rerankCandidateDocs=${rerankCandidateDocs}, useSnippets=${useSnippets}`
   );
 
-  if (rerankCandidateDocs) {
+  // When both are enabled, combine RERANK + TOP_SNIPPETS into a single ES|QL query
+  let rawSnippetsByDocId: Map<string, string[]> | undefined;
+
+  if (rerankCandidateDocs && useSnippets) {
+    try {
+      const combined = await rerankAndExtractSnippets({
+        docIds: hitOrder,
+        index,
+        term,
+        fields,
+        resultSize: hardCodedSize,
+        esClient,
+        logger,
+      });
+      hitOrder = combined.hitOrder;
+      rawSnippetsByDocId = combined.snippetsByDocId;
+    } catch (error) {
+      logger.info(
+        `Combined RERANK + TOP_SNIPPETS failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      hitOrder = hitOrder.slice(0, hardCodedSize);
+    }
+  } else if (rerankCandidateDocs) {
     try {
       hitOrder = await rerankDocuments({
         docIds: hitOrder,
@@ -370,23 +461,25 @@ export const performMatchSearch = async ({
     }
   }
 
-  const hitsByDocId = new Map(response.hits.hits.map((hit) => [hit._id!, hit]));
-
   if (useSnippets) {
-    let rawSnippetsByDocId = new Map<string, string[]>();
-    try {
-      rawSnippetsByDocId = await extractSnippetsBatch({
-        docIds: hitOrder,
-        index,
-        term,
-        fields,
-        esClient,
-        logger,
-      });
-    } catch (error) {
-      logger.info(
-        `TOP_SNIPPETS batch query failed: ${error instanceof Error ? error.message : String(error)}`
-      );
+    if (!rawSnippetsByDocId) {
+      rawSnippetsByDocId = new Map<string, string[]>();
+      try {
+        rawSnippetsByDocId = await extractSnippetsBatch({
+          docIds: hitOrder,
+          index,
+          term,
+          fields,
+          esClient,
+          logger,
+        });
+      } catch (error) {
+        logger.info(
+          `TOP_SNIPPETS batch query failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
     }
 
     // Dedup snippets per document

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -35,14 +35,15 @@ const numSnippets = 2;
 const numWords = 750;
 
 // The reranker inference ID to use. We assume this reranker is always available.
-const rerankInferenceID = '.jina-reranker-v3';
+const rerankInferenceID = '.jina-reranker-v2-base-multilingual';
+// const rerankInferenceID = '.jina-reranker-v3';
 // When true, perform RERANK on the documents that were returned via the RRF retriever.
 const rerankCandidateDocs = true;
 // When true, perform an additional rerank operation on the generated snippets for each document.
 const rerankSnippets = false;
 
 // Number of candidate documents to retrieve for doc reranking
-const rankWindowSize = 20;
+const rankWindowSize = 30;
 // Number of candidate snippets to extract per doc for snippet reranking
 const snippetRankWindowSize = 10;
 
@@ -157,7 +158,7 @@ const extractSnippetsBatch = async ({
 
   const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL doc = MV_DEDUPE(${mvAppendExpr}) | EVAL snippets = TOP_SNIPPETS(doc, "${escapedTerm}", {"num_snippets": ${snippetCount}, "num_words": ${numWords}}) | MV_EXPAND snippets | KEEP _id, snippets`;
 
-  logger.info(`TOP_SNIPPETS batch query for ${docIds.length} docs: ${esqlQuery}`);
+  logger.debug(`TOP_SNIPPETS batch query for ${docIds.length} docs: ${esqlQuery}`);
 
   const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
 
@@ -212,7 +213,7 @@ const rerankDocuments = async ({
   logger.info(`RERANK candidate docs query: ${esqlQuery}`);
 
   const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
-  logger.info(`RERANK candidate docs response: ${JSON.stringify(esqlResponse)}`);
+  logger.debug(`RERANK candidate docs response: ${JSON.stringify(esqlResponse)}`);
 
   return esqlResponse.values.map((row) => row[0]).filter((v): v is string => typeof v === 'string');
 };
@@ -324,7 +325,8 @@ export const performMatchSearch = async ({
   esClient: ElasticsearchClient;
   logger: Logger;
 }): Promise<PerformMatchSearchResponse> => {
-  const searchRequest = buildSearchRequest({ index, term, fields, size });
+  const hardCodedSize = 5;
+  const searchRequest = buildSearchRequest({ index, term, fields, size: hardCodedSize });
 
   logger.info(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
 
@@ -341,35 +343,30 @@ export const performMatchSearch = async ({
   }
 
   let hitOrder = response.hits.hits.map((hit) => hit._id!);
-  logger.info(
+  logger.debug(
     `Search returned ${hitOrder.length} hits: [${hitOrder.join(
       ', '
     )}], rerankCandidateDocs=${rerankCandidateDocs}, useSnippets=${useSnippets}`
   );
 
   if (rerankCandidateDocs) {
-    const originalOrder = hitOrder;
-    logger.info(`Entering RERANK candidate docs block with ${hitOrder.length} docs`);
     try {
       hitOrder = await rerankDocuments({
         docIds: hitOrder,
         index,
         term,
         fields,
-        resultSize: size,
+        resultSize: hardCodedSize,
         esClient,
         logger,
       });
-      logger.info(
-        `RERANK candidate docs: before=[${originalOrder.join(', ')}] after=[${hitOrder.join(', ')}]`
-      );
     } catch (error) {
       logger.info(
         `RERANK candidate docs failed, keeping original order: ${
           error instanceof Error ? error.message : String(error)
         }`
       );
-      hitOrder = hitOrder.slice(0, size);
+      hitOrder = hitOrder.slice(0, hardCodedSize);
     }
   }
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -157,7 +157,7 @@ const extractSnippetsBatch = async ({
 
   const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL doc = MV_DEDUPE(${mvAppendExpr}) | EVAL snippets = TOP_SNIPPETS(doc, "${escapedTerm}", {"num_snippets": ${snippetCount}, "num_words": ${numWords}}) | MV_EXPAND snippets | KEEP _id, snippets`;
 
-  logger.debug(`TOP_SNIPPETS batch query for ${docIds.length} docs: ${esqlQuery}`);
+  logger.info(`TOP_SNIPPETS batch query for ${docIds.length} docs: ${esqlQuery}`);
 
   const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
 
@@ -200,7 +200,7 @@ const rerankDocuments = async ({
   esClient: ElasticsearchClient;
   logger: Logger;
 }): Promise<string[]> => {
-  logger.debug(`rerankDocuments called with ${docIds.length} docs, resultSize=${resultSize}`);
+  logger.info(`rerankDocuments called with ${docIds.length} docs, resultSize=${resultSize}`);
   if (docIds.length === 0) return [];
 
   const fieldPaths = fields.map((f) => f.path);
@@ -211,10 +211,10 @@ const rerankDocuments = async ({
 
   const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL rerank_input = MV_CONCAT(MV_DEDUPE(${mvAppendExpr}), " ") | RERANK "${escapedTerm}" ON rerank_input WITH {"inference_id": "${rerankInferenceID}"} | KEEP _id | LIMIT ${resultSize}`;
 
-  logger.debug(`RERANK candidate docs query: ${esqlQuery}`);
+  logger.info(`RERANK candidate docs query: ${esqlQuery}`);
 
   const esqlResponse = await executeEsql({ query: esqlQuery, esClient });
-  logger.debug(`RERANK candidate docs response: ${JSON.stringify(esqlResponse)}`);
+  logger.info(`RERANK candidate docs response: ${JSON.stringify(esqlResponse)}`);
 
   return esqlResponse.values.map((row) => row[0]).filter((v): v is string => typeof v === 'string');
 };
@@ -302,7 +302,7 @@ const rerankAllSnippets = async ({
     }
     docScored.sort((a, b) => b.score - a.score);
     const topSnippets = docScored.slice(0, numSnippets).map((s) => s.snippet);
-    logger.debug(
+    logger.info(
       `RERANK snippets for doc="${docId}": ${count} candidates -> ${topSnippets.length} returned`
     );
     result.set(docId, topSnippets);
@@ -328,7 +328,7 @@ export const performMatchSearch = async ({
 }): Promise<PerformMatchSearchResponse> => {
   const searchRequest = buildSearchRequest({ index, term, fields, size });
 
-  logger.debug(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
+  logger.info(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
 
   let response;
   try {
@@ -343,7 +343,7 @@ export const performMatchSearch = async ({
   }
 
   let hitOrder = response.hits.hits.map((hit) => hit._id!);
-  logger.debug(
+  logger.info(
     `Search returned ${hitOrder.length} hits: [${hitOrder.join(
       ', '
     )}], rerankCandidateDocs=${rerankCandidateDocs}, useSnippets=${useSnippets}`
@@ -351,7 +351,7 @@ export const performMatchSearch = async ({
 
   if (rerankCandidateDocs) {
     const originalOrder = hitOrder;
-    logger.debug(`Entering RERANK candidate docs block with ${hitOrder.length} docs`);
+    logger.info(`Entering RERANK candidate docs block with ${hitOrder.length} docs`);
     try {
       hitOrder = await rerankDocuments({
         docIds: hitOrder,
@@ -362,7 +362,7 @@ export const performMatchSearch = async ({
         esClient,
         logger,
       });
-      logger.debug(
+      logger.info(
         `RERANK candidate docs: before=[${originalOrder.join(', ')}] after=[${hitOrder.join(', ')}]`
       );
     } catch (error) {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -205,8 +205,9 @@ const rerankDocuments = async ({
 
   const idList = docIds.map((id) => `"${escapeEsqlString(id)}"`).join(', ');
   const escapedTerm = escapeEsqlString(term);
+  const fieldPaths = fields.map((f) => f.path);
 
-  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | RERANK "${escapedTerm}" ON ${fields} WITH {"inference_id": "${rerankInferenceID}"} | SORT _score | KEEP _id | LIMIT ${resultSize}`;
+  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | RERANK "${escapedTerm}" ON ${fieldPaths} WITH {"inference_id": "${rerankInferenceID}"} | SORT _score | KEEP _id | LIMIT ${resultSize}`;
 
   logger.info(`RERANK candidate docs query: ${esqlQuery}`);
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -207,7 +207,7 @@ const rerankDocuments = async ({
   const escapedTerm = escapeEsqlString(term);
   const fieldPaths = fields.map((f) => f.path);
 
-  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | RERANK "${escapedTerm}" ON ${fieldPaths} WITH {"inference_id": "${rerankInferenceID}"} | SORT _score | KEEP _id | LIMIT ${resultSize}`;
+  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | RERANK "${escapedTerm}" ON ${fieldPaths} WITH {"inference_id": "${rerankInferenceID}"} | SORT _score DESC | KEEP _id | LIMIT ${resultSize}`;
 
   logger.info(`RERANK candidate docs query: ${esqlQuery}`);
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -39,7 +39,7 @@ const rerankInferenceID = '.jina-reranker-v3';
 // When true, perform RERANK on the documents that were returned via the RRF retriever.
 const rerankCandidateDocs = true;
 // When true, perform an additional rerank operation on the generated snippets for each document.
-const rerankSnippets = true;
+const rerankSnippets = false;
 
 // Number of candidate documents to retrieve for doc reranking
 const rankWindowSize = 20;
@@ -203,13 +203,10 @@ const rerankDocuments = async ({
   logger.info(`rerankDocuments called with ${docIds.length} docs, resultSize=${resultSize}`);
   if (docIds.length === 0) return [];
 
-  const fieldPaths = fields.map((f) => f.path);
-  const mvAppendExpr = buildMvAppendExpr(fieldPaths);
-
   const idList = docIds.map((id) => `"${escapeEsqlString(id)}"`).join(', ');
   const escapedTerm = escapeEsqlString(term);
 
-  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | EVAL rerank_input = MV_CONCAT(MV_DEDUPE(${mvAppendExpr}), " ") | RERANK "${escapedTerm}" ON rerank_input WITH {"inference_id": "${rerankInferenceID}"} | KEEP _id | LIMIT ${resultSize}`;
+  const esqlQuery = `FROM ${index} METADATA _id | WHERE _id IN (${idList}) | RERANK "${escapedTerm}" ON ${fields} WITH {"inference_id": "${rerankInferenceID}"} | SORT _score | KEEP _id | LIMIT ${resultSize}`;
 
   logger.info(`RERANK candidate docs query: ${esqlQuery}`);
 

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
@@ -31,12 +31,12 @@ If the user accepts the default or leaves it blank, use `$HOME/.gcs/gcs.client.d
 Launch Elasticsearch in the background using `run_in_background`. Include the GCS credentials:
 
 ```bash
-yarn es snapshot --license trial --secure-files gcs.client.default.credentials_file=<GCS_CREDENTIALS_PATH>
+yarn es snapshot --license trial --secure-files gcs.client.default.credentials_file=<GCS_CREDENTIALS_PATH> -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
 ```
 
 Tell the user Elasticsearch is starting up.
 
-### Step 3: Register GCS Snapshot Repository
+### Step 3: Set Up EIS and Register GCS Snapshot Repository
 
 Wait for Elasticsearch to become available by polling until the cluster health endpoint responds. Fail after 30 attempts (approximately 2.5 minutes):
 
@@ -46,7 +46,17 @@ MAX_RETRIES=30; COUNT=0; until curl -s -u elastic:changeme http://localhost:9200
 
 If the poll times out, show the error to the user and suggest checking the Elasticsearch background task output for startup errors.
 
-Once ES is ready, register the GCS snapshot repository with these defaults:
+Once ES is ready, run the EIS setup script to configure Cloud Connected Mode (CCM):
+
+```bash
+node scripts/eis.js
+```
+
+Verify it succeeds by checking for the "EIS API key successfully set" message. If it fails, show the error to the user.
+
+Tell the user EIS/CCM has been configured.
+
+Next, register the GCS snapshot repository with these defaults:
 
 - **Repository name**: `agent-builder-datasets`
 - **Bucket**: `agent-builder-datasets`
@@ -188,8 +198,6 @@ Display a summary and the command:
 > - Kibana: running (no base path)
 > - Phoenix: confirmed running
 > - EDOT: running
->
-> **Important:** Make sure Cloud Connected Mode (CCM) is enabled in Kibana before running the evaluation. Go to **Stack Management > Cloud Connected Mode** in the Kibana UI and enable it if it is not already active.
 >
 > **Run the following command in a separate terminal to start the evaluation:**
 >

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
@@ -119,13 +119,23 @@ Tell the user the snapshot has been restored.
 
 ### Step 5: Launch Kibana
 
-Launch Kibana in the background using `run_in_background`:
+Use `AskUserQuestion` to ask the user whether Kibana should be started:
+
+> Should Kibana be started?
+
+Options:
+- **Yes** — Launch Kibana in the background (recommended if Kibana is not already running)
+- **No, it's already running** — Skip launching Kibana and proceed to the next step
+
+If the user selects **Yes**, launch Kibana in the background using `run_in_background`:
 
 ```bash
 yarn start --no-base-path
 ```
 
 Tell the user Kibana is starting up.
+
+If the user selects **No, it's already running**, tell the user Kibana launch was skipped and proceed to the next step.
 
 ### Step 6: Confirm Phoenix Running
 

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: perform-agent-builder-eval
-description: Orchestrate agent-builder evaluation runs — init ES/Kibana/EDOT stack, run evaluations, and stop services.
-allowed-tools: Bash, Read
-argument-hint: [init|run|stop]
+description: Orchestrate agent-builder evaluation runs — init ES/Kibana/EDOT stack, run evaluations, sweep parameter variants, and stop services.
+allowed-tools: Bash, Read, Edit
+argument-hint: [init|run|sweep|stop]
 ---
 
 # Perform Agent Builder Evaluation
 
-This skill manages the lifecycle of running agent-builder evaluations. It accepts `$ARGUMENTS` as one of: `init`, `run`, or `stop`.
+This skill manages the lifecycle of running agent-builder evaluations. It accepts `$ARGUMENTS` as one of: `init`, `run`, `sweep`, or `stop`.
 
 - **`init`** — Launch ES, Kibana, EDOT, and Phoenix; restore snapshot data
 - **`run`** — Select parameters and execute evaluation jobs (requires `init` to have been run first)
+- **`sweep`** — Run evaluations across multiple values of a code parameter, with automatic file edits and Kibana reload between variants
 - **`stop`** — Kill background ES, Kibana, and EDOT processes
 
 ---
@@ -41,7 +42,7 @@ vault token lookup -format=json 2>/dev/null | grep -q '"id"'
 ```
 
 - **If valid**: tell the user Vault token is OK and continue.
-- **If invalid or expired**: tell the user to authenticate with `vault login --method oidc` (and connect to VPN if needed). Wait for them to confirm, then re-check.
+- **If invalid or expired**: tell the user to authenticate with `vault login --method oidc`. VPN is not required. Wait for them to confirm, then re-check.
 
 #### 1c: Detect Kibana
 
@@ -228,19 +229,22 @@ If no connectors are found, tell the user to configure connectors in `config/kib
 
 ### Step 3: Collect Parameters
 
-Use a single `AskUserQuestion` call with **3 questions**:
+Use `AskUserQuestion` with **2 questions**:
 
 1. **Judge** (header: "Judge"): "Which connector should be used as the evaluation judge (EVALUATION_CONNECTOR_ID)?"
    - Options: one per discovered connector, using `id (name)` as the label.
 2. **Model** (header: "Model"): "Which model should be evaluated (--project)?"
    - Options: one per discovered connector, using `id (name)` as the label.
-3. **Datasets** (header: "Datasets", **multiSelect: true**): "Which datasets should be evaluated in parallel?"
-   - Options:
-     - `agent-builder: text-retrieval: wix-qa`
-     - `agent-builder: text-retrieval: elastic-qa`
-     - `agent-builder: text-retrieval: quick-tester`
 
-Then use a second `AskUserQuestion` to ask how many iterations:
+Then use a second `AskUserQuestion` (free-text via "Other") to ask for datasets:
+
+> Which datasets should be evaluated in parallel? Enter dataset names separated by commas.
+>
+> Common datasets: `agent-builder: text-retrieval: wix-qa`, `agent-builder: text-retrieval: elastic-qa`, `agent-builder: text-retrieval: quick-tester`
+
+The user may enter any dataset name — do not restrict to the examples above.
+
+Then use a third `AskUserQuestion` to ask how many iterations:
 
 > How many iterations should each dataset be run? Each iteration produces a separate run ID.
 
@@ -293,6 +297,173 @@ After all iterations complete (or after an error), display a summary table:
 > | elastic-qa | 2      | `jkl012` |
 
 If any runs failed, add a note below the table listing which dataset/iteration failed and the error message.
+
+---
+
+## Action: `sweep`
+
+Run evaluations across named variant sets, where each variant can change one or more parameters across one or more files. The skill applies all edits for a variant, waits for Kibana to reload, runs evaluations, then moves to the next variant. Requires the stack to already be running (via `init`).
+
+### Step 1: Verify Stack is Running
+
+Same check as `run` Step 1 — verify ES and Kibana are reachable. If not, tell the user to run `init` first.
+
+### Step 2: Discover Connectors
+
+Same as `run` Step 2 — read `config/kibana.dev.yml` and parse preconfigured connectors.
+
+### Step 3: Collect Sweep Parameters
+
+Use `AskUserQuestion` with **2 questions**:
+
+1. **Judge** (header: "Judge"): "Which connector should be used as the evaluation judge?"
+   - Options: one per discovered connector, using `id (name)` as the label.
+2. **Model** (header: "Model"): "Which model should be evaluated?"
+   - Options: one per discovered connector, using `id (name)` as the label.
+
+Then use a second `AskUserQuestion` (free-text via "Other") to ask for datasets:
+
+> Which datasets should be evaluated in parallel? Enter dataset names separated by commas.
+>
+> Common datasets: `agent-builder: text-retrieval: wix-qa`, `agent-builder: text-retrieval: elastic-qa`, `agent-builder: text-retrieval: quick-tester`
+
+The user may enter any dataset name — do not restrict to the examples above.
+
+Then use a third `AskUserQuestion` to ask how many iterations:
+
+> How many iterations per variant? Each iteration produces a separate run ID.
+
+Options:
+- **1** — Single run per variant per dataset
+- **2** — Two runs per variant per dataset
+- **3** — Three runs per variant per dataset
+
+### Step 4: Collect Variant Definitions
+
+Use `AskUserQuestion` (free-text via "Other") to ask:
+
+> Define your variants. Two formats are supported:
+>
+> **Format A — Cartesian product (shorthand):**
+> List parameters with multiple values separated by commas. All combinations are generated automatically.
+> ```
+> file.ts#param1=val1,val2 x file.ts#param2=valA,valB
+> ```
+> This produces 4 variants: `(val1, valA)`, `(val1, valB)`, `(val2, valA)`, `(val2, valB)`.
+> Variant names are auto-generated from the values (e.g., `val1-valA`).
+>
+> **Format B — Named variant sets (explicit):**
+> Define each variant explicitly, one per line:
+> ```
+> variant-name: file.ts#param1=value, file.ts#param2=value
+> ```
+>
+> Examples:
+> ```
+> perform_match_search.ts#rerankInferenceID='.jina-v3','.jina-v2-base-multilingual' x perform_match_search.ts#rankWindowSize=20,30,40
+> ```
+> or:
+> ```
+> jina-v3-ws20: perform_match_search.ts#rerankInferenceID='.jina-v3', perform_match_search.ts#rankWindowSize=20
+> jina-v2-ws40: perform_match_search.ts#rerankInferenceID='.jina-v2-base-multilingual', perform_match_search.ts#rankWindowSize=40
+> ```
+
+**Parsing rules:**
+
+- **Format A** (detected by the presence of ` x ` between parameter groups):
+  1. Split on ` x ` to get parameter groups.
+  2. Each group is `file.ts#paramName=val1,val2,...` — split values on commas.
+  3. Compute the cartesian product of all groups.
+  4. Auto-generate variant names by joining the short values with `-` (e.g., `.jina-v3-20`, `.jina-v2-base-multilingual-40`). Use the last path segment of the value for readability (e.g., `jina-v3` instead of `.jina-reranker-v3`).
+
+- **Format B** (detected by `variant-name:` prefix on lines):
+  1. Each line defines one variant.
+  2. Parse `name: file#param=value, file#param=value`.
+
+For each file path: resolve to an absolute path. If the user gives a filename without a full path, search for it under the repo root.
+
+### Step 5: Read Files and Record Original Values
+
+For each unique file referenced across all variants:
+1. Read the file.
+2. For each parameter referenced in that file, find the line where it is defined (e.g., `const rankWindowSize = 40;`).
+3. Record the **exact line content** and the **current value**.
+
+These original values are used to restore the files at the end.
+
+### Step 6: Confirm the Plan
+
+Present the full plan to the user before starting:
+
+> **Sweep plan:**
+>
+> | Variant | Changes |
+> |---------|---------|
+> | baseline | `rankWindowSize=40`, `rerankInferenceID='.jina-reranker-v2-base-multilingual'` |
+> | jina-v2-ws20 | `rankWindowSize=20`, `rerankInferenceID='.jina-reranker-v2-base-multilingual'` |
+> | cohere-ws40 | `rankWindowSize=40`, `rerankInferenceID='.cohere-rerank-v3'` |
+> | cohere-ws80 | `rankWindowSize=80`, `rerankInferenceID='.cohere-rerank-v3'` |
+>
+> - Datasets: wix-qa, elastic-qa
+> - Iterations per variant: 2
+> - Total eval jobs: 4 variants x 2 datasets x 2 iterations = 16
+>
+> Proceed?
+
+Options:
+- **Yes** — Start the sweep
+- **No** — Abort
+
+### Step 7: Execute Sweep
+
+For each variant in order:
+
+1. **Apply all parameter changes** for this variant using the `Edit` tool. For each `{file, parameter, value}` in the variant, edit the line to set the new value. Track the current line content for each parameter so subsequent edits find the right text.
+
+2. **Wait for Kibana to reload.** Poll until Kibana is available:
+   ```bash
+   MAX_RETRIES=24; COUNT=0; until curl -s -o /dev/null -w "%{http_code}" http://localhost:5601/api/status 2>/dev/null | grep -qE "^(200|401)"; do COUNT=$((COUNT+1)); if [ "$COUNT" -ge "$MAX_RETRIES" ]; then echo "ERROR: Kibana did not become available after reload"; exit 1; fi; sleep 5; done
+   ```
+   This polls every 5 seconds for up to 2 minutes.
+
+3. **Run evaluations** for this variant — same as `run` Step 4 (launch all datasets in parallel for N iterations, extract run IDs). Record each run ID tagged with the variant name.
+
+4. If any job **failed**: record the error, display all collected results so far, and **stop** — do not proceed to the next variant. Still restore original values (Step 8).
+
+5. Tell the user which variant completed and move to the next.
+
+### Step 8: Restore Original Values
+
+After all variants are done (or after an error), restore **every parameter** in **every file** to its original value from Step 5 using the `Edit` tool. Wait for Kibana to reload.
+
+This ensures the working tree is left in its original state regardless of whether the sweep completed or was interrupted by an error.
+
+### Step 9: Display Results
+
+Display a summary table with the variant column:
+
+> **Sweep complete!**
+>
+> | Variant      | Dataset    | Iteration | Run ID   |
+> |--------------|------------|-----------|----------|
+> | baseline     | wix-qa     | 1         | `abc123` |
+> | baseline     | wix-qa     | 2         | `def456` |
+> | baseline     | elastic-qa | 1         | `ghi789` |
+> | baseline     | elastic-qa | 2         | `jkl012` |
+> | jina-v2-ws20 | wix-qa     | 1         | `mno345` |
+> | jina-v2-ws20 | wix-qa     | 2         | `pqr678` |
+> | jina-v2-ws20 | elastic-qa | 1         | `stu901` |
+> | jina-v2-ws20 | elastic-qa | 2         | `vwx234` |
+> | cohere-ws40  | wix-qa     | 1         | `yza567` |
+> | cohere-ws40  | wix-qa     | 2         | `bcd890` |
+> | cohere-ws40  | elastic-qa | 1         | `efg123` |
+> | cohere-ws40  | elastic-qa | 2         | `hij456` |
+> | cohere-ws80  | wix-qa     | 1         | `klm789` |
+> | cohere-ws80  | wix-qa     | 2         | `nop012` |
+> | cohere-ws80  | elastic-qa | 1         | `qrs345` |
+> | cohere-ws80  | elastic-qa | 2         | `tuv678` |
+
+If any runs failed, add a note below the table listing which variant/dataset/iteration failed and the error message.
 
 ---
 

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/.claude/skills/perform-agent-builder-eval/SKILL.md
@@ -1,30 +1,69 @@
 ---
 name: perform-agent-builder-eval
-description: Orchestrate agent-builder evaluation runs — init ES/Kibana/EDOT stack, collect eval parameters, output the run command, and stop services.
+description: Orchestrate agent-builder evaluation runs — init ES/Kibana/EDOT stack, run evaluations, and stop services.
 allowed-tools: Bash, Read
-argument-hint: [init|stop]
+argument-hint: [init|run|stop]
 ---
 
 # Perform Agent Builder Evaluation
 
-This skill manages the lifecycle of running agent-builder evaluations. It accepts `$ARGUMENTS` as one of: `init` or `stop`.
+This skill manages the lifecycle of running agent-builder evaluations. It accepts `$ARGUMENTS` as one of: `init`, `run`, or `stop`.
 
-- **`init`** — Launch ES, Kibana, and EDOT; collect eval parameters; output the run command
+- **`init`** — Launch ES, Kibana, EDOT, and Phoenix; restore snapshot data
+- **`run`** — Select parameters and execute evaluation jobs (requires `init` to have been run first)
 - **`stop`** — Kill background ES, Kibana, and EDOT processes
 
 ---
 
 ## Action: `init`
 
-Follow these steps sequentially. Each step requires confirmation before proceeding.
+Follow these steps sequentially.
 
-### Step 1: Prompt for GCS Credentials
+### Step 1: Preflight Checks
 
-Use `AskUserQuestion` to ask the user for the path to their GCS credentials file. The default path is **exactly** `~/.gcs/gcs.client.default.credentials_file.json` — do NOT suggest any other path (not `~/.config/gcloud/...`, not application_default_credentials, etc.).
+Run all preflight checks before launching any services. This catches problems early and avoids wasted time.
 
-> What is the path to your GCS credentials file? (default: ~/.gcs/gcs.client.default.credentials_file.json)
+#### 1a: Resolve GCS Credentials
 
-If the user accepts the default or leaves it blank, use `$HOME/.gcs/gcs.client.default.credentials_file.json` (expand `~` to the user's home directory). Validate that the resolved path starts with `/`. If it does not, ask again.
+The default GCS credentials path is **exactly** `$HOME/.gcs/gcs.client.default.credentials_file.json`.
+
+Check whether the default file exists (use Bash: `test -f "$HOME/.gcs/gcs.client.default.credentials_file.json"`).
+
+- **If it exists**: use it automatically and tell the user which path was detected. Do NOT prompt.
+- **If it does not exist**: use `AskUserQuestion` to ask the user for the path. Do NOT suggest any path other than the default (not `~/.config/gcloud/...`, not application_default_credentials, etc.). Validate that the provided path starts with `/` and the file exists. If not, ask again.
+
+#### 1b: Validate Vault Token
+
+Check that the user has a valid Vault token before proceeding:
+
+```bash
+vault token lookup -format=json 2>/dev/null | grep -q '"id"'
+```
+
+- **If valid**: tell the user Vault token is OK and continue.
+- **If invalid or expired**: tell the user to authenticate with `vault login --method oidc` (and connect to VPN if needed). Wait for them to confirm, then re-check.
+
+#### 1c: Detect Kibana
+
+Check if Kibana is already running:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5601/api/status 2>/dev/null
+```
+
+- **If it responds (any 2xx/3xx/401)**: note that Kibana is already running. Do NOT launch it later.
+- **If it does not respond**: note that Kibana will need to be launched.
+
+#### 1d: Detect Phoenix
+
+Check if Phoenix is already running:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:6006 2>/dev/null
+```
+
+- **If it responds (any 2xx/3xx)**: note that Phoenix is already running. Do NOT prompt later.
+- **If it does not respond**: note that Phoenix is not running. The user will be prompted later.
 
 ### Step 2: Launch Elasticsearch
 
@@ -117,17 +156,11 @@ Then re-run the restore command.
 
 Tell the user the snapshot has been restored.
 
-### Step 5: Launch Kibana
+### Step 5: Launch Kibana (if needed)
 
-Use `AskUserQuestion` to ask the user whether Kibana should be started:
+If Step 1c detected Kibana is already running, skip this step and tell the user Kibana was detected as already running.
 
-> Should Kibana be started?
-
-Options:
-- **Yes** — Launch Kibana in the background (recommended if Kibana is not already running)
-- **No, it's already running** — Skip launching Kibana and proceed to the next step
-
-If the user selects **Yes**, launch Kibana in the background using `run_in_background`:
+Otherwise, launch Kibana in the background using `run_in_background`:
 
 ```bash
 yarn start --no-base-path
@@ -135,17 +168,17 @@ yarn start --no-base-path
 
 Tell the user Kibana is starting up.
 
-If the user selects **No, it's already running**, tell the user Kibana launch was skipped and proceed to the next step.
+### Step 6: Confirm Phoenix Running (if needed)
 
-### Step 6: Confirm Phoenix Running
+If Step 1d detected Phoenix is already running, skip this step and tell the user Phoenix was detected as already running.
 
-Use `AskUserQuestion` to confirm Phoenix is running:
+Otherwise, use `AskUserQuestion` to tell the user Phoenix is not running:
 
-> Is Phoenix running and ready to receive traces?
+> Phoenix is not running on localhost:6006. Please start it, then let me know.
 
 Options:
-- **Yes** — Continue
-- **Not yet** — Wait for the user to start Phoenix, then ask again
+- **It's running now** — Continue
+- **Not yet** — Wait for the user to start Phoenix, then re-check with a curl
 
 ### Step 7: Launch EDOT
 
@@ -157,76 +190,109 @@ ELASTICSEARCH_HOST=http://localhost:9200 ELASTICSEARCH_USERNAME=elastic ELASTICS
 
 Tell the user EDOT is starting up.
 
-### Step 8: Collect Eval Parameters and Output Run Command
+### Step 8: Confirm Ready
 
-#### 8a: Discover available connectors
+Tell the user:
+
+> **Stack is ready!**
+>
+> - Elasticsearch: running (snapshot restored)
+> - Kibana: running
+> - Phoenix: running
+> - EDOT: running
+>
+> Use `/perform-agent-builder-eval run` to start evaluation jobs.
+
+---
+
+## Action: `run`
+
+This action collects evaluation parameters and executes evaluation jobs. It requires the stack to already be running (via `init`).
+
+### Step 1: Verify Stack is Running
+
+Quickly check that ES and Kibana are reachable:
+
+```bash
+curl -s -u elastic:changeme http://localhost:9200/_cluster/health | grep -q '"status"'
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5601/api/status 2>/dev/null
+```
+
+If either is unreachable, tell the user to run `/perform-agent-builder-eval init` first and stop.
+
+### Step 2: Discover Available Connectors
 
 Read `config/kibana.dev.yml` and parse the `xpack.actions.preconfigured` section to get the list of available connector IDs and names. These connectors are used for both `EVALUATION_CONNECTOR_ID` (the judge) and `--project` (the model being evaluated).
 
 If no connectors are found, tell the user to configure connectors in `config/kibana.dev.yml` under `xpack.actions.preconfigured` and abort.
 
-#### 8b: Select evaluation connector (judge)
+### Step 3: Collect Parameters
 
-Use `AskUserQuestion` to ask which connector to use as the evaluation judge. Present the discovered connectors as options:
+Use a single `AskUserQuestion` call with **3 questions**:
 
-> Which connector should be used as the evaluation judge (EVALUATION_CONNECTOR_ID)?
+1. **Judge** (header: "Judge"): "Which connector should be used as the evaluation judge (EVALUATION_CONNECTOR_ID)?"
+   - Options: one per discovered connector, using `id (name)` as the label.
+2. **Model** (header: "Model"): "Which model should be evaluated (--project)?"
+   - Options: one per discovered connector, using `id (name)` as the label.
+3. **Datasets** (header: "Datasets", **multiSelect: true**): "Which datasets should be evaluated in parallel?"
+   - Options:
+     - `agent-builder: text-retrieval: wix-qa`
+     - `agent-builder: text-retrieval: elastic-qa`
+     - `agent-builder: text-retrieval: quick-tester`
 
-Options: one per discovered connector, using `id (name)` as the label.
+Then use a second `AskUserQuestion` to ask how many iterations:
 
-#### 8c: Select project (model to evaluate)
-
-Use `AskUserQuestion` to ask which connector/model to evaluate. Present the discovered connectors as options:
-
-> Which model should be evaluated (--project)?
-
-Options: one per discovered connector, using `id (name)` as the label.
-
-#### 8d: Select dataset
-
-Use `AskUserQuestion` to ask which dataset to use:
-
-> Which dataset should be used?
+> How many iterations should each dataset be run? Each iteration produces a separate run ID.
 
 Options:
-- `agent-builder: text-retrieval: wix-qa`
-- `agent-builder: text-retrieval: elastic-qa`
-- `agent-builder: text-retrieval: quick-tester`
+- **1** — Single run per dataset
+- **2** — Two runs per dataset
+- **3** — Three runs per dataset
 
-#### 8e: Output the run command
+### Step 4: Execute Evaluations
 
-Using the collected values and the following defaults, output the exact command the user should run in a separate terminal:
+For each iteration (1 to N):
 
-- **SELECTED_EVALUATORS**: `Precision@K,Recall@K,F1@K,Latency,Input Tokens,Output Tokens,Tool Calls,Factuality,Groundedness,Relevance`
-- **RAG_EVAL_K**: `10,20,30,40`
-- **EVALUATION_REPETITIONS**: `1`
+1. Launch **one background job per selected dataset** in parallel using `run_in_background`. Each job runs:
 
-Display a summary and the command:
+```bash
+TRACING_ES_URL=http://elastic:changeme@localhost:9200 \
+SELECTED_EVALUATORS="Precision@K,Recall@K,F1@K,Latency,Input Tokens,Output Tokens,Tool Calls,Factuality,Groundedness,Relevance" \
+RAG_EVAL_K=10,20,30,40 \
+KBN_EVALS_EXECUTOR=phoenix \
+EVALUATION_CONNECTOR_ID=<judge> \
+DATASET_NAME="<dataset>" \
+EVALUATION_REPETITIONS=1 \
+KBN_EVALS_SKIP_CONNECTOR_SETUP=true \
+node scripts/playwright test \
+  --config x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/playwright.config.ts \
+  evals/external/external_dataset.spec.ts \
+  --project <model>
+```
 
-> **Stack is ready!**
+2. Wait for **all parallel jobs in this iteration** to complete.
+3. For each completed job, read its output file and extract the `run_id` from the log line matching:
+   ```
+   info [scout-worker] You can query the data using: environment.hostname:"..." AND task.model.id:"..." AND run_id:"<RUN_ID>"
+   ```
+   Use a grep/regex to extract the `run_id` value from the quotes.
+4. If a job **failed** (non-zero exit code or no `run_id` found): record the error, display all successfully collected run IDs so far, report which dataset(s) failed, and **stop** — do not start the next iteration.
+5. If all jobs succeeded, tell the user which iteration completed and proceed to the next iteration.
+
+### Step 5: Display Results
+
+After all iterations complete (or after an error), display a summary table:
+
+> **Evaluation runs complete!**
 >
-> - Elasticsearch: running (snapshot with GCS credentials)
-> - Kibana: running (no base path)
-> - Phoenix: confirmed running
-> - EDOT: running
->
-> **Run the following command in a separate terminal to start the evaluation:**
->
-> ```bash
-> TRACING_ES_URL=http://elastic:changeme@localhost:9200 \
-> SELECTED_EVALUATORS="<value>" \
-> RAG_EVAL_K=<value> \
-> KBN_EVALS_EXECUTOR=phoenix \
-> EVALUATION_CONNECTOR_ID=<value> \
-> DATASET_NAME="<value>" \
-> EVALUATION_REPETITIONS=<value> \
-> KBN_EVALS_SKIP_CONNECTOR_SETUP=true \
-> node scripts/playwright test \
->   --config x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/playwright.config.ts \
->   evals/external/external_dataset.spec.ts \
->   --project <value>
-> ```
+> | Dataset | Iteration | Run ID |
+> |---------|-----------|--------|
+> | wix-qa  | 1         | `abc123` |
+> | wix-qa  | 2         | `def456` |
+> | elastic-qa | 1      | `ghi789` |
+> | elastic-qa | 2      | `jkl012` |
 
-Substitute the actual user-selected values into the command. The user will copy-paste and run this themselves. Do NOT append any extra notes or warnings after the command block.
+If any runs failed, add a note below the table listing which dataset/iteration failed and the error message.
 
 ---
 


### PR DESCRIPTION
Creates a POC that support Agent Builder semantic reranking for the following scenarios: 

- Reranking documents
- Reranking snippets from returned documents 

Snippets are calculated using `TOP_SNIPPETS` by default. 