### PR TITLE
Mute React 18 warning in developer toolbar

### DIFF
--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/console_error/console_monitor.ts
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/console_error/console_monitor.ts
@@ -23,6 +23,12 @@ export class ConsoleMonitor implements Monitor<ConsoleErrorInfo | null> {
     // We're ignoring this error until we migrate to React 18's createRoot API.
     // https://github.com/elastic/kibana/issues/199100
     'Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead.',
+    /**
+     * React 18 concurrent mode logs a “race-condition” warning on unmount of nested roots.
+     * Tests show no real breakage, so we silence it for now.
+     * Revisit if the warning ever surfaces as an actual bug.
+     */
+    'Warning: Attempted to synchronously unmount a root while React was already rendering.',
   ] as const;
 
   private static readonly DEBOUNCE_DELAY = 100 as const; // ms


### PR DESCRIPTION
## Summary

This PR mutes `Warning: Attempted to synchronously unmount a root while React was already rendering.` warning, similar to how it was done in: https://github.com/elastic/kibana/pull/254500/changes#diff-6b78262bd0e97d4a460bf644fe12e7307536084595256a0650b5723e20ff9a8cR25


