### PR TITLE
[FTR][Saved Query Management] Split `saved query management/saved_query_management` config

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -266,7 +266,8 @@ enabled:
   - x-pack/platform/test/functional/apps/reporting_management/config.ts
   - x-pack/platform/test/functional/apps/rollup_job/config.ts
   - x-pack/platform/test/functional/apps/saved_objects_management/config.ts
-  - x-pack/platform/test/functional/apps/saved_query_management/config.ts
+  - x-pack/platform/test/functional/apps/saved_query_management/group1/config.ts
+  - x-pack/platform/test/functional/apps/saved_query_management/group2/config.ts
   - x-pack/platform/test/functional/apps/saved_query_management/config.v2.ts
   - x-pack/platform/test/functional/apps/security/config.ts
   - x-pack/platform/test/functional/apps/snapshot_restore/config.ts

--- a/x-pack/platform/test/functional/apps/saved_query_management/group1/config.ts
+++ b/x-pack/platform/test/functional/apps/saved_query_management/group1/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../../config.base.ts'));
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('./feature_controls/v1')],
+  };
+}

--- a/x-pack/platform/test/functional/apps/saved_query_management/group1/feature_controls/v1/index.ts
+++ b/x-pack/platform/test/functional/apps/saved_query_management/group1/feature_controls/v1/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('Saved query management - Feature controls - group1', function () {
+    loadTestFile(require.resolve('./security'));
+  });
+}

--- a/x-pack/platform/test/functional/apps/saved_query_management/group1/feature_controls/v1/security.ts
+++ b/x-pack/platform/test/functional/apps/saved_query_management/group1/feature_controls/v1/security.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { FeatureApp, FeatureName } from '../create_security_tests';
-import { createSecurityTests } from '../create_security_tests';
+import type { FeatureApp, FeatureName } from '../../../feature_controls/create_security_tests';
+import { createSecurityTests } from '../../../feature_controls/create_security_tests';
 
 const featureConfigs: Array<{
   feature: FeatureName;
@@ -21,16 +21,6 @@ const featureConfigs: Array<{
   {
     feature: 'dashboard',
     app: 'dashboard',
-    hasImplicitSaveQueryManagement: true,
-  },
-  {
-    feature: 'maps',
-    app: 'maps',
-    hasImplicitSaveQueryManagement: true,
-  },
-  {
-    feature: 'visualize',
-    app: 'visualize',
     hasImplicitSaveQueryManagement: true,
   },
 ];

--- a/x-pack/platform/test/functional/apps/saved_query_management/group2/config.ts
+++ b/x-pack/platform/test/functional/apps/saved_query_management/group2/config.ts
@@ -8,10 +8,10 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const functionalConfig = await readConfigFile(require.resolve('../../config.base.ts'));
+  const baseConfig = await readConfigFile(require.resolve('../group1/config.ts'));
 
   return {
-    ...functionalConfig.getAll(),
+    ...baseConfig.getAll(),
     testFiles: [require.resolve('./feature_controls/v1')],
   };
 }

--- a/x-pack/platform/test/functional/apps/saved_query_management/group2/feature_controls/v1/index.ts
+++ b/x-pack/platform/test/functional/apps/saved_query_management/group2/feature_controls/v1/index.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('Saved query management - Feature controls', function () {
+  describe('Saved query management - Feature controls - group2', function () {
     loadTestFile(require.resolve('./security'));
   });
 }

--- a/x-pack/platform/test/functional/apps/saved_query_management/group2/feature_controls/v1/security.ts
+++ b/x-pack/platform/test/functional/apps/saved_query_management/group2/feature_controls/v1/security.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FeatureApp, FeatureName } from '../../../feature_controls/create_security_tests';
+import { createSecurityTests } from '../../../feature_controls/create_security_tests';
+
+const featureConfigs: Array<{
+  feature: FeatureName;
+  app: FeatureApp;
+  hasImplicitSaveQueryManagement: boolean;
+}> = [
+  {
+    feature: 'maps',
+    app: 'maps',
+    hasImplicitSaveQueryManagement: true,
+  },
+  {
+    feature: 'visualize',
+    app: 'visualize',
+    hasImplicitSaveQueryManagement: true,
+  },
+];
+
+export default createSecurityTests(featureConfigs);


### PR DESCRIPTION
## Summary

Split `x-pack/platform/test/functional/apps/saved_query_management/config.ts` (~33 minutes) into smaller groups targeting 15–20 minutes each.

- Split `config.ts` into 2 groups by partitioning 4 feature security tests (discover+dashboard in `group1/`, maps+visualize in `group2/`)
- Moved `config.ts` and `security.ts` via `git mv` to `group1/`; created new `group2/` with its own `config.ts`, `index.ts`, and `security.ts`
- Registered both new configs in `.buildkite/ftr_platform_stateful_configs.yml` replacing the original entry

> [!NOTE]
> This PR was generated automatically by an AI coding agent ([Buildkite build](https://buildkite.com/elastic/appex-qa-ai-ftr-config-splitter/builds/31)).
> Please review carefully before merging.


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->