### PR TITLE
[9.3] Upgrade dompurify 3.3.0 → 3.3.2 (#256444)

### DIFF
--- a/oas_docs/package-lock.json
+++ b/oas_docs/package-lock.json
@@ -1461,10 +1461,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
-      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -1286,7 +1286,7 @@
     "del": "6.1.1",
     "diff": "8.0.3",
     "dom-to-image-more": "3.6.0",
-    "dompurify": "3.3.0",
+    "dompurify": "3.3.2",
     "dotenv": "17.2.4",
     "elastic-apm-node": "4.15.0",
     "email-addresses": "5.0.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -82,10 +82,10 @@ export const DEV_ONLY_LICENSE_ALLOWED = ['MPL-2.0', '(MPL-2.0 OR Apache-2.0)'];
 // but can be brought in on a per-package basis
 export const PER_PACKAGE_ALLOWED_LICENSES = {
   'openpgp@5.11.3': ['LGPL-3.0+'],
-  'dompurify@3.2.4': ['(MPL-2.0 OR Apache-2.0)'],
-  '@img/sharp-libvips-linuxmusl-x64@1.2.3': ['LGPL-3.0-or-later'],
-  '@img/sharp-libvips-linux-x64@1.2.3': ['LGPL-3.0-or-later'],
-  'dompurify@3.3.0': ['(MPL-2.0 OR Apache-2.0)'],
+  '@img/sharp-libvips-darwin-arm64@1.2.4': ['LGPL-3.0-or-later'],
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4': ['LGPL-3.0-or-later'],
+  '@img/sharp-libvips-linux-x64@1.2.4': ['LGPL-3.0-or-later'],
+  'dompurify@3.3.2': ['(MPL-2.0 OR Apache-2.0)'],
 };
 // Globally overrides a license for a given package@version
 export const LICENSE_OVERRIDES = {

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -82,9 +82,8 @@ export const DEV_ONLY_LICENSE_ALLOWED = ['MPL-2.0', '(MPL-2.0 OR Apache-2.0)'];
 // but can be brought in on a per-package basis
 export const PER_PACKAGE_ALLOWED_LICENSES = {
   'openpgp@5.11.3': ['LGPL-3.0+'],
-  '@img/sharp-libvips-darwin-arm64@1.2.4': ['LGPL-3.0-or-later'],
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4': ['LGPL-3.0-or-later'],
-  '@img/sharp-libvips-linux-x64@1.2.4': ['LGPL-3.0-or-later'],
+  '@img/sharp-libvips-linuxmusl-x64@1.2.3': ['LGPL-3.0-or-later'],
+  '@img/sharp-libvips-linux-x64@1.2.3': ['LGPL-3.0-or-later'],
   'dompurify@3.3.2': ['(MPL-2.0 OR Apache-2.0)'],
 };
 // Globally overrides a license for a given package@version

--- a/yarn.lock
+++ b/yarn.lock
@@ -19497,10 +19497,10 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@3.3.0, dompurify@^3.2.4:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.0.tgz#aaaadbb83d87e1c2fbb066452416359e5b62ec97"
-  integrity sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==
+dompurify@3.3.2, dompurify@^3.2.4:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.2.tgz#58c515d0f8508b8749452a028aa589ad80b36325"
+  integrity sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Upgrade dompurify 3.3.0 → 3.3.2 (#256444)](https://github.com/elastic/kibana/pull/256444)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-03-09T16:33:54Z","message":"Upgrade dompurify 3.3.0 → 3.3.2 (#256444)\n\n## Summary\n\nUpgrades `dompurify` to version 3.3.2, including OAS docs utility","sha":"d02804a35dc553cc3641210dc81c61be7c6584b5","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.4.0"],"title":"Upgrade dompurify 3.3.0 → 3.3.2","number":256444,"url":"https://github.com/elastic/kibana/pull/256444","mergeCommit":{"message":"Upgrade dompurify 3.3.0 → 3.3.2 (#256444)\n\n## Summary\n\nUpgrades `dompurify` to version 3.3.2, including OAS docs utility","sha":"d02804a35dc553cc3641210dc81c61be7c6584b5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256444","number":256444,"mergeCommit":{"message":"Upgrade dompurify 3.3.0 → 3.3.2 (#256444)\n\n## Summary\n\nUpgrades `dompurify` to version 3.3.2, including OAS docs utility","sha":"d02804a35dc553cc3641210dc81c61be7c6584b5"}}]}] BACKPORT-->