### PR TITLE
[Infra] Fix asset details locator params in custom dashboards

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/dashboards/dashboards.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/dashboards/dashboards.tsx
@@ -168,8 +168,8 @@ export function Dashboards() {
 
       return {
         assetDetails: { ...urlState, dashboardId: params.dashboardId },
-        assetType: entity.type,
-        assetId: entity.id,
+        entityType: entity.type,
+        entityId: entity.id,
         ...flyoutParams,
       };
     },

--- a/x-pack/solutions/observability/plugins/observability_shared/common/locators/infra/asset_details_locator.ts
+++ b/x-pack/solutions/observability/plugins/observability_shared/common/locators/infra/asset_details_locator.ts
@@ -54,6 +54,14 @@ export class AssetDetailsLocatorDefinition implements LocatorDefinition<AssetDet
   public readonly getLocation = async (
     params: AssetDetailsLocatorParams & { state?: SerializableRecord }
   ) => {
+    if (!params.entityType || !params.entityId) {
+      return {
+        app: 'metrics',
+        path: '/inventory',
+        state: {},
+      };
+    }
+
     // Check which asset types are currently supported
     const isSupportedByAssetDetails = Object.values(SupportedEntityTypes).includes(
       params.entityType as SupportedEntityTypes


### PR DESCRIPTION
## Summary

Closes #256161.

Fixes a crash (`"The inventory model you've attempted to find does not exist"`) that occurred when navigating from the **Dashboards** tab in the Infrastructure asset detail page.

### Root cause

The `getLocatorParams` function in the Dashboards tab component (`dashboards.tsx`) was passing `assetType` and `assetId` to the `ASSET_DETAILS_LOCATOR`, but the locator expects `entityType` and `entityId`. Because the expected properties were missing from the params, both resolved to `undefined`, producing a broken URL:

```
/app/metrics/detail/undefined/undefined
```

When this URL was matched by the router, `findInventoryModel("undefined")` threw because `"undefined"` is not a valid inventory type (`host`, `pod`, `container`, `awsEC2`, etc.).

### Changes

| File | Change | Purpose |
|------|--------|---------|
| `infra/.../dashboards/dashboards.tsx` | `assetType` → `entityType`, `assetId` → `entityId` | **Root cause fix** — passes the correct property names to the locator so the generated URL contains the actual entity type and ID |
| `observability_shared/.../asset_details_locator.ts` | Added early return to `/inventory` when `entityType` or `entityId` is falsy | **Defense in depth** — the locator will never produce `/detail/undefined/...` URLs, even if a caller passes missing params in the future |

### How to reproduce (before fix)

1. Navigate to **Infrastructure → Hosts** → click a host → **Open as page**
2. Go to the **Dashboards** tab (requires `observability:enableInfrastructureAssetCustomDashboards` advanced setting enabled)
3. Link any dashboard
4. Do a console.log in `x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/dashboards/dashboards.tsx` -> `console.log('locator', locator.getRedirectUrl({ dashboardId: '123' }));` in L196
 You can copy the URL from the console.log and navigate to a new tab, and you should see "detail/undefined/undefined..." (make sure you are not checked out to this branch)

### How to verify (after fix)

1. Same steps as above — the navigation works correctly and the URL contains the proper entity type and ID


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->