### PR TITLE
fix: bump disk space from 105 to 150

### DIFF
--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -466,7 +466,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 150
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -487,7 +487,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 150
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -466,7 +466,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 105
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -487,7 +487,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 105
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -466,7 +466,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 150
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -487,7 +487,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 150
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,7 +4,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 105
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -23,7 +23,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 105
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,7 +4,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 150
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -23,7 +23,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 150
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,7 +4,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 150
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
@@ -23,7 +23,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 120
+      diskSizeGb: 150
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:


### PR DESCRIPTION
Fix defend cypress tests failing due to insufficient disk space.

Failing tests: https://buildkite.com/elastic/kibana-on-merge/builds/90148





<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized test pipeline infrastructure by increasing disk space allocation for Cypress test steps from 105 GB to 150 GB. This change improves test execution reliability and stability across both standard and serverless test environments, reducing potential resource constraints and enhancing test consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->