### PR TITLE
[Alerting v2] [Rule authoring] Move consecutive breaches max to shared constants

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_count_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_count_field.tsx
@@ -7,12 +7,11 @@
 
 import React, { useCallback, useEffect } from 'react';
 import { EuiFieldNumber } from '@elastic/eui';
+import { MAX_CONSECUTIVE_BREACHES } from '@kbn/alerting-v2-schemas';
 import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { INVALID_NUMBER_KEYS, parsePositiveIntegerInput } from '../utils';
-
-const MAX_PENDING_COUNT = 1000;
 const DEFAULT_PENDING_COUNT = 2;
 
 interface StateTransitionCountFieldProps {
@@ -46,7 +45,7 @@ export const StateTransitionCountField: React.FC<StateTransitionCountFieldProps>
           defaultMessage: 'Consecutive breaches is required.',
         }),
         min: 1,
-        max: MAX_PENDING_COUNT,
+        max: MAX_CONSECUTIVE_BREACHES,
         validate: (value) => {
           if (value != null && !Number.isInteger(value)) {
             return i18n.translate('xpack.alertingV2.ruleForm.stateTransition.countIntegerError', {
@@ -61,13 +60,13 @@ export const StateTransitionCountField: React.FC<StateTransitionCountFieldProps>
           value={value ?? DEFAULT_PENDING_COUNT}
           onChange={(e) => {
             const parsedValue = parsePositiveIntegerInput(e.target.value);
-            if (parsedValue != null && parsedValue <= MAX_PENDING_COUNT) {
+            if (parsedValue != null && parsedValue <= MAX_CONSECUTIVE_BREACHES) {
               onChange(parsedValue);
             }
           }}
           onKeyDown={onKeyDown}
           min={1}
-          max={MAX_PENDING_COUNT}
+          max={MAX_CONSECUTIVE_BREACHES}
           step={1}
           isInvalid={!!error}
           data-test-subj="stateTransitionCountInput"

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Maximum number of consecutive breaches before transition */
+export const MAX_CONSECUTIVE_BREACHES = 1000;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './rule_data_schema';
+export * from './constants';
 export type { RuleResponse } from './rule_response';
 export { validateDuration, validateEsqlQuery } from './validation';
 export * from './notification_policy_data_schema';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -8,6 +8,7 @@
 import { z } from '@kbn/zod';
 import { validateEsqlQuery } from './validation';
 import { durationSchema } from './common';
+import { MAX_CONSECUTIVE_BREACHES } from './constants';
 
 /** Primitives */
 
@@ -111,7 +112,7 @@ const stateTransitionSchema = z
       .number()
       .int()
       .min(0)
-      .max(1000)
+      .max(MAX_CONSECUTIVE_BREACHES)
       .optional()
       .describe('Consecutive breaches before active.'),
     pending_timeframe: durationSchema.optional().describe('Time window for pending evaluation.'),


### PR DESCRIPTION
## Summary

Centralizes the Alerting V2 `pending_count` upper bound into a runtime-neutral shared location and reuses it in both schema validation and form validation.

## What Changed

- Added `MAX_CONSECUTIVE_BREACHES` to:
  - `x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/constants.ts`
- Exported shared constants from:
  - `x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/index.ts`
- Updated schema max validation to use the shared constant:
  - `x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts`
- Updated form field validation to use the same constant from `@kbn/alerting-v2-schemas`:
  - `x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_count_field.tsx`
- Removed duplicate local constant from:
  - `x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/constants.ts`

## Why

- Prevents duplicated limits across packages.
- Keeps API/schema and UI validation aligned.
- Corrects dependency direction by avoiding schema dependency on a browser-only package.

## Validation

- `ReadLints` on touched files: no lint errors.
- `node scripts/check_changes.ts`: exited with code `134` in local run (no output in this environment).

## Impact / Risk

- No intended behavior change.
- Low risk: refactor to single source of truth for a numeric validation limit.