### PR TITLE
[ES|QL] Fixes timefield regression for multiple indices with @timestamp

### DIFF
--- a/src/platform/plugins/shared/esql/server/integration_tests/esql_routes.test.ts
+++ b/src/platform/plugins/shared/esql/server/integration_tests/esql_routes.test.ts
@@ -221,6 +221,78 @@ describe('ESQL routes', () => {
       await client.indices.delete({ index: index2 });
     });
 
+    it('should return @timestamp for multiple indices without subqueries when all have @timestamp', async () => {
+      const index1 = 'multi_ts_index1';
+      const index2 = 'multi_ts_index2';
+      const client = testbed.esClient();
+
+      await client.indices.create({
+        index: index1,
+        mappings: {
+          properties: {
+            '@timestamp': { type: 'date' },
+            field1: { type: 'keyword' },
+          },
+        },
+      });
+
+      await client.indices.create({
+        index: index2,
+        mappings: {
+          properties: {
+            '@timestamp': { type: 'date' },
+            field2: { type: 'keyword' },
+          },
+        },
+      });
+
+      const query = `FROM ${index1}, ${index2}`;
+      const url = `/internal/esql/get_timefield/${encodeURIComponent(query)}`;
+      const result = await testbed.GET(url).send().expect(200);
+
+      expect(result.body.timeField).toBe('@timestamp');
+
+      // Cleanup
+      await client.indices.delete({ index: index1 });
+      await client.indices.delete({ index: index2 });
+    });
+
+    it('should return @timestamp for multiple indices without subqueries when only some have @timestamp', async () => {
+      const index1 = 'mixed_ts_index1';
+      const index2 = 'mixed_no_ts_index2';
+      const client = testbed.esClient();
+
+      await client.indices.create({
+        index: index1,
+        mappings: {
+          properties: {
+            '@timestamp': { type: 'date' },
+            field1: { type: 'keyword' },
+          },
+        },
+      });
+
+      await client.indices.create({
+        index: index2,
+        mappings: {
+          properties: {
+            created_at: { type: 'date' },
+            field2: { type: 'keyword' },
+          },
+        },
+      });
+
+      const query = `FROM ${index1}, ${index2}`;
+      const url = `/internal/esql/get_timefield/${encodeURIComponent(query)}`;
+      const result = await testbed.GET(url).send().expect(200);
+
+      expect(result.body.timeField).toBe('@timestamp');
+
+      // Cleanup
+      await client.indices.delete({ index: index1 });
+      await client.indices.delete({ index: index2 });
+    });
+
     it('should return @timestamp when ES|QL source is a view that returns @timestamp', async () => {
       const indexName = 'test_timefield_view_index';
       const viewName = 'test-timefield-view';

--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
@@ -11,7 +11,7 @@ import type { ElasticsearchClient, IRouter, PluginInitializerContext } from '@kb
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import type { FieldCapsResponse } from '@elastic/elasticsearch/lib/api/types';
 import { getIndexPatternFromESQLQuery, getTimeFieldFromESQLQuery } from '@kbn/esql-utils';
-import { Parser } from '@elastic/esql';
+import { Parser, isSubQuery } from '@elastic/esql';
 import { TIMEFIELD_ROUTE } from '@kbn/esql-types';
 import { EsqlService } from '../services/esql_service';
 
@@ -110,15 +110,22 @@ export const registerGetTimeFieldRoute = (
         });
       }
       const sources = getIndexPatternFromESQLQuery(query);
