### PR TITLE
[Streams] Make indexMode required for ingest streams in DiscoverBadgeButton

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
@@ -170,6 +170,7 @@ export function Wrapper({
                     <DiscoverBadgeButton
                       stream={definition.stream}
                       hasDataStream={definition.data_stream_exists}
+                      indexMode={definition.index_mode}
                       spellOut
                     />
                   )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/discover_badge_button.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/discover_badge_button.test.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { Streams } from '@kbn/streams-schema';
+import { DiscoverBadgeButton } from '.';
+
+const mockUseUrl = jest.fn();
+
+jest.mock('../../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    dependencies: {
+      start: {
+        share: {
+          url: {
+            locators: {
+              useUrl: mockUseUrl,
+            },
+          },
+        },
+      },
+    },
+  }),
+}));
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+const createWiredStreamDefinition = (name: string): Streams.WiredStream.Definition => ({
+  name,
+  description: '',
+  updated_at: '2024-01-01T00:00:00.000Z',
+  ingest: {
+    lifecycle: { dsl: {} },
+    settings: {},
+    processing: {
+      updated_at: '2024-01-01T00:00:00.000Z',
+      steps: [],
+    },
+    failure_store: { inherit: {} },
+    wired: {
+      fields: {},
+      routing: [],
+    },
+  },
+});
+
+const createQueryStreamDefinition = (name: string): Streams.QueryStream.Definition => ({
+  name,
+  description: '',
+  updated_at: '2024-01-01T00:00:00.000Z',
+  query: {
+    view: `view_${name}`,
+    esql: `FROM logs | WHERE name = "${name}"`,
+  },
+});
+
+describe('DiscoverBadgeButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseUrl.mockReturnValue('https://discover/link');
+  });
+
+  describe('with ingest stream', () => {
+    it('renders button when hasDataStream is true and discoverLink is available', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.test')).toBeInTheDocument();
+    });
+
+    it('returns null when hasDataStream is false', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      const { container } = renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={false} indexMode={undefined} />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('returns null when discoverLink is not available', () => {
+      mockUseUrl.mockReturnValue(null);
+      const stream = createWiredStreamDefinition('logs.test');
+
+      const { container } = renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders spelled out button when spellOut is true', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton
+          stream={stream}
+          hasDataStream={true}
+          indexMode={undefined}
+          spellOut={true}
+        />
+      );
+
+      expect(screen.getByText('View in Discover')).toBeInTheDocument();
+    });
+
+    it('passes time_series indexMode to getDiscoverEsqlQuery', () => {
+      const stream = createWiredStreamDefinition('logs.metrics');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode="time_series" />
+      );
+
+      expect(mockUseUrl).toHaveBeenCalled();
+      const callArgs = mockUseUrl.mock.calls[0];
+      const locatorParamsFactory = callArgs[0];
+      const params = locatorParamsFactory();
+      expect(params.params.query.esql).toContain('TS ');
+    });
+
+    it('uses FROM command when indexMode is undefined', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(mockUseUrl).toHaveBeenCalled();
+      const callArgs = mockUseUrl.mock.calls[0];
+      const locatorParamsFactory = callArgs[0];
+      const params = locatorParamsFactory();
+      expect(params.params.query.esql).toContain('FROM ');
+      expect(params.params.query.esql).not.toContain('TS ');
+    });
+  });
+
+  describe('with query stream', () => {
+    it('renders button when hasDataStream is true', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.query')).toBeInTheDocument();
+    });
+
+    it('uses FROM command with view name for query streams', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(mockUseUrl).toHaveBeenCalled();
+      const callArgs = mockUseUrl.mock.calls[0];
+      const locatorParamsFactory = callArgs[0];
+      const params = locatorParamsFactory();
+      expect(params.params.query.esql).toContain('FROM view_logs.query');
+    });
+
+    it('does not accept indexMode prop for query streams (TypeScript enforcement)', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.query')).toBeInTheDocument();
+    });
+  });
+
+  describe('type safety', () => {
+    it('requires indexMode for ingest streams', () => {
+      const stream = createWiredStreamDefinition('logs.test');
+
+      renderWithProviders(
+        <DiscoverBadgeButton stream={stream} hasDataStream={true} indexMode={undefined} />
+      );
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.test')).toBeInTheDocument();
+    });
+
+    it('forbids indexMode for query streams', () => {
+      const stream = createQueryStreamDefinition('logs.query');
+
+      renderWithProviders(<DiscoverBadgeButton stream={stream} hasDataStream={true} />);
+
+      expect(screen.getByTestId('streamsDiscoverActionButton-logs.query')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
@@ -215,17 +215,29 @@ export function LifecycleBadge({
   return <DataRetentionTooltip>{badge}</DataRetentionTooltip>;
 }
 
+interface DiscoverBadgeButtonBaseProps {
+  hasDataStream?: boolean;
+  spellOut?: boolean;
+}
+
+interface DiscoverBadgeButtonIngestProps extends DiscoverBadgeButtonBaseProps {
+  stream: Streams.ingest.all.Definition;
+  indexMode: IndicesIndexMode | undefined;
+}
+
+interface DiscoverBadgeButtonQueryProps extends DiscoverBadgeButtonBaseProps {
+  stream: Streams.QueryStream.Definition;
+  indexMode?: never;
+}
+
+type DiscoverBadgeButtonProps = DiscoverBadgeButtonIngestProps | DiscoverBadgeButtonQueryProps;
+
 export function DiscoverBadgeButton({
   stream,
   hasDataStream = false,
   spellOut = false,
   indexMode,
-}: {
-  stream: Streams.all.Definition;
-  hasDataStream?: boolean;
-  spellOut?: boolean;
-  indexMode?: IndicesIndexMode;
-}) {
+}: DiscoverBadgeButtonProps) {
   const {
     dependencies: {
       start: { share },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -524,13 +524,16 @@ export function StreamsTreeTable({
           align: 'left',
           sortable: false,
           dataType: 'string',
-          render: (_: unknown, item: TableRow) => (
-            <DiscoverBadgeButton
-              hasDataStream={!!item.data_stream || Streams.QueryStream.Definition.is(item.stream)}
-              indexMode={item.data_stream?.index_mode}
-              stream={item.stream}
-            />
-          ),
+          render: (_: unknown, item: TableRow) =>
+            Streams.QueryStream.Definition.is(item.stream) ? (
+              <DiscoverBadgeButton hasDataStream stream={item.stream} />
+            ) : (
+              <DiscoverBadgeButton
+                hasDataStream={!!item.data_stream}
+                indexMode={item.data_stream?.index_mode}
+                stream={item.stream}
+              />
+            ),
         },
       ]}
       itemId="name"


### PR DESCRIPTION
## Summary

Addresses the request from [this comment](https://github.com/elastic/kibana/pull/256445#issuecomment-4011670205) to make `indexMode` a required prop on `DiscoverBadgeButton` for ingest streams, preventing future bugs where developers forget to pass the index mode.

Changes:
- Uses discriminated union types to enforce `indexMode` is required for ingest streams and forbidden for query streams
- Adds unit tests for `DiscoverBadgeButton` covering both stream types and index mode behaviors

## Technical Details

The component now uses:
```typescript
interface DiscoverBadgeButtonIngestProps extends DiscoverBadgeButtonBaseProps {
  stream: Streams.ingest.all.Definition;
  indexMode: IndicesIndexMode | undefined;  // Required for ingest streams
}

interface DiscoverBadgeButtonQueryProps extends DiscoverBadgeButtonBaseProps {
  stream: Streams.QueryStream.Definition;
  indexMode?: never;  // Forbidden for query streams
}

type DiscoverBadgeButtonProps = DiscoverBadgeButtonIngestProps | DiscoverBadgeButtonQueryProps;
```

This provides compile-time safety - TypeScript will error if:
- An ingest stream is passed without `indexMode`
- A query stream is passed with `indexMode`

## Test plan
- [x] Unit tests added for `DiscoverBadgeButton`
- [ ] Manual verification that "Explore in Discover" link works correctly for both time-series and standard streams
- [ ] Manual verification that query streams display the correct ES|QL query

Refs: #256445

Made with [Cursor](https://cursor.com)