### PR TITLE
fix invalid commented line after describe.skip call

### DIFF
--- a/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/tests/schema.spec.ts
@@ -8,6 +8,7 @@
  */
 
 import type { RoleApiCredentials } from '@kbn/scout';
+import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
 import { apiTest, DASHBOARD_API_PATH } from '../fixtures';
 
@@ -21,9 +22,7 @@ import { apiTest, DASHBOARD_API_PATH } from '../fixtures';
  * See README.md for usage instructions.
  */
 // Failing: See https://github.com/elastic/kibana/issues/256140
-// describe('dashboard REST schema', { tag: tags.stateful.all }, () => {
-// eslint-disable-next-line playwright/no-skipped-test
-describe.skip('dashboard REST schema', () => {
+apiTest.describe.skip('dashboard REST schema', { tag: tags.stateful.all }, () => {
   let viewerCredentials: RoleApiCredentials;
 
   apiTest.beforeAll(async ({ requestAuth }) => {


### PR DESCRIPTION
## Summary

This fixes an issue introduced in this previous [PR](https://github.com/elastic/kibana/pull/256324) that was attempting to fix a linting issue.

