### PR TITLE
[SLO] Add GET /api/observability/slo_templates/_tags endpoint

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/slo_templates.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/slo_templates.ts
@@ -35,5 +35,14 @@ interface FindSLOTemplatesResponse {
   results: SLOTemplateResponse[];
 }
 
+interface FindSLOTemplateTagsResponse {
+  tags: string[];
+}
+
 export { findSLOTemplatesParamsSchema, getSLOTemplateParamsSchema };
-export type { SLOTemplateResponse, GetSLOTemplateResponse, FindSLOTemplatesResponse };
+export type {
+  SLOTemplateResponse,
+  GetSLOTemplateResponse,
+  FindSLOTemplatesResponse,
+  FindSLOTemplateTagsResponse,
+};

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
@@ -32,7 +32,11 @@ import { resetSLORoute } from './reset_slo';
 import { repairSLORoute } from './repair_slo';
 import { updateSLORoute } from './update_slo';
 import { updateSloSettings } from './update_slo_settings';
-import { getSLOTemplateRoute, findSLOTemplatesRoute } from './slo_templates';
+import {
+  getSLOTemplateRoute,
+  findSLOTemplatesRoute,
+  findSLOTemplateTagsRoute,
+} from './slo_templates';
 import { healthScanRoutes } from './health_scan';
 import { searchSloDefinitionsRoute } from './search_slo_definitions';
 
@@ -69,6 +73,7 @@ export const getSloRouteRepository = (isServerless?: boolean) => {
     ...findSLOInstancesRoute,
     ...getSLOTemplateRoute,
     ...findSLOTemplatesRoute,
+    ...findSLOTemplateTagsRoute,
     ...healthScanRoutes,
     ...searchSloDefinitionsRoute,
   };

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/slo_templates.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/slo_templates.ts
@@ -10,6 +10,7 @@ import {
   getSLOTemplateParamsSchema,
   sloTemplateSchema,
   type FindSLOTemplatesResponse,
+  type FindSLOTemplateTagsResponse,
   type GetSLOTemplateResponse,
 } from '@kbn/slo-schema';
 import { IllegalArgumentError } from '../../errors';
@@ -79,5 +80,27 @@ export const findSLOTemplatesRoute = createSloServerRoute({
       ...templatesPaginated,
       results: templatesPaginated.results.map((template) => sloTemplateSchema.encode(template)),
     };
+  },
+});
+
+export const findSLOTemplateTagsRoute = createSloServerRoute({
+  endpoint: 'GET /api/observability/slo_templates/_tags',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
+  },
+  handler: async ({
+    request,
+    logger,
+    plugins,
+    getScopedClients,
+  }): Promise<FindSLOTemplateTagsResponse> => {
+    await assertPlatinumLicense(plugins);
+    const { templateRepository } = await getScopedClients({ request, logger });
+
+    const tags = await templateRepository.tags();
+    return { tags };
   },
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
@@ -8,6 +8,7 @@
 import type { ResourceInstaller } from '../resource_installer';
 import type { BurnRatesClient } from '../burn_rates_client';
 import type { SLODefinitionRepository } from '../slo_definition_repository';
+import type { SLOTemplateRepository } from '../slo_template_repository';
 import type { SummaryClient } from '../summary_client';
 import type { SummarySearchClient } from '../summary_search_client/types';
 import type { TransformManager } from '../transform_manager';
@@ -71,11 +72,20 @@ const createBurnRatesClientMock = (): jest.Mocked<BurnRatesClient> => {
   };
 };
 
