### PR TITLE
[9.2] fix: bump disk space from 105 to 150 (#256503)

### DIFF
--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -238,7 +238,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 105
+      diskSizeGb: 150
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -258,7 +258,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 105
+      diskSizeGb: 150
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,7 +4,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 105
+      diskSizeGb: 150
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [fix: bump disk space from 105 to 120 (#256503)](https://github.com/elastic/kibana/pull/256503)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tamerlan Gudabayev","email":"37669316+TamerlanG@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-06T17:36:00Z","message":"fix: bump disk space from 105 to 120 (#256503)\n\nFix defend cypress tests failing due to insufficient disk space.\n\nFailing tests:\nhttps://buildkite.com/elastic/kibana-on-merge/builds/90148\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"89383520db79f31c6a1897c070fe780a95e482b4","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v9.4.0","v9.3.2"],"title":"fix: bump disk space from 105 to 150","number":256503,"url":"https://github.com/elastic/kibana/pull/256503","mergeCommit":{"message":"fix: bump disk space from 105 to 120 (#256503)\n\nFix defend cypress tests failing due to insufficient disk space.\n\nFailing tests:\nhttps://buildkite.com/elastic/kibana-on-merge/builds/90148\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"89383520db79f31c6a1897c070fe780a95e482b4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256503","number":256503,"mergeCommit":{"message":"fix: bump disk space from 105 to 120 (#256503)\n\nFix defend cypress tests failing due to insufficient disk space.\n\nFailing tests:\nhttps://buildkite.com/elastic/kibana-on-merge/builds/90148\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"89383520db79f31c6a1897c070fe780a95e482b4"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/256520","number":256520,"state":"MERGED","mergeCommit":{"sha":"94f9dd3d180c4c2b3a7b4c5c94ff0a98e159aa25","message":"[9.3] fix: bump disk space from 105 to 120 (#256503) (#256520)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [fix: bump disk space from 105 to 120\n(#256503)](https://github.com/elastic/kibana/pull/256503)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tamerlan Gudabayev <37669316+TamerlanG@users.noreply.github.com>\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/256623","number":256623,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->