### PR TITLE
[9.2] [CI] Constrain regions for c4d machines in build step (#256146)

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -27,7 +27,7 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-2
+      machineType: n2-highcpu-8
       diskSizeGb: 95
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
@@ -36,10 +36,10 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n4d-standard-16
+      machineType: c4d-standard-16
       diskType: hyperdisk-balanced
-      preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      zones: us-central1-a,us-central1-b,us-central1-c
+      diskSizeGb: 200
     key: build
     timeout_in_minutes: 60
     retry:
@@ -53,10 +53,9 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n4d-standard-8
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-8
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: quick_checks
     timeout_in_minutes: 60
@@ -71,10 +70,9 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n4d-standard-2
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-2
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: checks
     timeout_in_minutes: 60
@@ -89,10 +87,9 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n4d-standard-16
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-16
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: linting
     timeout_in_minutes: 60
@@ -107,10 +104,9 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n4d-standard-32
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-32
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: linting_with_types
     timeout_in_minutes: 60
@@ -127,7 +123,7 @@ steps:
       provider: gcp
       machineType: n2d-highmem-4
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60
@@ -142,9 +138,10 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-4
+      machineType: n2d-highmem-4
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
+      diskSizeGb: 105
     key: check_oas_snapshot
     timeout_in_minutes: 60
     retry:
@@ -161,9 +158,9 @@ steps:
       provider: gcp
       machineType: n2-highmem-4
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
-    timeout_in_minutes: 80
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'
@@ -254,7 +251,6 @@ steps:
       - checks
       - linting
       - linting_with_types
-      - check_oas_snapshot
       - check_types
 
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
@@ -265,7 +261,7 @@ steps:
       provider: gcp
       machineType: n2-standard-8
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
     key: storybooks
     depends_on:
       - build
@@ -283,7 +279,7 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -301,7 +297,7 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
     artifact_paths: 'target/plugin_so_types_snapshot.json'
     depends_on:
       - build

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -4,12 +4,11 @@ steps:
     agents:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
-      preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      zones: us-central1-a,us-central1-b,us-central1-c
       diskSizeGb: 200
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
-    timeout_in_minutes: 90
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'
@@ -18,10 +17,9 @@ steps:
   - command: .buildkite/scripts/steps/quick_checks.sh
     label: 'Quick Checks'
     agents:
-      machineType: c4d-standard-8
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-8
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: quick_checks
     timeout_in_minutes: 60
@@ -33,10 +31,9 @@ steps:
   - command: .buildkite/scripts/steps/checks.sh
     label: 'Checks'
     agents:
-      machineType: c4d-standard-2
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-2
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     timeout_in_minutes: 60
     key: checks
@@ -48,10 +45,9 @@ steps:
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
-      machineType: c4d-standard-16
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-16
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: linting
     timeout_in_minutes: 60
@@ -63,10 +59,9 @@ steps:
   - command: .buildkite/scripts/steps/lint_with_types.sh
     label: 'Linting (with types)'
     agents:
-      machineType: c4d-standard-32
-      diskType: hyperdisk-balanced
+      machineType: n2d-standard-32
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: linting_with_types
     timeout_in_minutes: 60
@@ -78,9 +73,9 @@ steps:
   - command: .buildkite/scripts/steps/checks/capture_oas_snapshot.sh
     label: 'Check OAS Snapshot'
     agents:
-      machineType: n2-standard-4
+      machineType: n2d-standard-2
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
     key: check_oas_snapshot
     timeout_in_minutes: 60
     retry:
@@ -91,10 +86,9 @@ steps:
   - command: .buildkite/scripts/steps/typecheck/check_types.sh
     label: 'Check Types'
     agents:
-      machineType: c4d-highmem-4
-      diskType: hyperdisk-balanced
+      machineType: n2d-highmem-4
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60
@@ -153,7 +147,7 @@ steps:
     agents:
       machineType: n2-highmem-4
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     key: build_api_docs
     timeout_in_minutes: 60


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[CI] Constrain regions for c4d machines in build step (#256146)](https://github.com/elastic/kibana/pull/256146)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-03-05T07:30:27Z","message":"[CI] Constrain regions for c4d machines in build step (#256146)\n\nSeeing \"The job, Build Kibana Distribution, has been canceled as it\nfailed to get an agent after 5 tries.\"\n\nBelieve it's due to the configuration not being available in all of the\ndefault regions.\n\nAdditionally, we have limited capacity of `c4d` currently, so changing\nto `n2` for everything not build distribution needing this until we can\nraise limits.\n\n---------\n\nSigned-off-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"1a156a9a003e8e44658b35a3ec0ed6f8cb571565","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0"],"title":"[CI] Constrain regions for c4d machines in build step","number":256146,"url":"https://github.com/elastic/kibana/pull/256146","mergeCommit":{"message":"[CI] Constrain regions for c4d machines in build step (#256146)\n\nSeeing \"The job, Build Kibana Distribution, has been canceled as it\nfailed to get an agent after 5 tries.\"\n\nBelieve it's due to the configuration not being available in all of the\ndefault regions.\n\nAdditionally, we have limited capacity of `c4d` currently, so changing\nto `n2` for everything not build distribution needing this until we can\nraise limits.\n\n---------\n\nSigned-off-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"1a156a9a003e8e44658b35a3ec0ed6f8cb571565"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256146","number":256146,"mergeCommit":{"message":"[CI] Constrain regions for c4d machines in build step (#256146)\n\nSeeing \"The job, Build Kibana Distribution, has been canceled as it\nfailed to get an agent after 5 tries.\"\n\nBelieve it's due to the configuration not being available in all of the\ndefault regions.\n\nAdditionally, we have limited capacity of `c4d` currently, so changing\nto `n2` for everything not build distribution needing this until we can\nraise limits.\n\n---------\n\nSigned-off-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"1a156a9a003e8e44658b35a3ec0ed6f8cb571565"}}]}] BACKPORT-->