### PR TITLE
fix(dev,ci): fix Scout Test Run config script location for the Cosmos DB emulator verification pipeline

### DIFF
--- a/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
+++ b/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
@@ -45,7 +45,7 @@ steps:
     env:
       UIAM_COSMOSDB_DOCKER_IMAGE: $UIAM_COSMOSDB_IMAGE
       SERVERLESS_TESTS_ONLY: 'true'
-      SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
+      SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
## Summary

Fix Scout Test Run config script location for the Cosmos DB emulator verification pipeline. 

The second part of https://github.com/elastic/kibana/pull/255340

Verified in https://buildkite.com/elastic/kibana-uiam-cosmos-db-emulator-verify-and-promote/builds/3