### PR TITLE
[SLO] Add SLO Templates tab to SLO Management page

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/slo_templates.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/slo_templates.ts
@@ -35,5 +35,14 @@ interface FindSLOTemplatesResponse {
   results: SLOTemplateResponse[];
 }
 
+interface FindSLOTemplateTagsResponse {
+  tags: string[];
+}
+
 export { findSLOTemplatesParamsSchema, getSLOTemplateParamsSchema };
-export type { SLOTemplateResponse, GetSLOTemplateResponse, FindSLOTemplatesResponse };
+export type {
+  SLOTemplateResponse,
+  GetSLOTemplateResponse,
+  FindSLOTemplatesResponse,
+  FindSLOTemplateTagsResponse,
+};

--- a/x-pack/platform/plugins/shared/slo_shared/common/locators/paths.ts
+++ b/x-pack/platform/plugins/shared/slo_shared/common/locators/paths.ts
@@ -15,12 +15,14 @@ export const SLO_CREATE_PATH = '/create' as const;
 export const SLO_EDIT_PATH = '/edit/:sloId' as const;
 export const SLO_SETTINGS_PATH = '/settings' as const;
 export const SLOS_MANAGEMENT_PATH = '/management' as const;
+export const SLOS_MANAGEMENT_TEMPLATES_PATH = '/management/templates' as const;
 
 export const paths = {
   slos: `${SLOS_BASE_PATH}${SLOS_PATH}`,
   slosSettings: `${SLOS_BASE_PATH}${SLO_SETTINGS_PATH}`,
   slosWelcome: `${SLOS_BASE_PATH}${SLOS_WELCOME_PATH}`,
   slosManagement: `${SLOS_BASE_PATH}${SLOS_MANAGEMENT_PATH}`,
+  slosManagementTemplates: `${SLOS_BASE_PATH}${SLOS_MANAGEMENT_TEMPLATES_PATH}`,
   sloCreate: `${SLOS_BASE_PATH}${SLO_CREATE_PATH}`,
   sloCreateWithEncodedForm: (encodedParams: string) =>
     `${SLOS_BASE_PATH}${SLO_CREATE_PATH}?_a=${encodedParams}`,

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/query_key_factory.ts
@@ -33,6 +33,13 @@ interface SLOOverviewFilter {
   lastRefresh?: number;
 }
 
+interface SloTemplateListFilter {
+  search?: string;
+  tags?: string[];
+  page: number;
+  perPage: number;
+}
+
 export const sloKeys = {
   all: ['slo'] as const,
   lists: () => [...sloKeys.all, 'list'] as const,
@@ -42,6 +49,8 @@ export const sloKeys = {
   overview: (filters: SLOOverviewFilter) => ['overview', filters] as const,
   templates: () => [...sloKeys.all, 'templates'] as const,
   template: (templateId: string) => [...sloKeys.templates(), templateId] as const,
+  templatesList: (filters: SloTemplateListFilter) => [...sloKeys.templates(), 'list', filters] as const,
+  templateTags: () => [...sloKeys.templates(), 'tags'] as const,
   details: () => [...sloKeys.all, 'details'] as const,
   detail: (sloId: string, instanceId: string | undefined, remoteName: string | undefined) =>
     [...sloKeys.details(), { sloId, instanceId, remoteName }] as const,

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_template_tags.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_template_tags.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import type { FindSLOTemplateTagsResponse } from '@kbn/slo-schema';
+import { sloKeys } from './query_key_factory';
+import { usePluginContext } from './use_plugin_context';
+
+export interface UseFetchSloTemplateTagsResponse {
+  isLoading: boolean;
+  isError: boolean;
+  data: FindSLOTemplateTagsResponse | undefined;
+}
+
+export function useFetchSloTemplateTags(): UseFetchSloTemplateTagsResponse {
+  const { sloClient } = usePluginContext();
+
+  const { isLoading, isError, data } = useQuery({
+    queryKey: sloKeys.templateTags(),
+    queryFn: async ({ signal }) => {
+      return await sloClient.fetch('GET /api/observability/slo_templates/_tags', {
+        signal,
+      });
+    },
+    refetchOnWindowFocus: false,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  });
+
+  return {
+    data,
+    isLoading,
+    isError,
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_templates.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_slo_templates.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import type { FindSLOTemplatesResponse } from '@kbn/slo-schema';
+import { sloKeys } from './query_key_factory';
+import { usePluginContext } from './use_plugin_context';
+
+interface UseFetchSloTemplatesParams {
+  search?: string;
+  tags?: string[];
+  page?: number;
+  perPage?: number;
+}
+
+export interface UseFetchSloTemplatesResponse {
+  isLoading: boolean;
+  isError: boolean;
+  data: FindSLOTemplatesResponse | undefined;
+}
+
+export function useFetchSloTemplates({
+  search,
+  tags,
+  page = 1,
+  perPage = 20,
+}: UseFetchSloTemplatesParams = {}): UseFetchSloTemplatesResponse {
+  const { sloClient } = usePluginContext();
+
+  const { isLoading, isError, data } = useQuery({
+    queryKey: sloKeys.templatesList({ search, tags, page, perPage }),
+    queryFn: async ({ signal }) => {
+      return await sloClient.fetch('GET /api/observability/slo_templates', {
+        params: {
+          query: {
+            ...(search && { search }),
+            ...(tags?.length && { tags }),
+            page,
+            perPage,
+          },
+        },
+        signal,
+      });
+    },
+    keepPreviousData: true,
+    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  return {
+    data,
+    isLoading,
+    isError,
+  };
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_templates_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_templates_search_bar.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiComboBoxOptionOption } from '@elastic/eui';
+import { EuiComboBox, EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useMemo } from 'react';
+import { useFetchSloTemplateTags } from '../../../hooks/use_fetch_slo_template_tags';
+
+interface Props {
+  search: string;
+  tags: string[];
+  onSearchChange: (search: string) => void;
+  onTagsChange: (tags: string[]) => void;
+}
+
+export function SloTemplatesSearchBar({ search, tags, onSearchChange, onTagsChange }: Props) {
+  const { data: tagsData } = useFetchSloTemplateTags();
+
+  const tagOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(
+    () => (tagsData?.tags ?? []).map((tag) => ({ label: tag, value: tag })),
+    [tagsData]
+  );
+
+  const selectedTagOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(
+    () => tags.map((tag) => ({ label: tag, value: tag })),
+    [tags]
+  );
+
+  return (
+    <EuiFlexGroup gutterSize="s" responsive>
+      <EuiFlexItem>
+        <EuiFieldSearch
+          fullWidth
+          placeholder={SEARCH_PLACEHOLDER}
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          data-test-subj="sloTemplatesSearchInput"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false} css={{ minWidth: 200 }}>
+        <EuiComboBox
+          compressed
+          aria-label={FILTER_TAGS_LABEL}
+          placeholder={FILTER_TAGS_LABEL}
+          options={tagOptions}
+          selectedOptions={selectedTagOptions}
+          onChange={(newOptions) => {
+            onTagsChange(newOptions.map((option) => String(option.value)));
+          }}
+          isClearable
+          data-test-subj="sloTemplatesFilterByTag"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}
+
+const SEARCH_PLACEHOLDER = i18n.translate('xpack.slo.sloTemplatesSearchBar.searchPlaceholder', {
+  defaultMessage: 'Search templates by name',
+});
+
+const FILTER_TAGS_LABEL = i18n.translate('xpack.slo.sloTemplatesSearchBar.filterByTag', {
+  defaultMessage: 'Filter tags',
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_templates_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_templates_table.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { useFetchSloTemplates } from '../../../hooks/use_fetch_slo_templates';
+import { useFetchSloTemplateTags } from '../../../hooks/use_fetch_slo_template_tags';
+import { useKibana } from '../../../hooks/use_kibana';
+import { usePermissions } from '../../../hooks/use_permissions';
+import { render } from '../../../utils/test_helper';
+import { SloTemplatesTable } from './slo_templates_table';
+
+jest.mock('../../../hooks/use_kibana');
+jest.mock('../../../hooks/use_permissions');
+jest.mock('../../../hooks/use_fetch_slo_templates');
+jest.mock('../../../hooks/use_fetch_slo_template_tags');
+
+const useKibanaMock = useKibana as jest.Mock;
+const usePermissionsMock = usePermissions as jest.Mock;
+const useFetchSloTemplatesMock = useFetchSloTemplates as jest.Mock;
+const useFetchSloTemplateTagsMock = useFetchSloTemplateTags as jest.Mock;
+
+const mockNavigateToUrl = jest.fn();
+
+describe('SloTemplatesTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useKibanaMock.mockReturnValue({
+      services: {
+        http: { basePath: { prepend: (path: string) => path } },
+        application: { navigateToUrl: mockNavigateToUrl },
+      },
+    });
+    usePermissionsMock.mockReturnValue({
+      data: { hasAllReadRequested: true, hasAllWriteRequested: true },
+    });
+    useFetchSloTemplateTagsMock.mockReturnValue({
+      data: { tags: ['production', 'latency'] },
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it('renders the empty state when no templates exist', () => {
+    useFetchSloTemplatesMock.mockReturnValue({
+      data: { total: 0, page: 1, perPage: 20, results: [] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SloTemplatesTable />);
+
+    expect(screen.getByTestId('sloTemplatesEmptyPrompt')).toBeTruthy();
+    expect(screen.getByText(/No SLO templates found/)).toBeTruthy();
+  });
+
+  it('renders the table with templates', () => {
+    useFetchSloTemplatesMock.mockReturnValue({
+      data: {
+        total: 2,
+        page: 1,
+        perPage: 20,
+        results: [
+          {
+            templateId: 'template-1',
+            name: 'Latency SLO Template',
+            description: 'A template for latency SLOs',
+            tags: ['latency', 'production'],
+          },
+          {
+            templateId: 'template-2',
+            name: 'Availability SLO Template',
+            description: 'A template for availability SLOs',
+            tags: ['availability'],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SloTemplatesTable />);
+
+    expect(screen.getByText('Latency SLO Template')).toBeTruthy();
+    expect(screen.getByText('Availability SLO Template')).toBeTruthy();
+    expect(screen.getByText('Showing 2 of 2 SLO templates')).toBeTruthy();
+  });
+
+  it('renders loading state', () => {
+    useFetchSloTemplatesMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<SloTemplatesTable />);
+
+    expect(screen.getByText('Showing 0 of 0 SLO templates')).toBeTruthy();
+  });
+
+  it('renders error state', () => {
+    useFetchSloTemplatesMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<SloTemplatesTable />);
+
+    expect(screen.getByText(/An error occurred while retrieving SLO templates/)).toBeTruthy();
+  });
+
+  it('renders the search bar', () => {
+    useFetchSloTemplatesMock.mockReturnValue({
+      data: { total: 1, page: 1, perPage: 20, results: [{ templateId: 't1', name: 'Test' }] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SloTemplatesTable />);
+
+    expect(screen.getByTestId('sloTemplatesSearchInput')).toBeTruthy();
+    expect(screen.getByTestId('sloTemplatesFilterByTag')).toBeTruthy();
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_templates_table.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_templates_table.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Criteria, DefaultItemAction, EuiBasicTableColumn } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { SLOTemplateResponse } from '@kbn/slo-schema';
+import { paths } from '@kbn/slo-shared-plugin/common/locators/paths';
+import React, { useCallback, useState } from 'react';
+import { useFetchSloTemplates } from '../../../hooks/use_fetch_slo_templates';
+import { useKibana } from '../../../hooks/use_kibana';
+import { usePermissions } from '../../../hooks/use_permissions';
+import { SloTemplatesSearchBar } from './slo_templates_search_bar';
+
+interface Props {
+  onTemplateSelect?: (templateId: string) => void;
+}
+
+export function SloTemplatesTable({ onTemplateSelect }: Props) {
+  const {
+    services: {
+      http,
+      application: { navigateToUrl },
+    },
+  } = useKibana();
+  const { data: permissions } = usePermissions();
+
+  const [search, setSearch] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [page, setPage] = useState(0);
+  const [perPage, setPerPage] = useState(20);
+
+  const { isLoading, isError, data } = useFetchSloTemplates({
+    search: search || undefined,
+    tags: tags.length ? tags : undefined,
+    page: page + 1,
+    perPage,
+  });
+
+  const handleCreateFromTemplate = useCallback(
+    (templateId: string) => {
+      if (onTemplateSelect) {
+        onTemplateSelect(templateId);
+      } else {
+        navigateToUrl(http.basePath.prepend(paths.sloCreateFromTemplate(templateId)));
+      }
+    },
+    [http.basePath, navigateToUrl, onTemplateSelect]
+  );
+
+  const actions: Array<DefaultItemAction<SLOTemplateResponse>> = [
+    {
+      type: 'icon',
+      icon: 'plusInCircle',
+      name: i18n.translate('xpack.slo.sloTemplatesTable.actions.createSlo', {
+        defaultMessage: 'Create SLO',
+      }),
+      description: i18n.translate('xpack.slo.sloTemplatesTable.actions.createSloDescription', {
+        defaultMessage: 'Create SLO from this template',
+      }),
+      'data-test-subj': 'sloTemplateActionCreate',
+      enabled: () => !!permissions?.hasAllWriteRequested,
+      onClick: (template: SLOTemplateResponse) => {
+        handleCreateFromTemplate(template.templateId);
+      },
+    },
+  ];
+
+  const columns: Array<EuiBasicTableColumn<SLOTemplateResponse>> = [
+    {
+      field: 'name',
+      name: i18n.translate('xpack.slo.sloTemplatesTable.columns.nameLabel', {
+        defaultMessage: 'Name',
+      }),
+      truncateText: true,
+    },
+    {
+      field: 'description',
+      name: i18n.translate('xpack.slo.sloTemplatesTable.columns.descriptionLabel', {
+        defaultMessage: 'Description',
+      }),
+      truncateText: true,
+    },
+    {
+      field: 'tags',
+      name: i18n.translate('xpack.slo.sloTemplatesTable.columns.tagsLabel', {
+        defaultMessage: 'Tags',
+      }),
+      render: (value: SLOTemplateResponse['tags']) => {
+        if (!value?.length) return null;
+        return (
+          <EuiFlexGroup gutterSize="xs" wrap responsive>
+            {value.map((tag) => (
+              <EuiFlexItem key={tag} grow={false}>
+                <EuiBadge>{tag}</EuiBadge>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        );
+      },
+    },
+    {
+      name: i18n.translate('xpack.slo.sloTemplatesTable.columns.actionsLabel', {
+        defaultMessage: 'Actions',
+      }),
+      width: '10%',
+      actions,
+    },
+  ];
+
+  const onTableChange = ({ page: newPage }: Criteria<SLOTemplateResponse>) => {
+    if (newPage) {
+      setPage(newPage.index);
+      setPerPage(newPage.size);
+    }
+  };
+
+  const pagination = {
+    pageIndex: page,
+    pageSize: perPage,
+    totalItemCount: data?.total ?? 0,
+    pageSizeOptions: [10, 25, 50, 100],
+    showPerPageOptions: true,
+  };
+
+  if (!isLoading && !isError && data?.total === 0 && !search && !tags.length) {
+    return (
+      <EuiPanel hasBorder>
+        <EuiEmptyPrompt
+          data-test-subj="sloTemplatesEmptyPrompt"
+          iconType="document"
+          title={
+            <h2>
+              {i18n.translate('xpack.slo.sloTemplatesTable.emptyTitle', {
+                defaultMessage: 'No SLO templates found',
+              })}
+            </h2>
+          }
+          body={
+            <p>
+              {i18n.translate('xpack.slo.sloTemplatesTable.emptyBody', {
+                defaultMessage:
+                  'SLO templates are installed via Fleet integration packages. Visit the Integrations page to install packages that include SLO templates.',
+              })}
+            </p>
+          }
+        />
+      </EuiPanel>
+    );
+  }
+
+  return (
+    <EuiPanel hasBorder>
+      <SloTemplatesSearchBar
+        search={search}
+        tags={tags}
+        onSearchChange={setSearch}
+        onTagsChange={setTags}
+      />
+      <EuiSpacer size="m" />
+      <EuiText size="xs">
+        {i18n.translate('xpack.slo.sloTemplatesTable.itemCount', {
+          defaultMessage: 'Showing {count} of {total} SLO templates',
+          values: {
+            count: data?.results.length ?? 0,
+            total: data?.total ?? 0,
+          },
+        })}
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiBasicTable<SLOTemplateResponse>
+        tableCaption={TABLE_CAPTION}
+        error={
+          isError
+            ? i18n.translate('xpack.slo.sloTemplatesTable.error', {
+                defaultMessage: 'An error occurred while retrieving SLO templates',
+              })
+            : undefined
+        }
+        items={data?.results ?? []}
+        rowHeader="name"
+        columns={columns}
+        itemId="templateId"
+        pagination={pagination}
+        onChange={onTableChange}
+        loading={isLoading}
+      />
+    </EuiPanel>
+  );
+}
+
+const TABLE_CAPTION = i18n.translate('xpack.slo.sloTemplatesTable.caption', {
+  defaultMessage: 'SLO Templates',
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/slo_management_page.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/slo_management_page.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { useFetchSloDefinitions } from '../../hooks/use_fetch_slo_definitions';
+import { useFetchSloTemplateTags } from '../../hooks/use_fetch_slo_template_tags';
+import { useFetchSloTemplates } from '../../hooks/use_fetch_slo_templates';
+import { useKibana } from '../../hooks/use_kibana';
+import { useLicense } from '../../hooks/use_license';
+import { usePermissions } from '../../hooks/use_permissions';
+import { render } from '../../utils/test_helper';
+import { SloManagementPage } from './slo_management_page';
+
+const mockNavigateToUrl = jest.fn();
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+    location: { pathname: '/management', search: '', hash: '' },
+    listen: jest.fn(),
+    replace: jest.fn(),
+  }),
+}));
+
+jest.mock('@kbn/observability-shared-plugin/public', () => ({
+  useBreadcrumbs: jest.fn(),
+}));
+jest.mock('../../hooks/use_kibana');
+jest.mock('../../hooks/use_license');
+jest.mock('../../hooks/use_permissions');
+jest.mock('../../hooks/use_fetch_slo_definitions');
+jest.mock('../../hooks/use_fetch_slo_templates');
+jest.mock('../../hooks/use_fetch_slo_template_tags');
+jest.mock('./components/slo_management_table', () => ({
+  SloManagementTable: () => <div data-test-subj="sloManagementTable">SLO Management Table</div>,
+}));
+jest.mock('./components/slo_management_outdated_filter_callout', () => ({
+  SloOutdatedFilterCallout: () => null,
+}));
+jest.mock('./components/header_control/header_control', () => ({
+  HeaderControl: () => <div>Header Control</div>,
+}));
+jest.mock('../../components/header_menu/header_menu', () => ({
+  HeaderMenu: () => null,
+}));
+jest.mock('./context/bulk_operation', () => ({
+  BulkOperationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock('../../context/action_modal', () => ({
+  ActionModalProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useKibanaMock = useKibana as jest.Mock;
+const useLicenseMock = useLicense as jest.Mock;
+const usePermissionsMock = usePermissions as jest.Mock;
+const useFetchSloDefinitionsMock = useFetchSloDefinitions as jest.Mock;
+const useFetchSloTemplatesMock = useFetchSloTemplates as jest.Mock;
+const useFetchSloTemplateTagsMock = useFetchSloTemplateTags as jest.Mock;
+
+describe('SloManagementPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useKibanaMock.mockReturnValue({
+      services: {
+        http: { basePath: { prepend: (path: string) => path } },
+        application: { navigateToUrl: mockNavigateToUrl },
+        serverless: undefined,
+      },
+    });
+    useLicenseMock.mockReturnValue({ hasAtLeast: () => true });
+    usePermissionsMock.mockReturnValue({
+      data: { hasAllReadRequested: true, hasAllWriteRequested: true },
+    });
+    useFetchSloDefinitionsMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { total: 10 },
+    });
+    useFetchSloTemplatesMock.mockReturnValue({
+      data: { total: 0, page: 1, perPage: 20, results: [] },
+      isLoading: false,
+      isError: false,
+    });
+    useFetchSloTemplateTagsMock.mockReturnValue({
+      data: { tags: [] },
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it('renders with SLOs tab selected by default', () => {
+    render(<SloManagementPage />);
+
+    expect(screen.getByTestId('managementTabSlos')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('managementTabTemplates')).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByTestId('sloManagementTable')).toBeTruthy();
+  });
+
+  it('navigates to templates tab when clicked', () => {
+    render(<SloManagementPage />);
+
+    fireEvent.click(screen.getByTestId('managementTabTemplates'));
+
+    expect(mockHistoryPush).toHaveBeenCalledWith('/management/templates');
+  });
+
+  it('navigates to slos tab when clicked', () => {
+    render(<SloManagementPage />);
+
+    fireEvent.click(screen.getByTestId('managementTabSlos'));
+
+    expect(mockHistoryPush).toHaveBeenCalledWith('/management');
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/slo_management_page.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/slo_management_page.tsx
@@ -5,11 +5,16 @@
  * 2.0.
  */
 
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiFlexGroup, EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useBreadcrumbs } from '@kbn/observability-shared-plugin/public';
-import { paths } from '@kbn/slo-shared-plugin/common/locators/paths';
-import React, { useEffect } from 'react';
+import {
+  SLOS_MANAGEMENT_PATH,
+  SLOS_MANAGEMENT_TEMPLATES_PATH,
+  paths,
+} from '@kbn/slo-shared-plugin/common/locators/paths';
+import React, { useEffect, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { HeaderMenu } from '../../components/header_menu/header_menu';
 import { ActionModalProvider } from '../../context/action_modal';
 import { useFetchSloDefinitions } from '../../hooks/use_fetch_slo_definitions';
@@ -21,7 +26,10 @@ import { LoadingPage } from '../loading_page';
 import { HeaderControl } from './components/header_control/header_control';
 import { SloOutdatedFilterCallout } from './components/slo_management_outdated_filter_callout';
 import { SloManagementTable } from './components/slo_management_table';
+import { SloTemplatesTable } from './components/slo_templates_table';
 import { BulkOperationProvider } from './context/bulk_operation';
+
+type ManagementTab = 'slos' | 'templates';
 
 export function SloManagementPage() {
   const {
@@ -29,6 +37,7 @@ export function SloManagementPage() {
     serverless,
     application: { navigateToUrl },
   } = useKibana().services;
+  const history = useHistory();
   const { ObservabilityPageTemplate } = usePluginContext();
   const { data: permissions } = usePermissions();
   const { hasAtLeast } = useLicense();
@@ -37,6 +46,18 @@ export function SloManagementPage() {
     isError,
     data: { total } = { total: 0 },
   } = useFetchSloDefinitions({ perPage: 0 });
+
+  const activeTab: ManagementTab = useMemo(() => {
+    return history.location.pathname === SLOS_MANAGEMENT_TEMPLATES_PATH ? 'templates' : 'slos';
+  }, [history.location.pathname]);
+
+  const onTabChange = (tab: ManagementTab) => {
+    if (tab === 'templates') {
+      history.push(SLOS_MANAGEMENT_TEMPLATES_PATH);
+    } else {
+      history.push(SLOS_MANAGEMENT_PATH);
+    }
+  };
 
   useEffect(() => {
     if (
@@ -78,24 +99,49 @@ export function SloManagementPage() {
         pageTitle: i18n.translate('xpack.slo.managementPage.pageTitle', {
           defaultMessage: 'SLO Management',
         }),
-        rightSideItems: !isLoading
-          ? [
-              <ActionModalProvider>
-                <HeaderControl />
-              </ActionModalProvider>,
-            ]
-          : undefined,
+        rightSideItems:
+          !isLoading && activeTab === 'slos'
+            ? [
+                <ActionModalProvider>
+                  <HeaderControl />
+                </ActionModalProvider>,
+              ]
+            : undefined,
       }}
     >
       <HeaderMenu />
-      <BulkOperationProvider>
-        <ActionModalProvider>
-          <EuiFlexGroup direction="column" gutterSize="m">
-            <SloOutdatedFilterCallout />
-            <SloManagementTable />
-          </EuiFlexGroup>
-        </ActionModalProvider>
-      </BulkOperationProvider>
+      <EuiTabs>
+        <EuiTab
+          isSelected={activeTab === 'slos'}
+          onClick={() => onTabChange('slos')}
+          data-test-subj="managementTabSlos"
+        >
+          {i18n.translate('xpack.slo.managementPage.tab.slos', {
+            defaultMessage: 'SLOs',
+          })}
+        </EuiTab>
+        <EuiTab
+          isSelected={activeTab === 'templates'}
+          onClick={() => onTabChange('templates')}
+          data-test-subj="managementTabTemplates"
+        >
+          {i18n.translate('xpack.slo.managementPage.tab.templates', {
+            defaultMessage: 'SLO Templates',
+          })}
+        </EuiTab>
+      </EuiTabs>
+      <EuiSpacer size="m" />
+      {activeTab === 'slos' && (
+        <BulkOperationProvider>
+          <ActionModalProvider>
+            <EuiFlexGroup direction="column" gutterSize="m">
+              <SloOutdatedFilterCallout />
+              <SloManagementTable />
+            </EuiFlexGroup>
+          </ActionModalProvider>
+        </BulkOperationProvider>
+      )}
+      {activeTab === 'templates' && <SloTemplatesTable />}
     </ObservabilityPageTemplate>
   );
 }

--- a/x-pack/solutions/observability/plugins/slo/public/routes/routes.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/routes/routes.tsx
@@ -7,6 +7,7 @@
 
 import {
   SLOS_MANAGEMENT_PATH,
+  SLOS_MANAGEMENT_TEMPLATES_PATH,
   SLOS_PATH,
   SLOS_WELCOME_PATH,
   SLO_CREATE_PATH,
@@ -61,6 +62,13 @@ export const getRoutes = (): {
     [SLO_SETTINGS_PATH]: {
       handler: () => {
         return <SloSettingsPage />;
+      },
+      params: {},
+      exact: true,
+    },
+    [SLOS_MANAGEMENT_TEMPLATES_PATH]: {
+      handler: () => {
+        return <SloManagementPage />;
       },
       params: {},
       exact: true,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
@@ -32,7 +32,11 @@ import { resetSLORoute } from './reset_slo';
 import { repairSLORoute } from './repair_slo';
 import { updateSLORoute } from './update_slo';
 import { updateSloSettings } from './update_slo_settings';
-import { getSLOTemplateRoute, findSLOTemplatesRoute } from './slo_templates';
+import {
+  getSLOTemplateRoute,
+  findSLOTemplatesRoute,
+  findSLOTemplateTagsRoute,
+} from './slo_templates';
 import { healthScanRoutes } from './health_scan';
 import { searchSloDefinitionsRoute } from './search_slo_definitions';
 
@@ -69,6 +73,7 @@ export const getSloRouteRepository = (isServerless?: boolean) => {
     ...findSLOInstancesRoute,
     ...getSLOTemplateRoute,
     ...findSLOTemplatesRoute,
+    ...findSLOTemplateTagsRoute,
     ...healthScanRoutes,
     ...searchSloDefinitionsRoute,
   };

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/slo_templates.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/slo_templates.ts
@@ -10,6 +10,7 @@ import {
   getSLOTemplateParamsSchema,
   sloTemplateSchema,
   type FindSLOTemplatesResponse,
+  type FindSLOTemplateTagsResponse,
   type GetSLOTemplateResponse,
 } from '@kbn/slo-schema';
 import { IllegalArgumentError } from '../../errors';
@@ -79,5 +80,27 @@ export const findSLOTemplatesRoute = createSloServerRoute({
       ...templatesPaginated,
       results: templatesPaginated.results.map((template) => sloTemplateSchema.encode(template)),
     };
+  },
+});
+
+export const findSLOTemplateTagsRoute = createSloServerRoute({
+  endpoint: 'GET /api/observability/slo_templates/_tags',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
+  },
+  handler: async ({
+    request,
+    logger,
+    plugins,
+    getScopedClients,
+  }): Promise<FindSLOTemplateTagsResponse> => {
+    await assertPlatinumLicense(plugins);
+    const { templateRepository } = await getScopedClients({ request, logger });
+
+    const tags = await templateRepository.tags();
+    return { tags };
   },
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
@@ -8,6 +8,7 @@
 import type { ResourceInstaller } from '../resource_installer';
 import type { BurnRatesClient } from '../burn_rates_client';
 import type { SLODefinitionRepository } from '../slo_definition_repository';
+import type { SLOTemplateRepository } from '../slo_template_repository';
 import type { SummaryClient } from '../summary_client';
 import type { SummarySearchClient } from '../summary_search_client/types';
 import type { TransformManager } from '../transform_manager';
@@ -71,11 +72,20 @@ const createBurnRatesClientMock = (): jest.Mocked<BurnRatesClient> => {
   };
 };
 
+const createSLOTemplateRepositoryMock = (): jest.Mocked<SLOTemplateRepository> => {
+  return {
+    findById: jest.fn(),
+    search: jest.fn(),
+    tags: jest.fn(),
+  };
+};
+
 export {
   createResourceInstallerMock,
   createTransformManagerMock,
   createSummaryTransformManagerMock,
   createSLODefinitionRepositoryMock as createSLORepositoryMock,
+  createSLOTemplateRepositoryMock,
   createSummaryClientMock,
   createSummarySearchClientMock,
   createBurnRatesClientMock,

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { DefaultSLOTemplateRepository } from './slo_template_repository';
+
+describe('DefaultSLOTemplateRepository', () => {
+  let soClient: jest.Mocked<SavedObjectsClientContract>;
+  let repository: DefaultSLOTemplateRepository;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    repository = new DefaultSLOTemplateRepository(soClient);
+  });
+
+  describe('tags', () => {
+    it('returns all unique tags from SLO templates', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+        aggregations: {
+          tagsAggs: {
+            buckets: [
+              { key: 'production', doc_count: 5 },
+              { key: 'latency', doc_count: 3 },
+              { key: 'availability', doc_count: 2 },
+            ],
+          },
+        },
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual(['production', 'latency', 'availability']);
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: 'slo_template',
+        perPage: 0,
+        aggs: {
+          tagsAggs: {
+            terms: {
+              field: 'slo_template.attributes.tags',
+              size: 10000,
+            },
+          },
+        },
+      });
+    });
+
+    it('returns an empty array when no templates exist', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+        aggregations: {
+          tagsAggs: {
+            buckets: [],
+          },
+        },
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual([]);
+    });
+
+    it('returns an empty array when aggregations are undefined', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [],
+        total: 0,
+        per_page: 0,
+        page: 1,
+      });
+
+      const tags = await repository.tags();
+
+      expect(tags).toEqual([]);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_template_repository.ts
@@ -29,9 +29,16 @@ interface SearchParams {
   search?: string;
   tags?: string[];
 }
+
+interface TagsAggregationResponse {
+  tagsAggs: {
+    buckets: Array<{ key: string; doc_count: number }>;
+  };
+}
 export interface SLOTemplateRepository {
   findById(templateId: string): Promise<SLOTemplate>;
   search(params: SearchParams): Promise<Paginated<SLOTemplate>>;
+  tags(): Promise<string[]>;
 }
 
 export class DefaultSLOTemplateRepository implements SLOTemplateRepository {
@@ -71,6 +78,24 @@ export class DefaultSLOTemplateRepository implements SLOTemplateRepository {
       page: response.page,
       results: response.saved_objects.map((so) => this.toSloTemplate(so.id, so.attributes)),
     };
+  }
+
+  async tags(): Promise<string[]> {
+    const response = await this.soClient.find<StoredSLOTemplate>({
+      type: SO_SLO_TEMPLATE_TYPE,
+      perPage: 0,
+      aggs: {
+        tagsAggs: {
+          terms: {
+            field: `${SO_SLO_TEMPLATE_TYPE}.attributes.tags`,
+            size: 10000,
+          },
+        },
+      },
+    });
+
+    const aggs = response.aggregations as TagsAggregationResponse | undefined;
+    return aggs?.tagsAggs?.buckets?.map(({ key }) => key) ?? [];
   }
 
   // We use .decode() instead of .is() when objects contains durationType fields


### PR DESCRIPTION
## Summary

Refactors the SLO Management page to include two tabs: **SLOs** (existing content) and **SLO Templates**. The Templates tab is accessible at `/app/slos/management/templates` and renders the shared `SloTemplatesTable` component.

Closes #256499
Part of #256495
Depends on #256543

### Changes

- **Paths**: Added `SLOS_MANAGEMENT_TEMPLATES_PATH` and `slosManagementTemplates` path entry
- **Routes**: Registered `/management/templates` route pointing to `SloManagementPage`
- **SloManagementPage**: Added `EuiTabs` with SLOs and SLO Templates tabs; tab state derived from URL path; "Actions" header control only shown on SLOs tab

### Test plan

- [x] Unit tests (3 test cases):
  - Renders with SLOs tab selected by default
  - Navigates to templates tab when clicked
  - Navigates to SLOs tab when clicked

Made with [Cursor](https://cursor.com)