### PR TITLE
POC: Add extraction.extract custom workflow step

### DIFF
--- a/x-pack/platform/plugins/shared/data_sources/common/steps/extract/extract_step.ts
+++ b/x-pack/platform/plugins/shared/data_sources/common/steps/extract/extract_step.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+
+export const ExtractStepTypeId = 'extraction.extract';
+
+const ExtractInputSchema = z.object({
+  content: z.string().describe('Base64-encoded file content to extract text from'),
+  filename: z.string().describe('Filename with extension, used for content type detection'),
+  doc_id: z
+    .string()
+    .optional()
+    .describe('Optional document identifier, passed as _id in the simulated doc'),
+});
+
+const ExtractConfigSchema = z.object({
+  method: z
+    .enum(['tika', 'inference', 'workflow', 'connector'])
+    .optional()
+    .describe(
+      'Extraction method. "tika" uses the built-in ingest attachment processor. ' +
+        '"inference" uses an ES inference endpoint. "workflow" delegates to a user-defined ' +
+        'workflow that conforms to the extraction contract. "connector" uses a stack connector ' +
+        'exposing an "extract" sub-action. Defaults to the global setting, or "tika" if unset.'
+    ),
+  inference_id: z
+    .string()
+    .optional()
+    .describe(
+      'Inference endpoint ID. Only used when method is "inference". ' +
+        'If omitted, automatically selects an available extraction endpoint.'
+    ),
+  workflow_id: z
+    .string()
+    .optional()
+    .describe(
+      'Workflow ID to delegate extraction to. Only used when method is "workflow". ' +
+        'The workflow must accept inputs: content (string), filename (string), doc_id (string, optional) ' +
+        'and output: content (string), content_type (string, optional).'
+    ),
+  connector_id: z
+    .string()
+    .optional()
+    .describe(
+      'Stack connector ID. Only used when method is "connector". ' +
+        'The connector must expose an "extract" sub-action accepting { content, filename, docId } ' +
+        'and returning { content, contentType }.'
+    ),
+});
+
+const ExtractOutputSchema = z.object({
+  content: z.string().describe('Extracted text content'),
+  content_type: z
+    .string()
+    .optional()
+    .describe('Detected MIME content type of the document (e.g. application/pdf)'),
+});
+
+export type ExtractInput = z.infer<typeof ExtractInputSchema>;
+export type ExtractConfig = z.infer<typeof ExtractConfigSchema>;
+export type ExtractOutput = z.infer<typeof ExtractOutputSchema>;
+
+export const extractStepCommonDefinition: CommonStepDefinition<
+  typeof ExtractInputSchema,
+  typeof ExtractOutputSchema,
+  typeof ExtractConfigSchema
+> = {
+  id: ExtractStepTypeId,
+  category: StepCategory.Elasticsearch,
+  label: i18n.translate('xpack.dataSources.extractStep.label', {
+    defaultMessage: 'Extract Content',
+  }),
+  description: i18n.translate('xpack.dataSources.extractStep.description', {
+    defaultMessage:
+      'Extract text content from base64-encoded files using Tika, an inference endpoint, a custom workflow, or a connector',
+  }),
+  documentation: {
+    details: i18n.translate('xpack.dataSources.extractStep.documentation.details', {
+      defaultMessage: `The extraction step converts base64-encoded file data into plain text.
+
+**Methods:**
+• **tika** (default) — Built-in Elasticsearch ingest attachment processor (Apache Tika). Supports PDFs, Word, Excel, PowerPoint, HTML, RTF, plain text, and more. Runs within your cluster.
+• **inference** — Sends the document to an Elasticsearch inference endpoint (e.g. a vision-capable LLM). Useful for scanned PDFs, images, or documents needing OCR.
+• **workflow** — Delegates to a user-defined workflow. The workflow must conform to the extraction contract (see below).
+• **connector** — Calls a stack connector that exposes an "extract" sub-action (see below).
+
+**Extraction contract (inputs):**
+• content (string, required) — Base64-encoded file data
+• filename (string, required) — Original filename with extension
+• doc_id (string, optional) — Document identifier for traceability
+
+**Extraction contract (outputs):**
+• content (string, required) — Extracted plain text
+• content_type (string, optional) — Detected MIME type (e.g. application/pdf)
+
+**Workflow method:** The referenced workflow must declare inputs named content, filename, and optionally doc_id. Its final output must include content (string) and optionally content_type (string).
+
+**Connector method:** The connector must expose a sub-action named "extract" that accepts {content, filename, docId} and returns {content, contentType}.
+
+**Configuration:**
+• method — Override the global default extraction method
+• inference_id — Inference endpoint ID (when method is "inference")
+• workflow_id — Workflow ID (when method is "workflow")
+• connector_id — Stack connector ID (when method is "connector")`,
+    }),
+    examples: [
+      `## Basic Tika extraction (default)
+\`\`\`yaml
+- name: extract
+  type: ${ExtractStepTypeId}
+  with:
+    content: "\${{steps.download.output.base64}}"
+    filename: "\${{steps.download.output.name}}"
+\`\`\``,
+      `## Extraction with inference endpoint
+\`\`\`yaml
+- name: extract
+  type: ${ExtractStepTypeId}
+  config:
+    method: inference
+    inference_id: my-document-extraction-model
+  with:
+    content: "\${{steps.download.output.base64}}"
+    filename: "\${{steps.download.output.name}}"
+\`\`\``,
+      `## Extraction with a custom workflow
+\`\`\`yaml
+- name: extract
+  type: ${ExtractStepTypeId}
+  config:
+    method: workflow
+    workflow_id: "workflow-abc123"
+  with:
+    content: "\${{steps.download.output.base64}}"
+    filename: "\${{steps.download.output.name}}"
+\`\`\``,
+      `## Extraction with a stack connector
+\`\`\`yaml
+- name: extract
+  type: ${ExtractStepTypeId}
+  config:
+    method: connector
+    connector_id: "my-unstructured-connector"
+  with:
+    content: "\${{steps.download.output.base64}}"
+    filename: "\${{steps.download.output.name}}"
+\`\`\``,
+    ],
+  },
+  inputSchema: ExtractInputSchema,
+  configSchema: ExtractConfigSchema,
+  outputSchema: ExtractOutputSchema,
+};

--- a/x-pack/platform/plugins/shared/data_sources/common/steps/extract/extraction_contract.ts
+++ b/x-pack/platform/plugins/shared/data_sources/common/steps/extract/extraction_contract.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * # Extraction Contract
+ *
+ * Any backend that provides content extraction — whether it's a workflow,
+ * a stack connector, or a future integration — must conform to this contract.
+ *
+ * ## Input
+ *
+ * | Field      | Type   | Required | Description                                          |
+ * |------------|--------|----------|------------------------------------------------------|
+ * | `content`  | string | yes      | Base64-encoded file data                             |
+ * | `filename` | string | yes      | Original filename with extension (e.g. "report.pdf") |
+ * | `doc_id`   | string | no       | Optional document identifier for traceability        |
+ *
+ * ## Output
+ *
+ * | Field          | Type   | Required | Description                                      |
+ * |----------------|--------|----------|--------------------------------------------------|
+ * | `content`      | string | yes      | Extracted plain-text content                     |
+ * | `content_type` | string | no       | Detected MIME type (e.g. "application/pdf")      |
+ *
+ * ---
+ *
+ * ## For workflows (`method: "workflow"`)
+ *
+ * The referenced workflow must declare matching `inputs` and its final step
+ * must produce the output fields above. Example:
+ *
+ * ```yaml
+ * version: '1'
+ * name: my-custom-extraction
+ * inputs:
+ *   - name: content
+ *     type: string
+ *   - name: filename
+ *     type: string
+ *   - name: doc_id
+ *     type: string
+ *     required: false
+ * steps:
+ *   # ... your extraction logic ...
+ *   - name: result
+ *     type: data.set
+ *     with:
+ *       content: "${{steps.your_step.output.text}}"
+ *       content_type: "application/pdf"
+ * ```
+ *
+ * ## For connectors (`method: "connector"`)
+ *
+ * The connector must expose a sub-action named `extract` with the input/output
+ * shapes above. The step calls:
+ *
+ * ```typescript
+ * actionsClient.execute({
+ *   actionId: connectorId,
+ *   params: {
+ *     subAction: 'extract',
+ *     subActionParams: { content, filename, docId },
+ *   },
+ * })
+ * ```
+ *
+ * and expects `result.data` to contain `{ content: string, contentType?: string }`.
+ */
+
+export interface ExtractionInput {
+  content: string;
+  filename: string;
+  doc_id?: string;
+}
+
+export interface ExtractionOutput {
+  content: string;
+  content_type?: string;
+}
+
+/**
+ * Sub-action name that extraction-capable connectors must expose.
+ */
+export const EXTRACTION_SUB_ACTION = 'extract';
+
+/**
+ * All supported extraction methods.
+ *
+ * - `tika` — Built-in Elasticsearch ingest attachment processor (Apache Tika).
+ * - `inference` — Elasticsearch inference endpoint (completion task type).
+ * - `workflow` — A user-defined workflow conforming to the extraction contract.
+ * - `connector` — A stack connector exposing the `extract` sub-action.
+ */
+export const EXTRACTION_METHODS = ['tika', 'inference', 'workflow', 'connector'] as const;
+
+export type ExtractionMethod = (typeof EXTRACTION_METHODS)[number];

--- a/x-pack/platform/plugins/shared/data_sources/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/data_sources/kibana.jsonc
@@ -11,8 +11,8 @@
     "server": true,
     "configPath": ["xpack", "dataSources"],
     "requiredPlugins": ["actions", "dataCatalog", "agentBuilder", "workflowsManagement", "triggersActionsUi"],
-    "optionalPlugins": ["taskManager"],
-    "requiredBundles": ["kibanaReact"],
+    "optionalPlugins": ["taskManager", "workflowsExtensions"],
+    "requiredBundles": ["kibanaReact", "workflowsExtensions"],
     "extraPublicDirs": [
       "common"
     ]

