### PR TITLE
[a11y] Remove no-op onClick handlers from connector stats badges

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connector_stats.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connector_stats.tsx
@@ -29,15 +29,12 @@ import { FetchSyncJobsStatsApiLogic } from '../../api/stats/fetch_sync_jobs_stat
 import {
   getConnectedConnectorsBadgeLabel,
   getConnectedConnectorsTooltipContent,
-  getConnectedBadgeAriaLabel,
   getIncompleteConnectorsBadgeLabel,
-  getIncompleteConnectorBadgeAriaLabel,
   getIncompleteConnectorsTooltip,
   getIdleJobsLabel,
   getIdleJobsTooltip,
   getOrphanedJobsLabel,
   getOrphanedJobsTooltip,
-  getRunningJobsBadgeAriaLabel,
   getRunningJobsBadgeLabel,
   getRunningJobsLabel,
   getRunningJobsTooltip,
@@ -127,11 +124,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getConnectedConnectorsTooltipContent(connectedCount, isCrawler)}
             >
-              <EuiBadge
-                color="success"
-                onClick={() => {}}
-                onClickAriaLabel={getConnectedBadgeAriaLabel(connectedCount)}
-              >
+              <EuiBadge color="success">
                 {getConnectedConnectorsBadgeLabel(connectedCount)}
               </EuiBadge>
             </EuiToolTip>
@@ -140,11 +133,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getIncompleteConnectorsTooltip(incompleteCount, isCrawler)}
             >
-              <EuiBadge
-                color="warning"
-                onClick={() => {}}
-                onClickAriaLabel={getIncompleteConnectorBadgeAriaLabel(incompleteCount)}
-              >
+              <EuiBadge color="warning">
                 {getIncompleteConnectorsBadgeLabel(incompleteCount)}
               </EuiBadge>
             </EuiToolTip>
@@ -175,17 +164,14 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getRunningJobsTooltip(inProgressCount, isCrawler)}
             >
-              <EuiBadge
-                onClick={() => {}}
-                onClickAriaLabel={getRunningJobsBadgeAriaLabel(inProgressCount, isCrawler)}
-              >
+              <EuiBadge>
                 {getRunningJobsBadgeLabel(inProgressCount, isCrawler)}
               </EuiBadge>
             </EuiToolTip>
 
             {!isCrawler && (
               <EuiToolTip anchorProps={tooltipAncherProps} content={getIdleJobsTooltip(idleCount)}>
-                <EuiBadge onClick={() => {}} onClickAriaLabel={getIdleJobsLabel(idleCount)}>
+                <EuiBadge>
                   {getIdleJobsLabel(idleCount)}
                 </EuiBadge>
               </EuiToolTip>
@@ -195,10 +181,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getOrphanedJobsTooltip(orphanedCount, isCrawler)}
             >
-              <EuiBadge
-                onClick={() => {}}
-                onClickAriaLabel={getOrphanedJobsLabel(orphanedCount, isCrawler)}
-              >
+              <EuiBadge>
                 {getOrphanedJobsLabel(orphanedCount, isCrawler)}
               </EuiBadge>
             </EuiToolTip>
@@ -207,11 +190,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getSyncJobErrorsTooltip(errorCount, isCrawler)}
             >
-              <EuiBadge
-                onClick={() => {}}
-                onClickAriaLabel={getSyncJobErrorsLabel(errorCount, isCrawler)}
-                color={errorCount > 0 ? 'danger' : 'default'}
-              >
+              <EuiBadge color={errorCount > 0 ? 'danger' : 'default'}>
                 {getSyncJobErrorsLabel(errorCount, isCrawler)}
               </EuiBadge>
             </EuiToolTip>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connector_stats.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connector_stats.tsx
@@ -164,16 +164,12 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getRunningJobsTooltip(inProgressCount, isCrawler)}
             >
-              <EuiBadge>
-                {getRunningJobsBadgeLabel(inProgressCount, isCrawler)}
-              </EuiBadge>
+              <EuiBadge>{getRunningJobsBadgeLabel(inProgressCount, isCrawler)}</EuiBadge>
             </EuiToolTip>
 
             {!isCrawler && (
               <EuiToolTip anchorProps={tooltipAncherProps} content={getIdleJobsTooltip(idleCount)}>
-                <EuiBadge>
-                  {getIdleJobsLabel(idleCount)}
-                </EuiBadge>
+                <EuiBadge>{getIdleJobsLabel(idleCount)}</EuiBadge>
               </EuiToolTip>
             )}
 
@@ -181,9 +177,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getOrphanedJobsTooltip(orphanedCount, isCrawler)}
             >
-              <EuiBadge>
-                {getOrphanedJobsLabel(orphanedCount, isCrawler)}
-              </EuiBadge>
+              <EuiBadge>{getOrphanedJobsLabel(orphanedCount, isCrawler)}</EuiBadge>
             </EuiToolTip>
 
             <EuiToolTip

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -167,16 +167,12 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getRunningJobsTooltip(inProgressCount, isCrawler)}
             >
