### PR TITLE
[ci/es_snapshots/promote] Remove old pipeline trigger

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -13,11 +13,6 @@ EOF
 
 ts-node "$(dirname "${0}")/promote_manifest.ts" "$ES_SNAPSHOT_MANIFEST"
 
-if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
-  echo "--- Trigger agent packer cache pipeline"
-  ts-node .buildkite/scripts/steps/trigger_pipeline.ts kibana-agent-packer-cache main
-fi
-
 cat << EOF | buildkite-agent pipeline upload
 steps:
   - label: "Update cache for ES $BUILDKITE_BRANCH snapshot"


### PR DESCRIPTION
This pipeline is no longer used.  The pipeline upload below is its replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build pipeline configuration to streamline snapshot promotion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->