### PR TITLE
[9.1] Fix: prevent JSON logger scalar meta field explosion (#256233)

### DIFF
--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
@@ -8,7 +8,9 @@
  */
 
 import { EcsVersion } from '@elastic/ecs';
-import { LogLevel, LogRecord } from '@kbn/logging';
+import { test as fcTest, fc } from '@fast-check/jest';
+import type { LogRecord } from '@kbn/logging';
+import { LogLevel } from '@kbn/logging';
 import { JsonLayout } from './json_layout';
 
 jest.spyOn(process, 'uptime').mockReturnValue(10);
@@ -553,6 +555,167 @@ test('format() correctly serializes meta.error after calling meta.toJSON() if me
     },
     process: {
       pid: 5355,
+      uptime: 10,
+    },
+  });
+});
+
+const nonObjectMetaArb = fc.oneof(
+  fc.string(),
+  fc.boolean(),
+  fc.integer(),
+  fc.float({ noNaN: false, noDefaultInfinity: true }),
+  fc.array(fc.string(), { maxLength: 20 })
+);
+
+fcTest.prop([nonObjectMetaArb])(
+  'format() serializes non-object meta as plain string in error',
+  (meta) => {
+    const layout = new JsonLayout();
+
+    expect(
+      JSON.parse(
+        layout.format({
+          message: 'foo',
+          timestamp,
+          level: LogLevel.Debug,
+          context: 'bar',
+          pid: 3,
+          // @ts-expect-error validating defensive runtime behavior
+          meta,
+        })
+      )
+    ).toStrictEqual({
+      ecs: { version: expect.any(String) },
+      '@timestamp': '2012-02-01T09:30:22.011-05:00',
+      message: 'foo',
+      log: {
+        level: 'DEBUG',
+        logger: 'bar',
+      },
+      error: String(meta),
+      process: {
+        pid: 3,
+        uptime: 10,
+      },
+    });
+  }
+);
+
+test('format() does not add error when meta is null', () => {
+  const layout = new JsonLayout();
+
+  expect(
+    JSON.parse(
+      layout.format({
+        message: 'foo',
+        timestamp,
+        level: LogLevel.Debug,
+        context: 'bar',
+        pid: 3,
+        // @ts-expect-error validating defensive runtime behavior
+        meta: null,
+      })
+    )
+  ).toStrictEqual({
+    ecs: { version: expect.any(String) },
+    '@timestamp': '2012-02-01T09:30:22.011-05:00',
+    message: 'foo',
+    log: {
+      level: 'DEBUG',
+      logger: 'bar',
+    },
+    process: {
+      pid: 3,
+      uptime: 10,
+    },
+  });
+});
+
+const nonObjectToJsonReturnArb = fc.oneof(
+  fc.string(),
+  fc.boolean(),
+  fc.integer(),
+  fc.constant(null),
+  fc.constant(undefined),
+  fc.array(fc.string(), { maxLength: 20 })
+);
+
+fcTest.prop([nonObjectToJsonReturnArb])(
+  'format() serializes non-object meta.toJSON() output as string in error',
+  (toJsonValue) => {
+    const layout = new JsonLayout();
+
+    expect(
+      JSON.parse(
+        layout.format({
+          message: 'foo',
+          timestamp,
+          level: LogLevel.Debug,
+          context: 'bar',
+          pid: 3,
+          meta: {
+            // @ts-expect-error validating defensive runtime behavior
+            toJSON() {
+              return toJsonValue;
+            },
+          },
+        })
+      )
+    ).toStrictEqual({
+      ecs: { version: expect.any(String) },
+      '@timestamp': '2012-02-01T09:30:22.011-05:00',
+      message: 'foo',
+      log: {
+        level: 'DEBUG',
+        logger: 'bar',
+      },
+      error: String(toJsonValue),
+      process: {
+        pid: 3,
+        uptime: 10,
+      },
+    });
+  }
+);
+
+test('format() serializes Error from meta.toJSON()', () => {
+  const layout = new JsonLayout();
+  const metaError = new Error('boom');
+  metaError.name = 'BoomError';
+  metaError.stack = 'BoomStack';
+
+  expect(
+    JSON.parse(
+      layout.format({
+        message: 'foo',
+        timestamp,
+        level: LogLevel.Debug,
+        context: 'bar',
+        pid: 3,
+        meta: {
+          // @ts-expect-error validating defensive runtime behavior
+          toJSON() {
+            return { error: metaError };
+          },
+        },
+      })
+    )
+  ).toStrictEqual({
+    ecs: { version: expect.any(String) },
+    '@timestamp': '2012-02-01T09:30:22.011-05:00',
+    message: 'foo',
+    log: {
+      level: 'DEBUG',
+      logger: 'bar',
+    },
+    error: {
+      message: metaError.message,
+      type: metaError.name,
+      stack_trace: metaError.stack,
+    },
+    process: {
+      pid: 3,
       uptime: 10,
     },
   });

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
@@ -26,18 +26,6 @@ const jsonLayoutSchema = object({
 export class JsonLayout implements Layout {
   public static configSchema = jsonLayoutSchema;
 
-  private static errorToSerializableObject(error: Error | undefined) {
-    if (error === undefined) {
-      return error;
-    }
-
-    return {
-      message: error.message,
-      type: error.name,
-      stack_trace: error.stack,
-    };
-  }
-
   public format(record: LogRecord): string {
     const spanId = record.meta?.span?.id ?? record.spanId;
     const traceId = record.meta?.trace?.id ?? record.traceId;
@@ -47,7 +35,7 @@ export class JsonLayout implements Layout {
       ecs: { version: EcsVersion },
       '@timestamp': moment(record.timestamp).format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
       message: record.message,
-      error: JsonLayout.errorToSerializableObject(record.error),
+      error: errorToSerializableObject(record.error),
       log: {
         level: record.level.id.toUpperCase(),
         logger: record.context,
@@ -62,15 +50,47 @@ export class JsonLayout implements Layout {
     };
 
     let output = log;
-    if (record.meta) {
-      // @ts-expect-error toJSON not defined on `LogMeta`, but some structured meta can have it defined
-      const serializedMeta = record.meta.toJSON ? record.meta.toJSON() : { ...record.meta };
+    if (record.meta != null) {
+      const serializedMeta = metaToSerializableObject(record.meta);
       if (serializedMeta.error instanceof Error) {
-        serializedMeta.error = JsonLayout.errorToSerializableObject(serializedMeta.error);
+        serializedMeta.error = errorToSerializableObject(serializedMeta.error);
       }
       output = merge(serializedMeta, log);
     }
 
     return JSON.stringify(output);
   }
+}
+
+/** Assumes non-nullish meta */
+function metaToSerializableObject(meta: unknown): Record<string, unknown> {
+  if (Array.isArray(meta) || typeof meta !== 'object') {
+    return { error: String(meta) };
+  }
+
+  const metaObject = meta as { toJSON?: () => unknown };
+  const serializedMeta =
+    typeof metaObject.toJSON === 'function' ? metaObject.toJSON() : { ...metaObject };
+
+  if (
+    serializedMeta == null ||
+    typeof serializedMeta !== 'object' ||
+    Array.isArray(serializedMeta)
+  ) {
+    return { error: String(serializedMeta) };
+  }
+
+  return serializedMeta as Record<string, unknown>;
+}
+
+function errorToSerializableObject(error: Error | undefined) {
+  if (error === undefined) {
+    return error;
+  }
+
+  return {
+    message: error.message,
+    type: error.name,
+    stack_trace: error.stack,
+  };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix: prevent JSON logger scalar meta field explosion (#256233)](https://github.com/elastic/kibana/pull/256233)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2026-03-06T09:23:30Z","message":"Fix: prevent JSON logger scalar meta field explosion (#256233)","sha":"29f3ffdebff244691cc79d8ba4739725eb83e00f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","v9.4.0"],"title":"Fix: prevent JSON logger scalar meta field explosion","number":256233,"url":"https://github.com/elastic/kibana/pull/256233","mergeCommit":{"message":"Fix: prevent JSON logger scalar meta field explosion (#256233)","sha":"29f3ffdebff244691cc79d8ba4739725eb83e00f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256233","number":256233,"mergeCommit":{"message":"Fix: prevent JSON logger scalar meta field explosion (#256233)","sha":"29f3ffdebff244691cc79d8ba4739725eb83e00f"}}]}] BACKPORT-->