### PR TITLE
[SLO] Add useFetchSloTemplates and useFetchSloTemplateTags hooks

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/slo_templates.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/slo_templates.ts
@@ -35,5 +35,14 @@ interface FindSLOTemplatesResponse {
   results: SLOTemplateResponse[];
 }
 
+interface FindSLOTemplateTagsResponse {
+  tags: string[];
+}
+
 export { findSLOTemplatesParamsSchema, getSLOTemplateParamsSchema };
-export type { SLOTemplateResponse, GetSLOTemplateResponse, FindSLOTemplatesResponse };
+export type {
+  SLOTemplateResponse,
+  GetSLOTemplateResponse,
+  FindSLOTemplatesResponse,
+  FindSLOTemplateTagsResponse,
+};

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
@@ -33,6 +33,13 @@ interface SLOOverviewFilter {
   lastRefresh?: number;
 }
 
+interface SloTemplateListFilter {
+  search?: string;
+  tags?: string[];
+  page: number;
+  perPage: number;
+}
+
 export const sloKeys = {
   all: ['slo'] as const,
   lists: () => [...sloKeys.all, 'list'] as const,
@@ -42,6 +49,8 @@ export const sloKeys = {
   overview: (filters: SLOOverviewFilter) => ['overview', filters] as const,
   templates: () => [...sloKeys.all, 'templates'] as const,
   template: (templateId: string) => [...sloKeys.templates(), templateId] as const,
+  templatesList: (filters: SloTemplateListFilter) => [...sloKeys.templates(), 'list', filters] as const,
+  templateTags: () => [...sloKeys.templates(), 'tags'] as const,
   details: () => [...sloKeys.all, 'details'] as const,
   detail: (sloId: string, instanceId: string | undefined, remoteName: string | undefined) =>
     [...sloKeys.details(), { sloId, instanceId, remoteName }] as const,

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_template_tags.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_template_tags.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import type { FindSLOTemplateTagsResponse } from '@kbn/slo-schema';
+import { sloKeys } from './query_key_factory';
+import { usePluginContext } from './use_plugin_context';
+
+export interface UseFetchSloTemplateTagsResponse {
+  isLoading: boolean;
+  isError: boolean;
+  data: FindSLOTemplateTagsResponse | undefined;
+}
+
+export function useFetchSloTemplateTags(): UseFetchSloTemplateTagsResponse {
+  const { sloClient } = usePluginContext();
+
+  const { isLoading, isError, data } = useQuery({
+    queryKey: sloKeys.templateTags(),
+    queryFn: async ({ signal }) => {
+      return await sloClient.fetch('GET /api/observability/slo_templates/_tags', {
+        signal,
+      });
+    },
+    refetchOnWindowFocus: false,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  });
+
+  return {
+    data,
+    isLoading,
+    isError,
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_templates.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_templates.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import type { FindSLOTemplatesResponse } from '@kbn/slo-schema';
+import { sloKeys } from './query_key_factory';
+import { usePluginContext } from './use_plugin_context';
+
+interface UseFetchSloTemplatesParams {
+  search?: string;
+  tags?: string[];
+  page?: number;
+  perPage?: number;
+}
+
+export interface UseFetchSloTemplatesResponse {
+  isLoading: boolean;
+  isError: boolean;
+  data: FindSLOTemplatesResponse | undefined;
+}
+
+export function useFetchSloTemplates({
+  search,
+  tags,
+  page = 1,
+  perPage = 20,
+}: UseFetchSloTemplatesParams = {}): UseFetchSloTemplatesResponse {
+  const { sloClient } = usePluginContext();
+
+  const { isLoading, isError, data } = useQuery({
+    queryKey: sloKeys.templatesList({ search, tags, page, perPage }),
+    queryFn: async ({ signal }) => {
+      return await sloClient.fetch('GET /api/observability/slo_templates', {
+        params: {
+          query: {
+            ...(search && { search }),
+            ...(tags?.length && { tags }),
+            page,
+            perPage,
+          },
+        },
+        signal,
+      });
+    },
+    keepPreviousData: true,
+    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  return {
+    data,
+    isLoading,
+    isError,
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
@@ -32,7 +32,11 @@ import { resetSLORoute } from './reset_slo';
 import { repairSLORoute } from './repair_slo';
 import { updateSLORoute } from './update_slo';
 import { updateSloSettings } from './update_slo_settings';
-import { getSLOTemplateRoute, findSLOTemplatesRoute } from './slo_templates';
+import {
+  getSLOTemplateRoute,
+  findSLOTemplatesRoute,
+  findSLOTemplateTagsRoute,
+} from './slo_templates';
 import { healthScanRoutes } from './health_scan';
 import { searchSloDefinitionsRoute } from './search_slo_definitions';
 
@@ -69,6 +73,7 @@ export const getSloRouteRepository = (isServerless?: boolean) => {
     ...findSLOInstancesRoute,
     ...getSLOTemplateRoute,
     ...findSLOTemplatesRoute,
+    ...findSLOTemplateTagsRoute,
     ...healthScanRoutes,
     ...searchSloDefinitionsRoute,
   };

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/slo_templates.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/slo_templates.ts
@@ -10,6 +10,7 @@ import {
   getSLOTemplateParamsSchema,
   sloTemplateSchema,
   type FindSLOTemplatesResponse,
+  type FindSLOTemplateTagsResponse,
   type GetSLOTemplateResponse,
 } from '@kbn/slo-schema';
 import { IllegalArgumentError } from '../../errors';
@@ -79,5 +80,27 @@ export const findSLOTemplatesRoute = createSloServerRoute({
       ...templatesPaginated,
       results: templatesPaginated.results.map((template) => sloTemplateSchema.encode(template)),
     };
+  },
+});
+
+export const findSLOTemplateTagsRoute = createSloServerRoute({
+  endpoint: 'GET /api/observability/slo_templates/_tags',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
+  },
+  handler: async ({
+    request,
+    logger,
+    plugins,
+    getScopedClients,
+  }): Promise<FindSLOTemplateTagsResponse> => {
+    await assertPlatinumLicense(plugins);
+    const { templateRepository } = await getScopedClients({ request, logger });
+
+    const tags = await templateRepository.tags();
+    return { tags };
   },
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
@@ -8,6 +8,7 @@
 import type { ResourceInstaller } from '../resource_installer';
 import type { BurnRatesClient } from '../burn_rates_client';
 import type { SLODefinitionRepository } from '../slo_definition_repository';
+import type { SLOTemplateRepository } from '../slo_template_repository';
 import type { SummaryClient } from '../summary_client';
 import type { SummarySearchClient } from '../summary_search_client/types';
 import type { TransformManager } from '../transform_manager';
@@ -71,11 +72,20 @@ const createBurnRatesClientMock = (): jest.Mocked<BurnRatesClient> => {
   };
 };
 
+const createSLOTemplateRepositoryMock = (): jest.Mocked<SLOTemplateRepository> => {
+  return {
+    findById: jest.fn(),
+    search: jest.fn(),
+    tags: jest.fn(),
+  };
+};
+
 export {
   createResourceInstallerMock,
   createTransformManagerMock,
   createSummaryTransformManagerMock,
   createSLODefinitionRepositoryMock as createSLORepositoryMock,
+  createSLOTemplateRepositoryMock,
   createSummaryClientMock,
   createSummarySearchClientMock,
   createBurnRatesClientMock,

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { DefaultSLOTemplateRepository } from './slo_template_repository';
+
+describe('DefaultSLOTemplateRepository', () => {
+  let soClient: jest.Mocked<SavedObjectsClientContract>;
+  let repository: DefaultSLOTemplateRepository;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    repository = new DefaultSLOTemplateRepository(soClient);
+  });
+
+  describe('tags', () => {
+    it('returns all unique tags from SLO templates', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+        aggregations: {
+          tagsAggs: {
+            buckets: [
+              { key: 'production', doc_count: 5 },
+              { key: 'latency', doc_count: 3 },
+              { key: 'availability', doc_count: 2 },
+            ],
+          },
+        },
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual(['production', 'latency', 'availability']);
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: 'slo_template',
+        perPage: 0,
+        aggs: {
+          tagsAggs: {
+            terms: {
+              field: 'slo_template.attributes.tags',
+              size: 10000,
+            },
+          },
+        },
+      });
+    });
+
+    it('returns an empty array when no templates exist', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+        aggregations: {
+          tagsAggs: {
+            buckets: [],
+          },
+        },
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual([]);
+    });
+
+    it('returns an empty array when aggregations are undefined', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual([]);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.ts
@@ -29,9 +29,16 @@ interface SearchParams {
   search?: string;
   tags?: string[];
 }
+
+interface TagsAggregationResponse {
+  tagsAggs: {
+    buckets: Array<{ key: string; doc_count: number }>;
+  };
+}
 export interface SLOTemplateRepository {
   findById(templateId: string): Promise<SLOTemplate>;
   search(params: SearchParams): Promise<Paginated<SLOTemplate>>;
+  tags(): Promise<string[]>;
 }
 
 export class DefaultSLOTemplateRepository implements SLOTemplateRepository {
@@ -71,6 +78,24 @@ export class DefaultSLOTemplateRepository implements SLOTemplateRepository {
       page: response.page,
       results: response.saved_objects.map((so) => this.toSloTemplate(so.id, so.attributes)),
     };
+  }
+
+  async tags(): Promise<string[]> {
+    const response = await this.soClient.find<StoredSLOTemplate>({
+      type: SO_SLO_TEMPLATE_TYPE,
+      perPage: 0,
+      aggs: {
+        tagsAggs: {
+          terms: {
+            field: `${SO_SLO_TEMPLATE_TYPE}.attributes.tags`,
+            size: 10000,
+          },
+        },
+      },
+    });
+
+    const aggs = response.aggregations as TagsAggregationResponse | undefined;
+    return aggs?.tagsAggs?.buckets?.map(({ key }) => key) ?? [];
   }
 
   // We use .decode() instead of .is() when objects contains durationType fields


### PR DESCRIPTION
## Summary

Adds frontend React Query hooks for fetching paginated SLO templates and template tags, plus the corresponding query keys.

Closes #256497
Part of #256495
Depends on #256539

### Changes

- **`useFetchSloTemplates`**: Hook calling `GET /api/observability/slo_templates` with pagination, search, and tags params
- **`useFetchSloTemplateTags`**: Hook calling `GET /api/observability/slo_templates/_tags` for tag filter options
- **Query key factory**: Added `templatesList(filters)` and `templateTags()` keys

### Test plan

- [ ] Hooks are thin react-query wrappers; tested indirectly via the components that consume them (next PRs)

Made with [Cursor](https://cursor.com)