### PR TITLE
[Agent Builder] POC: Context-aware tool result compaction

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -228,6 +228,11 @@ export interface RoundModelUsageStats {
    * Model identifier from the provider response, if available.
    */
   model?: string;
+  /**
+   * Estimated total context window size (in tokens) after this round completed.
+   * Includes previous rounds + current round. Uses a heuristic (~4 chars/token).
+   */
+  estimated_context_tokens?: number;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
@@ -165,12 +165,19 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
   const cycleLimit = 10;
   const graphRecursionLimit = getRecursionLimit(cycleLimit);
 
-  // Create unified result transformer for tool result optimization
+  const estimatedContextTokens = estimateConversationTokens(processedConversation);
+  const compactionEnabled = estimatedContextTokens > CONTEXT_TOKEN_BUDGET;
+
+  logger.debug(
+    `Context estimate: ~${estimatedContextTokens} tokens, compaction ${compactionEnabled ? 'enabled' : 'disabled'}`
+  );
+
   const resultTransformer = createResultTransformer({
     toolRegistry,
     toolManager,
     filestore,
     filestoreEnabled: experimentalFeatures.filestore,
+    compactionEnabled,
   });
 
   const promptFactory = createPromptFactory({
@@ -248,6 +255,7 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
       stateManager,
       attachmentStateManager: context.attachmentStateManager,
       configurationOverrides: effectiveOverrides,
+      estimatedPreviousContextTokens: estimatedContextTokens,
     }),
     evictInternalEvents(),
     shareReplay()
@@ -319,4 +327,10 @@ const getRecursionLimit = (cycleLimit: number): number => {
   // langchain's recursionLimit is basically the number of nodes we can traverse before hitting a recursion limit error
   // we have two steps per cycle (agent node + tool call node), and then a few other steps (prepare + answering), and some extra buffer
   return cycleLimit * 2 + 8;
+};
+
+const CONTEXT_TOKEN_BUDGET = 100_000;
+
+const estimateConversationTokens = (conversation: ProcessedConversation): number => {
+  return Math.ceil(JSON.stringify(conversation.previousRounds).length / 4);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/add_round_complete_event.ts
@@ -69,6 +69,7 @@ export const addRoundCompleteEvent = ({
   stateManager,
   attachmentStateManager,
   configurationOverrides,
+  estimatedPreviousContextTokens = 0,
 }: {
   pendingRound: ConversationRound | undefined;
   userInput: RoundInput;
@@ -79,6 +80,7 @@ export const addRoundCompleteEvent = ({
   attachmentStateManager: AttachmentStateManager;
   endTime?: Date;
   configurationOverrides?: RuntimeAgentConfigurationOverrides;
+  estimatedPreviousContextTokens?: number;
 }): OperatorFunction<SourceEvents, SourceEvents | RoundCompleteEvent> => {
   return (events$) => {
     const shared$ = events$.pipe(share());
@@ -98,6 +100,7 @@ export const addRoundCompleteEvent = ({
                 modelProvider,
                 attachmentRefs,
                 configurationOverrides,
+                estimatedPreviousContextTokens,
               })
             : createRound({
                 events,
@@ -107,6 +110,7 @@ export const addRoundCompleteEvent = ({
                 modelProvider,
                 attachmentRefs,
                 configurationOverrides,
+                estimatedPreviousContextTokens,
               });
 
           round.state = buildRoundState({ round, events, stateManager });
@@ -137,6 +141,7 @@ const resumeRound = ({
   modelProvider,
   attachmentRefs,
   configurationOverrides,
+  estimatedPreviousContextTokens = 0,
 }: {
   pendingRound: ConversationRound;
   events: SourceEvents[];
@@ -146,6 +151,7 @@ const resumeRound = ({
   modelProvider: ModelProvider;
   attachmentRefs: AttachmentVersionRef[];
   configurationOverrides?: RuntimeAgentConfigurationOverrides;
+  estimatedPreviousContextTokens?: number;
 }): ConversationRound => {
   // resuming / replaying tool events for the pending step
   const lastStep = pendingRound.steps[pendingRound.steps.length - 1];
@@ -173,6 +179,7 @@ const resumeRound = ({
     modelProvider,
     attachmentRefs,
     configurationOverrides,
+    estimatedPreviousContextTokens,
   });
 
   return mergeRounds(pendingRound, followUp);
@@ -248,6 +255,7 @@ const createRound = ({
   modelProvider,
   attachmentRefs,
   configurationOverrides,
+  estimatedPreviousContextTokens = 0,
 }: {
   events: SourceEvents[];
   input: RoundInput;
@@ -256,6 +264,7 @@ const createRound = ({
   modelProvider: ModelProvider;
   attachmentRefs: AttachmentVersionRef[];
   configurationOverrides?: RuntimeAgentConfigurationOverrides;
+  estimatedPreviousContextTokens?: number;
 }): ConversationRound => {
   const toolResults = events.filter(isToolResultEvent);
   const toolProgressions = events.filter(isToolProgressEvent);
@@ -298,6 +307,19 @@ const createRound = ({
     ? thinkingCompleteEvent.data.time_to_first_token
     : timeToLastToken;
 
+  const steps = stepEvents.flatMap(eventToStep);
+  const response = lastMessage
+    ? {
+        message: lastMessage.message_content,
+        structured_output: lastMessage.structured_output,
+      }
+    : { message: '' };
+
+  const currentRoundTokens = Math.ceil(
+    (JSON.stringify(steps).length + JSON.stringify(input).length + JSON.stringify(response).length) /
+      4
+  );
+
   const round: ConversationRound = {
     id: uuidv4(),
     status: promptRequest
@@ -309,18 +331,16 @@ const createRound = ({
       ...input,
       ...(attachmentRefs.length > 0 ? { attachment_refs: attachmentRefs } : {}),
     },
-    steps: stepEvents.flatMap(eventToStep),
+    steps,
     trace_id: getCurrentTraceId(),
     started_at: startTime.toISOString(),
     time_to_first_token: timeToFirstToken,
     time_to_last_token: timeToLastToken,
-    model_usage: getModelUsage(modelProvider.getUsageStats()),
-    response: lastMessage
-      ? {
-          message: lastMessage.message_content,
-          structured_output: lastMessage.structured_output,
-        }
-      : { message: '' },
+    model_usage: {
+      ...getModelUsage(modelProvider.getUsageStats()),
+      estimated_context_tokens: estimatedPreviousContextTokens + currentRoundTokens,
+    },
+    response,
     configuration_overrides: configurationOverrides,
   };
 
@@ -431,5 +451,6 @@ const mergeModelUsage = (
     input_tokens: a.input_tokens + b.input_tokens,
     output_tokens: a.output_tokens + b.output_tokens,
     model: a.model ?? b.model,
+    estimated_context_tokens: b.estimated_context_tokens ?? a.estimated_context_tokens,
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/create_result_transformer.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/create_result_transformer.ts
@@ -99,6 +99,12 @@ export interface CreateResultTransformerOptions {
    * Defaults to FILE_REFERENCE_TOKEN_THRESHOLD.
    */
   tokenThreshold?: number;
+  /**
+   * Whether file reference compaction is active.
+   * When false, Step 2 (file reference substitution) is skipped even if filestore is enabled.
+   * Defaults to true for backward compatibility.
+   */
+  compactionEnabled?: boolean;
 }
 
 /**
@@ -115,6 +121,7 @@ export const createResultTransformer = ({
   filestore,
   filestoreEnabled,
   tokenThreshold = FILE_REFERENCE_TOKEN_THRESHOLD,
+  compactionEnabled = true,
 }: CreateResultTransformerOptions): ToolCallResultTransformer => {
   return async (toolCall: ToolCallWithResult): Promise<ToolResult[]> => {
     // Skip if no results or all already cleaned
@@ -128,8 +135,8 @@ export const createResultTransformer = ({
       return summarized.map(markResultAsCleaned);
     }
 
-    // Step 2: Apply file reference substitution if enabled
-    if (filestoreEnabled) {
+    // Step 2: Apply file reference substitution if enabled and compaction is active
+    if (filestoreEnabled && compactionEnabled) {
       const transformed = await Promise.all(
         toolCall.results.map((result) =>
           tryFilestoreSubstitution({


### PR DESCRIPTION
## Summary

POC to change tool result redaction from per-round (always replace > 500 token results) to context-window-aware (only compact when estimated context exceeds 100K tokens).

- Adds `estimateConversationTokens` to estimate previous rounds' token footprint using a `JSON.stringify` length / 4 heuristic
- Adds `compactionEnabled` flag to `createResultTransformer` — Step 2 (file reference substitution) is skipped when context is under budget; Step 1 (tool-specific summarization) always runs
- Returns `estimated_context_tokens` on `model_usage` in each round response (previous rounds + current round)

### Files changed

- `agent-builder-common/chat/conversation.ts` — added `estimated_context_tokens` to `RoundModelUsageStats`
- `run_chat_agent.ts` — estimates context, gates compaction, passes estimate to round builder
- `create_result_transformer.ts` — `compactionEnabled` option on the transformer
- `add_round_complete_event.ts` — computes current round tokens at round-end, sets `estimated_context_tokens` on `model_usage`

## Notes

This is a **POC for evaluation only** — not intended for merge. Looking for feedback on the approach, once the effectiveness of the approach is validated, implementation optimizations will be part of follow up PRs


Made with Cursor + Claude

## Result
Context window > 100k, compaction [Trace](https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDozNTk0/spans/b052a976e01ba08676ed7a4dbae06258?selectedSpanNodeId=U3Bhbjo0ODkzNDI%3D)

Context window < 100k, no compaction [Trace](https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDozNTk0/spans/03b0e06985b1ea5aa5c906470bb2ec57?selectedSpanNodeId=U3Bhbjo0ODkzODg%3D)