### PR TITLE
[DOCS] Update alert & action settings yaml

### DIFF
--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -8,7 +8,7 @@ page_description: |
   Alerting and actions are enabled by default in {{kib}}, but require you to configure the following:
 
   1. [Set up {{kib}} to work with {{stack}} {{security-features}}](docs-content://deploy-manage/security/secure-your-cluster-deployment.md).
-  2. [Set up TLS encryption between {{kib}} and {{es}}](docs-content://deploy-manage/security/set-up-basic-security-plus-https.  md#encrypt-kibana-http).
+  2. [Set up TLS encryption between {{kib}} and {{es}}](docs-content://deploy-manage/security/set-up-basic-security-plus-https.md#encrypt-kibana-http).
   3. If you are using an **on-premises** Elastic Stack deployment, [specify a value for `xpack.encryptedSavedObjects.encryptionKey`](#general-alert-action-settings).
 
 note: 'If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
@@ -16,478 +16,272 @@ note: 'If a setting is applicable to {{ech}} environments, its name is followed 
 groups:
   - group: General settings
     id: general-alert-action-settings
-    # description: |
-    # example: |
     settings:
 
       - setting: xpack.encryptedSavedObjects.encryptionKey
-        # id:
         description: |
           A string of 32 or more characters used to encrypt sensitive properties on alerting rules and actions before they're stored in Elasticsearch. Third party credentials — such as the username and password used to connect to an SMTP service — are an example of encrypted properties.
 
-          Kibana offers a [CLI tool](/kibana/docs/reference/commands/kibana-encryption-keys.md) to help generate this encryption key.
+          Kibana offers a [CLI tool](/reference/commands/kibana-encryption-keys.md) to help generate this encryption key.
 
           If not set, Kibana will generate a random key on startup, but all alerting and action functions will be blocked. Generated keys are not allowed for alerting and actions because when a new key is generated on restart, existing encrypted data becomes inaccessible. For the same reason, alerting and actions in high-availability deployments of Kibana will behave unexpectedly if the key isn't the same on all instances of Kibana.
 
           Although the key can be specified in clear text in `kibana.yml`, it's recommended to store this key securely in the [Kibana Keystore](docs-content://deploy-manage/security/secure-settings.md). Be sure to back up the encryption key value somewhere safe, as your alerting rules and actions will cease to function due to decryption failures should you lose it.  If you want to rotate the encryption key, be sure to follow the instructions on [encryption key rotation](docs-content://deploy-manage/security/secure-saved-objects.md#encryption-key-rotation).
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
   - group: Action settings
     id: action-settings
-    # description: |
-    # example: |
     settings:
 
       - setting: xpack.actions.allowedHosts
-        # id:
         description: |
           A list of hostnames that Kibana is allowed to connect to when built-in actions are triggered. It defaults to `["*"]`, allowing any host, but keep in mind the potential for SSRF attacks when hosts are not explicitly added to the allowed hosts. An empty list `[]` can be used to block built-in actions from making any external connections.
 
           Note that hosts associated with built-in actions, such as Slack and PagerDuty, are not automatically added to allowed hosts. If you are not using the default `["*"]` setting, you must ensure that the corresponding endpoints are added to the allowed hosts as well.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.customHostSettings
-        # id:
         description: |
           A list of custom host settings to override existing global settings.
 
           Each entry in the list must have a `url` property, to associate a connection type (mail or https), hostname and port with the remaining options in the entry.
 
           The settings in `xpack.actions.customHostSettings` can be used to override the global option `xpack.actions.ssl.verificationMode` and provide customized TLS settings on a per-server basis. Set `xpack.actions.ssl.verificationMode` to the value to be used by default for all servers, then add an entry in `xpack.actions.customHostSettings` for every server that requires customized settings.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
         default: an empty list
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
+          stack: ga
+          ech: ga
+          self: ga
         example: |
           In the following example, two custom host settings are defined.  The first provides a custom host setting for mail server `mail.example.com` using port 465 that supplies server certificate authentication data from both a file and inline, and requires TLS for the connection.  The second provides a custom host setting for https server `webhook.example.com` which turns off server certificate authentication, that will allow Kibana to connect to the server if it's using a self-signed certificate.  The individual properties that can be used in the settings are documented below.
 
           ```yaml
           xpack.actions.customHostSettings:
-            - url: smtp://mail.example.com:465
-              ssl:
-                verificationMode: 'full'
-                certificateAuthoritiesFiles: [ 'one.crt' ]
-                certificateAuthoritiesData: |
-                    -----BEGIN CERTIFICATE-----
-                    MIIDTD...
-                    CwUAMD...
-                    ... multiple lines of certificate data ...
-                    -----END CERTIFICATE-----
-              smtp:
-                requireTLS: true
-            - url: https://webhook.example.com
-              ssl:
-                verificationMode: 'none'
+              - url: smtp://mail.example.com:465
+                ssl:
+                  verificationMode: 'full'
+                  certificateAuthoritiesFiles: [ 'one.crt' ]
+                  certificateAuthoritiesData: |
+                      -----BEGIN CERTIFICATE-----
+                      MIIDTD...
+                      CwUAMD...
+                      ... multiple lines of certificate data ...
+                      -----END CERTIFICATE-----
+                      -----BEGIN CERTIFICATE-----
+                      MIIDTD...
+                      CwUAMD...
+                      ... multiple lines of certificate data ...
+                      -----END CERTIFICATE-----
+                  smtp:
+                    requireTLS: true
+              - url: <EXAMPLE_WEBHOOK_URL>
+                ssl:
+                  verificationMode: 'none'
           ```
 
       - setting: xpack.actions.customHostSettings[n].url
-        # id:
         description: |
-          A URL associated with this custom host setting.  Should be in the form of `protocol://hostname:port`, where `protocol` is `https` or `smtp`.  If the port is not provided, 443 is used for `https` and 25 is used for `smtp`.  The `smtp` URLs are used for the Email actions that use this server, and the `https` URLs are used for actions which use `https` to connect to services.
+          A URL associated with this custom host setting. Should be in the form of `protocol://hostname:port`, where `protocol` is `https` or `smtp`. If the port is not provided, 443 is used for `https` and 25 is used for `smtp`. The `smtp` URLs are used for the Email actions that use this server, and the `https` URLs are used for actions which use `https` to connect to services.
 
           Entries with `https` URLs can use the `ssl` options, and entries with `smtp` URLs can use both the `ssl` and `smtp` options.
 
           No other URL values should be part of this URL, including paths, query strings, and authentication information.  When an http or smtp request is made as part of running an action, only the protocol, hostname, and port of the URL for that request are used to look up these configuration values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.customHostSettings[n].smtp.ignoreTLS
-        # id:
         description: |
           A boolean value indicating that TLS must not be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: bool
         default: false
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.customHostSettings[n].smtp.requireTLS
-        # id:
         description: |
           A boolean value indicating that TLS must be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: bool
         default: false
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.customHostSettings[n].ssl.verificationMode
         id: action-config-custom-host-verification-mode
         description: |
-          Controls the verification of the server certificate that Kibana receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. [Equivalent Kibana setting](/kibana/docs/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode). Overrides the general `xpack.actions.ssl.verificationMode` configuration for requests made for this hostname/port.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          Controls the verification of the server certificate that Kibana receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. [Equivalent Kibana setting](/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode). Overrides the general `xpack.actions.ssl.verificationMode` configuration for requests made for this hostname/port.
         datatype: enum
         default: full
         options:
-        - option: full
-        - option: certificate
-        - option: none
-        #     description: ""
-        # type: static/dynamic
+          - option: full
+          - option: certificate
+          - option: none
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesFiles
-        # id:
         description: |
           A file name or list of file names of PEM-encoded certificate files to use to validate the server.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesData
-        # id:
         description: |
           The contents of one or more PEM-encoded certificate files in multiline format. This configuration can be used for environments where the files cannot be made available.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.email.domain_allowlist
         id: action-config-email-domain-allowlist
         description: |
           A list of allowed email domains which can be used with the email connector. When this setting is not used, all email domains are allowed. When this setting is used, if any email is attempted to be sent that (a) includes an addressee with an email domain that is not in the allowlist, or (b) includes a from address domain that is not in the allowlist, it will fail with a message indicating the email is not allowed.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
         warning: "This feature is available in Kibana 7.17.4 and 8.3.0 onwards but is not supported in Kibana 8.0, 8.1 or 8.2. As such, this setting should be removed before upgrading from 7.17 to 8.0, 8.1 or 8.2. It is possible to configure the settings in 7.17.4 and then upgrade to 8.3.0 directly."
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.email.recipient_allowlist
         id: action-config-email-recipient-allowlist
         description: |
           A list of allowed email recipient patterns (`to`, `cc`, or `bcc`) that can be used with email connectors. If you attempt to send an email to a recipient that does not match the allowed patterns, the action will fail. The failure message indicates that the email is not allowed.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
         warning: "This setting cannot be used with `xpack.actions.email.domain_allowlist`."
-        # important: ""
         datatype: string
-        # default:
         applies_to:
           stack: ga 9.2
-          deployment:
-            self: ga
-            ess: ga
+          ech: ga
+          self: ga
         example: |
           For example:
 
           ```yaml
-          xpack.actions.email.recipient_allowlist:["admin-*@company.org", "sales-*@example.com"]
+          xpack.actions.email.recipient_allowlist: ["admin-*@company.org", "sales-*@example.com"]
           ```
 
           Only "to", "cc", or "bcc" email addresses that match the listed patterns will be accepted. For example, "admin-network@company.org" or "sales-north@example.com".
 
+      - setting: xpack.actions.email.maximum_body_length
+        description: |
+          The maximum length of an email body in bytes. Values longer than this length will be truncated. The default is 25MB, the maximum is 25MB.
+        datatype: int
+        default: "25000000 (25MB)"
+        applies_to:
+          stack: ga 9.3
+          ech: ga
+          self: ga
+
       - setting: xpack.actions.email.services.ses.host
         id: action-config-email-services-ses-host
         description: |
-          {applies_to}`stack: ga 9.1` The SMTP endpoint for an Amazon Simple Email Service (SES) service provider that can be used by email connectors.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        warning: "This setting alone is insufficient for overriding system defaults for the SES SMTP endpoint. You must also configure the `xpack.actions.email.services.ses.port` setting"
-        # important: ""
+          The SMTP endpoint for an Amazon Simple Email Service (SES) service provider that can be used by email connectors.
+        warning: "This setting alone is insufficient for overriding system defaults for the SES SMTP endpoint. You must also configure the `xpack.actions.email.services.ses.port` setting."
         datatype: string
         default: "email-smtp.us-east-1.amazonaws.com"
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
           stack: ga 9.1
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.email.services.ses.port
         id: action-config-email-services-ses-port
         description: |
-          {applies_to}`stack: ga 9.1` The port number for an Amazon Simple Email Service (SES) service provider that can be used by email connectors.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          The port number for an Amazon Simple Email Service (SES) service provider that can be used by email connectors.
         datatype: int
         default: 465
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
           stack: ga 9.1
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.email.services.enabled
-        id: action-config-email-services-
+        id: action-config-email-services-enabled
         description: |
-          {applies_to}`stack: ga 9.1` An array of strings indicating all email services that are enabled. Available options are `elastic-cloud`, `google-mail`, `microsoft-outlook`, `amazon-ses`, `microsoft-exchange`, and `other`. If the array is empty, no email services are enabled. The default value is `["*"]`, which enables all email services.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
-        datatype: enum
-        default: ["*"]
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+          An array of strings indicating all email services that are enabled. Available options are `elastic-cloud`, `google-mail`, `microsoft-outlook`, `amazon-ses`, `microsoft-exchange`, and `other`. If the array is empty, no email services are enabled. The default value is `["*"]`, which enables all email services.
+        datatype: string
+        default: '["*"]'
         applies_to:
           stack: ga 9.1
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.enableFooterInEmail
-        # id:
         description: |
           A boolean value indicating that a footer with a relevant link should be added to emails sent as alerting actions.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: bool
         default: true
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.enabledActionTypes
-        # id:
         description: |
-          A list of action types that are enabled. It defaults to `["*"]`, enabling all types. The names for built-in Kibana action types are prefixed with a `.` and include: `.email`, `.index`, `.jira`, `.opsgenie`, `.pagerduty`, `.resilient`, `.server-log`, `.servicenow`, .`servicenow-itom`, `.servicenow-sir`, `.slack`, `.swimlane`, `.teams`, `.tines`, `.torq`, `.xmatters`,  `.gen-ai`,  `.bedrock`, `.gemini`,  `.d3security`, and `.webhook`. An empty list `[]` will disable all action types.
+          A list of action types that are enabled. It defaults to `["*"]`, enabling all types. The names for built-in Kibana action types are prefixed with a `.` and include: `.email`, `.index`, `.jira`, `.opsgenie`, `.pagerduty`, `.resilient`, `.server-log`, `.servicenow`, `.servicenow-itom`, `.servicenow-sir`, `.slack`, `.swimlane`, `.teams`, `.tines`, `.torq`, `.xmatters`, `.gen-ai`, `.bedrock`, `.gemini`, `.d3security`, and `.webhook`. An empty list `[]` will disable all action types.
 
           Disabled action types will not appear as an option when creating new connectors, but existing connectors and actions of that type will remain in Kibana and will not function.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        important: "[Preconfigured connectors](/kibana/docs/reference/connectors-kibana/pre-configured-connectors.md) are not affected by this setting."
+        important: "[Preconfigured connectors](/reference/connectors-kibana/pre-configured-connectors.md) are not affected by this setting."
         datatype: string
-        default: ["*"]
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+        default: '["*"]'
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.microsoftExchangeUrl
-        # id:
         description: |
           The URL for the Microsoft Azure Active Directory endpoint to use for MS Exchange email authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        default: https://login.microsoftonline.com
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+        default: "https://login.microsoftonline.com"
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.microsoftGraphApiUrl
-        # id:
         description: |
           The URL for the Microsoft Graph API endpoint to use for MS Exchange email authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        default: https://graph.microsoft.com/v1.0
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+        default: "https://graph.microsoft.com/v1.0"
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.microsoftGraphApiScope
-        # id:
         description: |
           The URL for the Microsoft Graph API scope endpoint to use for MS Exchange email authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        default: https://graph.microsoft.com/.default
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+        default: "https://graph.microsoft.com/.default"
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.proxyUrl
-        # id:
         description: |
           Specifies the proxy URL to use, if using a proxy for actions. By default, no proxy is used.
 
@@ -496,51 +290,28 @@ groups:
           If your proxy is using the https protocol (vs the http protocol), the setting `xpack.actions.ssl.proxyVerificationMode: none` will likely be needed, unless your proxy's certificates are signed using a publicly available certificate authority.
 
           There is currently no support for using basic authentication with a proxy (authentication for the proxy itself, not the URL being requested through the proxy).
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
+          stack: ga
+          ech: ga
+          self: ga
         example: |
           To help diagnose problems using a proxy, you can use the `curl` command with options to use your proxy, and log debug information, with the following command, replacing the proxy and target URLs as appropriate.  This will force the request to be made to the proxy in tunneling mode, and display some of the interaction between the client and the proxy.
 
           ```sh
-          curl --verbose --proxytunnel --proxy http://localhost:8080 http://example.com
+          curl --verbose --proxytunnel --proxy http://localhost:8080 <EXAMPLE_URL>
           ```
 
       - setting: xpack.actions.proxyBypassHosts
-        # id:
         description: |
           Specifies hostnames which should not use the proxy, if using a proxy for actions. The value is an array of hostnames as strings.
 
           By default, all hosts will use the proxy, but if an action's hostname is in this list, the proxy will not be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
+          stack: ga
+          ech: ga
+          self: ga
         example: |
           For example:
 
@@ -548,31 +319,18 @@ groups:
           xpack.actions.proxyBypassHosts: [ "events.pagerduty.com" ]
           ```
 
-          If applicable, include the subdomain in the hostname
-
+          If applicable, include the subdomain in the hostname.
 
       - setting: xpack.actions.proxyOnlyHosts
-        # id:
         description: |
           Specifies hostnames which should only use the proxy, if using a proxy for actions. The value is an array of hostnames as strings.
 
           By default, no hosts will use the proxy, but if an action's hostname is in this list, the proxy will be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
+          stack: ga
+          ech: ga
+          self: ga
         example: |
           For example:
 
@@ -580,29 +338,17 @@ groups:
           xpack.actions.proxyOnlyHosts: [ "events.pagerduty.com" ]
           ```
 
-          If applicable, include the subdomain in the hostname
+          If applicable, include the subdomain in the hostname.
 
       - setting: xpack.actions.proxyHeaders
-        # id:
         description: |
           Specifies HTTP headers for the proxy, if using a proxy for actions.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
         default: '{}'
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.ssl.proxyVerificationMode
         id: action-config-proxy-verification-mode
@@ -611,141 +357,75 @@ groups:
 
           Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification.
 
-          [Equivalent Kibana setting](/kibana/docs/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode)
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          [Equivalent Kibana setting](/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode)
         datatype: enum
         default: full
         options:
           - option: full
           - option: certificate
           - option: none
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.ssl.verificationMode
         id: action-config-verification-mode
         description: |
           Controls the verification for the server certificate that Elastic Maps Server receives when making an outbound SSL/TLS connection for actions. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification.
 
-          [Equivalent Kibana setting](/kibana/docs/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode)
+          [Equivalent Kibana setting](/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode)
 
           This setting can be overridden for specific URLs by using the setting `xpack.actions.customHostSettings[n].ssl.verificationMode` (described above) to a different value.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: enum
         default: full
         options:
           - option: full
           - option: certificate
           - option: none
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.maxResponseContentLength
-        # id:
         description: |
           Specifies the max number of bytes of the http response for requests to external resources.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: int
-        default: 1000000 (1MB)
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+        default: "1000000 (1MB)"
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.responseTimeout
-        # id:
         description: |
           Specifies the time allowed for requests to external resources. Requests that take longer are canceled. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `60s`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.run.maxAttempts
-        # id:
         description: |
           Specifies the maximum number of times an action can be attempted to run.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: int
-        # default:
         options:
           - option: minimum 1 and maximum 10
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.run.connectorTypeOverrides
-        # id:
         description: |
           Overrides the configs under `xpack.actions.run` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
+          stack: ga
+          ech: ga
+          self: ga
         example: |
           For example:
 
@@ -758,26 +438,14 @@ groups:
           ```
 
       - setting: xpack.actions.queued.max
-        # id:
         description: |
-          Specifies the maximum number of actions that can be queued.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          Specifies the maximum number of actions that can be queued. It is available in {{ecloud}} 8.11.0 and later versions.
         datatype: int
         default: 1000000
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
   - group: Preconfigured connector settings
     id: preconfigured-connector-settings
@@ -793,65 +461,33 @@ groups:
           actionTypeId: .server-log
       ```
 
-      For more examples, go to [Preconfigured connectors](/kibana/docs/reference/connectors-kibana/pre-configured-connectors.md).
+      For more examples, go to [Preconfigured connectors](/reference/connectors-kibana/pre-configured-connectors.md).
 
     settings:
 
       - setting: xpack.actions.preconfiguredAlertHistoryEsIndex
-        # id:
         description: |
-          Enables a preconfigured alert history Elasticsearch [Index](/kibana/docs/reference/connectors-kibana/index-action-type.md) connector.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          Enables a preconfigured alert history Elasticsearch [Index](/reference/connectors-kibana/index-action-type.md) connector.
         datatype: bool
         default: false
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.actions.preconfigured
-        # id:
         description: |
           Specifies configuration details that are specific to the type of preconfigured connector.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.actionTypeId
-        # id:
         description: |
           The type of preconfigured connector.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
-        # datatype: string/bool/int/float/enum
-        # default:
+        datatype: enum
         options:
           - option: .email
           - option: .index
@@ -860,1705 +496,807 @@ groups:
           - option: .resilient
           - option: .slack
           - option: .webhook
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config
-        # id:
         description: |
           The configuration details, which are specific to the type of preconfigured connector.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.apiProvider
-        # id:
         description: |
-          For a [OpenAI connector](/kibana/docs/reference/connectors-kibana/openai-action-type.md), specifies the OpenAI API provider.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [OpenAI connector](/reference/connectors-kibana/openai-action-type.md), specifies the OpenAI API provider.
         datatype: enum
-        # default:
         options:
           - option: OpenAI
           - option: Azure OpenAI
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.apiUrl
-        # id:
         description: |
           A configuration URL that varies by connector:
 
-          * For an [{{bedrock}} connector](/kibana/docs/reference/connectors-kibana/bedrock-action-type.md), specifies the {{bedrock}} request URL.
-          * For an [{{gemini}} connector](/kibana/docs/reference/connectors-kibana/gemini-action-type.md), specifies the {{gemini}} request URL.
-          * For a [OpenAI connector](/kibana/docs/reference/connectors-kibana/openai-action-type.md), specifies the OpenAI request URL.
-          * For a [{{ibm-r}} connector](/kibana/docs/reference/connectors-kibana/resilient-action-type.md), specifies the {{ibm-r}} instance URL.
-          * For a [Jira connector](/kibana/docs/reference/connectors-kibana/jira-action-type.md), specifies the Jira instance URL.
-          * For an [{{opsgenie}} connector](/kibana/docs/reference/connectors-kibana/opsgenie-action-type.md), specifies the {{opsgenie}} URL. For example, `https://api.opsgenie.com` or `https://api.eu.opsgenie.com`.
-          * For a [PagerDuty connector](/kibana/docs/reference/connectors-kibana/pagerduty-action-type.md), specifies the PagerDuty event URL. Defaults to `https://events.pagerduty.com/v2/enqueue`.
-          * For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md) specifies the ServiceNow instance URL.
-          * For a [{{swimlane}} connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), specifies the {{swimlane}} instance URL.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          * For an [{{bedrock}} connector](/reference/connectors-kibana/bedrock-action-type.md), specifies the {{bedrock}} request URL.
+          * For an [{{gemini}} connector](/reference/connectors-kibana/gemini-action-type.md), specifies the {{gemini}} request URL.
+          * For a [OpenAI connector](/reference/connectors-kibana/openai-action-type.md), specifies the OpenAI request URL.
+          * For a [{{ibm-r}} connector](/reference/connectors-kibana/resilient-action-type.md), specifies the {{ibm-r}} instance URL.
+          * For a [Jira connector](/reference/connectors-kibana/jira-action-type.md), specifies the Jira instance URL.
+          * For an [{{opsgenie}} connector](/reference/connectors-kibana/opsgenie-action-type.md), specifies the {{opsgenie}} URL. For example, `https://api.opsgenie.com` or `https://api.eu.opsgenie.com`.
+          * For a [PagerDuty connector](/reference/connectors-kibana/pagerduty-action-type.md), specifies the PagerDuty event URL. Defaults to `https://events.pagerduty.com/v2/enqueue`.
+          * For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md) specifies the ServiceNow instance URL.
+          * For a [{{swimlane}} connector](/reference/connectors-kibana/swimlane-action-type.md), specifies the {{swimlane}} instance URL.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.appId
-        # id:
         description: |
           An application ID that varies by connector:
 
-          * For a [{{swimlane}} connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), specifies a {{swimlane}} application identifier.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          * For a [{{swimlane}} connector](/reference/connectors-kibana/swimlane-action-type.md), specifies a {{swimlane}} application identifier.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.clientId
-        # id:
         description: |
           A client identifier that varies by connector:
 
-          * For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies a GUID format value that corresponds to the client ID, which is a part of OAuth 2.0 client credentials authentication.
-          * For a [{{sn-itom}}](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), or [{{sn-sir}} connector](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md) specifies the client identifier assigned to the OAuth application.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          * For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies a GUID format value that corresponds to the client ID, which is a part of OAuth 2.0 client credentials authentication.
+          * For a [{{sn-itom}}](/reference/connectors-kibana/servicenow-itom-action-type.md), [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), or [{{sn-sir}} connector](/reference/connectors-kibana/servicenow-sir-action-type.md) specifies the client identifier assigned to the OAuth application.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.configUrl
-        # id:
         description: |
-          For an [xMatters connector](/kibana/docs/reference/connectors-kibana/xmatters-action-type.md) with basic authentication, specifies the request URL for the Elastic Alerts trigger in xMatters.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [xMatters connector](/reference/connectors-kibana/xmatters-action-type.md) with basic authentication, specifies the request URL for the Elastic Alerts trigger in xMatters.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentJson
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a stringified JSON payload with Mustache variables that is sent to the create comment URL to create a case comment. The required variable is `case.description`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a stringified JSON payload with Mustache variables that is sent to the create comment URL to create a case comment. The required variable is `case.description`.
         note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentMethod
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API HTTP request method to create a case comment in the third-party system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API HTTP request method to create a case comment in the third-party system.
         datatype: string
         default: put
         options:
           - option: post
           - option: put
           - option: patch
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentUrl
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a REST API URL string to create a case comment by ID in the third-party system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a REST API URL string to create a case comment by ID in the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentJson
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a stringified JSON payload with Mustache variables that is sent to the create case URL to create a case. Required variables are `case.title` and `case.description`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a stringified JSON payload with Mustache variables that is sent to the create case URL to create a case. Required variables are `case.title` and `case.description`.
         note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentMethod
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API HTTP request method to create a case in the third-party system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API HTTP request method to create a case in the third-party system.
         datatype: string
         default: post
         options:
           - option: post
           - option: put
           - option: patch
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentUrl
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a REST API URL string to create a case in the third-party system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a REST API URL string to create a case in the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentResponseKey
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a string from the response body of the create case method that corresponds to the external service identifier.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a string from the response body of the create case method that corresponds to the external service identifier.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.defaultModel
-        # id:
         description: |
           The default model to use for requests, which varies by connector:
 
           * For an [{{bedrock}} connector](/reference/connectors-kibana/bedrock-action-type.md), current support is for the Anthropic Claude models.
             * {applies_to}`serverless: ga` Defaults to `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
-            * {applies_to}`stack: ga 9.2` Defaults to `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
-            * {applies_to}`stack: ga 9.1` Defaults to `us.anthropic.claude-3-7-sonnet-20250219-v1:0`.
-            * {applies_to}`stack: ga 9.0` Defaults to `anthropic.claude-3-5-sonnet-20240620-v1:0`.
+            * {applies_to}`stack: ga 9.2+` Defaults to `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
+            * {applies_to}`stack: ga =9.1` Defaults to `us.anthropic.claude-3-7-sonnet-20250219-v1:0`.
+            * {applies_to}`stack: ga =9.0` Defaults to `anthropic.claude-3-5-sonnet-20240620-v1:0`.
           * For a [{{gemini}} connector](/reference/connectors-kibana/gemini-action-type.md), current support is for the Gemini models.
             * {applies_to}`serverless: ga` Defaults to `gemini-2.5-pro`.
-            * {applies_to}`stack: ga 9.1` Defaults to `gemini-2.5-pro`.
-            * {applies_to}`stack: ga 9.0` Defaults to `gemini-1.5-pro-002`.
+            * {applies_to}`stack: ga 9.1+` Defaults to `gemini-2.5-pro`.
+            * {applies_to}`stack: ga =9.0` Defaults to `gemini-1.5-pro-002`.
           * For a [OpenAI connector](/reference/connectors-kibana/openai-action-type.md), it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.executionTimeField
-        # id:
         description: |
-          For an [index connector](/kibana/docs/reference/connectors-kibana/index-action-type.md), a field that indicates when the document was indexed.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [index connector](/reference/connectors-kibana/index-action-type.md), a field that indicates when the document was indexed.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.from
-        # id:
         description: |
-          For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies the from address for all emails sent by the connector. It must be specified in `user@host-name` format.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies the from address for all emails sent by the connector. It must be specified in `user@host-name` format.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.getIncidentResponseExternalTitleKey
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a string from the response body of the get case method that corresponds to the external service title.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a string from the response body of the get case method that corresponds to the external service title.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.getIncidentUrl
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a REST API URL string with an external service ID Mustache variable to get the case from the third-party system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a REST API URL string with an external service ID Mustache variable to get the case from the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.hasAuth
-        # id:
         description: |
-          For an [email](/kibana/docs/reference/connectors-kibana/email-action-type.md), [webhook](/kibana/docs/reference/connectors-kibana/webhook-action-type.md), or [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies whether a user and password are required inside the secrets configuration.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [email](/reference/connectors-kibana/email-action-type.md), [webhook](/reference/connectors-kibana/webhook-action-type.md), or [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies whether a user and password are required inside the secrets configuration.
         datatype: bool
         default: true
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.headers
-        # id:
         description: |
-          For a [webhook](/kibana/docs/reference/connectors-kibana/webhook-action-type.md) or [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a set of key-value pairs sent as headers with the request.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [webhook](/reference/connectors-kibana/webhook-action-type.md) or [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a set of key-value pairs sent as headers with the request.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.host
-        # id:
         description: |
-          For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies the host name of the service provider.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies the host name of the service provider.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.index
-        # id:
         description: |
-          For an [index connector](/kibana/docs/reference/connectors-kibana/index-action-type.md), specifies the Elasticsearch index.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [index connector](/reference/connectors-kibana/index-action-type.md), specifies the Elasticsearch index.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.isOAuth
-        # id:
         description: |
-          For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies whether to use basic or OAuth authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies whether to use basic or OAuth authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.jwtKeyId
-        # id:
         description: |
-          For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the key ID assigned to the JWT verifier map of your OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the key ID assigned to the JWT verifier map of your OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), specifies field mappings.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), specifies field mappings.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.alertIdConfig
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), field mapping for the alert identifier. You must provide `fieldtype`, `id`, `key`, and `name` values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), field mapping for the alert identifier. You must provide `fieldtype`, `id`, `key`, and `name` values.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.caseIdConfig
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case identifier. You must provide `fieldtype`, `id`, `key`, and `name` values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case identifier. You must provide `fieldtype`, `id`, `key`, and `name` values.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.caseNameConfig
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case name. You must provide `fieldtype`, `id`, `key`, and `name` values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case name. You must provide `fieldtype`, `id`, `key`, and `name` values.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.commentsConfig
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case comments. You must provide `fieldtype`, `id`, `key`, and `name` values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case comments. You must provide `fieldtype`, `id`, `key`, and `name` values.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.descriptionConfig
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case description. You must provide `fieldtype`, `id`, `key`, and `name` values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), field mapping for the case description. You must provide `fieldtype`, `id`, `key`, and `name` values.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.ruleNameConfig
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), field mapping for the rule name. You must provide `fieldtype`, `id`, `key`, and `name` values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), field mapping for the rule name. You must provide `fieldtype`, `id`, `key`, and `name` values.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.severityConfig
-        # id:
         description: |
-          For a [Swimlane connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), specifies a field mapping for the severity. You must provide `fieldtype`, `id`, `key`, and `name` values.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Swimlane connector](/reference/connectors-kibana/swimlane-action-type.md), specifies a field mapping for the severity. You must provide `fieldtype`, `id`, `key`, and `name` values.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.method
-        # id:
         description: |
-          For a [webhook connector](/kibana/docs/reference/connectors-kibana/webhook-action-type.md), specifies the HTTP request method, either `post` or `put`. Defaults to `post`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [webhook connector](/reference/connectors-kibana/webhook-action-type.md), specifies the HTTP request method, either `post` or `put`. Defaults to `post`.
         datatype: enum
         default: post
         options:
           - option: post
           - option: put
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.orgId
-        # id:
         description: |
-          For an [{{ibm-r}} connector](/kibana/docs/reference/connectors-kibana/resilient-action-type.md), specifies the {{ibm-r}} organization identifier.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [{{ibm-r}} connector](/reference/connectors-kibana/resilient-action-type.md), specifies the {{ibm-r}} organization identifier.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.port
-        # id:
         description: |
-          For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies the port to connect to on the service provider.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies the port to connect to on the service provider.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.projectKey
-        # id:
         description: |
-          For a [Jira connector](/kibana/docs/reference/connectors-kibana/jira-action-type.md), specifies the Jira project key.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Jira connector](/reference/connectors-kibana/jira-action-type.md), specifies the Jira project key.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.secure
-        # id:
         description: |
-          For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies whether the connection will use TLS when connecting to the service provider. If not true, the connection will initially connect over TCP then attempt to switch to TLS via the SMTP STARTTLS command.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies whether the connection will use TLS when connecting to the service provider. If not true, the connection will initially connect over TCP then attempt to switch to TLS via the SMTP STARTTLS command.
         datatype: bool
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.service
-        # id:
         description: |
-          For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies the name of the email service. For example, `elastic_cloud`, `exchange_server`, `gmail`, `other`, `outlook365`, or `ses`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies the name of the email service. For example, `elastic_cloud`, `exchange_server`, `gmail`, `other`, `outlook365`, or `ses`.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.tenantId
-        # id:
         description: |
-          For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies a GUID format value that corresponds to a tenant ID, which is a part of OAuth 2.0 client credentials authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies a GUID format value that corresponds to a tenant ID, which is a part of OAuth 2.0 client credentials authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentJson
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a stringified JSON payload with Mustache variables that is sent to the update case URL to update a case. Required variables are `case.title` and `case.description`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a stringified JSON payload with Mustache variables that is sent to the update case URL to update a case. Required variables are `case.title` and `case.description`.
         note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentMethod
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API HTTP request method to update the case in the third-party system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API HTTP request method to update the case in the third-party system.
         datatype: enum
         default: put
         options:
           - option: post
           - option: put
           - option: patch
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentUrl
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API URL to update the case by ID in the third-party system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies the REST API URL to update the case by ID in the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.url
-        # id:
         description: |
           A configuration URL that varies by connector:
 
-          * For a [D3 Security connector](/kibana/docs/reference/connectors-kibana/d3security-action-type.md), specifies the D3 Security API request URL.
-          * For a [Tines connector](/kibana/docs/reference/connectors-kibana/tines-action-type.md), specifies the Tines tenant URL.
-          * For a [webhook connector](/kibana/docs/reference/connectors-kibana/webhook-action-type.md), specifies the web service request URL.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          * For a [D3 Security connector](/reference/connectors-kibana/d3security-action-type.md), specifies the D3 Security API request URL.
+          * For a [Tines connector](/reference/connectors-kibana/tines-action-type.md), specifies the Tines tenant URL.
+          * For a [webhook connector](/reference/connectors-kibana/webhook-action-type.md), specifies the web service request URL.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
-        datatype: stringm
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+        datatype: string
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.userIdentifierValue
-        # id:
         description: |
-          For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the user identifier. It is required when required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the user identifier. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.usesBasic
-        # id:
         description: |
-          For an [xMatters connector](/kibana/docs/reference/connectors-kibana/xmatters-action-type.md), specifies whether it uses HTTP basic authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [xMatters connector](/reference/connectors-kibana/xmatters-action-type.md), specifies whether it uses HTTP basic authentication.
         datatype: bool
         default: true
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.usesTableApi
-        # id:
         description: |
-          For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md) or [{{sn-sir}} connector](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), specifies whether the connector uses the Table API or the Import Set API. If set to `false`, the Elastic application should be installed in ServiceNow.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md) or [{{sn-sir}} connector](/reference/connectors-kibana/servicenow-sir-action-type.md), specifies whether the connector uses the Table API or the Import Set API. If set to `false`, the Elastic application should be installed in ServiceNow.
         datatype: bool
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.viewIncidentUrl
-        # id:
         description: |
-          For a [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a URL string with either the external service ID or external service title Mustache variable to view a case in the external system.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a URL string with either the external service ID or external service title Mustache variable to view a case in the external system.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.webhookIntegrationUrl
-        # id:
         description: |
-          For a [Torq connector](/kibana/docs/reference/connectors-kibana/torq-action-type.md), specifies the endpoint URL of the Elastic Security integration in Torq.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Torq connector](/reference/connectors-kibana/torq-action-type.md), specifies the endpoint URL of the Elastic Security integration in Torq.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.name
-        # id:
         description: |
           The name of the preconfigured connector.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets
-        # id:
         description: |
           Sensitive configuration details, such as username, password, and keys, which are specific to the connector type.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
         tip: "Sensitive properties, such as passwords, should be stored in the [Kibana keystore](docs-content://deploy-manage/security/secure-settings.md#creating-keystore)."
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.accessKey
-        # id:
         description: |
-          For an [{{bedrock}} connector](/kibana/docs/reference/connectors-kibana/bedrock-action-type.md), specifies the AWS access key for authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [{{bedrock}} connector](/reference/connectors-kibana/bedrock-action-type.md), specifies the AWS access key for authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apikey
-        # id:
         description: |
           An API key secret that varies by connector.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.credentialsJson
-        # id:
         description: |
-          For an [{{gemini}} connector](/kibana/docs/reference/connectors-kibana/gemini-action-type.md), specifies the GCP service account credentials JSON file for authentication.
+          A credentials secret that varies by connector:
 
-          * For a [OpenAI connector](/kibana/docs/reference/connectors-kibana/openai-action-type.md), specifies the OpenAI or Azure OpenAI API key for authentication.
-          * For an [{{opsgenie}} connector](/kibana/docs/reference/connectors-kibana/opsgenie-action-type.md), specifies the {{opsgenie}} API authentication key for HTTP basic authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          * For a [{{gemini}} connector](/reference/connectors-kibana/gemini-action-type.md), specifies the GCP service account credentials JSON file for authentication.
+          * For a [OpenAI connector](/reference/connectors-kibana/openai-action-type.md), specifies the OpenAI or Azure OpenAI API key for authentication.
+          * For an [{{opsgenie}} connector](/reference/connectors-kibana/opsgenie-action-type.md), specifies the {{opsgenie}} API authentication key for HTTP basic authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiKeyId
-        # id:
         description: |
-          For an [{{ibm-r}} connector](/kibana/docs/reference/connectors-kibana/resilient-action-type.md), specifies the authentication key ID for HTTP basic authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [{{ibm-r}} connector](/reference/connectors-kibana/resilient-action-type.md), specifies the authentication key ID for HTTP basic authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiKeySecret
-        # id:
         description: |
-          For an [{{ibm-r}} connector](/kibana/docs/reference/connectors-kibana/resilient-action-type.md), specifies the authentication key secret for HTTP basic authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [{{ibm-r}} connector](/reference/connectors-kibana/resilient-action-type.md), specifies the authentication key secret for HTTP basic authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiToken
-        # id:
         description: |
-          For a [Jira](/kibana/docs/reference/connectors-kibana/jira-action-type.md) or [{{swimlane}} connector](/kibana/docs/reference/connectors-kibana/swimlane-action-type.md), specifies the API authentication token for HTTP basic authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [Jira](/reference/connectors-kibana/jira-action-type.md) or [{{swimlane}} connector](/reference/connectors-kibana/swimlane-action-type.md), specifies the API authentication token for HTTP basic authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.clientSecret
-        # id:
         description: |
           A client secret that varies by connector:
 
-          * For an [email connector](/kibana/docs/reference/connectors-kibana/email-action-type.md), specifies the client secret that you generated for your app in the app registration portal. It is required when the email service is `exchange_server`, which uses OAuth 2.0 client credentials authentication.
-          * For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the client secret assigned to the OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          * For an [email connector](/reference/connectors-kibana/email-action-type.md), specifies the client secret that you generated for your app in the app registration portal. It is required when the email service is `exchange_server`, which uses OAuth 2.0 client credentials authentication.
+          * For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the client secret assigned to the OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
         note: "The client secret must be URL-encoded."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.email
-        # id:
         description: |
           An email address that varies by connector:
 
-          * For a [Jira connector](/kibana/docs/reference/connectors-kibana/jira-action-type.md), specifies the account email for HTTP basic authentication.
-          * For a [Tines connector](/kibana/docs/reference/connectors-kibana/tines-action-type.md), specifies the email used to sign in to Tines.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          * For a [Jira connector](/reference/connectors-kibana/jira-action-type.md), specifies the account email for HTTP basic authentication.
+          * For a [Tines connector](/reference/connectors-kibana/tines-action-type.md), specifies the email used to sign in to Tines.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.password
-        # id:
         description: |
           A password secret that varies by connector:
 
-          * For an [email](/kibana/docs/reference/connectors-kibana/email-action-type.md), [webhook](/kibana/docs/reference/connectors-kibana/webhook-action-type.md), or [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
-          * For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`.
-          * For an [xMatters connector](/kibana/docs/reference/connectors-kibana/xmatters-action-type.md), specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          * For an [email](/reference/connectors-kibana/email-action-type.md), [webhook](/reference/connectors-kibana/webhook-action-type.md), or [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+          * For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`.
+          * For an [xMatters connector](/reference/connectors-kibana/xmatters-action-type.md), specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.privateKey
-        # id:
         description: |
-          For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the RSA private key. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the RSA private key. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.privateKeyPassword
-        # id:
         description: |
-          For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the password for the RSA private key.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies the password for the RSA private key.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.routingKey
-        # id:
         description: |
-          For a [PagerDuty connector](/kibana/docs/reference/connectors-kibana/pagerduty-action-type.md), specifies the 32 character PagerDuty Integration Key for an integration on a service, also referred to as the routing key.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [PagerDuty connector](/reference/connectors-kibana/pagerduty-action-type.md), specifies the 32 character PagerDuty Integration Key for an integration on a service, also referred to as the routing key.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.secret
-        # id:
         description: |
-          For an [{{bedrock}} connector](/kibana/docs/reference/connectors-kibana/bedrock-action-type.md), specifies the AWS secret for authentication.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For an [{{bedrock}} connector](/reference/connectors-kibana/bedrock-action-type.md), specifies the AWS secret for authentication.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.secretsUrl
-        # id:
         description: |
-          For an [xMatters connector](/kibana/docs/reference/connectors-kibana/xmatters-action-type.md) with URL authentication, specifies the request URL for the Elastic Alerts trigger in xMatters with the API key included in the URL. It is used only when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `false`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          For an [xMatters connector](/reference/connectors-kibana/xmatters-action-type.md) with URL authentication, specifies the request URL for the Elastic Alerts trigger in xMatters with the API key included in the URL. It is used only when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `false`.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.token
-        # id:
         description: |
           A token secret that varies by connector:
 
-          * For a [D3 Security conector](/kibana/docs/reference/connectors-kibana/d3security-action-type.md), specifies the D3 Security token.
-          * For a [Slack connector](/kibana/docs/reference/connectors-kibana/slack-action-type.md), specifies the Slack bot user OAuth token.
-          * For a [Tines connector](/kibana/docs/reference/connectors-kibana/tines-action-type.md), specifies the Tines API token.
-          * For a [Torq connector](/kibana/docs/reference/connectors-kibana/torq-action-type.md), specifies the secret of the webhook authentication header.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          * For a [D3 Security connector](/reference/connectors-kibana/d3security-action-type.md), specifies the D3 Security token.
+          * For a [Slack connector](/reference/connectors-kibana/slack-action-type.md), specifies the Slack bot user OAuth token.
+          * For a [Tines connector](/reference/connectors-kibana/tines-action-type.md), specifies the Tines API token.
+          * For a [Torq connector](/reference/connectors-kibana/torq-action-type.md), specifies the secret of the webhook authentication header.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.user
-        # id:
         description: |
           A user name secret that varies by connector:
 
-          * For an [email](/kibana/docs/reference/connectors-kibana/email-action-type.md), [webhook](/kibana/docs/reference/connectors-kibana/webhook-action-type.md), or [{{webhook-cm}} connector](/kibana/docs/reference/connectors-kibana/cases-webhook-action-type.md), specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
-          * For an [xMatters connector](/kibana/docs/reference/connectors-kibana/xmatters-action-type.md), specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
-
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          * For an [email](/reference/connectors-kibana/email-action-type.md), [webhook](/reference/connectors-kibana/webhook-action-type.md), or [{{webhook-cm}} connector](/reference/connectors-kibana/cases-webhook-action-type.md), specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+          * For an [xMatters connector](/reference/connectors-kibana/xmatters-action-type.md), specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.webhookUrl
-        # id:
         description: |
           A URL that varies by connector:
 
-          * For a [Microsoft Teams](/kibana/docs/reference/connectors-kibana/teams-action-type.md), specifies the URL of the incoming webhook.
-          * For a [Slack connector](/kibana/docs/reference/connectors-kibana/slack-action-type.md), specifies the Slack webhook URL.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
+          * For a [Microsoft Teams connector](/reference/connectors-kibana/teams-action-type.md), specifies the URL of the incoming webhook.
+          * For a [Slack connector](/reference/connectors-kibana/slack-action-type.md), specifies the Slack webhook URL.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname is added to the allowed hosts."
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.username
-        # id:
         description: |
-          For a [{{sn-itsm}}](/kibana/docs/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/kibana/docs/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/kibana/docs/reference/connectors-kibana/servicenow-itom-action-type.md), specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          For a [{{sn-itsm}}](/reference/connectors-kibana/servicenow-action-type.md), [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md), or [{{sn-itom}} connector](/reference/connectors-kibana/servicenow-itom-action-type.md), specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`.
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.actions.webhook.ssl.pfx.enabled
-        # id:
         description: |
-          {applies_to}`stack: ga 9.1` Disable PFX file support for SSL client authentication. When set to `false`, the application will not accept PFX certificate files and will require separate certificate and private key files instead. Only applies to the [Webhook connector](/reference/connectors-kibana/webhook-action-type.md).
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+          Disable PFX file support for SSL client authentication. When set to `false`, the application will not accept PFX certificate files and will require separate certificate and private key files instead. Only applies to the [Webhook connector](/reference/connectors-kibana/webhook-action-type.md).
         datatype: bool
         default: true
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
           stack: ga 9.1
-          deployment:
-            self: all
-         # example: |
+          self: ga
+          ech: unavailable
 
   - group: Alerting settings
     id: alert-settings
-    # description: |
-    # example: |
     settings:
 
       - setting: xpack.alerting.cancelAlertsOnRuleTimeout
-        # id:
         description: |
           Specifies whether to skip writing alerts and scheduling actions if rule processing was cancelled due to a timeout. This setting can be overridden by individual rule types.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: bool
         default: true
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.alerting.rules.maxScheduledPerMinute
-        # id:
         description: |
           Specifies the maximum number of rules to run per minute.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
+        note: "In Serverless, the maximum number of rules to run per minute is set to `400` and can't be configured."
         datatype: int
-        default: 10000
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
+        default: 32000
         applies_to:
-          deployment:
-            self: all
-         # example: |
+          stack: ga
+          self: ga
+          ech: unavailable
 
       - setting: xpack.alerting.rules.minimumScheduleInterval.value
-        # id:
         description: |
           Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as a number and a time unit (`s`, `m`, `h`, or `d`). For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
         default: 1m
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.alerting.rules.minimumScheduleInterval.enforce
-        # id:
         description: |
           Specifies the behavior when a new or changed rule has a schedule interval less than the value defined in `xpack.alerting.rules.minimumScheduleInterval.value`. If `false`, rules with schedules less than the interval will be created but warnings will be logged. If `true`, rules with schedules less than the interval cannot be created.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: bool
         default: false
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.alerting.rules.run.actions.max
-        # id:
         description: |
           Specifies the maximum number of actions that a rule can generate each time detection checks run.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: int
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.alerting.rules.run.alerts.max
-        # id:
         description: |
           Specifies the maximum number of alerts that a rule can generate each time detection checks run.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        warning: "The exact number of alerts your cluster can safely handle depends on your cluster configuration and workload, however setting a value higher than the default (`1000`) is not recommended or supported. Doing so could strain system resources and lead to performance issues, delays in alert processing, and potential disruptions during high alert activity periods."
-        # important: ""
+        warning: "The exact number of alerts your cluster can safely handle depends on your cluster configuration and workload. While it is technically possible to increase this value above 1000, doing so is not recommended and not supported. Increasing this limit can significantly affect {{kib}} and {{es}} performance and memory usage. Carefully evaluate the impact on your deployment before making this change."
         datatype: int
         default: 1000
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.alerting.rules.run.timeout
-        # id:
         description: |
           Specifies the default timeout for tasks associated with all types of rules. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `5m`.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
-         # example: |
+          stack: ga
+          ech: ga
+          self: ga
 
       - setting: xpack.alerting.rules.run.ruleTypeOverrides
-        # id:
         description: |
           Overrides the configs under `xpack.alerting.rules.run` for the rule type with the given ID. List the rule identifier and its settings in an array of objects.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
+          stack: ga
+          ech: ga
+          self: ga
         example: |
           For example:
 
@@ -2571,25 +1309,13 @@ groups:
           ```
 
       - setting: xpack.alerting.rules.run.actions.connectorTypeOverrides
-        # id:
         description: |
           Overrides the configs under `xpack.alerting.rules.run.actions` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects.
-        # state: deprecated/hidden/tech-preview
-        # deprecation_details: ""
-        # note: ""
-        # tip: ""
-        # warning: ""
-        # important: ""
         datatype: string
-        # default:
-        # options:
-        #   - option:
-        #     description: ""
-        # type: static/dynamic
         applies_to:
-          deployment:
-            self: all
-            ess: all
+          stack: ga
+          ech: ga
+          self: ga
         example: |
           For example:
 
@@ -2600,24 +1326,4 @@ groups:
                   connectorTypeOverrides:
                       - id: '.server-log'
                         max: 5
-          ```
-
-      - setting: xpack.alerting.rules.apiKeyType
-        description: |
-          The API key type to use for executing alerting rules. The default value, corresponding to the existing behavior, is `es`, which uses an Elasticsearch API key. Set this to `uiam` to use UIAM API keys instead.
-        datatype: string
-        default: es
-        options:
-          - option: es
-            description: Elasticsearch API key
-          - option: uiam
-            description: UIAM api key
-        applies_to:
-          deployment:
-            ess: all
-        example: |
-          For example:
-
-          ```yaml
-          xpack.alerting.rules.apiKeyType: uiam
           ```


### PR DESCRIPTION
This updates the [yaml file](https://github.com/elastic/kibana/blob/main/docs/settings-gen/source/kibana-alert-action-settings.yml) from which we plan to source the [Alerting and action settings](https://www.elastic.co/docs/reference/kibana/configuration-reference/alerting-settings) page. The yaml is updated to:
 - match the latest settings [schema](https://github.com/elastic/kibana/blob/main/docs/settings-gen/readme.md) (which has reworked `applies_to` tagging, etc.)
 - update the setting descriptions against the latest Markdown
 - remove commented-out lines for all of the optional setting parameters
 - correct setting formatting, data types, and typos
 - verify in the code whether or not the setting is supported on ECH

@florent-leborgne, @theletterf  Sorry for the giant diff in this PR. I did check the differences setting by setting and everything looks good to me. I think this would be an ideal yaml file to use for testing the HTML rendering.

Rel: https://github.com/elastic/kibana/issues/206138?reload=1?reload=1