### PR TITLE
[Cascade] Specify strict layout guidance for rows and cell

### DIFF
--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.styles.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.styles.tsx
@@ -35,6 +35,8 @@ export const dataCascadeImplStyles = (euiTheme: UseEuiTheme['euiTheme']) => ({
     overflowYAuto,
     relativePosition,
     {
+      contain: 'layout style',
+      overflowAnchor: 'none',
       scrollbarGutter: 'auto',
       scrollbarWidth: 'thin',
       border: `${euiTheme.border.width.thin} solid ${euiTheme.border.color}`,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/cascade_row.styles.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/cascade_row.styles.ts
@@ -174,6 +174,7 @@ export const styles = (
       display: 'flex',
       position: 'absolute',
       width: '100%',
+      contain: 'layout style',
       padding: euiSizing[size],
       backgroundColor: euiTheme.colors.backgroundBasePlain,
       outlineColor: OUTLINE_COLOR,


### PR DESCRIPTION
## Summary
This PR is part of the cascade performance improvement work(https://github.com/elastic/kibana/issues/255745), culled from https://github.com/elastic/kibana/pull/256037.

Adds CSS `contain: layout style` and `overflowAnchor: none` to the DataCascade virtualized scroll container and row wrappers, scoping layout/style invalidation so that row DOM mutations during scrolling cannot trigger full-document relayouts.

## Changes

- **`data_cascade_impl.styles.tsx`** (`cascadeTreeGridBlock`): add `contain: 'layout style'` and `overflowAnchor: 'none'`
- **`cascade_row.styles.ts`** (`rowWrapper`): add `contain: 'layout style'`

## Performance impact (Generated by Cursor)

Compared using Chrome DevTools trace profiles (baseline vs this PR) during scroll interaction:

| Metric (per-second normalized) | Baseline | PR | Change |
|---|---|---|---|
| Layout total time | 3,737 us/s | 1,686 us/s | **-55%** |
| Full (non-partial) layouts | 9 | **0** | **-100%** |
| UpdateLayoutTree time | 63,821 us/s | 38,009 us/s | **-40%** |
| Paint time | 4,392 us/s | 1,025 us/s | **-77%** |
| Layout invalidations | 13.3/s | 6.7/s | **-50%** |
| Style recalc triggers | 20.6/s | 9.6/s | **-54%** |
| Long task (>50ms) time | 459,137 us/s | 237,431 us/s | **-48%** |
| Avg frame time | 5.9 ms | 3.4 ms | **-42%** |
| Worst-case frame | 203 ms | 73 ms | **-64%** |
| Max dirty objects/layout | 864 | 414 | **-52%** |
| Layout shifts | 4 | 2 | **-50%** |

The headline result is **complete elimination of full document layouts** during scroll. The two nested containment boundaries (container + rows) ensure layout invalidation from virtualizer DOM mutations stays confined to the contained subtree, turning expensive full-document relayouts into cheap scoped partial layouts. `overflowAnchor: none` prevents additional layout passes from scroll anchoring adjustments during DOM recycling.

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->