+const createSLOTemplateRepositoryMock = (): jest.Mocked<SLOTemplateRepository> => {
+  return {
+    findById: jest.fn(),
+    search: jest.fn(),
+    tags: jest.fn(),
+  };
+};
+
 export {
   createResourceInstallerMock,
   createTransformManagerMock,
   createSummaryTransformManagerMock,
   createSLODefinitionRepositoryMock as createSLORepositoryMock,
+  createSLOTemplateRepositoryMock,
   createSummaryClientMock,
   createSummarySearchClientMock,
   createBurnRatesClientMock,

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { DefaultSLOTemplateRepository } from './slo_template_repository';
+
+describe('DefaultSLOTemplateRepository', () => {
+  let soClient: jest.Mocked<SavedObjectsClientContract>;
+  let repository: DefaultSLOTemplateRepository;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    repository = new DefaultSLOTemplateRepository(soClient);
+  });
+
+  describe('tags', () => {
+    it('returns all unique tags from SLO templates', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+        aggregations: {
+          tagsAggs: {
+            buckets: [
+              { key: 'production', doc_count: 5 },
+              { key: 'latency', doc_count: 3 },
+              { key: 'availability', doc_count: 2 },
+            ],
+          },
+        },
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual(['production', 'latency', 'availability']);
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: 'slo_template',
+        perPage: 0,
+        aggs: {
+          tagsAggs: {
+            terms: {
+              field: 'slo_template.attributes.tags',
+              size: 10000,
+            },
+          },
+        },
+      });
+    });
+
+    it('returns an empty array when no templates exist', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+        aggregations: {
+          tagsAggs: {
+            buckets: [],
+          },
+        },
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual([]);
+    });
+
+    it('returns an empty array when aggregations are undefined', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual([]);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.ts
@@ -29,9 +29,16 @@ interface SearchParams {
   search?: string;
   tags?: string[];
 }
+
+interface TagsAggregationResponse {
+  tagsAggs: {
+    buckets: Array<{ key: string; doc_count: number }>;
+  };
+}
 export interface SLOTemplateRepository {
   findById(templateId: string): Promise<SLOTemplate>;
   search(params: SearchParams): Promise<Paginated<SLOTemplate>>;
+  tags(): Promise<string[]>;
 }
 
 export class DefaultSLOTemplateRepository implements SLOTemplateRepository {
@@ -71,6 +78,24 @@ export class DefaultSLOTemplateRepository implements SLOTemplateRepository {
       page: response.page,
       results: response.saved_objects.map((so) => this.toSloTemplate(so.id, so.attributes)),
     };
+  }
+
+  async tags(): Promise<string[]> {
+    const response = await this.soClient.find<StoredSLOTemplate>({
+      type: SO_SLO_TEMPLATE_TYPE,
+      perPage: 0,
+      aggs: {
+        tagsAggs: {
+          terms: {
+            field: `${SO_SLO_TEMPLATE_TYPE}.attributes.tags`,
+            size: 10000,
+          },
+        },
+      },
+    });
+
+    const aggs = response.aggregations as TagsAggregationResponse | undefined;
+    return aggs?.tagsAggs?.buckets?.map(({ key }) => key) ?? [];
   }
 
   // We use .decode() instead of .is() when objects contains durationType fields


### PR DESCRIPTION
## Summary

Adds a new internal API endpoint `GET /api/observability/slo_templates/_tags` that returns all unique tags from SLO templates. This endpoint uses saved object aggregations on the `slo_template.attributes.tags` keyword field.

Closes #256496
Part of #256495

### Changes

- **Schema**: Added `FindSLOTemplateTagsResponse` type to `kbn-slo-schema`
- **Repository**: Added `tags()` method to `SLOTemplateRepository` interface and `DefaultSLOTemplateRepository`
- **Route**: New `findSLOTemplateTagsRoute` with internal access and `slo_read` privilege
- **Mocks**: Added `createSLOTemplateRepositoryMock` for use in tests

### Test plan

- [x] Unit tests for `DefaultSLOTemplateRepository.tags()` (3 test cases)
  - Returns all unique tags from templates
  - Returns empty array when no templates exist
  - Returns empty array when aggregations are undefined

Made with [Cursor](https://cursor.com)