### PR TITLE
Skip flaky Dataset Quality test (Stateful)

### DIFF
--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
@@ -942,7 +942,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
           expect(linkURL?.includes('mapping')).to.be(true);
         });
 
-        it('should display increase field limit as a possible mitigation for special packages like apm app', async () => {
+        it.skip('should display increase field limit as a possible mitigation for special packages like apm app', async () => {
           await PageObjects.datasetQuality.navigateToDetails({
             dataStream: apmAppDataStreamName,
             expandedDegradedField: 'cloud.project',


### PR DESCRIPTION
Follow up after https://github.com/elastic/kibana/pull/256176 to also skip the same test for stateful.