### PR TITLE
Inject origin-only project_routing into transport.request CPS call sites

### DIFF
--- a/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
@@ -119,7 +119,7 @@ export const esqlAsyncSearchStrategyProvider = (
       {
         method: 'POST',
         path: `/_query/async`,
-        body: params,
+        body: { project_routing: '_alias:_origin', ...params },
         querystring: dropNullColumns ? 'drop_null_columns' : '',
       },
       {

--- a/src/platform/plugins/shared/data/server/search/strategies/esql_search/esql_search_strategy.ts
+++ b/src/platform/plugins/shared/data/server/search/strategies/esql_search/esql_search_strategy.ts
@@ -44,6 +44,7 @@ export const esqlSearchStrategyProvider = (
             path: `/_query`,
             querystring: dropNullColumns ? 'drop_null_columns' : '',
             body: {
+              project_routing: '_alias:_origin',
               ...requestParams,
             },
           },

--- a/x-pack/platform/plugins/shared/maps/server/mvt/mvt_routes.ts
+++ b/x-pack/platform/plugins/shared/maps/server/mvt/mvt_routes.ts
@@ -230,6 +230,7 @@ async function getTile({
           method: 'POST',
           path,
           body,
+          querystring: { project_routing: '_alias:_origin' },
         },
         {
           signal: abortController.signal,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/elasticsearch.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/elasticsearch.ts
@@ -55,7 +55,11 @@ export function registerElasticsearchFunction({
       const response = await esClient.asCurrentUser.transport.request({
         method,
         path,
-        body,
+        // POST _search: inject project_routing for CPS (stripped automatically when CPS is disabled)
+        body:
+          isSearchEndpoint && method === 'POST'
+            ? { project_routing: '_alias:_origin', ...body }
+            : body,
       });
 
       return { content: { response } };

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/elasticsearch_retriever.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/elasticsearch_retriever.ts
@@ -75,6 +75,7 @@ export class ElasticsearchRetriever extends BaseRetriever {
         method: 'POST',
         path: `/${this.index}/_search`,
         body: {
+          project_routing: '_alias:_origin',
           ...queryBody,
           size: this.k,
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/esql_request.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/esql_request.ts
@@ -85,7 +85,7 @@ export const performEsqlRequest = async ({
     const asyncEsqlResponse = await esClient.transport.request<AsyncEsqlResponse>({
       method: 'POST',
       path: '/_query/async',
-      body: requestBody,
+      body: { project_routing: '_alias:_origin', ...requestBody },
       querystring: requestQueryParams,
     });
     setLatestRequestDuration(asyncSearchStarted, loggedRequests);


### PR DESCRIPTION
## Summary

Adds explicit `project_routing: '_alias:_origin'` to all `transport.request()` call sites that target ES APIs supporting CPS project routing. This ensures a safe default for these transport calls so that enabling CPS doesn't suddenly expand the scope in unintended ways.

**Approach:** We inject `project_routing` directly into the request body (or querystring for query-level APIs like `search_mvt`). The CPS request handler strips `project_routing` unconditionally when CPS is disabled, so this is safe in all environments. The default is set first in the object spread so any caller-provided `project_routing` takes precedence.

**Call sites updated (6):**
- `esql_search_strategy.ts` — `POST /_query` (body)
- `esql_async_search_strategy.ts` — `POST /_query/async` submit (body)
- `elasticsearch_retriever.ts` — `POST /{index}/_search` (body)
- `esql_request.ts` — `POST /_query/async` submit (body)
- `mvt_routes.ts` — `POST /{index}/_mvt/...` (querystring)
- `observability_ai_assistant elasticsearch.ts` — conditional for `POST _search` (body)

**Not updated:**
- `workflows_execution_engine` — fully dynamic paths, cannot determine API support at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>