### PR TITLE
[8.19] [scout] fix tags filtering in config discovery (#253360)

### DIFF
--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -11,7 +11,15 @@ echo '--- Update Scout Test Config Manifests'
 node scripts/scout.js update-test-config-manifests
 
 echo '--- Discover Playwright Configs and upload to Buildkite artifacts'
-node scripts/scout discover-playwright-configs --target ech --include-custom-servers --save
+if [[ "${BUILDKITE_BRANCH:-}" == "main" || "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" == "main" ]]; then
+  SCOUT_DISCOVERY_TARGET="local"
+else
+  SCOUT_DISCOVERY_TARGET="local-stateful-only"
+fi
+node scripts/scout discover-playwright-configs \
+  --include-custom-servers \
+  --target "$SCOUT_DISCOVERY_TARGET" \
+  --save
 cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
 buildkite-agent artifact upload "scout_playwright_configs.json"
 

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -387,7 +387,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
           manifest: {
             path: 'pluginLocalServerless/config.playwright.config.ts',
             exists: true,
-            lastModified: '2024-01-01T00:00:00Z',
             sha1: 'local789',
             tests: [
               {

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -88,7 +88,11 @@ describe('runDiscoverPlaywrightConfigs', () => {
         {
           path: 'pluginA/config1.playwright.config.ts',
           hasTests: true,
-          tags: ['@local-stateful-classic', '@cloud-serverless-observability_complete'],
+          tags: [
+            '@local-stateful-classic',
+            '@cloud-stateful-classic',
+            '@cloud-serverless-observability_complete',
+          ],
           serverRunFlags: [
             '--arch stateful --domain classic',
             '--arch serverless --domain observability_complete',
@@ -161,7 +165,11 @@ describe('runDiscoverPlaywrightConfigs', () => {
                   title: 'Test 1',
                   expectedStatus: 'passed',
                   location: { file: 'test1.spec.ts', line: 1, column: 1 },
-                  tags: ['@local-stateful-classic', '@cloud-serverless-observability_complete'],
+                  tags: [
+                    '@local-stateful-classic',
+                    '@cloud-stateful-classic',
+                    '@cloud-serverless-observability_complete',
+                  ],
                 },
                 {
                   id: 'test2',
@@ -243,7 +251,11 @@ describe('runDiscoverPlaywrightConfigs', () => {
                   title: 'Test 5',
                   expectedStatus: 'passed',
                   location: { file: 'test5.spec.ts', line: 1, column: 1 },
-                  tags: ['@local-stateful-classic', '@cloud-serverless-observability_complete'],
+                  tags: [
+                    '@local-stateful-classic',
+                    '@cloud-stateful-classic',
+                    '@cloud-serverless-observability_complete',
+                  ],
                 },
               ],
             },
@@ -275,9 +287,9 @@ describe('runDiscoverPlaywrightConfigs', () => {
 
     runDiscoverPlaywrightConfigs(flagsReader, log);
 
-    // pluginA has stateful-classic, serverless-observability_complete, serverless-security_complete, serverless-search which are in DEPLOYMENT_AGNOSTIC
-    // pluginB has serverless-workplaceai which is NOT in DEPLOYMENT_AGNOSTIC, it should be excluded
-    // packageA has stateful-classic and serverless-observability_complete which are in DEPLOYMENT_AGNOSTIC
+    // pluginA has local/cloud-stateful-classic, serverless-observability_complete, serverless-security_complete, serverless-search which are in tags.deploymentAgnostic
+    // pluginB has serverless-workplaceai which is NOT in tags.deploymentAgnostic, it should be excluded
+    // packageA has local/cloud-stateful-classic and serverless-observability_complete which are in tags.deploymentAgnostic
 
     const infoCalls = log.info.mock.calls;
     const foundMessage = infoCalls.find((call) =>
@@ -288,15 +300,15 @@ describe('runDiscoverPlaywrightConfigs', () => {
     expect(foundMessage![0]).toContain('1 package(s)'); // packageA
   });
 
-  it('filters configs based on target tags for "mki" target (SERVERLESS_ONLY)', () => {
+  it('filters configs based on target tags for "mki" target (@cloud-serverless-*)', () => {
     flagsReader.enum.mockReturnValue('mki');
     flagsReader.boolean.mockReturnValue(false);
 
     runDiscoverPlaywrightConfigs(flagsReader, log);
 
-    // pluginA has serverless-observability_complete, serverless-security_complete, serverless-search which are in SERVERLESS_ONLY
-    // pluginB has serverless-workplaceai which is in SERVERLESS_ONLY
-    // packageA has serverless-observability_complete which is in SERVERLESS_ONLY
+    // pluginA has @cloud-serverless-observability_complete, @cloud-serverless-security_complete, @cloud-serverless-search
+    // pluginB has @cloud-serverless-workplaceai
+    // packageA has @cloud-serverless-observability_complete
 
     const infoCalls = log.info.mock.calls;
     const foundMessage = infoCalls.find((call) =>
@@ -308,15 +320,15 @@ describe('runDiscoverPlaywrightConfigs', () => {
     expect(foundMessage![0]).toContain('1 package(s)');
   });
 
-  it('filters configs based on target tags for "ech" target (ESS_ONLY)', () => {
+  it('filters configs based on target tags for "ech" target (@cloud-stateful-*)', () => {
     flagsReader.enum.mockReturnValue('ech');
     flagsReader.boolean.mockReturnValue(false);
 
     runDiscoverPlaywrightConfigs(flagsReader, log);
 
-    // pluginA has stateful-classic which is in ESS_ONLY
-    // pluginB has no stateful-classic, it should be excluded
-    // packageA has stateful-classic which is in ESS_ONLY
+    // pluginA has @cloud-stateful-classic which matches ech target
+    // pluginB has no cloud-stateful tags, it should be excluded
+    // packageA has @cloud-stateful-classic which matches ech target
 
     const infoCalls = log.info.mock.calls;
     const foundMessage = infoCalls.find((call) =>
@@ -325,6 +337,101 @@ describe('runDiscoverPlaywrightConfigs', () => {
     expect(foundMessage).toBeDefined();
     expect(foundMessage![0]).toContain('1 plugin(s)'); // pluginA only
     expect(foundMessage![0]).toContain('1 package(s)'); // packageA
+  });
+
+  it('filters configs based on target tags for "local" target (@local-*)', () => {
+    flagsReader.enum.mockReturnValue('local');
+    flagsReader.boolean.mockReturnValue(false);
+
+    runDiscoverPlaywrightConfigs(flagsReader, log);
+
+    // pluginA config1 has @local-stateful-classic which matches @local-*
+    // pluginA parallel has @cloud-serverless-search which does NOT match @local-*
+    // pluginB has @cloud-serverless-workplaceai which does NOT match @local-*
+    // packageA has @local-stateful-classic which matches @local-*
+
+    const infoCalls = log.info.mock.calls;
+    const foundMessage = infoCalls.find((call) =>
+      call[0].includes('Found Playwright config files')
+    );
+    expect(foundMessage).toBeDefined();
+    expect(foundMessage![0]).toContain('1 plugin(s)'); // pluginA only (config1 matches, parallel does not)
+    expect(foundMessage![0]).toContain('1 package(s)'); // packageA
+
+    // Verify only @local-* tags are kept
+    const configLogCall = infoCalls.find((call) =>
+      call[0].includes('config1.playwright.config.ts')
+    );
+    expect(configLogCall).toBeDefined();
+    expect(configLogCall![0]).toContain('@local-stateful-classic');
+    expect(configLogCall![0]).not.toContain('@cloud-stateful-classic');
+    expect(configLogCall![0]).not.toContain('@cloud-serverless-observability_complete');
+  });
+
+  it('filters configs based on target tags for "local-stateful-only" target (@local-stateful-*)', () => {
+    flagsReader.enum.mockReturnValue('local-stateful-only');
+    flagsReader.boolean.mockReturnValue(false);
+
+    // Add a module with @local-serverless-search to verify it gets excluded
+    mockTestableModules.modules.push({
+      name: 'pluginLocalServerless',
+      group: 'groupD',
+      type: 'plugin' as const,
+      visibility: 'private' as const,
+      root: 'x-pack/platform/plugins/private/pluginLocalServerless',
+      configs: [
+        {
+          path: 'pluginLocalServerless/config.playwright.config.ts',
+          category: 'ui',
+          type: 'playwright',
+          manifest: {
+            path: 'pluginLocalServerless/config.playwright.config.ts',
+            exists: true,
+            lastModified: '2024-01-01T00:00:00Z',
+            sha1: 'local789',
+            tests: [
+              {
+                id: 'localServerlessTest',
+                title: 'Local Serverless Test',
+                expectedStatus: 'passed',
+                location: { file: 'test.spec.ts', line: 1, column: 1 },
+                tags: ['@local-serverless-search'],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    runDiscoverPlaywrightConfigs(flagsReader, log);
+
+    // pluginA config1 has @local-stateful-classic which matches @local-stateful-*
+    // pluginA parallel has @cloud-serverless-search which does NOT match
+    // pluginB has @cloud-serverless-workplaceai which does NOT match
+    // pluginLocalServerless has @local-serverless-search which does NOT match @local-stateful-*
+    // packageA has @local-stateful-classic which matches @local-stateful-*
+
+    const infoCalls = log.info.mock.calls;
+    const foundMessage = infoCalls.find((call) =>
+      call[0].includes('Found Playwright config files')
+    );
+    expect(foundMessage).toBeDefined();
+    expect(foundMessage![0]).toContain('1 plugin(s)'); // pluginA only
+    expect(foundMessage![0]).toContain('1 package(s)'); // packageA
+
+    // Verify only @local-stateful-* tags are kept
+    const configLogCall = infoCalls.find((call) =>
+      call[0].includes('config1.playwright.config.ts')
+    );
+    expect(configLogCall).toBeDefined();
+    expect(configLogCall![0]).toContain('@local-stateful-classic');
+    expect(configLogCall![0]).not.toContain('@cloud-stateful-classic');
+    expect(configLogCall![0]).not.toContain('@cloud-serverless');
+    expect(configLogCall![0]).not.toContain('@local-serverless');
+
+    // pluginLocalServerless should be excluded
+    const localServerlessLog = infoCalls.find((call) => call[0].includes('pluginLocalServerless'));
+    expect(localServerlessLog).toBeUndefined();
   });
 
   it('includes custom-server configs alongside defaults when "include-custom-servers" is true', () => {
@@ -467,7 +574,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
   });
 
   it('filters config tags to only include cross tags', () => {
-    flagsReader.enum.mockReturnValue('ech'); // ESS_ONLY = ['@local-stateful-classic']
+    flagsReader.enum.mockReturnValue('ech'); // @cloud-stateful-* tags only
     flagsReader.boolean.mockReturnValue(false);
 
     runDiscoverPlaywrightConfigs(flagsReader, log);
@@ -479,8 +586,10 @@ describe('runDiscoverPlaywrightConfigs', () => {
     );
 
     expect(configLogCall).toBeDefined();
-    // pluginA config1 has tags ['@local-stateful-classic', '@cloud-serverless-observability_complete', '@cloud-serverless-security_complete'], but after filtering for ESS_ONLY, only [@local-stateful-classic] should remain
-    expect(configLogCall![0]).toContain('tags: [@local-stateful-classic]');
+    // pluginA config1 has tags ['@local-stateful-classic', '@cloud-stateful-classic', '@cloud-serverless-observability_complete', '@cloud-serverless-security_complete'],
+    // but after filtering for ech (@cloud-stateful-*), only [@cloud-stateful-classic] should remain
+    expect(configLogCall![0]).toContain('tags: [@cloud-stateful-classic]');
+    expect(configLogCall![0]).not.toContain('@local-stateful-classic');
     expect(configLogCall![0]).not.toContain('@cloud-serverless-observability_complete');
     expect(configLogCall![0]).not.toContain('@cloud-serverless-security_complete');
   });
@@ -504,7 +613,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
   });
 
   it('logs "No Playwright config files found" when no configs match target tags', () => {
-    flagsReader.enum.mockReturnValue('ech'); // ESS_ONLY
+    flagsReader.enum.mockReturnValue('ech'); // @cloud-stateful-* tags only
     flagsReader.boolean.mockReturnValue(false);
 
     // Set up modules with no matching tags
@@ -569,12 +678,12 @@ describe('runDiscoverPlaywrightConfigs', () => {
   });
 
   it('filters out modules with no matching configs after tag filtering', () => {
-    flagsReader.enum.mockReturnValue('ech'); // ESS_ONLY = ['@local-stateful-classic']
+    flagsReader.enum.mockReturnValue('ech'); // @cloud-stateful-* tags only
     flagsReader.boolean.mockReturnValue(false);
 
     runDiscoverPlaywrightConfigs(flagsReader, log);
 
-    // pluginB has serverless-workplaceai which is not in ESS_ONLY, it should be filtered out
+    // pluginB has @cloud-serverless-workplaceai which doesn't match @cloud-stateful-*, it should be filtered out
     const infoCalls = log.info.mock.calls;
     const moduleLogs = infoCalls.filter(
       (call) => call[0].includes('] plugin:') || call[0].includes('] package:')

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
@@ -233,10 +233,12 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
  * Scout tests, filters them based on deployment target tags, and optionally saves
  * or validates the results.
  *
- * The command supports three deployment targets:
+ * The command supports five deployment targets:
  * - 'all': Finds configs with deployment-agnostic tags
- * - 'mki': Finds configs with serverless-only tags
- * - 'ech': Finds configs with stateful-only tag
+ * - 'local': Finds configs with @local-* tags (local stateful + local serverless)
+ * - 'local-stateful-only': Finds configs with @local-stateful-* tags only
+ * - 'mki': Finds configs with @cloud-serverless-* tags
+ * - 'ech': Finds configs with @cloud-stateful-* tags
  *
  * Output formats:
  * - Standard: Lists modules grouped by plugin/package with their configs and tags
@@ -254,8 +256,10 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
   Options:
     --target <target>         Filter configs by deployment target:
                               - 'all': deployment-agnostic tags (default)
-                              - 'mki': serverless-only tags
-                              - 'ech': stateful-only tags
+                              - 'local': @local-* tags (local stateful + local serverless)
+                              - 'local-stateful-only': @local-stateful-* tags only
+                              - 'mki': @cloud-serverless-* tags
+                              - 'ech': @cloud-stateful-* tags
     --include-custom-servers  Include configs under 'test/scout_*' paths for custom server setups
     --validate                Validate that all discovered modules are registered in Scout CI config
     --save                    Validate and save enabled modules to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'
@@ -266,8 +270,17 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
     # Discover all deployment-agnostic configs
     node scripts/scout discover-playwright-configs
 
-    # Discover serverless-only configs
+    # Discover configs for local targets (@local-*)
+    node scripts/scout discover-playwright-configs --target local
+
+    # Discover only local stateful configs (@local-stateful-*)
+    node scripts/scout discover-playwright-configs --target local-stateful-only
+
+    # Discover cloud serverless configs (@cloud-serverless-*)
     node scripts/scout discover-playwright-configs --target mki
+
+    # Discover cloud stateful configs (@cloud-stateful-*)
+    node scripts/scout discover-playwright-configs --target ech
 
     # Discover local custom-server configs only
     node scripts/scout discover-playwright-configs --include-custom-servers

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.test.ts
@@ -10,18 +10,32 @@
 import { collectUniqueTags, getServerRunFlagsFromTags, getTestTagsForTarget } from './tag_utils';
 
 describe('getTestTagsForTarget', () => {
-  it('returns tags.serverless.all for target "mki"', () => {
+  it('returns only @local-* tags for target "local"', () => {
+    const result = getTestTagsForTarget('local');
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    result.forEach((tag) => expect(tag).toMatch(/^@local-/));
+  });
+
+  it('returns only @local-stateful-* tags for target "local-stateful-only"', () => {
+    const result = getTestTagsForTarget('local-stateful-only');
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    result.forEach((tag) => expect(tag).toMatch(/^@local-stateful-/));
+  });
+
+  it('returns only @cloud-serverless-* tags for target "mki"', () => {
     const result = getTestTagsForTarget('mki');
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBeGreaterThan(0);
-    result.forEach((tag) => expect(tag.startsWith('@')).toBe(true));
+    result.forEach((tag) => expect(tag).toMatch(/^@cloud-serverless-/));
   });
 
-  it('returns tags.stateful.all for target "ech"', () => {
+  it('returns only @cloud-stateful-* tags for target "ech"', () => {
     const result = getTestTagsForTarget('ech');
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBeGreaterThan(0);
-    result.forEach((tag) => expect(tag.startsWith('@')).toBe(true));
+    result.forEach((tag) => expect(tag).toMatch(/^@cloud-stateful-/));
   });
 
   it('returns tags.deploymentAgnostic for target "all"', () => {

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.ts
@@ -8,16 +8,20 @@
  */
 
 import type { ScoutTargetArch, ScoutTargetDomain } from '@kbn/scout-info';
-import { ScoutTestTarget } from '@kbn/scout-info';
+import { ScoutTestTarget, testTargets } from '@kbn/scout-info';
 import { tags } from '../playwright/tags';
 
 // Gets test tags for a given target type
 export const getTestTagsForTarget = (target: string): string[] => {
   switch (target) {
+    case 'local':
+      return testTargets.local.map((t) => t.playwrightTag);
+    case 'local-stateful-only':
+      return testTargets.local.filter((t) => t.arch === 'stateful').map((t) => t.playwrightTag);
     case 'mki':
-      return tags.serverless.all;
+      return testTargets.cloud.filter((t) => t.arch === 'serverless').map((t) => t.playwrightTag);
     case 'ech':
-      return tags.stateful.all;
+      return testTargets.cloud.filter((t) => t.arch === 'stateful').map((t) => t.playwrightTag);
     case 'all':
     default:
       return tags.deploymentAgnostic;

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
@@ -10,10 +10,10 @@
 // Target type for filtering Playwright configs by deployment target
 import type { ScoutTargetArch, ScoutTargetDomain } from '@kbn/scout-info';
 
-export type TargetType = 'all' | 'mki' | 'ech';
+export type TargetType = 'all' | 'local' | 'local-stateful-only' | 'mki' | 'ech';
 
 // Valid target types
-export const TARGET_TYPES: TargetType[] = ['all', 'mki', 'ech'];
+export const TARGET_TYPES: TargetType[] = ['all', 'local', 'local-stateful-only', 'mki', 'ech'];
 
 // Module discovery information used in regular CI pipelines with locally run servers
 export interface ModuleDiscoveryInfo {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] fix tags filtering in config discovery (#253360)](https://github.com/elastic/kibana/pull/253360)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-02-17T13:51:34Z","message":"[scout] fix tags filtering in config discovery (#253360)\n\n## Summary\n\nWith Scout tagging redesign our playwright config discovery returns\nincorrect scope for regular Kibana CI runs:\n\n<img width=\"1260\" height=\"282\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69250fa6-dca7-485b-8df8-ec890bc1222f\"\n/>\n\nIt includes both `@local-*` and `@cloud-` tags, while only the first one\nis running on regular pipelines.\n\nThis PR:\n<img width=\"1260\" height=\"282\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c0f980db-e057-4489-bb7f-7bd10c54e4d1\"\n/>\n\nCloses https://github.com/elastic/appex-qa-team/issues/695","sha":"650860c1ebda5df6c007ff19fe1ca429e7a5a9f6","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0","v9.3.1","v9.2.6"],"title":"[scout] fix tags filtering in config discovery","number":253360,"url":"https://github.com/elastic/kibana/pull/253360","mergeCommit":{"message":"[scout] fix tags filtering in config discovery (#253360)\n\n## Summary\n\nWith Scout tagging redesign our playwright config discovery returns\nincorrect scope for regular Kibana CI runs:\n\n<img width=\"1260\" height=\"282\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69250fa6-dca7-485b-8df8-ec890bc1222f\"\n/>\n\nIt includes both `@local-*` and `@cloud-` tags, while only the first one\nis running on regular pipelines.\n\nThis PR:\n<img width=\"1260\" height=\"282\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c0f980db-e057-4489-bb7f-7bd10c54e4d1\"\n/>\n\nCloses https://github.com/elastic/appex-qa-team/issues/695","sha":"650860c1ebda5df6c007ff19fe1ca429e7a5a9f6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253360","number":253360,"mergeCommit":{"message":"[scout] fix tags filtering in config discovery (#253360)\n\n## Summary\n\nWith Scout tagging redesign our playwright config discovery returns\nincorrect scope for regular Kibana CI runs:\n\n<img width=\"1260\" height=\"282\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69250fa6-dca7-485b-8df8-ec890bc1222f\"\n/>\n\nIt includes both `@local-*` and `@cloud-` tags, while only the first one\nis running on regular pipelines.\n\nThis PR:\n<img width=\"1260\" height=\"282\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c0f980db-e057-4489-bb7f-7bd10c54e4d1\"\n/>\n\nCloses https://github.com/elastic/appex-qa-team/issues/695","sha":"650860c1ebda5df6c007ff19fe1ca429e7a5a9f6"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/253755","number":253755,"state":"MERGED","mergeCommit":{"sha":"1ca21c8be0bdef94a67ed5c05c22965a499ce0d1","message":"[9.3] [scout] fix tags filtering in config discovery (#253360) (#253755)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[scout] fix tags filtering in config discovery\n(#253360)](https://github.com/elastic/kibana/pull/253360)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"9.2","label":"v9.2.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/253489","number":253489,"state":"MERGED","mergeCommit":{"sha":"e221fb6ed5b75b11cd4314a30746d5740cef17c2","message":"[9.2] [scout] fix tags filtering in config discovery (#253360) (#253489)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[scout] fix tags filtering in config discovery\n(#253360)](https://github.com/elastic/kibana/pull/253360)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}}]}] BACKPORT-->