### PR TITLE
Improve rendering doc viewer flyout for unified data table

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/index.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/index.ts
@@ -45,6 +45,7 @@ export {
 
 export { getDataGridDensity } from './src/hooks/use_data_grid_density';
 export { getRowHeight } from './src/hooks/use_row_height';
+export { useDocumentViewFlyoutConnectionHandler } from './src/hooks/use_document_view_flyout_connection_handler';
 
 export type { UnifiedDataTableRestorableState } from './src/restorable_state';
 export { UnifiedDataTableSummaryColumnHeader } from './src/components/data_table_summary_column_header';

--- a/src/platform/packages/shared/kbn-unified-data-table/index.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/index.ts
@@ -8,7 +8,12 @@
  */
 
 export { UnifiedDataTable, DataLoadingState } from './src/components/data_table';
-export type { UnifiedDataTableProps, SortOrder } from './src/components/data_table';
+export type {
+  UnifiedDataTableProps,
+  SortOrder,
+  GetDocViewerExternalStore,
+  DocViewerSnapshot,
+} from './src/components/data_table';
 export {
   RowHeightSettings,
   type RowHeightSettingsProps,

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -810,7 +810,7 @@ describe('UnifiedDataTable', () => {
             flattened: { test: jest.fn() },
           },
           setExpandedDoc: jest.fn(),
-          renderDocumentView: jest.fn(),
+          renderDocumentViewFlyout: jest.fn(),
           externalControlColumns: [testLeadingControlColumn],
           rowAdditionalLeadingControls: mockRowAdditionalLeadingControls,
         });
@@ -844,7 +844,7 @@ describe('UnifiedDataTable', () => {
             flattened: { test: jest.fn() },
           },
           setExpandedDoc: jest.fn(),
-          renderDocumentView: jest.fn(),
+          renderDocumentViewFlyout: jest.fn(),
           externalControlColumns: [testLeadingControlColumn],
           trailingControlColumns: testTrailingControlColumns,
         });
@@ -873,7 +873,7 @@ describe('UnifiedDataTable', () => {
             flattened: { test: jest.fn() },
           },
           setExpandedDoc: jest.fn(),
-          renderDocumentView: jest.fn(),
+          renderDocumentViewFlyout: jest.fn(),
           externalControlColumns: [testLeadingControlColumn],
         });
 
@@ -907,7 +907,7 @@ describe('UnifiedDataTable', () => {
         expandedDoc,
         setExpandedDoc: setExpandedDocMock,
         columnsMeta: columnsMetaOverride,
-        renderDocumentView: renderDocumentViewMock,
+        renderDocumentViewFlyout: renderDocumentViewMock,
         externalControlColumns: [testLeadingControlColumn],
       });
 
