### PR TITLE
[Streams] Fix TSDB Discover link in stream detail page header

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
@@ -170,6 +170,7 @@ export function Wrapper({
                     <DiscoverBadgeButton
                       stream={definition.stream}
                       hasDataStream={definition.data_stream_exists}
+                      indexMode={definition.index_mode}
                       spellOut
                     />
                   )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/discover_badge_button.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/discover_badge_button.test.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { Streams } from '@kbn/streams-schema';
+import { DiscoverBadgeButton } from '.';
+
+const mockUseUrl = jest.fn();
+
+jest.mock('../../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    dependencies: {
+      start: {
+        share: {
+          url: {
+            locators: {
+              useUrl: mockUseUrl,
+            },
+          },
+        },
+      },
+    },
+  }),
+}));
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+const createWiredStreamDefinition = (name: string): Streams.WiredStream.Definition => ({
+  name,
+  description: '',
+  updated_at: '2024-01-01T00:00:00.000Z',
+  ingest: {
+    lifecycle: { dsl: {} },
+    settings: {},
+    processing: {
+      updated_at: '2024-01-01T00:00:00.000Z',
+      steps: [],
+    },
+    failure_store: { inherit: {} },
+    wired: {
+      fields: {},
+      routing: [],
+    },
+  },
+});
+
+const createQueryStreamDefinition = (name: string): Streams.QueryStream.Definition => ({
+  name,
+  description: '',
+  updated_at: '2024-01-01T00:00:00.000Z',
+  query: {
+    view: `view_${name}`,
+    esql: `FROM logs | WHERE name = "${name}"`,
+  },
+});
+
+describe('DiscoverBadgeButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseUrl.mockReturnValue('https://discover/link');
+  });
+
+  describe('with ingest stream', () => {
+    it('renders button when hasDataStream is true and discoverLink is available', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.test')).toBeInTheDocument();
+    });
+
+    it('returns null when hasDataStream is false', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      const { container } = renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={false} indexMode={undefined} />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('returns null when discoverLink is not available', () => {
+      mockUseUrl.mockReturnValue(null);
+      const stream = createWiredStreamDefinition('logs.test');
+
+      const { container } = renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders spelled out button when spellOut is true', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton
+          stream={stream}
+          hasDataStream={true}
+          indexMode={undefined}
+          spellOut={true}
+        />
+      );
+
+      expect(screen.getByText('View in Discover')).toBeInTheDocument();
+    });
+
+    it('passes time_series indexMode to getDiscoverEsqlQuery', () => {
+      const stream = createWiredStreamDefinition('logs.metrics');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode="time_series" />
+      );
+
+      expect(mockUseUrl).toHaveBeenCalled();
+      const callArgs = mockUseUrl.mock.calls[0];
+      const locatorParamsFactory = callArgs[0];
+      const params = locatorParamsFactory();
+      expect(params.params.query.esql).toContain('TS ');
+    });
+
+    it('uses FROM command when indexMode is undefined', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(mockUseUrl).toHaveBeenCalled();
+      const callArgs = mockUseUrl.mock.calls[0];
+      const locatorParamsFactory = callArgs[0];
+      const params = locatorParamsFactory();
+      expect(params.params.query.esql).toContain('FROM ');
+      expect(params.params.query.esql).not.toContain('TS ');
+    });
+  });
+
+  describe('with query stream', () => {
+    it('renders button when hasDataStream is true', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.query')).toBeInTheDocument();
+    });
+
+    it('uses FROM command with view name for query streams', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(mockUseUrl).toHaveBeenCalled();
+      const callArgs = mockUseUrl.mock.calls[0];
+      const locatorParamsFactory = callArgs[0];
+      const params = locatorParamsFactory();
+      expect(params.params.query.esql).toContain('FROM view_logs.query');
+    });
+
+    it('does not accept indexMode prop for query streams (TypeScript enforcement)', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.query')).toBeInTheDocument();
+    });
+  });
+
+  describe('type safety', () => {
+    it('requires indexMode for ingest streams', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.test')).toBeInTheDocument();
+    });
+
+    it('forbids indexMode for query streams', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.query')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
@@ -215,17 +215,29 @@ export function LifecycleBadge({
   return <DataRetentionTooltip>{badge}</DataRetentionTooltip>;
 }
 
+interface DiscoverBadgeButtonBaseProps {
+  hasDataStream?: boolean;
+  spellOut?: boolean;
+}
+
+interface DiscoverBadgeButtonIngestProps extends DiscoverBadgeButtonBaseProps {
+  stream: Streams.ingest.all.Definition;
+  indexMode: IndicesIndexMode | undefined;
+}
+
+interface DiscoverBadgeButtonQueryProps extends DiscoverBadgeButtonBaseProps {
+  stream: Streams.QueryStream.Definition;
+  indexMode?: never;
+}
+
+type DiscoverBadgeButtonProps = DiscoverBadgeButtonIngestProps | DiscoverBadgeButtonQueryProps;
+
 export function DiscoverBadgeButton({
   stream,
   hasDataStream = false,
   spellOut = false,
   indexMode,
-}: {
-  stream: Streams.all.Definition;
-  hasDataStream?: boolean;
-  spellOut?: boolean;
-  indexMode?: IndicesIndexMode;
-}) {
+}: DiscoverBadgeButtonProps) {
   const {
     dependencies: {
       start: { share },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -524,13 +524,16 @@ export function StreamsTreeTable({
           align: 'left',
           sortable: false,
           dataType: 'string',
-          render: (_: unknown, item: TableRow) => (
-            <DiscoverBadgeButton
-              hasDataStream={!!item.data_stream || Streams.QueryStream.Definition.is(item.stream)}
-              indexMode={item.data_stream?.index_mode}
-              stream={item.stream}
-            />
-          ),
+          render: (_: unknown, item: TableRow) =>
+            Streams.QueryStream.Definition.is(item.stream) ? (
+              <DiscoverBadgeButton hasDataStream stream={item.stream} />
+            ) : (
+              <DiscoverBadgeButton
+                hasDataStream={!!item.data_stream}
+                indexMode={item.data_stream?.index_mode}
+                stream={item.stream}
+              />
+            ),
         },
       ]}
       itemId="name"

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/tsdb_discover_links.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/tsdb_discover_links.spec.ts
@@ -107,7 +107,7 @@ async function cleanupTsdbResources(esClient: EsClient, templateName: string, st
 }
 
 test.describe(
-  'TSDB-aware Discover links - Streams list view',
+  'TSDB-aware Discover links',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
     test.beforeAll(async ({ esClient, logsSynthtraceEsClient }) => {
@@ -125,12 +125,6 @@ test.describe(
       });
     });
 
-    test.beforeEach(async ({ browserAuth, pageObjects }) => {
-      await browserAuth.loginAsAdmin();
-      await pageObjects.streams.gotoStreamMainPage();
-      await pageObjects.streams.expectStreamsTableVisible();
-    });
-
     test.afterAll(async ({ esClient, apiServices, logsSynthtraceEsClient }) => {
       // Cleanup TSDB resources
       await cleanupTsdbResources(esClient, TSDB_TEMPLATE_NAME, TSDB_STREAM_NAME);
@@ -144,7 +138,14 @@ test.describe(
       await logsSynthtraceEsClient.clean();
     });
 
-    test('should use TS source command for TSDB stream Discover link', async ({ pageObjects }) => {
+    test('list view: should use TS source command for TSDB stream Discover link', async ({
+      browserAuth,
+      pageObjects,
+    }) => {
+      await browserAuth.loginAsAdmin();
+      await pageObjects.streams.gotoStreamMainPage();
+      await pageObjects.streams.expectStreamsTableVisible();
+
       await expect
         .poll(
           async () => {
@@ -158,9 +159,14 @@ test.describe(
         .toBe('TS');
     });
 
-    test('should use FROM source command for regular stream Discover link', async ({
+    test('list view: should use FROM source command for regular stream Discover link', async ({
+      browserAuth,
       pageObjects,
     }) => {
+      await browserAuth.loginAsAdmin();
+      await pageObjects.streams.gotoStreamMainPage();
+      await pageObjects.streams.expectStreamsTableVisible();
+
       await expect
         .poll(
           async () => {
@@ -169,6 +175,48 @@ test.describe(
           {
             message: 'Expected regular stream Discover link to use FROM source command',
             timeout: 10_000,
+          }
+        )
+        .toBe('FROM');
+    });
+
+    test('detail page header: should use TS source command for TSDB stream Discover link', async ({
+      browserAuth,
+      pageObjects,
+    }) => {
+      await browserAuth.loginAsAdmin();
+      await pageObjects.streams.gotoStreamManagementTab(TSDB_STREAM_NAME, 'overview');
+
+      await expect
+        .poll(
+          async () => {
+            return pageObjects.streams.getDiscoverButtonLinkSourceCommand(TSDB_STREAM_NAME);
+          },
+          {
+            message:
+              'Expected TSDB stream Discover link in detail page header to use TS source command',
+            timeout: 15_000,
+          }
+        )
+        .toBe('TS');
+    });
+
+    test('detail page header: should use FROM source command for regular stream Discover link', async ({
+      browserAuth,
+      pageObjects,
+    }) => {
+      await browserAuth.loginAsAdmin();
+      await pageObjects.streams.gotoStreamManagementTab(REGULAR_STREAM_NAME, 'overview');
+
+      await expect
+        .poll(
+          async () => {
+            return pageObjects.streams.getDiscoverButtonLinkSourceCommand(REGULAR_STREAM_NAME);
+          },
+          {
+            message:
+              'Expected regular stream Discover link in detail page header to use FROM source command',
+            timeout: 15_000,
           }
         )
         .toBe('FROM');


### PR DESCRIPTION
## Summary

Fixes the "Explore in Discover" link in the stream detail page header to use `TS` source command for time-series mode streams instead of always using `FROM`.

The issue was that `DiscoverBadgeButton` in the detail page header wrapper was not receiving the `indexMode` prop, even though it was available on the `definition` object. This caused the component to default to `FROM` for all streams.

## Changes

- Added `indexMode={definition.index_mode}` prop to `DiscoverBadgeButton` in `wrapper.tsx`
- Added Scout UI tests for the detail page header to verify `TS`/`FROM` source commands
- **Merged from #256464:** Added discriminated union types to enforce `indexMode` is required for ingest streams and forbidden for query streams (compile-time safety)
- **Merged from #256464:** Added unit tests for `DiscoverBadgeButton`
- **Merged from #256464:** Updated `tree_table.tsx` to use conditional rendering for query vs ingest streams

## Test plan

- [ ] Manually test navigating to a TSDB stream detail page and clicking "Explore in Discover" - should open with `TS` source command
- [ ] Manually test navigating to a regular stream detail page and clicking "Explore in Discover" - should open with `FROM` source command
- [ ] Run Scout UI tests: `node scripts/scout run-tests --arch stateful --domain classic --config x-pack/platform/plugins/shared/streams_app/test/scout/ui/config/stateful.classic.ts --testFiles x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/tsdb_discover_links.spec.ts`
- [ ] Run unit tests: `yarn test:jest x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/discover_badge_button.test.tsx`

Closes #246220

Made with [Cursor](https://cursor.com)