### PR TITLE
[9.2] Enhance getActiveMaintenanceWindows to handle paginated responses (#256020)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/get_active/get_active_maintenance_windows.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/get_active/get_active_maintenance_windows.test.ts
@@ -232,6 +232,50 @@ describe('MaintenanceWindowClient - getActiveMaintenanceWindows', () => {
     expect(result).toEqual([]);
   });
 
+  it('should return all active maintenance windows when SO find response is paginated', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-02-26T00:00:00.000Z'));
+
+    const firstPageSavedObjects = Array.from({ length: 2 }, (_, i) => ({
+      attributes: getMockMaintenanceWindow({ expirationDate: new Date().toISOString() }),
+      id: `test-${i + 1}`,
+    }));
+    const secondPageSavedObjects = Array.from({ length: 1 }, (_, i) => ({
+      attributes: getMockMaintenanceWindow({ expirationDate: new Date().toISOString() }),
+      id: `test-${i + 21}`,
+    }));
+
+    savedObjectsClient.find.mockResolvedValueOnce({
+      page: 1,
+      total: 2,
+      saved_objects: firstPageSavedObjects,
+    } as unknown as SavedObjectsFindResponse);
+    savedObjectsClient.find.mockResolvedValueOnce({
+      page: 2,
+      total: 2,
+      saved_objects: secondPageSavedObjects,
+    } as unknown as SavedObjectsFindResponse);
+
+    const result = await getActiveMaintenanceWindows(mockContext, undefined, 2);
+
+    expect(savedObjectsClient.find).toHaveBeenCalledTimes(2);
+    expect(savedObjectsClient.find.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        page: 1,
+        perPage: 2,
+      })
+    );
+    expect(savedObjectsClient.find.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        page: 2,
+        perPage: 2,
+      })
+    );
+    expect(result).toHaveLength(3);
+    expect(result.map((mw) => mw.id)).toEqual(
+      [...firstPageSavedObjects, ...secondPageSavedObjects].map((savedObject) => savedObject.id)
+    );
+  });
+
   it('should log and throw if an error is thrown', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2023-02-26T00:00:00.000Z'));
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/get_active/get_active_maintenance_windows.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/get_active/get_active_maintenance_windows.ts
@@ -6,10 +6,12 @@
  */
 
 import Boom from '@hapi/boom';
+import type { SavedObjectsFindResponse } from '@kbn/core/server';
 import type { KueryNode } from '@kbn/es-query';
 import { nodeBuilder } from '@kbn/es-query';
 import type { MaintenanceWindowClientContext } from '../../../../../common';
 import type { MaintenanceWindow } from '../../types';
+import type { MaintenanceWindowAttributes } from '../../../../data/maintenance_window/types';
 import { transformMaintenanceWindowAttributesToMaintenanceWindow } from '../../transforms';
 import { findMaintenanceWindowSo } from '../../../../data/maintenance_window';
 
@@ -25,7 +27,8 @@ export interface MaintenanceWindowAggregationResult {
 
 export async function getActiveMaintenanceWindows(
   context: MaintenanceWindowClientContext,
-  cacheIntervalMs?: number
+  cacheIntervalMs?: number,
+  perPage: number = 100
 ): Promise<MaintenanceWindow[]> {
   const { savedObjectsClient, logger } = context;
 
@@ -51,10 +54,22 @@ export async function getActiveMaintenanceWindows(
   ]);
 
   try {
-    const { saved_objects: savedObjects } = await findMaintenanceWindowSo({
-      savedObjectsClient,
-      savedObjectsFindOptions: { filter },
-    });
+    const savedObjects = [];
+    let page = 1;
+    let response: SavedObjectsFindResponse<
+      MaintenanceWindowAttributes,
+      MaintenanceWindowAggregationResult
+    >;
+
+    do {
+      response = await findMaintenanceWindowSo({
+        savedObjectsClient,
+        savedObjectsFindOptions: { filter, page, perPage },
+      });
+
+      savedObjects.push(...response.saved_objects);
+      page++;
+    } while (response.saved_objects.length === perPage);
 
     return savedObjects.map((savedObject) => {
       return transformMaintenanceWindowAttributesToMaintenanceWindow({


### PR DESCRIPTION
Manual backport of #256020 due to merge conflicts in 9.2.