### PR TITLE
[FTR][Lens] Split `lens/tsvb` config

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -237,7 +237,9 @@ enabled:
   - x-pack/platform/test/functional/apps/lens/group9/config.ts
   - x-pack/platform/test/functional/apps/lens/group10/config.ts
   - x-pack/platform/test/functional/apps/lens/group11/config.ts
-  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/config.ts
+  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts
+  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts
+  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts
   - x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based/config.ts
   - x-pack/platform/test/functional/apps/lens/open_in_lens/dashboard/config.ts
   - x-pack/platform/test/functional/apps/license_management/config.ts

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../../../../config.base.ts'));
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/dashboard.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/dashboard.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, timeToVisualize, dashboard, canvas, header } =

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EsArchiver } from '@kbn/es-archiver';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile, getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
@@ -17,7 +17,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
   const config = getService('config');
   let remoteEsArchiver;
 
-  describe('lens app - TSVB Open in Lens', () => {
+  describe('lens app - TSVB Open in Lens - group 1', () => {
     const esArchive = 'x-pack/platform/test/fixtures/es_archives/logstash_functional';
     const localIndexPatternString = 'logstash-*';
     const remoteIndexPatternString = 'ftr-remote:logstash-*';
@@ -55,26 +55,13 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.uiSettings.update({
         defaultIndex: indexPatternString,
         'dateFormat:tz': 'UTC',
-        // changing the timepicker default here saves us from having to set it in Discover (~8s)
-        // The TSVB tests are using a slightly difference end date, so it needs to be set manually here
         'timepicker:timeDefaults': `{ "from": "${timePicker.defaultStartTime}", "to": "Sep 22, 2015 @ 18:31:44.000" }`,
       });
       await kibanaServer.importExport.load(fixtureDirs.lensBasic);
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
     loadTestFile(require.resolve('./dashboard'));
-    loadTestFile(require.resolve('./metric'));
-    loadTestFile(require.resolve('./gauge'));
     loadTestFile(require.resolve('./timeseries'));
-    loadTestFile(require.resolve('./top_n'));
-    loadTestFile(require.resolve('./table'));
   });
 }

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/timeseries.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/timeseries.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts
@@ -8,10 +8,10 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const functionalConfig = await readConfigFile(require.resolve('../../../../config.base.ts'));
+  const baseConfig = await readConfigFile(require.resolve('../group1/config.ts'));
 
   return {
-    ...functionalConfig.getAll(),
+    ...baseConfig.getAll(),
     testFiles: [require.resolve('.')],
   };
 }

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/gauge.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/gauge.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([
@@ -19,15 +19,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
 
-  describe('Metric', function describeIndexTests() {
+  describe('Gauge', function describeIndexTests() {
     before(async () => {
       await visualize.initTests();
     });
 
     beforeEach(async () => {
       await visualBuilder.resetPage();
-      await visualBuilder.clickMetric();
-      await visualBuilder.clickDataTab('metric');
+      await visualBuilder.clickGauge();
+      await visualBuilder.clickDataTab('gauge');
     });
 
     it('should show the "Edit Visualization in Lens" menu item', async () => {
@@ -35,28 +35,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should convert to Lens', async () => {
+      await header.waitUntilLoadingHasFinished();
+
       await visualize.navigateToLensFromAnotherVisualization();
       await lens.waitForVisualization('mtrVis');
 
       const metricData = await lens.getMetricVisualizationData();
       expect(metricData[0].title).to.eql('Count of records');
-    });
-
-    it('should draw static value', async () => {
-      await visualBuilder.selectAggType('Static Value');
-      await visualBuilder.setStaticValue(10);
-
-      await header.waitUntilLoadingHasFinished();
-
-      await visualize.navigateToLensFromAnotherVisualization();
-      await lens.waitForVisualization('mtrVis');
-      await retry.try(async () => {
-        await lens.assertLayerCount(1);
-
-        const dimensions = await testSubjects.findAll('lns-dimensionTrigger');
-        expect(dimensions).to.have.length(1);
-        expect(await dimensions[0].getVisibleText()).to.be('10');
-      });
     });
 
     it('should convert metric with params', async () => {
@@ -68,11 +53,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visualize.navigateToLensFromAnotherVisualization();
       await lens.waitForVisualization('mtrVis');
       await retry.try(async () => {
-        await lens.assertLayerCount(1);
+        // layer tabs hidden for gauge/metric visualizations
+        await lens.assertLayerCount(0);
 
         const dimensions = await testSubjects.findAll('lns-dimensionTrigger');
-        expect(dimensions).to.have.length(1);
+        expect(dimensions).to.have.length(2);
         expect(await dimensions[0].getVisibleText()).to.be('Count of bytes');
+        expect(await dimensions[1].getVisibleText()).to.be('overall_max(count(bytes))');
       });
     });
 
@@ -94,10 +81,19 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should convert color ranges', async () => {
-      await visualBuilder.clickPanelOptions('metric');
+      await visualBuilder.setMetricsGroupByTerms('extension.raw');
+
+      await visualBuilder.clickPanelOptions('gauge');
+
       await visualBuilder.setColorRuleOperator('>= greater than or equal');
       await visualBuilder.setColorRuleValue(10);
-      await visualBuilder.setColorPickerValue('#54B399');
+      await visualBuilder.setColorPickerValue('#54B399', 2);
+
+      await visualBuilder.createColorRule();
+
+      await visualBuilder.setColorRuleOperator('>= greater than or equal');
+      await visualBuilder.setColorRuleValue(100, 1);
+      await visualBuilder.setColorPickerValue('#54A000', 4);
 
       await header.waitUntilLoadingHasFinished();
 
@@ -114,7 +110,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         }
 
         const dimensions = await testSubjects.findAll('lns-dimensionTrigger');
-        expect(dimensions).to.have.length(1);
+        expect(dimensions).to.have.length(3);
 
         await dimensions[0].click();
 
@@ -122,7 +118,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const colorStops = await lens.getPaletteColorStops();
 
         expect(colorStops).to.eql([
+          { stop: '', color: 'rgba(104, 188, 0, 1)' },
           { stop: '10', color: 'rgba(84, 179, 153, 1)' },
+          { stop: '100', color: 'rgba(84, 160, 0, 1)' },
           { stop: '', color: undefined },
         ]);
       });
@@ -138,7 +136,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should bring the ignore global filters configured at panel level over', async () => {
-      await visualBuilder.clickPanelOptions('metric');
+      await visualBuilder.clickPanelOptions('gauge');
       await visualBuilder.setIgnoreFilters(true);
       await header.waitUntilLoadingHasFinished();
       await visualize.navigateToLensFromAnotherVisualization();

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/index.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsArchiver } from '@kbn/es-archiver';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default function ({ loadTestFile, getService, getPageObjects }: FtrProviderContext) {
+  const browser = getService('browser');
+  const log = getService('log');
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const { timePicker } = getPageObjects(['timePicker']);
+  const config = getService('config');
+  let remoteEsArchiver;
+
+  describe('lens app - TSVB Open in Lens - group 2', () => {
+    const esArchive = 'x-pack/platform/test/fixtures/es_archives/logstash_functional';
+    const localIndexPatternString = 'logstash-*';
+    const remoteIndexPatternString = 'ftr-remote:logstash-*';
+    const localFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/default',
+    };
+
+    const remoteFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/default',
+    };
+    let esNode: EsArchiver;
+    let fixtureDirs: {
+      lensBasic: string;
+      lensDefault: string;
+    };
+    let indexPatternString: string;
+    before(async () => {
+      log.debug('Starting lens before method');
+      await browser.setWindowSize(1280, 1200);
+      try {
+        config.get('esTestCluster.ccs');
+        remoteEsArchiver = getService('remoteEsArchiver' as 'esArchiver');
+        esNode = remoteEsArchiver;
+        fixtureDirs = remoteFixtures;
+        indexPatternString = remoteIndexPatternString;
+      } catch (error) {
+        esNode = esArchiver;
+        fixtureDirs = localFixtures;
+        indexPatternString = localIndexPatternString;
+      }
+
+      await esNode.load(esArchive);
+      await kibanaServer.uiSettings.update({
+        defaultIndex: indexPatternString,
+        'dateFormat:tz': 'UTC',
+        'timepicker:timeDefaults': `{ "from": "${timePicker.defaultStartTime}", "to": "Sep 22, 2015 @ 18:31:44.000" }`,
+      });
+      await kibanaServer.importExport.load(fixtureDirs.lensBasic);
+      await kibanaServer.importExport.load(fixtureDirs.lensDefault);
+    });
+
+    loadTestFile(require.resolve('./gauge'));
+    loadTestFile(require.resolve('./metric'));
+  });
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/metric.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/metric.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([
@@ -19,15 +19,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
 
-  describe('Gauge', function describeIndexTests() {
+  describe('Metric', function describeIndexTests() {
     before(async () => {
       await visualize.initTests();
     });
 
     beforeEach(async () => {
       await visualBuilder.resetPage();
-      await visualBuilder.clickGauge();
-      await visualBuilder.clickDataTab('gauge');
+      await visualBuilder.clickMetric();
+      await visualBuilder.clickDataTab('metric');
     });
 
     it('should show the "Edit Visualization in Lens" menu item', async () => {
@@ -35,13 +35,28 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should convert to Lens', async () => {
-      await header.waitUntilLoadingHasFinished();
-
       await visualize.navigateToLensFromAnotherVisualization();
       await lens.waitForVisualization('mtrVis');
 
       const metricData = await lens.getMetricVisualizationData();
       expect(metricData[0].title).to.eql('Count of records');
+    });
+
+    it('should draw static value', async () => {
+      await visualBuilder.selectAggType('Static Value');
+      await visualBuilder.setStaticValue(10);
+
+      await header.waitUntilLoadingHasFinished();
+
+      await visualize.navigateToLensFromAnotherVisualization();
+      await lens.waitForVisualization('mtrVis');
+      await retry.try(async () => {
+        await lens.assertLayerCount(1);
+
+        const dimensions = await testSubjects.findAll('lns-dimensionTrigger');
+        expect(dimensions).to.have.length(1);
+        expect(await dimensions[0].getVisibleText()).to.be('10');
+      });
     });
 
     it('should convert metric with params', async () => {
@@ -53,13 +68,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visualize.navigateToLensFromAnotherVisualization();
       await lens.waitForVisualization('mtrVis');
       await retry.try(async () => {
-        // layer tabs hidden for gauge/metric visualizations
-        await lens.assertLayerCount(0);
+        await lens.assertLayerCount(1);
 
         const dimensions = await testSubjects.findAll('lns-dimensionTrigger');
-        expect(dimensions).to.have.length(2);
+        expect(dimensions).to.have.length(1);
         expect(await dimensions[0].getVisibleText()).to.be('Count of bytes');
-        expect(await dimensions[1].getVisibleText()).to.be('overall_max(count(bytes))');
       });
     });
 
@@ -81,19 +94,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should convert color ranges', async () => {
-      await visualBuilder.setMetricsGroupByTerms('extension.raw');
-
-      await visualBuilder.clickPanelOptions('gauge');
-
+      await visualBuilder.clickPanelOptions('metric');
       await visualBuilder.setColorRuleOperator('>= greater than or equal');
       await visualBuilder.setColorRuleValue(10);
-      await visualBuilder.setColorPickerValue('#54B399', 2);
-
-      await visualBuilder.createColorRule();
-
-      await visualBuilder.setColorRuleOperator('>= greater than or equal');
-      await visualBuilder.setColorRuleValue(100, 1);
-      await visualBuilder.setColorPickerValue('#54A000', 4);
+      await visualBuilder.setColorPickerValue('#54B399');
 
       await header.waitUntilLoadingHasFinished();
 
@@ -110,7 +114,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         }
 
         const dimensions = await testSubjects.findAll('lns-dimensionTrigger');
-        expect(dimensions).to.have.length(3);
+        expect(dimensions).to.have.length(1);
 
         await dimensions[0].click();
 
@@ -118,9 +122,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const colorStops = await lens.getPaletteColorStops();
 
         expect(colorStops).to.eql([
-          { stop: '', color: 'rgba(104, 188, 0, 1)' },
           { stop: '10', color: 'rgba(84, 179, 153, 1)' },
-          { stop: '100', color: 'rgba(84, 160, 0, 1)' },
           { stop: '', color: undefined },
         ]);
       });
@@ -136,7 +138,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should bring the ignore global filters configured at panel level over', async () => {
-      await visualBuilder.clickPanelOptions('gauge');
+      await visualBuilder.clickPanelOptions('metric');
       await visualBuilder.setIgnoreFilters(true);
       await header.waitUntilLoadingHasFinished();
       await visualize.navigateToLensFromAnotherVisualization();

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseConfig = await readConfigFile(require.resolve('../group1/config.ts'));
+
+  return {
+    ...baseConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/index.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsArchiver } from '@kbn/es-archiver';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default function ({ loadTestFile, getService, getPageObjects }: FtrProviderContext) {
+  const browser = getService('browser');
+  const log = getService('log');
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const { timePicker } = getPageObjects(['timePicker']);
+  const config = getService('config');
+  let remoteEsArchiver;
+
+  describe('lens app - TSVB Open in Lens - group 3', () => {
+    const esArchive = 'x-pack/platform/test/fixtures/es_archives/logstash_functional';
+    const localIndexPatternString = 'logstash-*';
+    const remoteIndexPatternString = 'ftr-remote:logstash-*';
+    const localFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/default',
+    };
+
+    const remoteFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/default',
+    };
+    let esNode: EsArchiver;
+    let fixtureDirs: {
+      lensBasic: string;
+      lensDefault: string;
+    };
+    let indexPatternString: string;
+    before(async () => {
+      log.debug('Starting lens before method');
+      await browser.setWindowSize(1280, 1200);
+      try {
+        config.get('esTestCluster.ccs');
+        remoteEsArchiver = getService('remoteEsArchiver' as 'esArchiver');
+        esNode = remoteEsArchiver;
+        fixtureDirs = remoteFixtures;
+        indexPatternString = remoteIndexPatternString;
+      } catch (error) {
+        esNode = esArchiver;
+        fixtureDirs = localFixtures;
+        indexPatternString = localIndexPatternString;
+      }
+
+      await esNode.load(esArchive);
+      await kibanaServer.uiSettings.update({
+        defaultIndex: indexPatternString,
+        'dateFormat:tz': 'UTC',
+        'timepicker:timeDefaults': `{ "from": "${timePicker.defaultStartTime}", "to": "Sep 22, 2015 @ 18:31:44.000" }`,
+      });
+      await kibanaServer.importExport.load(fixtureDirs.lensBasic);
+      await kibanaServer.importExport.load(fixtureDirs.lensDefault);
+    });
+
+    loadTestFile(require.resolve('./top_n'));
+    loadTestFile(require.resolve('./table'));
+  });
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/table.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/table.ts
@@ -13,7 +13,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/top_n.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/top_n.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([


### PR DESCRIPTION
## Summary

Split `x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/config.ts` (~34 minutes) into smaller groups targeting 15–20 minutes each.

- Split into 3 groups from the original monolithic config
- Moved 6 test files across `group1/`, `group2/`, `group3/`
- Registered all new configs in `.buildkite/ftr_platform_stateful_configs.yml`

> [!NOTE]
> This PR was generated automatically by an AI coding agent ([Buildkite build](https://buildkite.com/elastic/appex-qa-ai-ftr-config-splitter/builds/30)).
> Please review carefully before merging.

### New configs

* `x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts` (12 min)
* `x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts` (15 min)
* `x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts` (21 min)

[Buildkite build](https://buildkite.com/elastic/kibana-pull-request/builds/406857)

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->