### PR TITLE
[8.19] chore(NA): add missing timeouts in cypress tests

### DIFF
--- a/.buildkite/pipelines/pull_request/observability_onboarding_cypress.yml
+++ b/.buildkite/pipelines/pull_request/observability_onboarding_cypress.yml
@@ -7,7 +7,7 @@ steps:
       preemptible: true
     depends_on:
       - build
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/profiling_cypress.yml
+++ b/.buildkite/pipelines/pull_request/profiling_cypress.yml
@@ -8,7 +8,7 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
     depends_on:
       - build
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     parallelism: 3
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -9,6 +9,7 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
       - build
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -7,6 +7,7 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
       - build
+    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
This PR adds timeouts for buildkite steps in places where they were missing in 8.19 branch.