### PR TITLE
[DO NOT MERGE] POC - Explore APM SLOs in Discover

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/hooks/use_chart_layers_from_esql.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/hooks/use_chart_layers_from_esql.ts
@@ -11,6 +11,7 @@ import type { LensBaseLayer, LensSeriesLayer } from '@kbn/lens-embeddable-utils'
 import useAsync from 'react-use/lib/useAsync';
 import { useMemo } from 'react';
 import type { TimeRange } from '@kbn/data-plugin/common';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 import { getESQLQueryColumns } from '@kbn/esql-utils';
 import type { MetricUnit } from '../../../types';
 import { useEsqlQueryInfo } from '../../../hooks';
@@ -25,6 +26,7 @@ interface ChartLayersFromEsqlProps {
   seriesType: LensSeriesLayer['seriesType'];
   services: UnifiedMetricsGridProps['services'];
   abortController?: AbortController;
+  variables?: ESQLControlVariable[];
 }
 
 export interface ChartLayersFromEsqlResult {
@@ -41,6 +43,7 @@ export const useChartLayersFromEsql = ({
   services,
   unit,
   abortController,
+  variables,
 }: ChartLayersFromEsqlProps): ChartLayersFromEsqlResult => {
   const queryInfo = useEsqlQueryInfo({ query });
 
@@ -55,9 +58,10 @@ export const useChartLayersFromEsql = ({
         search: services.data.search.search,
         signal: abortController?.signal,
         timeRange,
+        variables,
       }),
 
-    [query, services.data.search, abortController, timeRange]
+    [query, services.data.search, abortController, timeRange, variables]
   );
 
   const layers = useMemo<LensSeriesLayer[]>(() => {

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
@@ -6,10 +6,12 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { PresentationPanelQuickActionContext } from '@kbn/presentation-panel-plugin/public';
+import type { AggregateQuery, Query } from '@kbn/es-query';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { LensProps } from './hooks/use_lens_props';
 import { useLensExtraActions } from './hooks/use_lens_extra_actions';
 import { ACTION_EXPLORE_IN_DISCOVER_TAB } from '../../common/constants';
@@ -82,19 +84,19 @@ export function LensWrapper({
     }
   `;
 
+  const resolvedQuery = useMemo(
+    () => resolveEsqlVariables(lensProps.attributes.state.query, lensProps.esqlVariables),
+    [lensProps.attributes.state.query, lensProps.esqlVariables]
+  );
+
   const handleExploreInDiscoverTab = useCallback(
     () =>
       onExploreInDiscoverTab?.({
-        query: lensProps.attributes.state.query,
+        query: resolvedQuery,
         tabLabel: lensProps.attributes.title,
         timeRange: lensProps.timeRange,
       }),
-    [
-      lensProps.attributes.state.query,
-      lensProps.attributes.title,
-      lensProps.timeRange,
-      onExploreInDiscoverTab,
-    ]
+    [resolvedQuery, lensProps.attributes.title, lensProps.timeRange, onExploreInDiscoverTab]
   );
 
   const extraActions = useLensExtraActions({
@@ -128,4 +130,21 @@ export function LensWrapper({
       </PresentationPanelQuickActionContext.Provider>
     </div>
   );
+}
+
+function resolveEsqlVariables(
+  query: Query | AggregateQuery,
+  variables: ESQLControlVariable[] | undefined
+): Query | AggregateQuery {
+  if (!variables?.length || !('esql' in query)) {
+    return query;
+  }
+
+  let resolved = query.esql;
+  for (const { key, value } of variables) {
+    const literal = typeof value === 'string' ? `"${value}"` : String(value);
+    resolved = resolved.replaceAll(`?${key}`, literal);
+  }
+
+  return { esql: resolved };
 }

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/error_rate.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/traces/error_rate.tsx
@@ -35,7 +35,7 @@ const ErrorRateChartContent = ({
 }: ErrorRateChartContentProps) => {
   const { services, fetchParams, discoverFetch$, onBrushEnd, onFilter, actions } =
     useTraceMetricsContext();
-  const { abortController, timeRange } = fetchParams;
+  const { abortController, timeRange, esqlVariables } = fetchParams;
 
   const {
     layers: chartLayers,
@@ -49,6 +49,7 @@ const ErrorRateChartContent = ({
     unit,
     color,
     abortController,
+    variables: esqlVariables,
   });
 
   return (

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_apm_indices.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_apm_indices.ts
@@ -18,7 +18,24 @@ export interface UseFetchApmIndex {
   isError: boolean;
 }
 
+interface ApmIndicesData {
+  metric: string;
+  transaction: string;
+}
+
+export interface UseFetchApmIndices {
+  data: ApmIndicesData;
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+}
+
 export function useFetchApmIndex(): UseFetchApmIndex {
+  const { data, ...rest } = useFetchApmIndices();
+  return { data: data.metric, ...rest };
+}
+
+export function useFetchApmIndices(): UseFetchApmIndices {
   const { apmSourcesAccess } = useKibana().services;
 
   const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data } = useQuery({
@@ -27,7 +44,10 @@ export function useFetchApmIndex(): UseFetchApmIndex {
       try {
         const response = await apmSourcesAccess.getApmIndices({ signal });
 
-        return response.metric ?? '';
+        return {
+          metric: response.metric ?? '',
+          transaction: response.transaction ?? '',
+        };
       } catch (error) {
         // ignore error
       }
@@ -36,7 +56,9 @@ export function useFetchApmIndex(): UseFetchApmIndex {
   });
 
   return {
-    data: isInitialLoading ? '' : data ?? '',
+    data: isInitialLoading
+      ? { metric: '', transaction: '' }
+      : data ?? { metric: '', transaction: '' },
     isLoading: isInitialLoading || isLoading || isRefetching,
     isSuccess,
     isError,

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/events_chart_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/events_chart_panel.tsx
@@ -19,10 +19,12 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
 import React from 'react';
+import { useFetchApmIndices } from '../../../../hooks/use_fetch_apm_indices';
 import { useGetPreviewData } from '../../../../hooks/use_get_preview_data';
 import { useKibana } from '../../../../hooks/use_kibana';
 import type { TimeBounds } from '../../types';
 import { getDiscoverLink } from '../../utils/discover_links/get_discover_link';
+import { getDiscoverEsqlLink } from '../../utils/discover_links/get_discover_esql_link';
 import { GoodBadEventsChart } from './good_bad_events_chart';
 import { MetricTimesliceEventsChart } from './metric_timeslice_events_chart';
 
@@ -35,6 +37,15 @@ export interface Props {
 
 export function EventsChartPanel({ slo, range, hideRangeDurationLabel = false, onBrushed }: Props) {
   const { discover, uiSettings } = useKibana().services;
+  const { data: apmIndices } = useFetchApmIndices();
+
+  const esqlLink = getDiscoverEsqlLink({
+    slo,
+    timeRange: { from: 'now-24h', to: 'now' },
+    discover,
+    apmTransactionIndex: apmIndices.transaction,
+  });
+
   const { isLoading, data } = useGetPreviewData({
     range,
     isValid: true,
@@ -109,24 +120,38 @@ export function EventsChartPanel({ slo, range, hideRangeDurationLabel = false, o
 
           <EuiFlexItem grow={0}>
             <EuiLink
-              color="text"
-              href={getDiscoverLink({
-                slo,
-                timeRange: {
-                  from: 'now-24h',
-                  to: 'now',
-                  mode: 'relative',
-                },
-                discover,
-                uiSettings,
-              })}
+              href={
+                esqlLink ??
+                getDiscoverLink({
+                  slo,
+                  timeRange: {
+                    from: 'now-24h',
+                    to: 'now',
+                    mode: 'relative',
+                  },
+                  discover,
+                  uiSettings,
+                })
+              }
               data-test-subj="sloDetailDiscoverLink"
             >
-              <EuiIcon type="sortRight" css={{ marginRight: '4px' }} />
-              <FormattedMessage
-                id="xpack.slo.sloDetails.viewEventsLink"
-                defaultMessage="View events"
-              />
+              {esqlLink ? (
+                <>
+                  <EuiIcon type="discoverApp" aria-hidden css={{ marginRight: '4px' }} />
+                  <FormattedMessage
+                    id="xpack.slo.sloDetails.openTracesLink"
+                    defaultMessage="Explore traces"
+                  />
+                </>
+              ) : (
+                <>
+                  <EuiIcon type="sortRight" aria-hidden css={{ marginRight: '4px' }} />
+                  <FormattedMessage
+                    id="xpack.slo.sloDetails.viewEventsLink"
+                    defaultMessage="View events"
+                  />
+                </>
+              )}
             </EuiLink>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/utils/discover_links/get_discover_esql_link.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/utils/discover_links/get_discover_esql_link.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DiscoverStart } from '@kbn/discover-plugin/public';
+import type { TimeRange } from '@kbn/es-query';
+import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
+import {
+  ALL_VALUE,
+  apmTransactionDurationIndicatorSchema,
+  apmTransactionErrorRateIndicatorSchema,
+  kqlWithFiltersSchema,
+} from '@kbn/slo-schema';
+
+const SLO_EVENT_VARIABLE = 'slo_event_filter';
+
+interface EsqlLinkConfig {
+  esql: string;
+}
+
+function getTransactionIndex(slo: SLOWithSummaryResponse, apmTransactionIndex: string): string {
+  if (slo.remote) {
+    return apmTransactionIndex
+      .split(',')
+      .map((p) => `${slo.remote!.remoteName}:${p.trim()}`)
+      .join(',');
+  }
+  return apmTransactionIndex;
+}
+
+function appendApmWhereFilters(
+  whereClauses: string[],
+  params: {
+    service: string;
+    environment: string;
+    transactionType: string;
+    transactionName: string;
+    filter?: unknown;
+  }
+) {
+  if (params.service !== ALL_VALUE) {
+    whereClauses.push(`service.name == "${params.service}"`);
+  }
+  if (params.environment !== ALL_VALUE) {
+    whereClauses.push(`service.environment == "${params.environment}"`);
+  }
+  if (params.transactionType !== ALL_VALUE) {
+    whereClauses.push(`transaction.type == "${params.transactionType}"`);
+  }
+  if (params.transactionName !== ALL_VALUE) {
+    whereClauses.push(`transaction.name == "${params.transactionName}"`);
+  }
+
+  if (params.filter) {
+    const filterKuery = kqlWithFiltersSchema.is(params.filter)
+      ? params.filter.kqlQuery
+      : String(params.filter);
+    if (filterKuery) {
+      whereClauses.push(filterKuery);
+    }
+  }
+}
+
+function buildApmLatencyEsqlConfig(
+  slo: SLOWithSummaryResponse,
+  apmTransactionIndex: string
+): EsqlLinkConfig | undefined {
+  if (!apmTransactionDurationIndicatorSchema.is(slo.indicator)) {
+    return undefined;
+  }
+
+  const { params } = slo.indicator;
+  const index = getTransactionIndex(slo, apmTransactionIndex);
+  const thresholdMicros = Math.trunc(params.threshold * 1000);
+
+  const whereClauses: string[] = ['TO_STRING(processor.event) == "transaction"'];
+  appendApmWhereFilters(whereClauses, params);
+
+  const sloEventFilter = [
+    `(?${SLO_EVENT_VARIABLE} == "bad" AND transaction.duration.us > ${thresholdMicros})`,
+    `OR (?${SLO_EVENT_VARIABLE} == "good" AND transaction.duration.us <= ${thresholdMicros})`,
+    `OR ?${SLO_EVENT_VARIABLE} == "all"`,
+  ].join(' ');
+
+  const esql = [
+    `FROM ${index}`,
+    `  | WHERE ${whereClauses.join(' AND ')}`,
+    `  | EVAL slo_event = CASE(transaction.duration.us <= ${thresholdMicros}, "good", "bad")`,
+    `  | WHERE ${sloEventFilter}`,
+  ].join('\n');
+
+  return { esql };
+}
+
+function buildApmAvailabilityEsqlConfig(
+  slo: SLOWithSummaryResponse,
+  apmTransactionIndex: string
+): EsqlLinkConfig | undefined {
+  if (!apmTransactionErrorRateIndicatorSchema.is(slo.indicator)) {
+    return undefined;
+  }
+
+  const { params } = slo.indicator;
+  const index = getTransactionIndex(slo, apmTransactionIndex);
+
+  const whereClauses: string[] = [
+    'TO_STRING(processor.event) == "transaction"',
+    'event.outcome IN ("success", "failure")',
+  ];
+  appendApmWhereFilters(whereClauses, params);
+
+  const sloEventFilter = [
+    `(?${SLO_EVENT_VARIABLE} == "bad" AND event.outcome == "failure")`,
+    `OR (?${SLO_EVENT_VARIABLE} == "good" AND event.outcome == "success")`,
+    `OR ?${SLO_EVENT_VARIABLE} == "all"`,
+  ].join(' ');
+
+  const esql = [
+    `FROM ${index}`,
+    `  | WHERE ${whereClauses.join(' AND ')}`,
+    `  | EVAL slo_event = CASE(event.outcome == "success", "good", "bad")`,
+    `  | WHERE ${sloEventFilter}`,
+  ].join('\n');
+
+  return { esql };
+}
+
+function buildEsqlConfig(
+  slo: SLOWithSummaryResponse,
+  apmTransactionIndex: string
+): EsqlLinkConfig | undefined {
+  return (
+    buildApmLatencyEsqlConfig(slo, apmTransactionIndex) ??
+    buildApmAvailabilityEsqlConfig(slo, apmTransactionIndex)
+  );
+}
+
+function buildSloEventControl() {
+  return {
+    'slo-event-control': {
+      type: 'esqlControl',
+      order: 0,
+      variable_name: SLO_EVENT_VARIABLE,
+      variable_type: 'values',
+      available_options: ['all', 'good', 'bad'],
+      selected_options: ['bad'],
+      single_select: true,
+      title: 'SLO event',
+      esql_query: '',
+      control_type: 'STATIC_VALUES',
+    },
+  };
+}
+
+export function getDiscoverEsqlLink({
+  slo,
+  timeRange,
+  discover,
+  apmTransactionIndex,
+}: {
+  slo: SLOWithSummaryResponse;
+  timeRange: TimeRange;
+  discover?: DiscoverStart;
+  apmTransactionIndex: string;
+}): string | undefined {
+  if (!apmTransactionIndex) {
+    return undefined;
+  }
+
+  const config = buildEsqlConfig(slo, apmTransactionIndex);
+  if (!config) {
+    return undefined;
+  }
+
+  return discover?.locator?.getRedirectUrl({
+    query: { esql: config.esql },
+    timeRange,
+    esqlControls: buildSloEventControl() as Record<string, unknown> as any,
+  });
+}


### PR DESCRIPTION

## Summary

> [!WARNING]
> This PR is not meant to be merged. 
It is a POC intended solely for product testing and validation purposes.


POC for exploring good vs bad SLO events in Discover's traces experience. When viewing an APM SLO (latency or availability), the "Good vs bad events" chart now offers an "Open traces" link that navigates to Discover with:

- An ES|QL query targeting APM transaction indices (fetched from APM settings) that classifies each event as "good" or "bad" based on the SLO threshold
- An interactive ES|QL control (`slo_event_filter`) defaulting to "bad", allowing users to toggle between bad, good, and all events
- The Discover traces experience activated (RED metrics charts + waterfall)

### Changes

**SLO plugin** (`x-pack/solutions/observability/plugins/slo/`)
- `get_discover_esql_link.ts` — New utility that builds an ES|QL query with `EVAL slo_event = CASE(...)` classification and a `WHERE` clause driven by the `?slo_event_filter` variable, plus the static control definition
- `use_fetch_apm_indices.ts` — New `useFetchApmIndices()` hook returning both `metric` and `transaction` index patterns from APM settings
- `events_chart_panel.tsx` — Conditionally renders "Open traces" with the Discover icon when the ES|QL link is available, falls back to the existing "View events" link

**Platform fixes** (`src/platform/packages/shared/kbn-unified-chart-section-viewer/`)
- `use_chart_layers_from_esql.ts` — Forward `variables` to `getESQLQueryColumns` (was missing, causing charts to fail with custom ES|QL variables)
- `error_rate.tsx` — Pass `fetchParams.esqlVariables` to the hook
- `lens_wrapper.tsx` — Resolve custom ES|QL variables to literal values in the query before opening a new Discover tab via "Explore"

### Supported SLO types

| Indicator | Filter logic | Classification |
|---|---|---|
| APM Latency (`sli.apm.transactionDuration`) | `transaction.duration.us > threshold` | good if duration <= threshold |
| APM Availability (`sli.apm.transactionErrorRate`) | `event.outcome == "failure"` | good if outcome == success |

### How to test

1. Create an APM SLO (latency or availability type) with synthtrace or real APM data
2. Navigate to the SLO detail page
3. Click "Open traces" on the "Good vs bad events" chart
4. Verify Discover opens with the traces experience, the ES|QL control defaults to "bad", and toggling the control filters events accordingly
5. Verify RED metrics charts render correctly
6. Verify "Explore" on a chart opens a new tab with resolved variable values