### PR TITLE
[Agent Builder] Add JOIN limitation instructions to ESQL prompt

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getEsqlInstructions } from './instructions_template';
+
+describe('getEsqlInstructions', () => {
+  it('includes JOIN limitations', () => {
+    const instructions = getEsqlInstructions();
+    expect(instructions).toContain('JOIN limitations');
+    expect(instructions).toContain('only supported with lookup indices');
+    expect(instructions).toContain('NOT with regular indices');
+  });
+
+  it('uses default limits when no params are provided', () => {
+    const instructions = getEsqlInstructions();
+    expect(instructions).toContain('LIMIT 100');
+    expect(instructions).toContain('LIMIT 250');
+  });
+
+  it('uses custom limits when params are provided', () => {
+    const instructions = getEsqlInstructions({ defaultLimit: 50, maxAllLimit: 500 });
+    expect(instructions).toContain('LIMIT 50');
+    expect(instructions).toContain('LIMIT 500');
+    expect(instructions).not.toContain('LIMIT 100');
+    expect(instructions).not.toContain('LIMIT 250');
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.ts
@@ -89,7 +89,7 @@ export const getEsqlInstructions = (params: InstructionsTemplateParams = {}): st
     Do NOT attempt to JOIN two regular indices together.
     If the user asks to combine rows from regular indices by a join key, explain that ES|QL does not support
     JOIN between regular indices. If the request is only to search or aggregate across multiple indices, use a
-    normal multi-index `FROM` query when the referenced fields are available there.
+    normal multi-index FROM query when the referenced fields are available there.
 
     ## Tool Usage Restrictions
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.ts
@@ -83,6 +83,13 @@ export const getEsqlInstructions = (params: InstructionsTemplateParams = {}): st
     When converting queries from one language to ES|QL, make sure that the functions are available
     and documented in ES|QL. E.g., for SPL's LEN, use LENGTH. For IF, use CASE.
 
+    ## JOIN limitations
+
+    ES|QL JOIN operations (such as LOOKUP JOIN) are only supported with lookup indices, NOT with regular indices.
+    Do NOT attempt to JOIN two regular indices together. If the user asks for a cross-index query involving
+    regular indices, inform them that JOIN between regular indices is not supported in ES|QL, and suggest
+    alternative approaches such as running separate queries on each index.
+
     ## Tool Usage Restrictions
 
     **CRITICAL**: Only use the tools that are explicitly defined in your available tool set. Do not call

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts/instructions_template.ts
@@ -86,9 +86,10 @@ export const getEsqlInstructions = (params: InstructionsTemplateParams = {}): st
     ## JOIN limitations
 
     ES|QL JOIN operations (such as LOOKUP JOIN) are only supported with lookup indices, NOT with regular indices.
-    Do NOT attempt to JOIN two regular indices together. If the user asks for a cross-index query involving
-    regular indices, inform them that JOIN between regular indices is not supported in ES|QL, and suggest
-    alternative approaches such as running separate queries on each index.
+    Do NOT attempt to JOIN two regular indices together.
+    If the user asks to combine rows from regular indices by a join key, explain that ES|QL does not support
+    JOIN between regular indices. If the request is only to search or aggregate across multiple indices, use a
+    normal multi-index `FROM` query when the referenced fields are available there.
 
     ## Tool Usage Restrictions
 


### PR DESCRIPTION
## Summary

Fixes elastic/search-team#12242

The agent was generating ESQL queries with JOIN clauses on regular indices, which is not supported in ES|QL. JOIN operations (`LOOKUP JOIN`) are only supported with lookup indices.

### Root cause

The ESQL generation prompt (`getEsqlInstructions`) had no mention of JOIN limitations, so the LLM defaulted to standard SQL behavior and attempted JOINs between regular indices.

### Changes

- Added a "JOIN limitations" section to the ESQL instructions template, explicitly stating that JOINs are only supported with lookup indices
- Added unit tests for `getEsqlInstructions` covering JOIN limitation content and configurable limit parameters

## Test plan

- [x] Unit tests pass (`yarn test:jest ...instructions_template.test.ts` — 3/3)
- [x] Existing `actions.test.ts` tests still pass (8/8)
- [ ] Ask the agent a cross-index query and verify it does not attempt a JOIN on regular indices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified ES|QL instructions with a new "JOIN limitations" subsection: JOINs are supported only with lookup indices (not regular indices) and guidance added for multi-index queries and alternative approaches.

* **Tests**
  * Added tests for the ES|QL instructions template to verify inclusion of JOIN limitation text and correct application of default and custom result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->