### PR TITLE
[Security Solution] Remove deprecated security-detections-response team from the codebase

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -610,7 +610,7 @@ src/platform/packages/shared/kbn-rison @elastic/kibana-operations
 src/platform/packages/shared/kbn-router-to-openapispec @elastic/kibana-core
 src/platform/packages/shared/kbn-router-utils @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-rrule @elastic/response-ops
-src/platform/packages/shared/kbn-rule-data-utils @elastic/security-detections-response @elastic/response-ops @elastic/actionable-obs-team
+src/platform/packages/shared/kbn-rule-data-utils @elastic/security-detection-rule-management @elastic/security-detection-engine @elastic/response-ops @elastic/actionable-obs-team
 src/platform/packages/shared/kbn-safer-lodash-set @elastic/kibana-security
 src/platform/packages/shared/kbn-saved-search-component @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-scout @elastic/appex-qa

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -79,7 +79,6 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/security-design',
     'elastic/security-detection-engine',
     'elastic/security-detection-rule-management',
-    'elastic/security-detections-response',
     'elastic/security-engineering-productivity',
     'elastic/security-entity-analytics',
     'elastic/security-generative-ai',

--- a/src/platform/packages/shared/kbn-rule-data-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-rule-data-utils/kibana.jsonc
@@ -2,7 +2,8 @@
   "type": "shared-common",
   "id": "@kbn/rule-data-utils",
   "owner": [
-    "@elastic/security-detections-response",
+    "@elastic/security-detection-rule-management",
+    "@elastic/security-detection-engine",
     "@elastic/response-ops",
     "@elastic/actionable-obs-team"
   ],

--- a/src/platform/packages/shared/kbn-rule-data-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-rule-data-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/rule-data-utils'
 type: unknown
 owners:
-  defaultOwner: '@elastic/security-detections-response'
+  defaultOwner: '@elastic/security-detection-rule-management'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/rule-data-utils'
   description: Moon project for @kbn/rule-data-utils
   channel: ''
-  owner: '@elastic/security-detections-response'
+  owner: '@elastic/security-detection-rule-management'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-rule-data-utils
 dependsOn:

--- a/x-pack/platform/plugins/shared/stack_connectors/README.md
+++ b/x-pack/platform/plugins/shared/stack_connectors/README.md
@@ -394,7 +394,7 @@ When creating a new connector type, your plugin will eventually call `server.plu
 
 Consider working with the alerting team on early structure /design feedback of new connectors, especially as the APIs and infrastructure are still under development.
 
-Don't forget to ping @elastic/security-detections-response to see if the new connector should be enabled within their solution.
+Don't forget to ping @elastic/security-detection-rule-management and @elastic/security-detection-engine to see if the new connector should be enabled within their solution.
 
 ## Licensing
 


### PR DESCRIPTION
## Summary

We're deprecating the umbrella @elastic/security-detections-response team and replacing it with:

- @elastic/security-detection-engine 
- @elastic/security-detection-rule-management 

This is a clean-up PR that removes the remaining mentions of the team.
