### PR TITLE
[Overlays System Flyout]: Support Child History

### DIFF
--- a/examples/flyout_system/public/components/_flyout_with_component.tsx
+++ b/examples/flyout_system/public/components/_flyout_with_component.tsx
@@ -63,12 +63,10 @@ const SessionFlyout: React.FC<SessionFlyoutProps> = React.memo((props) => {
 
   const handleOpenChildFlyoutA = () => {
     setIsChildFlyoutAOpen(true);
-    setIsChildFlyoutBOpen(false);
   };
 
   const handleOpenChildFlyoutB = () => {
     setIsChildFlyoutBOpen(true);
-    setIsChildFlyoutAOpen(false);
   };
 
   // Callbacks for state synchronization
@@ -81,11 +79,13 @@ const SessionFlyout: React.FC<SessionFlyoutProps> = React.memo((props) => {
     console.log('activate child flyout A', title); // eslint-disable-line no-console
   }, [title]);
 
+  const childFlyoutBOnActive = useCallback(() => {
+    console.log('activate child flyout B', title); // eslint-disable-line no-console
+  }, [title]);
+
   const handleCloseFlyout = useCallback(() => {
     console.log('close main flyout', title); // eslint-disable-line no-console
     setIsFlyoutOpen(false);
-    setIsChildFlyoutAOpen(false);
-    setIsChildFlyoutBOpen(false);
 
     // Return focus to main trigger button after closing main flyout
     // TODO: clean this up if EUI adds internal support for returning focus to the trigger element on close
@@ -304,7 +304,7 @@ const SessionFlyout: React.FC<SessionFlyoutProps> = React.memo((props) => {
           hasChildBackground={true}
           maxWidth={childMaxWidth}
           minWidth={FLYOUT_MIN_WIDTH}
-          onActive={childFlyoutAOnActive}
+          onActive={childFlyoutBOnActive}
           onClose={handleCloseChildFlyoutB}
           flyoutMenuProps={{
             title: `${title} - Child B`,

--- a/examples/flyout_system/public/components/_flyout_with_overlays.tsx
+++ b/examples/flyout_system/public/components/_flyout_with_overlays.tsx
@@ -139,7 +139,6 @@ const FlyoutContent: React.FC<FlyoutContentProps> = React.memo((props) => {
   }, [childFlyoutRefB]);
 
   const openChildFlyoutA = useCallback(() => {
-    handleCloseChildFlyoutB(); // Ensure only one child flyout is open at a time
     childFlyoutRefA.current = overlays.openSystemFlyout(
       <ChildFlyoutContent childSize={childSize} childMaxWidth={childMaxWidth} />,
       {
@@ -166,10 +165,9 @@ const FlyoutContent: React.FC<FlyoutContentProps> = React.memo((props) => {
       }
     );
     setIsChildFlyoutAOpen(true);
-  }, [childSize, childMaxWidth, overlays, title, childFlyoutRefA, handleCloseChildFlyoutB]);
+  }, [childSize, childMaxWidth, overlays, title, childFlyoutRefA]);
 
   const openChildFlyoutB = useCallback(() => {
-    handleCloseChildFlyoutA(); // Ensure only one child flyout is open at a time
     childFlyoutRefB.current = overlays.openSystemFlyout(
       <ChildFlyoutContent childSize={childSize} childMaxWidth={childMaxWidth} />,
       {
@@ -196,7 +194,7 @@ const FlyoutContent: React.FC<FlyoutContentProps> = React.memo((props) => {
       }
     );
     setIsChildFlyoutBOpen(true);
-  }, [childSize, childMaxWidth, overlays, title, childFlyoutRefB, handleCloseChildFlyoutA]);
+  }, [childSize, childMaxWidth, overlays, title, childFlyoutRefB]);
 
   return (
     <>

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
@@ -218,7 +218,11 @@ describe('SystemFlyoutService', () => {
       // Back in child2: child2 is removed, child1 is the destination (not in childHistory)
       emitEvent({
         type: 'CLOSE_SESSION',
-        session: { mainFlyoutId: 'parent-flyout', childFlyoutId: 'child-flyout-2', childHistory: [] },
+        session: {
+          mainFlyoutId: 'parent-flyout',
+          childFlyoutId: 'child-flyout-2',
+          childHistory: [],
+        },
       });
 
       expect((child2Ref as SystemFlyoutRef).isClosed).toBe(true);

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
@@ -21,7 +21,11 @@ import React from 'react';
 
 interface FlyoutManagerEvent {
   type: 'CLOSE_SESSION';
-  session: { mainFlyoutId: string; childFlyoutId: string | null };
+  session: {
+    mainFlyoutId: string;
+    childFlyoutId: string | null;
+    childHistory?: Array<{ flyoutId: string; title: string }>;
+  };
 }
 
 const eventListeners = new Set<(event: FlyoutManagerEvent) => void>();
@@ -86,10 +90,74 @@ describe('SystemFlyoutService', () => {
   });
 
   describe('openSystemFlyout()', () => {
-    it('closes the flyout when a CLOSE_SESSION event removes its session', () => {
-      const ref = systemFlyouts.open(<div>System flyout content</div>, {
+    it('pressing Back keeps the parent flyout open and closes the child flyout', () => {
+      // When Back is pressed in a child flyout, EUI emits CLOSE_SESSION with the
+      // parent as mainFlyoutId (destination) and the child as childFlyoutId (being removed).
+      // A child opened in a separate React root (session='inherit') must be closed
+      // explicitly via the subscription; EUI cannot reach across roots reliably.
+      // The parent (session='start') must NOT be closed — it is the Back destination.
+      const parentRef = systemFlyouts.open(<div>Parent flyout</div>, {
+        id: 'parent-flyout',
+        session: 'start',
+      });
+      const childRef = systemFlyouts.open(<div>Child flyout</div>, {
+        id: 'child-flyout',
+        session: 'inherit',
+      });
+
+      emitEvent({
+        type: 'CLOSE_SESSION',
+        session: { mainFlyoutId: 'parent-flyout', childFlyoutId: 'child-flyout' },
+      });
+
+      // Child (session='inherit') is explicitly closed by the subscription
+      expect((childRef as SystemFlyoutRef).isClosed).toBe(true);
+      // Parent (session='start') stays open — it is the Back destination.
+      // EUI calls the onClose prop if the whole session later ends; we don't close it here.
+      expect((parentRef as SystemFlyoutRef).isClosed).toBe(false);
+      expect(mockReactDomUnmount).toHaveBeenCalledTimes(1);
+    });
+
+    it('closing the top flyout also closes child flyouts in the session', () => {
+      // Closing the top flyout ends the entire session. EUI emits CLOSE_SESSION with
+      // the same structure as Back (mainFlyoutId = parent, childFlyoutId = child).
+      // The child flyout in its separate React root must be closed via the subscription.
+      // The parent flyout (session='start') is closed by EUI via the onClose prop.
+      const parentRef = systemFlyouts.open(<div>Parent flyout</div>, {
+        id: 'parent-flyout',
+        session: 'start',
+      });
+      const childRef = systemFlyouts.open(<div>Child flyout</div>, {
+        id: 'child-flyout',
+        session: 'inherit',
+      });
+
+      emitEvent({
+        type: 'CLOSE_SESSION',
+        session: { mainFlyoutId: 'parent-flyout', childFlyoutId: 'child-flyout' },
+      });
+
+      expect((childRef as SystemFlyoutRef).isClosed).toBe(true);
+      expect(mockReactDomUnmount).toHaveBeenCalledTimes(1);
+      // Parent closing is handled by EUI via onClose — not by our subscription
+      expect((parentRef as SystemFlyoutRef).isClosed).toBe(false);
+    });
+
+    it('closes child flyouts in childHistory when the session ends', () => {
+      // When a session has navigated through multiple child flyouts, the previous
+      // children are tracked in childHistory. All of them must be closed when the
+      // session ends, not just the currently active child.
+      const parentRef = systemFlyouts.open(<div>Parent</div>, {
         id: 'parent-flyout-demo',
         session: 'start',
+      });
+      const child1Ref = systemFlyouts.open(<div>Child 1</div>, {
+        id: 'child-flyout-demo-1',
+        session: 'inherit',
+      });
+      const child2Ref = systemFlyouts.open(<div>Child 2</div>, {
+        id: 'child-flyout-demo-2',
+        session: 'inherit',
       });
 
       expect(mockReactDomUnmount).not.toHaveBeenCalled();
@@ -98,12 +166,79 @@ describe('SystemFlyoutService', () => {
         type: 'CLOSE_SESSION',
         session: {
           mainFlyoutId: 'parent-flyout-demo',
-          childFlyoutId: null,
+          childFlyoutId: 'child-flyout-demo-2',
+          childHistory: [{ flyoutId: 'child-flyout-demo-1', title: 'Child 1' }],
         },
       });
 
-      expect((ref as SystemFlyoutRef).isClosed).toBe(true);
+      // Both child flyouts are closed: child2 via childFlyoutId, child1 via childHistory
+      expect((child1Ref as SystemFlyoutRef).isClosed).toBe(true);
+      expect((child2Ref as SystemFlyoutRef).isClosed).toBe(true);
+      expect(mockReactDomUnmount).toHaveBeenCalledTimes(2);
+      // Parent (session='start') is closed by EUI via onClose, not our subscription
+      expect((parentRef as SystemFlyoutRef).isClosed).toBe(false);
+    });
+
+    it('pressing Back to return to Session X does not close Session X (regression)', () => {
+      // Regression: with Session X and Session Y both open, pressing Back in Session Y
+      // emits CLOSE_SESSION with Session X as mainFlyoutId (destination) and
+      // Session Y as childFlyoutId (being removed). The old code closed any flyout
+      // whose ID matched mainFlyoutId OR childFlyoutId, which incorrectly closed
+      // Session X — the flyout the user was navigating back TO.
+      const refX = systemFlyouts.open(<div>Session X</div>, { id: 'session-x', session: 'start' });
+      const refY = systemFlyouts.open(<div>Session Y</div>, { id: 'session-y', session: 'start' });
+
+      // Back in Session Y: session-x is where we are going, session-y is being closed
+      emitEvent({
+        type: 'CLOSE_SESSION',
+        session: { mainFlyoutId: 'session-x', childFlyoutId: 'session-y' },
+      });
+
+      // Session X must remain open — it is the Back destination
+      expect((refX as SystemFlyoutRef).isClosed).toBe(false);
+      // Session Y is handled by EUI via onClose; our subscription does not close it
+      expect((refY as SystemFlyoutRef).isClosed).toBe(false);
+      expect(mockReactDomUnmount).not.toHaveBeenCalled();
+    });
+
+    it('pressing Back from child2 to child1 does not close child1', () => {
+      // When navigating from child1 to child2 and then pressing Back, EUI fires
+      // CLOSE_SESSION with child2 as childFlyoutId (being removed) and no entry for
+      // child1 in childHistory (child1 is the destination, not a flyout being closed).
+      // This verifies our childHistory check does not accidentally close the Back destination.
+      const child1Ref = systemFlyouts.open(<div>Child 1</div>, {
+        id: 'child-flyout-1',
+        session: 'inherit',
+      });
+      const child2Ref = systemFlyouts.open(<div>Child 2</div>, {
+        id: 'child-flyout-2',
+        session: 'inherit',
+      });
+
+      // Back in child2: child2 is removed, child1 is the destination (not in childHistory)
+      emitEvent({
+        type: 'CLOSE_SESSION',
+        session: { mainFlyoutId: 'parent-flyout', childFlyoutId: 'child-flyout-2', childHistory: [] },
+      });
+
+      expect((child2Ref as SystemFlyoutRef).isClosed).toBe(true);
+      expect((child1Ref as SystemFlyoutRef).isClosed).toBe(false);
       expect(mockReactDomUnmount).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close a child flyout when a different session ends', () => {
+      const childRef = systemFlyouts.open(<div>Child flyout</div>, {
+        id: 'child-flyout',
+        session: 'inherit',
+      });
+
+      emitEvent({
+        type: 'CLOSE_SESSION',
+        session: { mainFlyoutId: 'unrelated-parent', childFlyoutId: 'unrelated-child' },
+      });
+
+      expect((childRef as SystemFlyoutRef).isClosed).toBe(false);
+      expect(mockReactDomUnmount).not.toHaveBeenCalled();
     });
 
     it('renders a system flyout to the DOM', () => {

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
@@ -11,7 +11,8 @@ import React from 'react';
 import { render } from 'react-dom';
 import { v4 as uuidV4 } from 'uuid';
 
-import { EuiFlyout, getFlyoutManagerStore, type EuiFlyoutMenuProps } from '@elastic/eui';
+import type { EuiFlyoutMenuProps } from '@elastic/eui';
+import { EuiFlyout, getFlyoutManagerStore } from '@elastic/eui';
 import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { OverlayRef } from '@kbn/core-mount-utils-browser';
@@ -83,12 +84,19 @@ export class SystemFlyoutService {
           mergedFlyoutMenuProps = { title, ...flyoutMenuProps };
         }
 
-        // Subscribe to EUI flyout manager store to detect cascade closes
-        // This ensures child flyouts close when their parent closes, even across separate React roots
-        if (session !== 'never') {
-          // Use the EUI flyout ID (from options.id) for store lookups, not our internal container ID
+        // Subscribe to CLOSE_SESSION events for cascade closes of child flyouts.
+        // When a parent session closes, child flyouts in separate React roots must
+        // be explicitly closed since their deferred useEffect detection may not fire
+        // reliably across roots.
+        //
+        // IMPORTANT: We only handle child flyouts here (session === 'inherit').
+        // Main flyouts (session === 'start') must NOT be closed synchronously via
+        // this handler because unmountComponentAtNode triggers a useLayoutEffect
+        // cleanup that reads a stale ref (flyoutExistsInManagerRef) and calls
+        // closeAllFlyouts(), which would inadvertently close unrelated sessions
+        // (e.g., during goBack navigation).
+        if (session === 'inherit') {
           const euiFlyoutId = options.id || flyoutId;
-
           const { subscribeToEvents } = getFlyoutManagerStore();
 
           const unsubscribe = subscribeToEvents((event) => {
@@ -96,8 +104,10 @@ export class SystemFlyoutService {
               return;
             }
 
-            const { mainFlyoutId, childFlyoutId } = event.session;
-            const shouldClose = euiFlyoutId === mainFlyoutId || euiFlyoutId === childFlyoutId;
+            const { childFlyoutId, childHistory } = event.session;
+            const shouldClose =
+              euiFlyoutId === childFlyoutId ||
+              childHistory?.some((entry) => entry.flyoutId === euiFlyoutId);
 
             if (shouldClose && !flyoutRef.isClosed) {
               flyoutRef.close();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/2725

**Pertains to the System Flyout Service: `core.overlays.openSystemFlyout`**
These changes to the service ensure that when EUI supports child history, that closing a main flyout will cascade-close all correlated child flyouts. Currently, closing a main flyout with one or more children will result in only the most recent child to be closed.

**Before**
Note: Apply 09ba02ba0cd7637714e285f579eb0c17b60fedec to remove a workaround of the bug: the example app incorrectly had its own handling for cascade-closing multiple flyouts.

https://github.com/user-attachments/assets/7d5458b6-e4b2-4abf-b7cf-0a16a6657fc1

**After**

https://github.com/user-attachments/assets/f94da089-d755-41f7-a516-f45012b13aaf

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
- ~~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- ~~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
- ~~[ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
- ~~[ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
- ~~[ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~~