@@ -1014,7 +1014,7 @@ describe('UnifiedDataTable', () => {
             flattened: { test: jest.fn() },
           },
           setExpandedDoc: jest.fn(),
-          renderDocumentView: jest.fn(),
+          renderDocumentViewFlyout: jest.fn(),
           componentsTourSteps: { expandButton: 'test-expand' },
         });
 

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -109,7 +109,7 @@ const DataTable = (props: Partial<UnifiedDataTableProps>) => (
 
 const capabilities = capabilitiesServiceMock.createStartContract().capabilities;
 
-const renderDataTable = async (props: Partial<UnifiedDataTableProps>) => {
+const renderDataTable = async (props: Partial<UnifiedDataTableProps> = {}) => {
   const DataTableWrapped = () => {
     const [columns, setColumns] = useState(props.columns ?? []);
     const [settings, setSettings] = useState(props.settings);
@@ -842,9 +842,38 @@ describe('UnifiedDataTable', () => {
     it(
       'should render external leading control columns',
       async () => {
+        const setExpandedDocMock = jest.fn();
+        const subscribeMock = jest.fn(() => () => {});
+        const stableSnapshot = {
+          expandedDoc: {
+            id: 'test',
+            raw: {
+              _index: 'test_i',
+              _id: 'test',
+            },
+            flattened: { test: jest.fn() },
+          },
+        };
+        const getSnapshotMock = jest.fn(() => stableSnapshot);
+
+        const connectionHandlerMock = jest.fn(
+          (
+            _displayedRows: DataTableRecord[],
+            _displayedColumns: string[],
+            _customColumnsMeta?: object
+          ) => ({
+            externalStore: {
+              subscribe: subscribeMock,
+              getSnapshot: getSnapshotMock,
+              getServerSnapshot: getSnapshotMock,
+            },
+            setExpandedDoc: setExpandedDocMock,
+          })
+        );
+
         const component = await getComponent({
           ...getProps(),
-          documentViewFlyoutConnectionHandler: jest.fn(),
+          documentViewFlyoutConnectionHandler: connectionHandlerMock,
           externalControlColumns: [testLeadingControlColumn],
         });
 
@@ -862,7 +891,8 @@ describe('UnifiedDataTable', () => {
         const columnsMetaOverride = { testField: { type: 'number' as DatatableColumnType } };
         const setExpandedDocMock = jest.fn();
         const subscribeMock = jest.fn(() => () => {});
-        const getSnapshotMock = jest.fn(() => ({ expandedDoc: undefined }));
+        const stableSnapshot = { expandedDoc: undefined };
+        const getSnapshotMock = jest.fn(() => stableSnapshot);
 
         const connectionHandlerMock = jest.fn(
           (
@@ -903,7 +933,8 @@ describe('UnifiedDataTable', () => {
       'calls setExpandedDoc from documentViewFlyoutConnectionHandler when expand button is clicked',
       async () => {
         const setExpandedDocMock = jest.fn();
-        const getSnapshotMock = jest.fn(() => ({ expandedDoc: undefined }));
+        const stableSnapshot = { expandedDoc: undefined };
+        const getSnapshotMock = jest.fn(() => stableSnapshot);
 
         const connectionHandlerMock = jest.fn((_displayedRows: DataTableRecord[]) => ({
           externalStore: {
@@ -1016,9 +1047,38 @@ describe('UnifiedDataTable', () => {
     it(
       'should render tour step for the first row of leading control column expandButton',
       async () => {
+        const setExpandedDocMock = jest.fn();
+        const subscribeMock = jest.fn(() => () => {});
+        const stableSnapshot = {
+          expandedDoc: {
+            id: 'test',
+            raw: {
+              _index: 'test_i',
+              _id: 'test',
+            },
+            flattened: { test: jest.fn() },
+          },
+        };
+        const getSnapshotMock = jest.fn(() => stableSnapshot);
+
+        const connectionHandlerMock = jest.fn(
+          (
+            _displayedRows: DataTableRecord[],
+            _displayedColumns: string[],
+            _customColumnsMeta?: object
+          ) => ({
+            externalStore: {
+              subscribe: subscribeMock,
+              getSnapshot: getSnapshotMock,
+              getServerSnapshot: getSnapshotMock,
+            },
+            setExpandedDoc: setExpandedDocMock,
+          })
+        );
+
         const component = await getComponent({
           ...getProps(),
-          documentViewFlyoutConnectionHandler: jest.fn(),
+          documentViewFlyoutConnectionHandler: connectionHandlerMock,
           componentsTourSteps: { expandButton: 'test-expand' },
         });
 

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -75,7 +75,6 @@ function getProps(): UnifiedDataTableProps {
     columns: [],
     dataView: dataViewMock,
     loadingState: DataLoadingState.loaded,
-    expandedDoc: undefined,
     onFilter: jest.fn(),
     onResize: jest.fn(),
     onSetColumns: jest.fn(),
@@ -84,7 +83,6 @@ function getProps(): UnifiedDataTableProps {
     sampleSizeState: 30,
     searchDescription: '',
     searchTitle: '',
-    setExpandedDoc: jest.fn(),
     settings: {},
     showTimeCol: true,
     sort: [],
@@ -801,16 +799,7 @@ describe('UnifiedDataTable', () => {
       async () => {
         const component = await getComponent({
           ...getProps(),
-          expandedDoc: {
-            id: 'test',
-            raw: {
-              _index: 'test_i',
-              _id: 'test',
-            },
-            flattened: { test: jest.fn() },
-          },
-          setExpandedDoc: jest.fn(),
-          renderDocumentViewFlyout: jest.fn(),
+          documentViewFlyoutConnectionHandler: jest.fn(),
           externalControlColumns: [testLeadingControlColumn],
           rowAdditionalLeadingControls: mockRowAdditionalLeadingControls,
         });
@@ -835,16 +824,7 @@ describe('UnifiedDataTable', () => {
       async () => {
         const component = await getComponent({
           ...getProps(),
-          expandedDoc: {
-            id: 'test',
-            raw: {
-              _index: 'test_i',
-              _id: 'test',
-            },
-            flattened: { test: jest.fn() },
-          },
-          setExpandedDoc: jest.fn(),
-          renderDocumentViewFlyout: jest.fn(),
+          documentViewFlyoutConnectionHandler: jest.fn(),
           externalControlColumns: [testLeadingControlColumn],
           trailingControlColumns: testTrailingControlColumns,
         });
@@ -864,16 +844,7 @@ describe('UnifiedDataTable', () => {
       async () => {
         const component = await getComponent({
           ...getProps(),
-          expandedDoc: {
-            id: 'test',
-            raw: {
-              _index: 'test_i',
-              _id: 'test',
-            },
-            flattened: { test: jest.fn() },
-          },
-          setExpandedDoc: jest.fn(),
-          renderDocumentViewFlyout: jest.fn(),
+          documentViewFlyoutConnectionHandler: jest.fn(),
           externalControlColumns: [testLeadingControlColumn],
         });
 
@@ -884,45 +855,87 @@ describe('UnifiedDataTable', () => {
     );
   });
 
-  it(
-    'should render provided in renderDocumentView DocumentView on expand clicked',
-    async () => {
-      const expandedDoc = {
-        id: 'test',
-        raw: {
-          _index: 'test_i',
-          _id: 'test',
-        },
-        flattened: { test: jest.fn() },
-      };
-      const columnsMetaOverride = { testField: { type: 'number' as DatatableColumnType } };
-      const renderDocumentViewMock = jest.fn((hit: DataTableRecord) => (
-        <div data-test-subj="test-document-view">{hit.id}</div>
-      ));
+  describe('documentViewFlyoutConnectionHandler', () => {
+    it(
+      'calls documentViewFlyoutConnectionHandler with displayedRows, displayedColumns, and columnsMeta',
+      async () => {
+        const columnsMetaOverride = { testField: { type: 'number' as DatatableColumnType } };
+        const setExpandedDocMock = jest.fn();
+        const subscribeMock = jest.fn(() => () => {});
+        const getSnapshotMock = jest.fn(() => ({ expandedDoc: undefined }));
 
-      const setExpandedDocMock = jest.fn();
+        const connectionHandlerMock = jest.fn(
+          (
+            _displayedRows: DataTableRecord[],
+            _displayedColumns: string[],
+            _customColumnsMeta?: object
+          ) => ({
+            externalStore: {
+              subscribe: subscribeMock,
+              getSnapshot: getSnapshotMock,
+              getServerSnapshot: getSnapshotMock,
+            },
+            setExpandedDoc: setExpandedDocMock,
+          })
+        );
 
-      const component = await getComponent({
-        ...getProps(),
-        expandedDoc,
-        setExpandedDoc: setExpandedDocMock,
-        columnsMeta: columnsMetaOverride,
-        renderDocumentViewFlyout: renderDocumentViewMock,
-        externalControlColumns: [testLeadingControlColumn],
-      });
+        render(
+          <DataTable
+            {...{
+              columnsMeta: columnsMetaOverride,
+              documentViewFlyoutConnectionHandler: connectionHandlerMock,
+              externalControlColumns: [testLeadingControlColumn],
+            }}
+          />
+        );
 
-      findTestSubject(component, 'docTableExpandToggleColumn').first().simulate('click');
-      expect(findTestSubject(component, 'test-document-view').exists()).toBeTruthy();
-      expect(renderDocumentViewMock).toHaveBeenLastCalledWith(
-        expandedDoc,
-        getProps().rows,
-        ['_source'],
-        setExpandedDocMock,
-        columnsMetaOverride
-      );
-    },
-    EXTENDED_JEST_TIMEOUT
-  );
+        expect(connectionHandlerMock).toHaveBeenCalledWith(
+          expect.any(Array),
+          expect.arrayContaining(['_source']),
+          columnsMetaOverride
+        );
+        expect(connectionHandlerMock.mock.calls[0][0]).toHaveLength(getProps().rows!.length);
+      },
+      EXTENDED_JEST_TIMEOUT
+    );
+
+    it(
+      'calls setExpandedDoc from documentViewFlyoutConnectionHandler when expand button is clicked',
+      async () => {
+        const setExpandedDocMock = jest.fn();
+        const getSnapshotMock = jest.fn(() => ({ expandedDoc: undefined }));
+
+        const connectionHandlerMock = jest.fn((_displayedRows: DataTableRecord[]) => ({
+          externalStore: {
+            subscribe: () => () => {},
+            getSnapshot: getSnapshotMock,
+            getServerSnapshot: getSnapshotMock,
+          },
+          setExpandedDoc: setExpandedDocMock,
+        }));
+
+        render(
+          <DataTable
+            {...{
+              documentViewFlyoutConnectionHandler: connectionHandlerMock,
+              externalControlColumns: [testLeadingControlColumn],
+            }}
+          />
+        );
+
+        fireEvent.click(screen.getAllByTestId('docTableExpandToggleColumn')[0]);
+
+        expect(setExpandedDocMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.any(String),
+            raw: expect.any(Object),
+            flattened: expect.any(Object),
+          })
+        );
+      },
+      EXTENDED_JEST_TIMEOUT
+    );
+  });
 
   describe('externalAdditionalControls', () => {
     it(
@@ -1005,16 +1018,7 @@ describe('UnifiedDataTable', () => {
       async () => {
         const component = await getComponent({
           ...getProps(),
-          expandedDoc: {
-            id: 'test',
-            raw: {
-              _index: 'test_i',
-              _id: 'test',
-            },
-            flattened: { test: jest.fn() },
-          },
-          setExpandedDoc: jest.fn(),
-          renderDocumentViewFlyout: jest.fn(),
+          documentViewFlyoutConnectionHandler: jest.fn(),
           componentsTourSteps: { expandButton: 'test-expand' },
         });
 

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -138,7 +138,7 @@ export interface DocViewerSnapshot {
 }
 
 export interface GetDocViewerExternalStore {
-  subscribe: (onDocViewerSnapshotChange: () => void) => () => void;
+  subscribe: (onStoreChange: () => void) => () => void;
   getSnapshot: () => DocViewerSnapshot;
   getServerSnapshot: () => DocViewerSnapshot;
 }
@@ -332,14 +332,20 @@ interface InternalUnifiedDataTableProps {
     data: DataPublicPluginStart;
   };
   /**
-   * Callback to render DocumentView when the document is expanded
+   * Callback that allows the data table instance connect to the document view flyout
    */
-  renderDocumentViewFlyout?: (
+  documentViewFlyoutConnectionHandler?: (
     displayedRows: DataTableRecord[],
     displayedColumns: string[],
     columnsMeta?: DataTableColumnsMeta
   ) => {
+    /**
+     * External store that enables the data table instance to subscribe to the document view flyout and get the current state of the document view flyout
+     */
     externalStore: GetDocViewerExternalStore;
+    /**
+     * Function to set the expanded document, which is displayed in the document view flyout
+     */
     setExpandedDoc: (doc?: DataTableRecord) => void;
   };
 
@@ -554,7 +560,7 @@ const InternalUnifiedDataTable = React.forwardRef<
       trailingControlColumns, // TODO: deprecate in favor of rowAdditionalLeadingControls
       totalHits,
       onFetchMoreRecords,
-      renderDocumentViewFlyout: renderDocumentView,
+      documentViewFlyoutConnectionHandler,
       configRowHeight,
       showMultiFields = true,
       maxDocFieldsDisplayed = 50,
@@ -747,8 +753,8 @@ const InternalUnifiedDataTable = React.forwardRef<
     ]);
 
     const docViewerHelpers = useMemo(
-      () => renderDocumentView?.(displayedRows, displayedColumns, columnsMeta),
-      [renderDocumentView, displayedRows, displayedColumns, columnsMeta]
+      () => documentViewFlyoutConnectionHandler?.(displayedRows, displayedColumns, columnsMeta),
+      [documentViewFlyoutConnectionHandler, displayedRows, displayedColumns, columnsMeta]
     );
 
     const docViewerSnapshot = useSyncExternalStore(
@@ -1072,7 +1078,7 @@ const InternalUnifiedDataTable = React.forwardRef<
     const leadingControlColumns: EuiDataGridControlColumn[] = useMemo(() => {
       const { leadColumns, leadColumnsExtraContent } = getLeadControlColumns({
         rows: displayedRows,
-        canSetExpandedDoc: Boolean(renderDocumentView),
+        canSetExpandedDoc: Boolean(documentViewFlyoutConnectionHandler),
       });
 
       const filteredLeadColumns = leadColumns.filter((column) =>
@@ -1101,7 +1107,7 @@ const InternalUnifiedDataTable = React.forwardRef<
       displayedRows,
       externalControlColumns,
       getRowIndicator,
-      renderDocumentView,
+      documentViewFlyoutConnectionHandler,
       rowAdditionalLeadingControls,
     ]);
 

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -137,6 +137,9 @@ export interface DocViewerSnapshot {
   expandedDoc: DataTableRecord | undefined;
 }
 
+/** Stable snapshot for useSyncExternalStore fallback when no doc viewer handler is provided */
+const EMPTY_DOC_VIEWER_SNAPSHOT: DocViewerSnapshot = { expandedDoc: undefined };
+
 export interface GetDocViewerExternalStore {
   subscribe: (onStoreChange: () => void) => () => void;
   getSnapshot: () => DocViewerSnapshot;
@@ -213,10 +216,6 @@ interface InternalUnifiedDataTableProps {
    * Array of documents provided by Elasticsearch
    */
   rows?: DataTableRecord[];
-  /**
-   * Function to set the expanded document, which is displayed in a flyout
-   */
-  setExpandedDoc?: (doc?: DataTableRecord, options?: { initialTabId?: string }) => void;
   /**
    * Grid display settings persisted in Elasticsearch (e.g. column width)
    */
@@ -759,8 +758,8 @@ const InternalUnifiedDataTable = React.forwardRef<
 
     const docViewerSnapshot = useSyncExternalStore(
       docViewerHelpers?.externalStore.subscribe || (() => () => {}),
-      docViewerHelpers?.externalStore.getSnapshot || (() => ({ expandedDoc: undefined })),
-      docViewerHelpers?.externalStore.getServerSnapshot || (() => undefined)
+      docViewerHelpers?.externalStore.getSnapshot || (() => EMPTY_DOC_VIEWER_SNAPSHOT),
+      docViewerHelpers?.externalStore.getServerSnapshot || (() => EMPTY_DOC_VIEWER_SNAPSHOT)
     );
 
     const unifiedDataTableContextValue = useMemo<DataTableContext>(

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -15,6 +15,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import classnames from 'classnames';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -132,6 +133,16 @@ export enum DataLoadingState {
   loaded = 'loaded',
 }
 
+export interface DocViewerSnapshot {
+  expandedDoc: DataTableRecord | undefined;
+}
+
+export interface GetDocViewerExternalStore {
+  subscribe: (onDocViewerSnapshotChange: () => void) => () => void;
+  getSnapshot: () => DocViewerSnapshot;
+  getServerSnapshot: () => DocViewerSnapshot;
+}
+
 /**
  * Unified Data Table props
  */
@@ -174,10 +185,6 @@ interface InternalUnifiedDataTableProps {
    * Update header row height state
    */
   onUpdateHeaderRowHeight?: (headerRowHeight: number) => void;
-  /**
-   * If set, the given document is displayed in a flyout
-   */
-  expandedDoc?: DataTableRecord;
   /**
    * The used data view
    */
@@ -327,13 +334,15 @@ interface InternalUnifiedDataTableProps {
   /**
    * Callback to render DocumentView when the document is expanded
    */
-  renderDocumentView?: (
-    hit: DataTableRecord,
+  renderDocumentViewFlyout?: (
     displayedRows: DataTableRecord[],
     displayedColumns: string[],
-    expandedDocSetter: (doc?: DataTableRecord, options?: { initialTabId?: string }) => void,
     columnsMeta?: DataTableColumnsMeta
-  ) => JSX.Element | undefined;
+  ) => {
+    externalStore: GetDocViewerExternalStore;
+    setExpandedDoc: (doc?: DataTableRecord) => void;
+  };
+
   /**
    * Optional value for providing configuration setting for enabling to display the complex fields in the table. Default is true.
    */
@@ -545,9 +554,7 @@ const InternalUnifiedDataTable = React.forwardRef<
       trailingControlColumns, // TODO: deprecate in favor of rowAdditionalLeadingControls
       totalHits,
       onFetchMoreRecords,
-      renderDocumentView,
-      setExpandedDoc,
-      expandedDoc,
+      renderDocumentViewFlyout: renderDocumentView,
       configRowHeight,
       showMultiFields = true,
       maxDocFieldsDisplayed = 50,
@@ -739,10 +746,21 @@ const InternalUnifiedDataTable = React.forwardRef<
       changeCurrentPageIndex,
     ]);
 
+    const docViewerHelpers = useMemo(
+      () => renderDocumentView?.(displayedRows, displayedColumns, columnsMeta),
+      [renderDocumentView, displayedRows, displayedColumns, columnsMeta]
+    );
+
+    const docViewerSnapshot = useSyncExternalStore(
+      docViewerHelpers?.externalStore.subscribe || (() => () => {}),
+      docViewerHelpers?.externalStore.getSnapshot || (() => ({ expandedDoc: undefined })),
+      docViewerHelpers?.externalStore.getServerSnapshot || (() => undefined)
+    );
+
     const unifiedDataTableContextValue = useMemo<DataTableContext>(
       () => ({
-        expanded: expandedDoc,
-        setExpanded: setExpandedDoc,
+        expanded: docViewerSnapshot?.expandedDoc,
+        setExpanded: docViewerHelpers?.setExpandedDoc,
         getRowByIndex: (index: number) => displayedRows[index],
         onFilter,
         dataView,
@@ -754,17 +772,18 @@ const InternalUnifiedDataTable = React.forwardRef<
         pageSize: isPaginationEnabled ? paginationObj?.pageSize : displayedRows.length,
       }),
       [
-        componentsTourSteps,
+        docViewerSnapshot?.expandedDoc,
+        docViewerHelpers?.setExpandedDoc,
+        onFilter,
         dataView,
+        selectedDocsState,
+        valueToStringConverter,
+        componentsTourSteps,
         isPlainRecord,
         isPaginationEnabled,
+        paginationObj?.pageIndex,
+        paginationObj?.pageSize,
         displayedRows,
-        expandedDoc,
-        onFilter,
-        setExpandedDoc,
-        selectedDocsState,
-        paginationObj,
-        valueToStringConverter,
       ]
     );
 
@@ -1050,12 +1069,10 @@ const InternalUnifiedDataTable = React.forwardRef<
       ]
     );
 
-    const canSetExpandedDoc = Boolean(setExpandedDoc && !!renderDocumentView);
-
     const leadingControlColumns: EuiDataGridControlColumn[] = useMemo(() => {
       const { leadColumns, leadColumnsExtraContent } = getLeadControlColumns({
         rows: displayedRows,
-        canSetExpandedDoc,
+        canSetExpandedDoc: Boolean(renderDocumentView),
       });
 
       const filteredLeadColumns = leadColumns.filter((column) =>
@@ -1080,11 +1097,11 @@ const InternalUnifiedDataTable = React.forwardRef<
 
       return filteredLeadColumns;
     }, [
-      canSetExpandedDoc,
       controlColumnIds,
       displayedRows,
       externalControlColumns,
       getRowIndicator,
+      renderDocumentView,
       rowAdditionalLeadingControls,
     ]);
 
@@ -1453,15 +1470,6 @@ const InternalUnifiedDataTable = React.forwardRef<
               </p>
             </EuiScreenReaderOnly>
           )}
-          {canSetExpandedDoc &&
-            expandedDoc &&
-            renderDocumentView!(
-              expandedDoc,
-              displayedRows,
-              displayedColumns,
-              setExpandedDoc!,
-              columnsMeta
-            )}
         </span>
       </UnifiedDataTableContext.Provider>
     );

--- a/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_document_view_flyout_connection_handler.test.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_document_view_flyout_connection_handler.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import { dataViewMock, esHitsMock } from '@kbn/discover-utils/src/__mocks__';
+import { useDocumentViewFlyoutConnectionHandler } from './use_document_view_flyout_connection_handler';
+
+describe('useDocumentViewFlyoutConnectionHandler', () => {
+  it('returns documentViewFlyoutConnectionHandler and connectedGridMeta', () => {
+    const setExpandedDoc = jest.fn();
+    const { result } = renderHook(() =>
+      useDocumentViewFlyoutConnectionHandler({
+        expandedDoc: undefined,
+        setExpandedDoc,
+      })
+    );
+
+    expect(result.current.documentViewFlyoutConnectionHandler).toBeDefined();
+    expect(result.current.connectedGridMeta).toBeDefined();
+    expect(typeof result.current.documentViewFlyoutConnectionHandler).toBe('function');
+  });
+
+  it('documentViewFlyoutConnectionHandler returns externalStore and setExpandedDoc', () => {
+    const setExpandedDoc = jest.fn();
+    const { result } = renderHook(() =>
+      useDocumentViewFlyoutConnectionHandler({
+        expandedDoc: undefined,
+        setExpandedDoc,
+      })
+    );
+
+    const displayedRows = esHitsMock
+      .slice(0, 2)
+      .map((hit) => buildDataTableRecord(hit, dataViewMock));
+    const docViewerHelpers = result.current.documentViewFlyoutConnectionHandler(
+      displayedRows,
+      ['_source'],
+      undefined
+    );
+
+    expect(docViewerHelpers).toHaveProperty('externalStore');
+    expect(docViewerHelpers).toHaveProperty('setExpandedDoc');
+    expect(typeof docViewerHelpers.setExpandedDoc).toBe('function');
+  });
+
+  it('externalStore has subscribe, getSnapshot, and getServerSnapshot', () => {
+    const setExpandedDoc = jest.fn();
+    const { result } = renderHook(() =>
+      useDocumentViewFlyoutConnectionHandler({
+        expandedDoc: undefined,
+        setExpandedDoc,
+      })
+    );
+
+    const displayedRows = esHitsMock
+      .slice(0, 2)
+      .map((hit) => buildDataTableRecord(hit, dataViewMock));
+    const { externalStore } = result.current.documentViewFlyoutConnectionHandler(
+      displayedRows,
+      ['_source'],
+      undefined
+    );
+
+    expect(typeof externalStore.subscribe).toBe('function');
+    expect(typeof externalStore.getSnapshot).toBe('function');
+    expect(typeof externalStore.getServerSnapshot).toBe('function');
+  });
+
+  it('getSnapshot returns expandedDoc from store', async () => {
+    const displayedRows = esHitsMock
+      .slice(0, 2)
+      .map((hit) => buildDataTableRecord(hit, dataViewMock));
+    const docToExpand = displayedRows[0];
+
+    const setExpandedDoc = jest.fn();
+    const { result } = renderHook(() =>
+      useDocumentViewFlyoutConnectionHandler({
+        expandedDoc: undefined,
+        setExpandedDoc,
+      })
+    );
+
+    const { externalStore, setExpandedDoc: setExpandedDocFromHandler } =
+      result.current.documentViewFlyoutConnectionHandler(displayedRows, ['_source'], undefined);
+
+    expect(externalStore.getSnapshot()).toEqual({ expandedDoc: undefined });
+
+    await act(async () => {
+      setExpandedDocFromHandler(docToExpand);
+    });
+
+    expect(externalStore.getSnapshot().expandedDoc).toEqual(docToExpand);
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_document_view_flyout_connection_handler.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_document_view_flyout_connection_handler.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback, useMemo, useRef } from 'react';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import type {
+  DocViewerSnapshot,
+  GetDocViewerExternalStore,
+  UnifiedDataTableProps,
+} from '../components/data_table';
+import type { DataTableColumnsMeta } from '../types';
+
+export interface UseDocumentViewFlyoutConnectionHandlerOptions {
+  /** The expanded document - controlled by the consumer */
+  expandedDoc: DataTableRecord | undefined;
+  /** Callback to set the expanded document */
+  setExpandedDoc: (
+    doc?: DataTableRecord,
+    options?: { initialTabId?: string; initialTabState?: object }
+  ) => void;
+}
+
+export interface ConnectedGridMeta {
+  customColumnsMeta?: DataTableColumnsMeta;
+  displayedColumns: string[];
+  displayedRows: DataTableRecord[];
+}
+
+const createDefaultDocViewerSnapshot = (): DocViewerSnapshot => ({
+  expandedDoc: undefined,
+});
+
+/**
+ * Creates a connection handler for the document view flyout that the consumer passes
+ * to UnifiedDataTable via documentViewFlyoutConnectionHandler. The UnifiedDataTable
+ * uses this handler to subscribe to expanded doc state and to set the expanded doc
+ * when the user clicks the expand button.
+ *
+ * @example
+ * ```tsx
+ * const [expandedDoc, setExpandedDoc] = useState();
+ * const { documentViewFlyoutConnectionHandler, connectedGridMeta } =
+ *   useDocumentViewFlyoutConnectionHandler({
+ *     expandedDoc,
+ *     setExpandedDoc,
+ *   });
+ *
+ * return (
+ *   <>
+ *     <UnifiedDataTable
+ *       documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
+ *       {...props}
+ *     />
+ *     {expandedDoc && (
+ *       <DiscoverGridFlyout
+ *         hit={expandedDoc}
+ *         hits={connectedGridMeta.current?.displayedRows ?? []}
+ *         columns={connectedGridMeta.current?.displayedColumns ?? []}
+ *         columnsMeta={connectedGridMeta.current?.customColumnsMeta}
+ *         setExpandedDoc={setExpandedDoc}
+ *         onClose={() => setExpandedDoc(undefined)}
+ *         {...flyoutProps}
+ *       />
+ *     )}
+ *   </>
+ * );
+ * ```
+ */
+export function useDocumentViewFlyoutConnectionHandler({
+  expandedDoc,
+  setExpandedDoc,
+}: UseDocumentViewFlyoutConnectionHandlerOptions): {
+  documentViewFlyoutConnectionHandler: NonNullable<
+    UnifiedDataTableProps['documentViewFlyoutConnectionHandler']
+  >;
+  connectedGridMeta: React.MutableRefObject<ConnectedGridMeta | null>;
+} {
+  const latestExpandedDocRef = useRef(expandedDoc);
+  const connectedGridMeta = useRef<ConnectedGridMeta | null>(null);
+
+  const storeRef = useRef<{
+    listeners: Set<() => void>;
+    snapshot: DocViewerSnapshot;
+  }>({
+    listeners: new Set(),
+    snapshot: createDefaultDocViewerSnapshot(),
+  });
+
+  const notifyListeners = useCallback(() => {
+    storeRef.current.snapshot = {
+      expandedDoc: latestExpandedDocRef.current,
+    };
+    storeRef.current.listeners.forEach((listener) => listener());
+  }, []);
+
+  const wrappedSetExpandedDoc = useCallback(
+    (
+      doc: DataTableRecord | undefined,
+      options?: { initialTabId?: string; initialTabState?: object }
+    ) => {
+      latestExpandedDocRef.current = doc;
+      setExpandedDoc(doc, options);
+      notifyListeners();
+    },
+    [setExpandedDoc, notifyListeners]
+  );
+
+  const subscribe = useCallback((listener: () => void) => {
+    storeRef.current.listeners.add(listener);
+    return () => storeRef.current.listeners.delete(listener);
+  }, []);
+
+  const getSnapshot = useCallback((): DocViewerSnapshot => storeRef.current.snapshot, []);
+
+  const getServerSnapshot = useCallback(() => storeRef.current.snapshot, []);
+
+  const externalStore = useMemo<GetDocViewerExternalStore>(
+    () => ({
+      subscribe,
+      getSnapshot,
+      getServerSnapshot,
+    }),
+    [subscribe, getSnapshot, getServerSnapshot]
+  );
+
+  const documentViewFlyoutConnectionHandler = useCallback<
+    NonNullable<UnifiedDataTableProps['documentViewFlyoutConnectionHandler']>
+  >(
+    (displayedRows, displayedColumns, customColumnsMeta) => {
+      if (connectedGridMeta.current && latestExpandedDocRef.current) {
+        // if the document viewer is open we want to update the expanded doc to the first row of the grid
+        wrappedSetExpandedDoc(displayedRows[0]);
+      }
+
+      connectedGridMeta.current = {
+        customColumnsMeta,
+        displayedColumns,
+        displayedRows,
+      };
+
+      notifyListeners();
+
+      return {
+        externalStore,
+        setExpandedDoc: wrappedSetExpandedDoc,
+      };
+    },
+    [externalStore, notifyListeners, wrappedSetExpandedDoc]
+  );
+
+  return {
+    documentViewFlyoutConnectionHandler,
+    connectedGridMeta,
+  };
+}

--- a/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_document_view_flyout_connection_handler.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/hooks/use_document_view_flyout_connection_handler.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type {
   DocViewerSnapshot,
@@ -24,6 +24,17 @@ export interface UseDocumentViewFlyoutConnectionHandlerOptions {
     doc?: DataTableRecord,
     options?: { initialTabId?: string; initialTabState?: object }
   ) => void;
+  /**
+   * Callback to clear the expanded document
+   */
+  clearExpandedOnGridChange?: boolean;
+}
+
+interface UseDocumentViewFlyoutConnectionHandlerResult {
+  documentViewFlyoutConnectionHandler: NonNullable<
+    UnifiedDataTableProps['documentViewFlyoutConnectionHandler']
+  >;
+  connectedGridMeta: React.MutableRefObject<ConnectedGridMeta | null>;
 }
 
 export interface ConnectedGridMeta {
@@ -75,12 +86,8 @@ const createDefaultDocViewerSnapshot = (): DocViewerSnapshot => ({
 export function useDocumentViewFlyoutConnectionHandler({
   expandedDoc,
   setExpandedDoc,
-}: UseDocumentViewFlyoutConnectionHandlerOptions): {
-  documentViewFlyoutConnectionHandler: NonNullable<
-    UnifiedDataTableProps['documentViewFlyoutConnectionHandler']
-  >;
-  connectedGridMeta: React.MutableRefObject<ConnectedGridMeta | null>;
-} {
+  clearExpandedOnGridChange = true,
+}: UseDocumentViewFlyoutConnectionHandlerOptions): UseDocumentViewFlyoutConnectionHandlerResult {
   const latestExpandedDocRef = useRef(expandedDoc);
   const connectedGridMeta = useRef<ConnectedGridMeta | null>(null);
 
@@ -98,18 +105,6 @@ export function useDocumentViewFlyoutConnectionHandler({
     };
     storeRef.current.listeners.forEach((listener) => listener());
   }, []);
-
-  const wrappedSetExpandedDoc = useCallback(
-    (
-      doc: DataTableRecord | undefined,
-      options?: { initialTabId?: string; initialTabState?: object }
-    ) => {
-      latestExpandedDocRef.current = doc;
-      setExpandedDoc(doc, options);
-      notifyListeners();
-    },
-    [setExpandedDoc, notifyListeners]
-  );
 
   const subscribe = useCallback((listener: () => void) => {
     storeRef.current.listeners.add(listener);
@@ -129,12 +124,32 @@ export function useDocumentViewFlyoutConnectionHandler({
     [subscribe, getSnapshot, getServerSnapshot]
   );
 
+  const wrappedSetExpandedDoc = useCallback(
+    (
+      doc: DataTableRecord | undefined,
+      options?: { initialTabId?: string; initialTabState?: object }
+    ) => {
+      latestExpandedDocRef.current = doc;
+      setExpandedDoc(doc, options);
+      notifyListeners();
+    },
+    [setExpandedDoc, notifyListeners]
+  );
+
+  useEffect(() => {
+    if (latestExpandedDocRef.current !== expandedDoc) {
+      latestExpandedDocRef.current = expandedDoc;
+      notifyListeners();
+    }
+  }, [expandedDoc, notifyListeners]);
+
   const documentViewFlyoutConnectionHandler = useCallback<
     NonNullable<UnifiedDataTableProps['documentViewFlyoutConnectionHandler']>
   >(
     (displayedRows, displayedColumns, customColumnsMeta) => {
-      if (connectedGridMeta.current && latestExpandedDocRef.current) {
-        // if the document viewer is open we want to update the expanded doc to the first row of the grid
+      if (connectedGridMeta.current && latestExpandedDocRef.current && clearExpandedOnGridChange) {
+        // if the document viewer is open we want to update
+        // the expanded doc to the first row of the incoming grid displayed rows
         wrappedSetExpandedDoc(displayedRows[0]);
       }
 
@@ -144,14 +159,12 @@ export function useDocumentViewFlyoutConnectionHandler({
         displayedRows,
       };
 
-      notifyListeners();
-
       return {
         externalStore,
         setExpandedDoc: wrappedSetExpandedDoc,
       };
     },
-    [externalStore, notifyListeners, wrappedSetExpandedDoc]
+    [externalStore, wrappedSetExpandedDoc, clearExpandedOnGridChange]
   );
 
   return {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
@@ -15,7 +15,6 @@ export type {
   DataCascadeImplRef,
   DataCascadeRowProps,
   DataCascadeRowCellProps,
-  CascadeRowCellNestedVirtualizationAnchorProps,
 } from './src/components';
 export * from './src/lib';
 export { NumberBadge } from './src/components/helpers';

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -16,11 +16,7 @@ export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps, Dat
 export type { DataCascadeUISnapshot } from '../lib/core/api';
 export { DataCascadeRow, DataCascadeRowCell } from './data_cascade_impl';
 
-export type {
-  DataCascadeRowProps,
-  DataCascadeRowCellProps,
-  CascadeRowCellNestedVirtualizationAnchorProps,
-} from './data_cascade_impl';
+export type { DataCascadeRowProps, DataCascadeRowCellProps } from './data_cascade_impl';
 
 type DataCascadeProviderProps = ComponentProps<typeof DataCascadeProvider>;
 

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
@@ -28,7 +28,10 @@ import {
   ROW_HEIGHT_OPTION,
   SHOW_MULTIFIELDS,
 } from '@kbn/discover-utils';
-import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
+import {
+  type UnifiedDataTableProps,
+  useDocumentViewFlyoutConnectionHandler,
+} from '@kbn/unified-data-table';
 import { DataLoadingState, getDataGridDensity, getRowHeight } from '@kbn/unified-data-table';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import { useQuerySubscriber } from '@kbn/unified-field-list';
@@ -140,25 +143,11 @@ export function ContextAppContent({
     return [[dataView.timeFieldName!, SortDirection.desc]];
   }, [dataView]);
 
-  const renderDocumentView = useCallback(
-    (hit: DataTableRecord, displayedRows: DataTableRecord[], displayedColumns: string[]) => (
-      <DiscoverGridFlyout
-        dataView={dataView}
-        hit={hit}
-        hits={displayedRows}
-        // if default columns are used, dont make them part of the URL - the context state handling will take care to restore them
-        columns={displayedColumns}
-        onFilter={addFilter}
-        onRemoveColumn={onRemoveColumn}
-        onAddColumn={onAddColumn}
-        onClose={() => setExpandedDoc(undefined)}
-        initialTabId={initialTabId}
-        setExpandedDoc={setExpandedDocWithInitialTab}
-        docViewerRef={docViewerRef}
-      />
-    ),
-    [addFilter, dataView, onAddColumn, onRemoveColumn, setExpandedDocWithInitialTab, initialTabId]
-  );
+  const { documentViewFlyoutConnectionHandler, connectedGridMeta } =
+    useDocumentViewFlyoutConnectionHandler({
+      expandedDoc,
+      setExpandedDoc: setExpandedDocWithInitialTab,
+    });
 
   const onResize = useCallback<NonNullable<UnifiedDataTableProps['onResize']>>(
     (colSettings) => {
@@ -227,7 +216,6 @@ export function ContextAppContent({
             columns={columns}
             rows={rows}
             dataView={dataView}
-            expandedDoc={expandedDoc}
             loadingState={isAnchorLoading ? DataLoadingState.loading : DataLoadingState.loaded}
             sampleSizeState={0}
             sort={sort as SortOrder[]}
@@ -242,7 +230,7 @@ export function ContextAppContent({
             configRowHeight={configRowHeight}
             showMultiFields={services.uiSettings.get(SHOW_MULTIFIELDS)}
             maxDocFieldsDisplayed={services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-            documentViewFlyoutConnectionHandler={renderDocumentView}
+            documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
             services={services}
             configHeaderRowHeight={3}
             settings={grid}
@@ -251,6 +239,21 @@ export function ContextAppContent({
           />
         </CellActionsProvider>
       </div>
+      {expandedDoc && (
+        <DiscoverGridFlyout
+          dataView={dataView}
+          hit={expandedDoc}
+          hits={connectedGridMeta.current?.displayedRows ?? []}
+          columns={connectedGridMeta.current?.displayedColumns ?? []}
+          onFilter={addFilter}
+          onRemoveColumn={onRemoveColumn}
+          onAddColumn={onAddColumn}
+          onClose={() => setExpandedDoc(undefined)}
+          initialTabId={initialTabId}
+          setExpandedDoc={setExpandedDocWithInitialTab}
+          docViewerRef={docViewerRef}
+        />
+      )}
       <WrapperWithPadding>
         <ActionBarMemoized
           type={SurrDocType.SUCCESSORS}

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
@@ -242,7 +242,7 @@ export function ContextAppContent({
             configRowHeight={configRowHeight}
             showMultiFields={services.uiSettings.get(SHOW_MULTIFIELDS)}
             maxDocFieldsDisplayed={services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-            renderDocumentViewFlyout={renderDocumentView}
+            documentViewFlyoutConnectionHandler={renderDocumentView}
             services={services}
             configHeaderRowHeight={3}
             settings={grid}

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
@@ -147,6 +147,7 @@ export function ContextAppContent({
     useDocumentViewFlyoutConnectionHandler({
       expandedDoc,
       setExpandedDoc: setExpandedDocWithInitialTab,
+      clearExpandedOnGridChange: false,
     });
 
   const onResize = useCallback<NonNullable<UnifiedDataTableProps['onResize']>>(
@@ -237,23 +238,23 @@ export function ContextAppContent({
             onResize={onResize}
             externalCustomRenderers={cellRenderers}
           />
+          {expandedDoc && (
+            <DiscoverGridFlyout
+              dataView={dataView}
+              hit={expandedDoc}
+              hits={connectedGridMeta.current?.displayedRows ?? []}
+              columns={connectedGridMeta.current?.displayedColumns ?? []}
+              onFilter={addFilter}
+              onRemoveColumn={onRemoveColumn}
+              onAddColumn={onAddColumn}
+              onClose={() => setExpandedDoc(undefined)}
+              initialTabId={initialTabId}
+              setExpandedDoc={setExpandedDocWithInitialTab}
+              docViewerRef={docViewerRef}
+            />
+          )}
         </CellActionsProvider>
       </div>
-      {expandedDoc && (
-        <DiscoverGridFlyout
-          dataView={dataView}
-          hit={expandedDoc}
-          hits={connectedGridMeta.current?.displayedRows ?? []}
-          columns={connectedGridMeta.current?.displayedColumns ?? []}
-          onFilter={addFilter}
-          onRemoveColumn={onRemoveColumn}
-          onAddColumn={onAddColumn}
-          onClose={() => setExpandedDoc(undefined)}
-          initialTabId={initialTabId}
-          setExpandedDoc={setExpandedDocWithInitialTab}
-          docViewerRef={docViewerRef}
-        />
-      )}
       <WrapperWithPadding>
         <ActionBarMemoized
           type={SurrDocType.SUCCESSORS}

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
@@ -242,7 +242,7 @@ export function ContextAppContent({
             configRowHeight={configRowHeight}
             showMultiFields={services.uiSettings.get(SHOW_MULTIFIELDS)}
             maxDocFieldsDisplayed={services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-            renderDocumentView={renderDocumentView}
+            renderDocumentViewFlyout={renderDocumentView}
             services={services}
             configHeaderRowHeight={3}
             settings={grid}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
@@ -31,7 +31,7 @@ interface ESQLDataCascadeLeafCellProps
       | 'showTimeCol'
       | 'dataView'
       | 'showKeyboardShortcuts'
-      | 'renderDocumentViewFlyout'
+      | 'documentViewFlyoutConnectionHandler'
       | 'externalCustomRenderers'
       | 'onUpdateDataGridDensity'
     >,
@@ -196,7 +196,7 @@ export const ESQLDataCascadeLeafCell = React.memo(
     showTimeCol,
     dataView,
     showKeyboardShortcuts,
-    renderDocumentViewFlyout,
+    documentViewFlyoutConnectionHandler,
     externalCustomRenderers,
     getScrollElement,
     getScrollMargin,
@@ -298,7 +298,7 @@ export const ESQLDataCascadeLeafCell = React.memo(
         renderCustomToolbar={renderCustomToolbarWithElements}
         dataGridDensityState={cascadeDataGridDensityState}
         onUpdateDataGridDensity={setCascadeDataGridDensityState}
-        renderDocumentViewFlyout={renderDocumentViewFlyout}
+        documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
         renderCustomGridBody={renderCustomCascadeGridBodyCallback}
         onFullScreenChange={setIsCellInFullScreenMode}
         externalCustomRenderers={externalCustomRenderers}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
@@ -31,7 +31,7 @@ interface ESQLDataCascadeLeafCellProps
       | 'showTimeCol'
       | 'dataView'
       | 'showKeyboardShortcuts'
-      | 'renderDocumentView'
+      | 'renderDocumentViewFlyout'
       | 'externalCustomRenderers'
       | 'onUpdateDataGridDensity'
     >,
@@ -196,7 +196,7 @@ export const ESQLDataCascadeLeafCell = React.memo(
     showTimeCol,
     dataView,
     showKeyboardShortcuts,
-    renderDocumentView,
+    renderDocumentViewFlyout,
     externalCustomRenderers,
     getScrollElement,
     getScrollMargin,
@@ -205,7 +205,6 @@ export const ESQLDataCascadeLeafCell = React.memo(
     onUpdateDataGridDensity,
   }: ESQLDataCascadeLeafCellProps) => {
     const services = useDiscoverServices();
-    const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>();
     const [cascadeDataGridDensityState, setCascadeDataGridDensityState] = useState<DataGridDensity>(
       dataGridDensityState ?? DataGridDensity.COMPACT
     );
@@ -221,12 +220,6 @@ export const ESQLDataCascadeLeafCell = React.memo(
     }, [cascadeDataGridDensityState, onUpdateDataGridDensity]);
 
     const [isCellInFullScreenMode, setIsCellInFullScreenMode] = useState(false);
-
-    const setExpandedDocFn = useCallback(
-      (...args: Parameters<NonNullable<UnifiedDataTableProps['setExpandedDoc']>>) =>
-        setExpandedDoc(args[0]),
-      [setExpandedDoc]
-    );
 
     const renderCustomToolbarWithElements = useMemo(
       () =>
@@ -303,11 +296,9 @@ export const ESQLDataCascadeLeafCell = React.memo(
         columns={selectedColumns}
         onSetColumns={setSelectedColumns}
         renderCustomToolbar={renderCustomToolbarWithElements}
-        expandedDoc={expandedDoc}
-        setExpandedDoc={setExpandedDocFn}
         dataGridDensityState={cascadeDataGridDensityState}
         onUpdateDataGridDensity={setCascadeDataGridDensityState}
-        renderDocumentView={renderDocumentView}
+        renderDocumentViewFlyout={renderDocumentViewFlyout}
         renderCustomGridBody={renderCustomCascadeGridBodyCallback}
         onFullScreenChange={setIsCellInFullScreenMode}
         externalCustomRenderers={externalCustomRenderers}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -41,7 +41,7 @@ export interface ESQLDataCascadeProps
     | 'showTimeCol'
     | 'dataView'
     | 'showKeyboardShortcuts'
-    | 'renderDocumentViewFlyout'
+    | 'documentViewFlyoutConnectionHandler'
     | 'externalCustomRenderers'
     | 'onUpdateDataGridDensity'
   > {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -41,7 +41,7 @@ export interface ESQLDataCascadeProps
     | 'showTimeCol'
     | 'dataView'
     | 'showKeyboardShortcuts'
-    | 'renderDocumentView'
+    | 'renderDocumentViewFlyout'
     | 'externalCustomRenderers'
     | 'onUpdateDataGridDensity'
   > {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.tsx
@@ -42,6 +42,7 @@ export interface ESQLDataCascadeProps
     | 'dataView'
     | 'showKeyboardShortcuts'
     | 'documentViewFlyoutConnectionHandler'
+    | 'rowAdditionalLeadingControls'
     | 'externalCustomRenderers'
     | 'onUpdateDataGridDensity'
   > {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -341,6 +341,7 @@ function DiscoverDocumentsComponent({
   const setDocViewerUiState = useCurrentTabAction(internalStateActions.setDocViewerUiState);
 
   const latestDocViewerUiState = useLatest(docViewerUiState);
+  const latestInitialDocViewerTabId = useLatest(initialDocViewerTabId);
 
   const onInitialDocViewerStateChange = useCallback(
     (newDocViewerUiState: Partial<DocViewerRestorableState>) => {
@@ -377,7 +378,7 @@ function DiscoverDocumentsComponent({
         columnsMeta={customColumnsMeta}
         savedSearchId={persistedDiscoverSession?.id!}
         query={query}
-        initialTabId={initialDocViewerTabId}
+        initialTabId={latestInitialDocViewerTabId.current}
         onFilter={onAddFilter}
         onRemoveColumn={onRemoveColumnWithTracking}
         onAddColumn={onAddColumnWithTracking}
@@ -394,7 +395,7 @@ function DiscoverDocumentsComponent({
       dataView,
       persistedDiscoverSession?.id,
       query,
-      initialDocViewerTabId,
+      latestInitialDocViewerTabId,
       onAddFilter,
       onRemoveColumnWithTracking,
       onAddColumnWithTracking,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -314,9 +314,6 @@ function DiscoverDocumentsComponent({
   const docViewerUiState = useCurrentTabSelector((state) => state.uiState.docViewer);
   const setDocViewerUiState = useCurrentTabAction(internalStateActions.setDocViewerUiState);
 
-  const latestDocViewerUiState = useLatest(docViewerUiState);
-  const latestInitialDocViewerTabId = useLatest(initialDocViewerTabId);
-
   const onInitialDocViewerStateChange = useCallback(
     (newDocViewerUiState: Partial<DocViewerRestorableState>) => {
       dispatch(setDocViewerUiState({ docViewerUiState: newDocViewerUiState }));
@@ -543,13 +540,13 @@ function DiscoverDocumentsComponent({
         dataView={dataView}
         savedSearchId={persistedDiscoverSession?.id!}
         query={query}
-        initialTabId={latestInitialDocViewerTabId.current}
+        initialTabId={initialDocViewerTabId}
         onFilter={onAddFilter}
         onRemoveColumn={onRemoveColumnWithTracking}
         onAddColumn={onAddColumnWithTracking}
         docViewerExtensionActions={docViewerExtensionActions}
         onUpdateSelectedTabId={onUpdateSelectedTabId}
-        initialDocViewerState={latestDocViewerUiState.current}
+        initialDocViewerState={docViewerUiState}
         onInitialDocViewerStateChange={onInitialDocViewerStateChange}
       />
     </EuiFlexItem>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 import {
   EuiFlexItem,
   EuiLoadingSpinner,
@@ -22,7 +22,6 @@ import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SortOrder } from '@kbn/saved-search-plugin/public';
 import { CellActionsProvider } from '@kbn/cell-actions';
-import type { DataTableRecord } from '@kbn/discover-utils/types';
 import { SearchResponseWarningsCallout } from '@kbn/search-response-warnings';
 import type {
   DataGridDensity,
@@ -48,7 +47,7 @@ import {
 } from '@kbn/discover-utils';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { DiscoverGridSettings } from '@kbn/saved-search-plugin/common';
-import type { DocViewerApi, DocViewerRestorableState } from '@kbn/unified-doc-viewer';
+import type { DocViewerRestorableState } from '@kbn/unified-doc-viewer';
 import useLatest from 'react-use/lib/useLatest';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { DISCOVER_CELL_ACTIONS_TRIGGER_ID } from '@kbn/ui-actions-plugin/common/trigger_ids';
@@ -85,10 +84,7 @@ import {
   useInternalStateSelector,
 } from '../../state_management/redux';
 import { useScopedServices } from '../../../../components/scoped_services_provider';
-import {
-  DiscoverGridFlyout,
-  type DiscoverGridFlyoutProps,
-} from '../../../../components/discover_grid_flyout';
+import { useGetDiscoverGridFlyoutRenderer } from './helpers/render_document_view';
 import type { CascadedDocumentsContext } from './cascaded_documents';
 import { isCascadedDocumentsVisible } from './cascaded_documents';
 
@@ -148,7 +144,6 @@ function DiscoverDocumentsComponent({
       state.density,
     ];
   });
-  const expandedDoc = useCurrentTabSelector((state) => state.expandedDoc);
   const initialDocViewerTabId = useCurrentTabSelector((state) => state.initialDocViewerTabId);
   const isEsqlMode = useIsEsqlMode();
   const dataStateContainer = useCurrentTabDataStateContainer();
@@ -212,29 +207,7 @@ function DiscoverDocumentsComponent({
     [onRemoveColumn, scopedEBTManager, fieldsMetadata]
   );
 
-  const docViewerRef = useRef<DocViewerApi>(null);
-  const setExpandedDocAction = useCurrentTabAction(internalStateActions.setExpandedDoc);
-  const setExpandedDoc = useCallback(
-    (
-      doc: DataTableRecord | undefined,
-      options?: {
-        initialTabId?: string;
-        initialTabState?: object;
-      }
-    ) => {
-      dispatch(
-        setExpandedDocAction({
-          expandedDoc: doc,
-          initialDocViewerTabId: options?.initialTabId,
-          initialDocViewerTabState: options?.initialTabState,
-        })
-      );
-      if (options?.initialTabId) {
-        docViewerRef.current?.setSelectedTabId(options.initialTabId);
-      }
-    },
-    [dispatch, setExpandedDocAction]
-  );
+  const { DiscoverGridFlyoutRenderer, renderDocumentView } = useGetDiscoverGridFlyoutRenderer();
 
   const latestGrid = useLatest(grid);
   const onResizeDataGrid = useCallback<NonNullable<UnifiedDataTableProps['onResize']>>(
@@ -359,51 +332,6 @@ function DiscoverDocumentsComponent({
       dispatch(setInitialDocViewerTabIdAction({ initialDocViewerTabId: tabId }));
     },
     [dispatch, setInitialDocViewerTabIdAction]
-  );
-
-  const renderDocumentView = useCallback(
-    (
-      hit: DataTableRecord,
-      displayedRows: DataTableRecord[],
-      displayedColumns: string[],
-      expandedDocSetter: DiscoverGridFlyoutProps['setExpandedDoc'],
-      customColumnsMeta?: DataTableColumnsMeta
-    ) => (
-      <DiscoverGridFlyout
-        dataView={dataView}
-        hit={hit}
-        hits={displayedRows}
-        // if default columns are used, don't make them part of the URL - the context state handling will take care to restore them
-        columns={displayedColumns}
-        columnsMeta={customColumnsMeta}
-        savedSearchId={persistedDiscoverSession?.id!}
-        query={query}
-        initialTabId={latestInitialDocViewerTabId.current}
-        onFilter={onAddFilter}
-        onRemoveColumn={onRemoveColumnWithTracking}
-        onAddColumn={onAddColumnWithTracking}
-        setExpandedDoc={expandedDocSetter}
-        onClose={expandedDocSetter.bind(null, undefined)}
-        docViewerRef={docViewerRef}
-        docViewerExtensionActions={docViewerExtensionActions}
-        onUpdateSelectedTabId={onUpdateSelectedTabId}
-        initialDocViewerState={latestDocViewerUiState.current}
-        onInitialDocViewerStateChange={onInitialDocViewerStateChange}
-      />
-    ),
-    [
-      dataView,
-      persistedDiscoverSession?.id,
-      query,
-      latestInitialDocViewerTabId,
-      onAddFilter,
-      onRemoveColumnWithTracking,
-      onAddColumnWithTracking,
-      docViewerExtensionActions,
-      onUpdateSelectedTabId,
-      latestDocViewerUiState,
-      onInitialDocViewerStateChange,
-    ]
   );
 
   const dataGridUiState = useCurrentTabSelector((state) => state.uiState.dataGrid);
@@ -555,7 +483,6 @@ function DiscoverDocumentsComponent({
             cascadedDocumentsContext={cascadedDocumentsContext}
             columns={currentColumns}
             columnsMeta={columnsMeta}
-            expandedDoc={expandedDoc}
             dataView={dataView}
             loadingState={
               isDataLoading
@@ -568,7 +495,6 @@ function DiscoverDocumentsComponent({
             sort={(sort as SortOrder[]) || []}
             searchDescription={persistedDiscoverSession?.description}
             searchTitle={persistedDiscoverSession?.title} // TODO: should it be rather a tab label?
-            setExpandedDoc={setExpandedDoc}
             showTimeCol={showTimeCol}
             settings={grid}
             onFilter={onAddFilter as DocViewFilterFn}
@@ -592,7 +518,7 @@ function DiscoverDocumentsComponent({
             configRowHeight={configRowHeight}
             showMultiFields={uiSettings.get(SHOW_MULTIFIELDS)}
             maxDocFieldsDisplayed={uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-            renderDocumentView={renderDocumentView}
+            renderDocumentViewFlyout={renderDocumentView}
             renderCustomToolbar={renderCustomToolbarWithElements}
             services={services}
             totalHits={totalHits}
@@ -611,6 +537,19 @@ function DiscoverDocumentsComponent({
           />
         </CellActionsProvider>
       </div>
+      <DiscoverGridFlyoutRenderer
+        dataView={dataView}
+        savedSearchId={persistedDiscoverSession?.id!}
+        query={query}
+        initialTabId={latestInitialDocViewerTabId.current}
+        onFilter={onAddFilter}
+        onRemoveColumn={onRemoveColumnWithTracking}
+        onAddColumn={onAddColumnWithTracking}
+        docViewerExtensionActions={docViewerExtensionActions}
+        onUpdateSelectedTabId={onUpdateSelectedTabId}
+        initialDocViewerState={latestDocViewerUiState.current}
+        onInitialDocViewerStateChange={onInitialDocViewerStateChange}
+      />
     </EuiFlexItem>
   );
 }

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -207,7 +207,8 @@ function DiscoverDocumentsComponent({
     [onRemoveColumn, scopedEBTManager, fieldsMetadata]
   );
 
-  const { DiscoverGridFlyoutRenderer, renderDocumentView } = useGetDiscoverGridFlyoutRenderer();
+  const { DiscoverGridFlyoutRenderer, flyoutConnectionHandler } =
+    useGetDiscoverGridFlyoutRenderer();
 
   const latestGrid = useLatest(grid);
   const onResizeDataGrid = useCallback<NonNullable<UnifiedDataTableProps['onResize']>>(
@@ -518,7 +519,7 @@ function DiscoverDocumentsComponent({
             configRowHeight={configRowHeight}
             showMultiFields={uiSettings.get(SHOW_MULTIFIELDS)}
             maxDocFieldsDisplayed={uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-            renderDocumentViewFlyout={renderDocumentView}
+            documentViewFlyoutConnectionHandler={flyoutConnectionHandler}
             renderCustomToolbar={renderCustomToolbarWithElements}
             services={services}
             totalHits={totalHits}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -207,7 +207,7 @@ function DiscoverDocumentsComponent({
     [onRemoveColumn, scopedEBTManager, fieldsMetadata]
   );
 
-  const { DiscoverGridFlyoutRenderer, flyoutConnectionHandler } =
+  const { DiscoverGridFlyoutRenderer, flyoutConnectionHandler, setExpandedDoc } =
     useGetDiscoverGridFlyoutRenderer();
 
   const latestGrid = useLatest(grid);
@@ -519,6 +519,7 @@ function DiscoverDocumentsComponent({
             configRowHeight={configRowHeight}
             showMultiFields={uiSettings.get(SHOW_MULTIFIELDS)}
             maxDocFieldsDisplayed={uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
+            setExpandedDoc={setExpandedDoc}
             documentViewFlyoutConnectionHandler={flyoutConnectionHandler}
             renderCustomToolbar={renderCustomToolbarWithElements}
             services={services}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -340,6 +340,8 @@ function DiscoverDocumentsComponent({
   const docViewerUiState = useCurrentTabSelector((state) => state.uiState.docViewer);
   const setDocViewerUiState = useCurrentTabAction(internalStateActions.setDocViewerUiState);
 
+  const latestDocViewerUiState = useLatest(docViewerUiState);
+
   const onInitialDocViewerStateChange = useCallback(
     (newDocViewerUiState: Partial<DocViewerRestorableState>) => {
       dispatch(setDocViewerUiState({ docViewerUiState: newDocViewerUiState }));
@@ -384,7 +386,7 @@ function DiscoverDocumentsComponent({
         docViewerRef={docViewerRef}
         docViewerExtensionActions={docViewerExtensionActions}
         onUpdateSelectedTabId={onUpdateSelectedTabId}
-        initialDocViewerState={docViewerUiState}
+        initialDocViewerState={latestDocViewerUiState.current}
         onInitialDocViewerStateChange={onInitialDocViewerStateChange}
       />
     ),
@@ -398,7 +400,7 @@ function DiscoverDocumentsComponent({
       onAddColumnWithTracking,
       docViewerExtensionActions,
       onUpdateSelectedTabId,
-      docViewerUiState,
+      latestDocViewerUiState,
       onInitialDocViewerStateChange,
     ]
   );

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import { dataViewMock, esHitsMock } from '@kbn/discover-utils/src/__mocks__';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getDiscoverInternalStateMock } from '../../../../../__mocks__/discover_state.mock';
+import { DiscoverToolkitTestProvider } from '../../../../../__mocks__/test_provider';
+import { useGetDiscoverGridFlyoutRenderer } from './render_document_view';
+
+const createMockRecord = (id: string): DataTableRecord =>
+  buildDataTableRecord(
+    {
+      _index: 'test',
+      _id: id,
+      _score: 1,
+      _source: { message: `doc-${id}` },
+    },
+    dataViewMock
+  );
+
+describe('useGetDiscoverGridFlyoutRenderer', () => {
+  const setup = async () => {
+    const toolkit = getDiscoverInternalStateMock({
+      persistedDataViews: [dataViewMock],
+    });
+
+    await toolkit.initializeTabs();
+    await toolkit.initializeSingleTab({
+      tabId: toolkit.getCurrentTab().id,
+      skipWaitForDataFetching: true,
+    });
+
+    const { result } = renderHook(() => useGetDiscoverGridFlyoutRenderer(), {
+      wrapper: ({ children }) => (
+        <DiscoverToolkitTestProvider toolkit={toolkit}>{children}</DiscoverToolkitTestProvider>
+      ),
+    });
+
+    return { result, toolkit };
+  };
+
+  it('returns DiscoverGridFlyoutRenderer and renderDocumentView', async () => {
+    const { result } = await setup();
+
+    expect(result.current.DiscoverGridFlyoutRenderer).toBeDefined();
+    expect(result.current.flyoutConnectionHandler).toBeDefined();
+    expect(typeof result.current.DiscoverGridFlyoutRenderer).toBe('function');
+    expect(typeof result.current.flyoutConnectionHandler).toBe('function');
+  });
+
+  it('flyoutConnectionHandler returns externalStore and setExpandedDoc', async () => {
+    const { result } = await setup();
+    const displayedRows = esHitsMock
+      .slice(0, 2)
+      .map((hit) => buildDataTableRecord(hit, dataViewMock));
+    const displayedColumns = ['_source', 'message'];
+
+    const docViewerHelpers = result.current.flyoutConnectionHandler(
+      displayedRows,
+      displayedColumns,
+      undefined
+    );
+
+    expect(docViewerHelpers).toHaveProperty('externalStore');
+    expect(docViewerHelpers).toHaveProperty('setExpandedDoc');
+    expect(typeof docViewerHelpers.setExpandedDoc).toBe('function');
+  });
+
+  it('externalStore has subscribe, getSnapshot, and getServerSnapshot', async () => {
+    const { result } = await setup();
+    const displayedRows = esHitsMock
+      .slice(0, 2)
+      .map((hit) => buildDataTableRecord(hit, dataViewMock));
+
+    const { externalStore } = result.current.flyoutConnectionHandler(
+      displayedRows,
+      ['_source'],
+      undefined
+    );
+
+    expect(typeof externalStore.subscribe).toBe('function');
+    expect(typeof externalStore.getSnapshot).toBe('function');
+    expect(typeof externalStore.getServerSnapshot).toBe('function');
+  });
+
+  it('getSnapshot returns expandedDoc from store', async () => {
+    const { result } = await setup();
+    const displayedRows = esHitsMock
+      .slice(0, 2)
+      .map((hit) => buildDataTableRecord(hit, dataViewMock));
+
+    const { externalStore, setExpandedDoc } = result.current.flyoutConnectionHandler(
+      displayedRows,
+      ['_source'],
+      undefined
+    );
+
+    expect(externalStore.getSnapshot()).toEqual({ expandedDoc: undefined });
+
+    const docToExpand = displayedRows[0];
+    await act(async () => {
+      setExpandedDoc(docToExpand);
+    });
+
+    // Snapshot updates asynchronously via debounced notifyListeners (100ms)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+
+    expect(externalStore.getSnapshot().expandedDoc).toEqual(docToExpand);
+  });
+
+  it('does not call setExpandedDoc when first row id is the same', async () => {
+    const { result, toolkit } = await setup();
+    const dispatchSpy = jest.spyOn(toolkit.internalState, 'dispatch');
+
+    const rows = [createMockRecord('1'), createMockRecord('2')];
+    result.current.flyoutConnectionHandler(rows, ['_source'], undefined);
+    dispatchSpy.mockClear();
+
+    const sameFirstRowDifferentSecond = [rows[0], createMockRecord('3')];
+    result.current.flyoutConnectionHandler(sameFirstRowDifferentSecond, ['_source'], undefined);
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringContaining('setExpandedDoc'),
+        payload: expect.objectContaining({ expandedDoc: undefined }),
+      })
+    );
+  });
+});

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.tsx
@@ -7,14 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
+import React, { useCallback, useMemo, useRef } from 'react';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import type { DocViewerApi } from '@kbn/unified-doc-viewer';
-import type {
-  DocViewerSnapshot,
-  GetDocViewerExternalStore,
-  UnifiedDataTableProps,
-} from '@kbn/unified-data-table';
+import { useDocumentViewFlyoutConnectionHandler } from '@kbn/unified-data-table';
 import {
   DiscoverGridFlyout,
   type DiscoverGridFlyoutProps,
@@ -28,56 +24,11 @@ import { internalStateActions } from '../../../state_management/redux';
 
 export type { DiscoverGridFlyoutProps };
 
-const createDefaultDocViewerSnapshot = (): DocViewerSnapshot => ({
-  expandedDoc: undefined,
-});
-
 export function useGetDiscoverGridFlyoutRenderer() {
   const docViewerRef = useRef<DocViewerApi>(null);
   const dispatch = useInternalStateDispatch();
   const setExpandedDocAction = useCurrentTabAction(internalStateActions.setExpandedDoc);
   const expandedDoc = useCurrentTabSelector((state) => state.expandedDoc);
-
-  // Holds reference to the latest expanded doc
-  const latestExpandedDocRef = useRef(expandedDoc);
-
-  // Holds reference to the meta information of the connected grid (columns, rows, columns meta)
-  // without causing unnecessary re-renders when the connected grid changes,
-  // or copying over potentially large data (displayed rows).
-  const connectedGridMetaInfo = useRef<{
-    customColumnsMeta?: DataTableColumnsMeta;
-    displayedColumns: string[];
-    displayedRows: DataTableRecord[];
-  } | null>(null);
-
-  const storeRef = useRef<{
-    listeners: Set<() => void>;
-    snapshot: DocViewerSnapshot;
-  }>({
-    listeners: new Set(),
-    snapshot: createDefaultDocViewerSnapshot(),
-  });
-
-  /** Notifies all subscribed listeners that the store snapshot may have changed. */
-  const notifyListeners = useMemo(
-    () => () => {
-      storeRef.current.snapshot = {
-        expandedDoc: latestExpandedDocRef.current,
-      };
-
-      storeRef.current.listeners.forEach((listener) => listener());
-    },
-    []
-  );
-
-  // Sync the ref with Redux state when expandedDoc changes externally
-  // (e.g. via inspector, data view change, or saved search reset)
-  useEffect(() => {
-    if (latestExpandedDocRef.current !== expandedDoc) {
-      latestExpandedDocRef.current = expandedDoc;
-      notifyListeners();
-    }
-  }, [expandedDoc, notifyListeners]);
 
   const setExpandedDoc = useCallback(
     (
@@ -97,61 +48,19 @@ export function useGetDiscoverGridFlyoutRenderer() {
       if (options?.initialTabId) {
         docViewerRef.current?.setSelectedTabId(options.initialTabId);
       }
-
-      // Update the latest expanded doc reference
-      latestExpandedDocRef.current = doc;
-
-      notifyListeners();
     },
-    [dispatch, setExpandedDocAction, notifyListeners]
+    [dispatch, setExpandedDocAction]
   );
 
-  const subscribe = useCallback((listener: () => void) => {
-    storeRef.current.listeners.add(listener);
-    return () => {
-      storeRef.current.listeners.delete(listener);
-    };
-  }, []);
-
-  const getSnapshot = useCallback((): DocViewerSnapshot => storeRef.current.snapshot, []);
-
-  const getServerSnapshot = useCallback(() => storeRef.current.snapshot, []);
-
-  const getStateStore = useMemo<GetDocViewerExternalStore>(
-    () => ({
-      subscribe,
-      getSnapshot,
-      getServerSnapshot,
-    }),
-    [subscribe, getSnapshot, getServerSnapshot]
-  );
+  const { documentViewFlyoutConnectionHandler: flyoutConnectionHandler, connectedGridMeta } =
+    useDocumentViewFlyoutConnectionHandler({
+      expandedDoc,
+      setExpandedDoc,
+    });
 
   const onCloseDocViewer = useCallback(() => {
     setExpandedDoc(undefined);
   }, [setExpandedDoc]);
-
-  const flyoutConnectionHandler = useCallback<
-    NonNullable<UnifiedDataTableProps['documentViewFlyoutConnectionHandler']>
-  >(
-    (displayedRows, displayedColumns, customColumnsMeta) => {
-      // when connecting a new grid, we signal to the grid that no rows should be considered expanded by default, and provide the meta info of the connected grid to the flyout
-      latestExpandedDocRef.current = undefined;
-
-      connectedGridMetaInfo.current = {
-        customColumnsMeta,
-        displayedColumns,
-        displayedRows,
-      };
-
-      notifyListeners();
-
-      return {
-        externalStore: getStateStore,
-        setExpandedDoc,
-      };
-    },
-    [getStateStore, notifyListeners, setExpandedDoc]
-  );
 
   const curriedDiscoverGridFlyout = useCallback(
     (
@@ -162,17 +71,18 @@ export function useGetDiscoverGridFlyoutRenderer() {
     ) =>
       expandedDoc ? (
         <DiscoverGridFlyout
+          key={expandedDoc.id}
           hit={expandedDoc}
-          hits={connectedGridMetaInfo?.current?.displayedRows}
-          columns={connectedGridMetaInfo?.current?.displayedColumns || []}
-          columnsMeta={connectedGridMetaInfo?.current?.customColumnsMeta}
+          hits={connectedGridMeta.current?.displayedRows ?? []}
+          columns={connectedGridMeta.current?.displayedColumns ?? []}
+          columnsMeta={connectedGridMeta.current?.customColumnsMeta}
           docViewerRef={docViewerRef}
           setExpandedDoc={setExpandedDoc}
           onClose={onCloseDocViewer}
           {...props}
         />
       ) : null,
-    [expandedDoc, onCloseDocViewer, setExpandedDoc]
+    [expandedDoc, connectedGridMeta, onCloseDocViewer, setExpandedDoc]
   );
 
   const DiscoverGridFlyoutRenderer = useMemo(
@@ -180,5 +90,5 @@ export function useGetDiscoverGridFlyoutRenderer() {
     [curriedDiscoverGridFlyout]
   );
 
-  return { DiscoverGridFlyoutRenderer, flyoutConnectionHandler };
+  return { DiscoverGridFlyoutRenderer, flyoutConnectionHandler, setExpandedDoc };
 }

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
+import type { DocViewerApi } from '@kbn/unified-doc-viewer';
+import { debounce } from 'lodash';
+import useLatest from 'react-use/lib/useLatest';
+import type {
+  DocViewerSnapshot,
+  GetDocViewerExternalStore,
+  UnifiedDataTableProps,
+} from '@kbn/unified-data-table';
+import {
+  DiscoverGridFlyout,
+  type DiscoverGridFlyoutProps,
+} from '../../../../../components/discover_grid_flyout';
+import {
+  useCurrentTabAction,
+  useCurrentTabSelector,
+  useInternalStateDispatch,
+} from '../../../state_management/redux/hooks';
+import { internalStateActions } from '../../../state_management/redux';
+
+export type { DiscoverGridFlyoutProps };
+
+const createDefaultDocViewerSnapshot = (): DocViewerSnapshot => ({
+  expandedDoc: undefined,
+});
+
+export function useGetDiscoverGridFlyoutRenderer() {
+  const docViewerRef = useRef<DocViewerApi>(null);
+  const dispatch = useInternalStateDispatch();
+  const setExpandedDocAction = useCurrentTabAction(internalStateActions.setExpandedDoc);
+  const expandedDoc = useCurrentTabSelector((state) => state.expandedDoc);
+
+  const latestExpandedDocRef = useLatest(expandedDoc);
+
+  const setExpandedRowsRef = useRef<{
+    customColumnsMeta?: DataTableColumnsMeta;
+    displayedColumns: string[];
+    displayedRows: DataTableRecord[];
+  } | null>(null);
+
+  const storeRef = useRef<{
+    listeners: Set<() => void>;
+    snapshot: DocViewerSnapshot;
+  }>({
+    listeners: new Set(),
+    snapshot: createDefaultDocViewerSnapshot(),
+  });
+
+  /** Notifies all subscribed listeners that the store snapshot may have changed. */
+  const notifyListeners = useMemo(
+    () =>
+      debounce(() => {
+        storeRef.current.snapshot = {
+          expandedDoc: latestExpandedDocRef.current,
+        };
+
+        storeRef.current.listeners.forEach((listener) => listener());
+      }, 100),
+    [latestExpandedDocRef]
+  );
+
+  useEffect(() => () => notifyListeners.cancel(), [notifyListeners]);
+
+  const setExpandedDoc = useCallback(
+    (
+      doc: DataTableRecord | undefined,
+      options?: {
+        initialTabId?: string;
+        initialTabState?: object;
+      }
+    ) => {
+      dispatch(
+        setExpandedDocAction({
+          expandedDoc: doc,
+          initialDocViewerTabId: options?.initialTabId,
+          initialDocViewerTabState: options?.initialTabState,
+        })
+      );
+      if (options?.initialTabId) {
+        docViewerRef.current?.setSelectedTabId(options.initialTabId);
+      }
+
+      notifyListeners();
+    },
+    [dispatch, setExpandedDocAction, notifyListeners]
+  );
+
+  const subscribe = useCallback((onUISnapshotChange: () => void) => {
+    storeRef.current.listeners.add(onUISnapshotChange);
+    return () => {
+      storeRef.current.listeners.delete(onUISnapshotChange);
+    };
+  }, []);
+
+  const getSnapshot = useCallback((): DocViewerSnapshot => storeRef.current.snapshot, []);
+
+  const getServerSnapshot = useCallback(() => storeRef.current.snapshot, []);
+
+  const getStateStore = useMemo<GetDocViewerExternalStore>(
+    () => ({
+      subscribe,
+      getSnapshot,
+      getServerSnapshot,
+    }),
+    [subscribe, getSnapshot, getServerSnapshot]
+  );
+
+  const onCloseDocViewer = useCallback(() => {
+    setExpandedDoc(undefined);
+  }, [setExpandedDoc]);
+
+  const renderDocumentView = useCallback<
+    NonNullable<UnifiedDataTableProps['renderDocumentViewFlyout']>
+  >(
+    (displayedRows, displayedColumns, customColumnsMeta) => {
+      if (setExpandedRowsRef.current?.displayedRows[0]?.id !== displayedRows[0]?.id) {
+        setExpandedDoc(undefined);
+      }
+
+      setExpandedRowsRef.current = {
+        customColumnsMeta,
+        displayedColumns,
+        displayedRows,
+      };
+      return {
+        externalStore: getStateStore,
+        setExpandedDoc,
+      };
+    },
+    [getStateStore, setExpandedDoc]
+  );
+
+  const curriedDiscoverGridFlyout = useCallback(
+    (
+      props: Omit<
+        DiscoverGridFlyoutProps,
+        'docViewerRef' | 'setExpandedDoc' | 'hit' | 'hits' | 'columns' | 'columnsMeta' | 'onClose'
+      >
+    ) =>
+      expandedDoc ? (
+        <DiscoverGridFlyout
+          hit={expandedDoc}
+          hits={setExpandedRowsRef.current!.displayedRows}
+          columns={setExpandedRowsRef.current!.displayedColumns}
+          columnsMeta={setExpandedRowsRef.current!.customColumnsMeta}
+          docViewerRef={docViewerRef}
+          setExpandedDoc={setExpandedDoc}
+          onClose={onCloseDocViewer}
+          {...props}
+        />
+      ) : null,
+    [expandedDoc, onCloseDocViewer, setExpandedDoc]
+  );
+
+  const DiscoverGridFlyoutRenderer = useMemo(
+    () => curriedDiscoverGridFlyout,
+    [curriedDiscoverGridFlyout]
+  );
+
+  return { DiscoverGridFlyoutRenderer, renderDocumentView };
+}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/helpers/render_document_view.tsx
@@ -10,8 +10,6 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
 import type { DocViewerApi } from '@kbn/unified-doc-viewer';
-import { debounce } from 'lodash';
-import useLatest from 'react-use/lib/useLatest';
 import type {
   DocViewerSnapshot,
   GetDocViewerExternalStore,
@@ -40,9 +38,13 @@ export function useGetDiscoverGridFlyoutRenderer() {
   const setExpandedDocAction = useCurrentTabAction(internalStateActions.setExpandedDoc);
   const expandedDoc = useCurrentTabSelector((state) => state.expandedDoc);
 
-  const latestExpandedDocRef = useLatest(expandedDoc);
+  // Holds reference to the latest expanded doc
+  const latestExpandedDocRef = useRef(expandedDoc);
 
-  const setExpandedRowsRef = useRef<{
+  // Holds reference to the meta information of the connected grid (columns, rows, columns meta)
+  // without causing unnecessary re-renders when the connected grid changes,
+  // or copying over potentially large data (displayed rows).
+  const connectedGridMetaInfo = useRef<{
     customColumnsMeta?: DataTableColumnsMeta;
     displayedColumns: string[];
     displayedRows: DataTableRecord[];
@@ -58,18 +60,24 @@ export function useGetDiscoverGridFlyoutRenderer() {
 
   /** Notifies all subscribed listeners that the store snapshot may have changed. */
   const notifyListeners = useMemo(
-    () =>
-      debounce(() => {
-        storeRef.current.snapshot = {
-          expandedDoc: latestExpandedDocRef.current,
-        };
+    () => () => {
+      storeRef.current.snapshot = {
+        expandedDoc: latestExpandedDocRef.current,
+      };
 
-        storeRef.current.listeners.forEach((listener) => listener());
-      }, 100),
-    [latestExpandedDocRef]
+      storeRef.current.listeners.forEach((listener) => listener());
+    },
+    []
   );
 
-  useEffect(() => () => notifyListeners.cancel(), [notifyListeners]);
+  // Sync the ref with Redux state when expandedDoc changes externally
+  // (e.g. via inspector, data view change, or saved search reset)
+  useEffect(() => {
+    if (latestExpandedDocRef.current !== expandedDoc) {
+      latestExpandedDocRef.current = expandedDoc;
+      notifyListeners();
+    }
+  }, [expandedDoc, notifyListeners]);
 
   const setExpandedDoc = useCallback(
     (
@@ -90,15 +98,18 @@ export function useGetDiscoverGridFlyoutRenderer() {
         docViewerRef.current?.setSelectedTabId(options.initialTabId);
       }
 
+      // Update the latest expanded doc reference
+      latestExpandedDocRef.current = doc;
+
       notifyListeners();
     },
     [dispatch, setExpandedDocAction, notifyListeners]
   );
 
-  const subscribe = useCallback((onUISnapshotChange: () => void) => {
-    storeRef.current.listeners.add(onUISnapshotChange);
+  const subscribe = useCallback((listener: () => void) => {
+    storeRef.current.listeners.add(listener);
     return () => {
-      storeRef.current.listeners.delete(onUISnapshotChange);
+      storeRef.current.listeners.delete(listener);
     };
   }, []);
 
@@ -119,25 +130,27 @@ export function useGetDiscoverGridFlyoutRenderer() {
     setExpandedDoc(undefined);
   }, [setExpandedDoc]);
 
-  const renderDocumentView = useCallback<
-    NonNullable<UnifiedDataTableProps['renderDocumentViewFlyout']>
+  const flyoutConnectionHandler = useCallback<
+    NonNullable<UnifiedDataTableProps['documentViewFlyoutConnectionHandler']>
   >(
     (displayedRows, displayedColumns, customColumnsMeta) => {
-      if (setExpandedRowsRef.current?.displayedRows[0]?.id !== displayedRows[0]?.id) {
-        setExpandedDoc(undefined);
-      }
+      // when connecting a new grid, we signal to the grid that no rows should be considered expanded by default, and provide the meta info of the connected grid to the flyout
+      latestExpandedDocRef.current = undefined;
 
-      setExpandedRowsRef.current = {
+      connectedGridMetaInfo.current = {
         customColumnsMeta,
         displayedColumns,
         displayedRows,
       };
+
+      notifyListeners();
+
       return {
         externalStore: getStateStore,
         setExpandedDoc,
       };
     },
-    [getStateStore, setExpandedDoc]
+    [getStateStore, notifyListeners, setExpandedDoc]
   );
 
   const curriedDiscoverGridFlyout = useCallback(
@@ -150,9 +163,9 @@ export function useGetDiscoverGridFlyoutRenderer() {
       expandedDoc ? (
         <DiscoverGridFlyout
           hit={expandedDoc}
-          hits={setExpandedRowsRef.current!.displayedRows}
-          columns={setExpandedRowsRef.current!.displayedColumns}
-          columnsMeta={setExpandedRowsRef.current!.customColumnsMeta}
+          hits={connectedGridMetaInfo?.current?.displayedRows}
+          columns={connectedGridMetaInfo?.current?.displayedColumns || []}
+          columnsMeta={connectedGridMetaInfo?.current?.customColumnsMeta}
           docViewerRef={docViewerRef}
           setExpandedDoc={setExpandedDoc}
           onClose={onCloseDocViewer}
@@ -167,5 +180,5 @@ export function useGetDiscoverGridFlyoutRenderer() {
     [curriedDiscoverGridFlyout]
   );
 
-  return { DiscoverGridFlyoutRenderer, renderDocumentView };
+  return { DiscoverGridFlyoutRenderer, flyoutConnectionHandler };
 }

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -48,7 +48,11 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
     onFullScreenChange,
     ...props
   }) => {
-    const { dataView, setExpandedDoc, renderDocumentViewFlyout: renderDocumentView } = props;
+    const {
+      dataView,
+      setExpandedDoc,
+      documentViewFlyoutConnectionHandler: renderDocumentView,
+    } = props;
     const getRowIndicatorProvider = useProfileAccessor('getRowIndicatorProvider');
     const getRowIndicator = useMemo(() => {
       return getRowIndicatorProvider(() => undefined)({ dataView: props.dataView });

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -15,6 +15,8 @@ import {
   UnifiedDataTable,
   type UnifiedDataTableProps,
 } from '@kbn/unified-data-table';
+import type useLatest from 'react-use/lib/useLatest';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { UpdateESQLQueryFn } from '../../context_awareness';
 import { useProfileAccessor } from '../../context_awareness';
 import type { DiscoverAppState } from '../../application/main/state_management/redux';
@@ -25,7 +27,8 @@ import {
   CascadedDocumentsProvider,
 } from '../../application/main/components/layout/cascaded_documents';
 
-export interface DiscoverGridProps extends UnifiedDataTableProps {
+export interface DiscoverGridProps extends Omit<UnifiedDataTableProps, 'expandedDoc'> {
+  latestExpandedDoc?: ReturnType<typeof useLatest<DataTableRecord | undefined>>;
   query?: DiscoverAppState['query'];
   cascadedDocumentsContext?: CascadedDocumentsContext;
   onUpdateESQLQuery?: UpdateESQLQueryFn;
@@ -45,7 +48,7 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
     onFullScreenChange,
     ...props
   }) => {
-    const { dataView, setExpandedDoc, renderDocumentView } = props;
+    const { dataView, setExpandedDoc, renderDocumentViewFlyout: renderDocumentView } = props;
     const getRowIndicatorProvider = useProfileAccessor('getRowIndicatorProvider');
     const getRowIndicator = useMemo(() => {
       return getRowIndicatorProvider(() => undefined)({ dataView: props.dataView });

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -15,7 +15,6 @@ import {
   UnifiedDataTable,
   type UnifiedDataTableProps,
 } from '@kbn/unified-data-table';
-import type useLatest from 'react-use/lib/useLatest';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { UpdateESQLQueryFn } from '../../context_awareness';
 import { useProfileAccessor } from '../../context_awareness';
@@ -27,8 +26,11 @@ import {
   CascadedDocumentsProvider,
 } from '../../application/main/components/layout/cascaded_documents';
 
-export interface DiscoverGridProps extends Omit<UnifiedDataTableProps, 'expandedDoc'> {
-  latestExpandedDoc?: ReturnType<typeof useLatest<DataTableRecord | undefined>>;
+export interface DiscoverGridProps extends UnifiedDataTableProps {
+  /**
+   * Function to set the expanded document, which is displayed in a flyout, required for leading controls
+   */
+  setExpandedDoc?: (doc?: DataTableRecord, options?: { initialTabId?: string }) => void;
   query?: DiscoverAppState['query'];
   cascadedDocumentsContext?: CascadedDocumentsContext;
   onUpdateESQLQuery?: UpdateESQLQueryFn;
@@ -76,8 +78,8 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
       getRowAdditionalLeadingControlsAccessor,
       onUpdateESQLQuery,
       query,
-      setExpandedDoc,
       renderDocumentView,
+      setExpandedDoc,
     ]);
 
     const getPaginationConfigAccessor = useProfileAccessor('getPaginationConfig');

--- a/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
@@ -15,11 +15,11 @@ import type { SearchResponseWarning } from '@kbn/search-response-warnings';
 import { MAX_DOC_FIELDS_DISPLAYED, SHOW_MULTIFIELDS } from '@kbn/discover-utils';
 import {
   type UnifiedDataTableProps,
-  type DataTableColumnsMeta,
   DataLoadingState as DiscoverGridLoadingState,
   getRenderCustomToolbarWithElements,
   getDataGridDensity,
   getRowHeight,
+  useDocumentViewFlyoutConnectionHandler,
 } from '@kbn/unified-data-table';
 import type { DocViewerApi } from '@kbn/unified-doc-viewer';
 import { DiscoverGrid } from '../../components/discover_grid';
@@ -68,45 +68,11 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
     []
   );
 
-  const renderDocumentView = useCallback(
-    (
-      hit: DataTableRecord,
-      displayedRows: DataTableRecord[],
-      displayedColumns: string[],
-      expandedDocSetter: NonNullable<UnifiedDataTableProps['setExpandedDoc']>,
-      customColumnsMeta?: DataTableColumnsMeta
-    ) => (
-      <DiscoverGridFlyout
-        dataView={props.dataView}
-        hit={hit}
-        hits={displayedRows}
-        // if default columns are used, dont make them part of the URL - the context state handling will take care to restore them
-        columns={displayedColumns}
-        columnsMeta={customColumnsMeta}
-        savedSearchId={props.savedSearchId}
-        onFilter={props.onFilter}
-        onRemoveColumn={props.onRemoveColumn}
-        onAddColumn={props.onAddColumn}
-        onClose={() => expandedDocSetter(undefined)}
-        setExpandedDoc={expandedDocSetter}
-        initialTabId={initialTabId}
-        query={props.query}
-        filters={props.filters}
-        docViewerRef={docViewerRef}
-        hideFilteringOnComputedColumns={true}
-      />
-    ),
-    [
-      props.dataView,
-      props.savedSearchId,
-      props.onFilter,
-      props.onRemoveColumn,
-      props.onAddColumn,
-      props.query,
-      props.filters,
-      initialTabId,
-    ]
-  );
+  const { documentViewFlyoutConnectionHandler, connectedGridMeta } =
+    useDocumentViewFlyoutConnectionHandler({
+      expandedDoc,
+      setExpandedDoc: setExpandedDocWithInitialTab,
+    });
 
   const renderCustomToolbarWithElements = useMemo(
     () =>
@@ -151,24 +117,47 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
       interceptedWarnings={props.interceptedWarnings}
       inlineEditing={inlineEditing}
     >
-      <DiscoverGrid
-        {...gridProps}
-        isPaginationEnabled={!gridProps.isPlainRecord}
-        totalHits={props.totalHitCount}
-        setExpandedDoc={setExpandedDocWithInitialTab}
-        expandedDoc={expandedDoc}
-        showMultiFields={props.services.uiSettings.get(SHOW_MULTIFIELDS)}
-        hideFilteringOnComputedColumns={true}
-        maxDocFieldsDisplayed={props.services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-        documentViewFlyoutConnectionHandler={enableDocumentViewer ? renderDocumentView : undefined}
-        renderCustomToolbar={renderCustomToolbarWithElements}
-        externalCustomRenderers={cellRenderers}
-        enableComparisonMode
-        showColumnTokens
-        showFullScreenButton={false}
-        className="unifiedDataTable"
-        css={{ '.unifiedDataTableToolbar': { paddingBlockStart: euiTheme.size.xs } }}
-      />
+      <>
+        <DiscoverGrid
+          {...gridProps}
+          isPaginationEnabled={!gridProps.isPlainRecord}
+          totalHits={props.totalHitCount}
+          setExpandedDoc={setExpandedDocWithInitialTab}
+          showMultiFields={props.services.uiSettings.get(SHOW_MULTIFIELDS)}
+          hideFilteringOnComputedColumns={true}
+          maxDocFieldsDisplayed={props.services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
+          documentViewFlyoutConnectionHandler={
+            enableDocumentViewer ? documentViewFlyoutConnectionHandler : undefined
+          }
+          renderCustomToolbar={renderCustomToolbarWithElements}
+          externalCustomRenderers={cellRenderers}
+          enableComparisonMode
+          showColumnTokens
+          showFullScreenButton={false}
+          className="unifiedDataTable"
+          css={{ '.unifiedDataTableToolbar': { paddingBlockStart: euiTheme.size.xs } }}
+        />
+        {enableDocumentViewer && expandedDoc && (
+          <DiscoverGridFlyout
+            dataView={props.dataView}
+            hit={expandedDoc}
+            hits={connectedGridMeta.current?.displayedRows ?? []}
+            columns={connectedGridMeta.current?.displayedColumns ?? []}
+            columnsMeta={connectedGridMeta.current?.customColumnsMeta}
+            savedSearchId={props.savedSearchId}
+            onFilter={props.onFilter}
+            onRemoveColumn={props.onRemoveColumn}
+            onAddColumn={props.onAddColumn}
+            onClose={() => setExpandedDocWithInitialTab(undefined)}
+            setExpandedDoc={setExpandedDocWithInitialTab}
+            initialTabId={initialTabId}
+            query={props.query}
+            filters={props.filters}
+            docViewerRef={docViewerRef}
+            hideFilteringOnComputedColumns={true}
+          />
+        )}
+      </>
     </SavedSearchEmbeddableBase>
   );
 }

--- a/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
@@ -160,7 +160,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         showMultiFields={props.services.uiSettings.get(SHOW_MULTIFIELDS)}
         hideFilteringOnComputedColumns={true}
         maxDocFieldsDisplayed={props.services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-        renderDocumentView={enableDocumentViewer ? renderDocumentView : undefined}
+        renderDocumentViewFlyout={enableDocumentViewer ? renderDocumentView : undefined}
         renderCustomToolbar={renderCustomToolbarWithElements}
         externalCustomRenderers={cellRenderers}
         enableComparisonMode

--- a/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
@@ -160,7 +160,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         showMultiFields={props.services.uiSettings.get(SHOW_MULTIFIELDS)}
         hideFilteringOnComputedColumns={true}
         maxDocFieldsDisplayed={props.services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
-        renderDocumentViewFlyout={enableDocumentViewer ? renderDocumentView : undefined}
+        documentViewFlyoutConnectionHandler={enableDocumentViewer ? renderDocumentView : undefined}
         renderCustomToolbar={renderCustomToolbarWithElements}
         externalCustomRenderers={cellRenderers}
         enableComparisonMode

--- a/src/platform/plugins/shared/esql_datagrid/public/data_grid.tsx
+++ b/src/platform/plugins/shared/esql_datagrid/public/data_grid.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useState, useCallback, useMemo, type ComponentProps } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { zipObject } from 'lodash';
 import type { UnifiedDataTableRenderCustomToolbarProps } from '@kbn/unified-data-table';
 import {
@@ -15,6 +15,7 @@ import {
   DataLoadingState,
   type SortOrder,
   renderCustomToolbar,
+  useDocumentViewFlyoutConnectionHandler,
 } from '@kbn/unified-data-table';
 import { i18n } from '@kbn/i18n';
 import { EuiLink, EuiText, EuiIcon } from '@elastic/eui';
@@ -66,35 +67,11 @@ const DataGrid: React.FC<ESQLDataGridProps> = (props) => {
     setActiveColumns(columns);
   }, []);
 
-  const renderDocumentView = useCallback(
-    (
-      hit: DataTableRecord,
-      displayedRows: DataTableRecord[],
-      displayedColumns: string[],
-      expandedDocSetter: ComponentProps<typeof RowViewer>['setExpandedDoc'],
-      customColumnsMeta?: DataTableColumnsMeta
-    ) => (
-      <RowViewer
-        dataView={props.dataView}
-        notifications={props.core.notifications}
-        chrome={props.core.chrome}
-        hit={hit}
-        hits={displayedRows}
-        columns={displayedColumns}
-        columnsMeta={customColumnsMeta}
-        flyoutType={props.flyoutType ?? 'push'}
-        onRemoveColumn={(column) => {
-          setActiveColumns(activeColumns.filter((c) => c !== column));
-        }}
-        onAddColumn={(column) => {
-          setActiveColumns([...activeColumns, column]);
-        }}
-        onClose={() => expandedDocSetter(undefined)}
-        setExpandedDoc={expandedDocSetter}
-      />
-    ),
-    [activeColumns, props.core.notifications, props.core.chrome, props.dataView, props.flyoutType]
-  );
+  const { documentViewFlyoutConnectionHandler, connectedGridMeta } =
+    useDocumentViewFlyoutConnectionHandler({
+      expandedDoc,
+      setExpandedDoc,
+    });
 
   const columnsMeta = useMemo(() => {
     return props.columns.reduce((acc, column) => {
@@ -198,41 +175,61 @@ const DataGrid: React.FC<ESQLDataGridProps> = (props) => {
   );
 
   return (
-    <UnifiedDataTable
-      columns={activeColumns}
-      css={css`
-        .unifiedDataTableToolbar {
-          padding: 4px 0px;
-        }
-      `}
-      rows={rows}
-      columnsMeta={columnsMeta}
-      services={services}
-      enableInTableSearch
-      isPlainRecord
-      isSortEnabled={false}
-      loadingState={DataLoadingState.loaded}
-      dataView={props.dataView}
-      sampleSizeState={rows.length}
-      rowsPerPageState={rowsPerPage}
-      rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
-      onSetColumns={onSetColumns}
-      onUpdateRowsPerPage={setRowsPerPage}
-      expandedDoc={expandedDoc}
-      setExpandedDoc={setExpandedDoc}
-      showTimeCol
-      enableComparisonMode
-      sort={sortOrder}
-      ariaLabelledBy="esqlDataGrid"
-      maxDocFieldsDisplayed={100}
-      documentViewFlyoutConnectionHandler={renderDocumentView}
-      showFullScreenButton={false}
-      configRowHeight={DEFAULT_INITIAL_ROW_HEIGHT}
-      rowHeightState={rowHeight}
-      onUpdateRowHeight={setRowHeight}
-      controlColumnIds={props.controlColumnIds}
-      renderCustomToolbar={discoverLocator ? renderToolbar : undefined}
-    />
+    <>
+      <UnifiedDataTable
+        columns={activeColumns}
+        css={css`
+          .unifiedDataTableToolbar {
+            padding: 4px 0px;
+          }
+        `}
+        rows={rows}
+        columnsMeta={columnsMeta}
+        services={services}
+        enableInTableSearch
+        isPlainRecord
+        isSortEnabled={false}
+        loadingState={DataLoadingState.loaded}
+        dataView={props.dataView}
+        sampleSizeState={rows.length}
+        rowsPerPageState={rowsPerPage}
+        rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+        onSetColumns={onSetColumns}
+        onUpdateRowsPerPage={setRowsPerPage}
+        showTimeCol
+        enableComparisonMode
+        sort={sortOrder}
+        ariaLabelledBy="esqlDataGrid"
+        maxDocFieldsDisplayed={100}
+        documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
+        showFullScreenButton={false}
+        configRowHeight={DEFAULT_INITIAL_ROW_HEIGHT}
+        rowHeightState={rowHeight}
+        onUpdateRowHeight={setRowHeight}
+        controlColumnIds={props.controlColumnIds}
+        renderCustomToolbar={discoverLocator ? renderToolbar : undefined}
+      />
+      {expandedDoc && (
+        <RowViewer
+          dataView={props.dataView}
+          notifications={props.core.notifications}
+          chrome={props.core.chrome}
+          hit={expandedDoc}
+          hits={connectedGridMeta.current?.displayedRows ?? []}
+          columns={connectedGridMeta.current?.displayedColumns ?? []}
+          columnsMeta={connectedGridMeta.current?.customColumnsMeta}
+          flyoutType={props.flyoutType ?? 'push'}
+          onRemoveColumn={(column) => {
+            setActiveColumns((prev) => prev.filter((c) => c !== column));
+          }}
+          onAddColumn={(column) => {
+            setActiveColumns((prev) => [...prev, column]);
+          }}
+          onClose={() => setExpandedDoc(undefined)}
+          setExpandedDoc={setExpandedDoc}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/platform/plugins/shared/esql_datagrid/public/data_grid.tsx
+++ b/src/platform/plugins/shared/esql_datagrid/public/data_grid.tsx
@@ -225,7 +225,7 @@ const DataGrid: React.FC<ESQLDataGridProps> = (props) => {
       sort={sortOrder}
       ariaLabelledBy="esqlDataGrid"
       maxDocFieldsDisplayed={100}
-      renderDocumentViewFlyout={renderDocumentView}
+      documentViewFlyoutConnectionHandler={renderDocumentView}
       showFullScreenButton={false}
       configRowHeight={DEFAULT_INITIAL_ROW_HEIGHT}
       rowHeightState={rowHeight}

--- a/src/platform/plugins/shared/esql_datagrid/public/data_grid.tsx
+++ b/src/platform/plugins/shared/esql_datagrid/public/data_grid.tsx
@@ -176,6 +176,7 @@ const DataGrid: React.FC<ESQLDataGridProps> = (props) => {
                 css={css`
                   margin-right: 4px;
                 `}
+                aria-hidden={true}
               />
               <EuiText size="xs">
                 {i18n.translate('esqlDataGrid.openInDiscoverLabel', {
@@ -224,7 +225,7 @@ const DataGrid: React.FC<ESQLDataGridProps> = (props) => {
       sort={sortOrder}
       ariaLabelledBy="esqlDataGrid"
       maxDocFieldsDisplayed={100}
-      renderDocumentView={renderDocumentView}
+      renderDocumentViewFlyout={renderDocumentView}
       showFullScreenButton={false}
       configRowHeight={DEFAULT_INITIAL_ROW_HEIGHT}
       rowHeightState={rowHeight}

--- a/x-pack/platform/plugins/shared/osquery/public/results/unified_results_table.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/unified_results_table.test.tsx
@@ -77,17 +77,22 @@ jest.mock('@kbn/cell-actions', () => ({
 let capturedOnInitialStateChange: ((state: Partial<{ isCompareActive: boolean }>) => void) | null =
   null;
 
-jest.mock('@kbn/unified-data-table', () => ({
-  UnifiedDataTable: (props: {
-    onInitialStateChange?: (state: Partial<{ isCompareActive: boolean }>) => void;
-  }) => {
-    capturedOnInitialStateChange = props.onInitialStateChange ?? null;
+jest.mock('@kbn/unified-data-table', () => {
+  const module = jest.requireActual('@kbn/unified-data-table');
 
-    return <div data-test-subj="mockUnifiedDataTable" />;
-  },
-  DataLoadingState: { loading: 'loading', loaded: 'loaded' },
-  DataGridDensity: { EXPANDED: 'expanded', COMPACT: 'compact' },
-}));
+  return {
+    ...module,
+    UnifiedDataTable: (props: {
+      onInitialStateChange?: (state: Partial<{ isCompareActive: boolean }>) => void;
+    }) => {
+      capturedOnInitialStateChange = props.onInitialStateChange ?? null;
+
+      return <div data-test-subj="mockUnifiedDataTable" />;
+    },
+    DataLoadingState: { loading: 'loading', loaded: 'loaded' },
+    DataGridDensity: { EXPANDED: 'expanded', COMPACT: 'compact' },
+  };
+});
 
 jest.mock('./results_flyout', () => ({
   OsqueryResultsFlyout: () => null,

--- a/x-pack/platform/plugins/shared/osquery/public/results/unified_results_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/unified_results_table.tsx
@@ -23,7 +23,12 @@ import type {
   UnifiedDataTableSettings,
   UnifiedDataTableRestorableState,
 } from '@kbn/unified-data-table';
-import { UnifiedDataTable, DataLoadingState, DataGridDensity } from '@kbn/unified-data-table';
+import {
+  UnifiedDataTable,
+  DataLoadingState,
+  DataGridDensity,
+  useDocumentViewFlyoutConnectionHandler,
+} from '@kbn/unified-data-table';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import type { DataViewField } from '@kbn/data-views-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils';
@@ -51,6 +56,8 @@ import {
 } from './results_table_shared';
 
 const ITEMS_PER_PAGE_OPTIONS = [...PAGE_SIZE_OPTIONS];
+const EMPTY_ROWS: DataTableRecord[] = [];
+const EMPTY_COLUMNS: string[] = [];
 
 const CONTROL_COLUMN_IDS = ['openDetails', 'select'];
 
@@ -271,6 +278,12 @@ const UnifiedResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
   const [isCompareActive, setIsCompareActive] = useState(false);
   const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>();
 
+  const { documentViewFlyoutConnectionHandler, connectedGridMeta } =
+    useDocumentViewFlyoutConnectionHandler({
+      expandedDoc,
+      setExpandedDoc,
+    });
+
   const externalCustomRenderers = useMemo(
     () =>
       getOsqueryCellRenderers({
@@ -468,6 +481,8 @@ const UnifiedResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
     };
   }, [dataView, sourceFieldNamesKey, dataService.dataViews]);
 
+  const handleCloseFlyout = useCallback(() => setExpandedDoc(undefined), []);
+
   const searchBarIndexPatterns = useMemo(
     () => (filteredDataView ? [filteredDataView] : []),
     [filteredDataView]
@@ -480,30 +495,6 @@ const UnifiedResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
       }
     },
     []
-  );
-
-  const handleCloseFlyout = useCallback(() => {
-    setExpandedDoc(undefined);
-  }, []);
-
-  const renderDocumentView = useCallback(
-    (hit: DataTableRecord, displayedRows: DataTableRecord[], displayedColumns: string[]) => {
-      if (!dataView) return undefined;
-
-      return (
-        <OsqueryResultsFlyout
-          hit={hit}
-          hits={displayedRows}
-          dataView={dataView}
-          columns={displayedColumns}
-          onClose={handleCloseFlyout}
-          setExpandedDoc={setExpandedDoc}
-          toastNotifications={toasts}
-          chrome={chrome}
-        />
-      );
-    },
-    [dataView, handleCloseFlyout, toasts, chrome]
   );
 
   useEffect(
@@ -584,9 +575,7 @@ const UnifiedResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
                   columns={visibleColumns}
                   rows={rows}
                   loadingState={isLoading ? DataLoadingState.loading : DataLoadingState.loaded}
-                  expandedDoc={expandedDoc}
-                  setExpandedDoc={setExpandedDoc}
-                  renderDocumentView={renderDocumentView}
+                  documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
                   externalCustomRenderers={externalCustomRenderers}
                   sort={sortingColumns.map((col) => [col.id, col.direction])}
                   onSort={handleSort}
@@ -615,6 +604,18 @@ const UnifiedResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
                 />
               </CellActionsProvider>
             </div>
+            {expandedDoc && dataView && (
+              <OsqueryResultsFlyout
+                hit={expandedDoc}
+                hits={connectedGridMeta.current?.displayedRows ?? EMPTY_ROWS}
+                dataView={dataView}
+                columns={connectedGridMeta.current?.displayedColumns ?? EMPTY_COLUMNS}
+                onClose={handleCloseFlyout}
+                setExpandedDoc={setExpandedDoc}
+                toastNotifications={toasts}
+                chrome={chrome}
+              />
+            )}
 
             {!isCompareActive && (
               <EuiTablePagination

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -10,7 +10,11 @@ import type {
   UnifiedDataTableSettings,
   UnifiedDataTableSettingsColumn,
 } from '@kbn/unified-data-table';
-import { DataGridDensity, useColumns } from '@kbn/unified-data-table';
+import {
+  DataGridDensity,
+  useColumns,
+  useDocumentViewFlyoutConnectionHandler,
+} from '@kbn/unified-data-table';
 import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import type { HttpSetup } from '@kbn/core-http-browser';
@@ -41,6 +45,8 @@ export interface CloudSecurityDefaultColumn {
   id: string;
   width?: number;
 }
+
+const noopSetExpandedDoc = () => {};
 
 const gridStyle: EuiDataGridStyle = {
   border: 'horizontal',
@@ -259,6 +265,11 @@ export const CloudSecurityDataTable = ({
 
   const { expandedDoc, onExpandDocClick } = useExpandableFlyoutCsp(flyoutType);
 
+  const { documentViewFlyoutConnectionHandler } = useDocumentViewFlyoutConnectionHandler({
+    expandedDoc,
+    setExpandedDoc: onExpandDocClick ?? noopSetExpandedDoc,
+  });
+
   if (!onExpandDocClick) {
     return <></>;
   }
@@ -341,7 +352,6 @@ export const CloudSecurityDataTable = ({
           className={styles.gridStyle}
           ariaLabelledBy={title}
           columns={currentColumns}
-          expandedDoc={expandedDoc}
           dataView={dataView}
           loadingState={loadingState}
           onFilter={onAddFilter as DocViewFilterFn}
@@ -350,8 +360,7 @@ export const CloudSecurityDataTable = ({
           onSort={onSort}
           rows={rows}
           sampleSizeState={MAX_FINDINGS_TO_LOAD}
-          setExpandedDoc={onExpandDocClick}
-          renderDocumentView={onOpenFlyoutCallback}
+          documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
           sort={sort}
           rowsPerPageState={pageSize}
           totalHits={total}

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_data_table.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import _ from 'lodash';
 import { i18n } from '@kbn/i18n';
 import {
@@ -13,6 +13,7 @@ import {
   DataLoadingState,
   DataGridDensity,
   useColumns,
+  useDocumentViewFlyoutConnectionHandler,
   type UnifiedDataTableSettings,
   type UnifiedDataTableSettingsColumn,
   type CustomCellRenderer,
@@ -37,7 +38,6 @@ import {
   uiMetricService,
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import { METRIC_TYPE } from '@kbn/analytics';
-import { EmptyComponent } from '../../common/lib/cell_actions/helpers';
 import { type CriticalityLevelWithUnassigned } from '../../../common/entity_analytics/asset_criticality/types';
 import { useKibana } from '../../common/lib/kibana';
 import { AssetCriticalityBadge } from '../../entity_analytics/components/asset_criticality/asset_criticality_badge';
@@ -158,22 +158,30 @@ export const AssetInventoryDataTable = ({
     onFlyoutClose: () => setExpandedDoc(undefined),
   });
 
-  const openTableFlyout = (doc?: DataTableRecord | undefined) => {
-    if (doc && doc.raw._source) {
-      const source = doc.raw._source as GenericEntityRecord;
-      setExpandedDoc(doc); // Table is expecting the same doc ref to highlight the selected row
-      openDynamicFlyout({
-        entityDocId: doc.raw._id,
-        entityType: source.entity?.EngineMetadata?.Type,
-        entityName: source.entity?.name,
-        scopeId: ASSET_INVENTORY_TABLE_ID,
-        contextId: ASSET_INVENTORY_TABLE_ID,
-      });
-    } else {
-      closeDynamicFlyout();
-      setExpandedDoc(undefined);
-    }
-  };
+  const openTableFlyout = useCallback(
+    (doc?: DataTableRecord | undefined) => {
+      if (doc && doc.raw._source) {
+        const source = doc.raw._source as GenericEntityRecord;
+        setExpandedDoc(doc); // Table is expecting the same doc ref to highlight the selected row
+        openDynamicFlyout({
+          entityDocId: doc.raw._id,
+          entityType: source.entity?.EngineMetadata?.Type,
+          entityName: source.entity?.name,
+          scopeId: ASSET_INVENTORY_TABLE_ID,
+          contextId: ASSET_INVENTORY_TABLE_ID,
+        });
+      } else {
+        closeDynamicFlyout();
+        setExpandedDoc(undefined);
+      }
+    },
+    [openDynamicFlyout, closeDynamicFlyout]
+  );
+
+  const { documentViewFlyoutConnectionHandler } = useDocumentViewFlyoutConnectionHandler({
+    expandedDoc,
+    setExpandedDoc: openTableFlyout,
+  });
 
   // -----------------------------------------------------------------------------------------
 
@@ -388,9 +396,7 @@ export const AssetInventoryDataTable = ({
             onSort={onSort}
             rows={rows}
             sampleSizeState={MAX_ASSETS_TO_LOAD}
-            expandedDoc={expandedDoc}
-            setExpandedDoc={openTableFlyout}
-            renderDocumentView={EmptyComponent}
+            documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
             sort={sort}
             rowsPerPageState={pageSize}
             totalHits={totalHits}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -13,6 +13,7 @@ import {
   DataLoadingState,
   DataGridDensity,
   useColumns,
+  useDocumentViewFlyoutConnectionHandler,
   type UnifiedDataTableSettings,
   type UnifiedDataTableSettingsColumn,
   type CustomCellRenderer,
@@ -46,7 +47,6 @@ import { InspectButton } from '../../../../common/components/inspect';
 import { useInvestigateInTimeline } from '../../../../common/hooks/timeline/use_investigate_in_timeline';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useAgentBuilderAvailability } from '../../../../agent_builder/hooks/use_agent_builder_availability';
-import { EmptyComponent } from '../../../../common/lib/cell_actions/helpers';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { useKibana } from '../../../../common/lib/kibana';
 import {
@@ -211,6 +211,11 @@ export const EntitiesDataTable = ({
     },
     [openRightPanel, closeFlyout]
   );
+
+  const { documentViewFlyoutConnectionHandler } = useDocumentViewFlyoutConnectionHandler({
+    expandedDoc,
+    setExpandedDoc: openTableFlyout,
+  });
 
   const {
     data: rowsData,
@@ -558,9 +563,7 @@ export const EntitiesDataTable = ({
             onSort={onSort}
             rows={rows}
             sampleSizeState={MAX_ENTITIES_TO_LOAD}
-            expandedDoc={expandedDoc}
-            setExpandedDoc={openTableFlyout}
-            renderDocumentView={EmptyComponent}
+            documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
             sort={sort}
             rowsPerPageState={pageSize}
             totalHits={totalHits}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -36,7 +36,7 @@ const refetchMock = jest.fn();
 const onFetchMoreRecordsMock = jest.fn();
 
 const openFlyoutMock = jest.fn();
-
+const closeFlyoutMock = jest.fn();
 const updateSampleSizeSpy = jest.spyOn(timelineActions, 'updateSampleSize');
 
 jest.mock('@kbn/expandable-flyout');
@@ -119,6 +119,7 @@ describe('unified data table', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue(mockSourcererScope);
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
       openFlyout: openFlyoutMock,
+      closeFlyout: closeFlyoutMock,
     });
   });
   afterEach(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -12,7 +12,11 @@ import type {
   UnifiedDataTableProps,
   UnifiedDataTableSettingsColumn,
 } from '@kbn/unified-data-table';
-import { DataLoadingState, UnifiedDataTable } from '@kbn/unified-data-table';
+import {
+  DataLoadingState,
+  UnifiedDataTable,
+  useDocumentViewFlyoutConnectionHandler,
+} from '@kbn/unified-data-table';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type {
   EuiDataGridControlColumn,
@@ -31,7 +35,6 @@ import { DocumentDetailsRightPanelKey } from '../../../../../flyout/document_det
 import { AttackDetailsRightPanelKey } from '../../../../../flyout/attack_details/constants/panel_keys';
 import { selectTimelineById } from '../../../../store/selectors';
 import { RowRendererCount } from '../../../../../../common/api/timeline';
-import { EmptyComponent } from '../../../../../common/lib/cell_actions/helpers';
 import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
 import type { TimelineItem } from '../../../../../../common/search_strategy';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -256,6 +259,11 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       [tableRows, handleOnEventDetailPanelOpened, closeFlyout]
     );
 
+    const { documentViewFlyoutConnectionHandler } = useDocumentViewFlyoutConnectionHandler({
+      expandedDoc,
+      setExpandedDoc: onSetExpandedDoc,
+    });
+
     const onResizeDataGrid = useCallback<NonNullable<UnifiedDataTableProps['onResize']>>(
       (colSettings) => {
         if (colSettings.width) {
@@ -439,7 +447,6 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
             ariaLabelledBy="timelineDocumentsAriaLabel"
             className="udtTimeline"
             columns={columnIds}
-            expandedDoc={expandedDoc}
             gridStyleOverride={tableStylesOverride}
             dataView={dataView}
             showColumnTokens={true}
@@ -451,7 +458,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
             rows={tableRows}
             sampleSizeState={sampleSize || 500}
             onUpdateSampleSize={onUpdateSampleSize}
-            setExpandedDoc={onSetExpandedDoc}
+            documentViewFlyoutConnectionHandler={documentViewFlyoutConnectionHandler}
             showTimeCol={showTimeCol}
             isSortEnabled={isSortEnabled}
             sort={sort}
@@ -465,7 +472,6 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
             services={dataGridServices}
             visibleCellActions={3}
             externalCustomRenderers={customColumnRenderers}
-            renderDocumentView={EmptyComponent}
             rowsPerPageOptions={itemsPerPageOptions}
             showFullScreenButton={false}
             maxDocFieldsDisplayed={50}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/255435

The approach taken here is to decouple the document viewer from the unified data table, but define an expectation that an handler be provided to the unified data table to connect with (ideally any) flyout implementation that returns a store and a method to set the currently expanded row.

Why is this a feasible solution? 
Solutions teams have already moved away from leveraging the internal unified data table implementation by returning an empty component and rolling their own flyout implementation, the changes proposed in this PR standardises what providing an external component should have to meet the requirements for the unified data table, whilst allow for the flexibility to provide the component that gets rendered for row expansion.

What does this mean for the cascade experience? 
Adhering to this contract in discover grid, we are able to render the doc viewer outside for the data grid tree, making it such that when virtualized rows are scrolled out of view but had triggered the doc viewer open, the doc viewer doesn't unmount.

A side effect that manifests as some sort of easter egg because of the approach adopted is that generally in discover the user is able to have the doc viewer open, change their query, load a new set of rows with the viewer open and still be able to cycle through all the previous open rows as long as a new row is not expanded from the newly loaded query just yet.

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->