+      const subqueryArgs = sourceCommand.args.filter(isSubQuery);
+      const hasSubqueries = subqueryArgs.length > 0;
       const service = new EsqlService({ client: core.elasticsearch.client.asCurrentUser });
       const { views } = await service.getViews().catch(() => ({ views: [] }));
       const viewNames = new Set(views.map(({ name }) => name));
 
       try {
-        const indices = sources
-          .split(',')
-          .map((index) => index.trim())
-          .filter(Boolean);
+        // In case of subqueries we need to check all indices separately.
+        // Otherwise, pass the full sources string to fieldCaps so Elasticsearch
+        // evaluates the multi-index pattern holistically.
+        const indices = hasSubqueries
+          ? sources
+              .split(',')
+              .map((index) => index.trim())
+              .filter(Boolean)
+          : [sources];
 
         if (!indices.length) {
           return response.ok({
@@ -126,29 +133,52 @@ export const registerGetTimeFieldRoute = (
           });
         }
 
-        const sourceChecks = await Promise.all(
-          indices.map(async (sourceName) => {
-            // If ES tells us it's a view, skip fieldCaps and inspect the ES|QL schema instead.
-            // This is temporary until we have a proper way to detect the time field for ES|QL views using field caps.
-            if (viewNames.has(sourceName)) {
-              return checkViewLikeSourceForTimestamp({ client, sourceName });
-            }
-
+        const fieldCapsResults = await Promise.all(
+          indices.map(async (index) => {
             try {
               const fieldCapsResp = await client.fieldCaps({
-                index: sourceName,
+                index,
                 fields: '@timestamp',
                 include_unmapped: false,
               });
               return hasTimestampInFieldCapsResponse(fieldCapsResp);
             } catch (fieldCapsError) {
               logger.get().debug(toDebugString(fieldCapsError));
+              return false;
             }
           })
         );
 
+        const allHaveTimestamp = fieldCapsResults.every(Boolean);
+
+        if (allHaveTimestamp) {
+          return response.ok({
+            body: { timeField: ES_TIMESTAMP_FIELD_NAME },
+          });
+        }
+
+        // fieldCaps didn't find @timestamp — check if any sources are views
+        const allNames = sources
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const viewSources = allNames.filter((name) => viewNames.has(name));
+
+        if (viewSources.length) {
+          const viewChecks = await Promise.all(
+            viewSources.map((viewName) =>
+              checkViewLikeSourceForTimestamp({ client, sourceName: viewName })
+            )
+          );
+          if (viewChecks.every(Boolean)) {
+            return response.ok({
+              body: { timeField: ES_TIMESTAMP_FIELD_NAME },
+            });
+          }
+        }
+
         return response.ok({
-          body: { timeField: sourceChecks.every(Boolean) ? '@timestamp' : undefined },
+          body: { timeField: undefined },
         });
       } catch (error) {
         logger.get().debug(toDebugString(error));

--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
@@ -115,17 +115,16 @@ export const registerGetTimeFieldRoute = (
       const service = new EsqlService({ client: core.elasticsearch.client.asCurrentUser });
       const { views } = await service.getViews().catch(() => ({ views: [] }));
       const viewNames = new Set(views.map(({ name }) => name));
+      const splitSources = sources
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
 
       try {
         // In case of subqueries we need to check all indices separately.
         // Otherwise, pass the full sources string to fieldCaps so Elasticsearch
         // evaluates the multi-index pattern holistically.
-        const indices = hasSubqueries
-          ? sources
-              .split(',')
-              .map((index) => index.trim())
-              .filter(Boolean)
-          : [sources];
+        const indices = hasSubqueries ? splitSources : [sources];
 
         if (!indices.length) {
           return response.ok({
@@ -158,11 +157,7 @@ export const registerGetTimeFieldRoute = (
         }
 
         // fieldCaps didn't find @timestamp — check if any sources are views
-        const allNames = sources
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean);
-        const viewSources = allNames.filter((name) => viewNames.has(name));
+        const viewSources = splitSources.filter((name) => viewNames.has(name));
 
         if (viewSources.length) {
           const viewChecks = await Promise.all(


### PR DESCRIPTION
## Summary

Fixes a regression that was caused when I added the views support.

For queries which are querying multiple indices we want to enable the timepicker if at least one has @timestamp. This rule doesnt apply when we have subqueries

So for example

```
FROM kibana_sample_data_logs, kibana_sample_data_flights 
```

should enable the picker

but if ypu have


```
FROM kibana_sample_data_flights, (from kibana_sample_data_logs | where AvgTicketPrice IS NOT NULL) 
```

should not

I added unit tests to be sure that we wont break this again

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



