### PR TITLE
[ES|QL] Use parse instead of parseQuery

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_query_summary.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_query_summary.ts
@@ -57,7 +57,7 @@ function processCommand(
  * @returns An object containing sets of new columns, renamed column pairs, metadata columns, aggregates, and grouping.
  */
 export function getQuerySummary(query: string): ESQLCommandSummary {
-  const { root } = Parser.parseQuery(query);
+  const { root } = Parser.parse(query);
 
   const allNewColumns = new Set<string>();
   const allRenamedColumnsPairs = new Set<[string, string]>();


### PR DESCRIPTION
## Summary

I am changing the parseQuery with parse because Parser.parseQuery() explicitly throws the first parsing error if there are any. This means that if ES wants to check unmerged featur4es at kibana they might not be able to. 

So this is mostly for developing purposes and not a real bug