-              <EuiBadge>
-                {getRunningJobsBadgeLabel(inProgressCount, isCrawler)}
-              </EuiBadge>
+              <EuiBadge>{getRunningJobsBadgeLabel(inProgressCount, isCrawler)}</EuiBadge>
             </EuiToolTip>
 
             {!isCrawler && (
               <EuiToolTip anchorProps={tooltipAncherProps} content={getIdleJobsTooltip(idleCount)}>
-                <EuiBadge>
-                  {getIdleJobsLabel(idleCount)}
-                </EuiBadge>
+                <EuiBadge>{getIdleJobsLabel(idleCount)}</EuiBadge>
               </EuiToolTip>
             )}
 
@@ -184,9 +180,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getOrphanedJobsTooltip(orphanedCount, isCrawler)}
             >
-              <EuiBadge>
-                {getOrphanedJobsLabel(orphanedCount, isCrawler)}
-              </EuiBadge>
+              <EuiBadge>{getOrphanedJobsLabel(orphanedCount, isCrawler)}</EuiBadge>
             </EuiToolTip>
 
             <EuiToolTip

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -28,15 +28,12 @@ import { FetchSyncJobsStatsApiLogic } from '../../api/stats/fetch_sync_jobs_stat
 import {
   getConnectedConnectorsBadgeLabel,
   getConnectedConnectorsTooltipContent,
-  getConnectedBadgeAriaLabel,
   getIncompleteConnectorsBadgeLabel,
-  getIncompleteConnectorBadgeAriaLabel,
   getIncompleteConnectorsTooltip,
   getIdleJobsLabel,
   getIdleJobsTooltip,
   getOrphanedJobsLabel,
   getOrphanedJobsTooltip,
-  getRunningJobsBadgeAriaLabel,
   getRunningJobsBadgeLabel,
   getRunningJobsLabel,
   getRunningJobsTooltip,
@@ -130,11 +127,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getConnectedConnectorsTooltipContent(connectedCount, isCrawler)}
             >
-              <EuiBadge
-                color="success"
-                onClick={() => {}}
-                onClickAriaLabel={getConnectedBadgeAriaLabel(connectedCount)}
-              >
+              <EuiBadge color="success">
                 {getConnectedConnectorsBadgeLabel(connectedCount)}
               </EuiBadge>
             </EuiToolTip>
@@ -143,11 +136,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getIncompleteConnectorsTooltip(incompleteCount, isCrawler)}
             >
-              <EuiBadge
-                color="warning"
-                onClick={() => {}}
-                onClickAriaLabel={getIncompleteConnectorBadgeAriaLabel(incompleteCount)}
-              >
+              <EuiBadge color="warning">
                 {getIncompleteConnectorsBadgeLabel(incompleteCount)}
               </EuiBadge>
             </EuiToolTip>
@@ -178,17 +167,14 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getRunningJobsTooltip(inProgressCount, isCrawler)}
             >
-              <EuiBadge
-                onClick={() => {}}
-                onClickAriaLabel={getRunningJobsBadgeAriaLabel(inProgressCount, isCrawler)}
-              >
+              <EuiBadge>
                 {getRunningJobsBadgeLabel(inProgressCount, isCrawler)}
               </EuiBadge>
             </EuiToolTip>
 
             {!isCrawler && (
               <EuiToolTip anchorProps={tooltipAncherProps} content={getIdleJobsTooltip(idleCount)}>
-                <EuiBadge onClick={() => {}} onClickAriaLabel={getIdleJobsLabel(idleCount)}>
+                <EuiBadge>
                   {getIdleJobsLabel(idleCount)}
                 </EuiBadge>
               </EuiToolTip>
@@ -198,10 +184,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getOrphanedJobsTooltip(orphanedCount, isCrawler)}
             >
-              <EuiBadge
-                onClick={() => {}}
-                onClickAriaLabel={getOrphanedJobsLabel(orphanedCount, isCrawler)}
-              >
+              <EuiBadge>
                 {getOrphanedJobsLabel(orphanedCount, isCrawler)}
               </EuiBadge>
             </EuiToolTip>
@@ -210,11 +193,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
               anchorProps={tooltipAncherProps}
               content={getSyncJobErrorsTooltip(errorCount, isCrawler)}
             >
-              <EuiBadge
-                onClick={() => {}}
-                onClickAriaLabel={getSyncJobErrorsLabel(errorCount, isCrawler)}
-                color={errorCount > 0 ? 'danger' : 'default'}
-              >
+              <EuiBadge color={errorCount > 0 ? 'danger' : 'default'}>
                 {getSyncJobErrorsLabel(errorCount, isCrawler)}
               </EuiBadge>
             </EuiToolTip>


### PR DESCRIPTION
Badges on the Connectors and Web Crawlers pages were rendered as buttons because of empty onClick handlers, causing screen readers to incorrectly announce them as interactive. Removing onClick and onClickAriaLabel props makes them render as spans instead.

Closes #197396


