### PR TITLE
[SLO] update group by schema in SLO overview embeddable with remote

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
@@ -108,7 +108,12 @@ describe('schema validation', () => {
     });
 
     it('should validate group overview state with all group_by options', () => {
-      const groupByOptions = ['slo.tags', 'status', 'slo.indicator.type'] as const;
+      const groupByOptions = [
+        'slo.tags',
+        'status',
+        'slo.indicator.type',
+        '_index', // remote cluster
+      ] as const;
 
       groupByOptions.forEach((groupBy) => {
         const state = {
@@ -119,6 +124,26 @@ describe('schema validation', () => {
         };
 
         expect(() => overviewEmbeddableSchema.validate(state)).not.toThrow();
+      });
+    });
+
+    it('should validate group overview state with group_by _index (remote cluster)', () => {
+      const state = {
+        group_filters: {
+          group_by: '_index' as const,
+          groups: ['remote-cluster-1', 'remote-cluster-2'],
+        },
+        overview_mode: 'groups' as const,
+      };
+
+      expect(() => overviewEmbeddableSchema.validate(state)).not.toThrow();
+      const result = overviewEmbeddableSchema.validate(state);
+      expect(result).toMatchObject({
+        group_filters: {
+          group_by: '_index',
+          groups: ['remote-cluster-1', 'remote-cluster-2'],
+        },
+        overview_mode: 'groups',
       });
     });
 

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
@@ -36,6 +36,7 @@ const groupBySchema = schema.oneOf([
   schema.literal('slo.tags'),
   schema.literal('status'),
   schema.literal('slo.indicator.type'),
+  schema.literal('_index'), // remote cluster
 ]);
 
 const GroupOverviewCustomSchema = schema.object({


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/256419

This PR updates the schema of the SLO Overview embeddable to include `_index` (remote cluster).

<img width="400" height="443" alt="Screenshot 2026-03-06 at 12 56 21" src="https://github.com/user-attachments/assets/a74d5ec7-8f6b-4625-b47a-ef987fe2691c" />


<img width="400" height="366" alt="Screenshot 2026-03-06 at 12 57 01" src="https://github.com/user-attachments/assets/3eddd404-6794-4efb-957c-e574b5311ce9" />

## How to test
- Run oblt SLI
- Go to http://localhost:5601/app/slos/settings
- Enable `Use all remote clusters`
- Create some SLOs `node x-pack/scripts/data_forge.js --events-per-cycle 50 --lookback now-1d --dataset fake_stack --install-kibana-assets --event-template good`
- Go to Dashboard > Add panel > SLO overview > Grouped SLOs > group by `Remote cluster`
- Save the dashboard
- It should save successfully


## Acceptance criteria
- add `_index` (remote cluster) in the SLO overview schema group embeddable
- verify that a dashboard with a panel grouped by remote cluster saves successfully

