### PR TITLE
[kbn-router-to-openapispec] Add registerZodV4Component for stable OAS component names

### DIFF
--- a/src/platform/packages/shared/kbn-router-to-openapispec/index.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/index.ts
@@ -11,3 +11,5 @@ export {
   generateOpenApiDocument,
   type GenerateOpenApiDocumentOptionsFilters,
 } from './src/generate_oas';
+
+export { registerZodV4Component } from './src/oas_converter/zod/lib';

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.test.ts
@@ -12,7 +12,13 @@ import { z as z4 } from '@kbn/zod/v4';
 import { BooleanFromString, PassThroughAny } from '@kbn/zod-helpers';
 import { PassThroughAny as PassThroughAnyV4 } from '@kbn/zod-helpers/v4';
 import { DeepStrict } from '@kbn/zod-helpers/v4';
-import { convert, convertPathParameters, convertQuery, resetDefsCounter } from './lib';
+import {
+  convert,
+  convertPathParameters,
+  convertQuery,
+  registerZodV4Component,
+  resetDefsCounter,
+} from './lib';
 
 import { createLargeSchema, createLargeSchemaV4 } from './lib.test.util';
 
@@ -579,6 +585,82 @@ describe('zod v4', () => {
         query: [],
         shared: {},
       });
+    });
+  });
+
+  describe('registerZodV4Component', () => {
+    beforeEach(() => resetDefsCounter());
+
+    test('recursive schema: stable name used in $defs and $ref', () => {
+      const condition: z4.ZodType = z4.lazy(() =>
+        z4.union([
+          z4.object({ field: z4.string(), eq: z4.string() }),
+          z4.object({ and: z4.array(condition) }),
+          z4.object({ or: z4.array(condition) }),
+        ])
+      );
+      registerZodV4Component(condition, 'Condition');
+
+      const body = z4.object({ condition, name: z4.string() });
+      const result = convert(body as any);
+
+      // components/schemas should use the stable name, not an auto-generated one
+      expect(result.shared).toHaveProperty('Condition');
+      expect(Object.keys(result.shared).some((k) => k.startsWith('_zod_v4_'))).toBe(false);
+
+      // the body schema should reference the stable name
+      expect(result.schema).toMatchObject({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          condition: { $ref: '#/components/schemas/Condition' },
+        },
+      });
+
+      // no COMPONENT_ID_MARKER should leak into the output
+      const outputStr = JSON.stringify(result);
+      expect(outputStr).not.toContain('x-kbn-oas-component-id');
+    });
+
+    test('non-recursive schema: stable name used when schema is inlined (single use)', () => {
+      const address = z4.object({ street: z4.string(), city: z4.string() });
+      registerZodV4Component(address, 'Address');
+
+      const body = z4.object({ address, name: z4.string() });
+      const result = convert(body as any);
+
+      // Address should be extracted to shared under the stable name
+      expect(result.shared).toHaveProperty('Address');
+      expect(result.shared.Address).toMatchObject({
+        type: 'object',
+        properties: {
+          street: { type: 'string' },
+          city: { type: 'string' },
+        },
+      });
+
+      // the body schema should reference the stable name
+      expect(result.schema).toMatchObject({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          address: { $ref: '#/components/schemas/Address' },
+        },
+      });
+
+      // no COMPONENT_ID_MARKER should leak into the output
+      const outputStr = JSON.stringify(result);
+      expect(outputStr).not.toContain('x-kbn-oas-component-id');
+    });
+
+    test('registered schema passed directly to convert() produces $ref', () => {
+      const tag = z4.object({ id: z4.string(), label: z4.string() });
+      registerZodV4Component(tag, 'Tag');
+
+      const result = convert(tag as any);
+
+      expect(result.shared).toHaveProperty('Tag');
+      expect(result.schema).toEqual({ $ref: '#/components/schemas/Tag' });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
@@ -598,6 +598,41 @@ export const resetDefsCounter = () => {
 };
 
 /**
+ * Internal marker injected into a Zod v4 JSON schema node (via the `override`
+ * callback) to carry the user-supplied OAS component name through the
+ * conversion pipeline.  The key intentionally starts with `x-` so it is a
+ * valid JSON-Schema extension and is easy to strip afterwards.
+ */
+const COMPONENT_ID_MARKER = 'x-kbn-oas-component-id';
+
+/**
+ * Maps Zod v4 schema instances to their desired OAS `components/schemas` names.
+ * Uses a WeakMap so schema objects can be GC-ed when no longer referenced.
+ */
+const zodV4OasComponentRegistry = new WeakMap<object, string>();
+
+/**
+ * Register a Zod v4 schema so that the OAS converter emits it as a named
+ * component (`$ref: '#/components/schemas/<name>'`) instead of inlining it.
+ *
+ * Call this once per schema, at module load time (e.g. in an `oas_definitions.ts`
+ * file next to the schema definitions):
+ *
+ * ```ts
+ * import { registerZodV4Component } from '@kbn/router-to-openapispec';
+ * import { conditionSchema } from './schemas';
+ *
+ * registerZodV4Component(conditionSchema, 'Condition');
+ * ```
+ *
+ * The name must be unique across all registered schemas in the document.
+ * Names follow the same rules as OpenAPI component names: `[a-zA-Z0-9._-]+`.
+ */
+export const registerZodV4Component = (schema: z4.ZodType, name: string): void => {
+  zodV4OasComponentRegistry.set(schema as object, name);
+};
+
+/**
  * Recursively rewrite every `$ref` value that starts with `#/$defs/`
  * to point to `#/components/schemas/<uniqueKey>` instead.
  */
@@ -625,6 +660,10 @@ function rewriteDefsRefs(obj: unknown, replacements: Record<string, string>): un
  * the entries into `shared` (→ `components/schemas`), and rewrite all
  * `$ref: '#/$defs/...'` pointers so they resolve correctly in the OpenAPI
  * document root.
+ *
+ * When a `$defs` entry carries the `COMPONENT_ID_MARKER` property (injected by
+ * the `override` callback for registered schemas), that stable name is used
+ * instead of the auto-generated `_zod_v4_{batchId}_{key}` name.
  */
 function extractDefsToShared(
   defs: Record<string, unknown>,
@@ -635,9 +674,22 @@ function extractDefsToShared(
   const shared: Record<string, OpenAPIV3.SchemaObject> = {};
 
   for (const [key, value] of Object.entries(defs)) {
-    const uniqueKey = `_zod_v4_${batchId}_${key}`;
+    const def = value as Record<string, unknown>;
+
+    const stableId =
+      typeof def[COMPONENT_ID_MARKER] === 'string' ? (def[COMPONENT_ID_MARKER] as string) : null;
+
+    const uniqueKey = stableId ?? `_zod_v4_${batchId}_${key}`;
+
     replacements[`#/$defs/${key}`] = `#/components/schemas/${uniqueKey}`;
-    shared[uniqueKey] = value as OpenAPIV3.SchemaObject;
+
+    if (stableId) {
+      const { [COMPONENT_ID_MARKER]: _marker, ...rest } = def;
+
+      shared[uniqueKey] = rest as OpenAPIV3.SchemaObject;
+    } else {
+      shared[uniqueKey] = def as OpenAPIV3.SchemaObject;
+    }
   }
 
   // Rewrite $ref paths in the main schema
@@ -650,6 +702,59 @@ function extractDefsToShared(
   }
 
   return { schema: fixedSchema, shared };
+}
+
+/**
+ * Recursively traverse a (post-processed) JSON schema and extract any nodes
+ * that still carry the `COMPONENT_ID_MARKER`.  This covers the case where a
+ * registered schema appears exactly once (so Zod v4 inlined it rather than
+ * placing it in `$defs`): we still want it as a named OAS component.
+ *
+ * Marked nodes are moved into `shared` and replaced with a `$ref`.
+ */
+function hoistMarkedSchemas(
+  node: unknown,
+  shared: Record<string, OpenAPIV3.SchemaObject>
+): unknown {
+  if (typeof node !== 'object' || node === null) {
+    return node;
+  }
+
+  if (Array.isArray(node)) {
+    return node.map((item) => hoistMarkedSchemas(item, shared));
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  // $ref nodes are already references — don't recurse into them
+  if ('$ref' in obj) {
+    return obj;
+  }
+
+  const name = obj[COMPONENT_ID_MARKER];
+
+  if (typeof name === 'string') {
+    const { [COMPONENT_ID_MARKER]: _marker, ...rest } = obj;
+
+    // Recursively handle nested marked schemas within this node first
+    const processed: Record<string, unknown> = {};
+
+    for (const [k, v] of Object.entries(rest)) {
+      processed[k] = hoistMarkedSchemas(v, shared);
+    }
+
+    shared[name] = processed as OpenAPIV3.SchemaObject;
+
+    return { $ref: `#/components/schemas/${name}` };
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [k, v] of Object.entries(obj)) {
+    result[k] = hoistMarkedSchemas(v, shared);
+  }
+
+  return result;
 }
 
 /**
@@ -758,6 +863,16 @@ export const convert = (schema: z.ZodTypeAny) => {
             delete (js as any)[key];
           }
           (js as any).not = {};
+          return;
+        }
+
+        // Inject the stable OAS component name for registered schemas.
+        // This marker is picked up by extractDefsToShared (for $defs entries)
+        // and hoistMarkedSchemas (for inline, single-use schemas).
+        const componentName = zodV4OasComponentRegistry.get(zodSchema as object);
+
+        if (componentName) {
+          (js as any)[COMPONENT_ID_MARKER] = componentName;
         }
       },
     }) as Record<string, any>;
@@ -797,6 +912,15 @@ export const convert = (schema: z.ZodTypeAny) => {
 
     // Convert JSON Schema (OAS 3.1) constructs to OpenAPI 3.0 equivalents
     processedSchema = jsonSchemaToOpenApi30(processedSchema);
+
+    // Extract any registered schemas that were inlined by z4.toJSONSchema()
+    // (single-use, non-recursive schemas don't appear in $defs — we hoist them
+    // here so they still become named components).
+    processedSchema = hoistMarkedSchemas(processedSchema, shared) as Record<string, unknown>;
+
+    for (const [key, value] of Object.entries(shared)) {
+      shared[key] = hoistMarkedSchemas(value, shared) as OpenAPIV3.SchemaObject;
+    }
 
     // Apply the same JSON-description post-processing as v3
     const description = (unwrapped as any).description;


### PR DESCRIPTION
## Summary

Adds `registerZodV4Component` - a utility that lets Zod v4 schema authors assign a stable, human-readable name to their schema so it appears as a named $ref in the generated OAS output.

## Details

When `z4.toJSONSchema()` encounters recursive or reused schemas, it hoists them into `$defs` with auto-generated names like `_zod_v4_1___schema1`. These names are opaque, unstable across runs (they depend on a batch counter), and make the OAS output hard to read.

With `registerZodV4Component`, a schema is emitted as `$ref: '#/components/schemas/Condition'` instead of being inlined or given an auto-generated name. This works for three cases: recursive schemas, single-use inline schemas, and schemas passed directly as a route body.

## How to use

Call once at module load time (e.g. in an `oas_definitions.ts` file next to your schemas):

```
import { registerZodV4Component } from '@kbn/router-to-openapispec';

// Call once:
registerZodV4Component(conditionSchema, 'Condition');
registerZodV4Component(fieldDefinitionSchema, 'FieldDefinition');
```
Names must be unique across all schemas in the generated document and should match the pattern `[a-zA-Z0-9._-]+`.
