### PR TITLE
[8.19] [Console] Fix syntax highlighting for strings with unicode characters (#255649)

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/constants.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/constants.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { monaco } from '../../monaco_imports';
+
+// A regex character class that represents all valid identifier characters, including unicode.
+// This allows for normal identifiers plus non-ASCII (e.g., accents, Cyrillic, CJK).
+const ALPHANUM_UNICODE = '[a-zA-Z0-9_$\\u0080-\\uFFFF]';
+
+// A regex character class for letters and unicode, but no numbers.
+const ALPHA_UNICODE = '[a-zA-Z_\\u0080-\\uFFFF]';
+
+export const languageTolerantRules: monaco.languages.IMonarchLanguageRule[] = [
+  // Catch words with apostrophes (e.g., d'été, isn't) so they don't trigger string states
+  [new RegExp(`${ALPHANUM_UNICODE}+'${ALPHANUM_UNICODE}+`), 'identifier'],
+
+  // Catch words with non-ASCII characters (e.g. accents, Cyrillic, CJK)
+  // so they are treated as identifiers instead of invalid tokens.
+  [new RegExp(`${ALPHANUM_UNICODE}*[\\u0080-\\uFFFF]${ALPHANUM_UNICODE}*`), 'identifier'],
+
+  // Catch words that start with a number but contain letters/unicode (e.g. 1aB8, 6e).
+  // Without this, the lexer splits them into a number (e.g. 1) and an identifier (aB8),
+  // which results in incorrect coloring in the console.
+  [new RegExp(`\\d+${ALPHA_UNICODE}${ALPHANUM_UNICODE}*`), 'identifier'],
+];

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_esql.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_esql.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { lexerRules, keywords, builtinFunctions } from '../../esql/lib/esql_lexer_rules';
+import type { monaco } from '../../monaco_imports';
+
+const getNextState = (
+  action: monaco.languages.IMonarchLanguageAction | undefined
+): string | undefined => {
+  if (!action || typeof action !== 'object' || !('next' in action)) return undefined;
+  return typeof action.next === 'string' ? action.next : undefined;
+};
+
+const isRuleWithNextState = (
+  rule: monaco.languages.IMonarchLanguageRule,
+  next: string
+): boolean => {
+  if (!Array.isArray(rule) || rule.length < 2) return false;
+  const action = rule[1];
+  return getNextState(typeof action === 'string' ? undefined : action) === next;
+};
+
+jest.mock('../../esql/lib/esql_lexer_rules', () => {
+  const actual = jest.requireActual('../../esql/lib/esql_lexer_rules');
+  return {
+    ...actual,
+    lexerRules: {
+      ...actual.lexerRules,
+      tokenizer: {
+        ...actual.lexerRules.tokenizer,
+        strings: [
+          ...actual.lexerRules.tokenizer.strings,
+          // A string rule that shouldn't be remapped to cover the branch
+          [/ignore/, 'string'],
+          // A rule without a next state
+          [/ignore2/, { token: 'string' }],
+          // Not an array rule
+          'ignore3',
+        ],
+      },
+    },
+  };
+});
+
+import { languageTolerantRules } from './constants';
+import { buildEsqlStartRule, buildEsqlRules, esqlLanguageAttributes } from './nested_esql';
+
+describe('Console nested ES|QL lexer rules', () => {
+  describe('buildEsqlStartRule', () => {
+    it('builds a start rule for single quotes', () => {
+      const rule = buildEsqlStartRule(false);
+      expect(rule[0]).toEqual(/("query")(\s*?)(:)(\s*?)(")/);
+      expect(rule[1]).toEqual([
+        'variable',
+        'whitespace',
+        'punctuation.colon',
+        'whitespace',
+        {
+          token: 'punctuation',
+          next: '@esql_root_single_quotes',
+        },
+      ]);
+    });
+
+    it('builds a start rule for triple quotes', () => {
+      const rule = buildEsqlStartRule(true);
+      expect(rule[0]).toEqual(/("query")(\s*?)(:)(\s*?)(""")/);
+      expect(rule[1]).toEqual([
+        'variable',
+        'whitespace',
+        'punctuation.colon',
+        'whitespace',
+        {
+          token: 'punctuation',
+          next: '@esql_root_triple_quotes',
+        },
+      ]);
+    });
+
+    it('accepts a custom root state name', () => {
+      const rule = buildEsqlStartRule(true, 'custom_root');
+      const action = (rule[1] as Array<monaco.languages.IMonarchLanguageAction | string>)[4];
+      expect(getNextState(typeof action === 'string' ? undefined : action)).toEqual(
+        '@custom_root_triple_quotes'
+      );
+    });
+  });
+
+  describe('buildEsqlRules', () => {
+    it('builds esql rules with default root name', () => {
+      const rules = buildEsqlRules();
+      expect(rules).toHaveProperty('esql_root_triple_quotes');
+      expect(rules).toHaveProperty('esql_root_single_quotes');
+      expect(rules).toHaveProperty('esql_string');
+      expect(rules).toHaveProperty('comment');
+
+      // Verify the language tolerant rules are present at the beginning (after the pop rule)
+      const tripleQuotesRules = rules.esql_root_triple_quotes;
+      expect(tripleQuotesRules[1]).toEqual(languageTolerantRules[0]);
+      expect(tripleQuotesRules[2]).toEqual(languageTolerantRules[1]);
+      expect(tripleQuotesRules[3]).toEqual(languageTolerantRules[2]);
+
+      // Verify strings were remapped
+      const hasRemappedStringRule = tripleQuotesRules.some((r) =>
+        isRuleWithNextState(r, '@esql_string')
+      );
+      if (lexerRules.tokenizer.strings && lexerRules.tokenizer.strings.length > 0) {
+        expect(hasRemappedStringRule).toBe(true);
+      }
+    });
+
+    it('builds esql rules with custom root name', () => {
+      const rules = buildEsqlRules('custom_root');
+      expect(rules).toHaveProperty('custom_root_triple_quotes');
+      expect(rules).toHaveProperty('custom_root_single_quotes');
+    });
+
+    it('remaps string states correctly', () => {
+      const rules = buildEsqlRules();
+      const stringState = rules.esql_string;
+
+      // Should have lookahead pop rules at the start
+      expect(stringState[0]).toEqual([/(?=""")/, { token: '', next: '@pop' }]);
+      expect(stringState[1]).toEqual([/(?=")/, { token: '', next: '@pop' }]);
+
+      // Should contain the original string rules
+      expect(stringState.length).toBeGreaterThan(2);
+    });
+  });
+
+  describe('esqlLanguageAttributes', () => {
+    it('exports keywords and builtinFunctions', () => {
+      expect(esqlLanguageAttributes.keywords).toEqual(keywords);
+      expect(esqlLanguageAttributes.builtinFunctions).toEqual(builtinFunctions);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_esql.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_esql.ts
@@ -12,6 +12,10 @@ import {
   keywords,
   builtinFunctions,
 } from '../../esql/lib/esql_lexer_rules';
+import { languageTolerantRules } from './constants';
+import { remapStringsToNestedState } from './utils/remap_strings_to_nested_state';
+import type { monaco } from '../../monaco_imports';
+
 /*
  * This rule is used inside json root to start an esql highlighting sequence
  */
@@ -36,8 +40,15 @@ export const buildEsqlStartRule = (tripleQuotes: boolean, esqlRoot: string = 'es
  * It reuses the lexer rules from the "esql" language, but since not all rules are referenced in the root
  * tokenizer and to avoid conflicts with existing console rules, only selected rules are used.
  */
-export const buildEsqlRules = (esqlRoot: string = 'esql_root') => {
-  const { root, comment, numbers, strings } = esqlLexerRules.tokenizer;
+export const buildEsqlRules = (
+  esqlRoot: string = 'esql_root'
+): Record<string, monaco.languages.IMonarchLanguageRule[]> => {
+  const { root, comment, numbers, strings, string: esqlString } = esqlLexerRules.tokenizer;
+
+  // Remap transitions in `strings` to point to `@esql_string` to avoid
+  // conflict with the console's JSON `@string` state.
+  const remappedStrings = remapStringsToNestedState(strings, '@esql_string');
+
   return {
     [`${esqlRoot}_triple_quotes`]: [
       // the rule to end esql highlighting and get back to the previous tokenizer state
@@ -48,9 +59,11 @@ export const buildEsqlRules = (esqlRoot: string = 'esql_root') => {
           next: '@pop',
         },
       ],
+      ...languageTolerantRules,
       ...root,
       ...numbers,
-      ...strings,
+      ...remappedStrings,
+      [/./, 'text'],
     ],
     [`${esqlRoot}_single_quotes`]: [
       [/@escapes/, 'string.escape'],
@@ -62,9 +75,18 @@ export const buildEsqlRules = (esqlRoot: string = 'esql_root') => {
           next: '@pop',
         },
       ],
+      ...languageTolerantRules,
       ...root,
       ...numbers,
-      ...strings,
+      ...remappedStrings,
+      [/./, 'text'],
+    ],
+    esql_string: [
+      // If we see the JSON boundary closing quote while inside an unclosed ES|QL string,
+      // pop out of the ES|QL string without consuming the quote.
+      [/(?=""")/, { token: '', next: '@pop' }],
+      [/(?=")/, { token: '', next: '@pop' }],
+      ...(Array.isArray(esqlString) ? esqlString : []),
     ],
     comment,
   };

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_painless.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_painless.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { languageTolerantRules } from './constants';
+import {
+  buildPainlessStartRule,
+  buildPainlessRules,
+  painlessLanguageAttributes,
+} from './nested_painless';
+import { lexerRules as painlessLexerRules } from '../../painless/lexer_rules';
+import type { monaco } from '../../monaco_imports';
+
+const getNextState = (
+  action: monaco.languages.IMonarchLanguageAction | undefined
+): string | undefined => {
+  if (!action || typeof action !== 'object' || !('next' in action)) return undefined;
+  return typeof action.next === 'string' ? action.next : undefined;
+};
+
+describe('Console nested Painless lexer rules', () => {
+  describe('buildPainlessStartRule', () => {
+    it('builds a start rule for painless scripts', () => {
+      const rule = buildPainlessStartRule();
+      expect(rule[0]).toEqual(/("(?:[^"]*_)?script"|"inline"|"source")(\s*?)(:)(\s*?)(""")/);
+      expect(rule[1]).toEqual([
+        'variable',
+        'whitespace',
+        'punctuation.colon',
+        'whitespace',
+        {
+          token: 'punctuation',
+          next: '@painless_root',
+        },
+      ]);
+    });
+
+    it('accepts a custom root state name', () => {
+      const rule = buildPainlessStartRule('custom_painless_root');
+      const action = (rule[1] as Array<monaco.languages.IMonarchLanguageAction | string>)[4];
+      expect(getNextState(typeof action === 'string' ? undefined : action)).toEqual(
+        '@custom_painless_root'
+      );
+    });
+  });
+
+  describe('buildPainlessRules', () => {
+    it('builds painless rules with default root name', () => {
+      const rules = buildPainlessRules();
+      expect(rules).toHaveProperty('painless_root');
+      expect(rules).toHaveProperty('comment');
+      expect(rules).toHaveProperty('string_dq');
+      expect(rules).toHaveProperty('string_sq');
+
+      // Verify the language tolerant rules are present at the beginning (after the pop rule)
+      const painlessRootRules = rules.painless_root;
+      expect(painlessRootRules[1]).toEqual(languageTolerantRules[0]);
+      expect(painlessRootRules[2]).toEqual(languageTolerantRules[1]);
+      expect(painlessRootRules[3]).toEqual(languageTolerantRules[2]);
+    });
+
+    it('builds painless rules with custom root name', () => {
+      const rules = buildPainlessRules('custom_painless_root');
+      expect(rules).toHaveProperty('custom_painless_root');
+    });
+  });
+
+  describe('painlessLanguageAttributes', () => {
+    it('exports all necessary painless attributes', () => {
+      expect(painlessLanguageAttributes.keywords).toEqual(painlessLexerRules.keywords);
+      expect(painlessLanguageAttributes.primitives).toEqual(painlessLexerRules.primitives);
+      expect(painlessLanguageAttributes.constants).toEqual(painlessLexerRules.constants);
+      expect(painlessLanguageAttributes.operators).toEqual(painlessLexerRules.operators);
+      expect(painlessLanguageAttributes.symbols).toEqual(painlessLexerRules.symbols);
+      expect(painlessLanguageAttributes.digits).toEqual(painlessLexerRules.digits);
+      expect(painlessLanguageAttributes.octaldigits).toEqual(painlessLexerRules.octaldigits);
+      expect(painlessLanguageAttributes.binarydigits).toEqual(painlessLexerRules.binarydigits);
+      expect(painlessLanguageAttributes.hexdigits).toEqual(painlessLexerRules.hexdigits);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_painless.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_painless.ts
@@ -9,6 +9,9 @@
 
 import { lexerRules as painlessLexerRules } from '../../painless/lexer_rules';
 
+import { languageTolerantRules } from './constants';
+import type { monaco } from '../../monaco_imports';
+
 /*
  * This rule is used inside json root to start a painless highlighting sequence
  */
@@ -33,8 +36,11 @@ export const buildPainlessStartRule = (painlessRoot: string = 'painless_root') =
  * It reuses the lexer rules from the "painless" language, but since not all rules are referenced in the root
  * tokenizer and to avoid conflicts with existing console rules, only selected rules are used.
  */
-export const buildPainlessRules = (painlessRoot: string = 'painless_root') => {
+export const buildPainlessRules = (
+  painlessRoot: string = 'painless_root'
+): Record<string, monaco.languages.IMonarchLanguageRule[]> => {
   const { root, comment, string_dq, string_sq } = painlessLexerRules.tokenizer;
+
   return {
     [painlessRoot]: [
       // the rule to end painless highlighting and get back to the previous tokenizer state
@@ -45,6 +51,7 @@ export const buildPainlessRules = (painlessRoot: string = 'painless_root') => {
           next: '@pop',
         },
       ],
+      ...languageTolerantRules,
       ...root,
     ],
     comment,

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_sql.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_sql.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { keywords, builtinFunctions } from '../../sql/lexer_rules';
+import type { monaco } from '../../monaco_imports';
+
+const getNextState = (
+  action: monaco.languages.IMonarchLanguageAction | undefined
+): string | undefined => {
+  if (!action || typeof action !== 'object' || !('next' in action)) return undefined;
+  return typeof action.next === 'string' ? action.next : undefined;
+};
+
+jest.mock('../../sql/lexer_rules', () => {
+  const actual = jest.requireActual('../../sql/lexer_rules');
+  return {
+    ...actual,
+    lexerRules: {
+      ...actual.lexerRules,
+      tokenizer: {
+        ...actual.lexerRules.tokenizer,
+        strings: [
+          ...(actual.lexerRules.tokenizer.strings || []),
+          // A string rule that shouldn't be remapped to cover the branch
+          [/ignore/, 'string'],
+          // A rule without a next state
+          [/ignore2/, { token: 'string' }],
+          // Not an array rule
+          'ignore3',
+        ],
+      },
+    },
+  };
+});
+
+import { languageTolerantRules } from './constants';
+import { buildSqlStartRule, buildSqlRules, sqlLanguageAttributes } from './nested_sql';
+
+describe('Console nested SQL lexer rules', () => {
+  describe('buildSqlStartRule', () => {
+    it('builds a start rule for triple quotes', () => {
+      const rule = buildSqlStartRule();
+      expect(rule[0]).toEqual(/("query")(\s*?)(:)(\s*?)(""")/);
+      expect(rule[1]).toEqual([
+        'variable',
+        'whitespace',
+        'punctuation.colon',
+        'whitespace',
+        {
+          token: 'punctuation',
+          next: '@sql_root',
+        },
+      ]);
+    });
+
+    it('accepts a custom root state name', () => {
+      const rule = buildSqlStartRule('custom_sql_root');
+      const action = (rule[1] as Array<monaco.languages.IMonarchLanguageAction | string>)[4];
+      expect(getNextState(typeof action === 'string' ? undefined : action)).toEqual(
+        '@custom_sql_root'
+      );
+    });
+  });
+
+  describe('buildSqlRules', () => {
+    it('builds sql rules with default root name', () => {
+      const rules = buildSqlRules();
+      expect(rules).toHaveProperty('sql_root');
+      expect(rules).toHaveProperty('sql_string');
+      expect(rules).toHaveProperty('comment');
+
+      // Verify the language tolerant rules are present at the beginning
+      const sqlRootRules = rules.sql_root;
+      expect(sqlRootRules[1]).toEqual(languageTolerantRules[0]);
+      expect(sqlRootRules[2]).toEqual(languageTolerantRules[1]);
+      expect(sqlRootRules[3]).toEqual(languageTolerantRules[2]);
+
+      // Verify the fallback rule is present at the end
+      expect(sqlRootRules[sqlRootRules.length - 1]).toEqual([/./, 'text']);
+    });
+
+    it('builds sql rules with custom root name', () => {
+      const rules = buildSqlRules('custom_sql_root');
+      expect(rules).toHaveProperty('custom_sql_root');
+    });
+
+    it('remaps string states correctly', () => {
+      const rules = buildSqlRules();
+      const stringState = rules.sql_string;
+
+      // Should have lookahead pop rules at the start
+      expect(stringState[0]).toEqual([/(?=""")/, { token: '', next: '@pop' }]);
+      expect(stringState[1]).toEqual([/(?=")/, { token: '', next: '@pop' }]);
+
+      // Should contain the original string rules (if present)
+      expect(stringState.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('handles missing string and strings arrays gracefully', () => {
+      jest.resetModules();
+      jest.doMock('../../sql/lexer_rules', () => {
+        const actual = jest.requireActual('../../sql/lexer_rules');
+        return {
+          ...actual,
+          lexerRules: {
+            ...actual.lexerRules,
+            tokenizer: {
+              ...actual.lexerRules.tokenizer,
+              strings: undefined,
+              string: undefined,
+            },
+          },
+        };
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const isolatedNestedSql = require('./nested_sql');
+      const rules = isolatedNestedSql.buildSqlRules();
+
+      expect(rules.sql_root).toBeDefined();
+      expect(rules.sql_string).toBeDefined();
+      // Since string and strings are undefined, the sql_string state should just have the two lookahead rules
+      expect(rules.sql_string.length).toBe(2);
+    });
+  });
+
+  describe('sqlLanguageAttributes', () => {
+    it('exports keywords and builtinFunctions', () => {
+      expect(sqlLanguageAttributes.keywords).toEqual(keywords);
+      expect(sqlLanguageAttributes.builtinFunctions).toEqual(builtinFunctions);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_sql.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_sql.ts
@@ -8,6 +8,10 @@
  */
 
 import { lexerRules as sqlLexerRules, keywords, builtinFunctions } from '../../sql/lexer_rules';
+import { languageTolerantRules } from './constants';
+import { remapStringsToNestedState } from './utils/remap_strings_to_nested_state';
+import type { monaco } from '../../monaco_imports';
+
 /*
  * This rule is used inside json root to start a sql highlighting sequence
  */
@@ -32,8 +36,13 @@ export const buildSqlStartRule = (sqlRoot: string = 'sql_root') => {
  * It reuses the lexer ruls from the "sql" language, but since not all rules are referenced in the root
  * tokenizer and to avoid conflicts with existing console rules, only selected rules are used.
  */
-export const buildSqlRules = (sqlRoot: string = 'sql_root') => {
-  const { root, comment, numbers } = sqlLexerRules.tokenizer;
+export const buildSqlRules = (
+  sqlRoot: string = 'sql_root'
+): Record<string, monaco.languages.IMonarchLanguageRule[]> => {
+  const { root, comment, numbers, strings, string: sqlString } = sqlLexerRules.tokenizer;
+
+  const remappedStrings = remapStringsToNestedState(strings, '@sql_string');
+
   return {
     [sqlRoot]: [
       // the rule to end sql highlighting and get back to the previous tokenizer state
@@ -44,8 +53,16 @@ export const buildSqlRules = (sqlRoot: string = 'sql_root') => {
           next: '@pop',
         },
       ],
+      ...languageTolerantRules,
       ...root,
       ...numbers,
+      ...remappedStrings,
+      [/./, 'text'],
+    ],
+    sql_string: [
+      [/(?=""")/, { token: '', next: '@pop' }],
+      [/(?=")/, { token: '', next: '@pop' }],
+      ...(Array.isArray(sqlString) ? sqlString : []),
     ],
     comment,
   };

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/shared.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/shared.test.ts
@@ -192,7 +192,9 @@ describe('Lexer rule composition', () => {
   });
 
   it('json_root brace rules do not use @push/@pop', () => {
-    const jsonRoot = (consoleSharedLexerRules.tokenizer as any).json_root as any[];
+    const jsonRoot = (
+      consoleSharedLexerRules.tokenizer as Record<string, monaco.languages.IMonarchLanguageRule[]>
+    ).json_root;
 
     const braceRules = jsonRoot.filter((rule) => {
       const regex = Array.isArray(rule) ? rule[0] : rule?.regex;
@@ -208,7 +210,9 @@ describe('Lexer rule composition', () => {
   });
 
   it('json_root includes the Console-specific closing brace EOL rule', () => {
-    const jsonRoot = (consoleSharedLexerRules.tokenizer as any).json_root as any[];
+    const jsonRoot = (
+      consoleSharedLexerRules.tokenizer as Record<string, monaco.languages.IMonarchLanguageRule[]>
+    ).json_root;
 
     const hasRule = jsonRoot.some((rule) => {
       const regex = Array.isArray(rule) ? rule[0] : rule?.regex;
@@ -216,5 +220,75 @@ describe('Lexer rule composition', () => {
     });
 
     expect(hasRule).toBe(true);
+  });
+
+  it('correctly handles non-ASCII characters and apostrophes in "query" fields', () => {
+    const text = `GET _search
+{
+  "query": "Je cherche des vêtements d'été pour la plage",
+  "query": """Je cherche des vêtements d'été pour la plage""",
+  "query": "поиск"
+}`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+
+    for (const lineTokens of tokenizedLines) {
+      for (const token of lineTokens) {
+        // Assert no 'invalid' tokens are generated for these cases
+        expect(token.type).not.toContain('invalid');
+      }
+    }
+  });
+
+  it('correctly groups mixed alphanumeric words without splitting them into numbers', () => {
+    const text = `GET _search
+{
+  "query": "L 1aB8 cD 6e F3gH0jS5wY xQ9mP 7"
+}`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+    const getLine = getLineTokens(tokenizedLines, text);
+
+    const queryLineText = '  "query": "L 1aB8 cD 6e F3gH0jS5wY xQ9mP 7"';
+    const queryLine = getLine(queryLineText);
+
+    const oneAB8Token = queryLine.find(({ offset }) =>
+      queryLineText.substring(offset).startsWith('1aB8')
+    );
+    expect(oneAB8Token).toBeDefined();
+    // It should be treated as an identifier, not a number, so it shouldn't be split
+    expect(oneAB8Token?.type).toContain('identifier');
+
+    // 7 at the end should still be a number because it's just digits
+    const sevenToken = queryLine.find(({ offset }) =>
+      queryLineText.substring(offset).startsWith('7"')
+    );
+    expect(sevenToken).toBeDefined();
+    expect(sevenToken?.type).toContain('number');
+  });
+
+  it('correctly highlights KQL/Lucene syntax inside "query" fields', () => {
+    const text = `GET _search
+{
+  "query": "(information retrieval) OR (artificial intelligence)"
+}`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+    const getLine = getLineTokens(tokenizedLines, text);
+
+    const queryLineText = '  "query": "(information retrieval) OR (artificial intelligence)"';
+    const queryLine = getLine(queryLineText);
+
+    const orToken = queryLine.find(({ offset }) =>
+      queryLineText.substring(offset).startsWith('OR')
+    );
+    expect(orToken).toBeDefined();
+    expect(orToken?.type).toContain('keyword'); // OR should be a keyword
+
+    const bracketToken = queryLine.find(({ offset }) =>
+      queryLineText.substring(offset).startsWith('(')
+    );
+    expect(bracketToken).toBeDefined();
+    expect(bracketToken?.type).toContain('paren'); // brackets should be recognized (either paren or bracket type depending on the lexer)
   });
 });

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/shared.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/shared.ts
@@ -128,7 +128,7 @@ xjsonRules.json_root = [
   // @ts-expect-error include a rule to start esql highlighting
   buildEsqlStartRule(true),
   // Include remaining xjson rules, filtering out the original brace rules
-  ...originalJsonRoot.filter((rule: any) => {
+  ...originalJsonRoot.filter((rule) => {
     // Filter out the original @push/@pop brace rules from xjson
     if (Array.isArray(rule) && rule.length >= 2) {
       const regex = rule[0];
@@ -153,8 +153,8 @@ const esqlRules = buildEsqlRules();
 /*
  Lexer rules that are shared between the Console editor and the Console output panel.
  */
-export const consoleSharedLexerRules: monaco.languages.IMonarchLanguage = {
-  ...(globals as any),
+export const consoleSharedLexerRules = {
+  ...globals,
   defaultToken: 'invalid',
   ...sqlLanguageAttributes,
   ...painlessLanguageAttributes,
@@ -196,4 +196,7 @@ export const consoleSharedLexerRules: monaco.languages.IMonarchLanguage = {
     // include esql rules
     ...esqlRules,
   },
-};
+  // Monarch rules are written as array literals (e.g. [/regex/, action]) which TypeScript
+  // infers as general arrays, not tuples. The IMonarchLanguageRule union requires tuples,
+  // so the tokenizer shape cannot satisfy IMonarchLanguage without a type-level override.
+} as monaco.languages.IMonarchLanguage;

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/utils/remap_strings_to_nested_state.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/utils/remap_strings_to_nested_state.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { remapStringsToNestedState } from './remap_strings_to_nested_state';
+import type { monaco } from '../../../monaco_imports';
+
+describe('remapStringsToNestedState', () => {
+  it('handles empty or undefined rules array', () => {
+    expect(remapStringsToNestedState(undefined, '@nested_string')).toEqual([]);
+    expect(remapStringsToNestedState([], '@nested_string')).toEqual([]);
+  });
+
+  it('leaves non-array rules unmodified', () => {
+    const rules: monaco.languages.IMonarchLanguageRule[] = [{ include: '@comments' }];
+    expect(remapStringsToNestedState(rules, '@nested_string')).toEqual(rules);
+  });
+
+  it('leaves string action rules unmodified', () => {
+    const rules: monaco.languages.IMonarchLanguageRule[] = [[/"/, 'string']];
+    expect(remapStringsToNestedState(rules, '@nested_string')).toEqual(rules);
+  });
+
+  it('leaves object action rules without next:@string unmodified', () => {
+    const rules: monaco.languages.IMonarchLanguageRule[] = [
+      [/"/, { token: 'string', next: '@other' }],
+      [/"/, { token: 'string' }],
+    ];
+    expect(remapStringsToNestedState(rules, '@nested_string')).toEqual(rules);
+  });
+
+  it('remaps rules with next:@string to the nested state', () => {
+    const rules: monaco.languages.IMonarchLanguageRule[] = [
+      [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
+    ];
+    const remapped = remapStringsToNestedState(rules, '@nested_string');
+    expect(remapped).toEqual([
+      [/"/, { token: 'string.quote', bracket: '@open', next: '@nested_string' }],
+    ]);
+  });
+});

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/utils/remap_strings_to_nested_state.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/utils/remap_strings_to_nested_state.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { monaco } from '../../../monaco_imports';
+
+/**
+ * Rewrites string-entry rules so that `next: '@string'` points to a nested
+ * state instead, avoiding conflicts with the Console JSON `@string` state.
+ *
+ * The function narrows `IMonarchLanguageAction` through runtime checks so that
+ * the returned rules are fully typed without assertions or wide types.
+ */
+export const remapStringsToNestedState = (
+  rules: monaco.languages.IMonarchLanguageRule[] = [],
+  nestedState: string
+): monaco.languages.IMonarchLanguageRule[] => {
+  return rules.map((rule) => {
+    if (!Array.isArray(rule) || rule.length < 2) return rule;
+
+    const regex = rule[0];
+    const action = rule[1];
+
+    if (typeof action === 'string' || Array.isArray(action) || action.next !== '@string') {
+      return rule;
+    }
+
+    const remapped: monaco.languages.IShortMonarchLanguageRule1 = [
+      regex,
+      { ...action, next: nestedState },
+    ];
+    return remapped;
+  });
+};

--- a/src/platform/packages/shared/kbn-monaco/src/painless/lexer_rules/painless.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/painless/lexer_rules/painless.ts
@@ -11,7 +11,7 @@ import { monaco } from '../../monaco_imports';
 
 export interface Language extends monaco.languages.IMonarchLanguage {
   default: string;
-  brackets: any;
+  brackets: monaco.languages.IMonarchLanguage['brackets'];
   keywords: string[];
   symbols: RegExp;
   escapes: RegExp;
@@ -23,13 +23,13 @@ export interface Language extends monaco.languages.IMonarchLanguage {
   operators: string[];
 }
 
-export const lexerRules = {
+export const lexerRules: Language = {
   default: '',
   // painless does not use < >, so we define our own
   brackets: [
-    ['{', '}', 'delimiter.curly'],
-    ['[', ']', 'delimiter.square'],
-    ['(', ')', 'delimiter.parenthesis'],
+    { open: '{', close: '}', token: 'delimiter.curly' },
+    { open: '[', close: ']', token: 'delimiter.square' },
+    { open: '(', close: ')', token: 'delimiter.parenthesis' },
   ],
   keywords: [
     'if',
@@ -169,7 +169,7 @@ export const lexerRules = {
       [/'/, 'string', '@pop'],
     ],
   },
-} as Language;
+};
 
 export const languageConfiguration: monaco.languages.LanguageConfiguration = {
   brackets: [

--- a/src/platform/packages/shared/kbn-monaco/src/xjson/lexer_rules/xjson.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/xjson/lexer_rules/xjson.ts
@@ -104,14 +104,15 @@ export const buildXjsonRules = (root: string = 'root') => {
     ],
   };
 };
-export const lexerRules: monaco.languages.IMonarchLanguage = {
-  ...(globals as any),
-
+// Monarch rules are written as array literals (e.g. [/regex/, action]) which TypeScript
+// infers as general arrays, not tuples. The IMonarchLanguageRule union requires tuples,
+// so the tokenizer shape cannot satisfy IMonarchLanguage without a type-level override.
+export const lexerRules = {
+  ...globals,
   defaultToken: 'invalid',
   tokenPostfix: '',
-
   tokenizer: { ...buildXjsonRules() },
-};
+} as monaco.languages.IMonarchLanguage;
 
 export const languageConfiguration: monaco.languages.LanguageConfiguration = {
   brackets: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix syntax highlighting for strings with unicode characters (#255649)](https://github.com/elastic/kibana/pull/255649)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-03-05T12:58:35Z","message":"[Console] Fix syntax highlighting for strings with unicode characters (#255649)\n\nAddresses #232836\n\n## Summary\n- Fixes an issue in Dev Tools Console where syntax highlighting would\nbreak (turn white or dark) when typing strings containing accented\ncharacters (like `é`, `ê`), non-ASCII characters (Cyrillic, CJK), or\nmixed alphanumeric words (like `1aB8`).\n- Fixes an issue where the string highlighting context would incorrectly\npop states when encountering nested strings.\n- Replaced wide TypeScript types (`any`, `unknown`) across the lexer\nconfiguration to strictly conform to `IMonarchLanguage`.\n\n## Root Cause\n- The lexer rules for Monaco didn't account for unicode characters when\nidentifying identifiers or numbers, causing characters to be classified\nas `invalid` or incorrectly split. This caused visual glitches and input\nlag.\n- The ES|QL and SQL nested string lexer states collided with the global\nJSON string states, causing improper state pops when quotes were\nencountered inside query strings.\n\n## Fix\n- Added `languageTolerantRules` to properly classify words with unicode\ncharacters, apostrophes, and mixed alphanumerics as identifiers instead\nof invalid tokens.\n- Refactored `nested_esql.ts`, `nested_sql.ts`, and `nested_painless.ts`\nto properly isolate string states.\n- Cleaned up loose types (`any`, `unknown`) across the lexer\nconfigurations.\n- Added comprehensive unit tests for the lexer rules and utilities.\n\n## Screenshots\n\n### Before\n\n<img width=\"1719\" height=\"1399\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/554c71c7-0227-4a5e-8468-0b926709f871\"\n/>\n\n### After\n\n<img width=\"1715\" height=\"1411\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ef0bedaa-fb8c-4e22-a27e-4a88335bce3f\"\n/>\n\n\n## Test Plan\n- Run tests: `yarn test:jest\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/`\n- Manual verification:\n  1. Open the Dev Tools Console in Kibana.\n  2. Paste the original reproduction example from the issue:\n     ```json\n     GET adeoproducts7/_search\n     {\n       \"size\": 10,\n       \"_source\": {\n         \"exclude_vectors\": \"true\"\n       },\n       \"retriever\": {\n         \"rrf\": {\n           \"query\": \"Je cherche des vêtements d'été pour la plage\",\n           \"fields\": [\n             \"description\",\n             \"description.semantic_googlvertexai\"\n           ],\n           \"rank_constant\": 60,\n           \"rank_window_size\": 100\n         }  \n       },\n       \"highlight\": {\n         \"fields\": {\n           \"description.semantic_googlvertexai\": {\n             \"number_of_fragments\": 2,\n             \"order\": \"score\"\n           }\n         }\n       }\n     }\n     \n     GET adeoproducts7/_search\n     {\n       \"size\": 10,\n       \"_source\": {\n         \"exclude_vectors\": \"true\"\n       },\n       \"retriever\": {\n         \"text_similarity_reranker\": {\n           \"retriever\": {\n             \"rrf\": {\n               \"query\": \"Je cherche des vêtements d'été pour la plage\",\n               \"fields\": [\n                 \"description\",\n                 \"description.semantic_googlvertexai\"\n               ],\n               \"rank_constant\": 60,\n               \"rank_window_size\": 100\n             }\n           },\n           \"inference_id\": \"google_vertex_ai_rerank\",\n\"inference_text\": \"Je cherche des vêtements d'été pour la plage\",\n           \"field\": \"description\"\n         }\n       },\n       \"highlight\": {\n         \"fields\": {\n           \"description.semantic_googlvertexai\": {\n             \"number_of_fragments\": 2,\n             \"order\": \"score\"\n           }\n         }\n       }\n     }\n     ```\n3. Verify that the string `\"Je cherche des vêtements d'été pour la\nplage\"` stays properly highlighted (usually green) and doesn't break\ninto uncolored text.\n4. Verify that mixed alphanumerics (e.g. `1aB8`) don't break\nhighlighting.\n5. Verify that standard KQL/Lucene queries inside `query` strings still\nmaintain their syntax coloring by pasting this snippet:\n     ```json\n     GET _search\n     {\n       \"query\": \"(information retrieval) OR (artificial intelligence)\"\n     }\n     ```\nYou should see `OR` highlighted as a keyword (different color from the\nrest of the string) and the parentheses `()` recognized.\n\n## Release note\nFixes an issue in Dev Tools Console where syntax highlighting broke when\nqueries contained accented or non-ASCII characters.\n\n","sha":"457cf04dd523b469378e9d015131f205f08acbaa","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","release_note:fix","Team:Kibana Management","backport:all-open","v9.4.0","v9.2.7","v9.3.2"],"title":"[Console] Fix syntax highlighting for strings with unicode characters","number":255649,"url":"https://github.com/elastic/kibana/pull/255649","mergeCommit":{"message":"[Console] Fix syntax highlighting for strings with unicode characters (#255649)\n\nAddresses #232836\n\n## Summary\n- Fixes an issue in Dev Tools Console where syntax highlighting would\nbreak (turn white or dark) when typing strings containing accented\ncharacters (like `é`, `ê`), non-ASCII characters (Cyrillic, CJK), or\nmixed alphanumeric words (like `1aB8`).\n- Fixes an issue where the string highlighting context would incorrectly\npop states when encountering nested strings.\n- Replaced wide TypeScript types (`any`, `unknown`) across the lexer\nconfiguration to strictly conform to `IMonarchLanguage`.\n\n## Root Cause\n- The lexer rules for Monaco didn't account for unicode characters when\nidentifying identifiers or numbers, causing characters to be classified\nas `invalid` or incorrectly split. This caused visual glitches and input\nlag.\n- The ES|QL and SQL nested string lexer states collided with the global\nJSON string states, causing improper state pops when quotes were\nencountered inside query strings.\n\n## Fix\n- Added `languageTolerantRules` to properly classify words with unicode\ncharacters, apostrophes, and mixed alphanumerics as identifiers instead\nof invalid tokens.\n- Refactored `nested_esql.ts`, `nested_sql.ts`, and `nested_painless.ts`\nto properly isolate string states.\n- Cleaned up loose types (`any`, `unknown`) across the lexer\nconfigurations.\n- Added comprehensive unit tests for the lexer rules and utilities.\n\n## Screenshots\n\n### Before\n\n<img width=\"1719\" height=\"1399\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/554c71c7-0227-4a5e-8468-0b926709f871\"\n/>\n\n### After\n\n<img width=\"1715\" height=\"1411\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ef0bedaa-fb8c-4e22-a27e-4a88335bce3f\"\n/>\n\n\n## Test Plan\n- Run tests: `yarn test:jest\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/`\n- Manual verification:\n  1. Open the Dev Tools Console in Kibana.\n  2. Paste the original reproduction example from the issue:\n     ```json\n     GET adeoproducts7/_search\n     {\n       \"size\": 10,\n       \"_source\": {\n         \"exclude_vectors\": \"true\"\n       },\n       \"retriever\": {\n         \"rrf\": {\n           \"query\": \"Je cherche des vêtements d'été pour la plage\",\n           \"fields\": [\n             \"description\",\n             \"description.semantic_googlvertexai\"\n           ],\n           \"rank_constant\": 60,\n           \"rank_window_size\": 100\n         }  \n       },\n       \"highlight\": {\n         \"fields\": {\n           \"description.semantic_googlvertexai\": {\n             \"number_of_fragments\": 2,\n             \"order\": \"score\"\n           }\n         }\n       }\n     }\n     \n     GET adeoproducts7/_search\n     {\n       \"size\": 10,\n       \"_source\": {\n         \"exclude_vectors\": \"true\"\n       },\n       \"retriever\": {\n         \"text_similarity_reranker\": {\n           \"retriever\": {\n             \"rrf\": {\n               \"query\": \"Je cherche des vêtements d'été pour la plage\",\n               \"fields\": [\n                 \"description\",\n                 \"description.semantic_googlvertexai\"\n               ],\n               \"rank_constant\": 60,\n               \"rank_window_size\": 100\n             }\n           },\n           \"inference_id\": \"google_vertex_ai_rerank\",\n\"inference_text\": \"Je cherche des vêtements d'été pour la plage\",\n           \"field\": \"description\"\n         }\n       },\n       \"highlight\": {\n         \"fields\": {\n           \"description.semantic_googlvertexai\": {\n             \"number_of_fragments\": 2,\n             \"order\": \"score\"\n           }\n         }\n       }\n     }\n     ```\n3. Verify that the string `\"Je cherche des vêtements d'été pour la\nplage\"` stays properly highlighted (usually green) and doesn't break\ninto uncolored text.\n4. Verify that mixed alphanumerics (e.g. `1aB8`) don't break\nhighlighting.\n5. Verify that standard KQL/Lucene queries inside `query` strings still\nmaintain their syntax coloring by pasting this snippet:\n     ```json\n     GET _search\n     {\n       \"query\": \"(information retrieval) OR (artificial intelligence)\"\n     }\n     ```\nYou should see `OR` highlighted as a keyword (different color from the\nrest of the string) and the parentheses `()` recognized.\n\n## Release note\nFixes an issue in Dev Tools Console where syntax highlighting broke when\nqueries contained accented or non-ASCII characters.\n\n","sha":"457cf04dd523b469378e9d015131f205f08acbaa"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255649","number":255649,"mergeCommit":{"message":"[Console] Fix syntax highlighting for strings with unicode characters (#255649)\n\nAddresses #232836\n\n## Summary\n- Fixes an issue in Dev Tools Console where syntax highlighting would\nbreak (turn white or dark) when typing strings containing accented\ncharacters (like `é`, `ê`), non-ASCII characters (Cyrillic, CJK), or\nmixed alphanumeric words (like `1aB8`).\n- Fixes an issue where the string highlighting context would incorrectly\npop states when encountering nested strings.\n- Replaced wide TypeScript types (`any`, `unknown`) across the lexer\nconfiguration to strictly conform to `IMonarchLanguage`.\n\n## Root Cause\n- The lexer rules for Monaco didn't account for unicode characters when\nidentifying identifiers or numbers, causing characters to be classified\nas `invalid` or incorrectly split. This caused visual glitches and input\nlag.\n- The ES|QL and SQL nested string lexer states collided with the global\nJSON string states, causing improper state pops when quotes were\nencountered inside query strings.\n\n## Fix\n- Added `languageTolerantRules` to properly classify words with unicode\ncharacters, apostrophes, and mixed alphanumerics as identifiers instead\nof invalid tokens.\n- Refactored `nested_esql.ts`, `nested_sql.ts`, and `nested_painless.ts`\nto properly isolate string states.\n- Cleaned up loose types (`any`, `unknown`) across the lexer\nconfigurations.\n- Added comprehensive unit tests for the lexer rules and utilities.\n\n## Screenshots\n\n### Before\n\n<img width=\"1719\" height=\"1399\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/554c71c7-0227-4a5e-8468-0b926709f871\"\n/>\n\n### After\n\n<img width=\"1715\" height=\"1411\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ef0bedaa-fb8c-4e22-a27e-4a88335bce3f\"\n/>\n\n\n## Test Plan\n- Run tests: `yarn test:jest\nsrc/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/`\n- Manual verification:\n  1. Open the Dev Tools Console in Kibana.\n  2. Paste the original reproduction example from the issue:\n     ```json\n     GET adeoproducts7/_search\n     {\n       \"size\": 10,\n       \"_source\": {\n         \"exclude_vectors\": \"true\"\n       },\n       \"retriever\": {\n         \"rrf\": {\n           \"query\": \"Je cherche des vêtements d'été pour la plage\",\n           \"fields\": [\n             \"description\",\n             \"description.semantic_googlvertexai\"\n           ],\n           \"rank_constant\": 60,\n           \"rank_window_size\": 100\n         }  \n       },\n       \"highlight\": {\n         \"fields\": {\n           \"description.semantic_googlvertexai\": {\n             \"number_of_fragments\": 2,\n             \"order\": \"score\"\n           }\n         }\n       }\n     }\n     \n     GET adeoproducts7/_search\n     {\n       \"size\": 10,\n       \"_source\": {\n         \"exclude_vectors\": \"true\"\n       },\n       \"retriever\": {\n         \"text_similarity_reranker\": {\n           \"retriever\": {\n             \"rrf\": {\n               \"query\": \"Je cherche des vêtements d'été pour la plage\",\n               \"fields\": [\n                 \"description\",\n                 \"description.semantic_googlvertexai\"\n               ],\n               \"rank_constant\": 60,\n               \"rank_window_size\": 100\n             }\n           },\n           \"inference_id\": \"google_vertex_ai_rerank\",\n\"inference_text\": \"Je cherche des vêtements d'été pour la plage\",\n           \"field\": \"description\"\n         }\n       },\n       \"highlight\": {\n         \"fields\": {\n           \"description.semantic_googlvertexai\": {\n             \"number_of_fragments\": 2,\n             \"order\": \"score\"\n           }\n         }\n       }\n     }\n     ```\n3. Verify that the string `\"Je cherche des vêtements d'été pour la\nplage\"` stays properly highlighted (usually green) and doesn't break\ninto uncolored text.\n4. Verify that mixed alphanumerics (e.g. `1aB8`) don't break\nhighlighting.\n5. Verify that standard KQL/Lucene queries inside `query` strings still\nmaintain their syntax coloring by pasting this snippet:\n     ```json\n     GET _search\n     {\n       \"query\": \"(information retrieval) OR (artificial intelligence)\"\n     }\n     ```\nYou should see `OR` highlighted as a keyword (different color from the\nrest of the string) and the parentheses `()` recognized.\n\n## Release note\nFixes an issue in Dev Tools Console where syntax highlighting broke when\nqueries contained accented or non-ASCII characters.\n\n","sha":"457cf04dd523b469378e9d015131f205f08acbaa"}},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/256229","number":256229,"state":"MERGED","mergeCommit":{"sha":"6b3292989d4467d90422ebbaee2d2887a6d55fbb","message":"[9.2] [Console] Fix syntax highlighting for strings with unicode characters (#255649) (#256229)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Console] Fix syntax highlighting for strings with unicode characters\n(#255649)](https://github.com/elastic/kibana/pull/255649)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/256231","number":256231,"state":"MERGED","mergeCommit":{"sha":"b9de2c8a0418cfa0b8f18840fff59727e43e67c0","message":"[9.3] [Console] Fix syntax highlighting for strings with unicode characters (#255649) (#256231)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Console] Fix syntax highlighting for strings with unicode characters\n(#255649)](https://github.com/elastic/kibana/pull/255649)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>"}}]}] BACKPORT-->