--- a/x-pack/platform/plugins/shared/data_sources/public/application/features/settings/extraction_settings.tsx
+++ b/x-pack/platform/plugins/shared/data_sources/public/application/features/settings/extraction_settings.tsx
@@ -1,0 +1,736 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiText,
+  EuiSpacer,
+  EuiFormRow,
+  EuiSuperSelect,
+  EuiComboBox,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiHorizontalRule,
+  EuiAccordion,
+  EuiBadge,
+  EuiCodeBlock,
+  EuiTextArea,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  useExtractionConfig,
+  useInferenceEndpoints,
+  useWorkflows,
+  type ExtractionMethod,
+  type FormatOverride,
+} from '../../hooks/use_extraction_config';
+
+const EMPTY_OVERRIDES: Record<string, FormatOverride> = {};
+
+const KNOWN_FORMATS: Array<{ extension: string; label: string }> = [
+  { extension: '.pdf', label: 'PDF (.pdf)' },
+  { extension: '.docx', label: 'Word (.docx)' },
+  { extension: '.doc', label: 'Word legacy (.doc)' },
+  { extension: '.xlsx', label: 'Excel (.xlsx)' },
+  { extension: '.xls', label: 'Excel legacy (.xls)' },
+  { extension: '.pptx', label: 'PowerPoint (.pptx)' },
+  { extension: '.ppt', label: 'PowerPoint legacy (.ppt)' },
+  { extension: '.odt', label: 'OpenDocument Text (.odt)' },
+  { extension: '.ods', label: 'OpenDocument Spreadsheet (.ods)' },
+  { extension: '.odp', label: 'OpenDocument Presentation (.odp)' },
+  { extension: '.rtf', label: 'Rich Text (.rtf)' },
+  { extension: '.html', label: 'HTML (.html)' },
+  { extension: '.txt', label: 'Plain text (.txt)' },
+  { extension: '.csv', label: 'CSV (.csv)' },
+  { extension: '.epub', label: 'EPUB (.epub)' },
+  { extension: '.msg', label: 'Outlook (.msg)' },
+  { extension: '.eml', label: 'Email (.eml)' },
+  { extension: '.png', label: 'PNG image (.png)' },
+  { extension: '.jpg', label: 'JPEG image (.jpg)' },
+  { extension: '.tiff', label: 'TIFF image (.tiff)' },
+];
+
+const WORKFLOW_CONTRACT_TEXT = `The workflow must accept these inputs and produce the matching outputs:
+
+Inputs:
+  • content (string, required) — base64-encoded file data
+  • filename (string, required) — original filename with extension
+  • doc_id (string, optional) — document identifier
+
+Outputs:
+  • content (string, required) — extracted plain text
+  • content_type (string, optional) — MIME type (e.g. application/pdf)`;
+
+const METHOD_OPTIONS = [
+  {
+    value: 'tika' as const,
+    inputDisplay: i18n.translate('xpack.dataSources.settings.extraction.method.tika', {
+      defaultMessage: 'Tika (built-in)',
+    }),
+    dropdownDisplay: (
+      <>
+        <strong>
+          {i18n.translate('xpack.dataSources.settings.extraction.method.tika.title', {
+            defaultMessage: 'Tika (built-in)',
+          })}
+        </strong>
+        <EuiText size="xs" color="subdued">
+          {i18n.translate('xpack.dataSources.settings.extraction.method.tika.description', {
+            defaultMessage:
+              'Uses the Elasticsearch ingest attachment processor powered by Apache Tika. Supports PDFs, Word, Excel, HTML, and more. Runs entirely within your cluster.',
+          })}
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    value: 'inference' as const,
+    inputDisplay: i18n.translate('xpack.dataSources.settings.extraction.method.inference', {
+      defaultMessage: 'Inference endpoint',
+    }),
+    dropdownDisplay: (
+      <>
+        <strong>
+          {i18n.translate('xpack.dataSources.settings.extraction.method.inference.title', {
+            defaultMessage: 'Inference endpoint',
+          })}
+        </strong>
+        <EuiText size="xs" color="subdued">
+          {i18n.translate(
+            'xpack.dataSources.settings.extraction.method.inference.description',
+            {
+              defaultMessage:
+                'Sends documents to an Elasticsearch inference endpoint (e.g. a vision-capable LLM). Useful for scanned PDFs, images, or documents requiring OCR.',
+            }
+          )}
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    value: 'workflow' as const,
+    inputDisplay: i18n.translate('xpack.dataSources.settings.extraction.method.workflow', {
+      defaultMessage: 'Custom workflow',
+    }),
+    dropdownDisplay: (
+      <>
+        <strong>
+          {i18n.translate('xpack.dataSources.settings.extraction.method.workflow.title', {
+            defaultMessage: 'Custom workflow',
+          })}
+        </strong>
+        <EuiText size="xs" color="subdued">
+          {i18n.translate(
+            'xpack.dataSources.settings.extraction.method.workflow.description',
+            {
+              defaultMessage:
+                'Delegates extraction to a user-defined workflow. The workflow must conform to the extraction contract (specific inputs and outputs).',
+            }
+          )}
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    value: 'connector' as const,
+    inputDisplay: i18n.translate('xpack.dataSources.settings.extraction.method.connector', {
+      defaultMessage: 'Connector (coming soon)',
+    }),
+    disabled: true,
+    dropdownDisplay: (
+      <>
+        <strong>
+          {i18n.translate('xpack.dataSources.settings.extraction.method.connector.title', {
+            defaultMessage: 'Stack connector (coming soon)',
+          })}
+        </strong>
+        <EuiText size="xs" color="subdued">
+          {i18n.translate(
+            'xpack.dataSources.settings.extraction.method.connector.description',
+            {
+              defaultMessage:
+                'Uses a stack connector that exposes an "extract" sub-action (e.g. Unstructured.io, Amazon Textract). Not yet available.',
+            }
+          )}
+        </EuiText>
+      </>
+    ),
+  },
+];
+
+const METHOD_SELECT_OPTIONS = [
+  { value: 'tika' as const, inputDisplay: 'Tika' },
+  { value: 'inference' as const, inputDisplay: 'Inference' },
+  { value: 'workflow' as const, inputDisplay: 'Workflow' },
+  { value: 'connector' as const, inputDisplay: 'Connector', disabled: true },
+];
+
+interface FormatOverrideRowProps {
+  extension: string;
+  override: FormatOverride;
+  endpointOptions: Array<{ label: string }>;
+  endpointsLoading: boolean;
+  workflowOptions: Array<{ label: string; value: string }>;
+  workflowsLoading: boolean;
+  onChange: (ext: string, override: FormatOverride) => void;
+  onRemove: (ext: string) => void;
+}
+
+const FormatOverrideRow: React.FC<FormatOverrideRowProps> = ({
+  extension,
+  override,
+  endpointOptions,
+  endpointsLoading,
+  workflowOptions,
+  workflowsLoading,
+  onChange,
+  onRemove,
+}) => {
+  const selectedEndpoint = useMemo(
+    () => (override.inferenceId ? [{ label: override.inferenceId }] : []),
+    [override.inferenceId]
+  );
+
+  const formatLabel =
+    KNOWN_FORMATS.find((f) => f.extension === extension)?.label ?? extension;
+
+  return (
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false} style={{ width: 200 }}>
+        <EuiBadge color="hollow">{formatLabel}</EuiBadge>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false} style={{ width: 160 }}>
+        <EuiSuperSelect
+          options={METHOD_SELECT_OPTIONS}
+          valueOfSelected={override.method}
+          onChange={(value) => onChange(extension, { ...override, method: value })}
+          compressed
+        />
+      </EuiFlexItem>
+      {override.method === 'inference' && (
+        <EuiFlexItem grow>
+          <EuiComboBox
+            singleSelection={{ asPlainText: true }}
+            options={endpointOptions}
+            selectedOptions={selectedEndpoint}
+            onChange={(opts) =>
+              onChange(extension, { ...override, inferenceId: opts[0]?.label })
+            }
+            isLoading={endpointsLoading}
+            compressed
+            placeholder="Auto-discover"
+          />
+        </EuiFlexItem>
+      )}
+      {override.method === 'workflow' && (
+        <EuiFlexItem grow>
+          <EuiComboBox
+            singleSelection={{ asPlainText: true }}
+            options={workflowOptions}
+            selectedOptions={
+              override.workflowId ? [{ label: override.workflowId, value: override.workflowId }] : []
+            }
+            onCreateOption={(val) =>
+              onChange(extension, { ...override, workflowId: val })
+            }
+            onChange={(opts) => {
+              const picked = opts[0] as { label: string; value?: string } | undefined;
+              onChange(extension, { ...override, workflowId: picked?.value ?? picked?.label });
+            }}
+            isLoading={workflowsLoading}
+            compressed
+            placeholder="Select or type a workflow ID"
+          />
+        </EuiFlexItem>
+      )}
+      {(override.method === 'tika' || override.method === 'connector') && (
+        <EuiFlexItem grow />
+      )}
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          iconType="trash"
+          color="danger"
+          aria-label={`Remove ${extension} override`}
+          onClick={() => onRemove(extension)}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+export const ExtractionSettings: React.FC = () => {
+  const { config, isLoading, isError, updateConfig, isUpdating } = useExtractionConfig();
+  const { data: endpoints, isLoading: endpointsLoading } = useInferenceEndpoints();
+  const { data: workflows, isLoading: workflowsLoading } = useWorkflows();
+
+  const [method, setMethod] = useState<ExtractionMethod>(config.method);
+  const [inferenceId, setInferenceId] = useState<string | undefined>(config.inferenceId);
+  const [workflowId, setWorkflowId] = useState<string | undefined>(config.workflowId);
+  const [formatOverrides, setFormatOverrides] = useState<Record<string, FormatOverride>>(
+    config.formatOverrides ?? EMPTY_OVERRIDES
+  );
+  const [hasChanges, setHasChanges] = useState(false);
+  const [advancedJson, setAdvancedJson] = useState('');
+  const [advancedJsonError, setAdvancedJsonError] = useState<string | undefined>();
+
+  useEffect(() => {
+    setMethod(config.method);
+    setInferenceId(config.inferenceId);
+    setWorkflowId(config.workflowId);
+    setFormatOverrides(config.formatOverrides ?? EMPTY_OVERRIDES);
+    setHasChanges(false);
+  }, [config]);
+
+  const markDirty = useCallback(() => setHasChanges(true), []);
+
+  const handleMethodChange = useCallback(
+    (value: ExtractionMethod) => {
+      setMethod(value);
+      markDirty();
+    },
+    [markDirty]
+  );
+
+  const handleInferenceIdChange = useCallback(
+    (selectedOptions: Array<{ label: string }>) => {
+      setInferenceId(selectedOptions[0]?.label);
+      markDirty();
+    },
+    [markDirty]
+  );
+
+  const handleWorkflowIdChange = useCallback(
+    (value: string) => {
+      setWorkflowId(value || undefined);
+      markDirty();
+    },
+    [markDirty]
+  );
+
+  const handleFormatOverrideChange = useCallback(
+    (ext: string, override: FormatOverride) => {
+      setFormatOverrides((prev) => ({ ...prev, [ext]: override }));
+      markDirty();
+    },
+    [markDirty]
+  );
+
+  const handleRemoveFormatOverride = useCallback(
+    (ext: string) => {
+      setFormatOverrides((prev) => {
+        const next = { ...prev };
+        delete next[ext];
+        return next;
+      });
+      markDirty();
+    },
+    [markDirty]
+  );
+
+  const availableFormats = useMemo(
+    () => KNOWN_FORMATS.filter((f) => !formatOverrides[f.extension]),
+    [formatOverrides]
+  );
+
+  const formatDropdownOptions = useMemo(
+    () => availableFormats.map((f) => ({ label: f.label, value: f.extension })),
+    [availableFormats]
+  );
+
+  const handleAddFormatFromDropdown = useCallback(
+    (selectedOptions: Array<{ label: string; value?: string }>) => {
+      const ext = selectedOptions[0]?.value;
+      if (!ext) return;
+      setFormatOverrides((prev) => ({ ...prev, [ext]: { method: 'tika' } }));
+      markDirty();
+    },
+    [markDirty]
+  );
+
+  // Sync overrides -> advanced JSON when the accordion opens
+  const handleAdvancedToggle = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen) {
+        setAdvancedJson(JSON.stringify(formatOverrides, null, 2));
+        setAdvancedJsonError(undefined);
+      }
+    },
+    [formatOverrides]
+  );
+
+  const handleAdvancedJsonApply = useCallback(() => {
+    try {
+      const parsed = JSON.parse(advancedJson);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        setAdvancedJsonError('Must be a JSON object');
+        return;
+      }
+      const validMethods = new Set(['tika', 'inference', 'workflow', 'connector']);
+      for (const [key, val] of Object.entries(parsed)) {
+        if (typeof key !== 'string') {
+          setAdvancedJsonError(`Key must be a string: ${key}`);
+          return;
+        }
+        const v = val as Record<string, unknown>;
+        if (!v.method || !validMethods.has(v.method as string)) {
+          setAdvancedJsonError(
+            `Invalid method for "${key}": must be one of tika, inference, workflow, connector`
+          );
+          return;
+        }
+      }
+      setFormatOverrides(parsed as Record<string, FormatOverride>);
+      setAdvancedJsonError(undefined);
+      markDirty();
+    } catch (e) {
+      setAdvancedJsonError(`Invalid JSON: ${(e as Error).message}`);
+    }
+  }, [advancedJson, markDirty]);
+
+  const handleSave = useCallback(() => {
+    const overrides = Object.keys(formatOverrides).length > 0 ? formatOverrides : undefined;
+    updateConfig({
+      method,
+      inferenceId: method === 'inference' ? inferenceId : undefined,
+      workflowId: method === 'workflow' ? workflowId : undefined,
+      formatOverrides: overrides,
+    });
+  }, [method, inferenceId, workflowId, formatOverrides, updateConfig]);
+
+  const endpointOptions = useMemo(
+    () => (endpoints ?? []).map((ep) => ({ label: ep.inference_id })),
+    [endpoints]
+  );
+
+  const selectedEndpoint = useMemo(
+    () => (inferenceId ? [{ label: inferenceId }] : []),
+    [inferenceId]
+  );
+
+  const workflowOptions = useMemo(
+    () => {
+      const compatible = (workflows ?? []).filter((wf) => wf.compatible);
+      const incompatible = (workflows ?? []).filter((wf) => !wf.compatible);
+
+      const options: Array<{ label: string; value: string; color?: string }> = [];
+
+      for (const wf of compatible) {
+        options.push({ label: `${wf.name} (${wf.id})`, value: wf.id });
+      }
+
+      for (const wf of incompatible) {
+        const issueText = wf.issues?.length ? `: ${wf.issues.join(', ')}` : '';
+        options.push({
+          label: `${wf.name} (${wf.id}) — incompatible${issueText}`,
+          value: wf.id,
+          color: 'subdued',
+        });
+      }
+
+      return options;
+    },
+    [workflows]
+  );
+
+  const selectedWorkflow = useMemo(
+    () => {
+      if (!workflowId) return [];
+      const match = workflows?.find((wf) => wf.id === workflowId);
+      return [{ label: match ? `${match.name} (${match.id})` : workflowId, value: workflowId }];
+    },
+    [workflowId, workflows]
+  );
+
+  const overrideCount = Object.keys(formatOverrides).length;
+
+  if (isLoading) {
+    return <EuiLoadingSpinner size="l" />;
+  }
+
+  if (isError) {
+    return (
+      <EuiCallOut
+        title={i18n.translate('xpack.dataSources.settings.extraction.error', {
+          defaultMessage: 'Failed to load extraction settings',
+        })}
+        color="danger"
+        iconType="error"
+      />
+    );
+  }
+
+  return (
+    <EuiPanel hasBorder>
+      <EuiTitle size="s">
+        <h3>
+          {i18n.translate('xpack.dataSources.settings.extraction.title', {
+            defaultMessage: 'Content extraction',
+          })}
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        {i18n.translate('xpack.dataSources.settings.extraction.description', {
+          defaultMessage:
+            'Configure how text content is extracted from downloaded files (PDFs, Word docs, etc.). This setting applies as the default for all data sources. Individual workflow steps can override this.',
+        })}
+      </EuiText>
+
+      <EuiHorizontalRule margin="m" />
+
+      <EuiFormRow
+        label={i18n.translate('xpack.dataSources.settings.extraction.methodLabel', {
+          defaultMessage: 'Default extraction method',
+        })}
+        helpText={i18n.translate('xpack.dataSources.settings.extraction.methodHelp', {
+          defaultMessage:
+            'Choose how files are converted to text. Tika is the default and works for most file types. Use format overrides below to route specific file types differently.',
+        })}
+      >
+        <EuiSuperSelect
+          options={METHOD_OPTIONS}
+          valueOfSelected={method}
+          onChange={handleMethodChange}
+          data-test-subj="extractionMethodSelect"
+        />
+      </EuiFormRow>
+
+      {method === 'inference' && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiFormRow
+            label={i18n.translate('xpack.dataSources.settings.extraction.inferenceIdLabel', {
+              defaultMessage: 'Default inference endpoint',
+            })}
+            helpText={i18n.translate('xpack.dataSources.settings.extraction.inferenceIdHelp', {
+              defaultMessage:
+                'Select a completion inference endpoint. If left empty, the system will auto-discover an available one.',
+            })}
+          >
+            <EuiComboBox
+              singleSelection={{ asPlainText: true }}
+              options={endpointOptions}
+              selectedOptions={selectedEndpoint}
+              onChange={handleInferenceIdChange}
+              isLoading={endpointsLoading}
+              placeholder={i18n.translate(
+                'xpack.dataSources.settings.extraction.inferenceIdPlaceholder',
+                { defaultMessage: 'Auto-discover endpoint' }
+              )}
+              data-test-subj="extractionInferenceIdSelect"
+            />
+          </EuiFormRow>
+        </>
+      )}
+
+      {method === 'workflow' && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiFormRow
+            label={i18n.translate('xpack.dataSources.settings.extraction.workflowIdLabel', {
+              defaultMessage: 'Workflow',
+            })}
+            helpText={i18n.translate('xpack.dataSources.settings.extraction.workflowIdHelp', {
+              defaultMessage:
+                'Select a workflow or type an ID. Compatible workflows declare "content" and "filename" inputs. You can also paste an ID manually.',
+            })}
+          >
+            <EuiComboBox
+              singleSelection={{ asPlainText: true }}
+              options={workflowOptions}
+              selectedOptions={selectedWorkflow}
+              onCreateOption={(val) => handleWorkflowIdChange(val)}
+              onChange={(opts) => {
+                const picked = opts[0] as { label: string; value?: string } | undefined;
+                handleWorkflowIdChange(picked?.value ?? picked?.label ?? '');
+              }}
+              isLoading={workflowsLoading}
+              placeholder={i18n.translate(
+                'xpack.dataSources.settings.extraction.workflowIdPlaceholder',
+                { defaultMessage: 'Select or type a workflow ID...' }
+              )}
+              data-test-subj="extractionWorkflowIdSelect"
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            title={i18n.translate('xpack.dataSources.settings.extraction.workflowContract.title', {
+              defaultMessage: 'Extraction contract',
+            })}
+            iconType="iInCircle"
+            size="s"
+          >
+            <EuiText size="xs">
+              <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{WORKFLOW_CONTRACT_TEXT}</pre>
+            </EuiText>
+          </EuiCallOut>
+        </>
+      )}
+
+      <EuiSpacer size="l" />
+
+      <EuiAccordion
+        id="formatOverrides"
+        buttonContent={
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xs">
+                <h4>
+                  {i18n.translate('xpack.dataSources.settings.extraction.formatOverrides.title', {
+                    defaultMessage: 'Per-format overrides',
+                  })}
+                </h4>
+              </EuiTitle>
+            </EuiFlexItem>
+            {overrideCount > 0 && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge>{overrideCount}</EuiBadge>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        }
+        paddingSize="m"
+      >
+        <EuiText size="xs" color="subdued">
+          {i18n.translate(
+            'xpack.dataSources.settings.extraction.formatOverrides.description',
+            {
+              defaultMessage:
+                'Route specific file types to different extraction methods. For example, send PDFs to an inference endpoint while keeping everything else on Tika.',
+            }
+          )}
+        </EuiText>
+        <EuiSpacer size="m" />
+
+        {Object.entries(formatOverrides).map(([ext, override]) => (
+          <React.Fragment key={ext}>
+            <FormatOverrideRow
+              extension={ext}
+              override={override}
+              endpointOptions={endpointOptions}
+              endpointsLoading={endpointsLoading}
+              workflowOptions={workflowOptions}
+              workflowsLoading={workflowsLoading}
+              onChange={handleFormatOverrideChange}
+              onRemove={handleRemoveFormatOverride}
+            />
+            <EuiSpacer size="s" />
+          </React.Fragment>
+        ))}
+
+        <EuiFormRow
+          label={i18n.translate('xpack.dataSources.settings.extraction.formatOverrides.addLabel', {
+            defaultMessage: 'Add format override',
+          })}
+        >
+          <EuiComboBox
+            singleSelection={{ asPlainText: true }}
+            options={formatDropdownOptions}
+            selectedOptions={[]}
+            onChange={handleAddFormatFromDropdown}
+            placeholder={i18n.translate(
+              'xpack.dataSources.settings.extraction.formatOverrides.selectPlaceholder',
+              { defaultMessage: 'Select a file format...' }
+            )}
+            compressed
+            data-test-subj="addFormatOverrideDropdown"
+          />
+        </EuiFormRow>
+
+        <EuiSpacer size="l" />
+
+        <EuiAccordion
+          id="advancedJsonOverrides"
+          buttonContent={
+            <EuiTitle size="xxs">
+              <h5>
+                {i18n.translate('xpack.dataSources.settings.extraction.advanced.title', {
+                  defaultMessage: 'Advanced: JSON editor',
+                })}
+              </h5>
+            </EuiTitle>
+          }
+          paddingSize="s"
+          onToggle={handleAdvancedToggle}
+        >
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('xpack.dataSources.settings.extraction.advanced.description', {
+              defaultMessage:
+                'Paste or edit a JSON map of format overrides directly. Keys are file extensions (e.g. ".pdf"), values are objects with "method" and optional "inferenceId".',
+            })}
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiCodeBlock language="json" fontSize="s" paddingSize="s" isCopyable>
+            {`// Example:\n${JSON.stringify(
+              {
+                '.pdf': { method: 'inference', inferenceId: 'my-vision-model' },
+                '.docx': { method: 'tika' },
+                '.html': { method: 'workflow', workflowId: 'my-html-extractor' },
+              },
+              null,
+              2
+            )}`}
+          </EuiCodeBlock>
+          <EuiSpacer size="s" />
+          <EuiTextArea
+            value={advancedJson}
+            onChange={(e) => {
+              setAdvancedJson(e.target.value);
+              setAdvancedJsonError(undefined);
+            }}
+            rows={8}
+            fullWidth
+            isInvalid={!!advancedJsonError}
+            data-test-subj="advancedJsonOverridesTextarea"
+          />
+          {advancedJsonError && (
+            <>
+              <EuiSpacer size="s" />
+              <EuiCallOut size="s" color="danger" title={advancedJsonError} />
+            </>
+          )}
+          <EuiSpacer size="s" />
+          <EuiButtonEmpty
+            size="s"
+            iconType="check"
+            onClick={handleAdvancedJsonApply}
+            data-test-subj="applyAdvancedJsonButton"
+          >
+            {i18n.translate('xpack.dataSources.settings.extraction.advanced.apply', {
+              defaultMessage: 'Apply JSON',
+            })}
+          </EuiButtonEmpty>
+        </EuiAccordion>
+      </EuiAccordion>
+
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            fill
+            onClick={handleSave}
+            isLoading={isUpdating}
+            disabled={!hasChanges}
+            data-test-subj="saveExtractionConfigButton"
+          >
+            {i18n.translate('xpack.dataSources.settings.extraction.save', {
+              defaultMessage: 'Save',
+            })}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/plugins/shared/data_sources/public/application/hooks/use_extraction_config.ts
+++ b/x-pack/platform/plugins/shared/data_sources/public/application/hooks/use_extraction_config.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@kbn/react-query';
+import { useKibana } from './use_kibana';
+import {
+  EXTRACTION_CONFIG_QUERY_KEY,
+  INFERENCE_ENDPOINTS_QUERY_KEY,
+  WORKFLOWS_QUERY_KEY,
+} from '../query_keys';
+
+export type ExtractionMethod = 'tika' | 'inference' | 'workflow' | 'connector';
+
+export interface FormatOverride {
+  method: ExtractionMethod;
+  inferenceId?: string;
+  workflowId?: string;
+  connectorId?: string;
+}
+
+export interface ExtractionConfig {
+  method: ExtractionMethod;
+  inferenceId?: string;
+  workflowId?: string;
+  connectorId?: string;
+  formatOverrides?: Record<string, FormatOverride>;
+}
+
+interface InferenceEndpoint {
+  inference_id: string;
+  service: string;
+  task_type: string;
+}
+
+const DEFAULT_CONFIG: ExtractionConfig = { method: 'tika' };
+
+export const useExtractionConfig = () => {
+  const { http } = useKibana().services;
+  const queryClient = useQueryClient();
+
+  const configQuery = useQuery({
+    queryKey: [EXTRACTION_CONFIG_QUERY_KEY],
+    queryFn: () => http.get<ExtractionConfig>('/internal/data_sources/extraction_config'),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (newConfig: ExtractionConfig) =>
+      http.put<ExtractionConfig>('/internal/data_sources/extraction_config', {
+        body: JSON.stringify(newConfig),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [EXTRACTION_CONFIG_QUERY_KEY] });
+    },
+  });
+
+  const config = useMemo(
+    () => configQuery.data ?? DEFAULT_CONFIG,
+    [configQuery.data]
+  );
+
+  return {
+    config,
+    isLoading: configQuery.isLoading,
+    isError: configQuery.isError,
+    updateConfig: updateMutation.mutate,
+    isUpdating: updateMutation.isLoading,
+  };
+};
+
+export const useInferenceEndpoints = () => {
+  const { http } = useKibana().services;
+
+  return useQuery({
+    queryKey: [INFERENCE_ENDPOINTS_QUERY_KEY],
+    queryFn: async () => {
+      const response = await http.get<{ endpoints: InferenceEndpoint[] }>(
+        '/internal/data_sources/inference_endpoints'
+      );
+      return response.endpoints;
+    },
+  });
+};
+
+export interface WorkflowOption {
+  id: string;
+  name: string;
+  description: string;
+  compatible: boolean;
+  issues?: string[];
+}
+
+export const useWorkflows = () => {
+  const { http } = useKibana().services;
+
+  return useQuery({
+    queryKey: [WORKFLOWS_QUERY_KEY],
+    queryFn: async () => {
+      const response = await http.get<{ workflows: WorkflowOption[] }>(
+        '/internal/data_sources/workflows'
+      );
+      return response.workflows;
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/data_sources/public/application/pages/settings_page.tsx
+++ b/x-pack/platform/plugins/shared/data_sources/public/application/pages/settings_page.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { ExtractionSettings } from '../features/settings/extraction_settings';
+
+export const SettingsPage: React.FC = () => {
+  return (
+    <>
+      <EuiSpacer size="l" />
+      <ExtractionSettings />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/data_sources/public/application/pages/sources_page.tsx
+++ b/x-pack/platform/plugins/shared/data_sources/public/application/pages/sources_page.tsx
@@ -6,18 +6,33 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { EuiButton } from '@elastic/eui';
+import { EuiButton, EuiTabs, EuiTab, EuiSpacer } from '@elastic/eui';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { i18n } from '@kbn/i18n';
 import { SourcesList } from '../features/sources_list';
 import { SourceSelectionFlyout } from '../features/add_source/source_selection_flyout';
+import { SettingsPage } from './settings_page';
 import { useBreadcrumbs } from '../hooks/use_breadcrumbs';
 import { useAddConnectorFlyout } from '../hooks/use_add_connector_flyout';
 import type { Connector } from '../../types/connector';
 
+type TabId = 'sources' | 'settings';
+
+const TABS: Array<{ id: TabId; label: string }> = [
+  {
+    id: 'sources',
+    label: i18n.translate('xpack.dataSources.tabs.sources', { defaultMessage: 'Sources' }),
+  },
+  {
+    id: 'settings',
+    label: i18n.translate('xpack.dataSources.tabs.settings', { defaultMessage: 'Settings' }),
+  },
+];
+
 export const SourcesPage: React.FC = () => {
   useBreadcrumbs([]);
 
+  const [activeTab, setActiveTab] = useState<TabId>('sources');
   const [showSelectionFlyout, setShowSelectionFlyout] = useState(false);
 
   const { openFlyout: openAddSourceFlyout, flyout: addSourceFlyout } = useAddConnectorFlyout();
@@ -29,8 +44,6 @@ export const SourcesPage: React.FC = () => {
   const handleSourceSelected = useCallback(
     (source: Connector) => {
       setShowSelectionFlyout(false);
-      // source.type is the stack connector actionTypeId (e.g., ".github") used by triggersActionsUi
-      // source.id is the data source identifier (e.g., "github") used by our API
       openAddSourceFlyout(source.type, source.id);
     },
     [openAddSourceFlyout]
@@ -45,20 +58,24 @@ export const SourcesPage: React.FC = () => {
         description={i18n.translate('xpack.dataSources.pageDescription', {
           defaultMessage: 'Connect your data to power your agents and indices.',
         })}
-        rightSideItems={[
-          <EuiButton
-            key="addDataSource"
-            iconType="plusInCircle"
-            color="primary"
-            fill
-            onClick={handleAddSource}
-            data-test-subj="addDataSourceButton"
-          >
-            {i18n.translate('xpack.dataSources.addSourceButton', {
-              defaultMessage: 'Add data source',
-            })}
-          </EuiButton>,
-        ]}
+        rightSideItems={
+          activeTab === 'sources'
+            ? [
+                <EuiButton
+                  key="addDataSource"
+                  iconType="plusInCircle"
+                  color="primary"
+                  fill
+                  onClick={handleAddSource}
+                  data-test-subj="addDataSourceButton"
+                >
+                  {i18n.translate('xpack.dataSources.addSourceButton', {
+                    defaultMessage: 'Add data source',
+                  })}
+                </EuiButton>,
+              ]
+            : []
+        }
         css={({ euiTheme }) => ({
           backgroundColor: euiTheme.colors.backgroundBasePlain,
           borderBlockEnd: 'none',
@@ -66,7 +83,20 @@ export const SourcesPage: React.FC = () => {
       />
 
       <KibanaPageTemplate.Section>
-        <SourcesList />
+        <EuiTabs>
+          {TABS.map((tab) => (
+            <EuiTab
+              key={tab.id}
+              isSelected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              data-test-subj={`dataSourcesTab-${tab.id}`}
+            >
+              {tab.label}
+            </EuiTab>
+          ))}
+        </EuiTabs>
+        <EuiSpacer size="l" />
+        {activeTab === 'sources' ? <SourcesList /> : <SettingsPage />}
       </KibanaPageTemplate.Section>
 
       {showSelectionFlyout && (

--- a/x-pack/platform/plugins/shared/data_sources/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/data_sources/public/application/query_keys.ts
@@ -21,3 +21,7 @@ export const queryKeys = {
     byId: (id: string) => ['stackConnectors', 'detail', id] as const,
   },
 };
+
+export const EXTRACTION_CONFIG_QUERY_KEY = 'extractionConfig';
+export const INFERENCE_ENDPOINTS_QUERY_KEY = 'inferenceEndpoints';
+export const WORKFLOWS_QUERY_KEY = 'workflows';

--- a/x-pack/platform/plugins/shared/data_sources/public/eui_icons.d.ts
+++ b/x-pack/platform/plugins/shared/data_sources/public/eui_icons.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+declare module '@elastic/eui/es/components/icon/assets/*' {
+  import type * as React from 'react';
+
+  interface SVGRProps {
+    title?: string;
+    titleId?: string;
+  }
+  export const icon: ({
+    title,
+    titleId,
+    ...props
+  }: React.SVGProps<SVGSVGElement> & SVGRProps) => React.JSX.Element;
+  export {};
+}

--- a/x-pack/platform/plugins/shared/data_sources/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/data_sources/public/plugin.ts
@@ -19,6 +19,7 @@ import type {
   DataSourcesPluginStart,
   DataSourcesPluginStartDependencies,
 } from './types';
+import { createExtractStepDefinition } from './steps/extract/extract_step';
 
 export class DataSourcesPlugin
   implements
@@ -31,12 +32,18 @@ export class DataSourcesPlugin
 {
   constructor(context: PluginInitializerContext) {}
   setup(
-    core: CoreSetup<DataSourcesPluginStartDependencies, DataSourcesPluginStart>
+    core: CoreSetup<DataSourcesPluginStartDependencies, DataSourcesPluginStart>,
+    plugins: DataSourcesPluginSetupDependencies
   ): DataSourcesPluginSetup {
     const isDataSourcesEnabled = core.settings.client.get<boolean>(DATA_SOURCES_ENABLED_SETTING_ID);
     if (isDataSourcesEnabled) {
       registerApp({ core });
     }
+
+    if (plugins.workflowsExtensions) {
+      plugins.workflowsExtensions.registerStepDefinition(createExtractStepDefinition(core));
+    }
+
     return {};
   }
   start(core: CoreStart): DataSourcesPluginStart {

--- a/x-pack/platform/plugins/shared/data_sources/public/steps/extract/extract_step.ts
+++ b/x-pack/platform/plugins/shared/data_sources/public/steps/extract/extract_step.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { CoreSetup, HttpStart } from '@kbn/core/public';
+import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { extractStepCommonDefinition } from '../../../common/steps/extract/extract_step';
+import { createInferenceIdSelectionHandler } from './inference_id_selection';
+
+export const createExtractStepDefinition = (core: CoreSetup) => {
+  let httpPromise: Promise<HttpStart> | null = null;
+
+  const getHttp = async (): Promise<HttpStart> => {
+    if (!httpPromise) {
+      httpPromise = core.getStartServices().then(([coreStart]) => coreStart.http);
+    }
+    return httpPromise;
+  };
+
+  return createPublicStepDefinition({
+    ...extractStepCommonDefinition,
+    icon: React.lazy(() =>
+      import('@elastic/eui/es/components/icon/assets/document_edit').then(({ icon }) => ({
+        default: icon,
+      }))
+    ),
+    editorHandlers: {
+      config: {
+        inference_id: {
+          selection: createInferenceIdSelectionHandler(getHttp),
+        },
+      },
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/data_sources/public/steps/extract/inference_id_selection.ts
+++ b/x-pack/platform/plugins/shared/data_sources/public/steps/extract/inference_id_selection.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpStart } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import type {
+  PropertySelectionHandler,
+  SelectionOption,
+  SelectionDetails,
+  SelectionContext,
+} from '@kbn/workflows';
+
+interface InferenceEndpoint {
+  inference_id: string;
+  service: string;
+  task_type: string;
+}
+
+async function loadCompletionEndpoints(http: HttpStart): Promise<InferenceEndpoint[]> {
+  const response = await http.get<{ endpoints: InferenceEndpoint[] }>(
+    '/internal/data_sources/inference_endpoints'
+  );
+  return response.endpoints;
+}
+
+export function createInferenceIdSelectionHandler(
+  getHttp: () => Promise<HttpStart>
+): PropertySelectionHandler<string> {
+  return {
+    search: async (
+      input: string,
+      _context: SelectionContext
+    ): Promise<SelectionOption<string>[]> => {
+      try {
+        const http = await getHttp();
+        const endpoints = await loadCompletionEndpoints(http);
+        return endpoints
+          .filter((ep) => input === '' || ep.inference_id.includes(input))
+          .map((ep) => ({
+            value: ep.inference_id,
+            label: ep.inference_id,
+            description: i18n.translate(
+              'xpack.dataSources.extractStep.inferenceIdSelection.service',
+              {
+                defaultMessage: 'Service: {service}',
+                values: { service: ep.service },
+              }
+            ),
+          }));
+      } catch {
+        return [];
+      }
+    },
+
+    resolve: async (
+      value: string,
+      _context: SelectionContext
+    ): Promise<SelectionOption<string> | null> => {
+      try {
+        const http = await getHttp();
+        const endpoints = await loadCompletionEndpoints(http);
+        const endpoint = endpoints.find((ep) => ep.inference_id === value);
+        if (!endpoint) return null;
+
+        return {
+          value: endpoint.inference_id,
+          label: endpoint.inference_id,
+          description: i18n.translate(
+            'xpack.dataSources.extractStep.inferenceIdSelection.service',
+            {
+              defaultMessage: 'Service: {service}',
+              values: { service: endpoint.service },
+            }
+          ),
+        };
+      } catch {
+        return null;
+      }
+    },
+
+    getDetails: async (
+      input: string,
+      _context: SelectionContext,
+      option: SelectionOption<string> | null
+    ): Promise<SelectionDetails> => {
+      if (option) {
+        return {
+          message: i18n.translate(
+            'xpack.dataSources.extractStep.inferenceIdSelection.connected',
+            {
+              defaultMessage: 'Connected to endpoint ({label})',
+              values: { label: option.label },
+            }
+          ),
+        };
+      }
+      return {
+        message: i18n.translate(
+          'xpack.dataSources.extractStep.inferenceIdSelection.notFound',
+          {
+            defaultMessage: 'Inference endpoint "{input}" not found',
+            values: { input },
+          }
+        ),
+      };
+    },
+  };
+}

--- a/x-pack/platform/plugins/shared/data_sources/public/types.ts
+++ b/x-pack/platform/plugins/shared/data_sources/public/types.ts
@@ -8,12 +8,15 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import type { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 
 export interface DataSourcesPluginSetup {}
 
 export interface DataSourcesPluginStart {}
 
-export interface DataSourcesPluginSetupDependencies {}
+export interface DataSourcesPluginSetupDependencies {
+  workflowsExtensions?: WorkflowsExtensionsPublicPluginSetup;
+}
 
 export interface DataSourcesPluginStartDependencies {
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;

--- a/x-pack/platform/plugins/shared/data_sources/server/extraction_config/index.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/extraction_config/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EXTRACTION_CONFIG_SO_TYPE, EXTRACTION_CONFIG_SO_ID } from './saved_object';
+export type {
+  ExtractionConfigAttributes,
+  ExtractionGlobalConfig,
+  ExtractionMethod,
+  FormatOverride,
+} from './types';
+export { getExtractionConfig, updateExtractionConfig, DEFAULT_EXTRACTION_CONFIG } from './service';

--- a/x-pack/platform/plugins/shared/data_sources/server/extraction_config/saved_object.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/extraction_config/saved_object.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type {
+  SavedObjectsServiceSetup,
+  SavedObjectsTypeMappingDefinition,
+} from '@kbn/core/server';
+
+export const EXTRACTION_CONFIG_SO_TYPE = 'data_sources_extraction_config';
+export const EXTRACTION_CONFIG_SO_ID = 'data-sources-extraction-config';
+
+const methodSchema = schema.oneOf([
+  schema.literal('tika'),
+  schema.literal('inference'),
+  schema.literal('workflow'),
+  schema.literal('connector'),
+]);
+
+const formatOverrideSchema = schema.object({
+  method: methodSchema,
+  inferenceId: schema.maybe(schema.string()),
+  workflowId: schema.maybe(schema.string()),
+  connectorId: schema.maybe(schema.string()),
+});
+
+const extractionConfigSchema = schema.object({
+  method: methodSchema,
+  inferenceId: schema.maybe(schema.string()),
+  workflowId: schema.maybe(schema.string()),
+  connectorId: schema.maybe(schema.string()),
+  formatOverrides: schema.maybe(schema.recordOf(schema.string(), formatOverrideSchema)),
+});
+
+const extractionConfigMappings: SavedObjectsTypeMappingDefinition = {
+  dynamic: false,
+  properties: {
+    method: { type: 'keyword' },
+    inferenceId: { type: 'keyword' },
+    workflowId: { type: 'keyword' },
+    connectorId: { type: 'keyword' },
+  },
+};
+
+export function registerExtractionConfigSavedObject(savedObjects: SavedObjectsServiceSetup) {
+  savedObjects.registerType({
+    name: EXTRACTION_CONFIG_SO_TYPE,
+    hidden: true,
+    namespaceType: 'multiple-isolated',
+    mappings: extractionConfigMappings,
+    modelVersions: {
+      1: {
+        changes: [],
+        schemas: {
+          forwardCompatibility: extractionConfigSchema.extends({}, { unknowns: 'ignore' }),
+          create: extractionConfigSchema,
+        },
+      },
+    },
+  });
+}

--- a/x-pack/platform/plugins/shared/data_sources/server/extraction_config/service.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/extraction_config/service.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { EXTRACTION_CONFIG_SO_TYPE, EXTRACTION_CONFIG_SO_ID } from './saved_object';
+import type { ExtractionConfigAttributes, ExtractionGlobalConfig } from './types';
+
+export const DEFAULT_EXTRACTION_CONFIG: ExtractionGlobalConfig = {
+  method: 'tika',
+};
+
+export async function getExtractionConfig(
+  savedObjectsClient: SavedObjectsClientContract
+): Promise<ExtractionGlobalConfig> {
+  try {
+    const so = await savedObjectsClient.get<ExtractionConfigAttributes>(
+      EXTRACTION_CONFIG_SO_TYPE,
+      EXTRACTION_CONFIG_SO_ID
+    );
+    return {
+      method: so.attributes.method,
+      inferenceId: so.attributes.inferenceId,
+      workflowId: so.attributes.workflowId,
+      connectorId: so.attributes.connectorId,
+      formatOverrides: so.attributes.formatOverrides,
+    };
+  } catch (err: unknown) {
+    const statusCode = (err as { output?: { statusCode?: number } })?.output?.statusCode;
+    if (statusCode === 404) {
+      return DEFAULT_EXTRACTION_CONFIG;
+    }
+    throw err;
+  }
+}
+
+export async function updateExtractionConfig(
+  savedObjectsClient: SavedObjectsClientContract,
+  config: ExtractionGlobalConfig
+): Promise<ExtractionGlobalConfig> {
+  const attributes: ExtractionConfigAttributes = {
+    method: config.method,
+    inferenceId: config.inferenceId,
+    workflowId: config.workflowId,
+    connectorId: config.connectorId,
+    formatOverrides: config.formatOverrides,
+  };
+
+  await savedObjectsClient.create<ExtractionConfigAttributes>(
+    EXTRACTION_CONFIG_SO_TYPE,
+    attributes,
+    { id: EXTRACTION_CONFIG_SO_ID, overwrite: true }
+  );
+
+  return config;
+}

--- a/x-pack/platform/plugins/shared/data_sources/server/extraction_config/types.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/extraction_config/types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { ExtractionMethod } from '../../common/steps/extract/extraction_contract';
+
+export interface FormatOverride {
+  method: 'tika' | 'inference' | 'workflow' | 'connector';
+  inferenceId?: string;
+  workflowId?: string;
+  connectorId?: string;
+}
+
+export interface ExtractionGlobalConfig {
+  method: 'tika' | 'inference' | 'workflow' | 'connector';
+  inferenceId?: string;
+  workflowId?: string;
+  connectorId?: string;
+  formatOverrides?: Record<string, FormatOverride>;
+}
+
+export interface ExtractionConfigAttributes {
+  method: 'tika' | 'inference' | 'workflow' | 'connector';
+  inferenceId?: string;
+  workflowId?: string;
+  connectorId?: string;
+  formatOverrides?: Record<string, FormatOverride>;
+}

--- a/x-pack/platform/plugins/shared/data_sources/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/plugin.ts
@@ -23,6 +23,10 @@ import type {
 import { registerUISettings } from './register';
 import { setupSavedObjects } from './saved_objects';
 import { BulkDeleteTask } from './tasks/bulk_delete_task';
+import { registerExtractionConfigSavedObject } from './extraction_config/saved_object';
+import { createExtractStepDefinition } from './steps/extract/extract_step';
+import { getExtractionConfig, DEFAULT_EXTRACTION_CONFIG } from './extraction_config';
+import { registerExtractionConfigRoutes } from './routes/extraction_config_routes';
 
 export class DataSourcesServerPlugin
   implements
@@ -51,8 +55,40 @@ export class DataSourcesServerPlugin
 
     registerUISettings({ uiSettings });
 
-    // Register saved objects type
+    // Register saved objects types
     setupSavedObjects(savedObjects);
+    registerExtractionConfigSavedObject(savedObjects);
+
+    // Register the extraction.extract custom workflow step
+    if (plugins.workflowsExtensions) {
+      const getGlobalConfig = async () => {
+        try {
+          const [coreStart] = await core.getStartServices();
+          const soClient = coreStart.savedObjects.createInternalRepository();
+          return await getExtractionConfig({
+            get: soClient.get.bind(soClient),
+          } as Parameters<typeof getExtractionConfig>[0]);
+        } catch {
+          return DEFAULT_EXTRACTION_CONFIG;
+        }
+      };
+
+      const workflowRunner = {
+        getWorkflow: workflowsManagement.management.getWorkflow.bind(
+          workflowsManagement.management
+        ),
+        runWorkflow: workflowsManagement.management.runWorkflow.bind(
+          workflowsManagement.management
+        ),
+        getWorkflowExecution: workflowsManagement.management.getWorkflowExecution.bind(
+          workflowsManagement.management
+        ),
+      };
+
+      plugins.workflowsExtensions.registerStepDefinition(
+        createExtractStepDefinition(getGlobalConfig, workflowRunner)
+      );
+    }
 
     // Register bulk delete task if Task Manager is available
     if (plugins.taskManager) {
@@ -69,6 +105,12 @@ export class DataSourcesServerPlugin
     registerRoutes({
       router,
       logger: this.logger,
+      getStartServices: core.getStartServices,
+      workflowManagement: workflowsManagement,
+    });
+
+    registerExtractionConfigRoutes({
+      router,
       getStartServices: core.getStartServices,
       workflowManagement: workflowsManagement,
     });

--- a/x-pack/platform/plugins/shared/data_sources/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/plugin.ts
@@ -23,7 +23,10 @@ import type {
 import { registerUISettings } from './register';
 import { setupSavedObjects } from './saved_objects';
 import { BulkDeleteTask } from './tasks/bulk_delete_task';
-import { registerExtractionConfigSavedObject } from './extraction_config/saved_object';
+import {
+  registerExtractionConfigSavedObject,
+  EXTRACTION_CONFIG_SO_TYPE,
+} from './extraction_config/saved_object';
 import { createExtractStepDefinition } from './steps/extract/extract_step';
 import { getExtractionConfig, DEFAULT_EXTRACTION_CONFIG } from './extraction_config';
 import { registerExtractionConfigRoutes } from './routes/extraction_config_routes';
@@ -64,7 +67,9 @@ export class DataSourcesServerPlugin
       const getGlobalConfig = async () => {
         try {
           const [coreStart] = await core.getStartServices();
-          const soClient = coreStart.savedObjects.createInternalRepository();
+          const soClient = coreStart.savedObjects.createInternalRepository([
+            EXTRACTION_CONFIG_SO_TYPE,
+          ]);
           return await getExtractionConfig({
             get: soClient.get.bind(soClient),
           } as Parameters<typeof getExtractionConfig>[0]);

--- a/x-pack/platform/plugins/shared/data_sources/server/routes/extraction_config_routes.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/routes/extraction_config_routes.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter, StartServicesAccessor } from '@kbn/core/server';
+import { schema } from '@kbn/config-schema';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import type { DataSourcesServerStartDependencies } from '../types';
+import {
+  getExtractionConfig,
+  updateExtractionConfig,
+} from '../extraction_config';
+
+const EXTRACTION_CONFIG_PATH = '/internal/data_sources/extraction_config';
+const INFERENCE_ENDPOINTS_PATH = '/internal/data_sources/inference_endpoints';
+const WORKFLOWS_PATH = '/internal/data_sources/workflows';
+
+interface RouteDependencies {
+  router: IRouter;
+  getStartServices: StartServicesAccessor<DataSourcesServerStartDependencies>;
+  workflowManagement: WorkflowsServerPluginSetup;
+}
+
+export function registerExtractionConfigRoutes({
+  router,
+  getStartServices,
+  workflowManagement,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: EXTRACTION_CONFIG_PATH,
+      validate: false,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Authorization is delegated to underlying service plugins',
+        },
+      },
+    },
+    async (context, _request, response) => {
+      const coreContext = await context.core;
+      const soClient = coreContext.savedObjects.client;
+
+      try {
+        const config = await getExtractionConfig(soClient);
+        return response.ok({ body: config });
+      } catch (error) {
+        return response.customError({
+          statusCode: 500,
+          body: { message: `Failed to get extraction config: ${(error as Error).message}` },
+        });
+      }
+    }
+  );
+
+  router.put(
+    {
+      path: EXTRACTION_CONFIG_PATH,
+      validate: {
+        body: schema.object({
+          method: schema.oneOf([
+            schema.literal('tika'),
+            schema.literal('inference'),
+            schema.literal('workflow'),
+            schema.literal('connector'),
+          ]),
+          inferenceId: schema.maybe(schema.string()),
+          workflowId: schema.maybe(schema.string()),
+          connectorId: schema.maybe(schema.string()),
+          formatOverrides: schema.maybe(
+            schema.recordOf(
+              schema.string(),
+              schema.object({
+                method: schema.oneOf([
+                  schema.literal('tika'),
+                  schema.literal('inference'),
+                  schema.literal('workflow'),
+                  schema.literal('connector'),
+                ]),
+                inferenceId: schema.maybe(schema.string()),
+                workflowId: schema.maybe(schema.string()),
+                connectorId: schema.maybe(schema.string()),
+              })
+            )
+          ),
+        }),
+      },
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Authorization is delegated to underlying service plugins',
+        },
+      },
+    },
+    async (context, request, response) => {
+      const coreContext = await context.core;
+      const soClient = coreContext.savedObjects.client;
+
+      try {
+        const updated = await updateExtractionConfig(soClient, request.body);
+        return response.ok({ body: updated });
+      } catch (error) {
+        return response.customError({
+          statusCode: 500,
+          body: { message: `Failed to update extraction config: ${(error as Error).message}` },
+        });
+      }
+    }
+  );
+
+  router.get(
+    {
+      path: INFERENCE_ENDPOINTS_PATH,
+      validate: false,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Authorization is delegated to underlying service plugins',
+        },
+      },
+    },
+    async (context, _request, response) => {
+      const coreContext = await context.core;
+      const esClient = coreContext.elasticsearch.client.asCurrentUser;
+
+      try {
+        const { endpoints } = await esClient.inference.get({
+          inference_id: '_all',
+          task_type: 'completion',
+        });
+
+        const mapped = (endpoints ?? []).map((ep) => ({
+          inference_id: ep.inference_id,
+          service: ep.service,
+          task_type: ep.task_type,
+        }));
+
+        return response.ok({ body: { endpoints: mapped } });
+      } catch (error) {
+        return response.ok({ body: { endpoints: [] } });
+      }
+    }
+  );
+
+  router.get(
+    {
+      path: WORKFLOWS_PATH,
+      validate: false,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Authorization is delegated to underlying service plugins',
+        },
+      },
+    },
+    async (context, _request, response) => {
+      try {
+        const coreContext = await context.core;
+        const spaceId = coreContext.savedObjects.client.getCurrentNamespace() ?? 'default';
+        const list = await workflowManagement.management.getWorkflows(
+          { size: 200, page: 1, enabled: [true] },
+          spaceId
+        );
+
+        const workflows = list.results.map((wf) => {
+          const inputProps =
+            (wf.definition?.inputs as {
+              properties?: Record<string, { type?: string }>;
+              required?: string[];
+            } | undefined) ?? {};
+          const props = inputProps.properties ?? {};
+          const required = new Set(inputProps.required ?? []);
+
+          const contentOk = props.content?.type === 'string';
+          const filenameOk = props.filename?.type === 'string';
+          const hasOptionalDocId = !props.doc_id || props.doc_id.type === 'string';
+
+          const compatible = contentOk && filenameOk && hasOptionalDocId;
+
+          const issues: string[] = [];
+          if (!contentOk) issues.push('missing input "content" (string)');
+          if (!filenameOk) issues.push('missing input "filename" (string)');
+          if (!hasOptionalDocId) issues.push('"doc_id" must be string');
+          if (!required.has('content')) issues.push('"content" should be required');
+          if (!required.has('filename')) issues.push('"filename" should be required');
+
+          return {
+            id: wf.id,
+            name: wf.name,
+            description: wf.description,
+            compatible,
+            issues: issues.length > 0 ? issues : undefined,
+          };
+        });
+
+        return response.ok({ body: { workflows } });
+      } catch (error) {
+        return response.ok({ body: { workflows: [] } });
+      }
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/data_sources/server/routes/extraction_config_routes.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/routes/extraction_config_routes.ts
@@ -12,6 +12,7 @@ import type { DataSourcesServerStartDependencies } from '../types';
 import {
   getExtractionConfig,
   updateExtractionConfig,
+  EXTRACTION_CONFIG_SO_TYPE,
 } from '../extraction_config';
 
 const EXTRACTION_CONFIG_PATH = '/internal/data_sources/extraction_config';
@@ -40,11 +41,12 @@ export function registerExtractionConfigRoutes({
         },
       },
     },
-    async (context, _request, response) => {
-      const coreContext = await context.core;
-      const soClient = coreContext.savedObjects.client;
-
+    async (_context, _request, response) => {
       try {
+        const [coreStart] = await getStartServices();
+        const soClient = coreStart.savedObjects.createInternalRepository([
+          EXTRACTION_CONFIG_SO_TYPE,
+        ]);
         const config = await getExtractionConfig(soClient);
         return response.ok({ body: config });
       } catch (error) {
@@ -95,11 +97,12 @@ export function registerExtractionConfigRoutes({
         },
       },
     },
-    async (context, request, response) => {
-      const coreContext = await context.core;
-      const soClient = coreContext.savedObjects.client;
-
+    async (_context, request, response) => {
       try {
+        const [coreStart] = await getStartServices();
+        const soClient = coreStart.savedObjects.createInternalRepository([
+          EXTRACTION_CONFIG_SO_TYPE,
+        ]);
         const updated = await updateExtractionConfig(soClient, request.body);
         return response.ok({ body: updated });
       } catch (error) {

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/google_drive/workflows/download.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/google_drive/workflows/download.yaml
@@ -38,30 +38,19 @@ steps:
         with:
           fileId: "${{foreach.item}}"
       - name: extract_content
-        type: elasticsearch.request
+        type: extraction.extract
         with:
-          method: POST
-          path: /_ingest/pipeline/_simulate
-          body:
-            pipeline:
-              processors:
-                - attachment:
-                    field: data
-                    indexed_chars: -1
-                    remove_binary: true
-            docs:
-              - _id: "${{foreach.item}}"
-                _source:
-                  filename: "${{steps.download_file.output.name}}"
-                  data: "${{steps.download_file.output.content}}"
+          content: "${{steps.download_file.output.content}}"
+          filename: "${{steps.download_file.output.name}}"
+          doc_id: "${{foreach.item}}"
       - name: normalize_result
         type: data.set
         with:
           normalized:
             fileId: "${{foreach.item}}"
             filename: "${{steps.download_file.output.name}}"
-            content: "${{steps.extract_content.output.docs[0].doc._source.attachment.content}}"
-            content_type: "${{steps.extract_content.output.docs[0].doc._source.attachment.content_type}}"
+            content: "${{steps.extract_content.output.content}}"
+            content_type: "${{steps.extract_content.output.content_type}}"
       - name: accumulate_result
         type: data.set
         with:

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/servicenow/workflows/get_attachment.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/servicenow/workflows/get_attachment.yaml
@@ -17,27 +17,15 @@ steps:
     with:
       sysId: "${{ inputs.sys_id }}"
   - name: extract-content
-    type: elasticsearch.request
+    type: extraction.extract
     with:
-      method: POST
-      path: /_ingest/pipeline/_simulate
-      body:
-        pipeline:
-          processors:
-            - attachment:
-                field: data
-                indexed_chars: -1
-                remove_binary: true
-        docs:
-          - _id: "${{ inputs.sys_id }}"
-            _source:
-              filename: "${{ steps.download-attachment.output.fileName }}"
-              data: "${{ steps.download-attachment.output.base64 }}"
+      content: "${{ steps.download-attachment.output.base64 }}"
+      filename: "${{ steps.download-attachment.output.fileName }}"
+      doc_id: "${{ inputs.sys_id }}"
   - name: set-result
     type: data.set
     with:
       result:
         fileName: "${{ steps.download-attachment.output.fileName }}"
-        contentType: "${{ steps.download-attachment.output.contentType }}"
-        content: "${{ steps.extract-content.output.docs[0].doc._source.attachment.content }}"
-        contentLength: "${{ steps.extract-content.output.docs[0].doc._source.attachment.content_length }}"
+        contentType: "${{ steps.extract-content.output.content_type }}"
+        content: "${{ steps.extract-content.output.content }}"

--- a/x-pack/platform/plugins/shared/data_sources/server/sources/sharepoint_online/workflows/download.yaml
+++ b/x-pack/platform/plugins/shared/data_sources/server/sources/sharepoint_online/workflows/download.yaml
@@ -1,6 +1,6 @@
 version: '1'
 name: 'sources.sharepoint.download'
-description: 'Download SharePoint content. Actions and inputs: downloadDriveItem (drive_id, item_id) for markdown/plain-text files; downloadItemFromURL + ingest extract (download_url) for PDFs, .docx, and other files that require preprocessing (extracted text available in simulate response under docs[0].doc._source.attachment.content); getSitePageContents (site_id, page_id) for SharePoint site page content.'
+description: 'Download SharePoint content. Actions and inputs: downloadDriveItem (drive_id, item_id) for markdown/plain-text files; downloadItemFromURL + extract (download_url) for PDFs, .docx, and other files that require preprocessing (extracted text available under output.content); getSitePageContents (site_id, page_id) for SharePoint site page content.'
 tags: ['agent-builder-tool']
 enabled: true
 triggers:
@@ -45,22 +45,11 @@ steps:
         with:
           downloadUrl: "${{ inputs.download_url }}"
       - name: extract-content
-        type: elasticsearch.request
+        type: extraction.extract
         with:
-          method: POST
-          path: /_ingest/pipeline/_simulate
-          body:
-            pipeline:
-              processors:
-                - attachment:
-                    field: data
-                    indexed_chars: -1
-                    remove_binary: true
-            docs:
-              - _id: "${{ inputs.download_url }}"
-                _source:
-                  filename: "${{ inputs.download_url }}"
-                  data: "${{ steps.download-item-from-url.output.base64 }}"
+          content: "${{ steps.download-item-from-url.output.base64 }}"
+          filename: "${{ inputs.download_url }}"
+          doc_id: "${{ inputs.download_url }}"
   - name: get-site-page-contents
     type: sharepoint-online.getSitePageContents
     if: "${{ inputs.download_action == 'getSitePageContents' }}"

--- a/x-pack/platform/plugins/shared/data_sources/server/steps/extract/extract_step.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/steps/extract/extract_step.ts
@@ -1,0 +1,445 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, KibanaRequest } from '@kbn/core/server';
+import type {
+  WorkflowDetailDto,
+  WorkflowExecutionDto,
+  WorkflowExecutionEngineModel,
+} from '@kbn/workflows/types/v1';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import {
+  extractStepCommonDefinition,
+  type ExtractConfig,
+} from '../../../common/steps/extract/extract_step';
+import type { ExtractionOutput } from '../../../common/steps/extract/extraction_contract';
+import type { ExtractionGlobalConfig, FormatOverride } from '../../extraction_config';
+
+type GetGlobalConfig = () => Promise<ExtractionGlobalConfig>;
+
+const WORKFLOW_POLL_INTERVAL_MS = 1000;
+const WORKFLOW_POLL_MAX_ATTEMPTS = 300;
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled', 'timed_out', 'skipped']);
+
+/**
+ * Thin interface over WorkflowsManagementApi so we only couple to what we need.
+ */
+export interface WorkflowRunner {
+  getWorkflow(id: string, spaceId: string): Promise<WorkflowDetailDto | null>;
+  runWorkflow(
+    workflow: WorkflowExecutionEngineModel,
+    spaceId: string,
+    inputs: Record<string, unknown>,
+    request: KibanaRequest
+  ): Promise<string>;
+  getWorkflowExecution(
+    executionId: string,
+    spaceId: string,
+    options?: { includeInput?: boolean; includeOutput?: boolean }
+  ): Promise<WorkflowExecutionDto | null>;
+}
+
+interface AttachmentResult {
+  content?: string;
+  content_type?: string;
+}
+
+async function extractWithTika(
+  esClient: ElasticsearchClient,
+  content: string,
+  filename: string,
+  docId: string | undefined,
+  logger: { debug(msg: string, meta?: object): void }
+): Promise<ExtractionOutput> {
+  logger.debug('Extracting with Tika (ingest attachment processor)', { filename, docId });
+
+  const response = await esClient.transport.request<{
+    docs: Array<{ doc: { _source: { attachment?: AttachmentResult } } }>;
+  }>({
+    method: 'POST',
+    path: '/_ingest/pipeline/_simulate',
+    body: {
+      pipeline: {
+        processors: [
+          {
+            attachment: {
+              field: 'data',
+              indexed_chars: -1,
+              remove_binary: true,
+            },
+          },
+        ],
+      },
+      docs: [
+        {
+          _id: docId ?? '_placeholder',
+          _source: {
+            filename,
+            data: content,
+          },
+        },
+      ],
+    },
+  });
+
+  const attachment = response.docs?.[0]?.doc?._source?.attachment;
+  if (!attachment?.content) {
+    throw new Error(
+      `Tika extraction returned no content for file "${filename}". ` +
+        'The file may be empty, corrupted, or in an unsupported format.'
+    );
+  }
+
+  return {
+    content: attachment.content,
+    content_type: attachment.content_type,
+  };
+}
+
+async function discoverExtractionEndpoint(
+  esClient: ElasticsearchClient,
+  logger: { debug(msg: string, meta?: object): void }
+): Promise<string | undefined> {
+  try {
+    const { endpoints } = await esClient.inference.get({
+      inference_id: '_all',
+      task_type: 'completion',
+    });
+
+    if (!endpoints || endpoints.length === 0) {
+      return undefined;
+    }
+
+    const typedEndpoints = endpoints as Array<{
+      inference_id: string;
+      service: string;
+      task_type: string;
+    }>;
+
+    const elastic = typedEndpoints.find((ep) => ep.service === 'elastic');
+    if (elastic) return elastic.inference_id;
+
+    return typedEndpoints[0].inference_id;
+  } catch (error) {
+    logger.debug('Failed to discover extraction inference endpoints', error as object);
+    return undefined;
+  }
+}
+
+async function extractWithInference(
+  esClient: ElasticsearchClient,
+  content: string,
+  filename: string,
+  inferenceId: string | undefined,
+  logger: {
+    debug(msg: string, meta?: object): void;
+    info(msg: string, meta?: object): void;
+  }
+): Promise<ExtractionOutput> {
+  let endpointId = inferenceId;
+
+  if (!endpointId) {
+    logger.info('No inference_id provided, discovering available extraction endpoints');
+    endpointId = await discoverExtractionEndpoint(esClient, logger);
+
+    if (!endpointId) {
+      throw new Error(
+        'No inference_id provided and no completion inference endpoints found. ' +
+          'Please configure an inference endpoint or switch to the "tika" method.'
+      );
+    }
+
+    logger.debug(`Discovered extraction endpoint: ${endpointId}`);
+  }
+
+  logger.debug('Extracting with inference endpoint', { endpointId, filename });
+
+  const prompt =
+    `Extract all text content from the following base64-encoded file named "${filename}". ` +
+    `Return only the extracted text, no commentary or formatting.\n\n${content}`;
+
+  const response = await esClient.inference.inference({
+    inference_id: endpointId,
+    task_type: 'completion',
+    input: prompt,
+    timeout: '5m',
+  });
+
+  const completion = response as unknown as {
+    completion?: Array<{ result?: string }>;
+  };
+  const result = completion?.completion?.[0]?.result;
+
+  if (!result) {
+    throw new Error(
+      `Inference endpoint "${endpointId}" returned no content for file "${filename}".`
+    );
+  }
+
+  return { content: result };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run a user-defined extraction workflow and poll until it completes.
+ * The workflow must conform to the extraction contract (see extraction_contract.ts).
+ */
+async function extractWithWorkflow(
+  runner: WorkflowRunner,
+  workflowId: string,
+  content: string,
+  filename: string,
+  docId: string | undefined,
+  spaceId: string,
+  request: KibanaRequest,
+  logger: {
+    debug(msg: string, meta?: object): void;
+    info(msg: string, meta?: object): void;
+  }
+): Promise<ExtractionOutput> {
+  logger.info('Extracting with custom workflow', { workflowId, filename });
+
+  const workflow = await runner.getWorkflow(workflowId, spaceId);
+  if (!workflow) {
+    throw new Error(
+      `Extraction workflow "${workflowId}" not found. ` +
+        'Verify the workflow ID in your extraction settings.'
+    );
+  }
+  if (!workflow.enabled) {
+    throw new Error(`Extraction workflow "${workflowId}" is disabled. Enable it to use it.`);
+  }
+  if (!workflow.valid) {
+    throw new Error(`Extraction workflow "${workflowId}" has validation errors.`);
+  }
+
+  const inputs: Record<string, unknown> = { content, filename };
+  if (docId) {
+    inputs.doc_id = docId;
+  }
+
+  const engineModel: WorkflowExecutionEngineModel = {
+    id: workflow.id,
+    name: workflow.name,
+    enabled: workflow.enabled,
+    definition: workflow.definition ?? undefined,
+    yaml: workflow.yaml,
+  };
+
+  const executionId = await runner.runWorkflow(engineModel, spaceId, inputs, request);
+
+  logger.debug(`Extraction workflow started, execution: ${executionId}`);
+
+  for (let attempt = 0; attempt < WORKFLOW_POLL_MAX_ATTEMPTS; attempt++) {
+    await delay(WORKFLOW_POLL_INTERVAL_MS);
+
+    const execution = await runner.getWorkflowExecution(executionId, spaceId, {
+      includeOutput: true,
+    });
+
+    if (!execution) {
+      throw new Error(`Extraction workflow execution "${executionId}" disappeared.`);
+    }
+
+    if (!TERMINAL_STATUSES.has(execution.status)) {
+      continue;
+    }
+
+    if (execution.status !== 'completed') {
+      const errorMsg = execution.error?.message ?? `Workflow finished with status: ${execution.status}`;
+      throw new Error(`Extraction workflow "${workflowId}" failed: ${errorMsg}`);
+    }
+
+    const output = extractOutputFromExecution(execution);
+    if (!output?.content) {
+      throw new Error(
+        `Extraction workflow "${workflowId}" completed but returned no content. ` +
+          'Ensure the workflow outputs "content" (string) and optionally "content_type" (string).'
+      );
+    }
+
+    return output;
+  }
+
+  throw new Error(
+    `Extraction workflow "${workflowId}" timed out after ${WORKFLOW_POLL_MAX_ATTEMPTS} poll attempts.`
+  );
+}
+
+/**
+ * Pull `{ content, content_type }` from a completed workflow execution.
+ * Checks workflow-level output first (from a `workflow.output` step),
+ * then falls back to the last step execution's output.
+ */
+function extractOutputFromExecution(execution: WorkflowExecutionDto): ExtractionOutput | undefined {
+  const steps = execution.stepExecutions ?? [];
+  const lastStep = steps.length > 0 ? steps[steps.length - 1] : undefined;
+  const raw = (lastStep?.output ?? undefined) as Record<string, unknown> | undefined;
+
+  if (!raw) return undefined;
+
+  const text = typeof raw.content === 'string' ? raw.content : undefined;
+  if (!text) return undefined;
+
+  return {
+    content: text,
+    content_type: typeof raw.content_type === 'string' ? raw.content_type : undefined,
+  };
+}
+
+export const createExtractStepDefinition = (
+  getGlobalConfig: GetGlobalConfig,
+  workflowRunner?: WorkflowRunner
+) =>
+  createServerStepDefinition({
+    ...extractStepCommonDefinition,
+    handler: async (context) => {
+      try {
+        const esClient = context.contextManager.getScopedEsClient();
+        const { content, filename, doc_id: docId } = context.input;
+
+        context.logger.debug('Extract step started', { filename, docId });
+
+        const globalConfig = await getGlobalConfig();
+        const method = resolveMethod(context.config, globalConfig, filename);
+
+        let result: ExtractionOutput;
+
+        if (method === 'workflow') {
+          const workflowId = resolveWorkflowId(context.config, globalConfig, filename);
+          if (!workflowId) {
+            throw new Error(
+              'method is "workflow" but no workflow_id is configured. ' +
+                'Set a workflow_id in the step config or global extraction settings.'
+            );
+          }
+          if (!workflowRunner) {
+            throw new Error(
+              'Workflow execution is not available. ' +
+                'Ensure the workflowsManagement plugin is enabled.'
+            );
+          }
+          const stepContext = context.contextManager.getContext();
+          const spaceId = stepContext.workflow?.spaceId ?? 'default';
+          const request = context.contextManager.getFakeRequest();
+
+          result = await extractWithWorkflow(
+            workflowRunner,
+            workflowId,
+            content,
+            filename,
+            docId,
+            spaceId,
+            request,
+            context.logger
+          );
+        } else if (method === 'inference') {
+          const inferenceId = resolveInferenceId(context.config, globalConfig, filename);
+          result = await extractWithInference(
+            esClient,
+            content,
+            filename,
+            inferenceId,
+            context.logger
+          );
+        } else if (method === 'connector') {
+          throw new Error(
+            'method "connector" is not yet implemented. ' +
+              'Use "tika", "inference", or "workflow" instead.'
+          );
+        } else {
+          result = await extractWithTika(esClient, content, filename, docId, context.logger);
+        }
+
+        context.logger.info('Extract step completed', {
+          filename,
+          method,
+          contentLength: result.content.length,
+          contentType: result.content_type,
+        });
+
+        return { output: result };
+      } catch (error) {
+        context.logger.error('Extract step failed', error as Error);
+        return {
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    },
+  });
+
+/**
+ * Extract the file extension from a filename, normalized to lowercase with leading dot.
+ * e.g. "report.PDF" -> ".pdf", "archive.tar.gz" -> ".gz"
+ */
+function getFileExtension(filename: string): string | undefined {
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot <= 0 || lastDot === filename.length - 1) return undefined;
+  return filename.substring(lastDot).toLowerCase();
+}
+
+/**
+ * Look up a format override by file extension. Matches both ".pdf" and "pdf" keys.
+ */
+function getFormatOverride(
+  globalConfig: ExtractionGlobalConfig,
+  filename: string
+): FormatOverride | undefined {
+  const { formatOverrides } = globalConfig;
+  if (!formatOverrides) return undefined;
+
+  const ext = getFileExtension(filename);
+  if (!ext) return undefined;
+
+  return formatOverrides[ext] ?? formatOverrides[ext.substring(1)];
+}
+
+/**
+ * Resolution chain: step-level YAML > format override > global default > hardcoded fallback
+ */
+function resolveMethod(
+  stepConfig: ExtractConfig | undefined,
+  globalConfig: ExtractionGlobalConfig,
+  filename: string
+): 'tika' | 'inference' | 'workflow' | 'connector' {
+  if (stepConfig?.method) return stepConfig.method;
+
+  const formatOverride = getFormatOverride(globalConfig, filename);
+  if (formatOverride?.method) return formatOverride.method;
+
+  return globalConfig.method ?? 'tika';
+}
+
+function resolveInferenceId(
+  stepConfig: ExtractConfig | undefined,
+  globalConfig: ExtractionGlobalConfig,
+  filename: string
+): string | undefined {
+  if (stepConfig?.inference_id) return stepConfig.inference_id;
+
+  const formatOverride = getFormatOverride(globalConfig, filename);
+  if (formatOverride?.inferenceId) return formatOverride.inferenceId;
+
+  return globalConfig.inferenceId;
+}
+
+function resolveWorkflowId(
+  stepConfig: ExtractConfig | undefined,
+  globalConfig: ExtractionGlobalConfig,
+  filename: string
+): string | undefined {
+  if (stepConfig?.workflow_id) return stepConfig.workflow_id;
+
+  const formatOverride = getFormatOverride(globalConfig, filename);
+  if (formatOverride?.workflowId) return formatOverride.workflowId;
+
+  return globalConfig.workflowId;
+}

--- a/x-pack/platform/plugins/shared/data_sources/server/types.ts
+++ b/x-pack/platform/plugins/shared/data_sources/server/types.ts
@@ -24,6 +24,7 @@ import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
@@ -36,6 +37,7 @@ export interface DataSourcesServerSetupDependencies {
   dataCatalog: DataCatalogPluginSetup;
   agentBuilder: AgentBuilderPluginSetup;
   workflowsManagement: WorkflowsServerPluginSetup;
+  workflowsExtensions?: WorkflowsExtensionsServerPluginSetup;
   taskManager?: TaskManagerSetupContract;
 }
 

--- a/x-pack/platform/plugins/shared/data_sources/tsconfig.json
+++ b/x-pack/platform/plugins/shared/data_sources/tsconfig.json
@@ -43,6 +43,8 @@
     "@kbn/deeplinks-agent-builder",
     "@kbn/connector-schemas",
     "@kbn/task-manager-plugin",
-    "@kbn/workflows"
+    "@kbn/workflows",
+    "@kbn/workflows-extensions",
+    "@kbn/zod"
   ]
 }


### PR DESCRIPTION
## Summary

Replaces duplicated inline Tika extraction logic across data source download workflows (Google Drive, SharePoint, ServiceNow) with a centralized `extraction.extract` custom step registered via `workflowsExtensions`.

### What's included

**Custom step (`extraction.extract`)**
- Encapsulates Tika and inference endpoint extraction behind a single step type
- Formal extraction contract defined in `common/steps/extract/extraction_contract.ts`
- Step-level config supports method override and inference_id/workflow_id

**Four extraction methods**
- `tika` (default) — built-in ES ingest attachment processor (Apache Tika)
- `inference` — ES inference endpoint (completion task type)
- `workflow` — delegates to a user-defined workflow conforming to the extraction contract, polls for completion
- `connector` — **placeholder** for future stack connector integration (disabled in UI, clear error if invoked). Awaiting a real extraction connector to finalize the sub-action contract.

**Global configuration**
- Singleton Saved Object (`data_sources_extraction_config`) with REST API
- Multi-level resolution chain: step YAML config → per-format override → global default → hardcoded fallback
- Per-format overrides: route specific file extensions to different methods/endpoints

**Settings UI**
- New "Settings" tab on the Data Sources management page
- Method picker (Tika, Inference, Workflow, Connector)
- Workflow selector populated from available workflows, with contract compatibility checking (validates inputs declare `content` + `filename` as strings)
- Per-format override rows with add/remove
- Advanced JSON editor for bulk override editing
- Extraction contract documentation shown inline when "workflow" is selected

**Workflow updates**
- Google Drive, SharePoint, ServiceNow download workflows updated to use `extraction.extract` instead of inline `elasticsearch.request` blocks

### Extraction contract

Any backend (workflow, connector) must conform to:

| Direction | Field | Type | Required |
|-----------|-------|------|----------|
| Input | `content` | string (base64) | yes |
| Input | `filename` | string | yes |
| Input | `doc_id` | string | no |
| Output | `content` | string (plain text) | yes |
| Output | `content_type` | string (MIME) | no |


## How this looks:

Default, everything looks clean:

<img width="1123" height="791" alt="Screenshot 2026-03-06 at 11 31 35 PM" src="https://github.com/user-attachments/assets/746a5b56-c8e8-463d-9b89-5caf976b158e" />

Using the UI to configure a lot of different approaches:

<img width="1123" height="791" alt="Screenshot 2026-03-06 at 10 07 56 PM" src="https://github.com/user-attachments/assets/2ea4cc97-d4ea-4abe-bb5a-aad3f40816bb" />

Users can set this up to default to whatever is their preference, then override granularly. 
This gives a lot of flexibility - use the default Tika, use an inference endpoint (like Gemini 3.0 Flash which could be a default as well for PDFs), but they can also define connectors that conform to a specific interface (this is to cover future connectors to external extraction services) or any workflow that also conforms to an interface (this is to provide full flexibility, and workarounds when trying to fix unexpected problems).

The step itself as it looks in the workflows:

<img width="1152" height="572" alt="Screenshot 2026-03-06 at 8 12 55 PM" src="https://github.com/user-attachments/assets/e939fd60-674c-4d8c-b101-451f51e5f270" />


Made with [Cursor](https://cursor.com)